### PR TITLE
Add initial Leptos adapter shell with use_machine hook

### DIFF
--- a/.agents/settings.json
+++ b/.agents/settings.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path // .tool_response.filePath' | { read -r f; [[ \"$f\" == *.rs ]] && cargo +nightly fmt -- \"$f\" || true; } 2>/dev/null || true",
+            "timeout": 30,
+            "statusMessage": "Formatting with rustfmt..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@v2
       - name: Cargo clippy
-        run: cargo clippy --workspace --all-targets -- -D warnings
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
   check:
     name: Workspace Check
@@ -40,7 +40,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Cargo check
-        run: cargo check --workspace
+        run: cargo check --workspace --all-features
 
   unit:
     name: Unit Tests
@@ -50,7 +50,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Unit test tier
-        run: cargo test -p ars-a11y -p ars-core -p ars-interactions -p ars-forms
+        run: cargo test -p ars-a11y -p ars-core -p ars-interactions -p ars-forms --all-targets --all-features
 
   integration:
     name: Integration Tests
@@ -70,4 +70,4 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Adapter harness tier
-        run: cargo test -p ars-test-harness -p ars-test-harness-leptos -p ars-test-harness-dioxus -p ars-leptos -p ars-dioxus
+        run: cargo test -p ars-test-harness -p ars-test-harness-leptos -p ars-test-harness-dioxus -p ars-leptos -p ars-dioxus --all-targets --all-features

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,20 @@ Default delivery rules:
 - **Zero warnings policy.** All code must compile with zero warnings under the workspace's configured clippy and rustc lints. Fix the root cause instead of suppressing. When suppression is genuinely needed, use `#[expect(lint, reason = "...")]` — never `#[allow(...)]`.
 - **Derive documentation from the spec.** Doc comments should describe the _purpose and semantics_ of the item as defined in the corresponding `spec/` files, not just restate the type signature.
 
+### Adapter Prelude Convention
+
+Both `ars-leptos` and `ars-dioxus` expose a `prelude` module targeting **end users** — application developers who consume the ready-made components. `use ars_leptos::prelude::*` (or `use ars_dioxus::prelude::*`) should give them everything they need.
+
+The prelude contains only user-facing items:
+
+1. **Component modules** — as components land, their public module paths (e.g., `button`, `dialog`) are re-exported so users can write `button::Props`, etc.
+2. **User-facing traits** — traits end users call on component outputs (e.g., `Translate` from `ars-i18n`). Re-export the trait so consumers don't need a direct dependency on the subsystem crate.
+3. **Configuration types** — types that appear in component props or configure behaviour (e.g., `Locale`, `Direction`, `Orientation`, `Selection`).
+
+The prelude does **not** include implementation details consumed only by component authors inside the adapter crate: core engine types (`Machine`, `Service`, `ConnectApi`, `AttrMap`), accessibility primitives (`AriaRole`, `AriaAttribute`), interaction helpers (`merge_attrs`), or adapter hooks (`use_machine`, `UseMachineReturn`). Those remain accessible via their normal crate paths for advanced users building custom machines.
+
+Both adapter preludes must stay symmetric: same items, same structure. When adding a new re-export to one adapter's prelude, add it to the other as well in the same PR.
+
 ## Spec Synchronization During Implementation
 
 The specification remains authoritative during implementation.

--- a/crates/ars-leptos/Cargo.toml
+++ b/crates/ars-leptos/Cargo.toml
@@ -9,17 +9,19 @@ rust-version.workspace = true
 
 [features]
 default = []
-ssr     = ["ars-dom/ssr"]
-hydrate = []
-csr     = []
+ssr     = ["leptos/ssr", "ars-dom/ssr"]
+hydrate = ["leptos/hydrate"]
+csr     = ["leptos/csr"]
 
 [dependencies]
 ars-a11y         = { path = "../ars-a11y" }
+ars-collections  = { path = "../ars-collections" }
 ars-core         = { path = "../ars-core" }
 ars-dom          = { path = "../ars-dom" }
 ars-forms        = { path = "../ars-forms" }
 ars-i18n         = { path = "../ars-i18n" }
 ars-interactions = { path = "../ars-interactions" }
