### PR TITLE
Add adapter contract reference and spec-sync checklist

### DIFF
--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -83,7 +83,7 @@ body:
     id: spec_impact
     attributes:
       label: Spec impact
-      description: State whether this epic is expected to update the spec.
+      description: State whether this epic is expected to update the spec. For adapter epics, state whether the Mandatory Promotion Rule applies. See docs/implementation/adapter-contract.md.
       placeholder: No spec change required, or list exact files/sections.
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -20,7 +20,7 @@ body:
     id: spec_refs
     attributes:
       label: Spec refs
-      description: Cite exact spec files and sections.
+      description: Cite exact spec files and sections. For adapter work, include the relevant foundation adapter spec (08 or 09) and any agnostic component spec sections the adapter maps.
     validations:
       required: true
   - type: textarea
@@ -91,13 +91,14 @@ body:
     attributes:
       label: Acceptance criteria
       description: Phrase these as observable behavior or validation outcomes.
+      placeholder: "For adapter tasks, include: parity with other adapter verified, deviations documented, spec sync confirmed."
     validations:
       required: true
   - type: textarea
     id: spec_impact
     attributes:
       label: Spec impact
-      description: State either no change is required or the exact files/sections that must be updated in the same task.
+      description: State either no change is required or the exact files/sections that must be updated in the same task. For adapter work, state whether the Mandatory Promotion Rule applies (shared behavior must be promoted to foundation spec, not left only in adapter code). See docs/implementation/adapter-contract.md.
     validations:
       required: true
   - type: textarea

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,6 +26,18 @@ Closes #
 
 If spec changed, list exact files and sections:
 
+### Adapter sync (fill if Layer = Adapter or Framework != None)
+
+- [ ] Referenced foundation spec sections this work depends on
+- [ ] Mandatory Promotion Rule checked — shared behavior promoted to foundation spec, not left only in adapter code
+- [ ] Deviations from agnostic spec documented with justification
+- [ ] Parity: both-adapter coverage verified or single-adapter scope justified
+- [ ] Adapter concerns reviewed (AttrMap, events, SSR, controlled values, cleanup)
+- [ ] Adapter component spec follows 31-section structure (if adding a new component spec)
+- [ ] Not applicable — this PR does not touch adapter or framework-specific code
+
+See [Adapter contract reference](docs/implementation/adapter-contract.md) for details.
+
 ---
 
 ## Notes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,6 +94,13 @@ ars-ui/
 3. Write tests for new functionality
 4. Open a pull request with a clear description of what changed and why
 
+## Spec Synchronization
+
+If your change affects the specification or adapter layers, review the
+[Adapter contract reference](docs/implementation/adapter-contract.md) before
+opening a PR. The PR template includes an adapter sync checklist that must be
+completed for any adapter or framework-specific work.
+
 ## License
 
 By contributing to ars-ui, you agree that your contributions will be licensed under the same terms as the project: MIT OR Apache-2.0, at the user's choice.

--- a/docs/implementation/README.md
+++ b/docs/implementation/README.md
@@ -16,3 +16,4 @@ Start with:
 2. [project-board.md](./project-board.md) for fields, workflow, and sizing rules.
 3. [initial-backlog.md](./initial-backlog.md) for the seed epics and first implementation tasks.
 4. The GitHub Project and initial issue backlog are expected to be kept in sync with these docs.
+5. [adapter-contract.md](./adapter-contract.md) for adapter work obligations and spec-sync checklist.

