### PR TITLE
[codex] Implement spec-compliant HasId and ComponentPart derives

### DIFF
--- a/crates/ars-core/Cargo.toml
+++ b/crates/ars-core/Cargo.toml
@@ -16,11 +16,13 @@ debug        = []
 embedded-css = []
 
 [dependencies]
+ars-derive = { path = "../ars-derive" }
 ars-i18n = { path = "../ars-i18n", default-features = false }
 serde    = { version = "1", default-features = false, features = ["alloc", "derive"], optional = true }
 
 [dev-dependencies]
 serde_json = "1"
+trybuild   = "1"
 
 [lints]
 workspace = true

--- a/crates/ars-core/src/lib.rs
+++ b/crates/ars-core/src/lib.rs
@@ -16,8 +16,9 @@
 #![warn(clippy::std_instead_of_core)]
 
 extern crate alloc;
+extern crate self as ars_core;
 
-use alloc::vec::Vec;
+use alloc::{string::String, vec::Vec};
 use core::fmt::Debug;
 
 pub mod companion_css;
@@ -25,6 +26,21 @@ mod connect;
 pub mod platform;
 pub mod provider;
 
+/// Hidden re-exports used by proc macros to stay hygienic without forcing
+/// downstream crates to import `alloc`.
+///
+/// The derive macros expand in the downstream crate, so using `::alloc::...`
+/// directly would require every consumer to write `extern crate alloc;`, even
+/// in ordinary `std` crates. Routing through `::ars_core::__private` keeps the
+/// generated code portable across `std` and `no_std + alloc` consumers while
+/// preserving a stable macro expansion path.
+#[doc(hidden)]
+pub mod __private {
+    pub use alloc::{string::String, vec::Vec};
+}
+
+#[doc(inline)]
+pub use ars_derive::{ComponentPart, HasId};
 // Re-export `Direction` from ars-i18n for convenience — used by
 // `PlatformEffects::resolved_direction` so consumers don't need a
 // separate `ars-i18n` dependency just for the return type.
@@ -187,18 +203,48 @@ impl<T: Clone + PartialEq + Debug> Bindable<T> {
     }
 }
 
+/// Trait for props types that carry a framework-stable DOM ID.
+///
+/// Adapters use this contract to read and replace component IDs without knowing the
+/// concrete props type. The `#[derive(HasId)]` macro implements this trait for any
+/// struct with a `pub id: String` field.
+pub trait HasId: Sized {
+    /// Returns the current DOM ID.
+    fn id(&self) -> &str;
+
+    /// Returns a copy of `self` with the DOM ID replaced.
+    #[must_use]
+    fn with_id(self, id: String) -> Self;
+
+    /// Updates the DOM ID in place.
+    fn set_id(&mut self, id: String);
+}
+
 /// A named DOM part of a component (e.g. root, trigger, content, label).
 ///
 /// Each component defines an enum of its parts that implements this trait,
 /// typically via `#[derive(ComponentPart)]`. The connect API uses parts to
 /// produce the correct [`AttrMap`] for each element in the component's DOM tree.
 pub trait ComponentPart: Clone + Debug + PartialEq + Eq + core::hash::Hash + 'static {
-    /// Returns the root part of this component.
-    fn root() -> Self;
+    /// The root part of this component.
+    const ROOT: Self;
+
+    /// Returns the scope name used for `data-ars-scope`.
+    fn scope() -> &'static str;
+
     /// Returns the string name of this part (e.g. `"root"`, `"trigger"`).
     fn name(&self) -> &'static str;
+
     /// Returns all parts defined for this component.
     fn all() -> Vec<Self>;
+
+    /// Returns the canonical `data-ars-scope` and `data-ars-part` attrs for this part.
+    fn data_attrs(&self) -> [(HtmlAttr, &'static str); 2] {
+        [
+            (HtmlAttr::Data("ars-scope"), Self::scope()),
+            (HtmlAttr::Data("ars-part"), self.name()),
+        ]
+    }
 }
 
 /// Produces HTML attributes for each component part based on current machine state.
