### PR TITLE
Add ars-a11y role and common state helper APIs

### DIFF
--- a/crates/ars-a11y/src/aria/apply.rs
+++ b/crates/ars-a11y/src/aria/apply.rs
@@ -1,0 +1,143 @@
+//! Role assignment helpers for `connect()` implementations.
+//!
+//! These functions apply ARIA roles and attributes to typed [`ars_core::AttrMap`]s,
+//! providing the shared accessibility layer used by all component connect
+//! functions.
+
+use ars_core::{AttrMap, HtmlAttr};
+
+use super::{attribute::AriaAttribute, role::AriaRole};
+
+/// Applies an ARIA role to an attribute map.
+///
+/// Abstract roles are silently ignored — callers may derive roles dynamically,
+/// so validation is deferred to `AriaValidator` rather than panicking here.
+///
+/// # Examples
+///
+/// ```
+/// # use ars_a11y::aria::apply::apply_role;
+/// # use ars_a11y::AriaRole;
+/// # use ars_core::{AttrMap, HtmlAttr};
+/// let mut attrs = AttrMap::new();
+/// apply_role(&mut attrs, AriaRole::Button);
+/// assert_eq!(attrs.get(&HtmlAttr::Role), Some("button"));
+/// ```
+#[inline]
+pub fn apply_role(attrs: &mut AttrMap, role: AriaRole) {
+    if let Some(value) = role.to_attr_value() {
+        attrs.set(HtmlAttr::Role, value);
+    }
+    // Abstract roles are silently ignored — no debug_assert here because
+    // callers may derive roles dynamically; instead, validate via AriaValidator.
+}
+
+/// Batch-applies ARIA attributes to an attribute map.
+///
+/// Each attribute delegates to [`AriaAttribute::apply_to`], which handles
+/// serialization and nullable attribute removal.
+///
+/// # Examples
+///
+/// ```
+/// # use ars_a11y::aria::apply::apply_aria;
+/// # use ars_a11y::AriaAttribute;
+/// # use ars_core::AttrMap;
+/// let mut attrs = AttrMap::new();
+/// apply_aria(&mut attrs, [
+///     AriaAttribute::Disabled(true),
+///     AriaAttribute::Expanded(Some(false)),
+/// ]);
+/// ```
+#[inline]
+pub fn apply_aria(attr_map: &mut AttrMap, aria_attrs: impl IntoIterator<Item = AriaAttribute>) {
+    for attr in aria_attrs {
+        attr.apply_to(attr_map);
+    }
+}
+
+/// Compile-time checked role assignment.
+///
+/// Use this macro to get a compile error for abstract roles.
+///
+/// **Note:** The compile-time check is enforced only when the argument is a `const`
+/// expression (e.g., a literal `AriaRole::Button`). For runtime role values, call
+/// [`AriaRole::is_abstract()`] manually before calling `set_role!`.
+///
+/// # Usage
+///
+/// ```
+/// # use ars_a11y::set_role;
+/// # use ars_a11y::AriaRole;
+/// # use ars_core::{AttrMap, HtmlAttr};
+/// let mut attrs = AttrMap::new();
+/// set_role!(attrs, AriaRole::Button);
+/// assert_eq!(attrs.get(&HtmlAttr::Role), Some("button"));
+/// ```
+#[macro_export]
+macro_rules! set_role {
+    ($attrs:expr, $role:expr) => {{
+        const _: () = {
+            // Evaluated at compile time — will fail if role is abstract.
+            // The trick: abstract roles have `to_attr_value` returning None,
+            // but we use a const fn check.
+            assert!(
+                !$role.is_abstract(),
+                "Cannot set an abstract ARIA role on a DOM element"
+            );
+        };
+        $crate::aria::apply::apply_role(&mut $attrs, $role);
+    }};
+}
+
+#[cfg(test)]
+mod tests {
+    use ars_core::{AriaAttr, AttrMap, HtmlAttr};
+
+    use super::*;
+
+    #[test]
+    fn apply_role_sets_role_attribute() {
+        let mut attrs = AttrMap::new();
+        apply_role(&mut attrs, AriaRole::Button);
+        assert_eq!(attrs.get(&HtmlAttr::Role), Some("button"));
+    }
+
+    #[test]
+    fn apply_role_ignores_abstract_role() {
+        let mut attrs = AttrMap::new();
+        apply_role(&mut attrs, AriaRole::Widget);
+        assert!(!attrs.contains(&HtmlAttr::Role));
+    }
+
+    #[test]
+    fn apply_aria_applies_multiple_attributes() {
+        let mut attrs = AttrMap::new();
+        apply_aria(
+            &mut attrs,
+            [
+                AriaAttribute::Disabled(true),
+                AriaAttribute::Expanded(Some(false)),
+            ],
+        );
+        assert_eq!(attrs.get(&HtmlAttr::Aria(AriaAttr::Disabled)), Some("true"));
+        assert_eq!(
+            attrs.get(&HtmlAttr::Aria(AriaAttr::Expanded)),
+            Some("false")
+        );
+    }
+
+    #[test]
+    fn apply_aria_empty_iterator_is_noop() {
+        let mut attrs = AttrMap::new();
+        apply_aria(&mut attrs, core::iter::empty());
+        assert_eq!(attrs.attrs().len(), 0);
+    }
+
+    #[test]
+    fn set_role_macro_with_concrete_role() {
+        let mut attrs = AttrMap::new();
+        set_role!(attrs, AriaRole::Checkbox);
+        assert_eq!(attrs.get(&HtmlAttr::Role), Some("checkbox"));
+    }
+}

