### PR TITLE
Add baseline unit tests and close bootstrap issues #12-#19

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,11 +21,16 @@ Agents working on implementation should use the GitHub Project roadmap and issue
 For implementation tasks:
 
 1. Read the assigned or selected GitHub issue first.
-2. Review the cited spec sections and any dependency issues.
-3. Add or update the named tests first.
-4. Implement only the scope required to make those tests pass.
-5. If implementation changes the intended contract, update the relevant spec in the same task.
-6. Keep the issue, PR, and Project status aligned with the actual work state.
+2. Move the issue to **In Progress** on the GitHub Project board.
+3. Review the cited spec sections and any dependency issues.
+4. Add or update the named tests first.
+5. Implement only the scope required to make those tests pass.
+6. If implementation changes the intended contract, update the relevant spec in the same task.
+7. Present the final result for user review before any commit.
+8. After user approval, commit and push a PR targeting `main`.
+9. Only after CI passes and the PR is merged, close the issue.
+
+Never close a GitHub issue without a merged PR that passes CI. Never commit or push without explicit user approval. Keep the issue, PR, and Project board status aligned with the actual work state at every step.
 
 Default delivery rules:
 
@@ -38,8 +43,8 @@ Default delivery rules:
 ### Code Quality Standards
 
 - **Document all public items.** Every public struct, enum, trait, function, constant, type alias, method, field, and variant must have a `///` doc comment. Every `lib.rs` must have a `//!` crate-level doc comment. The workspace enforces `missing_docs` linting — undocumented public items are build failures.
-- **Zero warnings policy.** All code must compile with zero warnings under the workspace's configured clippy and rustc lints. Do not suppress warnings with `#[allow(...)]` unless there is a documented reason. Fix the root cause instead.
-- **Derive documentation from the spec.** Doc comments should describe the *purpose and semantics* of the item as defined in the corresponding `spec/` files, not just restate the type signature.
+- **Zero warnings policy.** All code must compile with zero warnings under the workspace's configured clippy and rustc lints. Fix the root cause instead of suppressing. When suppression is genuinely needed, use `#[expect(lint, reason = "...")]` — never `#[allow(...)]`.
+- **Derive documentation from the spec.** Doc comments should describe the _purpose and semantics_ of the item as defined in the corresponding `spec/` files, not just restate the type signature.
 
 ## Spec Synchronization During Implementation
 

--- a/crates/ars-a11y/src/lib.rs
+++ b/crates/ars-a11y/src/lib.rs
@@ -71,3 +71,47 @@ impl ComponentIds {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn aria_role_clone_and_equality() {
+        let role = AriaRole::Button;
+        let cloned = role.clone();
+        assert_eq!(role, cloned);
+        assert_ne!(AriaRole::Button, AriaRole::Dialog);
+    }
+
+    #[test]
+    fn aria_attribute_clone_and_equality() {
+        let attr = AriaAttribute::Label;
+        let cloned = attr.clone();
+        assert_eq!(attr, cloned);
+        assert_ne!(AriaAttribute::Label, AriaAttribute::Invalid);
+    }
+
+    #[test]
+    fn component_ids_named_creates_root_only() {
+        let ids = ComponentIds::named("my-component");
+        assert_eq!(ids.root, "my-component");
+        assert!(ids.label.is_none());
+        assert!(ids.description.is_none());
+        assert!(ids.error.is_none());
+    }
+
+    #[test]
+    fn component_ids_default_has_empty_root() {
+        let ids = ComponentIds::default();
+        assert!(ids.root.is_empty());
+        assert!(ids.label.is_none());
+        assert!(ids.description.is_none());
+        assert!(ids.error.is_none());
+    }
+
+    #[test]
+    fn data_ars_state_constant_value() {
+        assert_eq!(DATA_ARS_STATE, "data-ars-state");
+    }
+}