+leptos           = { version = "0.8", default-features = false }
 
 [lints]
 workspace = true

--- a/crates/ars-leptos/src/ephemeral.rs
+++ b/crates/ars-leptos/src/ephemeral.rs
@@ -1,0 +1,86 @@
+//! Ephemeral reference wrapper that prevents borrowed data from escaping into signals.
+
+use std::{fmt, marker::PhantomData, rc::Rc};
+
+/// A non-cloneable, non-copyable wrapper that prevents storing borrowed data in signals.
+///
+/// Used by [`with_api_ephemeral()`](crate::UseMachineReturn::with_api_ephemeral) to wrap
+/// the borrowed connect API, ensuring it cannot be stored in a `Signal<T>` or `RwSignal<T>`
+/// (which require `T: 'static`).
+///
+/// The `PhantomData<(Rc<()>, &'a ())>` marker provides three compile-time guarantees:
+/// - **`!Send` and `!Sync`**: `Rc<()>` is neither `Send` nor `Sync`
+/// - **Not `'static`**: the `&'a ()` prevents coercion to `'static`
+/// - **`!Clone` and `!Copy`**: no derive, so duplication is impossible
+///
+/// This eliminates the use-after-free class of bugs where `Api<'a>` might outlive the
+/// `Service` reference it borrows from.
+///
+/// ```rust,compile_fail
+/// # use ars_leptos::EphemeralRef;
+/// // Cannot send across threads:
+/// fn assert_send<T: Send>(_: T) {}
+/// let e = EphemeralRef::new(42);
+/// assert_send(e); // ERROR: Rc<()> is not Send
+/// ```
+///
+/// ```rust,compile_fail
+/// # use ars_leptos::EphemeralRef;
+/// // Cannot share across threads:
+/// fn assert_sync<T: Sync>(_: T) {}
+/// let e = EphemeralRef::new(42);
+/// assert_sync(e); // ERROR: Rc<()> is not Sync
+/// ```
+///
+/// ```rust,compile_fail
+/// # use ars_leptos::EphemeralRef;
+/// // Cannot clone:
+/// let e = EphemeralRef::new(42);
+/// let _ = e.clone(); // ERROR: no Clone impl
+/// ```
+pub struct EphemeralRef<'a, T> {
+    value: T,
+    _marker: PhantomData<(Rc<()>, &'a ())>,
+}
+
+impl<'a, T> EphemeralRef<'a, T> {
+    /// Creates a new ephemeral reference wrapping the given value.
+    ///
+    /// Only callable within `with_api_ephemeral()` closures where the borrow
+    /// lifetime `'a` is tied to the `Service` access scope.
+    pub fn new(value: T) -> Self {
+        Self {
+            value,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Returns a shared reference to the inner value.
+    pub fn get(&self) -> &T {
+        &self.value
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for EphemeralRef<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("EphemeralRef").field(&self.value).finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ephemeral_ref_provides_access_to_inner_value() {
+        let e = EphemeralRef::new(42);
+        assert_eq!(*e.get(), 42);
+    }
+
+    #[test]
+    fn ephemeral_ref_debug_shows_inner_value() {
+        let e = EphemeralRef::new("hello");
+        let debug = format!("{e:?}");
+        assert!(debug.contains("hello"));
+    }
+}

--- a/crates/ars-leptos/src/id.rs
+++ b/crates/ars-leptos/src/id.rs
@@ -1,0 +1,125 @@
+//! Hydration-safe deterministic ID generation.
+//!
+//! Provides monotonic counters that produce the same ID sequence on both SSR and
+//! client when the component tree renders in the same order.
+
+// On WASM (single-threaded), use a thread-local Cell for zero-overhead counting.
+#[cfg(target_arch = "wasm32")]
+mod counter {
+    use std::cell::Cell;
+
+    thread_local! {
+        static ID_COUNTER: Cell<u64> = const { Cell::new(0) };
+    }
+
+    pub(super) fn next_id() -> u64 {
+        ID_COUNTER.with(|c| {
+            let v = c.get();
+            c.set(v + 1);
+            v
+        })
+    }
+
+    /// Resets the ID counter to zero.
+    ///
+    /// Must be called at the start of each SSR request so that server-rendered IDs
+    /// match the client-side hydration sequence.
+    #[cfg(feature = "ssr")]
+    pub(super) fn reset() {
+        ID_COUNTER.with(|c| c.set(0));
+    }
+}
+
+// On native (multi-threaded SSR), use an atomic counter.
+#[cfg(not(target_arch = "wasm32"))]
+mod counter {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static ID_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    pub(super) fn next_id() -> u64 {
+        ID_COUNTER.fetch_add(1, Ordering::Relaxed)
+    }
+
+    /// Resets the ID counter to zero.
+    ///
+    /// Must be called at the start of each SSR request so that server-rendered IDs
+    /// match the client-side hydration sequence.
+    #[cfg(feature = "ssr")]
+    pub(super) fn reset() {
+        ID_COUNTER.store(0, Ordering::Relaxed);
+    }
+}
+
+/// Generates a deterministic component ID with the given prefix.
+///
+/// Returns a string of the form `"{prefix}-{counter}"`. The counter is global and
+/// monotonically increasing, ensuring uniqueness within a single render pass.
+///
+/// # Hydration safety
+///
+/// The counter produces identical sequences on SSR and client when the component tree
+/// renders in the same order. Call [`reset_id_counter()`] at the start of each SSR
+/// request to reset the sequence.
+///
+/// # Examples
+///
+/// ```
+/// use ars_leptos::use_id;
+///
+/// let id1 = use_id("dialog");
+/// let id2 = use_id("dialog");
+/// // id1 and id2 are guaranteed to differ
+/// assert_ne!(id1, id2);
+/// ```
+pub fn use_id(prefix: &str) -> String {
+    format!("{prefix}-{}", counter::next_id())
+}
+
+/// Generates a related element ID by appending a suffix to a base ID.
+///
+/// # Examples
+///
+/// ```
+/// use ars_leptos::related_id;
+///
+/// let base = "menu-1";
+/// assert_eq!(related_id(base, "trigger"), "menu-1-trigger");
+/// assert_eq!(related_id(base, "content"), "menu-1-content");
+/// ```
+pub fn related_id(base: &str, suffix: &str) -> String {
+    format!("{base}-{suffix}")
+}
+
+/// Resets the ID counter to zero for a new SSR request.
+///
+/// Must be called at the start of each server-side render pass so that the generated
+/// IDs match the client-side hydration sequence exactly.
+#[cfg(feature = "ssr")]
+pub fn reset_id_counter() {
+    counter::reset();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn use_id_produces_prefixed_ids() {
+        let id = use_id("test");
+        assert!(id.starts_with("test-"));
+    }
+
+    #[test]
+    fn use_id_produces_unique_ids() {
+        let id1 = use_id("component");
+        let id2 = use_id("component");
+        assert_ne!(id1, id2);
+    }
+
+    #[test]
+    fn related_id_appends_suffix() {
+        assert_eq!(related_id("menu-1", "trigger"), "menu-1-trigger");
+        assert_eq!(related_id("menu-1", "content"), "menu-1-content");
+    }
+}

--- a/crates/ars-leptos/src/lib.rs
+++ b/crates/ars-leptos/src/lib.rs
@@ -2,6 +2,24 @@
 //!
 //! Bridges [`ars_core::Machine`] implementations to Leptos's fine-grained reactivity
 //! system, providing SSR and hydration support for web-based applications.
+//!
+//! # Core primitives
+//!
+//! - [`use_machine`] — creates a reactive machine service from props
+//! - [`UseMachineReturn`] — handle for state, send, derive, and API access
+//! - [`EphemeralRef`] — borrow wrapper preventing signal storage of borrowed APIs
+//! - [`use_id`] / [`related_id`] — hydration-safe deterministic ID generation
+
+mod ephemeral;
+mod id;
+pub mod prelude;
+mod use_machine;
+
+pub use ephemeral::EphemeralRef;
+#[cfg(feature = "ssr")]
+pub use id::reset_id_counter;
+pub use id::{related_id, use_id};
+pub use use_machine::{UseMachineReturn, use_machine, use_machine_with_reactive_props};
 
 /// The name of this framework adapter, used in diagnostic messages and feature gating.
 pub const ADAPTER_NAME: &str = "leptos";

--- a/crates/ars-leptos/src/prelude.rs
+++ b/crates/ars-leptos/src/prelude.rs
@@ -1,0 +1,57 @@
+//! Convenience re-exports for end users of the Leptos adapter.
+//!
+//! A single `use ars_leptos::prelude::*;` gives application authors access to
+//! the components, user-facing traits, and configuration types they need —
+//! without hunting through individual `ars_*` crates.
+//!
+//! # What belongs in the prelude
+//!
+//! Only items that **end users** interact with directly:
+//!
+//! 1. **Component modules** — as components land (e.g., `button`, `dialog`,
+//!    `select`), their public module paths are re-exported here so users can
+//!    write `button::Props`, `dialog::Machine`, etc.
+//!
+//! 2. **User-facing traits** — traits that end users call on component outputs
+//!    (e.g., `Translate` from `ars-i18n` for localised strings). Re-exporting
+//!    the trait avoids forcing users to add a direct dependency on the
+//!    subsystem crate just to call a method.
+//!
+//! 3. **Configuration types** — types that appear in component props or that
+//!    users pass to configure behaviour (e.g., `Locale`, `Direction`,
+//!    `Orientation`, `Selection`).
+//!
+//! # What does NOT belong in the prelude
+//!
+//! - **Core engine internals** — `Machine`, `Service`, `ConnectApi`,
+//!   `ComponentPart`, `AttrMap`, `Bindable`, `TransitionPlan`, `PendingEffect`.
+//!   These are implementation details used by component authors *inside* the
+//!   adapter crate, not by end users consuming components.
+//! - **Accessibility primitives** — `AriaRole`, `AriaAttribute`, `ComponentIds`.
+//!   Wired internally by each component; end users never construct these.
+//! - **Interaction primitives** — `merge_attrs`, `PressState`, `FocusState`.
+//!   Internal to component implementations.
+//! - **Adapter hooks** — `use_machine`, `UseMachineReturn`, `EphemeralRef`.
+//!   Used by component modules inside the adapter crate, not by end users
+//!   who consume the ready-made components. (Still publicly accessible via
+//!   `ars_leptos::use_machine` for advanced users building custom machines.)
+//! - **Framework re-exports** — `leptos::prelude::*` should be imported
+//!   separately; we do not re-export Leptos types to avoid version coupling.
+//!
+//! # Growth policy
+//!
+//! When adding a new item, ask: "Does an end user writing `<Button>` or
+//! `<Dialog>` in their app need this?" If yes, add it. If only component
+//! implementors inside this crate need it, keep it as a regular import.
+
+// -- User-facing configuration types --
+pub use ars_i18n::{Direction, Locale, Orientation};
+
+// -- User-facing traits --
+// (planned: `ars_i18n::Translate` once the trait lands)
+
+// -- Component modules --
+// (none yet — added as components are implemented, e.g.:
+//   pub use crate::{button, Button};
+//   pub use crate::{dialog, Dialog};
+// )

--- a/crates/ars-leptos/src/use_machine.rs
+++ b/crates/ars-leptos/src/use_machine.rs
@@ -1,0 +1,454 @@
+//! Reactive hook bridging [`ars_core::Machine`] to Leptos signals.
+//!
+//! The [`use_machine`] hook creates a [`Service`] instance, wraps it in Leptos
+//! reactive primitives, and returns a [`UseMachineReturn`] handle for reading
+//! state, sending events, and deriving fine-grained reactive values.
+
+use ars_core::{Machine, Service};
+use leptos::prelude::*;
+
+use crate::ephemeral::EphemeralRef;
+
+/// Return type from [`use_machine`].
+///
+/// Provides reactive access to a running [`Machine`] instance. All fields are
+/// `Copy` (arena-allocated Leptos handles), so this struct can be freely passed
+/// into closures without cloning.
+///
+/// # Reactive contract
+///
+/// - Reading [`state`](Self::state) in a reactive scope subscribes to state changes.
+/// - Calling [`send`](Self::send) dispatches an event and may update state/context.
+/// - [`derive()`](Self::derive) creates fine-grained memos from the connect API.
+/// - [`with_api_snapshot()`](Self::with_api_snapshot) provides one-shot imperative access.
+pub struct UseMachineReturn<M: Machine + 'static>
+where
+    M::State: Clone + PartialEq + Send + Sync + 'static,
+    M::Context: Clone + Send + Sync + 'static,
+{
+    /// Reactive signal for the current machine state.
+    /// Reading it inside a reactive scope creates a dependency.
+    pub state: ReadSignal<M::State>,
+
+    /// Send an event to the machine.
+    /// Safe to call from any closure — does not require reactive scope.
+    pub send: Callback<M::Event>,
+
+    /// Access the full service (context + state) via a `StoredValue`.
+    /// Use sparingly — prefer [`derive()`](Self::derive) for reactive data and
+    /// [`with_api_ephemeral()`](Self::with_api_ephemeral) for imperative access.
+    pub service: StoredValue<Service<M>>,
+
+    /// Monotonically increasing counter that increments whenever context changes.
+    /// Used by [`derive()`](Self::derive) to track context mutations even when
+    /// state remains the same.
+    pub context_version: ReadSignal<u64>,
+}
+
+// Manual Clone/Copy impls to avoid requiring M: Clone/Copy — all fields are
+// arena-allocated Leptos handles that are always Copy regardless of M.
+impl<M: Machine + 'static> Clone for UseMachineReturn<M>
+where
+    M::State: Clone + PartialEq + Send + Sync + 'static,
+    M::Context: Clone + Send + Sync + 'static,
+{
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<M: Machine + 'static> Copy for UseMachineReturn<M>
+where
+    M::State: Clone + PartialEq + Send + Sync + 'static,
+    M::Context: Clone + Send + Sync + 'static,
+{
+}
+
+impl<M: Machine + 'static> std::fmt::Debug for UseMachineReturn<M>
+where
+    M::State: Clone + PartialEq + Send + Sync + 'static,
+    M::Context: Clone + Send + Sync + 'static,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("UseMachineReturn")
+            .field("state", &self.state)
+            .field("context_version", &self.context_version)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<M: Machine + 'static> UseMachineReturn<M>
+where
+    M::State: Clone + PartialEq + Send + Sync + 'static,
+    M::Context: Clone + Send + Sync + 'static,
+    M::Props: Clone + PartialEq + Send + Sync + 'static,
+{
+    /// Gets a one-shot snapshot of the connect API.
+    ///
+    /// **Prefer [`derive()`](Self::derive) for reactive data** — this method does
+    /// not track dependencies. Use `with_api_snapshot` only for imperative
+    /// operations (e.g., reading a value once inside an event handler).
+    ///
+    /// The connect closure uses a panic callback because `with_value` holds an
+    /// immutable borrow on the `StoredValue`, preventing `send` (which calls
+    /// `update_value`) from re-entering. Sending events from API snapshots would
+    /// cause a re-entrant borrow panic.
+    pub fn with_api_snapshot<T>(&self, f: impl Fn(&M::Api<'_>) -> T) -> T {
+        self.service.with_value(|svc| {
+            let api = svc.connect(&|_e| {
+                #[cfg(debug_assertions)]
+                panic!("Cannot send events inside with_api_snapshot — use event handlers instead");
+            });
+            f(&api)
+        })
+    }
+
+    /// Creates a fine-grained memo that derives a value from the connect API.
+    ///
+    /// Only re-computes when the underlying state or context changes, and only
+    /// notifies dependents when the derived value actually changes.
+    ///
+    /// **Important:** `Api<'a>` has a non-`'static` lifetime and cannot be stored
+    /// in Leptos signals. The `&M::Api<'_>` reference passed to the closure is
+    /// valid only for that closure call. Extract the values you need (strings,
+    /// booleans, [`AttrMap`](ars_core::AttrMap)) and return them.
+    ///
+    /// The closure must not call `send()` — it is a read-only projection.
+    pub fn derive<T: Clone + PartialEq + Send + Sync + 'static>(
+        &self,
+        f: impl Fn(&M::Api<'_>) -> T + Send + Sync + 'static,
+    ) -> Memo<T> {
+        let state = self.state;
+        let context_version = self.context_version;
+        let service = self.service;
+        Memo::new(move |_| {
+            // Subscribe to both state and context_version so the memo
+            // re-computes when either changes.
+            state.track();
+            context_version.track();
+            service.with_value(|svc| {
+                let api = svc.connect(&|_e| {
+                    #[cfg(debug_assertions)]
+                    panic!("Cannot send events inside derive() — use event handlers instead");
+                });
+                f(&api)
+            })
+        })
+    }
+
+    /// Provides imperative, non-reactive API access wrapped in an [`EphemeralRef`].
+    ///
+    /// Use this inside event handlers when you need to read the current API state
+    /// without creating a reactive subscription. The `EphemeralRef` wrapper prevents
+    /// the borrowed API from being stored in signals.
+    ///
+    /// For reactive derived values, use [`derive()`](Self::derive) instead.
+    pub fn with_api_ephemeral<R>(&self, f: impl Fn(EphemeralRef<'_, M::Api<'_>>) -> R) -> R {
+        let send = self.send;
+        self.service.with_value(|svc| {
+            let send_fn = move |e| send.run(e);
+            let api = svc.connect(&send_fn);
+            f(EphemeralRef::new(api))
+        })
+    }
+}
+
+/// Creates and manages a machine service with Leptos reactivity.
+///
+/// This is the central primitive for using `ars-core` machines in Leptos components.
+/// It creates a [`Service<M>`], wraps it in reactive signals, and returns a
+/// [`UseMachineReturn`] handle.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// #[component]
+/// pub fn Toggle() -> impl IntoView {
+///     let machine = use_machine::<toggle::Machine>(toggle::Props::default());
+///     let is_on = machine.derive(|api| api.is_on());
+///     view! {
+///         <button on:click=move |_| machine.send.run(toggle::Event::Toggle)>
+///             {move || if is_on.get() { "ON" } else { "OFF" }}
+///         </button>
+///     }
+/// }
+/// ```
+pub fn use_machine<M: Machine + 'static>(props: M::Props) -> UseMachineReturn<M>
+where
+    M::State: Clone + PartialEq + Send + Sync + 'static,
+    M::Context: Clone + Send + Sync + 'static,
+    M::Props: Clone + PartialEq + Send + Sync + 'static,
+    M::Event: Send + Sync + 'static,
+{
+    let (result, ..) = use_machine_inner::<M>(props);
+    result
+}
+
+/// Creates a machine that watches an external props signal for changes.
+///
+/// When the props signal changes, the machine re-initializes with the new props.
+/// Use this for components with externally controlled state (e.g., a controlled
+/// checkbox whose `checked` value comes from a parent signal).
+///
+/// # Panics
+///
+/// Currently unimplemented — requires `Service::set_props()` which is not yet
+/// available in `ars-core`. Will be implemented when the core runtime is extended.
+pub fn use_machine_with_reactive_props<M: Machine + 'static>(
+    _props_signal: Signal<M::Props>,
+) -> UseMachineReturn<M>
+where
+    M::State: Clone + PartialEq + Send + Sync + 'static,
+    M::Context: Clone + Send + Sync + 'static,
+    M::Props: Clone + PartialEq + Send + Sync + 'static,
+    M::Event: Send + Sync + 'static,
+{
+    todo!("Requires Service::set_props() — blocked on ars-core SendResult addition")
+}
+
+/// Internal implementation shared between public hooks.
+///
+/// Returns the public `UseMachineReturn` plus internal write handles needed by
+/// `use_machine_with_reactive_props` for syncing external prop changes.
+fn use_machine_inner<M: Machine + 'static>(
+    props: M::Props,
+) -> (UseMachineReturn<M>, WriteSignal<u64>, WriteSignal<M::State>)
+where
+    M::State: Clone + PartialEq + Send + Sync + 'static,
+    M::Context: Clone + Send + Sync + 'static,
+    M::Props: Clone + PartialEq + Send + Sync + 'static,
+    M::Event: Send + Sync + 'static,
+{
+    // Create the service once — runs only on component initialization.
+    let service = StoredValue::new(Service::<M>::new(props));
+
+    // Create a signal tracking the current state.
+    let initial_state = service.with_value(|s| s.state().clone());
+    let (state_read, state_write) = signal(initial_state);
+
+    // Context version counter — incremented on every context change so that
+    // derive() memos re-run even when state itself hasn't changed.
+    let (context_version_read, context_version_write) = signal(0u64);
+
+    // Build the send callback. When an event is sent:
+    // 1. Snapshot the old state for comparison
+    // 2. Forward the event to Service::send()
+    // 3. Update signals if state/context changed
+    //
+    // Note: Without SendResult from ars-core, we detect state changes by
+    // comparing before/after, and conservatively bump context_version
+    // whenever a transition was applied (non-empty effects or state change).
+    let send: Callback<M::Event> = Callback::new(move |event: M::Event| {
+        let old_state = service.with_value(|s| s.state().clone());
+
+        // StoredValue::update_value returns (), so extract effects via side-channel.
+        let mut effects = Vec::new();
+        service.update_value(|s| {
+            effects = s.send(event);
+        });
+
+        let new_state = service.with_value(|s| s.state().clone());
+        let state_changed = new_state != old_state;
+
+        if state_changed {
+            state_write.set(new_state);
+        }
+
+        // Conservative: bump context_version whenever a transition was applied.
+        // A transition was applied if state changed OR effects were produced.
+        // This may over-notify but is always correct. Will be precise once
+        // ars-core returns SendResult with context_changed flag.
+        if state_changed || !effects.is_empty() {
+            context_version_write.update(|v| *v += 1);
+        }
+
+        // TODO: Effects are collected but not dispatched — PendingEffect::run() does
+        // not exist yet in ars-core. Effect lifecycle management will be added
+        // when component implementations need it.
+        drop(effects);
+    });
+
+    // Clean up effects when the component unmounts.
+    on_cleanup(move || {
+        // Placeholder: when effect dispatch is implemented, drain all
+        // active effect cleanups here in LIFO order.
+    });
+
+    let result = UseMachineReturn {
+        state: state_read,
+        send,
+        service,
+        context_version: context_version_read,
+    };
+
+    (result, context_version_write, state_write)
+}
+
+#[cfg(test)]
+mod tests {
+    use ars_core::{AttrMap, ComponentPart, ConnectApi, TransitionPlan};
+
+    use super::*;
+
+    // --- Test Machine (mirrors ars-core's ToggleMachine) ---
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    enum ToggleState {
+        Off,
+        On,
+    }
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    enum ToggleEvent {
+        Toggle,
+    }
+
+    #[derive(Clone, Debug, Default, PartialEq, Eq)]
+    struct ToggleContext;
+
+    #[derive(Clone, Debug, Default, PartialEq, Eq)]
+    struct ToggleProps;
+
+    #[derive(Clone, Debug)]
+    struct TogglePart;
+
+    impl ComponentPart for TogglePart {
+        fn root() -> Self {
+            Self
+        }
+
+        fn name(&self) -> &'static str {
+            "root"
+        }
+
+        fn all() -> Vec<Self> {
+            vec![Self]
+        }
+    }
+
+    struct ToggleApi {
+        is_on: bool,
+    }
+
+    impl ConnectApi for ToggleApi {
+        type Part = TogglePart;
+
+        fn part_attrs(&self, _part: Self::Part) -> AttrMap {
+            let mut attrs = AttrMap::new();
+            attrs.insert("aria-pressed".into(), self.is_on.to_string());
+            attrs
+        }
+    }
+
+    struct ToggleMachine;
+
+    impl Machine for ToggleMachine {
+        type State = ToggleState;
+        type Event = ToggleEvent;
+        type Context = ToggleContext;
+        type Props = ToggleProps;
+        type Api<'a> = ToggleApi;
+
+        fn init(_props: &Self::Props) -> (Self::State, Self::Context) {
+            (ToggleState::Off, ToggleContext)
+        }
+
+        fn transition(
+            state: &Self::State,
+            _event: &Self::Event,
+            _context: &Self::Context,
+            _props: &Self::Props,
+        ) -> Option<TransitionPlan<Self::State, Self::Event, Self::Context>> {
+            match state {
+                ToggleState::Off => Some(TransitionPlan::new(Some(ToggleState::On))),
+                ToggleState::On => Some(TransitionPlan::new(Some(ToggleState::Off))),
+            }
+        }
+
+        fn connect<'a>(
+            state: &'a Self::State,
+            _context: &'a Self::Context,
+            _props: &'a Self::Props,
+            _send: &'a dyn Fn(Self::Event),
+        ) -> Self::Api<'a> {
+            ToggleApi {
+                is_on: *state == ToggleState::On,
+            }
+        }
+    }
+
+    // --- Tests ---
+
+    #[test]
+    fn use_machine_return_type_is_copy() {
+        // Verify the struct is Copy by checking that all field types are Copy.
+        // This is a compile-time check — if UseMachineReturn<ToggleMachine> is
+        // not Copy, this function won't compile.
+        fn assert_copy<T: Copy>() {}
+        assert_copy::<UseMachineReturn<ToggleMachine>>();
+    }
+
+    #[test]
+    fn use_machine_creates_service_with_initial_state() {
+        // Test use_machine within a Leptos reactive Owner.
+        let owner = Owner::new();
+        owner.with(|| {
+            let machine = use_machine::<ToggleMachine>(ToggleProps);
+
+            // Initial state should be Off
+            assert_eq!(machine.state.get_untracked(), ToggleState::Off);
+
+            // Context version starts at 0
+            assert_eq!(machine.context_version.get_untracked(), 0);
+        });
+    }
+
+    #[test]
+    fn use_machine_send_updates_state() {
+        let owner = Owner::new();
+        owner.with(|| {
+            let machine = use_machine::<ToggleMachine>(ToggleProps);
+
+            assert_eq!(machine.state.get_untracked(), ToggleState::Off);
+
+            machine.send.run(ToggleEvent::Toggle);
+            assert_eq!(machine.state.get_untracked(), ToggleState::On);
+
+            machine.send.run(ToggleEvent::Toggle);
+            assert_eq!(machine.state.get_untracked(), ToggleState::Off);
+        });
+    }
+
+    #[test]
+    fn with_api_snapshot_reads_current_state() {
+        let owner = Owner::new();
+        owner.with(|| {
+            let machine = use_machine::<ToggleMachine>(ToggleProps);
+
+            let is_on = machine.with_api_snapshot(|api| api.is_on);
+            assert!(!is_on);
+
+            machine.send.run(ToggleEvent::Toggle);
+
+            let is_on = machine.with_api_snapshot(|api| api.is_on);
+            assert!(is_on);
+        });
+    }
+
+    #[test]
+    fn context_version_increments_on_transition() {
+        let owner = Owner::new();
+        owner.with(|| {
+            let machine = use_machine::<ToggleMachine>(ToggleProps);
+
+            assert_eq!(machine.context_version.get_untracked(), 0);
+
+            machine.send.run(ToggleEvent::Toggle);
+            // Conservative: bumps on any applied transition
+            assert_eq!(machine.context_version.get_untracked(), 1);
+
+            machine.send.run(ToggleEvent::Toggle);
+            assert_eq!(machine.context_version.get_untracked(), 2);
+        });
+    }
+}


### PR DESCRIPTION
## Summary

- Wire `ars-leptos` to Leptos 0.8 with reactive `use_machine` hook, `UseMachineReturn`, `EphemeralRef`, and hydration-safe ID generation
- Add user-facing `prelude` module with configuration types (`Locale`, `Direction`, `Orientation`)
- Add `--all-features` to CI clippy, check, unit, and adapter test jobs
- Add PostToolUse rustfmt hook to `.claude/settings.json`

## Test plan

- [x] `cargo test -p ars-leptos --all-targets --all-features` — 10 unit tests pass
- [x] `cargo clippy -p ars-leptos --all-targets --all-features -- -D warnings` — zero warnings
- [x] Feature combos compile: `ssr`, `hydrate`, `csr`
- [x] 3 compile_fail doctests verify `EphemeralRef` is `!Send`, `!Sync`, `!Clone`
- [x] `cargo test --workspace` — zero regressions

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)