--- a/crates/ars-a11y/src/aria/mod.rs
+++ b/crates/ars-a11y/src/aria/mod.rs
@@ -1,9 +1,15 @@
-//! WAI-ARIA attribute types and role definitions.
+//! WAI-ARIA attribute types, role definitions, and shared helpers.
 //!
 //! - [`role::AriaRole`] — complete WAI-ARIA 1.2 role enum with validation methods
 //! - [`attribute::AriaAttribute`] — typed ARIA states and properties with serialization
+//! - [`apply`] — role assignment helpers for `connect()` implementations
+//! - [`state`] — common ARIA state transition helpers
 
+/// Role assignment helpers for `connect()` implementations.
+pub mod apply;
 /// Typed WAI-ARIA 1.2 states and properties with serialization support.
 pub mod attribute;
 /// Complete WAI-ARIA 1.2 role enum with validation methods.
 pub mod role;
+/// Common ARIA state transition helpers.
+pub mod state;

--- a/crates/ars-a11y/src/aria/role.rs
+++ b/crates/ars-a11y/src/aria/role.rs
@@ -1,6 +1,6 @@
 //! WAI-ARIA 1.2 role system.
 //!
-//! Defines the [`AriaRole`] enum covering all WAI-ARIA 1.2 role definitions
+//! Defines the [`AriaRole`](crate::AriaRole) enum covering all WAI-ARIA 1.2 role definitions
 //! (plus select WAI-ARIA 1.3 draft roles), organised by category: abstract,
 //! window, widget, composite, document structure, live region, and landmark.
 //!

