### PR TITLE
[codex] Implement typed connect primitives and reset foundation backlog

### DIFF
--- a/crates/ars-core/src/connect.rs
+++ b/crates/ars-core/src/connect.rs
@@ -1,0 +1,1495 @@
+//! Typed connect primitives used by component `connect()` APIs.
+//!
+//! This module defines the typed HTML attribute, DOM event, and CSS property
+//! enums used by the architecture specification. They provide a framework-agnostic
+//! vocabulary for converting machine state into DOM-facing metadata without
+//! relying on raw string literals throughout the codebase.
+
+use core::fmt;
+
+/// Typed `aria-*` attribute names used by [`HtmlAttr::Aria`].
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum AriaAttr {
+    /// `aria-activedescendant`
+    ActiveDescendant,
+    /// `aria-autocomplete`
+    AutoComplete,
+    /// `aria-checked`
+    Checked,
+    /// `aria-disabled`
+    Disabled,
+    /// `aria-errormessage`
+    ErrorMessage,
+    /// `aria-expanded`
+    Expanded,
+    /// `aria-haspopup`
+    HasPopup,
+    /// `aria-hidden`
+    Hidden,
+    /// `aria-invalid`
+    Invalid,
+    /// `aria-keyshortcuts`
+    KeyShortcuts,
+    /// `aria-label`
+    Label,
+    /// `aria-labelledby`
+    LabelledBy,
+    /// `aria-level`
+    Level,
+    /// `aria-modal`
+    Modal,
+    /// `aria-multiline`
+    MultiLine,
+    /// `aria-multiselectable`
+    MultiSelectable,
+    /// `aria-orientation`
+    Orientation,
+    /// `aria-placeholder`
+    Placeholder,
+    /// `aria-pressed`
+    Pressed,
+    /// `aria-readonly`
+    ReadOnly,
+    /// `aria-required`
+    Required,
+    /// `aria-roledescription`
+    RoleDescription,
+    /// `aria-selected`
+    Selected,
+    /// `aria-sort`
+    Sort,
+    /// `aria-valuemax`
+    ValueMax,
+    /// `aria-valuemin`
+    ValueMin,
+    /// `aria-valuenow`
+    ValueNow,
+    /// `aria-valuetext`
+    ValueText,
+    /// `aria-atomic`
+    Atomic,
+    /// `aria-busy`
+    Busy,
+    /// `aria-live`
+    Live,
+    /// `aria-relevant`
+    Relevant,
+    /// `aria-dropeffect`
+    DropEffect,
+    /// `aria-grabbed`
+    Grabbed,
+    /// `aria-colcount`
+    ColCount,
+    /// `aria-colindex`
+    ColIndex,
+    /// `aria-colspan`
+    ColSpan,
+    /// `aria-controls`
+    Controls,
+    /// `aria-current`
+    Current,
+    /// `aria-describedby`
+    DescribedBy,
+    /// `aria-description`
+    Description,
+    /// `aria-details`
+    Details,
+    /// `aria-flowto`
+    FlowTo,
+    /// `aria-owns`
+    Owns,
+    /// `aria-posinset`
+    PosInSet,
+    /// `aria-rowcount`
+    RowCount,
+    /// `aria-rowindex`
+    RowIndex,
+    /// `aria-rowspan`
+    RowSpan,
+    /// `aria-setsize`
+    SetSize,
+}
+
+impl AriaAttr {
+    /// Returns the HTML attribute spelling for this ARIA discriminant.
+    #[must_use]
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::ActiveDescendant => "aria-activedescendant",
+            Self::AutoComplete => "aria-autocomplete",
+            Self::Checked => "aria-checked",
+            Self::Disabled => "aria-disabled",
+            Self::ErrorMessage => "aria-errormessage",
+            Self::Expanded => "aria-expanded",
+            Self::HasPopup => "aria-haspopup",
+            Self::Hidden => "aria-hidden",
+            Self::Invalid => "aria-invalid",
+            Self::KeyShortcuts => "aria-keyshortcuts",
+            Self::Label => "aria-label",
+            Self::LabelledBy => "aria-labelledby",
+            Self::Level => "aria-level",
+            Self::Modal => "aria-modal",
+            Self::MultiLine => "aria-multiline",
+            Self::MultiSelectable => "aria-multiselectable",
+            Self::Orientation => "aria-orientation",
+            Self::Placeholder => "aria-placeholder",
+            Self::Pressed => "aria-pressed",
+            Self::ReadOnly => "aria-readonly",
+            Self::Required => "aria-required",
+            Self::RoleDescription => "aria-roledescription",
+            Self::Selected => "aria-selected",
+            Self::Sort => "aria-sort",
+            Self::ValueMax => "aria-valuemax",
+            Self::ValueMin => "aria-valuemin",
+            Self::ValueNow => "aria-valuenow",
+            Self::ValueText => "aria-valuetext",
+            Self::Atomic => "aria-atomic",
+            Self::Busy => "aria-busy",
+            Self::Live => "aria-live",
+            Self::Relevant => "aria-relevant",
+            Self::DropEffect => "aria-dropeffect",
+            Self::Grabbed => "aria-grabbed",
+            Self::ColCount => "aria-colcount",
+            Self::ColIndex => "aria-colindex",
+            Self::ColSpan => "aria-colspan",
+            Self::Controls => "aria-controls",
+            Self::Current => "aria-current",
+            Self::DescribedBy => "aria-describedby",
+            Self::Description => "aria-description",
+            Self::Details => "aria-details",
+            Self::FlowTo => "aria-flowto",
+            Self::Owns => "aria-owns",
+            Self::PosInSet => "aria-posinset",
+            Self::RowCount => "aria-rowcount",
+            Self::RowIndex => "aria-rowindex",
+            Self::RowSpan => "aria-rowspan",
+            Self::SetSize => "aria-setsize",
+        }
+    }
+}
+
+impl fmt::Display for AriaAttr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Typed HTML attribute names used by `connect()` APIs.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum HtmlAttr {
+    /// `data-*` attributes with a compile-time suffix.
+    Data(&'static str),
+    /// `aria-*` attributes backed by [`AriaAttr`].
+    Aria(AriaAttr),
+    /// `accesskey`
+    AccessKey,
+    /// `autocapitalize`
+    AutoCapitalize,
+    /// `autocorrect`
+    AutoCorrect,
+    /// `autofocus`
+    AutoFocus,
+    /// `class`
+    Class,
+    /// `contenteditable`
+    ContentEditable,
+    /// `dir`
+    Dir,
+    /// `draggable`
+    Draggable,
+    /// `enterkeyhint`
+    EnterKeyHint,
+    /// `hidden`
+    Hidden,
+    /// `id`
+    Id,
+    /// `inert`
+    Inert,
+    /// `inputmode`
+    InputMode,
+    /// `is`
+    Is,
+    /// `itemid`
+    ItemId,
+    /// `itemprop`
+    ItemProp,
+    /// `itemref`
+    ItemRef,
+    /// `itemscope`
+    ItemScope,
+    /// `itemtype`
+    ItemType,
+    /// `lang`
+    Lang,
+    /// `nonce`
+    Nonce,
+    /// `popover`
+    Popover,
+    /// `role`
+    Role,
+    /// `slot`
+    Slot,
+    /// `spellcheck`
+    SpellCheck,
+    /// `tabindex`
+    TabIndex,
+    /// `title`
+    Title,
+    /// `translate`
+    Translate,
+    /// `writingsuggestions`
+    WritingSuggestions,
+    /// `accept`
+    Accept,
+    /// `accept-charset`
+    AcceptCharset,
+    /// `action`
+    Action,
+    /// `alpha`
+    Alpha,
+    /// `autocomplete`
+    AutoComplete,
+    /// `capture`
+    Capture,
+    /// `checked`
+    Checked,
+    /// `cols`
+    Cols,
+    /// `colorspace`
+    ColorSpace,
+    /// `command`
+    Command,
+    /// `commandfor`
+    CommandFor,
+    /// `disabled`
+    Disabled,
+    /// `dirname`
+    DirName,
+    /// `enctype`
+    EncType,
+    /// `for`
+    For,
+    /// `form`
+    Form,
+    /// `formaction`
+    FormAction,
+    /// `formenctype`
+    FormEncType,
+    /// `formmethod`
+    FormMethod,
+    /// `formnovalidate`
+    FormNoValidate,
+    /// `formtarget`
+    FormTarget,
+    /// `high`
+    High,
+    /// `list`
+    List,
+    /// `low`
+    Low,
+    /// `max`
+    Max,
+    /// `maxlength`
+    MaxLength,
+    /// `method`
+    Method,
+    /// `min`
+    Min,
+    /// `minlength`
+    MinLength,
+    /// `multiple`
+    Multiple,
+    /// `name`
+    Name,
+    /// `novalidate`
+    NoValidate,
+    /// `optimum`
+    Optimum,
+    /// `pattern`
+    Pattern,
+    /// `placeholder`
+    Placeholder,
+    /// `readonly`
+    ReadOnly,
+    /// `required`
+    Required,
+    /// `rows`
+    Rows,
+    /// `selected`
+    Selected,
+    /// `size`
+    Size,
+    /// `step`
+    Step,
+    /// `type`
+    Type,
+    /// `value`
+    Value,
+    /// `wrap`
+    Wrap,
+    /// `as`
+    As,
+    /// `async`
+    Async,
+    /// `blocking`
+    Blocking,
+    /// `charset`
+    Charset,
+    /// `color`
+    Color,
+    /// `defer`
+    Defer,
+    /// `http-equiv`
+    HttpEquiv,
+    /// `imagesizes`
+    ImageSizes,
+    /// `imagesrcset`
+    ImageSrcSet,
+    /// `allow`
+    Allow,
+    /// `alt`
+    Alt,
+    /// `autoplay`
+    AutoPlay,
+    /// `controls`
+    Controls,
+    /// `crossorigin`
+    CrossOrigin,
+    /// `decoding`
+    Decoding,
+    /// `default`
+    Default,
+    /// `download`
+    Download,
+    /// `fetchpriority`
+    FetchPriority,
+    /// `height`
+    Height,
+    /// `href`
+    Href,
+    /// `hreflang`
+    HrefLang,
+    /// `integrity`
+    Integrity,
+    /// `ismap`
+    IsMap,
+    /// `kind`
+    Kind,
+    /// `label`
+    Label,
+    /// `loading`
+    Loading,
+    /// `loop`
+    Loop,
+    /// `media`
+    Media,
+    /// `muted`
+    Muted,
+    /// The object element's `data` attribute.
+    ObjectData,
+    /// `ping`
+    Ping,
+    /// `playsinline`
+    PlaysInline,
+    /// `poster`
+    Poster,
+    /// `preload`
+    Preload,
+    /// `referrerpolicy`
+    ReferrerPolicy,
+    /// `rel`
+    Rel,
+    /// `sandbox`
+    Sandbox,
+    /// `shape`
+    Shape,
+    /// `sizes`
+    Sizes,
+    /// `src`
+    Src,
+    /// `srcdoc`
+    SrcDoc,
+    /// `srclang`
+    SrcLang,
+    /// `srcset`
+    SrcSet,
+    /// `target`
+    Target,
+    /// `usemap`
+    UseMap,
+    /// `width`
+    Width,
+    /// `abbr`
+    Abbr,
+    /// `colspan`
+    ColSpan,
+    /// `headers`
+    Headers,
+    /// `rowspan`
+    RowSpan,
+    /// `scope`
+    Scope,
+    /// `span`
+    Span,
+    /// `shadowrootclonable`
+    ShadowRootClonable,
+    /// `shadowrootcustomelementregistry`
+    ShadowRootCustomElementRegistry,
+    /// `shadowrootdelegatesfocus`
+    ShadowRootDelegatesFocus,
+    /// `shadowrootmode`
+    ShadowRootMode,
+    /// `shadowrootserializable`
+    ShadowRootSerializable,
+    /// `cite`
+    Cite,
+    /// `closedby`
+    ClosedBy,
+    /// `content`
+    Content,
+    /// `coords`
+    Coords,
+    /// `datetime`
+    DateTime,
+    /// `open`
+    Open,
+    /// `reversed`
+    Reversed,
+    /// `start`
+    Start,
+    /// `summary`
+    Summary,
+    /// `webkitdirectory`
+    WebkitDirectory,
+}
+
+impl HtmlAttr {
+    /// Returns the static attribute name for non-`data-*` variants.
+    ///
+    /// `HtmlAttr::Data(_)` requires runtime formatting and therefore returns `None`.
+    #[must_use]
+    pub const fn static_name(&self) -> Option<&'static str> {
+        match self {
+            Self::Data(_) => None,
+            Self::Aria(attr) => Some(attr.as_str()),
+            Self::AccessKey => Some("accesskey"),
+            Self::AutoCapitalize => Some("autocapitalize"),
+            Self::AutoCorrect => Some("autocorrect"),
+            Self::AutoFocus => Some("autofocus"),
+            Self::Class => Some("class"),
+            Self::ContentEditable => Some("contenteditable"),
+            Self::Dir => Some("dir"),
+            Self::Draggable => Some("draggable"),
+            Self::EnterKeyHint => Some("enterkeyhint"),
+            Self::Hidden => Some("hidden"),
+            Self::Id => Some("id"),
+            Self::Inert => Some("inert"),
+            Self::InputMode => Some("inputmode"),
+            Self::Is => Some("is"),
+            Self::ItemId => Some("itemid"),
+            Self::ItemProp => Some("itemprop"),
+            Self::ItemRef => Some("itemref"),
+            Self::ItemScope => Some("itemscope"),
+            Self::ItemType => Some("itemtype"),
+            Self::Lang => Some("lang"),
+            Self::Nonce => Some("nonce"),
+            Self::Popover => Some("popover"),
+            Self::Role => Some("role"),
+            Self::Slot => Some("slot"),
+            Self::SpellCheck => Some("spellcheck"),
+            Self::TabIndex => Some("tabindex"),
+            Self::Title => Some("title"),
+            Self::Translate => Some("translate"),
+            Self::WritingSuggestions => Some("writingsuggestions"),
+            Self::Accept => Some("accept"),
+            Self::AcceptCharset => Some("accept-charset"),
+            Self::Action => Some("action"),
+            Self::Alpha => Some("alpha"),
+            Self::AutoComplete => Some("autocomplete"),
+            Self::Capture => Some("capture"),
+            Self::Checked => Some("checked"),
+            Self::Cols => Some("cols"),
+            Self::ColorSpace => Some("colorspace"),
+            Self::Command => Some("command"),
+            Self::CommandFor => Some("commandfor"),
+            Self::Disabled => Some("disabled"),
+            Self::DirName => Some("dirname"),
+            Self::EncType => Some("enctype"),
+            Self::For => Some("for"),
+            Self::Form => Some("form"),
+            Self::FormAction => Some("formaction"),
+            Self::FormEncType => Some("formenctype"),
+            Self::FormMethod => Some("formmethod"),
+            Self::FormNoValidate => Some("formnovalidate"),
+            Self::FormTarget => Some("formtarget"),
+            Self::High => Some("high"),
+            Self::List => Some("list"),
+            Self::Low => Some("low"),
+            Self::Max => Some("max"),
+            Self::MaxLength => Some("maxlength"),
+            Self::Method => Some("method"),
+            Self::Min => Some("min"),
+            Self::MinLength => Some("minlength"),
+            Self::Multiple => Some("multiple"),
+            Self::Name => Some("name"),
+            Self::NoValidate => Some("novalidate"),
+            Self::Optimum => Some("optimum"),
+            Self::Pattern => Some("pattern"),
+            Self::Placeholder => Some("placeholder"),
+            Self::ReadOnly => Some("readonly"),
+            Self::Required => Some("required"),
+            Self::Rows => Some("rows"),
+            Self::Selected => Some("selected"),
+            Self::Size => Some("size"),
+            Self::Step => Some("step"),
+            Self::Type => Some("type"),
+            Self::Value => Some("value"),
+            Self::Wrap => Some("wrap"),
+            Self::As => Some("as"),
+            Self::Async => Some("async"),
+            Self::Blocking => Some("blocking"),
+            Self::Charset => Some("charset"),
+            Self::Color => Some("color"),
+            Self::Defer => Some("defer"),
+            Self::HttpEquiv => Some("http-equiv"),
+            Self::ImageSizes => Some("imagesizes"),
+            Self::ImageSrcSet => Some("imagesrcset"),
+            Self::Allow => Some("allow"),
+            Self::Alt => Some("alt"),
+            Self::AutoPlay => Some("autoplay"),
+            Self::Controls => Some("controls"),
+            Self::CrossOrigin => Some("crossorigin"),
+            Self::Decoding => Some("decoding"),
+            Self::Default => Some("default"),
+            Self::Download => Some("download"),
+            Self::FetchPriority => Some("fetchpriority"),
+            Self::Height => Some("height"),
+            Self::Href => Some("href"),
+            Self::HrefLang => Some("hreflang"),
+            Self::Integrity => Some("integrity"),
+            Self::IsMap => Some("ismap"),
+            Self::Kind => Some("kind"),
+            Self::Label => Some("label"),
+            Self::Loading => Some("loading"),
+            Self::Loop => Some("loop"),
+            Self::Media => Some("media"),
+            Self::Muted => Some("muted"),
+            Self::ObjectData => Some("data"),
+            Self::Ping => Some("ping"),
+            Self::PlaysInline => Some("playsinline"),
+            Self::Poster => Some("poster"),
+            Self::Preload => Some("preload"),
+            Self::ReferrerPolicy => Some("referrerpolicy"),
+            Self::Rel => Some("rel"),
+            Self::Sandbox => Some("sandbox"),
+            Self::Shape => Some("shape"),
+            Self::Sizes => Some("sizes"),
+            Self::Src => Some("src"),
+            Self::SrcDoc => Some("srcdoc"),
+            Self::SrcLang => Some("srclang"),
+            Self::SrcSet => Some("srcset"),
+            Self::Target => Some("target"),
+            Self::UseMap => Some("usemap"),
+            Self::Width => Some("width"),
+            Self::Abbr => Some("abbr"),
+            Self::ColSpan => Some("colspan"),
+            Self::Headers => Some("headers"),
+            Self::RowSpan => Some("rowspan"),
+            Self::Scope => Some("scope"),
+            Self::Span => Some("span"),
+            Self::ShadowRootClonable => Some("shadowrootclonable"),
+            Self::ShadowRootCustomElementRegistry => Some("shadowrootcustomelementregistry"),
+            Self::ShadowRootDelegatesFocus => Some("shadowrootdelegatesfocus"),
+            Self::ShadowRootMode => Some("shadowrootmode"),
+            Self::ShadowRootSerializable => Some("shadowrootserializable"),
+            Self::Cite => Some("cite"),
+            Self::ClosedBy => Some("closedby"),
+            Self::Content => Some("content"),
+            Self::Coords => Some("coords"),
+            Self::DateTime => Some("datetime"),
+            Self::Open => Some("open"),
+            Self::Reversed => Some("reversed"),
+            Self::Start => Some("start"),
+            Self::Summary => Some("summary"),
+            Self::WebkitDirectory => Some("webkitdirectory"),
+        }
+    }
+}
+
+impl fmt::Display for HtmlAttr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Data(suffix) => write!(f, "data-{suffix}"),
+            _ => f.write_str(
+                self.static_name()
+                    .expect("non-data attributes have static names"),
+            ),
+        }
+    }
+}
+
+/// Typed DOM event names used by adapter event wiring.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum HtmlEvent {
+    /// `auxclick`
+    AuxClick,
+    /// `click`
+    Click,
+    /// `contextmenu`
+    ContextMenu,
+    /// `dblclick`
+    DblClick,
+    /// `mousedown`
+    MouseDown,
+    /// `mouseenter`
+    MouseEnter,
+    /// `mouseleave`
+    MouseLeave,
+    /// `mousemove`
+    MouseMove,
+    /// `mouseout`
+    MouseOut,
+    /// `mouseover`
+    MouseOver,
+    /// `mouseup`
+    MouseUp,
+    /// `gotpointercapture`
+    GotPointerCapture,
+    /// `lostpointercapture`
+    LostPointerCapture,
+    /// `pointercancel`
+    PointerCancel,
+    /// `pointerdown`
+    PointerDown,
+    /// `pointerenter`
+    PointerEnter,
+    /// `pointerleave`
+    PointerLeave,
+    /// `pointermove`
+    PointerMove,
+    /// `pointerout`
+    PointerOut,
+    /// `pointerover`
+    PointerOver,
+    /// `pointerup`
+    PointerUp,
+    /// `keydown`
+    KeyDown,
+    /// `keyup`
+    KeyUp,
+    /// `blur`
+    Blur,
+    /// `focus`
+    Focus,
+    /// `focusin`
+    FocusIn,
+    /// `focusout`
+    FocusOut,
+    /// `change`
+    Change,
+    /// `input`
+    Input,
+    /// `beforeinput`
+    BeforeInput,
+    /// `invalid`
+    Invalid,
+    /// `reset`
+    Reset,
+    /// `select`
+    Select,
+    /// `submit`
+    Submit,
+    /// `drag`
+    Drag,
+    /// `dragend`
+    DragEnd,
+    /// `dragenter`
+    DragEnter,
+    /// `dragleave`
+    DragLeave,
+    /// `dragover`
+    DragOver,
+    /// `dragstart`
+    DragStart,
+    /// `drop`
+    Drop,
+    /// `touchcancel`
+    TouchCancel,
+    /// `touchend`
+    TouchEnd,
+    /// `touchmove`
+    TouchMove,
+    /// `touchstart`
+    TouchStart,
+    /// `scroll`
+    Scroll,
+    /// `scrollend`
+    ScrollEnd,
+    /// `wheel`
+    Wheel,
+    /// `copy`
+    Copy,
+    /// `cut`
+    Cut,
+    /// `paste`
+    Paste,
+    /// `compositionend`
+    CompositionEnd,
+    /// `compositionstart`
+    CompositionStart,
+    /// `compositionupdate`
+    CompositionUpdate,
+    /// `animationcancel`
+    AnimationCancel,
+    /// `animationend`
+    AnimationEnd,
+    /// `animationiteration`
+    AnimationIteration,
+    /// `animationstart`
+    AnimationStart,
+    /// `transitioncancel`
+    TransitionCancel,
+    /// `transitionend`
+    TransitionEnd,
+    /// `transitionrun`
+    TransitionRun,
+    /// `transitionstart`
+    TransitionStart,
+    /// `abort`
+    Abort,
+    /// `error`
+    Error,
+    /// `load`
+    Load,
+    /// `resize`
+    Resize,
+    /// `canplay`
+    CanPlay,
+    /// `canplaythrough`
+    CanPlayThrough,
+    /// `durationchange`
+    DurationChange,
+    /// `emptied`
+    Emptied,
+    /// `ended`
+    Ended,
+    /// `loadeddata`
+    LoadedData,
+    /// `loadedmetadata`
+    LoadedMetaData,
+    /// `loadstart`
+    LoadStart,
+    /// `pause`
+    Pause,
+    /// `play`
+    Play,
+    /// `playing`
+    Playing,
+    /// `progress`
+    Progress,
+    /// `ratechange`
+    RateChange,
+    /// `seeked`
+    Seeked,
+    /// `seeking`
+    Seeking,
+    /// `stalled`
+    Stalled,
+    /// `suspend`
+    Suspend,
+    /// `timeupdate`
+    TimeUpdate,
+    /// `volumechange`
+    VolumeChange,
+    /// `waiting`
+    Waiting,
+    /// `cancel`
+    Cancel,
+    /// `close`
+    Close,
+    /// `fullscreenchange`
+    FullscreenChange,
+    /// `fullscreenerror`
+    FullscreenError,
+    /// `selectionchange`
+    SelectionChange,
+    /// `slotchange`
+    SlotChange,
+    /// `toggle`
+    Toggle,
+}
+
+impl fmt::Display for HtmlEvent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let event = match self {
+            Self::AuxClick => "auxclick",
+            Self::Click => "click",
+            Self::ContextMenu => "contextmenu",
+            Self::DblClick => "dblclick",
+            Self::MouseDown => "mousedown",
+            Self::MouseEnter => "mouseenter",
+            Self::MouseLeave => "mouseleave",
+            Self::MouseMove => "mousemove",
+            Self::MouseOut => "mouseout",
+            Self::MouseOver => "mouseover",
+            Self::MouseUp => "mouseup",
+            Self::GotPointerCapture => "gotpointercapture",
+            Self::LostPointerCapture => "lostpointercapture",
+            Self::PointerCancel => "pointercancel",
+            Self::PointerDown => "pointerdown",
+            Self::PointerEnter => "pointerenter",
+            Self::PointerLeave => "pointerleave",
+            Self::PointerMove => "pointermove",
+            Self::PointerOut => "pointerout",
+            Self::PointerOver => "pointerover",
+            Self::PointerUp => "pointerup",
+            Self::KeyDown => "keydown",
+            Self::KeyUp => "keyup",
+            Self::Blur => "blur",
+            Self::Focus => "focus",
+            Self::FocusIn => "focusin",
+            Self::FocusOut => "focusout",
+            Self::Change => "change",
+            Self::Input => "input",
+            Self::BeforeInput => "beforeinput",
+            Self::Invalid => "invalid",
+            Self::Reset => "reset",
+            Self::Select => "select",
+            Self::Submit => "submit",
+            Self::Drag => "drag",
+            Self::DragEnd => "dragend",
+            Self::DragEnter => "dragenter",
+            Self::DragLeave => "dragleave",
+            Self::DragOver => "dragover",
+            Self::DragStart => "dragstart",
+            Self::Drop => "drop",
+            Self::TouchCancel => "touchcancel",
+            Self::TouchEnd => "touchend",
+            Self::TouchMove => "touchmove",
+            Self::TouchStart => "touchstart",
+            Self::Scroll => "scroll",
+            Self::ScrollEnd => "scrollend",
+            Self::Wheel => "wheel",
+            Self::Copy => "copy",
+            Self::Cut => "cut",
+            Self::Paste => "paste",
+            Self::CompositionEnd => "compositionend",
+            Self::CompositionStart => "compositionstart",
+            Self::CompositionUpdate => "compositionupdate",
+            Self::AnimationCancel => "animationcancel",
+            Self::AnimationEnd => "animationend",
+            Self::AnimationIteration => "animationiteration",
+            Self::AnimationStart => "animationstart",
+            Self::TransitionCancel => "transitioncancel",
+            Self::TransitionEnd => "transitionend",
+            Self::TransitionRun => "transitionrun",
+            Self::TransitionStart => "transitionstart",
+            Self::Abort => "abort",
+            Self::Error => "error",
+            Self::Load => "load",
+            Self::Resize => "resize",
+            Self::CanPlay => "canplay",
+            Self::CanPlayThrough => "canplaythrough",
+            Self::DurationChange => "durationchange",
+            Self::Emptied => "emptied",
+            Self::Ended => "ended",
+            Self::LoadedData => "loadeddata",
+            Self::LoadedMetaData => "loadedmetadata",
+            Self::LoadStart => "loadstart",
+            Self::Pause => "pause",
+            Self::Play => "play",
+            Self::Playing => "playing",
+            Self::Progress => "progress",
+            Self::RateChange => "ratechange",
+            Self::Seeked => "seeked",
+            Self::Seeking => "seeking",
+            Self::Stalled => "stalled",
+            Self::Suspend => "suspend",
+            Self::TimeUpdate => "timeupdate",
+            Self::VolumeChange => "volumechange",
+            Self::Waiting => "waiting",
+            Self::Cancel => "cancel",
+            Self::Close => "close",
+            Self::FullscreenChange => "fullscreenchange",
+            Self::FullscreenError => "fullscreenerror",
+            Self::SelectionChange => "selectionchange",
+            Self::SlotChange => "slotchange",
+            Self::Toggle => "toggle",
+        };
+
+        f.write_str(event)
+    }
+}
+
+/// Typed CSS property names used by future `AttrMap` style storage.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum CssProperty {
+    /// CSS custom property names, rendered with a leading `--`.
+    Custom(&'static str),
+    /// `box-sizing`
+    BoxSizing,
+    /// `width`
+    Width,
+    /// `min-width`
+    MinWidth,
+    /// `max-width`
+    MaxWidth,
+    /// `height`
+    Height,
+    /// `min-height`
+    MinHeight,
+    /// `max-height`
+    MaxHeight,
+    /// `margin`
+    Margin,
+    /// `margin-top`
+    MarginTop,
+    /// `margin-right`
+    MarginRight,
+    /// `margin-bottom`
+    MarginBottom,
+    /// `margin-left`
+    MarginLeft,
+    /// `padding`
+    Padding,
+    /// `padding-top`
+    PaddingTop,
+    /// `padding-right`
+    PaddingRight,
+    /// `padding-bottom`
+    PaddingBottom,
+    /// `padding-left`
+    PaddingLeft,
+    /// `border`
+    Border,
+    /// `border-width`
+    BorderWidth,
+    /// `border-style`
+    BorderStyle,
+    /// `border-color`
+    BorderColor,
+    /// `border-radius`
+    BorderRadius,
+    /// `border-collapse`
+    BorderCollapse,
+    /// `border-spacing`
+    BorderSpacing,
+    /// `inline-size`
+    InlineSize,
+    /// `block-size`
+    BlockSize,
+    /// `min-inline-size`
+    MinInlineSize,
+    /// `max-inline-size`
+    MaxInlineSize,
+    /// `min-block-size`
+    MinBlockSize,
+    /// `max-block-size`
+    MaxBlockSize,
+    /// `margin-inline`
+    MarginInline,
+    /// `margin-inline-start`
+    MarginInlineStart,
+    /// `margin-inline-end`
+    MarginInlineEnd,
+    /// `margin-block`
+    MarginBlock,
+    /// `margin-block-start`
+    MarginBlockStart,
+    /// `margin-block-end`
+    MarginBlockEnd,
+    /// `padding-inline`
+    PaddingInline,
+    /// `padding-inline-start`
+    PaddingInlineStart,
+    /// `padding-inline-end`
+    PaddingInlineEnd,
+    /// `padding-block`
+    PaddingBlock,
+    /// `padding-block-start`
+    PaddingBlockStart,
+    /// `padding-block-end`
+    PaddingBlockEnd,
+    /// `inset-inline-start`
+    InsetInlineStart,
+    /// `inset-inline-end`
+    InsetInlineEnd,
+    /// `inset-block-start`
+    InsetBlockStart,
+    /// `inset-block-end`
+    InsetBlockEnd,
+    /// `position`
+    Position,
+    /// `top`
+    Top,
+    /// `right`
+    Right,
+    /// `bottom`
+    Bottom,
+    /// `left`
+    Left,
+    /// `z-index`
+    ZIndex,
+    /// `float`
+    Float,
+    /// `clear`
+    Clear,
+    /// `display`
+    Display,
+    /// `flex-direction`
+    FlexDirection,
+    /// `flex-wrap`
+    FlexWrap,
+    /// `flex-flow`
+    FlexFlow,
+    /// `flex-grow`
+    FlexGrow,
+    /// `flex-shrink`
+    FlexShrink,
+    /// `flex-basis`
+    FlexBasis,
+    /// `order`
+    Order,
+    /// `align-items`
+    AlignItems,
+    /// `align-self`
+    AlignSelf,
+    /// `align-content`
+    AlignContent,
+    /// `justify-content`
+    JustifyContent,
+    /// `justify-items`
+    JustifyItems,
+    /// `justify-self`
+    JustifySelf,
+    /// `place-items`
+    PlaceItems,
+    /// `place-content`
+    PlaceContent,
+    /// `gap`
+    Gap,
+    /// `row-gap`
+    RowGap,
+    /// `column-gap`
+    ColumnGap,
+    /// `grid-template-columns`
+    GridTemplateColumns,
+    /// `grid-template-rows`
+    GridTemplateRows,
+    /// `grid-column`
+    GridColumn,
+    /// `grid-row`
+    GridRow,
+    /// `grid-area`
+    GridArea,
+    /// `grid-auto-flow`
+    GridAutoFlow,
+    /// `grid-auto-columns`
+    GridAutoColumns,
+    /// `grid-auto-rows`
+    GridAutoRows,
+    /// `color`
+    Color,
+    /// `font-family`
+    FontFamily,
+    /// `font-size`
+    FontSize,
+    /// `font-weight`
+    FontWeight,
+    /// `font-style`
+    FontStyle,
+    /// `line-height`
+    LineHeight,
+    /// `text-align`
+    TextAlign,
+    /// `text-decoration`
+    TextDecoration,
+    /// `text-transform`
+    TextTransform,
+    /// `text-overflow`
+    TextOverflow,
+    /// `text-indent`
+    TextIndent,
+    /// `text-shadow`
+    TextShadow,
+    /// `white-space`
+    WhiteSpace,
+    /// `word-break`
+    WordBreak,
+    /// `word-wrap`
+    WordWrap,
+    /// `overflow-wrap`
+    OverflowWrap,
+    /// `letter-spacing`
+    LetterSpacing,
+    /// `word-spacing`
+    WordSpacing,
+    /// `background`
+    Background,
+    /// `background-color`
+    BackgroundColor,
+    /// `background-image`
+    BackgroundImage,
+    /// `background-position`
+    BackgroundPosition,
+    /// `background-size`
+    BackgroundSize,
+    /// `background-repeat`
+    BackgroundRepeat,
+    /// `opacity`
+    Opacity,
+    /// `visibility`
+    Visibility,
+    /// `box-shadow`
+    BoxShadow,
+    /// `outline`
+    Outline,
+    /// `outline-width`
+    OutlineWidth,
+    /// `outline-style`
+    OutlineStyle,
+    /// `outline-color`
+    OutlineColor,
+    /// `outline-offset`
+    OutlineOffset,
+    /// `cursor`
+    Cursor,
+    /// `pointer-events`
+    PointerEvents,
+    /// `user-select`
+    UserSelect,
+    /// `overflow`
+    Overflow,
+    /// `overflow-x`
+    OverflowX,
+    /// `overflow-y`
+    OverflowY,
+    /// `clip`
+    Clip,
+    /// `clip-path`
+    ClipPath,
+    /// `scroll-behavior`
+    ScrollBehavior,
+    /// `scroll-snap-type`
+    ScrollSnapType,
+    /// `scroll-snap-align`
+    ScrollSnapAlign,
+    /// `overscroll-behavior`
+    OverscrollBehavior,
+    /// `transform`
+    Transform,
+    /// `transform-origin`
+    TransformOrigin,
+    /// `transition`
+    Transition,
+    /// `transition-property`
+    TransitionProperty,
+    /// `transition-duration`
+    TransitionDuration,
+    /// `transition-timing-function`
+    TransitionTimingFunction,
+    /// `transition-delay`
+    TransitionDelay,
+    /// `animation`
+    Animation,
+    /// `animation-name`
+    AnimationName,
+    /// `animation-duration`
+    AnimationDuration,
+    /// `animation-timing-function`
+    AnimationTimingFunction,
+    /// `animation-delay`
+    AnimationDelay,
+    /// `animation-iteration-count`
+    AnimationIterationCount,
+    /// `animation-direction`
+    AnimationDirection,
+    /// `animation-fill-mode`
+    AnimationFillMode,
+    /// `animation-play-state`
+    AnimationPlayState,
+    /// `aspect-ratio`
+    AspectRatio,
+    /// `object-fit`
+    ObjectFit,
+    /// `object-position`
+    ObjectPosition,
+    /// `contain`
+    Contain,
+    /// `content-visibility`
+    ContentVisibility,
+    /// `will-change`
+    WillChange,
+    /// `appearance`
+    Appearance,
+    /// `resize`
+    Resize,
+    /// `touch-action`
+    TouchAction,
+    /// `filter`
+    Filter,
+    /// `backdrop-filter`
+    BackdropFilter,
+    /// `content`
+    Content,
+    /// `list-style`
+    ListStyle,
+    /// `list-style-type`
+    ListStyleType,
+    /// `list-style-position`
+    ListStylePosition,
+    /// `table-layout`
+    TableLayout,
+    /// `vertical-align`
+    VerticalAlign,
+}
+
+impl fmt::Display for CssProperty {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let property = match self {
+            Self::Custom(name) => return write!(f, "--{name}"),
+            Self::BoxSizing => "box-sizing",
+            Self::Width => "width",
+            Self::MinWidth => "min-width",
+            Self::MaxWidth => "max-width",
+            Self::Height => "height",
+            Self::MinHeight => "min-height",
+            Self::MaxHeight => "max-height",
+            Self::Margin => "margin",
+            Self::MarginTop => "margin-top",
+            Self::MarginRight => "margin-right",
+            Self::MarginBottom => "margin-bottom",
+            Self::MarginLeft => "margin-left",
+            Self::Padding => "padding",
+            Self::PaddingTop => "padding-top",
+            Self::PaddingRight => "padding-right",
+            Self::PaddingBottom => "padding-bottom",
+            Self::PaddingLeft => "padding-left",
+            Self::Border => "border",
+            Self::BorderWidth => "border-width",
+            Self::BorderStyle => "border-style",
+            Self::BorderColor => "border-color",
+            Self::BorderRadius => "border-radius",
+            Self::BorderCollapse => "border-collapse",
+            Self::BorderSpacing => "border-spacing",
+            Self::InlineSize => "inline-size",
+            Self::BlockSize => "block-size",
+            Self::MinInlineSize => "min-inline-size",
+            Self::MaxInlineSize => "max-inline-size",
+            Self::MinBlockSize => "min-block-size",
+            Self::MaxBlockSize => "max-block-size",
+            Self::MarginInline => "margin-inline",
+            Self::MarginInlineStart => "margin-inline-start",
+            Self::MarginInlineEnd => "margin-inline-end",
+            Self::MarginBlock => "margin-block",
+            Self::MarginBlockStart => "margin-block-start",
+            Self::MarginBlockEnd => "margin-block-end",
+            Self::PaddingInline => "padding-inline",
+            Self::PaddingInlineStart => "padding-inline-start",
+            Self::PaddingInlineEnd => "padding-inline-end",
+            Self::PaddingBlock => "padding-block",
+            Self::PaddingBlockStart => "padding-block-start",
+            Self::PaddingBlockEnd => "padding-block-end",
+            Self::InsetInlineStart => "inset-inline-start",
+            Self::InsetInlineEnd => "inset-inline-end",
+            Self::InsetBlockStart => "inset-block-start",
+            Self::InsetBlockEnd => "inset-block-end",
+            Self::Position => "position",
+            Self::Top => "top",
+            Self::Right => "right",
+            Self::Bottom => "bottom",
+            Self::Left => "left",
+            Self::ZIndex => "z-index",
+            Self::Float => "float",
+            Self::Clear => "clear",
+            Self::Display => "display",
+            Self::FlexDirection => "flex-direction",
+            Self::FlexWrap => "flex-wrap",
+            Self::FlexFlow => "flex-flow",
+            Self::FlexGrow => "flex-grow",
+            Self::FlexShrink => "flex-shrink",
+            Self::FlexBasis => "flex-basis",
+            Self::Order => "order",
+            Self::AlignItems => "align-items",
+            Self::AlignSelf => "align-self",
+            Self::AlignContent => "align-content",
+            Self::JustifyContent => "justify-content",
+            Self::JustifyItems => "justify-items",
+            Self::JustifySelf => "justify-self",
+            Self::PlaceItems => "place-items",
+            Self::PlaceContent => "place-content",
+            Self::Gap => "gap",
+            Self::RowGap => "row-gap",
+            Self::ColumnGap => "column-gap",
+            Self::GridTemplateColumns => "grid-template-columns",
+            Self::GridTemplateRows => "grid-template-rows",
+            Self::GridColumn => "grid-column",
+            Self::GridRow => "grid-row",
+            Self::GridArea => "grid-area",
+            Self::GridAutoFlow => "grid-auto-flow",
+            Self::GridAutoColumns => "grid-auto-columns",
+            Self::GridAutoRows => "grid-auto-rows",
+            Self::Color => "color",
+            Self::FontFamily => "font-family",
+            Self::FontSize => "font-size",
+            Self::FontWeight => "font-weight",
+            Self::FontStyle => "font-style",
+            Self::LineHeight => "line-height",
+            Self::TextAlign => "text-align",
+            Self::TextDecoration => "text-decoration",
+            Self::TextTransform => "text-transform",
+            Self::TextOverflow => "text-overflow",
+            Self::TextIndent => "text-indent",
+            Self::TextShadow => "text-shadow",
+            Self::WhiteSpace => "white-space",
+            Self::WordBreak => "word-break",
+            Self::WordWrap => "word-wrap",
+            Self::OverflowWrap => "overflow-wrap",
+            Self::LetterSpacing => "letter-spacing",
+            Self::WordSpacing => "word-spacing",
+            Self::Background => "background",
+            Self::BackgroundColor => "background-color",
+            Self::BackgroundImage => "background-image",
+            Self::BackgroundPosition => "background-position",
+            Self::BackgroundSize => "background-size",
+            Self::BackgroundRepeat => "background-repeat",
+            Self::Opacity => "opacity",
+            Self::Visibility => "visibility",
+            Self::BoxShadow => "box-shadow",
+            Self::Outline => "outline",
+            Self::OutlineWidth => "outline-width",
+            Self::OutlineStyle => "outline-style",
+            Self::OutlineColor => "outline-color",
+            Self::OutlineOffset => "outline-offset",
+            Self::Cursor => "cursor",
+            Self::PointerEvents => "pointer-events",
+            Self::UserSelect => "user-select",
+            Self::Overflow => "overflow",
+            Self::OverflowX => "overflow-x",
+            Self::OverflowY => "overflow-y",
+            Self::Clip => "clip",
+            Self::ClipPath => "clip-path",
+            Self::ScrollBehavior => "scroll-behavior",
+            Self::ScrollSnapType => "scroll-snap-type",
+            Self::ScrollSnapAlign => "scroll-snap-align",
+            Self::OverscrollBehavior => "overscroll-behavior",
+            Self::Transform => "transform",
+            Self::TransformOrigin => "transform-origin",
+            Self::Transition => "transition",
+            Self::TransitionProperty => "transition-property",
+            Self::TransitionDuration => "transition-duration",
+            Self::TransitionTimingFunction => "transition-timing-function",
+            Self::TransitionDelay => "transition-delay",
+            Self::Animation => "animation",
+            Self::AnimationName => "animation-name",
+            Self::AnimationDuration => "animation-duration",
+            Self::AnimationTimingFunction => "animation-timing-function",
+            Self::AnimationDelay => "animation-delay",
+            Self::AnimationIterationCount => "animation-iteration-count",
+            Self::AnimationDirection => "animation-direction",
+            Self::AnimationFillMode => "animation-fill-mode",
+            Self::AnimationPlayState => "animation-play-state",
+            Self::AspectRatio => "aspect-ratio",
+            Self::ObjectFit => "object-fit",
+            Self::ObjectPosition => "object-position",
+            Self::Contain => "contain",
+            Self::ContentVisibility => "content-visibility",
+            Self::WillChange => "will-change",
+            Self::Appearance => "appearance",
+            Self::Resize => "resize",
+            Self::TouchAction => "touch-action",
+            Self::Filter => "filter",
+            Self::BackdropFilter => "backdrop-filter",
+            Self::Content => "content",
+            Self::ListStyle => "list-style",
+            Self::ListStyleType => "list-style-type",
+            Self::ListStylePosition => "list-style-position",
+            Self::TableLayout => "table-layout",
+            Self::VerticalAlign => "vertical-align",
+        };
+
+        f.write_str(property)
+    }
+}
+
+/// Event listener configuration used when adapters bind typed handlers.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct EventOptions {
+    /// Whether the listener is passive.
+    pub passive: bool,
+    /// Whether the listener captures during the capture phase.
+    pub capture: bool,
+}
+
+/// Convenience constructor for `data-*` attributes.
+#[must_use]
+pub const fn data(name: &'static str) -> HtmlAttr {
+    HtmlAttr::Data(name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn aria_attr_display_matches_attribute_name() {
+        assert_eq!(AriaAttr::Label.to_string(), "aria-label");
+        assert_eq!(AriaAttr::DescribedBy.as_str(), "aria-describedby");
+    }
+
+    #[test]
+    fn html_attr_display_formats_data_and_static_names() {
+        assert_eq!(HtmlAttr::Data("ars-state").to_string(), "data-ars-state");
+        assert_eq!(HtmlAttr::Id.to_string(), "id");
+        assert_eq!(
+            HtmlAttr::Aria(AriaAttr::Expanded).to_string(),
+            "aria-expanded"
+        );
+    }
+
+    #[test]
+    fn html_attr_static_name_is_none_for_data_attributes() {
+        assert_eq!(HtmlAttr::Data("ars-scope").static_name(), None);
+        assert_eq!(HtmlAttr::Role.static_name(), Some("role"));
+        assert_eq!(
+            HtmlAttr::Aria(AriaAttr::Controls).static_name(),
+            Some("aria-controls")
+        );
+    }
+
+    #[test]
+    fn html_event_display_matches_dom_event_names() {
+        assert_eq!(HtmlEvent::PointerDown.to_string(), "pointerdown");
+        assert_eq!(HtmlEvent::BeforeInput.to_string(), "beforeinput");
+        assert_eq!(HtmlEvent::TransitionEnd.to_string(), "transitionend");
+    }
+
+    #[test]
+    fn css_property_display_matches_css_spelling() {
+        assert_eq!(CssProperty::ZIndex.to_string(), "z-index");
+        assert_eq!(
+            CssProperty::ScrollSnapAlign.to_string(),
+            "scroll-snap-align"
+        );
+        assert_eq!(
+            CssProperty::Custom("ars-timer-progress").to_string(),
+            "--ars-timer-progress"
+        );
+    }
+
+    #[test]
+    fn event_options_default_to_non_passive_bubbling_listener() {
+        let options = EventOptions::default();
+        assert!(!options.passive);
+        assert!(!options.capture);
+    }
+
+    #[test]
+    fn data_helper_constructs_data_variant() {
+        assert_eq!(data("ars-part"), HtmlAttr::Data("ars-part"));
+    }
+}

--- a/crates/ars-core/src/lib.rs
+++ b/crates/ars-core/src/lib.rs
@@ -20,6 +20,10 @@ extern crate alloc;
 use alloc::{collections::BTreeMap, string::String, vec::Vec};
 use core::fmt::Debug;
 
+mod connect;
+
+pub use connect::{AriaAttr, CssProperty, EventOptions, HtmlAttr, HtmlEvent, data};
+
 /// Map of HTML attribute names to their string values.
 ///
 /// Used by [`ConnectApi::part_attrs`] to produce data-only attributes (ARIA, `data-*`,

--- a/docs/implementation/README.md
+++ b/docs/implementation/README.md
@@ -17,3 +17,4 @@ Start with:
 3. [initial-backlog.md](./initial-backlog.md) for the seed epics and first implementation tasks.
 4. The GitHub Project and initial issue backlog are expected to be kept in sync with these docs.
 5. [adapter-contract.md](./adapter-contract.md) for adapter work obligations and spec-sync checklist.
+6. [foundation-gap-audit.md](./foundation-gap-audit.md) for the backlog reset that defers `#24` and promotes the missing foundation contracts into issue-ready follow-on tasks.

--- a/docs/implementation/foundation-gap-audit.md
+++ b/docs/implementation/foundation-gap-audit.md
@@ -1,0 +1,323 @@
+# Foundation Gap Audit and Backlog Reset
+
+This audit resets the implementation backlog after the initial seed tasks landed only the thinnest crate shells. It explains why [issue #24](https://github.com/fogodev/ars-ui/issues/24) is premature, identifies the missing middle-layer contracts, and defines a corrected foundation-first task sequence before any adapter utility slice decomposition resumes.
+
+## Summary
+
+- `#24` is blocked because the repo does not yet implement the shared connect, anatomy, provider, forms, and DOM contracts that the first utility slice assumes.
+- The earlier seed backlog correctly created crate shells, but it stopped before several spec-defined contracts became issue-backed work.
+- The corrected sequence below promotes those missing contracts into explicit, issue-ready tasks sized at `5` points or less.
+- The first post-audit implementation task should come from `ars-core`, not from adapter utility components.
+
+## Gap Matrix
+
+| Area                                       | Current implemented surface                                                                                                                                                                                                                                                                                         | Spec-required surface                                                                                                                                                                                                                                    | Blocker impact                                                                                                                                                                 | Classification                                    |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------- |
+| `ars-core` connect primitives              | [`crates/ars-core/src/lib.rs`](/Users/ericson/Workspace/Rust/ars-ui/crates/ars-core/src/lib.rs) defines `AttrMap` as `BTreeMap<String, String>` and does not expose typed HTML attrs, event names, or CSS properties.                                                                                               | `HtmlAttr`, `HtmlEvent`, `CssProperty`, `EventOptions`, and typed state-to-DOM primitives from [`spec/foundation/01-architecture.md`](/Users/ericson/Workspace/Rust/ars-ui/spec/foundation/01-architecture.md):3.1.1-3.1.3.                              | Blocks every spec-compliant `connect()` API because specs use typed attrs and CSS properties, not raw strings.                                                                 | Must land before any utility-slice implementation |
+| `ars-core` attribute model                 | `AttrMap` lacks `AttrValue`, boolean values, style storage, space-separated token merging, user-attr filtering, and style strategy support.                                                                                                                                                                         | `AttrMap`, `AttrValue`, `UserAttrs`, `StyleStrategy`, and merge semantics from [`spec/foundation/01-architecture.md`](/Users/ericson/Workspace/Rust/ars-ui/spec/foundation/01-architecture.md):3.2-3.2.2.                                                | Blocks all spec-defined `*_attrs()` methods, adapter attr conversion, and `as_child`/composition behavior.                                                                     | Must land before any utility-slice implementation |
+| `ars-a11y` ARIA bridge                     | [`crates/ars-a11y/src/aria/attribute.rs`](/Users/ericson/Workspace/Rust/ars-ui/crates/ars-a11y/src/aria/attribute.rs) has a deferred TODO for `attr_name()`, `to_html_attr()`, `apply_to()`, and `AriaAttr`/`HtmlAttr` conversion impls pending `ars-core` typed attr work.                                         | `AriaAttribute` bridging helpers and conversions from [`spec/foundation/03-accessibility.md`](/Users/ericson/Workspace/Rust/ars-ui/spec/foundation/03-accessibility.md):2.2.                                                                             | Blocks spec-compliant ARIA application and prevents downstream connect code from using the typed accessibility layer rather than raw attr wiring.                              | Can land before specific utilities only           |
+| `ars-a11y` role and state helpers          | Baseline `AriaRole`, `AriaAttribute`, and `ComponentIds` exist, but the helper layer for applying roles and common ARIA states to typed `AttrMap`s is missing.                                                                                                                                                      | `apply_role`, `apply_aria`, `set_expanded`, `set_selected`, `set_checked`, `set_disabled`, `set_busy`, and `set_invalid` from [`spec/foundation/03-accessibility.md`](/Users/ericson/Workspace/Rust/ars-ui/spec/foundation/03-accessibility.md):2.3-2.5. | Blocks reuse of the spec-defined accessibility patterns in component connect functions and encourages ad hoc ARIA wiring in downstream components.                             | Can land before specific utilities only           |
+| Anatomy and derive support                 | [`crates/ars-derive/src/lib.rs`](/Users/ericson/Workspace/Rust/ars-ui/crates/ars-derive/src/lib.rs) contains empty `HasId` and `ComponentPart` derive macros; [`crates/ars-core/src/lib.rs`](/Users/ericson/Workspace/Rust/ars-ui/crates/ars-core/src/lib.rs) lacks the scope/data-attr helpers the spec relies on. | `ComponentPart` scope/name/all/data-attr behavior and derive generation from [`spec/foundation/01-architecture.md`](/Users/ericson/Workspace/Rust/ars-ui/spec/foundation/01-architecture.md):4.1.                                                        | Blocks all anatomy enums in utility/component specs because `data-ars-scope` and `data-ars-part` generation are not available.                                                 | Must land before any utility-slice implementation |
+| Provider and platform contracts            | No `PlatformEffects`, `ColorMode`, `NullPlatformEffects`, or shared provider-facing environment types exist in the current crates.                                                                                                                                                                                  | `PlatformEffects` and `ArsProvider` shared environment contract from [`spec/foundation/01-architecture.md`](/Users/ericson/Workspace/Rust/ars-ui/spec/foundation/01-architecture.md):2.2.7 and 6.4.                                                      | Blocks effect execution, environment propagation, and the `ArsProvider` slice item itself. Some stateless utilities could proceed without it, but the slice as planned cannot. | Can land before specific utilities only           |
+| `ars-forms` context and field association  | [`crates/ars-forms/src/lib.rs`](/Users/ericson/Workspace/Rust/ars-ui/crates/ars-forms/src/lib.rs) currently implements only validation primitives and `FieldState`.                                                                                                                                                 | `FormContext`, `ValidationMode`, `FieldDescriptors`, `FieldCtx`, hidden-input contracts, and server-error sync scaffolding from [`spec/foundation/07-forms.md`](/Users/ericson/Workspace/Rust/ars-ui/spec/foundation/07-forms.md):5-7 and 12.6.          | Blocks `Field`, `Fieldset`, `Form`, `ToggleButton`, and later form-participating components, but not stateless utilities like `VisuallyHidden`.                                | Can land before specific utilities only           |
+| `ars-forms` submit lifecycle               | No form submit machine or focus-on-error helper exists.                                                                                                                                                                                                                                                             | `form_submit::Machine`, server-error sync, and invalid-field focus flow from [`spec/foundation/07-forms.md`](/Users/ericson/Workspace/Rust/ars-ui/spec/foundation/07-forms.md):8-10.                                                                     | Blocks `Form` and any adapter contract that relies on stateful submit/validation behavior.                                                                                     | Can land before specific utilities only           |
+| `ars-dom` focus and focus-scope primitives | [`crates/ars-dom/src/lib.rs`](/Users/ericson/Workspace/Rust/ars-ui/crates/ars-dom/src/lib.rs) only defines `ScrollLockToken` and `PlatformFeatures`.                                                                                                                                                                | DOM focus querying, focus management, and concrete `FocusScope` support from [`spec/foundation/11-dom-utilities.md`](/Users/ericson/Workspace/Rust/ars-ui/spec/foundation/11-dom-utilities.md):3.1-3.3.                                                  | Blocks `FocusScope` directly and also blocks any focus-management effects routed through `PlatformEffects`.                                                                    | Can land before specific utilities only           |
+| `ars-dom` scroll locking                   | No reference-counted scroll lock implementation exists.                                                                                                                                                                                                                                                             | `ScrollLockManager`, low-level `acquire`/`release`, and public aliases from [`spec/foundation/11-dom-utilities.md`](/Users/ericson/Workspace/Rust/ars-ui/spec/foundation/11-dom-utilities.md):5.2-5.4.                                                   | Not needed for the first utility slice, but required before overlay work starts.                                                                                               | Can wait until later slices                       |
+| Interaction composition depth              | [`crates/ars-interactions/src/lib.rs`](/Users/ericson/Workspace/Rust/ars-ui/crates/ars-interactions/src/lib.rs) only does shallow overwrite merging.                                                                                                                                                                | Token-aware composition behavior expected by [`spec/foundation/05-interactions.md`](/Users/ericson/Workspace/Rust/ars-ui/spec/foundation/05-interactions.md):8.1-8.2 and by `as_child`/button specs.                                                     | Blocks `AsChild`, `Button`, and other composed interactive utilities, but not all utility work.                                                                                | Can land before specific utilities only           |
+
+## Why `#24` Is Blocked
+
+`#24` assumed the first utility slice could be decomposed directly into adapter-facing delivery cards. The audit shows that the current repo still lacks the shared contracts those cards would depend on:
+
+- Utility specs already call for typed `HtmlAttr`, `AttrMap::set_bool`, style handling, and part-derived `data_attrs()`.
+- `Field`, `Fieldset`, `Form`, and `ToggleButton` all assume `FormContext`, `FieldCtx`, hidden-input helpers, and submit lifecycle machinery that do not exist yet.
+- `FocusScope` and any effectful component assume DOM focus helpers and `PlatformEffects` integration that are still missing.
+
+Because of that, decomposing the utility slice now would create issue cards that are blocked on unstated prerequisites. `#24` should stay deferred until the replacement foundation tasks below exist as issue-backed work.
+
+## Replacement Task Sequence
+
+The tasks below are issue-ready replacements for the missing middle layer. They are ordered by dependency, not by epic label.
+
+### [#31](https://github.com/fogodev/ars-ui/issues/31): Implement typed connect primitives in `ars-core`
+
+- Points: `5`
+- Layer: `Core`
+- Framework: `None`
+- Test tier: `Unit`
+- Depends on: `#13`
+- Spec refs:
+  - `spec/foundation/01-architecture.md#31-typed-property-enums`
+  - `spec/foundation/01-architecture.md#311-htmlattr`
+  - `spec/foundation/01-architecture.md#312-htmlevent`
+  - `spec/foundation/01-architecture.md#313-cssproperty`
+- Goal: add the typed HTML attribute, event, and CSS property model used by all spec-defined `connect()` APIs.
+- Out of scope: `AttrMap` merge/storage behavior, derive macros, adapter conversion code.
+- Tests to add first:
+  - Unit tests for `Display`/name serialization of representative `HtmlAttr`, `HtmlEvent`, and `CssProperty` values.
+  - Unit tests for helpers such as `HtmlAttr::static_name()` and `data()`.
+- Acceptance criteria:
+  - `ars-core` exposes typed attr/event/style enums matching the spec naming contract.
+  - Downstream crates can reference typed keys without raw string literals.
+- Spec impact: `No spec change required`.
+- Board update rule: if blocked, keep `Status` in `Todo` and record the exact missing spec or dependency issue.
+
+### [#32](https://github.com/fogodev/ars-ui/issues/32): Implement spec-compliant `AttrMap`, `AttrValue`, `UserAttrs`, and `StyleStrategy`
+
+- Points: `5`
+- Layer: `Core`
+- Framework: `None`
+- Test tier: `Unit`
+- Depends on: `#31`
+- Spec refs:
+  - `spec/foundation/01-architecture.md#32-attrmap`
+  - `spec/foundation/01-architecture.md#321-stylestrategy`
+  - `spec/foundation/01-architecture.md#322-companion-stylesheet-ars-basecss`
+- Goal: replace the stringly `AttrMap` shell with the spec-defined typed attribute and style container.
+- Out of scope: adapter-side conversion into framework props, user-facing components.
+- Tests to add first:
+  - Unit tests for `set`, `set_bool`, `set_style`, `contains`, `get`, and `merge`.
+  - Unit tests for space-separated token list dedup (`class`, `aria-labelledby`, `aria-describedby`).
+  - Unit tests proving blocked `UserAttrs` keys are rejected.
+- Acceptance criteria:
+  - `AttrMap` stores typed attrs and styles with spec-defined merge behavior.
+  - `StyleStrategy` exists with documented default behavior.
+  - SSR-safe consumers can inspect attrs/styles without string-key ad hoc logic.
+- Spec impact: `No spec change required`.
+- Board update rule: if blocked, keep `Status` in `Todo` and name the missing `#31` surface or spec ambiguity.
+
+### [#33](https://github.com/fogodev/ars-ui/issues/33): Complete the `ars-a11y` `AriaAttribute` ↔ `ars-core` bridge
+
+- Points: `3`
+- Layer: `Subsystem`
+- Framework: `None`
+- Test tier: `Unit`
+- Depends on: `#31`, `#32`, `#15`
+- Spec refs:
+  - `spec/foundation/03-accessibility.md#22-ariaattribute-enum`
+- Goal: finish the deferred bridging layer between `AriaAttribute` and the typed `ars-core` attr model.
+- Out of scope: role/state helper convenience functions, component-specific connect code, validator logic.
+- Tests to add first:
+  - Unit tests for `AriaAttribute::attr_name()`, `to_html_attr()`, and `apply_to()`.
+  - Unit tests for `From<AriaAttr> for AriaAttribute`, `TryFrom<HtmlAttr> for AriaAttribute`, and `From<&AriaAttribute> for AriaAttr`.
+  - Unit tests proving removal semantics map to `AttrValue::None` for nullable ARIA attrs such as `Expanded(None)` and `Hidden(None)`.
+- Acceptance criteria:
+  - `ars-a11y` no longer carries deferred TODOs for the typed ARIA bridge.
+  - `AriaAttribute` can apply itself to the spec-compliant `AttrMap` without raw string keys.
+  - Downstream code can round-trip between `AriaAttribute`, `AriaAttr`, and `HtmlAttr::Aria(...)`.
+- Spec impact: `No spec change required`.
+- Board update rule: if blocked, keep `Status` in `Todo` and record whether the blocker is missing typed `AttrMap` behavior or an accessibility-spec mismatch.
+
+### [#34](https://github.com/fogodev/ars-ui/issues/34): Add `ars-a11y` role and common state helper APIs
+
+- Points: `3`
+- Layer: `Subsystem`
+- Framework: `None`
+- Test tier: `Unit`
+- Depends on: `#32`, `#33`, `#15`
+- Spec refs:
+  - `spec/foundation/03-accessibility.md#23-role-assignment-patterns`
+  - `spec/foundation/03-accessibility.md#25-state-and-property-management`
+- Goal: add the shared helper layer for applying roles and common ARIA states to typed `AttrMap`s.
+- Out of scope: full validator work, adapter-side enforcement, component-specific accessibility composition.
+- Tests to add first:
+  - Unit tests for `apply_role()` and `apply_aria()` against typed `AttrMap`.
+  - Unit tests for `set_expanded`, `set_selected`, `set_checked`, `set_disabled`, `set_busy`, and `set_invalid`.
+  - Unit tests verifying `set_invalid` clears `aria-errormessage` when no error ID is supplied.
+- Acceptance criteria:
+  - `ars-a11y` exposes the helper APIs that the accessibility spec uses in connect examples.
+  - Components can apply standard ARIA role/state patterns without handwritten attr-key branching.
+  - Removal behavior for nullable state attrs is aligned with the spec and typed `AttrMap`.
+- Spec impact: `No spec change required`.
+- Board update rule: if blocked, keep `Status` in `Todo` and record whether the blocker is in `ars-core` attr semantics or unresolved accessibility helper scope.
+
+### [#35](https://github.com/fogodev/ars-ui/issues/35): Implement `ComponentPart` scope/data-attr helpers and derive macros
+
+- Points: `3`
+- Layer: `Core`
+- Framework: `None`
+- Test tier: `Unit`
+- Depends on: `#31`, `#14`
+- Spec refs:
+  - `spec/foundation/01-architecture.md#4-anatomy-system`
+  - `spec/foundation/01-architecture.md#41-anatomy-definition`
+- Goal: implement the actual `HasId` and `ComponentPart` derive output required by spec anatomy enums.
+- Out of scope: adapter rendering, component-specific anatomy definitions.
+- Tests to add first:
+  - Proc-macro tests for `#[derive(HasId)]`.
+  - Proc-macro tests for `#[derive(ComponentPart)]` including scope lookup, kebab-case part names, `all()`, and `data_attrs()`.
+- Acceptance criteria:
+  - Generated code matches the spec contract for `scope`, `name`, `all`, and representative instances.
+  - Components can derive anatomy helpers without handwritten boilerplate.
+- Spec impact: `No spec change required`.
+- Board update rule: if blocked, keep `Status` in `Todo` and record the exact missing `#31` attr type or macro constraint.
+
+### [#36](https://github.com/fogodev/ars-ui/issues/36): Introduce shared provider and platform-effect contracts
+
+- Points: `3`
+- Layer: `Core`
+- Framework: `None`
+- Test tier: `Unit`
+- Depends on: `#31`
+- Spec refs:
+  - `spec/foundation/01-architecture.md#227-platformeffects-trait`
+  - `spec/foundation/01-architecture.md#64-arsprovider`
+- Goal: add the shared environment-side contract types that adapters and effect closures depend on before `ArsProvider` itself is implemented.
+- Out of scope: Leptos/Dioxus context wiring, DOM-backed implementations, component rendering.
+- Tests to add first:
+  - Compile coverage for `PlatformEffects` consumers and no-op/default implementations.
+  - Unit tests for default environment types such as `ColorMode`.
+- Acceptance criteria:
+  - Shared provider/platform interfaces exist in a crate that downstream code can depend on.
+  - Effect closures no longer need to assume direct DOM access.
+- Spec impact: `No spec change required`.
+- Board update rule: if blocked, keep `Status` in `Todo` and record whether the blocker is in `ars-core`, `ars-i18n`, or `ars-dom`.
+
+### [#37](https://github.com/fogodev/ars-ui/issues/37): Implement `FormContext`, field descriptors, `FieldCtx`, and hidden-input helpers
+
+- Points: `5`
+- Layer: `Subsystem`
+- Framework: `None`
+- Test tier: `Unit`
+- Depends on: `#17`
+- Spec refs:
+  - `spec/foundation/07-forms.md#5-form-context`
+  - `spec/foundation/07-forms.md#6-field-association-ids-for-aria`
+  - `spec/foundation/07-forms.md#7-hidden-inputs-for-form-submission`
+  - `spec/foundation/07-forms.md#126-fieldctx-shared-context-for-child-fields`
+- Goal: extend `ars-forms` from validation primitives into the shared field/form context layer expected by form-related utilities.
+- Out of scope: adapter hooks, submit lifecycle state machine, adapter components.
+- Tests to add first:
+  - Unit tests for field registration order and field association helpers.
+  - Unit tests for hidden-input serialization, including multi-value and disabled/form-associated cases.
+  - Unit tests for server-error injection and field-level clearing behavior.
+- Acceptance criteria:
+  - `FormContext` and related field metadata types exist with spec-defined behavior.
+  - Hidden-input helpers cover the common single/multi-value cases used by downstream components.
+- Spec impact: `No spec change required`.
+- Board update rule: if blocked, keep `Status` in `Todo` and name the missing dependency or unresolved forms-spec question.
+
+### [#38](https://github.com/fogodev/ars-ui/issues/38): Implement the `form_submit` machine and focus-on-error helpers
+
+- Points: `5`
+- Layer: `Subsystem`
+- Framework: `None`
+- Test tier: `Unit`
+- Depends on: `#31`, `#32`, `#33`, `#37`
+- Spec refs:
+  - `spec/foundation/07-forms.md#8-form-submit-state-machine`
+  - `spec/foundation/07-forms.md#81-server-side-validation-error-sync-pattern`
+  - `spec/foundation/07-forms.md#9-focus-management-on-submit-error`
+- Goal: add the spec-defined form submission state machine and shared invalid-field focus helpers.
+- Out of scope: Leptos/Dioxus hook APIs, concrete DOM focus calls, end-user form components.
+- Tests to add first:
+  - Unit tests for submit state transitions, validation failure, submission success/failure, and reset behavior.
+  - Unit tests for `SetServerErrors` and first-invalid-field selection order.
+- Acceptance criteria:
+  - `ars-forms` exposes the submission lifecycle contract required by the `Form` utility.
+  - Server-side validation error sync is part of the shared forms layer, not an adapter-only behavior.
+- Spec impact: `No spec change required`.
+- Board update rule: if blocked, keep `Status` in `Todo` and record whether the blocker is missing `FormContext` or missing core attr/connect types.
+
+### [#39](https://github.com/fogodev/ars-ui/issues/39): Implement DOM focus query and focus-scope support primitives in `ars-dom`
+
+- Points: `5`
+- Layer: `Subsystem`
+- Framework: `None`
+- Test tier: `Mixed`
+- Depends on: `#36`, `#18`
+- Spec refs:
+  - `spec/foundation/11-dom-utilities.md#3-focus-utilities`
+  - `spec/foundation/11-dom-utilities.md#31-element-querying`
+  - `spec/foundation/11-dom-utilities.md#32-focus-management`
+  - `spec/foundation/11-dom-utilities.md#33-focusscope-implementation`
+- Goal: implement the focus and focus-scope DOM utilities that the platform effects layer and `FocusScope` utility depend on.
+- Out of scope: overlay scroll locking and positioning engine work.
+- Tests to add first:
+  - Unit tests for pure wrapper logic and fallback ordering where the code does not require a live DOM.
+  - Web-targeted smoke tests or compile coverage for DOM query/focus entry points.
+- Acceptance criteria:
+  - `ars-dom` exposes the focus primitives needed by `PlatformEffects`.
+  - Focus restoration and containment behavior exist as shared DOM utilities rather than adapter-local code.
+- Spec impact: `No spec change required`.
+- Board update rule: if blocked, keep `Status` in `Todo` and note whether the blocker is DOM test infrastructure or missing provider/platform contracts.
+
+### [#40](https://github.com/fogodev/ars-ui/issues/40): Implement reference-counted scroll locking in `ars-dom`
+
+- Points: `3`
+- Layer: `Subsystem`
+- Framework: `None`
+- Test tier: `Unit`
+- Depends on: `#18`
+- Spec refs:
+  - `spec/foundation/01-architecture.md#25-scrolllockmanager-ars-dom`
+  - `spec/foundation/11-dom-utilities.md#52-scrolllockmanager-reference-counted`
+  - `spec/foundation/11-dom-utilities.md#53-low-level-api-acquirerelease-with-depth-counter`
+- Goal: replace the current shell with the reference-counted scroll lock manager required by overlay work.
+- Out of scope: overlay machines and component-level integration.
+- Tests to add first:
+  - Unit tests for depth counting, duplicate owner protection, and restoration on last unlock.
+  - Unit tests for public alias behavior (`prevent_scroll`, `restore_scroll`).
+- Acceptance criteria:
+  - `ars-dom` exposes the scroll locking API defined by the architecture and DOM specs.
+  - Nested overlay locking semantics are covered without relying on component code.
+- Spec impact: `No spec change required`.
+- Board update rule: if blocked, keep `Status` in `Todo` and record the exact runtime or platform constraint.
+
+### [#41](https://github.com/fogodev/ars-ui/issues/41): Strengthen `ars-interactions` attribute composition for composed utilities
+
+- Points: `3`
+- Layer: `Subsystem`
+- Framework: `None`
+- Test tier: `Unit`
+- Depends on: `#31`, `#32`, `#16`
+- Spec refs:
+  - `spec/foundation/05-interactions.md#81-the-composition-problem`
+  - `spec/foundation/05-interactions.md#82-merge_attrs`
+  - `spec/components/utility/as-child.md#32-aria-attribute-merge-rules`
+- Goal: bring attribute composition in line with the token-aware merge behavior expected by `AsChild`, `Button`, and related utilities.
+- Out of scope: framework event-handler composition in adapters.
+- Tests to add first:
+  - Unit tests for merge precedence, token-list concatenation, and ARIA ID-list behavior.
+- Acceptance criteria:
+  - Shared interaction composition no longer does naive overwrite-only merging.
+  - Downstream `as_child` and composed-control work has a spec-compliant shared merge base.
+- Spec impact: `No spec change required`.
+- Board update rule: if blocked, keep `Status` in `Todo` and note whether the blocker is in core attr modeling or in the interaction spec itself.
+
+## Corrected Execution Order
+
+The corrected order for near-term work is:
+
+1. `#31` — typed connect primitives in `ars-core`
+2. `#32` — spec-compliant `AttrMap` and style strategy
+3. `#33` — `ars-a11y` ARIA bridge onto typed attrs
+4. `#34` — `ars-a11y` role and state helpers
+5. `#35` — anatomy/derive support
+6. `#36` — provider and platform-effect shared contracts
+7. `#41` — interaction composition depth
+8. `#37` — forms context, field association, and hidden inputs
+9. `#38` — form submit machine
+10. `#39` — DOM focus and focus-scope primitives
+11. `#40` — DOM scroll locking
+12. Revisit `#24` only after the utility-slice prerequisites above exist as issue-backed work
+
+This order intentionally front-loads the contracts that utility specs already import implicitly, then brings back slice decomposition only when those prerequisites are visible in the backlog.
+
+## Concrete Next Task
+
+The next unblocked, high-leverage implementation task after [#31](https://github.com/fogodev/ars-ui/issues/31) is:
+
+**[#32](https://github.com/fogodev/ars-ui/issues/32): Implement spec-compliant `AttrMap`, `AttrValue`, `UserAttrs`, and `StyleStrategy`**.
+
+Why this is next:
+
+- It is the direct follow-up to `#31`, which introduced the typed connect enums.
+- It unlocks `#33`, `#35`, and `#41`, all of which depend on the typed attribute container.
+- It removes the biggest remaining source of spec/code mismatch in the shared connect layer, since the current specs already assume typed `AttrMap` behavior everywhere.
+
+## Status of `#24`
+
+- Keep `#24` open but deferred.
+- Do not move it to `In Progress`.
+- Treat this audit as the prerequisite planning artifact for replacing `#24` with the missing foundation cards above.

--- a/docs/implementation/initial-backlog.md
+++ b/docs/implementation/initial-backlog.md
@@ -2,6 +2,8 @@
 
 This backlog is the seed set for the implementation program. It intentionally stops at the first shippable utility slice instead of attempting the whole library at once.
 
+> **Backlog reset note (2026-04-03):** The seed backlog reached the crate-shell milestone, but the remaining open planning card `#24` is premature. Before any utility-slice decomposition resumes, use [foundation-gap-audit.md](./foundation-gap-audit.md) as the canonical reference for the missing middle-layer contracts and the replacement foundation-first task sequence.
+
 ## Epics
 
 ### Epic: Workspace bootstrap
@@ -142,6 +144,8 @@ This backlog is the seed set for the implementation program. It intentionally st
 - Acceptance: adapter/component crates can depend on shared a11y types
 - Spec impact: `No spec change required`
 
+Note: this seed task only covered baseline a11y types. The follow-up `AriaAttribute` bridge onto typed `HtmlAttr`/`AttrMap` and the shared role/state helper layer are now tracked as [#33](https://github.com/fogodev/ars-ui/issues/33) and [#34](https://github.com/fogodev/ars-ui/issues/34), and are documented in [foundation-gap-audit.md](/Users/ericson/Workspace/Rust/ars-ui/docs/implementation/foundation-gap-audit.md).
+
 ### #16: Add baseline `ars-interactions` merge and state primitives
 
 - Points: `3`
@@ -249,3 +253,12 @@ This backlog is the seed set for the implementation program. It intentionally st
 - Tests first: not applicable; verify each card includes tests-first details
 - Acceptance: the first slice is decomposed into component-level or behavior-level cards no larger than `5`
 - Spec impact: `No spec change required`
+
+## Backlog Reset
+
+The original seed tasks correctly established workspace, core, subsystem, harness, and adapter shells. They did **not** fully surface the shared contracts required by the first utility slice. The missing follow-on work is now tracked in [foundation-gap-audit.md](./foundation-gap-audit.md), which:
+
+- explains why `#24` is blocked,
+- identifies the missing shared contracts in `ars-core`, `ars-derive`, `ars-dom`, `ars-forms`, provider/platform wiring, and interaction composition,
+- defines the corrected issue-ready replacement task sequence, and
+- names the next unblocked high-leverage task: typed connect primitives in `ars-core`.

--- a/spec/foundation/01-architecture.md
+++ b/spec/foundation/01-architecture.md
@@ -4087,22 +4087,16 @@ impl UserAttrs {
 }
 
 /// Convenience constructor for data attributes.
-pub fn data(name: &'static str) -> HtmlAttr {
+pub const fn data(name: &'static str) -> HtmlAttr {
     HtmlAttr::Data(name)
 }
 
 /// Options for event listener registration.
 /// Used by adapters when wiring typed handler methods to native DOM events.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct EventOptions {
     pub passive: bool,
     pub capture: bool,
-}
-
-impl Default for EventOptions {
-    fn default() -> Self {
-        Self { passive: false, capture: false }
-    }
 }
 
 impl From<&str> for AttrValue {


### PR DESCRIPTION
## Summary
- add typed HTML, ARIA, event, and CSS connect primitives in `ars-core`
- align the architecture spec with the chosen `data()` and `EventOptions` API
- sync the implementation docs with the reset foundation backlog and real issue dependencies

## Validation
- `cargo test -p ars-core`
- `cargo clippy -p ars-core --all-targets -- -D warnings`

Closes #31