--- a/crates/ars-core/src/lib.rs
+++ b/crates/ars-core/src/lib.rs
@@ -259,6 +259,10 @@ impl<M: Machine> Service<M> {
     /// Returns the list of pending side effects that the adapter should execute.
     /// If the event is ignored (transition returns `None`), the returned list is empty.
     #[must_use]
+    #[expect(
+        clippy::needless_pass_by_value,
+        reason = "spec-defined by-value signature; event ownership needed for future effect dispatch"
+    )]
     pub fn send(&mut self, event: M::Event) -> Vec<PendingEffect<M::Event>> {
         let Some(plan) = M::transition(&self.state, &event, &self.context, &self.props) else {
             return Vec::new();

--- a/crates/ars-forms/src/lib.rs
+++ b/crates/ars-forms/src/lib.rs
@@ -47,3 +47,57 @@ pub trait Validator<T> {
     /// Validates the given value and returns a result with any errors found.
     fn validate(&self, value: &T) -> ValidationResult;
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::{string::ToString, vec};
+
+    #[test]
+    fn empty_validation_result_is_valid() {
+        let result = ValidationResult::default();
+        assert!(result.is_valid());
+    }
+
+    #[test]
+    fn validation_result_with_errors_is_not_valid() {
+        let result = ValidationResult {
+            errors: vec![ValidationError {
+                code: "required".to_string(),
+                message: "This field is required".to_string(),
+            }],
+        };
+        assert!(!result.is_valid());
+    }
+
+    #[test]
+    fn field_state_default_not_dirty_not_touched() {
+        let state = FieldState::default();
+        assert!(!state.dirty);
+        assert!(!state.touched);
+    }
+
+    struct RequiredValidator;
+
+    impl Validator<String> for RequiredValidator {
+        fn validate(&self, value: &String) -> ValidationResult {
+            if value.is_empty() {
+                ValidationResult {
+                    errors: vec![ValidationError {
+                        code: "required".to_string(),
+                        message: "Value is required".to_string(),
+                    }],
+                }
+            } else {
+                ValidationResult::default()
+            }
+        }
+    }
+
+    #[test]
+    fn validator_trait_can_be_implemented() {
+        let validator = RequiredValidator;
+        assert!(!validator.validate(&String::new()).is_valid());
+        assert!(validator.validate(&"hello".to_string()).is_valid());
+    }
+}

--- a/crates/ars-test-harness/src/lib.rs
+++ b/crates/ars-test-harness/src/lib.rs
@@ -61,3 +61,33 @@ impl TestHarness {
         self.locale.as_ref()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn element_handle_stores_selector() {
+        let handle = ElementHandle::new("button.primary");
+        assert_eq!(handle.selector(), "button.primary");
+    }
+
+    #[test]
+    fn element_handle_default_has_empty_selector() {
+        let handle = ElementHandle::default();
+        assert!(handle.selector().is_empty());
+    }
+
+    #[test]
+    fn test_harness_with_locale() {
+        let harness = TestHarness::with_locale(Locale::new("en-US"));
+        let locale = harness.locale().expect("locale should be set");
+        assert_eq!(locale.as_str(), "en-US");
+    }
+
+    #[test]
+    fn test_harness_default_has_no_locale() {
+        let harness = TestHarness::default();
+        assert!(harness.locale().is_none());
+    }
+}


### PR DESCRIPTION
## Summary

- Adds unit tests for `ars-a11y` (5 tests), `ars-forms` (4 tests), `ars-test-harness` (4 tests) to satisfy the acceptance criteria of #15, #17, #19
- Adds `#[expect(clippy::needless_pass_by_value)]` to `Service::send` in ars-core — the by-value signature is spec-defined (#13)
- Updates CLAUDE.md/AGENTS.md with PR-gated issue closure workflow and `#[expect]` over `#[allow]` policy

Issues #12, #13, #14, #16, #18 were already satisfied by the initial implementation setup commit. This PR adds the missing pieces for #15, #17, #19.

Closes #12, #13, #14, #15, #16, #17, #18, #19

## Test plan

- [ ] `cargo clippy --workspace` — zero warnings
- [ ] `cargo test --workspace` — 16 tests pass (13 new + 3 pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)