--- a/crates/ars-a11y/src/aria/state.rs
+++ b/crates/ars-a11y/src/aria/state.rs
@@ -1,0 +1,213 @@
+//! Common ARIA state transition helpers for `connect()` implementations.
+//!
+//! These functions normalize the most frequent state transitions used inside
+//! component connect functions, handling nullable attribute removal and
+//! multi-attribute coordination (e.g., `set_invalid` managing both
+//! `aria-invalid` and `aria-errormessage`).
+
+use alloc::string::String;
+
+use ars_core::{AriaAttr, AttrMap, AttrValue, HtmlAttr};
+
+use super::attribute::{AriaAttribute, AriaChecked, AriaIdRef, AriaInvalid};
+
+/// Sets `aria-expanded` based on boolean state.
+///
+/// `None` removes the attribute entirely, for elements that do not inherently
+/// have an expanded concept.
+#[inline]
+pub fn set_expanded(attrs: &mut AttrMap, expanded: Option<bool>) {
+    AriaAttribute::Expanded(expanded).apply_to(attrs);
+}
+
+/// Sets `aria-selected`.
+///
+/// `None` removes the attribute entirely, for elements where selection is not
+/// applicable in the current context.
+#[inline]
+pub fn set_selected(attrs: &mut AttrMap, selected: Option<bool>) {
+    AriaAttribute::Selected(selected).apply_to(attrs);
+}
+
+/// Sets `aria-checked` for checkbox, radio, and switch semantics.
+#[inline]
+pub fn set_checked(attrs: &mut AttrMap, checked: AriaChecked) {
+    AriaAttribute::Checked(checked).apply_to(attrs);
+}
+
+/// Sets `aria-disabled`.
+///
+/// Uses `aria-disabled` rather than the HTML `disabled` attribute for non-form
+/// elements. For `<button>` and `<input>`, use the native `disabled` attribute
+/// in addition to `aria-disabled`.
+///
+/// **Note:** `data-ars-disabled` is NOT set by this helper — that attribute is
+/// the responsibility of interaction primitives (e.g., `PressResult::current_attrs()`)
+/// and component connect functions.
+#[inline]
+pub fn set_disabled(attrs: &mut AttrMap, disabled: bool) {
+    if disabled {
+        AriaAttribute::Disabled(true).apply_to(attrs);
+    } else {
+        attrs.set(HtmlAttr::Aria(AriaAttr::Disabled), AttrValue::None);
+    }
+}
+
+/// Sets `aria-busy` for loading states.
+#[inline]
+pub fn set_busy(attrs: &mut AttrMap, busy: bool) {
+    AriaAttribute::Busy(busy).apply_to(attrs);
+}
+
+/// Sets `aria-invalid` with an optional error message reference.
+///
+/// **Note on `aria-errormessage` vs `aria-describedby`**: While this function
+/// sets `aria-errormessage` per the ARIA 1.2 spec, screen reader support for
+/// `aria-errormessage` remains poor as of 2025 (NVDA and JAWS have limited
+/// support; `VoiceOver` does not announce it reliably). For maximum
+/// compatibility, callers should **also** include the error message element's
+/// ID in `aria-describedby`. The `FieldContext` (see spec §5.4) handles
+/// this automatically by appending the error ID to `describedby_ids` when the
+/// field is invalid. Using both attributes is not harmful — `aria-describedby`
+/// provides the fallback announcement while `aria-errormessage` provides
+/// the semantic relationship for assistive technologies that support it.
+#[inline]
+pub fn set_invalid(attrs: &mut AttrMap, invalid: AriaInvalid, error_id: Option<&str>) {
+    AriaAttribute::Invalid(invalid).apply_to(attrs);
+    if let Some(id) = error_id {
+        AriaAttribute::ErrorMessage(AriaIdRef(String::from(id))).apply_to(attrs);
+    } else {
+        attrs.set(HtmlAttr::Aria(AriaAttr::ErrorMessage), AttrValue::None);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ars_core::{AriaAttr, AttrMap, HtmlAttr};
+
+    use super::*;
+
+    #[test]
+    fn set_expanded_true() {
+        let mut attrs = AttrMap::new();
+        set_expanded(&mut attrs, Some(true));
+        assert_eq!(attrs.get(&HtmlAttr::Aria(AriaAttr::Expanded)), Some("true"));
+    }
+
+    #[test]
+    fn set_expanded_false() {
+        let mut attrs = AttrMap::new();
+        set_expanded(&mut attrs, Some(false));
+        assert_eq!(
+            attrs.get(&HtmlAttr::Aria(AriaAttr::Expanded)),
+            Some("false")
+        );
+    }
+
+    #[test]
+    fn set_expanded_none_removes() {
+        let mut attrs = AttrMap::new();
+        set_expanded(&mut attrs, Some(true));
+        assert!(attrs.contains(&HtmlAttr::Aria(AriaAttr::Expanded)));
+        set_expanded(&mut attrs, None);
+        assert!(!attrs.contains(&HtmlAttr::Aria(AriaAttr::Expanded)));
+    }
+
+    #[test]
+    fn set_selected_true() {
+        let mut attrs = AttrMap::new();
+        set_selected(&mut attrs, Some(true));
+        assert_eq!(attrs.get(&HtmlAttr::Aria(AriaAttr::Selected)), Some("true"));
+    }
+
+    #[test]
+    fn set_selected_none_removes() {
+        let mut attrs = AttrMap::new();
+        set_selected(&mut attrs, Some(true));
+        assert!(attrs.contains(&HtmlAttr::Aria(AriaAttr::Selected)));
+        set_selected(&mut attrs, None);
+        assert!(!attrs.contains(&HtmlAttr::Aria(AriaAttr::Selected)));
+    }
+
+    #[test]
+    fn set_checked_true() {
+        let mut attrs = AttrMap::new();
+        set_checked(&mut attrs, AriaChecked::True);
+        assert_eq!(attrs.get(&HtmlAttr::Aria(AriaAttr::Checked)), Some("true"));
+    }
+
+    #[test]
+    fn set_checked_mixed() {
+        let mut attrs = AttrMap::new();
+        set_checked(&mut attrs, AriaChecked::Mixed);
+        assert_eq!(attrs.get(&HtmlAttr::Aria(AriaAttr::Checked)), Some("mixed"));
+    }
+
+    #[test]
+    fn set_disabled_true() {
+        let mut attrs = AttrMap::new();
+        set_disabled(&mut attrs, true);
+        assert_eq!(attrs.get(&HtmlAttr::Aria(AriaAttr::Disabled)), Some("true"));
+    }
+
+    #[test]
+    fn set_disabled_false_removes() {
+        let mut attrs = AttrMap::new();
+        set_disabled(&mut attrs, true);
+        assert!(attrs.contains(&HtmlAttr::Aria(AriaAttr::Disabled)));
+        set_disabled(&mut attrs, false);
+        assert!(!attrs.contains(&HtmlAttr::Aria(AriaAttr::Disabled)));
+    }
+
+    #[test]
+    fn set_busy_true() {
+        let mut attrs = AttrMap::new();
+        set_busy(&mut attrs, true);
+        assert_eq!(attrs.get(&HtmlAttr::Aria(AriaAttr::Busy)), Some("true"));
+    }
+
+    #[test]
+    fn set_busy_false() {
+        let mut attrs = AttrMap::new();
+        set_busy(&mut attrs, false);
+        assert_eq!(attrs.get(&HtmlAttr::Aria(AriaAttr::Busy)), Some("false"));
+    }
+
+    #[test]
+    fn set_invalid_with_error_id() {
+        let mut attrs = AttrMap::new();
+        set_invalid(&mut attrs, AriaInvalid::True, Some("err-1"));
+        assert_eq!(attrs.get(&HtmlAttr::Aria(AriaAttr::Invalid)), Some("true"));
+        assert_eq!(
+            attrs.get(&HtmlAttr::Aria(AriaAttr::ErrorMessage)),
+            Some("err-1")
+        );
+    }
+
+    #[test]
+    fn set_invalid_without_error_clears_errormessage() {
+        let mut attrs = AttrMap::new();
+        // First set with an error ID.
+        set_invalid(&mut attrs, AriaInvalid::True, Some("err-1"));
+        assert!(attrs.contains(&HtmlAttr::Aria(AriaAttr::ErrorMessage)));
+
+        // Now clear the error ID.
+        set_invalid(&mut attrs, AriaInvalid::True, None);
+        assert_eq!(attrs.get(&HtmlAttr::Aria(AriaAttr::Invalid)), Some("true"));
+        assert!(!attrs.contains(&HtmlAttr::Aria(AriaAttr::ErrorMessage)));
+    }
+
+    #[test]
+    fn set_invalid_grammar() {
+        let mut attrs = AttrMap::new();
+        set_invalid(&mut attrs, AriaInvalid::Grammar, Some("g-1"));
+        assert_eq!(
+            attrs.get(&HtmlAttr::Aria(AriaAttr::Invalid)),
+            Some("grammar")
+        );
+        assert_eq!(
+            attrs.get(&HtmlAttr::Aria(AriaAttr::ErrorMessage)),
+            Some("g-1")
+        );
+    }
+}

--- a/crates/ars-a11y/src/lib.rs
+++ b/crates/ars-a11y/src/lib.rs
@@ -18,11 +18,13 @@ pub mod focus;
 #[cfg(feature = "aria-drag-drop-compat")]
 pub use aria::attribute::AriaDropeffect;
 pub use aria::{
+    apply::{apply_aria, apply_role},
     attribute::{
         AriaAttribute, AriaAutocomplete, AriaChecked, AriaCurrent, AriaHasPopup, AriaIdList,
         AriaIdRef, AriaInvalid, AriaLive, AriaOrientation, AriaPressed, AriaRelevant, AriaSort,
     },
     role::AriaRole,
+    state::{set_busy, set_checked, set_disabled, set_expanded, set_invalid, set_selected},
 };
 pub use focus::{FocusScopeBehavior, FocusScopeOptions, FocusStrategy, FocusTarget};
 

--- a/spec/foundation/03-accessibility.md
+++ b/spec/foundation/03-accessibility.md
@@ -1220,7 +1220,7 @@ pub fn set_busy(attrs: &mut AttrMap, busy: bool) {
 pub fn set_invalid(attrs: &mut AttrMap, invalid: AriaInvalid, error_id: Option<&str>) {
     AriaAttribute::Invalid(invalid).apply_to(attrs);
     if let Some(id) = error_id {
-        AriaAttribute::ErrorMessage(AriaIdRef(id.to_string())).apply_to(attrs);
+        AriaAttribute::ErrorMessage(AriaIdRef(String::from(id))).apply_to(attrs);
     } else {
         attrs.set(HtmlAttr::Aria(AriaAttr::ErrorMessage), AttrValue::None);
     }


### PR DESCRIPTION
## Summary

- Add `aria/apply.rs` with `apply_role()`, `apply_aria()`, and `set_role!` macro for spec-compliant role assignment
- Add `aria/state.rs` with `set_expanded`, `set_selected`, `set_checked`, `set_disabled`, `set_busy`, `set_invalid` state helpers
- Sync spec `set_invalid` code example to use `no_std`-compatible `String::from()` instead of `.to_string()`

19 unit tests + 3 doc-tests covering all helpers including nullable attribute removal and `set_invalid` error message clearing.

Closes #34

## Test plan

- [x] `cargo test -p ars-a11y` — 54 tests pass (19 new)
- [x] `cargo clippy --workspace -- -D warnings` — zero warnings
- [x] `cargo doc --no-deps -p ars-a11y` — clean build

🤖 Generated with [Claude Code](https://claude.com/claude-code)