--- a/docs/implementation/adapter-contract.md
+++ b/docs/implementation/adapter-contract.md
@@ -1,0 +1,101 @@
+# Adapter Contract Reference
+
+This document defines the shared obligations for any work touching the adapter
+layer. It consolidates rules from the specification, workflow templates, and
+implementation program into a single contributor-facing reference.
+
+## When This Applies
+
+Any PR or issue where:
+
+- Layer = **Adapter**
+- Framework = **Leptos**, **Dioxus**, or **Both**
+- The change touches `crates/ars-leptos/`, `crates/ars-dioxus/`, or adapter
+  specs under `spec/leptos-components/` or `spec/dioxus-components/`
+
+## Obligations
+
+### 1. Foundation Spec References
+
+Adapter work must cite the foundation spec sections it depends on. At minimum:
+
+- `spec/foundation/01-architecture.md` section 6 (Adapter Architecture)
+- `spec/foundation/08-adapter-leptos.md` or `spec/foundation/09-adapter-dioxus.md`
+- The framework-agnostic component spec for any component being adapted
+
+Issues must list these in the **Spec refs** field. PRs must list them in the
+**Spec refs** section.
+
+### 2. Mandatory Promotion Rule
+
+If implementation reveals behavior that is shared across both adapters, that
+behavior must be promoted into the appropriate `spec/foundation/` or
+`spec/shared/` file. It must not live only in adapter code or adapter specs.
+
+This rule comes from
+`spec/foundation/12-adapter-component-spec-template.md` section 2. It applies
+to both hard requirements and recommendation-level guidance.
+
+### 3. Deviation Documentation
+
+Any deviation from the framework-agnostic spec must be documented with explicit
+justification. Deviations belong in the adapter component spec's
+**Parity Summary and Intentional Deviations** section. Undocumented deviations
+are review blockers.
+
+### 4. Parity Testing
+
+When both adapters exist for a component, parity testing is required: both
+adapters must produce equivalent behavior, ARIA output, and `data-ars-*`
+attributes for the same inputs.
+
+If a PR touches only one adapter, state why single-adapter scope is justified
+(for example, the other adapter does not yet exist for this component).
+
+### 5. Adapter Concern Checklist
+
+When reviewing or authoring adapter work, verify these concern categories
+against the spec (from `12-adapter-component-spec-template.md` section 3):
+
+- [ ] AttrMap merge and ownership
+- [ ] Event normalization and handler composition
+- [ ] SSR and hydration gating
+- [ ] Controlled value synchronization
+- [ ] Cleanup and disposal ordering
+- [ ] Ref and node ownership
+- [ ] Context registration and descendant propagation
+- [ ] Native semantic repair
+- [ ] Platform-specific fallback
+- [ ] Form bridging
+
+Not every concern applies to every PR. Check the ones relevant to the change
+and note "N/A" for the rest.
+
+### 6. Adapter Component Spec Structure
+
+New adapter component specs must follow the 31-section structure defined in
+`spec/foundation/12-adapter-component-spec-template.md` section 5. Section
+numbering is mandatory and sequential with no gaps.
+
+## Spec Synchronization Rules
+
+These rules apply to all implementation work, not just adapter tasks. They are
+restated here for completeness.
+
+1. Each task must declare **Spec impact** in the issue.
+2. If implementation proves the spec wrong or incomplete, update the spec in the
+   same task.
+3. Shared abstraction changes go into `spec/foundation/` or `spec/shared/`.
+4. Adapter-specific realization belongs in `spec/foundation/08-adapter-leptos.md`,
+   `spec/foundation/09-adapter-dioxus.md`, and the per-component adapter specs.
+5. Adapter code must not become the only authoritative explanation for behavior
+   that future framework ports would need to reproduce.
+
+## Related Documents
+
+- `spec/foundation/01-architecture.md` section 6 — Adapter Architecture
+- `spec/foundation/08-adapter-leptos.md` — Leptos adapter contract
+- `spec/foundation/09-adapter-dioxus.md` — Dioxus adapter contract
+- `spec/foundation/12-adapter-component-spec-template.md` — Adapter component spec authoring rules
+- `spec/testing/05-adapter-harness.md` — Adapter parity testing
+- `docs/implementation/roadmap.md` — Spec synchronization rules


### PR DESCRIPTION
## Summary

- Add `docs/implementation/adapter-contract.md` consolidating adapter obligations (foundation refs, promotion rule, deviation docs, parity testing, concern checklist, spec structure)
- Enhance PR template with an "Adapter sync" checklist subsection under Spec synchronization
- Update issue templates (`task.yml`, `epic.yml`) with adapter-specific guidance in field descriptions

Closes #21

## Test plan

- [x] PR template renders "Adapter sync" subsection with 7 checkboxes
- [x] `task.yml` spec_refs and spec_impact descriptions reference adapter obligations
- [x] `epic.yml` spec_impact description mentions Mandatory Promotion Rule
- [x] `adapter-contract.md` covers all six obligations and references authoritative spec files
- [x] `CONTRIBUTING.md` points to adapter-contract doc
- [x] `docs/implementation/README.md` lists adapter-contract doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)