@@ -226,7 +272,7 @@ pub trait Machine {
     /// Internal context accumulated across transitions (e.g. focused index, scroll offset).
     type Context: Clone + Debug;
     /// External configuration passed in by the parent component.
-    type Props: Clone + PartialEq;
+    type Props: Clone + PartialEq + HasId;
     /// The connect API type that produces attributes from current state.
     type Api<'a>: ConnectApi
     where
@@ -357,14 +403,32 @@ mod tests {
     struct ToggleContext;
 
     #[derive(Clone, Debug, PartialEq, Eq)]
-    struct ToggleProps;
+    struct ToggleProps {
+        id: String,
+    }
+
+    impl HasId for ToggleProps {
+        fn id(&self) -> &str {
+            &self.id
+        }
+
+        fn with_id(self, id: String) -> Self {
+            Self { id }
+        }
+
+        fn set_id(&mut self, id: String) {
+            self.id = id;
+        }
+    }
 
     #[derive(Clone, Debug, PartialEq, Eq, Hash)]
     struct TogglePart;
 
     impl ComponentPart for TogglePart {
-        fn root() -> Self {
-            Self
+        const ROOT: Self = Self;
+
+        fn scope() -> &'static str {
+            "toggle"
         }
 
         fn name(&self) -> &'static str {
@@ -427,7 +491,9 @@ mod tests {
 
     #[test]
     fn service_applies_transitions() {
-        let mut service = Service::<ToggleMachine>::new(ToggleProps);
+        let mut service = Service::<ToggleMachine>::new(ToggleProps {
+            id: String::from("toggle"),
+        });
         assert_eq!(service.state(), &ToggleState::Off);
 
         let effects = service.send(ToggleEvent::Toggle);

--- a/crates/ars-core/tests/derive_contract.rs
+++ b/crates/ars-core/tests/derive_contract.rs
@@ -1,0 +1,280 @@
+//! Derive-contract coverage for `HasId` and `ComponentPart`.
+
+use std::{
+    collections::hash_map::DefaultHasher,
+    hash::{Hash, Hasher},
+};
+
+use ars_core::{ComponentPart, HasId};
+
+#[derive(HasId)]
+struct Props {
+    pub id: String,
+    pub label: String,
+}
+
+#[derive(HasId)]
+struct GenericProps<T>
+where
+    T: Clone + PartialEq,
+{
+    pub id: String,
+    pub value: T,
+}
+
+#[derive(HasId)]
+struct LifetimeProps<'a, T>
+where
+    T: ?Sized,
+{
+    pub id: String,
+    pub value: &'a T,
+}
+
+#[derive(ComponentPart)]
+#[scope = "dialog"]
+enum DialogPart {
+    Root,
+    Trigger,
+    CloseTrigger,
+}
+
+#[derive(ComponentPart)]
+#[scope = "tabs"]
+enum TabsPart {
+    Root,
+    List,
+    Tab(String, String),
+    Panel { panel_id: String, tab_id: String },
+    TabIndicator,
+}
+
+#[derive(ComponentPart)]
+#[scope = "generic"]
+enum GenericPart<T>
+where
+    T: Clone + std::fmt::Debug + PartialEq + Eq + Hash + Default + 'static,
+{
+    Root,
+    HiddenInput,
+    Item(T),
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+struct CustomDefaultKey(&'static str);
+
+#[derive(ComponentPart)]
+#[scope = "named"]
+enum NamedPart {
+    Root,
+    FieldRow { key: CustomDefaultKey, index: usize },
+    HelperText { field_id: String },
+}
+
+#[derive(ComponentPart)]
+#[scope = "naming"]
+enum NamingPart {
+    Root,
+    URLField,
+    HTMLInput,
+    Step2Label,
+}
+
+#[derive(ComponentPart)]
+#[scope = "ordered"]
+enum OrderedPart {
+    Root,
+    Gamma,
+    Alpha,
+    Beta(String),
+    Delta { id: String },
+}
+
+#[test]
+fn has_id_derive_exposes_spec_contract() {
+    let mut props = Props {
+        id: String::from("heading-1"),
+        label: String::from("Title"),
+    };
+    assert_eq!(props.id(), "heading-1");
+
+    props.set_id(String::from("heading-3"));
+    assert_eq!(props.id(), "heading-3");
+
+    let renamed = props.with_id(String::from("heading-2"));
+    assert_eq!(renamed.id(), "heading-2");
+    assert_eq!(renamed.label, "Title");
+}
+
+#[test]
+fn has_id_derive_preserves_generics_and_where_clauses() {
+    let props = GenericProps {
+        id: String::from("generic-1"),
+        value: vec![1_u8, 2, 3],
+    };
+    assert_eq!(props.id(), "generic-1");
+
+    let renamed = props.with_id(String::from("generic-2"));
+    assert_eq!(renamed.id(), "generic-2");
+    assert_eq!(renamed.value, vec![1_u8, 2, 3]);
+}
+
+#[test]
+fn has_id_derive_supports_lifetimes() {
+    let value = String::from("payload");
+    let props = LifetimeProps {
+        id: String::from("lifetime-1"),
+        value: &value,
+    };
+    assert_eq!(props.id(), "lifetime-1");
+
+    let renamed = props.with_id(String::from("lifetime-2"));
+    assert_eq!(renamed.id(), "lifetime-2");
+    assert_eq!(renamed.value, "payload");
+}
+
+#[test]
+fn component_part_derive_supports_unit_variants() {
+    assert_eq!(DialogPart::ROOT, DialogPart::Root);
+    assert_eq!(DialogPart::scope(), "dialog");
+    assert_eq!(DialogPart::CloseTrigger.name(), "close-trigger");
+    assert_eq!(
+        DialogPart::CloseTrigger.data_attrs(),
+        [
+            (ars_core::HtmlAttr::Data("ars-scope"), "dialog"),
+            (ars_core::HtmlAttr::Data("ars-part"), "close-trigger"),
+        ]
+    );
+    assert_eq!(
+        DialogPart::all(),
+        vec![
+            DialogPart::Root,
+            DialogPart::Trigger,
+            DialogPart::CloseTrigger
+        ]
+    );
+}
+
+#[test]
+fn component_part_derive_supports_mixed_variants_and_trait_impls() {
+    assert_eq!(TabsPart::ROOT, TabsPart::Root);
+    assert_eq!(TabsPart::scope(), "tabs");
+    assert_eq!(TabsPart::Tab(String::new(), String::new()).name(), "tab");
+    assert_eq!(
+        TabsPart::Panel {
+            panel_id: String::from("panel-1"),
+            tab_id: String::from("tab-1"),
+        }
+        .name(),
+        "panel"
+    );
+    assert_eq!(
+        TabsPart::all(),
+        vec![
+            TabsPart::Root,
+            TabsPart::List,
+            TabsPart::Tab(String::new(), String::new()),
+            TabsPart::Panel {
+                panel_id: String::new(),
+                tab_id: String::new(),
+            },
+            TabsPart::TabIndicator,
+        ]
+    );
+
+    let part = TabsPart::Panel {
+        panel_id: String::from("panel-1"),
+        tab_id: String::from("tab-1"),
+    };
+    let clone = part.clone();
+    assert_eq!(part, clone);
+    assert!(format!("{clone:?}").contains("Panel"));
+
+    let mut left = DefaultHasher::new();
+    let mut right = DefaultHasher::new();
+    part.hash(&mut left);
+    clone.hash(&mut right);
+    assert_eq!(left.finish(), right.finish());
+}
+
+#[test]
+fn component_part_derive_preserves_generics_where_clauses_and_kebab_case() {
+    assert_eq!(GenericPart::<String>::ROOT, GenericPart::Root);
+    assert_eq!(GenericPart::<String>::scope(), "generic");
+    assert_eq!(GenericPart::<String>::HiddenInput.name(), "hidden-input");
+    assert_eq!(GenericPart::<String>::Item(String::new()).name(), "item");
+    assert_eq!(
+        GenericPart::<String>::HiddenInput.data_attrs(),
+        [
+            (ars_core::HtmlAttr::Data("ars-scope"), "generic"),
+            (ars_core::HtmlAttr::Data("ars-part"), "hidden-input"),
+        ]
+    );
+    assert_eq!(
+        GenericPart::<String>::all(),
+        vec![
+            GenericPart::Root,
+            GenericPart::HiddenInput,
+            GenericPart::Item(String::new()),
+        ]
+    );
+}
+
+#[test]
+fn component_part_derive_supports_named_payload_variants() {
+    assert_eq!(
+        NamedPart::FieldRow {
+            key: CustomDefaultKey("field"),
+            index: 2,
+        }
+        .name(),
+        "field-row"
+    );
+    assert_eq!(
+        NamedPart::HelperText {
+            field_id: String::from("field-1"),
+        }
+        .name(),
+        "helper-text"
+    );
+    assert_eq!(
+        NamedPart::all(),
+        vec![
+            NamedPart::Root,
+            NamedPart::FieldRow {
+                key: CustomDefaultKey::default(),
+                index: usize::default(),
+            },
+            NamedPart::HelperText {
+                field_id: String::default(),
+            },
+        ]
+    );
+}
+
+#[test]
+fn component_part_derive_handles_acronyms_and_digits_in_kebab_case() {
+    assert_eq!(NamingPart::URLField.name(), "url-field");
+    assert_eq!(NamingPart::HTMLInput.name(), "html-input");
+    assert_eq!(NamingPart::Step2Label.name(), "step2-label");
+}
+
+#[test]
+fn component_part_derive_preserves_declaration_order_in_all() {
+    assert_eq!(
+        OrderedPart::all(),
+        vec![
+            OrderedPart::Root,
+            OrderedPart::Gamma,
+            OrderedPart::Alpha,
+            OrderedPart::Beta(String::new()),
+            OrderedPart::Delta { id: String::new() },
+        ]
+    );
+}
+
+#[test]
+fn derive_contract_ui_tests() {
+    let cases = trybuild::TestCases::new();
+    cases.compile_fail("tests/ui/*.rs");
+}

--- a/crates/ars-core/tests/ui/component_part_missing_scope.rs
+++ b/crates/ars-core/tests/ui/component_part_missing_scope.rs
@@ -1,0 +1,9 @@
+use ars_core::ComponentPart;
+
+#[derive(ComponentPart)]
+enum Part {
+    Root,
+    Trigger,
+}
+
+fn main() {}

--- a/crates/ars-core/tests/ui/component_part_missing_scope.stderr
+++ b/crates/ars-core/tests/ui/component_part_missing_scope.stderr
@@ -1,0 +1,7 @@
+error: ComponentPart requires a #[scope = "kebab-case-name"] attribute
+ --> tests/ui/component_part_missing_scope.rs:3:10
+  |
+3 | #[derive(ComponentPart)]
+  |          ^^^^^^^^^^^^^
+  |
+  = note: this error originates in the derive macro `ComponentPart` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/ars-core/tests/ui/component_part_non_root.rs
+++ b/crates/ars-core/tests/ui/component_part_non_root.rs
@@ -1,0 +1,10 @@
+use ars_core::ComponentPart;
+
+#[derive(ComponentPart)]
+#[scope = "dialog"]
+enum Part {
+    Trigger,
+    Root,
+}
+
+fn main() {}

--- a/crates/ars-core/tests/ui/component_part_non_root.stderr
+++ b/crates/ars-core/tests/ui/component_part_non_root.stderr
@@ -1,0 +1,5 @@
+error: ComponentPart requires the first variant to be `Root`
+ --> tests/ui/component_part_non_root.rs:6:5
+  |
+6 |     Trigger,
+  |     ^^^^^^^

--- a/crates/ars-core/tests/ui/component_part_on_struct.rs
+++ b/crates/ars-core/tests/ui/component_part_on_struct.rs
@@ -1,0 +1,6 @@
+use ars_core::ComponentPart;
+
+#[derive(ComponentPart)]
+struct Part;
+
+fn main() {}

--- a/crates/ars-core/tests/ui/component_part_on_struct.stderr
+++ b/crates/ars-core/tests/ui/component_part_on_struct.stderr
@@ -1,0 +1,5 @@
+error: ComponentPart can only be derived for enums
+ --> tests/ui/component_part_on_struct.rs:4:1
+  |
+4 | struct Part;
+  | ^^^^^^^^^^^^

--- a/crates/ars-core/tests/ui/component_part_root_not_unit.rs
+++ b/crates/ars-core/tests/ui/component_part_root_not_unit.rs
@@ -1,0 +1,10 @@
+use ars_core::ComponentPart;
+
+#[derive(ComponentPart)]
+#[scope = "dialog"]
+enum Part {
+    Root(String),
+    Trigger,
+}
+
+fn main() {}

--- a/crates/ars-core/tests/ui/component_part_root_not_unit.stderr
+++ b/crates/ars-core/tests/ui/component_part_root_not_unit.stderr
@@ -1,0 +1,5 @@
+error: ComponentPart requires `Root` to be a unit variant
+ --> tests/ui/component_part_root_not_unit.rs:6:5
+  |
+6 |     Root(String),
+  |     ^^^^^^^^^^^^

--- a/crates/ars-core/tests/ui/component_part_scope_not_string.rs
+++ b/crates/ars-core/tests/ui/component_part_scope_not_string.rs
@@ -1,0 +1,9 @@
+use ars_core::ComponentPart;
+
+#[derive(ComponentPart)]
+#[scope = 123]
+enum Part {
+    Root,
+}
+
+fn main() {}

--- a/crates/ars-core/tests/ui/component_part_scope_not_string.stderr
+++ b/crates/ars-core/tests/ui/component_part_scope_not_string.stderr
@@ -1,0 +1,5 @@
+error: ComponentPart requires a #[scope = "kebab-case-name"] attribute
+ --> tests/ui/component_part_scope_not_string.rs:4:1
+  |
+4 | #[scope = 123]
+  | ^^^^^^^^^^^^^^

--- a/crates/ars-core/tests/ui/has_id_missing_id.rs
+++ b/crates/ars-core/tests/ui/has_id_missing_id.rs
@@ -1,0 +1,8 @@
+use ars_core::HasId;
+
+#[derive(HasId)]
+struct Props {
+    pub label: String,
+}
+
+fn main() {}

--- a/crates/ars-core/tests/ui/has_id_missing_id.stderr
+++ b/crates/ars-core/tests/ui/has_id_missing_id.stderr
@@ -1,0 +1,7 @@
+error: HasId requires a field named `id` of type String
+ --> tests/ui/has_id_missing_id.rs:4:1
+  |
+4 | / struct Props {
+5 | |     pub label: String,
+6 | | }
+  | |_^

--- a/crates/ars-core/tests/ui/has_id_on_enum.rs
+++ b/crates/ars-core/tests/ui/has_id_on_enum.rs
@@ -1,0 +1,8 @@
+use ars_core::HasId;
+
+#[derive(HasId)]
+enum Props {
+    Root,
+}
+
+fn main() {}

--- a/crates/ars-core/tests/ui/has_id_on_enum.stderr
+++ b/crates/ars-core/tests/ui/has_id_on_enum.stderr
@@ -1,0 +1,7 @@
+error: HasId can only be derived for structs
+ --> tests/ui/has_id_on_enum.rs:4:1
+  |
+4 | / enum Props {
+5 | |     Root,
+6 | | }
+  | |_^

--- a/crates/ars-core/tests/ui/has_id_on_tuple_struct.rs
+++ b/crates/ars-core/tests/ui/has_id_on_tuple_struct.rs
@@ -1,0 +1,6 @@
+use ars_core::HasId;
+
+#[derive(HasId)]
+struct Props(String);
+
+fn main() {}

--- a/crates/ars-core/tests/ui/has_id_on_tuple_struct.stderr
+++ b/crates/ars-core/tests/ui/has_id_on_tuple_struct.stderr
@@ -1,0 +1,5 @@
+error: HasId requires a field named `id` of type String
+ --> tests/ui/has_id_on_tuple_struct.rs:4:1
+  |
+4 | struct Props(String);
+  | ^^^^^^^^^^^^^^^^^^^^^

--- a/crates/ars-core/tests/ui/has_id_on_unit_struct.rs
+++ b/crates/ars-core/tests/ui/has_id_on_unit_struct.rs
@@ -1,0 +1,6 @@
+use ars_core::HasId;
+
+#[derive(HasId)]
+struct Props;
+
+fn main() {}

--- a/crates/ars-core/tests/ui/has_id_on_unit_struct.stderr
+++ b/crates/ars-core/tests/ui/has_id_on_unit_struct.stderr
@@ -1,0 +1,5 @@
+error: HasId requires a field named `id` of type String
+ --> tests/ui/has_id_on_unit_struct.rs:4:1
+  |
+4 | struct Props;
+  | ^^^^^^^^^^^^^

--- a/crates/ars-core/tests/ui/has_id_private_id.rs
+++ b/crates/ars-core/tests/ui/has_id_private_id.rs
@@ -1,0 +1,8 @@
+use ars_core::HasId;
+
+#[derive(HasId)]
+struct Props {
+    id: String,
+}
+
+fn main() {}

--- a/crates/ars-core/tests/ui/has_id_private_id.stderr
+++ b/crates/ars-core/tests/ui/has_id_private_id.stderr
@@ -1,0 +1,7 @@
+error: HasId: `id` field must be public
+ --> tests/ui/has_id_private_id.rs:3:10
+  |
+3 | #[derive(HasId)]
+  |          ^^^^^
+  |
+  = note: this error originates in the derive macro `HasId` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/ars-core/tests/ui/has_id_wrong_type.rs
+++ b/crates/ars-core/tests/ui/has_id_wrong_type.rs
@@ -1,0 +1,8 @@
+use ars_core::HasId;
+
+#[derive(HasId)]
+struct Props {
+    pub id: u64,
+}
+
+fn main() {}

--- a/crates/ars-core/tests/ui/has_id_wrong_type.stderr
+++ b/crates/ars-core/tests/ui/has_id_wrong_type.stderr
@@ -1,0 +1,5 @@
+error: HasId: `id` field must be of type String
+ --> tests/ui/has_id_wrong_type.rs:5:13
+  |
+5 |     pub id: u64,
+  |             ^^^

--- a/crates/ars-derive/Cargo.toml
+++ b/crates/ars-derive/Cargo.toml
@@ -10,5 +10,11 @@ rust-version.workspace = true
 [lib]
 proc-macro = true
 
+[dependencies]
+heck        = "0.5"
+proc-macro2 = "1"
+quote       = "1"
+syn         = { version = "2", features = ["full"] }
+
 [lints]
 workspace = true

--- a/crates/ars-derive/src/lib.rs
+++ b/crates/ars-derive/src/lib.rs
@@ -3,22 +3,533 @@
 //! Provides `#[derive(HasId)]` and `#[derive(ComponentPart)]` to generate
 //! boilerplate trait implementations for component ID access and DOM part enums.
 
+use heck::ToKebabCase as _;
 use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::{format_ident, quote};
+use syn::{
+    Data, DeriveInput, Expr, Fields, Generics, Ident, Lit, LitStr, Meta, Type, Variant, Visibility,
+    parse_macro_input, parse_quote,
+};
 
 /// Derives the `HasId` trait for a struct with a `pub id: String` field.
 ///
 /// Generates `id()`, `with_id()`, and `set_id()` methods for typed access
-/// to the component's DOM identifier.
+/// to the component's DOM identifier. Generated code uses hidden
+/// `::ars_core::__private` re-exports so downstream crates do not need to
+/// import `alloc` just to use the derive.
 #[proc_macro_derive(HasId)]
-pub fn derive_has_id(_input: TokenStream) -> TokenStream {
-    TokenStream::new()
+pub fn derive_has_id(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    match expand_has_id(&input) {
+        Ok(tokens) => tokens.into(),
+        Err(error) => error.to_compile_error().into(),
+    }
 }
 
 /// Derives the [`ComponentPart`](ars_core::ComponentPart) trait for a part enum.
 ///
-/// Generates `root()`, `name()`, and `all()` methods. Use `#[scope = "component-name"]`
-/// on the enum to set the component namespace for data attribute generation.
-#[proc_macro_derive(ComponentPart)]
-pub fn derive_component_part(_input: TokenStream) -> TokenStream {
-    TokenStream::new()
+/// Generates `ROOT`, `scope()`, `name()`, and `all()` methods. Use
+/// `#[scope = "component-name"]` on the enum to set the component namespace
+/// for data attribute generation. Generated code uses hidden
+/// `::ars_core::__private` re-exports so downstream crates do not need to
+/// import `alloc` just to use the derive.
+#[proc_macro_derive(ComponentPart, attributes(scope))]
+pub fn derive_component_part(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    match expand_component_part(&input) {
+        Ok(tokens) => tokens.into(),
+        Err(error) => error.to_compile_error().into(),
+    }
+}
+
+fn expand_has_id(input: &DeriveInput) -> syn::Result<TokenStream2> {
+    let Data::Struct(data) = &input.data else {
+        return Err(syn::Error::new_spanned(
+            input,
+            "HasId can only be derived for structs",
+        ));
+    };
+
+    let id_field = find_id_field(data).ok_or_else(|| {
+        syn::Error::new_spanned(input, "HasId requires a field named `id` of type String")
+    })?;
+
+    if !is_string_type(&id_field.ty) {
+        return Err(syn::Error::new_spanned(
+            &id_field.ty,
+            "HasId: `id` field must be of type String",
+        ));
+    }
+
+    if !matches!(id_field.vis, Visibility::Public(_)) {
+        return Err(syn::Error::new_spanned(
+            &id_field.vis,
+            "HasId: `id` field must be public",
+        ));
+    }
+
+    let name = &input.ident;
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+    Ok(quote! {
+        impl #impl_generics ::ars_core::HasId for #name #ty_generics #where_clause {
+            fn id(&self) -> &str {
+                &self.id
+            }
+
+            fn with_id(self, id: ::ars_core::__private::String) -> Self {
+                Self { id, ..self }
+            }
+
+            fn set_id(&mut self, id: ::ars_core::__private::String) {
+                self.id = id;
+            }
+        }
+    })
+}
+
+fn expand_component_part(input: &DeriveInput) -> syn::Result<TokenStream2> {
+    let Data::Enum(data) = &input.data else {
+        return Err(syn::Error::new_spanned(
+            input,
+            "ComponentPart can only be derived for enums",
+        ));
+    };
+
+    let scope = find_scope_attr(&input.attrs)?;
+    validate_root_variant(data)?;
+
+    let name = &input.ident;
+    let field_types = collect_field_types(data);
+
+    let component_part_generics = with_field_bounds(
+        &input.generics,
+        &field_types,
+        &[
+            quote!(::core::clone::Clone),
+            quote!(::core::fmt::Debug),
+            quote!(::core::cmp::PartialEq),
+            quote!(::core::cmp::Eq),
+            quote!(::core::hash::Hash),
+            quote!(::core::default::Default),
+        ],
+    );
+    let clone_generics = with_field_bounds(
+        &input.generics,
+        &field_types,
+        &[quote!(::core::clone::Clone)],
+    );
+    let debug_generics =
+        with_field_bounds(&input.generics, &field_types, &[quote!(::core::fmt::Debug)]);
+    let partial_eq_generics = with_field_bounds(
+        &input.generics,
+        &field_types,
+        &[quote!(::core::cmp::PartialEq)],
+    );
+    let eq_generics = with_field_bounds(&input.generics, &field_types, &[quote!(::core::cmp::Eq)]);
+    let hash_generics =
+        with_field_bounds(&input.generics, &field_types, &[quote!(::core::hash::Hash)]);
+
+    let (component_part_impl_generics, component_part_ty_generics, component_part_where_clause) =
+        component_part_generics.split_for_impl();
+    let (clone_impl_generics, clone_ty_generics, clone_where_clause) =
+        clone_generics.split_for_impl();
+    let (debug_impl_generics, debug_ty_generics, debug_where_clause) =
+        debug_generics.split_for_impl();
+    let (partial_eq_impl_generics, partial_eq_ty_generics, partial_eq_where_clause) =
+        partial_eq_generics.split_for_impl();
+    let (eq_impl_generics, eq_ty_generics, eq_where_clause) = eq_generics.split_for_impl();
+    let (hash_impl_generics, hash_ty_generics, hash_where_clause) = hash_generics.split_for_impl();
+
+    let name_arms = data.variants.iter().map(name_arm);
+    let all_values = data.variants.iter().map(all_value);
+    let clone_arms = data.variants.iter().map(clone_arm);
+    let debug_arms = data.variants.iter().map(debug_arm);
+    let partial_eq_arms = data
+        .variants
+        .iter()
+        .enumerate()
+        .map(|(index, variant)| partial_eq_arm(index, variant));
+    let hash_arms = data
+        .variants
+        .iter()
+        .enumerate()
+        .map(|(index, variant)| hash_arm(index, variant));
+
+    Ok(quote! {
+        impl #component_part_impl_generics ::ars_core::ComponentPart for #name #component_part_ty_generics #component_part_where_clause {
+            const ROOT: Self = Self::Root;
+
+            fn scope() -> &'static str {
+                #scope
+            }
+
+            fn name(&self) -> &'static str {
+                match self {
+                    #(#name_arms),*
+                }
+            }
+
+            fn all() -> ::ars_core::__private::Vec<Self> {
+                ::ars_core::__private::Vec::from([#(#all_values),*])
+            }
+        }
+
+        impl #clone_impl_generics ::core::clone::Clone for #name #clone_ty_generics #clone_where_clause {
+            fn clone(&self) -> Self {
+                match self {
+                    #(#clone_arms),*
+                }
+            }
+        }
+
+        impl #debug_impl_generics ::core::fmt::Debug for #name #debug_ty_generics #debug_where_clause {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+                match self {
+                    #(#debug_arms),*
+                }
+            }
+        }
+
+        impl #partial_eq_impl_generics ::core::cmp::PartialEq for #name #partial_eq_ty_generics #partial_eq_where_clause {
+            fn eq(&self, other: &Self) -> bool {
+                match (self, other) {
+                    #(#partial_eq_arms),*,
+                    _ => false,
+                }
+            }
+        }
+
+        impl #eq_impl_generics ::core::cmp::Eq for #name #eq_ty_generics #eq_where_clause {}
+
+        impl #hash_impl_generics ::core::hash::Hash for #name #hash_ty_generics #hash_where_clause {
+            fn hash<H: ::core::hash::Hasher>(&self, state: &mut H) {
+                match self {
+                    #(#hash_arms),*
+                }
+            }
+        }
+    })
+}
+
+fn find_id_field(data: &syn::DataStruct) -> Option<&syn::Field> {
+    let Fields::Named(fields) = &data.fields else {
+        return None;
+    };
+
+    fields
+        .named
+        .iter()
+        .find(|field| field.ident.as_ref().is_some_and(|ident| ident == "id"))
+}
+
+fn find_scope_attr(attrs: &[syn::Attribute]) -> syn::Result<LitStr> {
+    for attr in attrs {
+        if !attr.path().is_ident("scope") {
+            continue;
+        }
+
+        let Meta::NameValue(name_value) = &attr.meta else {
+            break;
+        };
+        let Expr::Lit(expr_lit) = &name_value.value else {
+            break;
+        };
+        let Lit::Str(scope) = &expr_lit.lit else {
+            break;
+        };
+
+        return Ok(scope.clone());
+    }
+
+    Err(syn::Error::new_spanned(
+        attrs.first().map_or_else(
+            proc_macro2::TokenStream::new,
+            quote::ToTokens::to_token_stream,
+        ),
+        "ComponentPart requires a #[scope = \"kebab-case-name\"] attribute",
+    ))
+}
+
+fn validate_root_variant(data: &syn::DataEnum) -> syn::Result<()> {
+    let Some(first_variant) = data.variants.first() else {
+        return Err(syn::Error::new_spanned(
+            data.enum_token,
+            "ComponentPart requires the first variant to be `Root`",
+        ));
+    };
+
+    if first_variant.ident != "Root" {
+        return Err(syn::Error::new_spanned(
+            &first_variant.ident,
+            "ComponentPart requires the first variant to be `Root`",
+        ));
+    }
+
+    if !matches!(first_variant.fields, Fields::Unit) {
+        return Err(syn::Error::new_spanned(
+            first_variant,
+            "ComponentPart requires `Root` to be a unit variant",
+        ));
+    }
+
+    Ok(())
+}
+
+fn is_string_type(ty: &Type) -> bool {
+    let Type::Path(type_path) = ty else {
+        return false;
+    };
+
+    type_path.qself.is_none()
+        && type_path
+            .path
+            .segments
+            .last()
+            .is_some_and(|segment| segment.ident == "String" && segment.arguments.is_empty())
+}
+
+fn collect_field_types(data: &syn::DataEnum) -> Vec<Type> {
+    data.variants
+        .iter()
+        .flat_map(|variant| match &variant.fields {
+            Fields::Unit => Vec::new(),
+            Fields::Unnamed(fields) => fields
+                .unnamed
+                .iter()
+                .map(|field| field.ty.clone())
+                .collect(),
+            Fields::Named(fields) => fields.named.iter().map(|field| field.ty.clone()).collect(),
+        })
+        .collect()
+}
+
+fn with_field_bounds(
+    generics: &Generics,
+    field_types: &[Type],
+    bounds: &[TokenStream2],
+) -> Generics {
+    let mut generics = generics.clone();
+    let where_clause = generics.make_where_clause();
+
+    for field_ty in field_types {
+        for bound in bounds {
+            where_clause
+                .predicates
+                .push(parse_quote!(#field_ty: #bound));
+        }
+    }
+
+    generics
+}
+
+fn name_arm(variant: &Variant) -> TokenStream2 {
+    let ident = &variant.ident;
+    let name = LitStr::new(&ident.to_string().to_kebab_case(), ident.span());
+
+    match &variant.fields {
+        Fields::Unit => quote!(Self::#ident => #name),
+        Fields::Unnamed(_) => quote!(Self::#ident(..) => #name),
+        Fields::Named(_) => quote!(Self::#ident { .. } => #name),
+    }
+}
+
+fn all_value(variant: &Variant) -> TokenStream2 {
+    let ident = &variant.ident;
+
+    match &variant.fields {
+        Fields::Unit => quote!(Self::#ident),
+        Fields::Unnamed(fields) => {
+            let defaults = fields
+                .unnamed
+                .iter()
+                .map(|_| quote!(::core::default::Default::default()));
+            quote!(Self::#ident(#(#defaults),*))
+        }
+        Fields::Named(fields) => {
+            let defaults = fields.named.iter().map(|field| {
+                let ident = field.ident.as_ref().expect("named field");
+                quote!(#ident: ::core::default::Default::default())
+            });
+            quote!(Self::#ident { #(#defaults),* })
+        }
+    }
+}
+
+fn clone_arm(variant: &Variant) -> TokenStream2 {
+    let ident = &variant.ident;
+
+    match &variant.fields {
+        Fields::Unit => quote!(Self::#ident => Self::#ident),
+        Fields::Unnamed(fields) => {
+            let bindings: Vec<_> = (0..fields.unnamed.len())
+                .map(|index| format_ident!("field_{index}"))
+                .collect();
+            let clones = bindings
+                .iter()
+                .map(|binding| quote!(::core::clone::Clone::clone(#binding)));
+
+            quote!(Self::#ident(#(#bindings),*) => Self::#ident(#(#clones),*))
+        }
+        Fields::Named(fields) => {
+            let bindings: Vec<_> = fields
+                .named
+                .iter()
+                .map(|field| field.ident.as_ref().expect("named field").clone())
+                .collect();
+            let clones = bindings
+                .iter()
+                .map(|binding| quote!(#binding: ::core::clone::Clone::clone(#binding)));
+
+            quote!(Self::#ident { #(#bindings),* } => Self::#ident { #(#clones),* })
+        }
+    }
+}
+
+fn debug_arm(variant: &Variant) -> TokenStream2 {
+    let ident = &variant.ident;
+    let debug_name = LitStr::new(&ident.to_string(), ident.span());
+
+    match &variant.fields {
+        Fields::Unit => quote!(Self::#ident => f.write_str(#debug_name)),
+        Fields::Unnamed(fields) => {
+            let bindings: Vec<_> = (0..fields.unnamed.len())
+                .map(|index| format_ident!("field_{index}"))
+                .collect();
+            let field_calls = bindings
+                .iter()
+                .map(|binding| quote!(debug.field(#binding);));
+
+            quote! {
+                Self::#ident(#(#bindings),*) => {
+                    let mut debug = f.debug_tuple(#debug_name);
+                    #(#field_calls)*
+                    debug.finish()
+                }
+            }
+        }
+        Fields::Named(fields) => {
+            let bindings: Vec<_> = fields
+                .named
+                .iter()
+                .map(|field| field.ident.as_ref().expect("named field").clone())
+                .collect();
+            let field_calls = bindings.iter().map(|binding| {
+                let name = LitStr::new(&binding.to_string(), binding.span());
+                quote!(debug.field(#name, #binding);)
+            });
+
+            quote! {
+                Self::#ident { #(#bindings),* } => {
+                    let mut debug = f.debug_struct(#debug_name);
+                    #(#field_calls)*
+                    debug.finish()
+                }
+            }
+        }
+    }
+}
+
+fn partial_eq_arm(_index: usize, variant: &Variant) -> TokenStream2 {
+    let ident = &variant.ident;
+
+    match &variant.fields {
+        Fields::Unit => quote!((Self::#ident, Self::#ident) => true),
+        Fields::Unnamed(fields) => {
+            let lefts: Vec<_> = (0..fields.unnamed.len())
+                .map(|index| format_ident!("left_{index}"))
+                .collect();
+            let rights: Vec<_> = (0..fields.unnamed.len())
+                .map(|index| format_ident!("right_{index}"))
+                .collect();
+            let comparisons = lefts
+                .iter()
+                .zip(rights.iter())
+                .map(|(left, right)| quote!(#left == #right));
+
+            quote!((Self::#ident(#(#lefts),*), Self::#ident(#(#rights),*)) => true #(&& #comparisons)*)
+        }
+        Fields::Named(fields) => {
+            let lefts: Vec<_> = fields
+                .named
+                .iter()
+                .map(|field| format_ident!("left_{}", field.ident.as_ref().expect("named field")))
+                .collect();
+            let rights: Vec<_> = fields
+                .named
+                .iter()
+                .map(|field| format_ident!("right_{}", field.ident.as_ref().expect("named field")))
+                .collect();
+            let left_pattern = fields.named.iter().zip(lefts.iter()).map(|(field, left)| {
+                let ident = field.ident.as_ref().expect("named field");
+                quote!(#ident: #left)
+            });
+            let right_pattern = fields
+                .named
+                .iter()
+                .zip(rights.iter())
+                .map(|(field, right)| {
+                    let ident = field.ident.as_ref().expect("named field");
+                    quote!(#ident: #right)
+                });
+            let comparisons = lefts
+                .iter()
+                .zip(rights.iter())
+                .map(|(left, right)| quote!(#left == #right));
+
+            quote! {
+                (
+                    Self::#ident { #(#left_pattern),* },
+                    Self::#ident { #(#right_pattern),* }
+                ) => true #(&& #comparisons)*
+            }
+        }
+    }
+}
+
+fn hash_arm(index: usize, variant: &Variant) -> TokenStream2 {
+    let ident = &variant.ident;
+
+    match &variant.fields {
+        Fields::Unit => quote! {
+            Self::#ident => {
+                ::core::hash::Hash::hash(&#index, state);
+            }
+        },
+        Fields::Unnamed(fields) => {
+            let bindings: Vec<_> = (0..fields.unnamed.len())
+                .map(|field_index| format_ident!("field_{field_index}"))
+                .collect();
+            let hashes = bindings
+                .iter()
+                .map(|binding| quote!(::core::hash::Hash::hash(#binding, state);));
+
+            quote! {
+                Self::#ident(#(#bindings),*) => {
+                    ::core::hash::Hash::hash(&#index, state);
+                    #(#hashes)*
+                }
+            }
+        }
+        Fields::Named(fields) => {
+            let bindings: Vec<Ident> = fields
+                .named
+                .iter()
+                .map(|field| field.ident.as_ref().expect("named field").clone())
+                .collect();
+            let hashes = bindings
+                .iter()
+                .map(|binding| quote!(::core::hash::Hash::hash(#binding, state);));
+
+            quote! {
+                Self::#ident { #(#bindings),* } => {
+                    ::core::hash::Hash::hash(&#index, state);
+                    #(#hashes)*
+                }
+            }
+        }
+    }
 }

--- a/crates/ars-dioxus/src/use_machine.rs
+++ b/crates/ars-dioxus/src/use_machine.rs
@@ -284,7 +284,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use ars_core::{AriaAttr, AttrMap, ComponentPart, ConnectApi, HtmlAttr, TransitionPlan};
+    use ars_core::{AriaAttr, AttrMap, ComponentPart, ConnectApi, HasId, HtmlAttr, TransitionPlan};
 
     use super::*;
 
@@ -305,14 +305,32 @@ mod tests {
     struct ToggleContext;
 
     #[derive(Clone, Debug, PartialEq, Eq)]
-    struct ToggleProps;
+    struct ToggleProps {
+        id: String,
+    }
+
+    impl HasId for ToggleProps {
+        fn id(&self) -> &str {
+            &self.id
+        }
+
+        fn with_id(self, id: String) -> Self {
+            Self { id }
+        }
+
+        fn set_id(&mut self, id: String) {
+            self.id = id;
+        }
+    }
 
     #[derive(Clone, Debug, PartialEq, Eq, Hash)]
     struct TogglePart;
 
     impl ComponentPart for TogglePart {
-        fn root() -> Self {
-            Self
+        const ROOT: Self = Self;
+
+        fn scope() -> &'static str {
+            "toggle"
         }
 
         fn name(&self) -> &'static str {
@@ -389,7 +407,9 @@ mod tests {
     #[test]
     fn use_machine_creates_service_with_initial_state() {
         fn app() -> Element {
-            let machine = use_machine::<ToggleMachine>(ToggleProps);
+            let machine = use_machine::<ToggleMachine>(ToggleProps {
+                id: String::from("toggle"),
+            });
 
             // Initial state should be Off
             assert_eq!(*machine.state.peek(), ToggleState::Off);
@@ -407,7 +427,9 @@ mod tests {
     #[test]
     fn use_machine_send_updates_state() {
         fn app() -> Element {
-            let machine = use_machine::<ToggleMachine>(ToggleProps);
+            let machine = use_machine::<ToggleMachine>(ToggleProps {
+                id: String::from("toggle"),
+            });
 
             assert_eq!(*machine.state.peek(), ToggleState::Off);
 
@@ -427,7 +449,9 @@ mod tests {
     #[test]
     fn with_api_snapshot_reads_current_state() {
         fn app() -> Element {
-            let machine = use_machine::<ToggleMachine>(ToggleProps);
+            let machine = use_machine::<ToggleMachine>(ToggleProps {
+                id: String::from("toggle"),
+            });
 
             let is_on = machine.with_api_snapshot(|api| api.is_on);
             assert!(!is_on);
@@ -447,7 +471,9 @@ mod tests {
     #[test]
     fn context_version_increments_on_transition() {
         fn app() -> Element {
-            let machine = use_machine::<ToggleMachine>(ToggleProps);
+            let machine = use_machine::<ToggleMachine>(ToggleProps {
+                id: String::from("toggle"),
+            });
 
             assert_eq!(*machine.context_version.peek(), 0);
 

--- a/crates/ars-leptos/src/use_machine.rs
+++ b/crates/ars-leptos/src/use_machine.rs
@@ -286,7 +286,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use ars_core::{AriaAttr, AttrMap, ComponentPart, ConnectApi, HtmlAttr, TransitionPlan};
+    use ars_core::{AriaAttr, AttrMap, ComponentPart, ConnectApi, HasId, HtmlAttr, TransitionPlan};
 
     use super::*;
 
@@ -307,14 +307,32 @@ mod tests {
     struct ToggleContext;
 
     #[derive(Clone, Debug, PartialEq, Eq)]
-    struct ToggleProps;
+    struct ToggleProps {
+        id: String,
+    }
+
+    impl HasId for ToggleProps {
+        fn id(&self) -> &str {
+            &self.id
+        }
+
+        fn with_id(self, id: String) -> Self {
+            Self { id }
+        }
+
+        fn set_id(&mut self, id: String) {
+            self.id = id;
+        }
+    }
 
     #[derive(Clone, Debug, PartialEq, Eq, Hash)]
     struct TogglePart;
 
     impl ComponentPart for TogglePart {
-        fn root() -> Self {
-            Self
+        const ROOT: Self = Self;
+
+        fn scope() -> &'static str {
+            "toggle"
         }
 
         fn name(&self) -> &'static str {
@@ -393,7 +411,9 @@ mod tests {
         // Test use_machine within a Leptos reactive Owner.
         let owner = Owner::new();
         owner.with(|| {
-            let machine = use_machine::<ToggleMachine>(ToggleProps);
+            let machine = use_machine::<ToggleMachine>(ToggleProps {
+                id: String::from("toggle"),
+            });
 
             // Initial state should be Off
             assert_eq!(machine.state.get_untracked(), ToggleState::Off);
@@ -407,7 +427,9 @@ mod tests {
     fn use_machine_send_updates_state() {
         let owner = Owner::new();
         owner.with(|| {
-            let machine = use_machine::<ToggleMachine>(ToggleProps);
+            let machine = use_machine::<ToggleMachine>(ToggleProps {
+                id: String::from("toggle"),
+            });
 
             assert_eq!(machine.state.get_untracked(), ToggleState::Off);
 
@@ -423,7 +445,9 @@ mod tests {
     fn with_api_snapshot_reads_current_state() {
         let owner = Owner::new();
         owner.with(|| {
-            let machine = use_machine::<ToggleMachine>(ToggleProps);
+            let machine = use_machine::<ToggleMachine>(ToggleProps {
+                id: String::from("toggle"),
+            });
 
             let is_on = machine.with_api_snapshot(|api| api.is_on);
             assert!(!is_on);
@@ -439,7 +463,9 @@ mod tests {
     fn context_version_increments_on_transition() {
         let owner = Owner::new();
         owner.with(|| {
-            let machine = use_machine::<ToggleMachine>(ToggleProps);
+            let machine = use_machine::<ToggleMachine>(ToggleProps {
+                id: String::from("toggle"),
+            });
 
             assert_eq!(machine.context_version.get_untracked(), 0);
 


### PR DESCRIPTION
## Summary
- add the spec-compliant `HasId` trait and align `ComponentPart` with the architecture contract in `ars-core`
- implement and re-export `HasId` and `ComponentPart` derive macros with exact validation diagnostics and consumer-safe path generation
- add positive and UI-failure coverage for derives, including generics, lifetimes, declaration order, kebab-case behavior, and invalid targets

## Why
Issue #35 closes the contract gap between the architecture spec and the current implementation for component IDs and component-part derivation. This also removes the need for downstream crates to import `alloc` just to use the derives.

## Impact
- `Machine::Props` now requires `HasId`
- downstream `ars-core` consumers can use `#[derive(HasId, ComponentPart)]` via `ars_core`
- derive failures now surface spec-aligned diagnostics for invalid inputs

## Validation
- `cargo test -p ars-core -- --nocapture`
- `cargo test -p ars-leptos --lib -- --nocapture`
- `cargo test -p ars-dioxus --lib -- --nocapture`

Closes #35