### PR TITLE
[codex] Introduce shared modality context

### DIFF
--- a/crates/ars-a11y/src/aria/role.rs
+++ b/crates/ars-a11y/src/aria/role.rs
@@ -493,13 +493,130 @@ mod tests {
     use super::*;
 
     #[test]
+    fn abstract_roles_report_expected_names_and_no_dom_value() {
+        let cases = [
+            (AriaRole::Command, "Command"),
+            (AriaRole::Composite, "Composite"),
+            (AriaRole::Input, "Input"),
+            (AriaRole::Landmark, "Landmark"),
+            (AriaRole::Range, "Range"),
+            (AriaRole::RoleType, "RoleType"),
+            (AriaRole::Section, "Section"),
+            (AriaRole::SectionHead, "SectionHead"),
+            (AriaRole::Select, "Select"),
+            (AriaRole::Structure, "Structure"),
+            (AriaRole::Widget, "Widget"),
+            (AriaRole::Window, "Window"),
+        ];
+
+        for (role, name) in cases {
+            assert_eq!(role.to_attr_value(), None);
+            assert!(role.is_abstract());
+            assert_eq!(role.name(), name);
+        }
+    }
+
+    #[test]
     fn abstract_role_returns_none() {
         assert!(AriaRole::Command.to_attr_value().is_none());
     }
 
     #[test]
-    fn concrete_role_returns_value() {
-        assert_eq!(AriaRole::Button.to_attr_value().unwrap(), "button");
+    fn concrete_roles_round_trip_to_dom_names() {
+        let cases = [
+            (AriaRole::Alertdialog, "alertdialog"),
+            (AriaRole::Dialog, "dialog"),
+            (AriaRole::Button, "button"),
+            (AriaRole::Checkbox, "checkbox"),
+            (AriaRole::Gridcell, "gridcell"),
+            (AriaRole::Link, "link"),
+            (AriaRole::Menuitem, "menuitem"),
+            (AriaRole::Menuitemcheckbox, "menuitemcheckbox"),
+            (AriaRole::Menuitemradio, "menuitemradio"),
+            (AriaRole::Option, "option"),
+            (AriaRole::Progressbar, "progressbar"),
+            (AriaRole::Radio, "radio"),
+            (AriaRole::Scrollbar, "scrollbar"),
+            (AriaRole::Searchbox, "searchbox"),
+            (AriaRole::Separator, "separator"),
+            (AriaRole::Slider, "slider"),
+            (AriaRole::Spinbutton, "spinbutton"),
+            (AriaRole::Switch, "switch"),
+            (AriaRole::Tab, "tab"),
+            (AriaRole::Tabpanel, "tabpanel"),
+            (AriaRole::Textbox, "textbox"),
+            (AriaRole::Treeitem, "treeitem"),
+            (AriaRole::Combobox, "combobox"),
+            (AriaRole::Grid, "grid"),
+            (AriaRole::Listbox, "listbox"),
+            (AriaRole::Menu, "menu"),
+            (AriaRole::Menubar, "menubar"),
+            (AriaRole::Radiogroup, "radiogroup"),
+            (AriaRole::Tablist, "tablist"),
+            (AriaRole::Tree, "tree"),
+            (AriaRole::Treegrid, "treegrid"),
+            (AriaRole::Application, "application"),
+            (AriaRole::Article, "article"),
+            (AriaRole::BlockQuote, "blockquote"),
+            (AriaRole::Caption, "caption"),
+            (AriaRole::Cell, "cell"),
+            (AriaRole::Code, "code"),
+            (AriaRole::Columnheader, "columnheader"),
+            (AriaRole::Comment, "comment"),
+            (AriaRole::Definition, "definition"),
+            (AriaRole::Deletion, "deletion"),
+            (AriaRole::Directory, "directory"),
+            (AriaRole::Document, "document"),
+            (AriaRole::Emphasis, "emphasis"),
+            (AriaRole::Feed, "feed"),
+            (AriaRole::Figure, "figure"),
+            (AriaRole::Generic, "generic"),
+            (AriaRole::Group, "group"),
+            (AriaRole::Heading, "heading"),
+            (AriaRole::Img, "img"),
+            (AriaRole::Insertion, "insertion"),
+            (AriaRole::List, "list"),
+            (AriaRole::Listitem, "listitem"),
+            (AriaRole::Mark, "mark"),
+            (AriaRole::Math, "math"),
+            (AriaRole::Meter, "meter"),
+            (AriaRole::None, "none"),
+            (AriaRole::Note, "note"),
+            (AriaRole::Paragraph, "paragraph"),
+            (AriaRole::Presentation, "presentation"),
+            (AriaRole::Row, "row"),
+            (AriaRole::Rowgroup, "rowgroup"),
+            (AriaRole::Rowheader, "rowheader"),
+            (AriaRole::Strong, "strong"),
+            (AriaRole::Subscript, "subscript"),
+            (AriaRole::Suggestion, "suggestion"),
+            (AriaRole::Superscript, "superscript"),
+            (AriaRole::Table, "table"),
+            (AriaRole::Term, "term"),
+            (AriaRole::Time, "time"),
+            (AriaRole::Toolbar, "toolbar"),
+            (AriaRole::Tooltip, "tooltip"),
+            (AriaRole::Alert, "alert"),
+            (AriaRole::Log, "log"),
+            (AriaRole::Marquee, "marquee"),
+            (AriaRole::Status, "status"),
+            (AriaRole::Timer, "timer"),
+            (AriaRole::Banner, "banner"),
+            (AriaRole::Complementary, "complementary"),
+            (AriaRole::Contentinfo, "contentinfo"),
+            (AriaRole::Form, "form"),
+            (AriaRole::Main, "main"),
+            (AriaRole::Navigation, "navigation"),
+            (AriaRole::Region, "region"),
+            (AriaRole::Search, "search"),
+            (AriaRole::StructuralSeparator, "separator"),
+        ];
+
+        for (role, value) in cases {
+            assert_eq!(role.to_attr_value(), Some(value));
+            assert!(!role.is_abstract());
+            assert_eq!(role.name(), value);
+        }
     }
 
     #[test]
@@ -526,5 +643,40 @@ mod tests {
         let required = AriaRole::List.required_owned_elements();
         assert_eq!(required.len(), 1);
         assert_eq!(required[0], &[AriaRole::Listitem]);
+    }
+
+    #[test]
+    fn required_owned_elements_cover_composite_patterns() {
+        assert_eq!(
+            AriaRole::Grid.required_owned_elements(),
+            &[&[AriaRole::Row], &[AriaRole::Rowgroup]]
+        );
+        assert_eq!(
+            AriaRole::Listbox.required_owned_elements(),
+            &[&[AriaRole::Option], &[AriaRole::Group]]
+        );
+        assert_eq!(
+            AriaRole::Menu.required_owned_elements(),
+            &[
+                &[AriaRole::Menuitem],
+                &[AriaRole::Menuitemcheckbox],
+                &[AriaRole::Menuitemradio],
+                &[AriaRole::Group],
+            ]
+        );
+        assert_eq!(
+            AriaRole::Row.required_owned_elements(),
+            &[
+                &[AriaRole::Cell],
+                &[AriaRole::Columnheader],
+                &[AriaRole::Gridcell],
+                &[AriaRole::Rowheader],
+            ]
+        );
+        assert_eq!(
+            AriaRole::Tree.required_owned_elements(),
+            &[&[AriaRole::Treeitem], &[AriaRole::Group]]
+        );
+        assert!(AriaRole::Button.required_owned_elements().is_empty());
     }
 }

--- a/crates/ars-a11y/src/focus.rs
+++ b/crates/ars-a11y/src/focus.rs
@@ -1,5 +1,9 @@
 //! Shared focus-management contracts.
 
+use core::cell::Cell;
+
+use ars_core::{AttrMap, AttrValue, HtmlAttr, KeyModifiers, KeyboardKey};
+
 /// Options controlling [`FocusScopeBehavior`] implementations.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct FocusScopeOptions {
@@ -84,6 +88,92 @@ pub enum FocusStrategy {
     RovingTabindex,
     /// Keep DOM focus on the container and expose the active item through `aria-activedescendant`.
     ActiveDescendant,
+}
+
+/// Tracks whether the current focus should render a visible keyboard ring.
+///
+/// `FocusRing` is intentionally separate from the shared modality context: it
+/// owns accessibility-specific focus-visible heuristics while consuming the same
+/// normalized event stream adapters feed into modality tracking.
+#[derive(Clone, Debug, Default)]
+pub struct FocusRing {
+    keyboard_modality: Cell<bool>,
+}
+
+impl FocusRing {
+    /// Creates a new focus-ring tracker with no active keyboard modality.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            keyboard_modality: Cell::new(false),
+        }
+    }
+
+    /// Records a pointer interaction and suppresses keyboard-only focus styling.
+    pub fn on_pointer_down(&self) {
+        self.keyboard_modality.set(false);
+    }
+
+    /// Records a keyboard interaction that implies intentional focus navigation.
+    ///
+    /// Modified key chords using Ctrl, Meta, or Alt are ignored because they
+    /// typically represent browser or operating-system shortcuts rather than
+    /// in-document focus navigation.
+    pub fn on_key_down(&self, key: KeyboardKey, modifiers: KeyModifiers) {
+        if modifiers.ctrl || modifiers.meta || modifiers.alt {
+            return;
+        }
+
+        if matches!(
+            key,
+            KeyboardKey::Tab
+                | KeyboardKey::ArrowUp
+                | KeyboardKey::ArrowDown
+                | KeyboardKey::ArrowLeft
+                | KeyboardKey::ArrowRight
+                | KeyboardKey::Home
+                | KeyboardKey::End
+                | KeyboardKey::PageUp
+                | KeyboardKey::PageDown
+                | KeyboardKey::Enter
+                | KeyboardKey::Space
+                | KeyboardKey::Escape
+                | KeyboardKey::F1
+                | KeyboardKey::F2
+                | KeyboardKey::F3
+                | KeyboardKey::F4
+                | KeyboardKey::F5
+                | KeyboardKey::F6
+                | KeyboardKey::F7
+                | KeyboardKey::F8
+                | KeyboardKey::F9
+                | KeyboardKey::F10
+                | KeyboardKey::F11
+                | KeyboardKey::F12
+        ) {
+            self.keyboard_modality.set(true);
+        }
+    }
+
+    /// Records a virtual or assistive-technology interaction as focus-visible.
+    pub fn on_virtual_input(&self) {
+        self.keyboard_modality.set(true);
+    }
+
+    /// Returns whether the next focused element should render the focus ring.
+    #[must_use]
+    pub fn should_show_focus_ring(&self) -> bool {
+        self.keyboard_modality.get()
+    }
+
+    /// Writes the canonical focus-visible data attribute into an [`AttrMap`].
+    pub fn apply_focus_attrs(&self, attrs: &mut AttrMap, is_focused: bool) {
+        if is_focused && self.should_show_focus_ring() {
+            attrs.set_bool(HtmlAttr::Data("ars-focus-visible"), true);
+        } else {
+            attrs.set(HtmlAttr::Data("ars-focus-visible"), AttrValue::None);
+        }
+    }
 }
 
 #[cfg(test)]
@@ -173,5 +263,59 @@ mod tests {
         assert!(!behavior.is_active());
 
         assert_eq!(scope.last_target, Some(FocusTarget::PreviouslyActive));
+    }
+
+    #[test]
+    fn focus_ring_starts_hidden() {
+        let ring = FocusRing::new();
+        assert!(!ring.should_show_focus_ring());
+    }
+
+    #[test]
+    fn focus_ring_tracks_keyboard_navigation_keys() {
+        let ring = FocusRing::new();
+        ring.on_key_down(KeyboardKey::Tab, KeyModifiers::default());
+        assert!(ring.should_show_focus_ring());
+
+        ring.on_pointer_down();
+        assert!(!ring.should_show_focus_ring());
+
+        ring.on_key_down(
+            KeyboardKey::ArrowRight,
+            KeyModifiers {
+                shift: false,
+                ctrl: true,
+                alt: false,
+                meta: false,
+            },
+        );
+        assert!(!ring.should_show_focus_ring());
+    }
+
+    #[test]
+    fn focus_ring_virtual_input_is_visible() {
+        let ring = FocusRing::new();
+        ring.on_virtual_input();
+        assert!(ring.should_show_focus_ring());
+    }
+
+    #[test]
+    fn apply_focus_attrs_writes_and_clears_attribute() {
+        let ring = FocusRing::new();
+        let mut attrs = AttrMap::new();
+
+        ring.on_pointer_down();
+        ring.apply_focus_attrs(&mut attrs, true);
+        assert_eq!(attrs.get_value(&HtmlAttr::Data("ars-focus-visible")), None);
+
+        ring.on_key_down(KeyboardKey::Enter, KeyModifiers::default());
+        ring.apply_focus_attrs(&mut attrs, true);
+        assert_eq!(
+            attrs.get_value(&HtmlAttr::Data("ars-focus-visible")),
+            Some(&AttrValue::Bool(true))
+        );
+
+        ring.apply_focus_attrs(&mut attrs, false);
+        assert_eq!(attrs.get_value(&HtmlAttr::Data("ars-focus-visible")), None);
     }
 }

--- a/crates/ars-a11y/src/lib.rs
+++ b/crates/ars-a11y/src/lib.rs
@@ -26,7 +26,7 @@ pub use aria::{
     role::AriaRole,
     state::{set_busy, set_checked, set_disabled, set_expanded, set_invalid, set_selected},
 };
-pub use focus::{FocusScopeBehavior, FocusScopeOptions, FocusStrategy, FocusTarget};
+pub use focus::{FocusRing, FocusScopeBehavior, FocusScopeOptions, FocusStrategy, FocusTarget};
 
 /// Custom data attribute used to expose machine state on the root DOM element.
 ///

--- a/crates/ars-core/src/lib.rs
+++ b/crates/ars-core/src/lib.rs
@@ -27,6 +27,7 @@ use core::fmt::{self, Debug};
 
 pub mod companion_css;
 mod connect;
+pub mod modality;
 pub mod platform;
 pub mod provider;
 
@@ -53,10 +54,14 @@ pub use connect::{
     AriaAttr, AttrMap, AttrMapParts, AttrValue, CssProperty, EventOptions, HtmlAttr, HtmlEvent,
     StyleStrategy, UserAttrs, data,
 };
+pub use modality::{
+    DefaultModalityContext, KeyModifiers, KeyboardKey, ModalityContext, ModalitySnapshot,
+    NullModalityContext, PointerType,
+};
 pub use platform::{
     MissingProviderEffects, NullPlatformEffects, PlatformEffects, Rect, TimerHandle,
 };
-pub use provider::ColorMode;
+pub use provider::{ArsContext, ColorMode};
 
 // ────────────────────────────────────────────────────────────────────
 // Callback, WeakSend, and effect cleanup types

--- a/crates/ars-core/src/modality.rs
+++ b/crates/ars-core/src/modality.rs
@@ -1,0 +1,1466 @@
+//! Shared input-modality state and normalization primitives.
+//!
+//! This module provides the platform-agnostic modality contract shared by
+//! interaction, accessibility, and adapter layers. It intentionally models
+//! modality as instance-scoped state so each provider root, window, or scene
+//! can track its own last input modality independently.
+
+use core::cell::Cell;
+
+/// The input modality that initiated an interaction.
+///
+/// Matches the values exposed by the Pointer Events API, extended with
+/// keyboard and virtual activation for accessibility and scripted focus flows.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum PointerType {
+    /// Physical mouse or trackpad.
+    Mouse,
+    /// Finger on a touchscreen.
+    Touch,
+    /// Stylus or digital pen.
+    Pen,
+    /// Keyboard-driven interaction.
+    Keyboard,
+    /// Programmatic or virtual-cursor activation.
+    Virtual,
+}
+
+/// Raw platform keyboard modifier state captured from an input event.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub struct KeyModifiers {
+    /// Whether the Shift key was held.
+    pub shift: bool,
+    /// Whether the physical Ctrl key was held.
+    pub ctrl: bool,
+    /// Whether the Alt/Option key was held.
+    pub alt: bool,
+    /// Whether the Meta/Cmd/Windows key was held.
+    pub meta: bool,
+}
+
+/// Named keyboard keys normalized from W3C `KeyboardEvent.key` values.
+///
+/// Reference: [W3C UI Events KeyboardEvent key Values](https://www.w3.org/TR/uievents-key/).
+///
+/// Printable characters are intentionally excluded. Consumers should use a
+/// separate character field for text input and reserve this enum for named keys.
+#[expect(
+    missing_docs,
+    reason = "The variants mirror the W3C named-key registry and are self-describing."
+)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum KeyboardKey {
+    Unidentified,
+    Alt,
+    AltGraph,
+    CapsLock,
+    Control,
+    Fn,
+    FnLock,
+    Meta,
+    NumLock,
+    ScrollLock,
+    Shift,
+    Symbol,
+    SymbolLock,
+    Hyper,
+    Super,
+    Enter,
+    Tab,
+    Space,
+    ArrowDown,
+    ArrowLeft,
+    ArrowRight,
+    ArrowUp,
+    End,
+    Home,
+    PageDown,
+    PageUp,
+    Backspace,
+    Clear,
+    Copy,
+    CrSel,
+    Cut,
+    Delete,
+    EraseEof,
+    ExSel,
+    Insert,
+    Paste,
+    Redo,
+    Undo,
+    Accept,
+    Again,
+    Attn,
+    Cancel,
+    ContextMenu,
+    Escape,
+    Execute,
+    Find,
+    Help,
+    Pause,
+    Play,
+    Props,
+    Select,
+    ZoomIn,
+    ZoomOut,
+    BrightnessDown,
+    BrightnessUp,
+    Eject,
+    LogOff,
+    Power,
+    PowerOff,
+    PrintScreen,
+    Hibernate,
+    Standby,
+    WakeUp,
+    AllCandidates,
+    Alphanumeric,
+    CodeInput,
+    Compose,
+    Convert,
+    Dead,
+    FinalMode,
+    GroupFirst,
+    GroupLast,
+    GroupNext,
+    GroupPrevious,
+    ModeChange,
+    NextCandidate,
+    NonConvert,
+    PreviousCandidate,
+    Process,
+    SingleCandidate,
+    HangulMode,
+    HanjaMode,
+    JunjaMode,
+    Eisu,
+    Hankaku,
+    Hiragana,
+    HiraganaKatakana,
+    KanaMode,
+    KanjiMode,
+    Katakana,
+    Romaji,
+    Zenkaku,
+    ZenkakuHankaku,
+    F1,
+    F2,
+    F3,
+    F4,
+    F5,
+    F6,
+    F7,
+    F8,
+    F9,
+    F10,
+    F11,
+    F12,
+    Soft1,
+    Soft2,
+    Soft3,
+    Soft4,
+    ChannelDown,
+    ChannelUp,
+    Close,
+    MailForward,
+    MailReply,
+    MailSend,
+    MediaClose,
+    MediaFastForward,
+    MediaPause,
+    MediaPlay,
+    MediaPlayPause,
+    MediaRecord,
+    MediaRewind,
+    MediaStop,
+    MediaTrackNext,
+    MediaTrackPrevious,
+    New,
+    Open,
+    Print,
+    Save,
+    SpellCheck,
+    Key11,
+    Key12,
+    AudioBalanceLeft,
+    AudioBalanceRight,
+    AudioBassBoostDown,
+    AudioBassBoostToggle,
+    AudioBassBoostUp,
+    AudioFaderFront,
+    AudioFaderRear,
+    AudioSurroundModeNext,
+    AudioTrebleDown,
+    AudioTrebleUp,
+    AudioVolumeDown,
+    AudioVolumeUp,
+    AudioVolumeMute,
+    MicrophoneToggle,
+    MicrophoneVolumeDown,
+    MicrophoneVolumeUp,
+    MicrophoneVolumeMute,
+    SpeechCorrectionList,
+    SpeechInputToggle,
+    LaunchApplication1,
+    LaunchApplication2,
+    LaunchCalendar,
+    LaunchContacts,
+    LaunchMail,
+    LaunchMediaPlayer,
+    LaunchMusicPlayer,
+    LaunchPhone,
+    LaunchScreenSaver,
+    LaunchSpreadsheet,
+    LaunchWebBrowser,
+    LaunchWebCam,
+    LaunchWordProcessor,
+    BrowserBack,
+    BrowserFavorites,
+    BrowserForward,
+    BrowserHome,
+    BrowserRefresh,
+    BrowserSearch,
+    BrowserStop,
+    AppSwitch,
+    Call,
+    Camera,
+    CameraFocus,
+    EndCall,
+    GoBack,
+    GoHome,
+    HeadsetHook,
+    LastNumberRedial,
+    Notification,
+    MannerMode,
+    VoiceDial,
+    Tv,
+    Tv3DMode,
+    TvAntennaCable,
+    TvAudioDescription,
+    TvAudioDescriptionMixDown,
+    TvAudioDescriptionMixUp,
+    TvContentsMenu,
+    TvDataService,
+    TvInput,
+    TvInputComponent1,
+    TvInputComponent2,
+    TvInputComposite1,
+    TvInputComposite2,
+    TvInputHdmi1,
+    TvInputHdmi2,
+    TvInputHdmi3,
+    TvInputHdmi4,
+    TvInputVga1,
+    TvMediaContext,
+    TvNetwork,
+    TvNumberEntry,
+    TvPower,
+    TvRadioService,
+    TvSatellite,
+    TvSatelliteBS,
+    TvSatelliteCS,
+    TvSatelliteToggle,
+    TvTerrestrialAnalog,
+    TvTerrestrialDigital,
+    TvTimer,
+    AvrInput,
+    AvrPower,
+    ColorF0Red,
+    ColorF1Green,
+    ColorF2Yellow,
+    ColorF3Blue,
+    ColorF4Grey,
+    ColorF5Brown,
+    ClosedCaptionToggle,
+    Dimmer,
+    DisplaySwap,
+    Dvr,
+    Exit,
+    FavoriteClear0,
+    FavoriteClear1,
+    FavoriteClear2,
+    FavoriteClear3,
+    FavoriteRecall0,
+    FavoriteRecall1,
+    FavoriteRecall2,
+    FavoriteRecall3,
+    FavoriteStore0,
+    FavoriteStore1,
+    FavoriteStore2,
+    FavoriteStore3,
+    Guide,
+    GuideNextDay,
+    GuidePreviousDay,
+    Info,
+    InstantReplay,
+    Link,
+    ListProgram,
+    LiveContent,
+    Lock,
+    MediaApps,
+    MediaAudioTrack,
+    MediaLast,
+    MediaSkipBackward,
+    MediaSkipForward,
+    MediaStepBackward,
+    MediaStepForward,
+    MediaTopMenu,
+    NavigateIn,
+    NavigateNext,
+    NavigateOut,
+    NavigatePrevious,
+    NextFavoriteChannel,
+    NextUserProfile,
+    OnDemand,
+    Pairing,
+    PinPDown,
+    PinPMove,
+    PinPToggle,
+    PinPUp,
+    PlaySpeedDown,
+    PlaySpeedReset,
+    PlaySpeedUp,
+    RandomToggle,
+    RcLowBattery,
+    RecordSpeedNext,
+    RfBypass,
+    ScanChannelsToggle,
+    ScreenModeNext,
+    Settings,
+    SplitScreenToggle,
+    StbInput,
+    StbPower,
+    Subtitle,
+    Teletext,
+    VideoModeNext,
+    Wink,
+    ZoomToggle,
+}
+
+impl KeyboardKey {
+    /// Parses a W3C key string into a named key.
+    ///
+    /// Unrecognized values, including printable character keys, map to
+    /// [`KeyboardKey::Unidentified`].
+    #[must_use]
+    pub fn from_key_str(value: &str) -> Self {
+        match value {
+            " " | "Space" => Self::Space,
+            "11" => Self::Key11,
+            "12" => Self::Key12,
+            "TV" => Self::Tv,
+            "TV3DMode" => Self::Tv3DMode,
+            "TVAntennaCable" => Self::TvAntennaCable,
+            "TVAudioDescription" => Self::TvAudioDescription,
+            "TVAudioDescriptionMixDown" => Self::TvAudioDescriptionMixDown,
+            "TVAudioDescriptionMixUp" => Self::TvAudioDescriptionMixUp,
+            "TVContentsMenu" => Self::TvContentsMenu,
+            "TVDataService" => Self::TvDataService,
+            "TVInput" => Self::TvInput,
+            "TVInputComponent1" => Self::TvInputComponent1,
+            "TVInputComponent2" => Self::TvInputComponent2,
+            "TVInputComposite1" => Self::TvInputComposite1,
+            "TVInputComposite2" => Self::TvInputComposite2,
+            "TVInputHDMI1" => Self::TvInputHdmi1,
+            "TVInputHDMI2" => Self::TvInputHdmi2,
+            "TVInputHDMI3" => Self::TvInputHdmi3,
+            "TVInputHDMI4" => Self::TvInputHdmi4,
+            "TVInputVGA1" => Self::TvInputVga1,
+            "TVMediaContext" => Self::TvMediaContext,
+            "TVNetwork" => Self::TvNetwork,
+            "TVNumberEntry" => Self::TvNumberEntry,
+            "TVPower" => Self::TvPower,
+            "TVRadioService" => Self::TvRadioService,
+            "TVSatellite" => Self::TvSatellite,
+            "TVSatelliteBS" => Self::TvSatelliteBS,
+            "TVSatelliteCS" => Self::TvSatelliteCS,
+            "TVSatelliteToggle" => Self::TvSatelliteToggle,
+            "TVTerrestrialAnalog" => Self::TvTerrestrialAnalog,
+            "TVTerrestrialDigital" => Self::TvTerrestrialDigital,
+            "TVTimer" => Self::TvTimer,
+            "AVRInput" => Self::AvrInput,
+            "AVRPower" => Self::AvrPower,
+            "DVR" => Self::Dvr,
+            "STBInput" => Self::StbInput,
+            "STBPower" => Self::StbPower,
+            _ => match value {
+                "Alt" => Self::Alt,
+                "AltGraph" => Self::AltGraph,
+                "CapsLock" => Self::CapsLock,
+                "Control" => Self::Control,
+                "Fn" => Self::Fn,
+                "FnLock" => Self::FnLock,
+                "Meta" => Self::Meta,
+                "NumLock" => Self::NumLock,
+                "ScrollLock" => Self::ScrollLock,
+                "Shift" => Self::Shift,
+                "Symbol" => Self::Symbol,
+                "SymbolLock" => Self::SymbolLock,
+                "Hyper" => Self::Hyper,
+                "Super" => Self::Super,
+                "Enter" => Self::Enter,
+                "Tab" => Self::Tab,
+                "ArrowDown" => Self::ArrowDown,
+                "ArrowLeft" => Self::ArrowLeft,
+                "ArrowRight" => Self::ArrowRight,
+                "ArrowUp" => Self::ArrowUp,
+                "End" => Self::End,
+                "Home" => Self::Home,
+                "PageDown" => Self::PageDown,
+                "PageUp" => Self::PageUp,
+                "Backspace" => Self::Backspace,
+                "Clear" => Self::Clear,
+                "Copy" => Self::Copy,
+                "CrSel" => Self::CrSel,
+                "Cut" => Self::Cut,
+                "Delete" => Self::Delete,
+                "EraseEof" => Self::EraseEof,
+                "ExSel" => Self::ExSel,
+                "Insert" => Self::Insert,
+                "Paste" => Self::Paste,
+                "Redo" => Self::Redo,
+                "Undo" => Self::Undo,
+                "Accept" => Self::Accept,
+                "Again" => Self::Again,
+                "Attn" => Self::Attn,
+                "Cancel" => Self::Cancel,
+                "ContextMenu" => Self::ContextMenu,
+                "Escape" => Self::Escape,
+                "Execute" => Self::Execute,
+                "Find" => Self::Find,
+                "Help" => Self::Help,
+                "Pause" => Self::Pause,
+                "Play" => Self::Play,
+                "Props" => Self::Props,
+                "Select" => Self::Select,
+                "ZoomIn" => Self::ZoomIn,
+                "ZoomOut" => Self::ZoomOut,
+                "BrightnessDown" => Self::BrightnessDown,
+                "BrightnessUp" => Self::BrightnessUp,
+                "Eject" => Self::Eject,
+                "LogOff" => Self::LogOff,
+                "Power" => Self::Power,
+                "PowerOff" => Self::PowerOff,
+                "PrintScreen" => Self::PrintScreen,
+                "Hibernate" => Self::Hibernate,
+                "Standby" => Self::Standby,
+                "WakeUp" => Self::WakeUp,
+                "AllCandidates" => Self::AllCandidates,
+                "Alphanumeric" => Self::Alphanumeric,
+                "CodeInput" => Self::CodeInput,
+                "Compose" => Self::Compose,
+                "Convert" => Self::Convert,
+                "Dead" => Self::Dead,
+                "FinalMode" => Self::FinalMode,
+                "GroupFirst" => Self::GroupFirst,
+                "GroupLast" => Self::GroupLast,
+                "GroupNext" => Self::GroupNext,
+                "GroupPrevious" => Self::GroupPrevious,
+                "ModeChange" => Self::ModeChange,
+                "NextCandidate" => Self::NextCandidate,
+                "NonConvert" => Self::NonConvert,
+                "PreviousCandidate" => Self::PreviousCandidate,
+                "Process" => Self::Process,
+                "SingleCandidate" => Self::SingleCandidate,
+                "HangulMode" => Self::HangulMode,
+                "HanjaMode" => Self::HanjaMode,
+                "JunjaMode" => Self::JunjaMode,
+                "Eisu" => Self::Eisu,
+                "Hankaku" => Self::Hankaku,
+                "Hiragana" => Self::Hiragana,
+                "HiraganaKatakana" => Self::HiraganaKatakana,
+                "KanaMode" => Self::KanaMode,
+                "KanjiMode" => Self::KanjiMode,
+                "Katakana" => Self::Katakana,
+                "Romaji" => Self::Romaji,
+                "Zenkaku" => Self::Zenkaku,
+                "ZenkakuHankaku" => Self::ZenkakuHankaku,
+                "F1" => Self::F1,
+                "F2" => Self::F2,
+                "F3" => Self::F3,
+                "F4" => Self::F4,
+                "F5" => Self::F5,
+                "F6" => Self::F6,
+                "F7" => Self::F7,
+                "F8" => Self::F8,
+                "F9" => Self::F9,
+                "F10" => Self::F10,
+                "F11" => Self::F11,
+                "F12" => Self::F12,
+                "Soft1" => Self::Soft1,
+                "Soft2" => Self::Soft2,
+                "Soft3" => Self::Soft3,
+                "Soft4" => Self::Soft4,
+                "ChannelDown" => Self::ChannelDown,
+                "ChannelUp" => Self::ChannelUp,
+                "Close" => Self::Close,
+                "MailForward" => Self::MailForward,
+                "MailReply" => Self::MailReply,
+                "MailSend" => Self::MailSend,
+                "MediaClose" => Self::MediaClose,
+                "MediaFastForward" => Self::MediaFastForward,
+                "MediaPause" => Self::MediaPause,
+                "MediaPlay" => Self::MediaPlay,
+                "MediaPlayPause" => Self::MediaPlayPause,
+                "MediaRecord" => Self::MediaRecord,
+                "MediaRewind" => Self::MediaRewind,
+                "MediaStop" => Self::MediaStop,
+                "MediaTrackNext" => Self::MediaTrackNext,
+                "MediaTrackPrevious" => Self::MediaTrackPrevious,
+                "New" => Self::New,
+                "Open" => Self::Open,
+                "Print" => Self::Print,
+                "Save" => Self::Save,
+                "SpellCheck" => Self::SpellCheck,
+                "AudioBalanceLeft" => Self::AudioBalanceLeft,
+                "AudioBalanceRight" => Self::AudioBalanceRight,
+                "AudioBassBoostDown" => Self::AudioBassBoostDown,
+                "AudioBassBoostToggle" => Self::AudioBassBoostToggle,
+                "AudioBassBoostUp" => Self::AudioBassBoostUp,
+                "AudioFaderFront" => Self::AudioFaderFront,
+                "AudioFaderRear" => Self::AudioFaderRear,
+                "AudioSurroundModeNext" => Self::AudioSurroundModeNext,
+                "AudioTrebleDown" => Self::AudioTrebleDown,
+                "AudioTrebleUp" => Self::AudioTrebleUp,
+                "AudioVolumeDown" => Self::AudioVolumeDown,
+                "AudioVolumeUp" => Self::AudioVolumeUp,
+                "AudioVolumeMute" => Self::AudioVolumeMute,
+                "MicrophoneToggle" => Self::MicrophoneToggle,
+                "MicrophoneVolumeDown" => Self::MicrophoneVolumeDown,
+                "MicrophoneVolumeUp" => Self::MicrophoneVolumeUp,
+                "MicrophoneVolumeMute" => Self::MicrophoneVolumeMute,
+                "SpeechCorrectionList" => Self::SpeechCorrectionList,
+                "SpeechInputToggle" => Self::SpeechInputToggle,
+                "LaunchApplication1" => Self::LaunchApplication1,
+                "LaunchApplication2" => Self::LaunchApplication2,
+                "LaunchCalendar" => Self::LaunchCalendar,
+                "LaunchContacts" => Self::LaunchContacts,
+                "LaunchMail" => Self::LaunchMail,
+                "LaunchMediaPlayer" => Self::LaunchMediaPlayer,
+                "LaunchMusicPlayer" => Self::LaunchMusicPlayer,
+                "LaunchPhone" => Self::LaunchPhone,
+                "LaunchScreenSaver" => Self::LaunchScreenSaver,
+                "LaunchSpreadsheet" => Self::LaunchSpreadsheet,
+                "LaunchWebBrowser" => Self::LaunchWebBrowser,
+                "LaunchWebCam" => Self::LaunchWebCam,
+                "LaunchWordProcessor" => Self::LaunchWordProcessor,
+                "BrowserBack" => Self::BrowserBack,
+                "BrowserFavorites" => Self::BrowserFavorites,
+                "BrowserForward" => Self::BrowserForward,
+                "BrowserHome" => Self::BrowserHome,
+                "BrowserRefresh" => Self::BrowserRefresh,
+                "BrowserSearch" => Self::BrowserSearch,
+                "BrowserStop" => Self::BrowserStop,
+                "AppSwitch" => Self::AppSwitch,
+                "Call" => Self::Call,
+                "Camera" => Self::Camera,
+                "CameraFocus" => Self::CameraFocus,
+                "EndCall" => Self::EndCall,
+                "GoBack" => Self::GoBack,
+                "GoHome" => Self::GoHome,
+                "HeadsetHook" => Self::HeadsetHook,
+                "LastNumberRedial" => Self::LastNumberRedial,
+                "Notification" => Self::Notification,
+                "MannerMode" => Self::MannerMode,
+                "VoiceDial" => Self::VoiceDial,
+                "ColorF0Red" => Self::ColorF0Red,
+                "ColorF1Green" => Self::ColorF1Green,
+                "ColorF2Yellow" => Self::ColorF2Yellow,
+                "ColorF3Blue" => Self::ColorF3Blue,
+                "ColorF4Grey" => Self::ColorF4Grey,
+                "ColorF5Brown" => Self::ColorF5Brown,
+                "ClosedCaptionToggle" => Self::ClosedCaptionToggle,
+                "Dimmer" => Self::Dimmer,
+                "DisplaySwap" => Self::DisplaySwap,
+                "Exit" => Self::Exit,
+                "FavoriteClear0" => Self::FavoriteClear0,
+                "FavoriteClear1" => Self::FavoriteClear1,
+                "FavoriteClear2" => Self::FavoriteClear2,
+                "FavoriteClear3" => Self::FavoriteClear3,
+                "FavoriteRecall0" => Self::FavoriteRecall0,
+                "FavoriteRecall1" => Self::FavoriteRecall1,
+                "FavoriteRecall2" => Self::FavoriteRecall2,
+                "FavoriteRecall3" => Self::FavoriteRecall3,
+                "FavoriteStore0" => Self::FavoriteStore0,
+                "FavoriteStore1" => Self::FavoriteStore1,
+                "FavoriteStore2" => Self::FavoriteStore2,
+                "FavoriteStore3" => Self::FavoriteStore3,
+                "Guide" => Self::Guide,
+                "GuideNextDay" => Self::GuideNextDay,
+                "GuidePreviousDay" => Self::GuidePreviousDay,
+                "Info" => Self::Info,
+                "InstantReplay" => Self::InstantReplay,
+                "Link" => Self::Link,
+                "ListProgram" => Self::ListProgram,
+                "LiveContent" => Self::LiveContent,
+                "Lock" => Self::Lock,
+                "MediaApps" => Self::MediaApps,
+                "MediaAudioTrack" => Self::MediaAudioTrack,
+                "MediaLast" => Self::MediaLast,
+                "MediaSkipBackward" => Self::MediaSkipBackward,
+                "MediaSkipForward" => Self::MediaSkipForward,
+                "MediaStepBackward" => Self::MediaStepBackward,
+                "MediaStepForward" => Self::MediaStepForward,
+                "MediaTopMenu" => Self::MediaTopMenu,
+                "NavigateIn" => Self::NavigateIn,
+                "NavigateNext" => Self::NavigateNext,
+                "NavigateOut" => Self::NavigateOut,
+                "NavigatePrevious" => Self::NavigatePrevious,
+                "NextFavoriteChannel" => Self::NextFavoriteChannel,
+                "NextUserProfile" => Self::NextUserProfile,
+                "OnDemand" => Self::OnDemand,
+                "Pairing" => Self::Pairing,
+                "PinPDown" => Self::PinPDown,
+                "PinPMove" => Self::PinPMove,
+                "PinPToggle" => Self::PinPToggle,
+                "PinPUp" => Self::PinPUp,
+                "PlaySpeedDown" => Self::PlaySpeedDown,
+                "PlaySpeedReset" => Self::PlaySpeedReset,
+                "PlaySpeedUp" => Self::PlaySpeedUp,
+                "RandomToggle" => Self::RandomToggle,
+                "RcLowBattery" => Self::RcLowBattery,
+                "RecordSpeedNext" => Self::RecordSpeedNext,
+                "RfBypass" => Self::RfBypass,
+                "ScanChannelsToggle" => Self::ScanChannelsToggle,
+                "ScreenModeNext" => Self::ScreenModeNext,
+                "Settings" => Self::Settings,
+                "SplitScreenToggle" => Self::SplitScreenToggle,
+                "Subtitle" => Self::Subtitle,
+                "Teletext" => Self::Teletext,
+                "VideoModeNext" => Self::VideoModeNext,
+                "Wink" => Self::Wink,
+                "ZoomToggle" => Self::ZoomToggle,
+                _ => Self::Unidentified,
+            },
+        }
+    }
+
+    /// Returns the canonical W3C key string for this named key.
+    #[must_use]
+    pub const fn as_w3c_str(self) -> &'static str {
+        match self {
+            Self::Unidentified => "Unidentified",
+            Self::Alt => "Alt",
+            Self::AltGraph => "AltGraph",
+            Self::CapsLock => "CapsLock",
+            Self::Control => "Control",
+            Self::Fn => "Fn",
+            Self::FnLock => "FnLock",
+            Self::Meta => "Meta",
+            Self::NumLock => "NumLock",
+            Self::ScrollLock => "ScrollLock",
+            Self::Shift => "Shift",
+            Self::Symbol => "Symbol",
+            Self::SymbolLock => "SymbolLock",
+            Self::Hyper => "Hyper",
+            Self::Super => "Super",
+            Self::Enter => "Enter",
+            Self::Tab => "Tab",
+            Self::Space => " ",
+            Self::ArrowDown => "ArrowDown",
+            Self::ArrowLeft => "ArrowLeft",
+            Self::ArrowRight => "ArrowRight",
+            Self::ArrowUp => "ArrowUp",
+            Self::End => "End",
+            Self::Home => "Home",
+            Self::PageDown => "PageDown",
+            Self::PageUp => "PageUp",
+            Self::Backspace => "Backspace",
+            Self::Clear => "Clear",
+            Self::Copy => "Copy",
+            Self::CrSel => "CrSel",
+            Self::Cut => "Cut",
+            Self::Delete => "Delete",
+            Self::EraseEof => "EraseEof",
+            Self::ExSel => "ExSel",
+            Self::Insert => "Insert",
+            Self::Paste => "Paste",
+            Self::Redo => "Redo",
+            Self::Undo => "Undo",
+            Self::Accept => "Accept",
+            Self::Again => "Again",
+            Self::Attn => "Attn",
+            Self::Cancel => "Cancel",
+            Self::ContextMenu => "ContextMenu",
+            Self::Escape => "Escape",
+            Self::Execute => "Execute",
+            Self::Find => "Find",
+            Self::Help => "Help",
+            Self::Pause => "Pause",
+            Self::Play => "Play",
+            Self::Props => "Props",
+            Self::Select => "Select",
+            Self::ZoomIn => "ZoomIn",
+            Self::ZoomOut => "ZoomOut",
+            Self::BrightnessDown => "BrightnessDown",
+            Self::BrightnessUp => "BrightnessUp",
+            Self::Eject => "Eject",
+            Self::LogOff => "LogOff",
+            Self::Power => "Power",
+            Self::PowerOff => "PowerOff",
+            Self::PrintScreen => "PrintScreen",
+            Self::Hibernate => "Hibernate",
+            Self::Standby => "Standby",
+            Self::WakeUp => "WakeUp",
+            Self::AllCandidates => "AllCandidates",
+            Self::Alphanumeric => "Alphanumeric",
+            Self::CodeInput => "CodeInput",
+            Self::Compose => "Compose",
+            Self::Convert => "Convert",
+            Self::Dead => "Dead",
+            Self::FinalMode => "FinalMode",
+            Self::GroupFirst => "GroupFirst",
+            Self::GroupLast => "GroupLast",
+            Self::GroupNext => "GroupNext",
+            Self::GroupPrevious => "GroupPrevious",
+            Self::ModeChange => "ModeChange",
+            Self::NextCandidate => "NextCandidate",
+            Self::NonConvert => "NonConvert",
+            Self::PreviousCandidate => "PreviousCandidate",
+            Self::Process => "Process",
+            Self::SingleCandidate => "SingleCandidate",
+            Self::HangulMode => "HangulMode",
+            Self::HanjaMode => "HanjaMode",
+            Self::JunjaMode => "JunjaMode",
+            Self::Eisu => "Eisu",
+            Self::Hankaku => "Hankaku",
+            Self::Hiragana => "Hiragana",
+            Self::HiraganaKatakana => "HiraganaKatakana",
+            Self::KanaMode => "KanaMode",
+            Self::KanjiMode => "KanjiMode",
+            Self::Katakana => "Katakana",
+            Self::Romaji => "Romaji",
+            Self::Zenkaku => "Zenkaku",
+            Self::ZenkakuHankaku => "ZenkakuHankaku",
+            Self::F1 => "F1",
+            Self::F2 => "F2",
+            Self::F3 => "F3",
+            Self::F4 => "F4",
+            Self::F5 => "F5",
+            Self::F6 => "F6",
+            Self::F7 => "F7",
+            Self::F8 => "F8",
+            Self::F9 => "F9",
+            Self::F10 => "F10",
+            Self::F11 => "F11",
+            Self::F12 => "F12",
+            Self::Soft1 => "Soft1",
+            Self::Soft2 => "Soft2",
+            Self::Soft3 => "Soft3",
+            Self::Soft4 => "Soft4",
+            Self::ChannelDown => "ChannelDown",
+            Self::ChannelUp => "ChannelUp",
+            Self::Close => "Close",
+            Self::MailForward => "MailForward",
+            Self::MailReply => "MailReply",
+            Self::MailSend => "MailSend",
+            Self::MediaClose => "MediaClose",
+            Self::MediaFastForward => "MediaFastForward",
+            Self::MediaPause => "MediaPause",
+            Self::MediaPlay => "MediaPlay",
+            Self::MediaPlayPause => "MediaPlayPause",
+            Self::MediaRecord => "MediaRecord",
+            Self::MediaRewind => "MediaRewind",
+            Self::MediaStop => "MediaStop",
+            Self::MediaTrackNext => "MediaTrackNext",
+            Self::MediaTrackPrevious => "MediaTrackPrevious",
+            Self::New => "New",
+            Self::Open => "Open",
+            Self::Print => "Print",
+            Self::Save => "Save",
+            Self::SpellCheck => "SpellCheck",
+            Self::Key11 => "11",
+            Self::Key12 => "12",
+            Self::AudioBalanceLeft => "AudioBalanceLeft",
+            Self::AudioBalanceRight => "AudioBalanceRight",
+            Self::AudioBassBoostDown => "AudioBassBoostDown",
+            Self::AudioBassBoostToggle => "AudioBassBoostToggle",
+            Self::AudioBassBoostUp => "AudioBassBoostUp",
+            Self::AudioFaderFront => "AudioFaderFront",
+            Self::AudioFaderRear => "AudioFaderRear",
+            Self::AudioSurroundModeNext => "AudioSurroundModeNext",
+            Self::AudioTrebleDown => "AudioTrebleDown",
+            Self::AudioTrebleUp => "AudioTrebleUp",
+            Self::AudioVolumeDown => "AudioVolumeDown",
+            Self::AudioVolumeUp => "AudioVolumeUp",
+            Self::AudioVolumeMute => "AudioVolumeMute",
+            Self::MicrophoneToggle => "MicrophoneToggle",
+            Self::MicrophoneVolumeDown => "MicrophoneVolumeDown",
+            Self::MicrophoneVolumeUp => "MicrophoneVolumeUp",
+            Self::MicrophoneVolumeMute => "MicrophoneVolumeMute",
+            Self::SpeechCorrectionList => "SpeechCorrectionList",
+            Self::SpeechInputToggle => "SpeechInputToggle",
+            Self::LaunchApplication1 => "LaunchApplication1",
+            Self::LaunchApplication2 => "LaunchApplication2",
+            Self::LaunchCalendar => "LaunchCalendar",
+            Self::LaunchContacts => "LaunchContacts",
+            Self::LaunchMail => "LaunchMail",
+            Self::LaunchMediaPlayer => "LaunchMediaPlayer",
+            Self::LaunchMusicPlayer => "LaunchMusicPlayer",
+            Self::LaunchPhone => "LaunchPhone",
+            Self::LaunchScreenSaver => "LaunchScreenSaver",
+            Self::LaunchSpreadsheet => "LaunchSpreadsheet",
+            Self::LaunchWebBrowser => "LaunchWebBrowser",
+            Self::LaunchWebCam => "LaunchWebCam",
+            Self::LaunchWordProcessor => "LaunchWordProcessor",
+            Self::BrowserBack => "BrowserBack",
+            Self::BrowserFavorites => "BrowserFavorites",
+            Self::BrowserForward => "BrowserForward",
+            Self::BrowserHome => "BrowserHome",
+            Self::BrowserRefresh => "BrowserRefresh",
+            Self::BrowserSearch => "BrowserSearch",
+            Self::BrowserStop => "BrowserStop",
+            Self::AppSwitch => "AppSwitch",
+            Self::Call => "Call",
+            Self::Camera => "Camera",
+            Self::CameraFocus => "CameraFocus",
+            Self::EndCall => "EndCall",
+            Self::GoBack => "GoBack",
+            Self::GoHome => "GoHome",
+            Self::HeadsetHook => "HeadsetHook",
+            Self::LastNumberRedial => "LastNumberRedial",
+            Self::Notification => "Notification",
+            Self::MannerMode => "MannerMode",
+            Self::VoiceDial => "VoiceDial",
+            Self::Tv => "TV",
+            Self::Tv3DMode => "TV3DMode",
+            Self::TvAntennaCable => "TVAntennaCable",
+            Self::TvAudioDescription => "TVAudioDescription",
+            Self::TvAudioDescriptionMixDown => "TVAudioDescriptionMixDown",
+            Self::TvAudioDescriptionMixUp => "TVAudioDescriptionMixUp",
+            Self::TvContentsMenu => "TVContentsMenu",
+            Self::TvDataService => "TVDataService",
+            Self::TvInput => "TVInput",
+            Self::TvInputComponent1 => "TVInputComponent1",
+            Self::TvInputComponent2 => "TVInputComponent2",
+            Self::TvInputComposite1 => "TVInputComposite1",
+            Self::TvInputComposite2 => "TVInputComposite2",
+            Self::TvInputHdmi1 => "TVInputHDMI1",
+            Self::TvInputHdmi2 => "TVInputHDMI2",
+            Self::TvInputHdmi3 => "TVInputHDMI3",
+            Self::TvInputHdmi4 => "TVInputHDMI4",
+            Self::TvInputVga1 => "TVInputVGA1",
+            Self::TvMediaContext => "TVMediaContext",
+            Self::TvNetwork => "TVNetwork",
+            Self::TvNumberEntry => "TVNumberEntry",
+            Self::TvPower => "TVPower",
+            Self::TvRadioService => "TVRadioService",
+            Self::TvSatellite => "TVSatellite",
+            Self::TvSatelliteBS => "TVSatelliteBS",
+            Self::TvSatelliteCS => "TVSatelliteCS",
+            Self::TvSatelliteToggle => "TVSatelliteToggle",
+            Self::TvTerrestrialAnalog => "TVTerrestrialAnalog",
+            Self::TvTerrestrialDigital => "TVTerrestrialDigital",
+            Self::TvTimer => "TVTimer",
+            Self::AvrInput => "AVRInput",
+            Self::AvrPower => "AVRPower",
+            Self::ColorF0Red => "ColorF0Red",
+            Self::ColorF1Green => "ColorF1Green",
+            Self::ColorF2Yellow => "ColorF2Yellow",
+            Self::ColorF3Blue => "ColorF3Blue",
+            Self::ColorF4Grey => "ColorF4Grey",
+            Self::ColorF5Brown => "ColorF5Brown",
+            Self::ClosedCaptionToggle => "ClosedCaptionToggle",
+            Self::Dimmer => "Dimmer",
+            Self::DisplaySwap => "DisplaySwap",
+            Self::Dvr => "DVR",
+            Self::Exit => "Exit",
+            Self::FavoriteClear0 => "FavoriteClear0",
+            Self::FavoriteClear1 => "FavoriteClear1",
+            Self::FavoriteClear2 => "FavoriteClear2",
+            Self::FavoriteClear3 => "FavoriteClear3",
+            Self::FavoriteRecall0 => "FavoriteRecall0",
+            Self::FavoriteRecall1 => "FavoriteRecall1",
+            Self::FavoriteRecall2 => "FavoriteRecall2",
+            Self::FavoriteRecall3 => "FavoriteRecall3",
+            Self::FavoriteStore0 => "FavoriteStore0",
+            Self::FavoriteStore1 => "FavoriteStore1",
+            Self::FavoriteStore2 => "FavoriteStore2",
+            Self::FavoriteStore3 => "FavoriteStore3",
+            Self::Guide => "Guide",
+            Self::GuideNextDay => "GuideNextDay",
+            Self::GuidePreviousDay => "GuidePreviousDay",
+            Self::Info => "Info",
+            Self::InstantReplay => "InstantReplay",
+            Self::Link => "Link",
+            Self::ListProgram => "ListProgram",
+            Self::LiveContent => "LiveContent",
+            Self::Lock => "Lock",
+            Self::MediaApps => "MediaApps",
+            Self::MediaAudioTrack => "MediaAudioTrack",
+            Self::MediaLast => "MediaLast",
+            Self::MediaSkipBackward => "MediaSkipBackward",
+            Self::MediaSkipForward => "MediaSkipForward",
+            Self::MediaStepBackward => "MediaStepBackward",
+            Self::MediaStepForward => "MediaStepForward",
+            Self::MediaTopMenu => "MediaTopMenu",
+            Self::NavigateIn => "NavigateIn",
+            Self::NavigateNext => "NavigateNext",
+            Self::NavigateOut => "NavigateOut",
+            Self::NavigatePrevious => "NavigatePrevious",
+            Self::NextFavoriteChannel => "NextFavoriteChannel",
+            Self::NextUserProfile => "NextUserProfile",
+            Self::OnDemand => "OnDemand",
+            Self::Pairing => "Pairing",
+            Self::PinPDown => "PinPDown",
+            Self::PinPMove => "PinPMove",
+            Self::PinPToggle => "PinPToggle",
+            Self::PinPUp => "PinPUp",
+            Self::PlaySpeedDown => "PlaySpeedDown",
+            Self::PlaySpeedReset => "PlaySpeedReset",
+            Self::PlaySpeedUp => "PlaySpeedUp",
+            Self::RandomToggle => "RandomToggle",
+            Self::RcLowBattery => "RcLowBattery",
+            Self::RecordSpeedNext => "RecordSpeedNext",
+            Self::RfBypass => "RfBypass",
+            Self::ScanChannelsToggle => "ScanChannelsToggle",
+            Self::ScreenModeNext => "ScreenModeNext",
+            Self::Settings => "Settings",
+            Self::SplitScreenToggle => "SplitScreenToggle",
+            Self::StbInput => "STBInput",
+            Self::StbPower => "STBPower",
+            Self::Subtitle => "Subtitle",
+            Self::Teletext => "Teletext",
+            Self::VideoModeNext => "VideoModeNext",
+            Self::Wink => "Wink",
+            Self::ZoomToggle => "ZoomToggle",
+        }
+    }
+}
+
+/// Snapshot of the current modality state for a single provider root.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ModalitySnapshot {
+    /// The most recent input modality observed for this context.
+    pub last_pointer_type: Option<PointerType>,
+    /// Whether any press interaction is currently active for this context.
+    pub global_press_active: bool,
+}
+
+impl ModalitySnapshot {
+    /// Returns whether the snapshot represents a physical pointer interaction.
+    #[must_use]
+    pub const fn had_pointer_interaction(self) -> bool {
+        matches!(
+            self.last_pointer_type,
+            Some(PointerType::Mouse | PointerType::Touch | PointerType::Pen)
+        )
+    }
+}
+
+/// Shared, instance-scoped modality contract.
+pub trait ModalityContext {
+    /// Returns a copy of the current modality snapshot.
+    fn snapshot(&self) -> ModalitySnapshot;
+
+    /// Returns the most recent input modality observed by this context.
+    fn last_pointer_type(&self) -> Option<PointerType> {
+        self.snapshot().last_pointer_type
+    }
+
+    /// Returns whether the context currently reflects a pointer interaction.
+    fn had_pointer_interaction(&self) -> bool {
+        self.snapshot().had_pointer_interaction()
+    }
+
+    /// Returns whether any press interaction is currently active.
+    fn is_global_press_active(&self) -> bool {
+        self.snapshot().global_press_active
+    }
+
+    /// Records a keyboard-driven interaction.
+    fn on_key_down(&self, key: KeyboardKey, modifiers: KeyModifiers);
+
+    /// Records a pointer-driven interaction.
+    fn on_pointer_down(&self, pointer_type: PointerType);
+
+    /// Records a virtual or programmatic interaction source.
+    fn on_virtual_input(&self);
+
+    /// Sets the global press-active flag.
+    fn set_global_press_active(&self, active: bool);
+
+    /// Clears all modality state for deterministic tests and provider resets.
+    fn clear(&self);
+}
+
+/// Default interior-mutable modality context implementation.
+#[derive(Debug, Default)]
+pub struct DefaultModalityContext {
+    snapshot: Cell<ModalitySnapshot>,
+}
+
+impl DefaultModalityContext {
+    /// Creates a new context with no prior modality and no active press state.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            snapshot: Cell::new(ModalitySnapshot {
+                last_pointer_type: None,
+                global_press_active: false,
+            }),
+        }
+    }
+}
+
+impl ModalityContext for DefaultModalityContext {
+    fn snapshot(&self) -> ModalitySnapshot {
+        self.snapshot.get()
+    }
+
+    fn on_key_down(&self, _key: KeyboardKey, _modifiers: KeyModifiers) {
+        let mut snapshot = self.snapshot.get();
+        snapshot.last_pointer_type = Some(PointerType::Keyboard);
+        self.snapshot.set(snapshot);
+    }
+
+    fn on_pointer_down(&self, pointer_type: PointerType) {
+        let mut snapshot = self.snapshot.get();
+        snapshot.last_pointer_type = Some(pointer_type);
+        self.snapshot.set(snapshot);
+    }
+
+    fn on_virtual_input(&self) {
+        let mut snapshot = self.snapshot.get();
+        snapshot.last_pointer_type = Some(PointerType::Virtual);
+        self.snapshot.set(snapshot);
+    }
+
+    fn set_global_press_active(&self, active: bool) {
+        let mut snapshot = self.snapshot.get();
+        snapshot.global_press_active = active;
+        self.snapshot.set(snapshot);
+    }
+
+    fn clear(&self) {
+        self.snapshot.set(ModalitySnapshot::default());
+    }
+}
+
+/// No-op modality context for SSR and tests that intentionally disable tracking.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct NullModalityContext;
+
+impl ModalityContext for NullModalityContext {
+    fn snapshot(&self) -> ModalitySnapshot {
+        ModalitySnapshot::default()
+    }
+
+    fn on_key_down(&self, _key: KeyboardKey, _modifiers: KeyModifiers) {}
+
+    fn on_pointer_down(&self, _pointer_type: PointerType) {}
+
+    fn on_virtual_input(&self) {}
+
+    fn set_global_press_active(&self, _active: bool) {}
+
+    fn clear(&self) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keyboard_key_round_trips_across_w3c_registry() {
+        let cases = [
+            (KeyboardKey::Unidentified, "Unidentified"),
+            (KeyboardKey::Alt, "Alt"),
+            (KeyboardKey::AltGraph, "AltGraph"),
+            (KeyboardKey::CapsLock, "CapsLock"),
+            (KeyboardKey::Control, "Control"),
+            (KeyboardKey::Fn, "Fn"),
+            (KeyboardKey::FnLock, "FnLock"),
+            (KeyboardKey::Meta, "Meta"),
+            (KeyboardKey::NumLock, "NumLock"),
+            (KeyboardKey::ScrollLock, "ScrollLock"),
+            (KeyboardKey::Shift, "Shift"),
+            (KeyboardKey::Symbol, "Symbol"),
+            (KeyboardKey::SymbolLock, "SymbolLock"),
+            (KeyboardKey::Hyper, "Hyper"),
+            (KeyboardKey::Super, "Super"),
+            (KeyboardKey::Enter, "Enter"),
+            (KeyboardKey::Tab, "Tab"),
+            (KeyboardKey::Space, " "),
+            (KeyboardKey::ArrowDown, "ArrowDown"),
+            (KeyboardKey::ArrowLeft, "ArrowLeft"),
+            (KeyboardKey::ArrowRight, "ArrowRight"),
+            (KeyboardKey::ArrowUp, "ArrowUp"),
+            (KeyboardKey::End, "End"),
+            (KeyboardKey::Home, "Home"),
+            (KeyboardKey::PageDown, "PageDown"),
+            (KeyboardKey::PageUp, "PageUp"),
+            (KeyboardKey::Backspace, "Backspace"),
+            (KeyboardKey::Clear, "Clear"),
+            (KeyboardKey::Copy, "Copy"),
+            (KeyboardKey::CrSel, "CrSel"),
+            (KeyboardKey::Cut, "Cut"),
+            (KeyboardKey::Delete, "Delete"),
+            (KeyboardKey::EraseEof, "EraseEof"),
+            (KeyboardKey::ExSel, "ExSel"),
+            (KeyboardKey::Insert, "Insert"),
+            (KeyboardKey::Paste, "Paste"),
+            (KeyboardKey::Redo, "Redo"),
+            (KeyboardKey::Undo, "Undo"),
+            (KeyboardKey::Accept, "Accept"),
+            (KeyboardKey::Again, "Again"),
+            (KeyboardKey::Attn, "Attn"),
+            (KeyboardKey::Cancel, "Cancel"),
+            (KeyboardKey::ContextMenu, "ContextMenu"),
+            (KeyboardKey::Escape, "Escape"),
+            (KeyboardKey::Execute, "Execute"),
+            (KeyboardKey::Find, "Find"),
+            (KeyboardKey::Help, "Help"),
+            (KeyboardKey::Pause, "Pause"),
+            (KeyboardKey::Play, "Play"),
+            (KeyboardKey::Props, "Props"),
+            (KeyboardKey::Select, "Select"),
+            (KeyboardKey::ZoomIn, "ZoomIn"),
+            (KeyboardKey::ZoomOut, "ZoomOut"),
+            (KeyboardKey::BrightnessDown, "BrightnessDown"),
+            (KeyboardKey::BrightnessUp, "BrightnessUp"),
+            (KeyboardKey::Eject, "Eject"),
+            (KeyboardKey::LogOff, "LogOff"),
+            (KeyboardKey::Power, "Power"),
+            (KeyboardKey::PowerOff, "PowerOff"),
+            (KeyboardKey::PrintScreen, "PrintScreen"),
+            (KeyboardKey::Hibernate, "Hibernate"),
+            (KeyboardKey::Standby, "Standby"),
+            (KeyboardKey::WakeUp, "WakeUp"),
+            (KeyboardKey::AllCandidates, "AllCandidates"),
+            (KeyboardKey::Alphanumeric, "Alphanumeric"),
+            (KeyboardKey::CodeInput, "CodeInput"),
+            (KeyboardKey::Compose, "Compose"),
+            (KeyboardKey::Convert, "Convert"),
+            (KeyboardKey::Dead, "Dead"),
+            (KeyboardKey::FinalMode, "FinalMode"),
+            (KeyboardKey::GroupFirst, "GroupFirst"),
+            (KeyboardKey::GroupLast, "GroupLast"),
+            (KeyboardKey::GroupNext, "GroupNext"),
+            (KeyboardKey::GroupPrevious, "GroupPrevious"),
+            (KeyboardKey::ModeChange, "ModeChange"),
+            (KeyboardKey::NextCandidate, "NextCandidate"),
+            (KeyboardKey::NonConvert, "NonConvert"),
+            (KeyboardKey::PreviousCandidate, "PreviousCandidate"),
+            (KeyboardKey::Process, "Process"),
+            (KeyboardKey::SingleCandidate, "SingleCandidate"),
+            (KeyboardKey::HangulMode, "HangulMode"),
+            (KeyboardKey::HanjaMode, "HanjaMode"),
+            (KeyboardKey::JunjaMode, "JunjaMode"),
+            (KeyboardKey::Eisu, "Eisu"),
+            (KeyboardKey::Hankaku, "Hankaku"),
+            (KeyboardKey::Hiragana, "Hiragana"),
+            (KeyboardKey::HiraganaKatakana, "HiraganaKatakana"),
+            (KeyboardKey::KanaMode, "KanaMode"),
+            (KeyboardKey::KanjiMode, "KanjiMode"),
+            (KeyboardKey::Katakana, "Katakana"),
+            (KeyboardKey::Romaji, "Romaji"),
+            (KeyboardKey::Zenkaku, "Zenkaku"),
+            (KeyboardKey::ZenkakuHankaku, "ZenkakuHankaku"),
+            (KeyboardKey::F1, "F1"),
+            (KeyboardKey::F2, "F2"),
+            (KeyboardKey::F3, "F3"),
+            (KeyboardKey::F4, "F4"),
+            (KeyboardKey::F5, "F5"),
+            (KeyboardKey::F6, "F6"),
+            (KeyboardKey::F7, "F7"),
+            (KeyboardKey::F8, "F8"),
+            (KeyboardKey::F9, "F9"),
+            (KeyboardKey::F10, "F10"),
+            (KeyboardKey::F11, "F11"),
+            (KeyboardKey::F12, "F12"),
+            (KeyboardKey::Soft1, "Soft1"),
+            (KeyboardKey::Soft2, "Soft2"),
+            (KeyboardKey::Soft3, "Soft3"),
+            (KeyboardKey::Soft4, "Soft4"),
+            (KeyboardKey::ChannelDown, "ChannelDown"),
+            (KeyboardKey::ChannelUp, "ChannelUp"),
+            (KeyboardKey::Close, "Close"),
+            (KeyboardKey::MailForward, "MailForward"),
+            (KeyboardKey::MailReply, "MailReply"),
+            (KeyboardKey::MailSend, "MailSend"),
+            (KeyboardKey::MediaClose, "MediaClose"),
+            (KeyboardKey::MediaFastForward, "MediaFastForward"),
+            (KeyboardKey::MediaPause, "MediaPause"),
+            (KeyboardKey::MediaPlay, "MediaPlay"),
+            (KeyboardKey::MediaPlayPause, "MediaPlayPause"),
+            (KeyboardKey::MediaRecord, "MediaRecord"),
+            (KeyboardKey::MediaRewind, "MediaRewind"),
+            (KeyboardKey::MediaStop, "MediaStop"),
+            (KeyboardKey::MediaTrackNext, "MediaTrackNext"),
+            (KeyboardKey::MediaTrackPrevious, "MediaTrackPrevious"),
+            (KeyboardKey::New, "New"),
+            (KeyboardKey::Open, "Open"),
+            (KeyboardKey::Print, "Print"),
+            (KeyboardKey::Save, "Save"),
+            (KeyboardKey::SpellCheck, "SpellCheck"),
+            (KeyboardKey::Key11, "11"),
+            (KeyboardKey::Key12, "12"),
+            (KeyboardKey::AudioBalanceLeft, "AudioBalanceLeft"),
+            (KeyboardKey::AudioBalanceRight, "AudioBalanceRight"),
+            (KeyboardKey::AudioBassBoostDown, "AudioBassBoostDown"),
+            (KeyboardKey::AudioBassBoostToggle, "AudioBassBoostToggle"),
+            (KeyboardKey::AudioBassBoostUp, "AudioBassBoostUp"),
+            (KeyboardKey::AudioFaderFront, "AudioFaderFront"),
+            (KeyboardKey::AudioFaderRear, "AudioFaderRear"),
+            (KeyboardKey::AudioSurroundModeNext, "AudioSurroundModeNext"),
+            (KeyboardKey::AudioTrebleDown, "AudioTrebleDown"),
+            (KeyboardKey::AudioTrebleUp, "AudioTrebleUp"),
+            (KeyboardKey::AudioVolumeDown, "AudioVolumeDown"),
+            (KeyboardKey::AudioVolumeUp, "AudioVolumeUp"),
+            (KeyboardKey::AudioVolumeMute, "AudioVolumeMute"),
+            (KeyboardKey::MicrophoneToggle, "MicrophoneToggle"),
+            (KeyboardKey::MicrophoneVolumeDown, "MicrophoneVolumeDown"),
+            (KeyboardKey::MicrophoneVolumeUp, "MicrophoneVolumeUp"),
+            (KeyboardKey::MicrophoneVolumeMute, "MicrophoneVolumeMute"),
+            (KeyboardKey::SpeechCorrectionList, "SpeechCorrectionList"),
+            (KeyboardKey::SpeechInputToggle, "SpeechInputToggle"),
+            (KeyboardKey::LaunchApplication1, "LaunchApplication1"),
+            (KeyboardKey::LaunchApplication2, "LaunchApplication2"),
+            (KeyboardKey::LaunchCalendar, "LaunchCalendar"),
+            (KeyboardKey::LaunchContacts, "LaunchContacts"),
+            (KeyboardKey::LaunchMail, "LaunchMail"),
+            (KeyboardKey::LaunchMediaPlayer, "LaunchMediaPlayer"),
+            (KeyboardKey::LaunchMusicPlayer, "LaunchMusicPlayer"),
+            (KeyboardKey::LaunchPhone, "LaunchPhone"),
+            (KeyboardKey::LaunchScreenSaver, "LaunchScreenSaver"),
+            (KeyboardKey::LaunchSpreadsheet, "LaunchSpreadsheet"),
+            (KeyboardKey::LaunchWebBrowser, "LaunchWebBrowser"),
+            (KeyboardKey::LaunchWebCam, "LaunchWebCam"),
+            (KeyboardKey::LaunchWordProcessor, "LaunchWordProcessor"),
+            (KeyboardKey::BrowserBack, "BrowserBack"),
+            (KeyboardKey::BrowserFavorites, "BrowserFavorites"),
+            (KeyboardKey::BrowserForward, "BrowserForward"),
+            (KeyboardKey::BrowserHome, "BrowserHome"),
+            (KeyboardKey::BrowserRefresh, "BrowserRefresh"),
+            (KeyboardKey::BrowserSearch, "BrowserSearch"),
+            (KeyboardKey::BrowserStop, "BrowserStop"),
+            (KeyboardKey::AppSwitch, "AppSwitch"),
+            (KeyboardKey::Call, "Call"),
+            (KeyboardKey::Camera, "Camera"),
+            (KeyboardKey::CameraFocus, "CameraFocus"),
+            (KeyboardKey::EndCall, "EndCall"),
+            (KeyboardKey::GoBack, "GoBack"),
+            (KeyboardKey::GoHome, "GoHome"),
+            (KeyboardKey::HeadsetHook, "HeadsetHook"),
+            (KeyboardKey::LastNumberRedial, "LastNumberRedial"),
+            (KeyboardKey::Notification, "Notification"),
+            (KeyboardKey::MannerMode, "MannerMode"),
+            (KeyboardKey::VoiceDial, "VoiceDial"),
+            (KeyboardKey::Tv, "TV"),
+            (KeyboardKey::Tv3DMode, "TV3DMode"),
+            (KeyboardKey::TvAntennaCable, "TVAntennaCable"),
+            (KeyboardKey::TvAudioDescription, "TVAudioDescription"),
+            (
+                KeyboardKey::TvAudioDescriptionMixDown,
+                "TVAudioDescriptionMixDown",
+            ),
+            (
+                KeyboardKey::TvAudioDescriptionMixUp,
+                "TVAudioDescriptionMixUp",
+            ),
+            (KeyboardKey::TvContentsMenu, "TVContentsMenu"),
+            (KeyboardKey::TvDataService, "TVDataService"),
+            (KeyboardKey::TvInput, "TVInput"),
+            (KeyboardKey::TvInputComponent1, "TVInputComponent1"),
+            (KeyboardKey::TvInputComponent2, "TVInputComponent2"),
+            (KeyboardKey::TvInputComposite1, "TVInputComposite1"),
+            (KeyboardKey::TvInputComposite2, "TVInputComposite2"),
+            (KeyboardKey::TvInputHdmi1, "TVInputHDMI1"),
+            (KeyboardKey::TvInputHdmi2, "TVInputHDMI2"),
+            (KeyboardKey::TvInputHdmi3, "TVInputHDMI3"),
+            (KeyboardKey::TvInputHdmi4, "TVInputHDMI4"),
+            (KeyboardKey::TvInputVga1, "TVInputVGA1"),
+            (KeyboardKey::TvMediaContext, "TVMediaContext"),
+            (KeyboardKey::TvNetwork, "TVNetwork"),
+            (KeyboardKey::TvNumberEntry, "TVNumberEntry"),
+            (KeyboardKey::TvPower, "TVPower"),
+            (KeyboardKey::TvRadioService, "TVRadioService"),
+            (KeyboardKey::TvSatellite, "TVSatellite"),
+            (KeyboardKey::TvSatelliteBS, "TVSatelliteBS"),
+            (KeyboardKey::TvSatelliteCS, "TVSatelliteCS"),
+            (KeyboardKey::TvSatelliteToggle, "TVSatelliteToggle"),
+            (KeyboardKey::TvTerrestrialAnalog, "TVTerrestrialAnalog"),
+            (KeyboardKey::TvTerrestrialDigital, "TVTerrestrialDigital"),
+            (KeyboardKey::TvTimer, "TVTimer"),
+            (KeyboardKey::AvrInput, "AVRInput"),
+            (KeyboardKey::AvrPower, "AVRPower"),
+            (KeyboardKey::ColorF0Red, "ColorF0Red"),
+            (KeyboardKey::ColorF1Green, "ColorF1Green"),
+            (KeyboardKey::ColorF2Yellow, "ColorF2Yellow"),
+            (KeyboardKey::ColorF3Blue, "ColorF3Blue"),
+            (KeyboardKey::ColorF4Grey, "ColorF4Grey"),
+            (KeyboardKey::ColorF5Brown, "ColorF5Brown"),
+            (KeyboardKey::ClosedCaptionToggle, "ClosedCaptionToggle"),
+            (KeyboardKey::Dimmer, "Dimmer"),
+            (KeyboardKey::DisplaySwap, "DisplaySwap"),
+            (KeyboardKey::Dvr, "DVR"),
+            (KeyboardKey::Exit, "Exit"),
+            (KeyboardKey::FavoriteClear0, "FavoriteClear0"),
+            (KeyboardKey::FavoriteClear1, "FavoriteClear1"),
+            (KeyboardKey::FavoriteClear2, "FavoriteClear2"),
+            (KeyboardKey::FavoriteClear3, "FavoriteClear3"),
+            (KeyboardKey::FavoriteRecall0, "FavoriteRecall0"),
+            (KeyboardKey::FavoriteRecall1, "FavoriteRecall1"),
+            (KeyboardKey::FavoriteRecall2, "FavoriteRecall2"),
+            (KeyboardKey::FavoriteRecall3, "FavoriteRecall3"),
+            (KeyboardKey::FavoriteStore0, "FavoriteStore0"),
+            (KeyboardKey::FavoriteStore1, "FavoriteStore1"),
+            (KeyboardKey::FavoriteStore2, "FavoriteStore2"),
+            (KeyboardKey::FavoriteStore3, "FavoriteStore3"),
+            (KeyboardKey::Guide, "Guide"),
+            (KeyboardKey::GuideNextDay, "GuideNextDay"),
+            (KeyboardKey::GuidePreviousDay, "GuidePreviousDay"),
+            (KeyboardKey::Info, "Info"),
+            (KeyboardKey::InstantReplay, "InstantReplay"),
+            (KeyboardKey::Link, "Link"),
+            (KeyboardKey::ListProgram, "ListProgram"),
+            (KeyboardKey::LiveContent, "LiveContent"),
+            (KeyboardKey::Lock, "Lock"),
+            (KeyboardKey::MediaApps, "MediaApps"),
+            (KeyboardKey::MediaAudioTrack, "MediaAudioTrack"),
+            (KeyboardKey::MediaLast, "MediaLast"),
+            (KeyboardKey::MediaSkipBackward, "MediaSkipBackward"),
+            (KeyboardKey::MediaSkipForward, "MediaSkipForward"),
+            (KeyboardKey::MediaStepBackward, "MediaStepBackward"),
+            (KeyboardKey::MediaStepForward, "MediaStepForward"),
+            (KeyboardKey::MediaTopMenu, "MediaTopMenu"),
+            (KeyboardKey::NavigateIn, "NavigateIn"),
+            (KeyboardKey::NavigateNext, "NavigateNext"),
+            (KeyboardKey::NavigateOut, "NavigateOut"),
+            (KeyboardKey::NavigatePrevious, "NavigatePrevious"),
+            (KeyboardKey::NextFavoriteChannel, "NextFavoriteChannel"),
+            (KeyboardKey::NextUserProfile, "NextUserProfile"),
+            (KeyboardKey::OnDemand, "OnDemand"),
+            (KeyboardKey::Pairing, "Pairing"),
+            (KeyboardKey::PinPDown, "PinPDown"),
+            (KeyboardKey::PinPMove, "PinPMove"),
+            (KeyboardKey::PinPToggle, "PinPToggle"),
+            (KeyboardKey::PinPUp, "PinPUp"),
+            (KeyboardKey::PlaySpeedDown, "PlaySpeedDown"),
+            (KeyboardKey::PlaySpeedReset, "PlaySpeedReset"),
+            (KeyboardKey::PlaySpeedUp, "PlaySpeedUp"),
+            (KeyboardKey::RandomToggle, "RandomToggle"),
+            (KeyboardKey::RcLowBattery, "RcLowBattery"),
+            (KeyboardKey::RecordSpeedNext, "RecordSpeedNext"),
+            (KeyboardKey::RfBypass, "RfBypass"),
+            (KeyboardKey::ScanChannelsToggle, "ScanChannelsToggle"),
+            (KeyboardKey::ScreenModeNext, "ScreenModeNext"),
+            (KeyboardKey::Settings, "Settings"),
+            (KeyboardKey::SplitScreenToggle, "SplitScreenToggle"),
+            (KeyboardKey::StbInput, "STBInput"),
+            (KeyboardKey::StbPower, "STBPower"),
+            (KeyboardKey::Subtitle, "Subtitle"),
+            (KeyboardKey::Teletext, "Teletext"),
+            (KeyboardKey::VideoModeNext, "VideoModeNext"),
+            (KeyboardKey::Wink, "Wink"),
+            (KeyboardKey::ZoomToggle, "ZoomToggle"),
+        ];
+
+        for (key, value) in cases {
+            assert_eq!(KeyboardKey::from_key_str(value), key);
+            assert_eq!(key.as_w3c_str(), value);
+        }
+    }
+
+    #[test]
+    fn keyboard_key_rejects_printable_and_unknown_values() {
+        assert_eq!(KeyboardKey::from_key_str("a"), KeyboardKey::Unidentified);
+        assert_eq!(
+            KeyboardKey::from_key_str("Enter "),
+            KeyboardKey::Unidentified
+        );
+        assert_eq!(
+            KeyboardKey::from_key_str("UnknownKey"),
+            KeyboardKey::Unidentified
+        );
+    }
+
+    #[test]
+    fn default_modality_context_starts_empty() {
+        let context = DefaultModalityContext::new();
+
+        assert_eq!(context.last_pointer_type(), None);
+        assert!(!context.had_pointer_interaction());
+        assert!(!context.is_global_press_active());
+    }
+
+    #[test]
+    fn keyboard_input_sets_keyboard_modality() {
+        let context = DefaultModalityContext::new();
+        context.on_key_down(KeyboardKey::Tab, KeyModifiers::default());
+
+        assert_eq!(context.last_pointer_type(), Some(PointerType::Keyboard));
+        assert!(!context.had_pointer_interaction());
+    }
+
+    #[test]
+    fn pointer_input_tracks_pointer_modalities() {
+        let context = DefaultModalityContext::new();
+
+        context.on_pointer_down(PointerType::Mouse);
+        assert_eq!(context.last_pointer_type(), Some(PointerType::Mouse));
+        assert!(context.had_pointer_interaction());
+
+        context.on_pointer_down(PointerType::Touch);
+        assert_eq!(context.last_pointer_type(), Some(PointerType::Touch));
+        assert!(context.had_pointer_interaction());
+
+        context.on_pointer_down(PointerType::Pen);
+        assert_eq!(context.last_pointer_type(), Some(PointerType::Pen));
+        assert!(context.had_pointer_interaction());
+    }
+
+    #[test]
+    fn virtual_input_is_not_pointer_interaction() {
+        let context = DefaultModalityContext::new();
+        context.on_virtual_input();
+
+        assert_eq!(context.last_pointer_type(), Some(PointerType::Virtual));
+        assert!(!context.had_pointer_interaction());
+    }
+
+    #[test]
+    fn global_press_active_toggles() {
+        let context = DefaultModalityContext::new();
+
+        context.set_global_press_active(true);
+        assert!(context.is_global_press_active());
+
+        context.set_global_press_active(false);
+        assert!(!context.is_global_press_active());
+    }
+
+    #[test]
+    fn contexts_do_not_share_state() {
+        let left = DefaultModalityContext::new();
+        let right = DefaultModalityContext::new();
+
+        left.on_pointer_down(PointerType::Mouse);
+
+        assert_eq!(left.last_pointer_type(), Some(PointerType::Mouse));
+        assert_eq!(right.last_pointer_type(), None);
+    }
+
+    #[test]
+    fn clear_resets_context_state() {
+        let context = DefaultModalityContext::new();
+        context.on_pointer_down(PointerType::Touch);
+        context.set_global_press_active(true);
+
+        context.clear();
+
+        assert_eq!(context.snapshot(), ModalitySnapshot::default());
+    }
+
+    #[test]
+    fn null_modality_context_is_a_no_op() {
+        let context = NullModalityContext;
+        context.on_key_down(KeyboardKey::Tab, KeyModifiers::default());
+        context.on_pointer_down(PointerType::Mouse);
+        context.on_virtual_input();
+        context.set_global_press_active(true);
+
+        assert_eq!(context.snapshot(), ModalitySnapshot::default());
+    }
+}

--- a/crates/ars-core/src/provider.rs
+++ b/crates/ars-core/src/provider.rs
@@ -1,13 +1,24 @@
 //! Shared provider contract types for the `ArsProvider` root context.
 //!
-//! [`ArsProvider`](crate) is the single root provider that supplies shared configuration,
-//! platform capabilities, i18n resources, and style strategy to all descendant components.
-//! This module defines the framework-agnostic types used across all adapters.
+//! [`ArsContext`] captures the framework-agnostic values adapters propagate from
+//! the root provider into descendant components, including platform effects and
+//! the shared instance-scoped modality context.
+
+extern crate alloc;
+
+use alloc::{rc::Rc, string::String};
+use core::fmt;
+
+use ars_i18n::{Direction, Locale};
+
+use crate::{
+    DefaultModalityContext, ModalityContext, NullPlatformEffects, PlatformEffects, StyleStrategy,
+};
 
 /// Active color mode for theme-aware rendering.
 ///
 /// Components access this via `ArsProvider` context. The `System` variant defers
-/// to the user's OS-level preference (e.g., `prefers-color-scheme` on the web).
+/// to the user's OS-level preference (for example `prefers-color-scheme` on the web).
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum ColorMode {
     /// Light color scheme.
@@ -19,9 +30,164 @@ pub enum ColorMode {
     System,
 }
 
+/// Framework-agnostic provider context shared with descendant components.
+#[derive(Clone)]
+pub struct ArsContext {
+    locale: Locale,
+    direction: Direction,
+    color_mode: ColorMode,
+    disabled: bool,
+    read_only: bool,
+    id_prefix: Option<String>,
+    portal_container_id: Option<String>,
+    root_node_id: Option<String>,
+    platform: Rc<dyn PlatformEffects>,
+    modality: Rc<dyn ModalityContext>,
+    style_strategy: StyleStrategy,
+}
+
+impl ArsContext {
+    /// Creates a new provider context from explicitly supplied values.
+    #[must_use]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "ArsContext intentionally mirrors root-provider context fields."
+    )]
+    pub fn new(
+        locale: Locale,
+        direction: Direction,
+        color_mode: ColorMode,
+        disabled: bool,
+        read_only: bool,
+        id_prefix: Option<String>,
+        portal_container_id: Option<String>,
+        root_node_id: Option<String>,
+        platform: Rc<dyn PlatformEffects>,
+        modality: Rc<dyn ModalityContext>,
+        style_strategy: StyleStrategy,
+    ) -> Self {
+        Self {
+            locale,
+            direction,
+            color_mode,
+            disabled,
+            read_only,
+            id_prefix,
+            portal_container_id,
+            root_node_id,
+            platform,
+            modality,
+            style_strategy,
+        }
+    }
+
+    /// Returns the active locale.
+    #[must_use]
+    pub fn locale(&self) -> &Locale {
+        &self.locale
+    }
+
+    /// Returns the reading direction.
+    #[must_use]
+    pub const fn direction(&self) -> Direction {
+        self.direction
+    }
+
+    /// Returns the active color mode.
+    #[must_use]
+    pub const fn color_mode(&self) -> ColorMode {
+        self.color_mode
+    }
+
+    /// Returns whether descendants should render as disabled.
+    #[must_use]
+    pub const fn disabled(&self) -> bool {
+        self.disabled
+    }
+
+    /// Returns whether descendants should render as read-only.
+    #[must_use]
+    pub const fn read_only(&self) -> bool {
+        self.read_only
+    }
+
+    /// Returns the optional generated-ID prefix.
+    #[must_use]
+    pub fn id_prefix(&self) -> Option<&str> {
+        self.id_prefix.as_deref()
+    }
+
+    /// Returns the optional portal container element ID.
+    #[must_use]
+    pub fn portal_container_id(&self) -> Option<&str> {
+        self.portal_container_id.as_deref()
+    }
+
+    /// Returns the optional scoped root-node ID.
+    #[must_use]
+    pub fn root_node_id(&self) -> Option<&str> {
+        self.root_node_id.as_deref()
+    }
+
+    /// Returns the shared platform-effects handle.
+    #[must_use]
+    pub fn platform(&self) -> Rc<dyn PlatformEffects> {
+        Rc::clone(&self.platform)
+    }
+
+    /// Returns the shared modality context for this provider root.
+    #[must_use]
+    pub fn modality(&self) -> Rc<dyn ModalityContext> {
+        Rc::clone(&self.modality)
+    }
+
+    /// Returns the active style strategy.
+    #[must_use]
+    pub fn style_strategy(&self) -> &StyleStrategy {
+        &self.style_strategy
+    }
+}
+
+impl Default for ArsContext {
+    fn default() -> Self {
+        Self {
+            locale: Locale::new("en-US"),
+            direction: Direction::Ltr,
+            color_mode: ColorMode::System,
+            disabled: false,
+            read_only: false,
+            id_prefix: None,
+            portal_container_id: None,
+            root_node_id: None,
+            platform: Rc::new(NullPlatformEffects),
+            modality: Rc::new(DefaultModalityContext::new()),
+            style_strategy: StyleStrategy::Inline,
+        }
+    }
+}
+
+impl fmt::Debug for ArsContext {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ArsContext")
+            .field("locale", &self.locale)
+            .field("direction", &self.direction)
+            .field("color_mode", &self.color_mode)
+            .field("disabled", &self.disabled)
+            .field("read_only", &self.read_only)
+            .field("id_prefix", &self.id_prefix)
+            .field("portal_container_id", &self.portal_container_id)
+            .field("root_node_id", &self.root_node_id)
+            .field("platform", &"<dyn PlatformEffects>")
+            .field("modality", &"<dyn ModalityContext>")
+            .field("style_strategy", &self.style_strategy)
+            .finish()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{ModalitySnapshot, NullModalityContext};
 
     #[test]
     fn color_mode_default_is_system() {
@@ -38,7 +204,42 @@ mod tests {
     #[test]
     fn color_mode_is_copy() {
         let a = ColorMode::Dark;
-        let b = a; // Copy
+        let b = a;
         assert_eq!(a, b);
+    }
+
+    #[test]
+    fn ars_context_default_uses_default_modality_context() {
+        let context = ArsContext::default();
+
+        assert_eq!(context.locale().as_str(), "en-US");
+        assert_eq!(context.direction(), Direction::Ltr);
+        assert_eq!(context.color_mode(), ColorMode::System);
+        assert_eq!(context.modality().snapshot(), ModalitySnapshot::default());
+    }
+
+    #[test]
+    fn ars_context_constructor_preserves_values() {
+        let context = ArsContext::new(
+            Locale::new("pt-BR"),
+            Direction::Ltr,
+            ColorMode::Dark,
+            true,
+            true,
+            Some(String::from("prefix")),
+            Some(String::from("portal-root")),
+            Some(String::from("app-root")),
+            Rc::new(NullPlatformEffects),
+            Rc::new(NullModalityContext),
+            StyleStrategy::Cssom,
+        );
+
+        assert_eq!(context.locale().as_str(), "pt-BR");
+        assert!(context.disabled());
+        assert!(context.read_only());
+        assert_eq!(context.id_prefix(), Some("prefix"));
+        assert_eq!(context.portal_container_id(), Some("portal-root"));
+        assert_eq!(context.root_node_id(), Some("app-root"));
+        assert_eq!(context.style_strategy(), &StyleStrategy::Cssom);
     }
 }

--- a/crates/ars-dom/Cargo.toml
+++ b/crates/ars-dom/Cargo.toml
@@ -22,11 +22,17 @@ web-sys          = { version = "0.3", optional = true, features = [
     "CssStyleDeclaration",
     "Document",
     "Element",
+    "EventTarget",
+    "FocusEvent",
     "FocusOptions",
     "HtmlElement",
+    "KeyboardEvent",
+    "MouseEvent",
     "Navigator",
     "Node",
     "NodeList",
+    "PointerEvent",
+    "TouchEvent",
     "Window",
 ] }
 

--- a/crates/ars-dom/src/focus.rs
+++ b/crates/ars-dom/src/focus.rs
@@ -724,6 +724,74 @@ mod tests {
     use super::*;
 
     #[test]
+    fn focus_scope_new_starts_inactive_with_expected_fields() {
+        let scope = FocusScope::new("dialog-root", FocusScopeOptions::default());
+
+        assert_eq!(scope.container_id, "dialog-root");
+        assert_eq!(scope.options, FocusScopeOptions::default());
+        assert_eq!(scope.previously_focused, None);
+        assert!(!scope.active);
+    }
+
+    #[test]
+    fn focus_scope_activate_and_deactivate_are_safe_on_host() {
+        let mut scope = FocusScope::new("dialog-root", FocusScopeOptions::default());
+
+        scope.activate(FocusTarget::First);
+        assert!(scope.active);
+        assert_eq!(scope.previously_focused, None);
+        assert!(scope.is_active());
+
+        scope.deactivate();
+        assert!(!scope.active);
+        assert_eq!(scope.previously_focused, None);
+        assert!(!scope.is_active());
+    }
+
+    #[test]
+    fn focus_scope_focus_helpers_are_host_safe() {
+        let scope = FocusScope::new("dialog-root", FocusScopeOptions::default());
+
+        scope.focus_first(FocusTarget::First);
+        scope.focus_first(FocusTarget::Last);
+        scope.focus_first(FocusTarget::AutofocusMarked);
+        scope.focus_first(FocusTarget::PreviouslyActive);
+        scope.focus_last();
+
+        assert!(!scope.contains_element("child"));
+    }
+
+    #[test]
+    fn host_focus_query_helpers_return_safe_defaults() {
+        let focused = FocusedElement(String::from("field"));
+
+        assert_eq!(active_element_id(), None);
+        assert_eq!(get_currently_focused(), None);
+        assert!(!is_element_in_dom(&focused));
+        assert!(!document_contains_id_impl("field"));
+        assert_eq!(active_element_id_impl(), None);
+        assert_eq!(current_tabbable_index("dialog-root"), None);
+        assert_eq!(tabbable_count("dialog-root"), 0);
+        assert!(!focus_autofocus_marked("dialog-root"));
+        assert!(!focus_element_by_id_impl("field"));
+        assert!(!focus_first_tabbable_impl("dialog-root"));
+        assert!(!focus_last_tabbable_impl("dialog-root"));
+        assert!(!contains_element_by_id("dialog-root", "field"));
+    }
+
+    #[test]
+    fn host_focus_side_effect_helpers_are_safe_to_call() {
+        focus_focused_element(&FocusedElement(String::from("field")));
+        focus_container_parent("dialog-root");
+        focus_container("dialog-root");
+        focus_body_impl();
+        focus_element_by_id("field");
+        focus_first_tabbable("dialog-root");
+        focus_last_tabbable("dialog-root");
+        focus_body();
+    }
+
+    #[test]
     fn restore_target_prefers_previous_then_parent_then_body() {
         assert_eq!(
             resolve_restore_target(true, true),
@@ -789,6 +857,14 @@ mod tests {
     }
 
     #[test]
+    fn tab_navigation_shift_with_non_boundary_keeps_browser_default() {
+        assert_eq!(
+            resolve_tab_navigation(true, true, 4, Some(2), true),
+            TabNavigationAction::AllowBrowserDefault
+        );
+    }
+
+    #[test]
     fn tabbable_selector_keeps_focusable_ordering_contract() {
         assert!(TABBABLE_SELECTOR.contains("button:not([disabled])"));
         assert!(TABBABLE_SELECTOR.contains("[tabindex]:not([tabindex='-1'])"));
@@ -808,5 +884,10 @@ mod tests {
             get_previously_active_element("dialog-b"),
             Some(FocusedElement(String::from("input-b")))
         );
+    }
+
+    #[test]
+    fn previously_active_lookup_returns_none_for_unknown_scope() {
+        assert_eq!(get_previously_active_element("missing-scope"), None);
     }
 }

--- a/crates/ars-dom/src/lib.rs
+++ b/crates/ars-dom/src/lib.rs
@@ -5,6 +5,7 @@
 //! platform capability detection.
 
 mod focus;
+pub mod modality;
 pub mod scroll_lock;
 
 pub use focus::{
@@ -15,6 +16,7 @@ pub use focus::{
     document_contains, focus_element, get_first_focusable, get_focusable_elements,
     get_html_element_by_id, get_last_focusable,
 };
+pub use modality::ModalityManager;
 pub use scroll_lock::{
     ScrollLockManager, acquire, depth, is_locked, prevent_scroll, release, restore_scroll,
 };

--- a/crates/ars-dom/src/modality.rs
+++ b/crates/ars-dom/src/modality.rs
@@ -1,0 +1,409 @@
+//! Web listener management for the shared modality context.
+
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
+use std::cell::RefCell;
+use std::{cell::Cell, fmt, rc::Rc};
+
+use ars_a11y::FocusRing;
+use ars_core::{KeyModifiers, KeyboardKey, ModalityContext, PointerType};
+
+/// Adapter-facing coordinator that keeps shared modality and focus-visible state in sync.
+pub struct ModalityManager {
+    modality: Rc<dyn ModalityContext>,
+    focus_ring: FocusRing,
+    listeners_installed: Cell<bool>,
+    listener_refcount: Cell<u32>,
+    #[cfg(all(feature = "web", target_arch = "wasm32"))]
+    listeners: RefCell<Option<WasmListenerHandles>>,
+}
+
+impl ModalityManager {
+    /// Creates a new modality manager for a single provider root.
+    #[must_use]
+    pub fn new(modality: Rc<dyn ModalityContext>) -> Self {
+        Self {
+            modality,
+            focus_ring: FocusRing::new(),
+            listeners_installed: Cell::new(false),
+            listener_refcount: Cell::new(0),
+            #[cfg(all(feature = "web", target_arch = "wasm32"))]
+            listeners: RefCell::new(None),
+        }
+    }
+
+    /// Returns the shared modality context owned by this manager.
+    #[must_use]
+    pub fn modality(&self) -> Rc<dyn ModalityContext> {
+        Rc::clone(&self.modality)
+    }
+
+    /// Returns the accessibility focus-ring tracker kept in sync with modality events.
+    #[must_use]
+    pub const fn focus_ring(&self) -> &FocusRing {
+        &self.focus_ring
+    }
+
+    /// Records a keyboard interaction in both modality and focus-visible tracking.
+    pub fn on_key_down(&self, key: KeyboardKey, modifiers: KeyModifiers) {
+        self.modality.on_key_down(key, modifiers);
+        self.focus_ring.on_key_down(key, modifiers);
+    }
+
+    /// Records a pointer interaction in both modality and focus-visible tracking.
+    pub fn on_pointer_down(&self, pointer_type: PointerType) {
+        self.modality.on_pointer_down(pointer_type);
+        self.focus_ring.on_pointer_down();
+    }
+
+    /// Records a virtual interaction in both modality and focus-visible tracking.
+    pub fn on_virtual_input(&self) {
+        self.modality.on_virtual_input();
+        self.focus_ring.on_virtual_input();
+    }
+
+    /// Installs browser-level modality listeners when DOM access is available.
+    pub fn ensure_listeners(&self) {
+        #[cfg(all(feature = "web", target_arch = "wasm32"))]
+        {
+            let Some(document) = document() else {
+                return;
+            };
+
+            if self.acquire_listener_consumer() {
+                self.install_wasm_listeners(&document);
+            }
+        }
+    }
+
+    /// Removes browser-level modality listeners when the last consumer releases them.
+    pub fn remove_listeners(&self) {
+        #[cfg(all(feature = "web", target_arch = "wasm32"))]
+        {
+            let Some(document) = document() else {
+                return;
+            };
+
+            if self.release_listener_consumer() {
+                self.uninstall_wasm_listeners(&document);
+            }
+        }
+    }
+
+    #[cfg(any(test, all(feature = "web", target_arch = "wasm32")))]
+    fn acquire_listener_consumer(&self) -> bool {
+        self.listener_refcount
+            .set(self.listener_refcount.get().saturating_add(1));
+
+        let should_install = !self.listeners_installed.get();
+        if should_install {
+            self.listeners_installed.set(true);
+        }
+        should_install
+    }
+
+    #[cfg(any(test, all(feature = "web", target_arch = "wasm32")))]
+    fn release_listener_consumer(&self) -> bool {
+        let count = self.listener_refcount.get();
+        if count == 0 {
+            return false;
+        }
+
+        let next = count - 1;
+        self.listener_refcount.set(next);
+
+        if next == 0 {
+            self.listeners_installed.set(false);
+            true
+        } else {
+            false
+        }
+    }
+
+    #[cfg(test)]
+    fn listener_state(&self) -> (bool, u32) {
+        (self.listeners_installed.get(), self.listener_refcount.get())
+    }
+}
+
+impl fmt::Debug for ModalityManager {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ModalityManager")
+            .field("modality", &"<dyn ModalityContext>")
+            .field("focus_ring", &self.focus_ring)
+            .field("listeners_installed", &self.listeners_installed.get())
+            .field("listener_refcount", &self.listener_refcount.get())
+            .finish()
+    }
+}
+
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
+use wasm_bindgen::{JsCast, closure::Closure};
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
+use web_sys::{Document, FocusEvent, KeyboardEvent, MouseEvent, PointerEvent, TouchEvent};
+
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
+struct WasmListenerHandles {
+    keydown: Closure<dyn FnMut(KeyboardEvent)>,
+    pointerdown: Closure<dyn FnMut(PointerEvent)>,
+    mousedown: Closure<dyn FnMut(MouseEvent)>,
+    touchstart: Closure<dyn FnMut(TouchEvent)>,
+    focus: Closure<dyn FnMut(FocusEvent)>,
+}
+
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
+fn document() -> Option<Document> {
+    web_sys::window().and_then(|window| window.document())
+}
+
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
+impl ModalityManager {
+    fn install_wasm_listeners(&self, document: &Document) {
+        let modality = self.modality();
+        let focus_ring = self.focus_ring.clone();
+        let keydown = Closure::wrap(Box::new(move |event: KeyboardEvent| {
+            let key = KeyboardKey::from_key_str(&event.key());
+            let modifiers = KeyModifiers {
+                shift: event.shift_key(),
+                ctrl: event.ctrl_key(),
+                alt: event.alt_key(),
+                meta: event.meta_key(),
+            };
+            modality.on_key_down(key, modifiers);
+            focus_ring.on_key_down(key, modifiers);
+        }) as Box<dyn FnMut(KeyboardEvent)>);
+
+        let modality = self.modality();
+        let focus_ring = self.focus_ring.clone();
+        let pointerdown = Closure::wrap(Box::new(move |event: PointerEvent| {
+            let pointer_type = pointer_type_from_web(&event.pointer_type());
+            modality.on_pointer_down(pointer_type);
+            focus_ring.on_pointer_down();
+        }) as Box<dyn FnMut(PointerEvent)>);
+
+        let modality = self.modality();
+        let focus_ring = self.focus_ring.clone();
+        let mousedown = Closure::wrap(Box::new(move |_event: MouseEvent| {
+            modality.on_pointer_down(PointerType::Mouse);
+            focus_ring.on_pointer_down();
+        }) as Box<dyn FnMut(MouseEvent)>);
+
+        let modality = self.modality();
+        let focus_ring = self.focus_ring.clone();
+        let touchstart = Closure::wrap(Box::new(move |_event: TouchEvent| {
+            modality.on_pointer_down(PointerType::Touch);
+            focus_ring.on_pointer_down();
+        }) as Box<dyn FnMut(TouchEvent)>);
+
+        let focus =
+            Closure::wrap(Box::new(move |_event: FocusEvent| {}) as Box<dyn FnMut(FocusEvent)>);
+
+        let keydown_result =
+            document.add_event_listener_with_callback("keydown", keydown.as_ref().unchecked_ref());
+        debug_assert!(
+            keydown_result.is_ok(),
+            "failed to attach keydown modality listener"
+        );
+
+        let pointerdown_result = document
+            .add_event_listener_with_callback("pointerdown", pointerdown.as_ref().unchecked_ref());
+        debug_assert!(
+            pointerdown_result.is_ok(),
+            "failed to attach pointerdown modality listener"
+        );
+
+        let mousedown_result = document
+            .add_event_listener_with_callback("mousedown", mousedown.as_ref().unchecked_ref());
+        debug_assert!(
+            mousedown_result.is_ok(),
+            "failed to attach mousedown modality listener"
+        );
+
+        let touchstart_result = document
+            .add_event_listener_with_callback("touchstart", touchstart.as_ref().unchecked_ref());
+        debug_assert!(
+            touchstart_result.is_ok(),
+            "failed to attach touchstart modality listener"
+        );
+
+        let focus_result = document.add_event_listener_with_callback_and_bool(
+            "focus",
+            focus.as_ref().unchecked_ref(),
+            true,
+        );
+        debug_assert!(
+            focus_result.is_ok(),
+            "failed to attach focus modality listener"
+        );
+
+        self.listeners.replace(Some(WasmListenerHandles {
+            keydown,
+            pointerdown,
+            mousedown,
+            touchstart,
+            focus,
+        }));
+    }
+
+    fn uninstall_wasm_listeners(&self, document: &Document) {
+        if let Some(handles) = self.listeners.borrow_mut().take() {
+            let keydown_result = document.remove_event_listener_with_callback(
+                "keydown",
+                handles.keydown.as_ref().unchecked_ref(),
+            );
+            debug_assert!(
+                keydown_result.is_ok(),
+                "failed to detach keydown modality listener"
+            );
+
+            let pointerdown_result = document.remove_event_listener_with_callback(
+                "pointerdown",
+                handles.pointerdown.as_ref().unchecked_ref(),
+            );
+            debug_assert!(
+                pointerdown_result.is_ok(),
+                "failed to detach pointerdown modality listener"
+            );
+
+            let mousedown_result = document.remove_event_listener_with_callback(
+                "mousedown",
+                handles.mousedown.as_ref().unchecked_ref(),
+            );
+            debug_assert!(
+                mousedown_result.is_ok(),
+                "failed to detach mousedown modality listener"
+            );
+
+            let touchstart_result = document.remove_event_listener_with_callback(
+                "touchstart",
+                handles.touchstart.as_ref().unchecked_ref(),
+            );
+            debug_assert!(
+                touchstart_result.is_ok(),
+                "failed to detach touchstart modality listener"
+            );
+
+            let focus_result = document.remove_event_listener_with_callback_and_bool(
+                "focus",
+                handles.focus.as_ref().unchecked_ref(),
+                true,
+            );
+            debug_assert!(
+                focus_result.is_ok(),
+                "failed to detach focus modality listener"
+            );
+        }
+    }
+}
+
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
+fn pointer_type_from_web(pointer_type: &str) -> PointerType {
+    match pointer_type {
+        "touch" => PointerType::Touch,
+        "pen" => PointerType::Pen,
+        _ => PointerType::Mouse,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ars_core::{DefaultModalityContext, ModalitySnapshot};
+
+    use super::*;
+
+    #[test]
+    fn keydown_updates_modality_and_focus_ring() {
+        let modality: Rc<dyn ModalityContext> = Rc::new(DefaultModalityContext::new());
+        let manager = ModalityManager::new(Rc::clone(&modality));
+
+        manager.on_key_down(KeyboardKey::Tab, KeyModifiers::default());
+
+        assert_eq!(
+            manager.modality().snapshot(),
+            ModalitySnapshot {
+                last_pointer_type: Some(PointerType::Keyboard),
+                global_press_active: false,
+            }
+        );
+        assert!(manager.focus_ring().should_show_focus_ring());
+    }
+
+    #[test]
+    fn modality_accessor_returns_shared_context() {
+        let modality: Rc<dyn ModalityContext> = Rc::new(DefaultModalityContext::new());
+        let manager = ModalityManager::new(Rc::clone(&modality));
+
+        let owned = manager.modality();
+        assert!(Rc::ptr_eq(&owned, &modality));
+    }
+
+    #[test]
+    fn pointerdown_updates_modality_and_clears_focus_ring() {
+        let modality: Rc<dyn ModalityContext> = Rc::new(DefaultModalityContext::new());
+        let manager = ModalityManager::new(Rc::clone(&modality));
+
+        manager.on_key_down(KeyboardKey::Enter, KeyModifiers::default());
+        manager.on_pointer_down(PointerType::Touch);
+
+        assert_eq!(modality.last_pointer_type(), Some(PointerType::Touch));
+        assert!(modality.had_pointer_interaction());
+        assert!(!manager.focus_ring().should_show_focus_ring());
+    }
+
+    #[test]
+    fn pen_pointerdown_counts_as_pointer_interaction() {
+        let modality: Rc<dyn ModalityContext> = Rc::new(DefaultModalityContext::new());
+        let manager = ModalityManager::new(Rc::clone(&modality));
+
+        manager.on_pointer_down(PointerType::Pen);
+
+        assert_eq!(modality.last_pointer_type(), Some(PointerType::Pen));
+        assert!(modality.had_pointer_interaction());
+        assert!(!manager.focus_ring().should_show_focus_ring());
+    }
+
+    #[test]
+    fn virtual_input_updates_both_trackers() {
+        let modality: Rc<dyn ModalityContext> = Rc::new(DefaultModalityContext::new());
+        let manager = ModalityManager::new(modality);
+
+        manager.on_virtual_input();
+
+        assert_eq!(
+            manager.modality().snapshot(),
+            ModalitySnapshot {
+                last_pointer_type: Some(PointerType::Virtual),
+                global_press_active: false,
+            }
+        );
+        assert!(manager.focus_ring().should_show_focus_ring());
+    }
+
+    #[test]
+    fn listener_refcount_transitions_are_stable() {
+        let manager = ModalityManager::new(Rc::new(DefaultModalityContext::new()));
+
+        assert_eq!(manager.listener_state(), (false, 0));
+
+        assert!(manager.acquire_listener_consumer());
+        assert_eq!(manager.listener_state(), (true, 1));
+
+        assert!(!manager.acquire_listener_consumer());
+        assert_eq!(manager.listener_state(), (true, 2));
+
+        assert!(!manager.release_listener_consumer());
+        assert_eq!(manager.listener_state(), (true, 1));
+
+        assert!(manager.release_listener_consumer());
+        assert_eq!(manager.listener_state(), (false, 0));
+
+        assert!(!manager.release_listener_consumer());
+        assert_eq!(manager.listener_state(), (false, 0));
+    }
+
+    #[test]
+    fn host_listener_api_is_safe_to_call() {
+        let manager = ModalityManager::new(Rc::new(DefaultModalityContext::new()));
+        manager.ensure_listeners();
+        manager.remove_listeners();
+    }
+}

--- a/crates/ars-dom/src/scroll_lock.rs
+++ b/crates/ars-dom/src/scroll_lock.rs
@@ -28,11 +28,11 @@ use std::sync::atomic::{AtomicU32, Ordering};
 // Global state
 // ---------------------------------------------------------------------------
 
-/// Process-global scroll lock depth counter (WASM — single-threaded).
+// Process-global scroll lock depth counter (WASM — single-threaded).
 #[cfg(target_arch = "wasm32")]
 thread_local! {
-    static SCROLL_LOCK_DEPTH: Cell<u32> = Cell::new(0);
-    static SCROLL_LOCK_SAVED: RefCell<Option<ScrollLockSavedState>> = RefCell::new(None);
+    static SCROLL_LOCK_DEPTH: Cell<u32> = const { Cell::new(0) };
+    static SCROLL_LOCK_SAVED: RefCell<Option<ScrollLockSavedState>> = const { RefCell::new(None) };
 }
 
 /// Process-global scroll lock depth counter (native — multi-threaded).
@@ -58,9 +58,12 @@ static SCROLL_LOCK_SAVED: Mutex<Option<ScrollLockSavedState>> = Mutex::new(None)
 /// All fields are read on `wasm32` targets inside [`restore_scroll_state`].
 /// On native/test targets the struct is created but never destructured
 /// (restore is a no-op), so the fields appear unused to the compiler.
-#[expect(
-    dead_code,
-    reason = "fields read only on wasm32; struct kept for platform parity"
+#[cfg_attr(
+    not(target_arch = "wasm32"),
+    expect(
+        dead_code,
+        reason = "fields read only on wasm32; struct kept for platform parity"
+    )
 )]
 struct ScrollLockSavedState {
     /// Original `overflow` style on the body element.
@@ -166,7 +169,7 @@ pub fn release() {
         if prev == 1 {
             SCROLL_LOCK_SAVED.with(|s| {
                 if let Some(saved) = s.borrow_mut().take() {
-                    restore_scroll_state(saved);
+                    restore_scroll_state(&saved);
                 }
             });
         }
@@ -194,7 +197,7 @@ pub fn depth() -> u32 {
 /// Returns the current nesting depth of active scroll locks.
 #[cfg(target_arch = "wasm32")]
 pub fn depth() -> u32 {
-    SCROLL_LOCK_DEPTH.with(|d| d.get())
+    SCROLL_LOCK_DEPTH.with(Cell::get)
 }
 
 // ---------------------------------------------------------------------------
@@ -321,21 +324,17 @@ impl Default for ScrollLockManager {
 fn save_current_scroll_state() -> ScrollLockSavedState {
     use wasm_bindgen::JsCast;
 
-    let window = match web_sys::window() {
-        Some(w) => w,
-        None => return ScrollLockSavedState::default(),
+    let Some(window) = web_sys::window() else {
+        return ScrollLockSavedState::default();
     };
-    let document = match window.document() {
-        Some(d) => d,
-        None => return ScrollLockSavedState::default(),
+    let Some(document) = window.document() else {
+        return ScrollLockSavedState::default();
     };
-    let body = match document.body() {
-        Some(b) => b,
-        None => return ScrollLockSavedState::default(),
+    let Some(body) = document.body() else {
+        return ScrollLockSavedState::default();
     };
-    let doc_el = match document.document_element() {
-        Some(el) => el,
-        None => return ScrollLockSavedState::default(),
+    let Some(doc_el) = document.document_element() else {
+        return ScrollLockSavedState::default();
     };
 
     let body_style = body.style();
@@ -371,21 +370,17 @@ fn save_current_scroll_state() -> ScrollLockSavedState {
 fn apply_scroll_lock() {
     use wasm_bindgen::JsCast;
 
-    let window = match web_sys::window() {
-        Some(w) => w,
-        None => return,
+    let Some(window) = web_sys::window() else {
+        return;
     };
-    let document = match window.document() {
-        Some(d) => d,
-        None => return,
+    let Some(document) = window.document() else {
+        return;
     };
-    let body = match document.body() {
-        Some(b) => b,
-        None => return,
+    let Some(body) = document.body() else {
+        return;
     };
-    let doc_el = match document.document_element() {
-        Some(el) => el,
-        None => return,
+    let Some(doc_el) = document.document_element() else {
+        return;
     };
 
     let body_style = body.style();
@@ -393,18 +388,18 @@ fn apply_scroll_lock() {
     if needs_ios_workaround() {
         // Tier 2 — iOS Safari fallback: position:fixed on <body>
         let scroll_y = window.scroll_y().unwrap_or(0.0);
-        let _ = body_style.set_property("position", "fixed");
-        let _ = body_style.set_property("top", &format!("-{scroll_y}px"));
-        let _ = body_style.set_property("width", "100%");
-        let _ = body_style.set_property("overflow", "hidden");
+        drop(body_style.set_property("position", "fixed"));
+        drop(body_style.set_property("top", &format!("-{scroll_y}px")));
+        drop(body_style.set_property("width", "100%"));
+        drop(body_style.set_property("overflow", "hidden"));
     } else {
         // Tier 1 — Modern browsers: overflow:clip on <html> + overscroll-behavior:contain on <body>
         let doc_el_html: &web_sys::HtmlElement = match doc_el.dyn_ref() {
             Some(el) => el,
             None => return,
         };
-        let _ = doc_el_html.style().set_property("overflow", "clip");
-        let _ = body_style.set_property("overscroll-behavior", "contain");
+        drop(doc_el_html.style().set_property("overflow", "clip"));
+        drop(body_style.set_property("overscroll-behavior", "contain"));
     }
 
     // Scrollbar width compensation
@@ -412,34 +407,30 @@ fn apply_scroll_lock() {
 }
 
 #[cfg(all(feature = "web", target_arch = "wasm32"))]
-fn restore_scroll_state(saved: ScrollLockSavedState) {
+fn restore_scroll_state(saved: &ScrollLockSavedState) {
     use wasm_bindgen::JsCast;
 
-    let window = match web_sys::window() {
-        Some(w) => w,
-        None => return,
+    let Some(window) = web_sys::window() else {
+        return;
     };
-    let document = match window.document() {
-        Some(d) => d,
-        None => return,
+    let Some(document) = window.document() else {
+        return;
     };
-    let body = match document.body() {
-        Some(b) => b,
-        None => return,
+    let Some(body) = document.body() else {
+        return;
     };
-    let doc_el = match document.document_element() {
-        Some(el) => el,
-        None => return,
+    let Some(doc_el) = document.document_element() else {
+        return;
     };
 
     let body_style = body.style();
 
     if needs_ios_workaround() {
         // Restore iOS fixed-position overrides
-        let _ = body_style.remove_property("position");
-        let _ = body_style.remove_property("width");
-        let _ = body_style.set_property("top", &saved.body_top);
-        let _ = body_style.set_property("overflow", &saved.overflow);
+        drop(body_style.remove_property("position"));
+        drop(body_style.remove_property("width"));
+        drop(body_style.set_property("top", &saved.body_top));
+        drop(body_style.set_property("overflow", &saved.overflow));
         // Restore scroll position after removing fixed positioning
         window.scroll_to_with_x_and_y(saved.scroll_x, saved.scroll_y);
     } else {
@@ -448,19 +439,21 @@ fn restore_scroll_state(saved: ScrollLockSavedState) {
             Some(el) => el,
             None => return,
         };
-        let _ = doc_el_html
-            .style()
-            .set_property("overflow", &saved.html_overflow);
-        let _ = body_style.set_property("overscroll-behavior", &saved.overscroll_behavior);
+        drop(
+            doc_el_html
+                .style()
+                .set_property("overflow", &saved.html_overflow),
+        );
+        drop(body_style.set_property("overscroll-behavior", &saved.overscroll_behavior));
     }
 
     // Remove scrollbar compensation
-    let _ = body_style.set_property("padding-right", &saved.padding_right);
+    drop(body_style.set_property("padding-right", &saved.padding_right));
 }
 
 /// Detect whether the iOS scroll lock workaround is needed.
 ///
-/// Returns `true` on iOS Safari and iOS WebView.
+/// Returns `true` on iOS Safari and iOS `WebView`.
 #[cfg(all(feature = "web", target_arch = "wasm32"))]
 pub fn needs_ios_workaround() -> bool {
     web_sys::window()
@@ -494,17 +487,14 @@ pub fn needs_ios_workaround() -> bool {
 /// This measurement is performed live and accounts for zoom level.
 #[cfg(all(feature = "web", target_arch = "wasm32"))]
 pub fn scrollbar_width() -> f64 {
-    let window = match web_sys::window() {
-        Some(w) => w,
-        None => return 0.0,
+    let Some(window) = web_sys::window() else {
+        return 0.0;
     };
-    let document = match window.document() {
-        Some(d) => d,
-        None => return 0.0,
+    let Some(document) = window.document() else {
+        return 0.0;
     };
-    let doc_el = match document.document_element() {
-        Some(el) => el,
-        None => return 0.0,
+    let Some(doc_el) = document.document_element() else {
+        return 0.0;
     };
     // inner_width includes scrollbar; client_width excludes it
     let inner = window
@@ -512,7 +502,7 @@ pub fn scrollbar_width() -> f64 {
         .ok()
         .and_then(|v| v.as_f64())
         .unwrap_or(0.0);
-    let client = doc_el.client_width() as f64;
+    let client = f64::from(doc_el.client_width());
     (inner - client).max(0.0)
 }
 
@@ -529,9 +519,10 @@ fn apply_scrollbar_compensation() {
             .and_then(|w| w.document())
             .and_then(|d| d.body())
         {
-            let _ = body
-                .style()
-                .set_property("padding-right", &format!("{width}px"));
+            drop(
+                body.style()
+                    .set_property("padding-right", &format!("{width}px")),
+            );
         }
     }
 }

--- a/crates/ars-interactions/src/lib.rs
+++ b/crates/ars-interactions/src/lib.rs
@@ -6,25 +6,11 @@
 
 pub mod compose;
 
+pub use ars_core::{
+    DefaultModalityContext, KeyModifiers, KeyboardKey, ModalityContext, ModalitySnapshot,
+    NullModalityContext, PointerType,
+};
 pub use compose::merge_attrs;
-
-/// The input modality that initiated an interaction.
-///
-/// Matches the values exposed by the Pointer Events API, extended with
-/// virtual activation from screen readers and scripted events.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub enum PointerType {
-    /// Physical mouse or trackpad.
-    Mouse,
-    /// Finger on a touchscreen.
-    Touch,
-    /// Stylus or digital pen.
-    Pen,
-    /// Keyboard (Enter, Space, or arrow key).
-    Keyboard,
-    /// Programmatic / screen reader virtual cursor activation.
-    Virtual,
-}
 
 /// The current state of the press state machine.
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -107,6 +93,16 @@ impl FocusState {
     pub fn is_focused(&self) -> bool {
         !matches!(self, FocusState::Unfocused)
     }
+
+    /// Returns whether the current focus state should render a visible indicator.
+    #[must_use]
+    pub fn is_focus_visible(&self, modality: &dyn ModalityContext) -> bool {
+        match self {
+            Self::FocusedByKeyboard => true,
+            Self::FocusedProgrammatic => !modality.had_pointer_interaction(),
+            Self::FocusedByPointer | Self::Unfocused => false,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -153,5 +149,28 @@ mod tests {
         assert!(FocusState::FocusedByPointer.is_focused());
         assert!(FocusState::FocusedByKeyboard.is_focused());
         assert!(FocusState::FocusedProgrammatic.is_focused());
+    }
+
+    #[test]
+    fn focus_state_programmatic_visibility_uses_injected_modality() {
+        let modality = DefaultModalityContext::new();
+
+        assert!(FocusState::FocusedProgrammatic.is_focus_visible(&modality));
+
+        modality.on_pointer_down(PointerType::Mouse);
+        assert!(!FocusState::FocusedProgrammatic.is_focus_visible(&modality));
+
+        modality.on_key_down(KeyboardKey::Tab, KeyModifiers::default());
+        assert!(FocusState::FocusedProgrammatic.is_focus_visible(&modality));
+    }
+
+    #[test]
+    fn focus_state_keyboard_visibility_is_always_true() {
+        let modality = DefaultModalityContext::new();
+        modality.on_pointer_down(PointerType::Mouse);
+
+        assert!(FocusState::FocusedByKeyboard.is_focus_visible(&modality));
+        assert!(!FocusState::FocusedByPointer.is_focus_visible(&modality));
+        assert!(!FocusState::Unfocused.is_focus_visible(&modality));
     }
 }

--- a/docs/implementation/foundation-completion-roadmap.md
+++ b/docs/implementation/foundation-completion-roadmap.md
@@ -40,16 +40,16 @@ The project needs a fully stable foundation before component work starts. Compon
 
 **Goal:** Enable Button, VisuallyHidden, and Separator — the simplest components.
 
-**Parallelism:** #55, #56, #57, and #61 can all run in parallel. #58, #59, and #60 depend on #57.
+**Parallelism:** #55, #56, and #61 can all run in parallel. The original `#57` thread-local modality task is superseded by #90. #58, #59, and #60 depend on #90.
 
 | GitHub                                             | Title                                                                                      | Points | Epic | Deps |
 | -------------------------------------------------- | ------------------------------------------------------------------------------------------ | ------ | ---- | ---- |
 | [#55](https://github.com/fogodev/ars-ui/issues/55) | Implement `attr_map_to_leptos` and `use_style_strategy` in ars-leptos                      | 3      | #8   | —    |
 | [#56](https://github.com/fogodev/ars-ui/issues/56) | Implement `attr_map_to_dioxus`, `intern_attr_name`, and `use_style_strategy` in ars-dioxus | 3      | #9   | —    |
-| [#57](https://github.com/fogodev/ars-ui/issues/57) | Implement global input modality tracking in ars-interactions                               | 2      | #4   | —    |
-| [#58](https://github.com/fogodev/ars-ui/issues/58) | Implement Press interaction state machine in ars-interactions                              | 5      | #4   | #57  |
-| [#59](https://github.com/fogodev/ars-ui/issues/59) | Implement Hover interaction state machine in ars-interactions                              | 2      | #4   | #57  |
-| [#60](https://github.com/fogodev/ars-ui/issues/60) | Implement Focus and FocusWithin interactions in ars-interactions                           | 3      | #4   | #57  |
+| [#57](https://github.com/fogodev/ars-ui/issues/57) | Superseded thread-local modality task in ars-interactions                                  | 2      | #4   | —    |
+| [#58](https://github.com/fogodev/ars-ui/issues/58) | Implement Press interaction state machine in ars-interactions                              | 5      | #4   | #90  |
+| [#59](https://github.com/fogodev/ars-ui/issues/59) | Implement Hover interaction state machine in ars-interactions                              | 2      | #4   | #90  |
+| [#60](https://github.com/fogodev/ars-ui/issues/60) | Implement Focus and FocusWithin interactions in ars-interactions                           | 3      | #4   | #90  |
 | [#61](https://github.com/fogodev/ars-ui/issues/61) | Implement LogicalDirection and resolve_arrow_key in ars-interactions                       | 1      | #4   | —    |
 
 **Total:** 19 points
@@ -111,7 +111,7 @@ The project needs a fully stable foundation before component work starts. Compon
   - `dioxus_attrs!` macro.
 - Spec impact: `No spec change required`.
 
-#### W1-3: Implement global input modality tracking in ars-interactions
+#### W1-3: Superseded thread-local modality task in ars-interactions
 
 - Points: `2`
 - Layer: `Subsystem`
@@ -119,23 +119,15 @@ The project needs a fully stable foundation before component work starts. Compon
 - Test tier: `Unit`
 - Depends on: none
 - Spec refs:
-  - `spec/foundation/05-interactions.md` §4.4 "Focus Visible Detection: Global Modality Tracking" (L1135)
+  - `spec/foundation/05-interactions.md` §4.4 "Focus Visible Detection: Shared Modality Tracking" (L1135)
   - `spec/foundation/05-interactions.md` §3.4 "Integration with Press" (L881)
-- Goal: implement the thread-local state tracking infrastructure required by all interaction primitives.
-- Files to create/modify: `crates/ars-interactions/src/modality.rs` (new), wire into `crates/ars-interactions/src/lib.rs`
-- Tests to add first:
-  - Unit tests for `set_last_pointer_type()` / `last_pointer_type()` round-trip.
-  - Unit tests for `had_pointer_interaction()` returning true after pointer event, false after keyboard.
-  - Unit tests for `set_global_press_active()` / `is_global_press_active()` flag.
-  - Unit tests for `ensure_modality_listeners()` / `remove_modality_listeners()` ref-counting (count increments/decrements correctly, hits zero on last remove).
+- Goal: historical only. The old thread-local design is superseded by #90 and should not be implemented independently.
+- Files to create/modify: none
+- Tests to add first: none
 - Acceptance criteria:
-  - Thread-local statics: `LAST_POINTER_TYPE`, `GLOBAL_PRESS_ACTIVE`, `MODALITY_LISTENERS_INSTALLED`, `MODALITY_LISTENER_REFCOUNT`.
-  - `ensure_modality_listeners()` with ref-counted install and Web Worker guard (`js_sys::Reflect::has`).
-  - `remove_modality_listeners()` with ref-counted cleanup.
-  - `had_pointer_interaction() -> bool`, `last_pointer_type() -> Option<PointerType>`, `set_last_pointer_type(PointerType)`.
-  - `set_global_press_active(bool)` and `is_global_press_active() -> bool`.
-  - Web APIs gated behind `#[cfg(target_arch = "wasm32")]`.
-- Spec impact: `No spec change required`.
+  - This task remains unimplemented.
+  - All modality work is redirected to #90.
+- Spec impact: `No separate spec work; see #90`.
 
 #### W1-4: Implement Press interaction state machine in ars-interactions
 
@@ -143,7 +135,7 @@ The project needs a fully stable foundation before component work starts. Compon
 - Layer: `Subsystem`
 - Framework: `None`
 - Test tier: `Unit`
-- Depends on: #57
+- Depends on: #90
 - Spec refs:
   - `spec/foundation/05-interactions.md` §2 "Press Interaction" (L115)
   - `spec/foundation/05-interactions.md` §2.2 "Types" (L121)
@@ -156,7 +148,7 @@ The project needs a fully stable foundation before component work starts. Compon
   - Unit tests for disabled config suppressing all transitions.
   - Unit tests for touch scroll cancellation via `scroll_threshold_px`.
   - Unit tests for `current_attrs()` producing `data-ars-pressed` and `data-ars-disabled`.
-  - Unit tests for `GLOBAL_PRESS_ACTIVE` integration (set on press start, cleared on press end).
+  - Unit tests for shared modality `global_press_active` integration (set on press start, cleared on press end).
 - Acceptance criteria:
   - `PressConfig` with all fields per spec §2.2: `disabled`, `prevent_text_selection`, `allow_press_on_exit`, `scroll_threshold_px`, `on_press_start/end/press/change/up`, `pointer_capture_timeout`, `long_press_cancel_flag`.
   - `PressEvent` with `pointer_type`, `event_type`, `client_x/y`, `modifiers: KeyModifiers`, `is_within_element`, `continue_propagation: Rc<Cell<bool>>`.
@@ -172,7 +164,7 @@ The project needs a fully stable foundation before component work starts. Compon
 - Layer: `Subsystem`
 - Framework: `None`
 - Test tier: `Unit`
-- Depends on: #57
+- Depends on: #90
 - Spec refs:
   - `spec/foundation/05-interactions.md` §3 "Hover Interaction" (L796)
   - `spec/foundation/05-interactions.md` §3.2 "Types" (L802)
@@ -184,7 +176,7 @@ The project needs a fully stable foundation before component work starts. Compon
 - Tests to add first:
   - Unit tests for NotHovered → Hovered on mouse/pen enter, Hovered → NotHovered on leave.
   - Unit tests for touch and keyboard events being ignored.
-  - Unit tests for hover suppression when `GLOBAL_PRESS_ACTIVE` is true.
+  - Unit tests for hover suppression when shared modality `global_press_active` is true.
   - Unit tests for disabled config suppressing transitions.
   - Unit tests for `current_attrs()` producing `data-ars-hovered`.
 - Acceptance criteria:
@@ -202,7 +194,7 @@ The project needs a fully stable foundation before component work starts. Compon
 - Layer: `Subsystem`
 - Framework: `None`
 - Test tier: `Unit`
-- Depends on: #57
+- Depends on: #90
 - Spec refs:
   - `spec/foundation/05-interactions.md` §4 "Focus Interaction" (L995)
   - `spec/foundation/05-interactions.md` §4.2 "Types" (L1011)
@@ -489,18 +481,21 @@ The project needs a fully stable foundation before component work starts. Compon
 
 **Depends on:** Wave 2 complete.
 
-**Parallelism:** All Wave 3 tasks can run in parallel.
+**Parallelism:** #70, #71, #73, #74, #75, #88, and #90 can run in parallel. #89 depends on #90. #72 depends on #90 and #89.
 
-| GitHub                                             | Title                                                                | Points | Epic | Deps     |
-| -------------------------------------------------- | -------------------------------------------------------------------- | ------ | ---- | -------- |
-| [#70](https://github.com/fogodev/ars-ui/issues/70) | Implement type-ahead / type-select state machine in ars-collections  | 3      | #53  | #63      |
-| [#71](https://github.com/fogodev/ars-ui/issues/71) | Implement CollectionBuilder in ars-collections                       | 3      | #53  | #62, #63 |
-| [#72](https://github.com/fogodev/ars-ui/issues/72) | Implement ModalityManager for overlay stacking in ars-dom            | 3      | #6   | #69      |
-| [#73](https://github.com/fogodev/ars-ui/issues/73) | Implement LiveAnnouncer for screen reader announcements              | 3      | #3   | —        |
-| [#74](https://github.com/fogodev/ars-ui/issues/74) | Implement scroll_into_view_if_needed with Safari fallback in ars-dom | 3      | #6   | —        |
-| [#75](https://github.com/fogodev/ars-ui/issues/75) | Replace ars-i18n Locale stub with ICU4X-backed implementation        | 5      | #54  | —        |
+| GitHub                                             | Title                                                                       | Points | Epic | Deps     |
+| -------------------------------------------------- | --------------------------------------------------------------------------- | ------ | ---- | -------- |
+| [#70](https://github.com/fogodev/ars-ui/issues/70) | Implement type-ahead / type-select state machine in ars-collections         | 3      | #53  | #63      |
+| [#71](https://github.com/fogodev/ars-ui/issues/71) | Implement CollectionBuilder in ars-collections                              | 3      | #53  | #62, #63 |
+| [#90](https://github.com/fogodev/ars-ui/issues/90) | Introduce shared ModalityContext in ars-core and migrate modality contracts | 5      | #4   | —        |
+| [#89](https://github.com/fogodev/ars-ui/issues/89) | Integrate FocusRing with shared modality event stream in ars-a11y           | 2      | #3   | #90      |
+| [#72](https://github.com/fogodev/ars-ui/issues/72) | Implement web ModalityManager listener ownership in ars-dom                 | 2      | #6   | #90, #89 |
+| [#88](https://github.com/fogodev/ars-ui/issues/88) | Implement overlay stack registry for nested overlay dismissal in ars-dom    | 3      | #6   | #68, #69 |
+| [#73](https://github.com/fogodev/ars-ui/issues/73) | Implement LiveAnnouncer for screen reader announcements                     | 3      | #3   | —        |
+| [#74](https://github.com/fogodev/ars-ui/issues/74) | Implement scroll_into_view_if_needed with Safari fallback in ars-dom        | 3      | #6   | —        |
+| [#75](https://github.com/fogodev/ars-ui/issues/75) | Replace ars-i18n Locale stub with ICU4X-backed implementation               | 5      | #54  | —        |
 
-**Total:** 20 points
+**Total:** 29 points
 
 ---
 
@@ -555,28 +550,105 @@ The project needs a fully stable foundation before component work starts. Compon
   - Level tracking for nested sections.
 - Spec impact: `No spec change required`.
 
-#### W3-3: Implement ModalityManager for overlay stacking in ars-dom
+#### W3-3core: Introduce shared ModalityContext in ars-core and migrate modality contracts
+
+- Points: `5`
+- Layer: `Core`
+- Framework: `None`
+- Test tier: `Unit`
+- Depends on: none
+- Spec refs:
+  - `spec/foundation/01-architecture.md` §2.2.7 "PlatformEffects Trait" and §6.4 "ArsProvider"
+  - `spec/foundation/05-interactions.md` §3.4 "Integration with Press"
+  - `spec/foundation/05-interactions.md` §4.4 "Focus Visible Detection: Shared Modality Tracking"
+- Goal: replace the old `ars-interactions` thread-local design with the shared provider-scoped `ModalityContext` contract in `ars-core`.
+- Files to create/modify: `crates/ars-core/src/modality.rs` (new), `crates/ars-core/src/lib.rs`, `crates/ars-core/src/provider.rs`, `crates/ars-interactions/src/lib.rs`, `crates/ars-interactions/Cargo.toml`
+- Tests to add first:
+  - Unit tests for `DefaultModalityContext` startup state and per-instance isolation.
+  - Unit tests for keyboard, pointer, and virtual modality updates.
+  - Unit tests for `set_global_press_active()` / `is_global_press_active()` semantics.
+  - Unit tests for `FocusState::is_focus_visible()` consulting injected modality instead of ambient globals.
+- Acceptance criteria:
+  - `ars-core` exposes `PointerType`, `KeyModifiers`, `KeyboardKey`, `ModalitySnapshot`, `ModalityContext`, `DefaultModalityContext`, and `NullModalityContext`.
+  - Modality state is instance-scoped and provider-friendly, not thread-local.
+  - `ArsContext` exposes a shared `Rc<dyn ModalityContext>` alongside `PlatformEffects`.
+  - `ars-interactions` re-exports the shared modality types and no longer owns DOM listener installation.
+- Spec impact: `Update architecture/interactions/provider specs in the same task`.
+
+#### W3-3a: Integrate FocusRing with shared modality event stream in ars-a11y
+
+- Points: `2`
+- Layer: `Subsystem`
+- Framework: `None`
+- Test tier: `Unit`
+- Depends on: #90
+- Spec refs:
+  - `spec/foundation/03-accessibility.md` §3.4 "FocusRing" (L1591)
+  - `spec/foundation/05-interactions.md` §4.4 "Focus Visible Detection: Shared Modality Tracking" (L1135)
+- Goal: align `FocusRing` with the shared modality event stream without making it responsible for platform listener ownership.
+- Files to create/modify: `crates/ars-a11y/src/focus.rs`, `crates/ars-a11y/src/lib.rs`
+- Tests to add first:
+  - Unit tests for `on_pointer_down()` clearing keyboard modality.
+  - Unit tests for `on_key_down()` enabling keyboard modality only for navigation keys.
+  - Unit tests for ctrl/meta/alt-modified key chords being ignored.
+  - Unit tests for `on_virtual_input()` and `apply_focus_attrs()` semantics.
+- Acceptance criteria:
+  - `FocusRing` consumes the same normalized key/pointer/virtual events as `ModalityContext`.
+  - `FocusRing` remains separate from `PlatformEffects` and DOM listener installation.
+  - `should_show_focus_ring()` and `apply_focus_attrs()` match the updated spec contract.
+- Spec impact: `Keep accessibility spec aligned with the shared-modality architecture`.
+
+#### W3-3b: Implement web ModalityManager listener ownership in ars-dom
+
+- Points: `2`
+- Layer: `Subsystem`
+- Framework: `None`
+- Test tier: `Unit`
+- Depends on: #90, #89
+- Spec refs:
+  - `spec/foundation/11-dom-utilities.md` §8 "Modality Manager" (L2531)
+  - `spec/foundation/05-interactions.md` §4.4 "Focus Visible Detection: Shared Modality Tracking" (L1135)
+  - `spec/foundation/03-accessibility.md` §3.4 "FocusRing" (L1591)
+- Goal: implement the browser listener layer that keeps `ModalityContext` and `FocusRing` synchronized through a single adapter-facing API.
+- Files to create/modify: `crates/ars-dom/src/modality.rs` (new), `crates/ars-dom/src/lib.rs` (wire new module), `crates/ars-dom/Cargo.toml`
+- Tests to add first:
+  - Unit tests for `on_key_down()` updating both `ModalityContext` and `FocusRing`.
+  - Unit tests for `on_pointer_down()` updating both trackers atomically.
+  - Unit tests for `on_virtual_input()` semantics.
+  - Unit tests for refcounted listener install/remove transitions and host-build safety.
+- Acceptance criteria:
+  - `ModalityManager` holds `Rc<dyn ModalityContext>` plus `FocusRing`.
+  - `on_key_down(key, modifiers)`, `on_pointer_down(pointer_type)`, and `on_virtual_input()` fan out to both consumers.
+  - `ensure_listeners()` / `remove_listeners()` own browser listener installation and cleanup.
+  - Browser listener lifecycle is refcounted, document-guarded, and no-op outside web DOM environments.
+  - `focus_ring(&self) -> &FocusRing`.
+  - Adapter-facing API matches the spec and replaces direct tracker updates.
+- Spec impact: `No spec change required beyond the shared-modality migration`.
+
+#### W3-3c: Implement overlay stack registry for nested overlay dismissal in ars-dom
 
 - Points: `3`
 - Layer: `Subsystem`
 - Framework: `None`
 - Test tier: `Unit`
-- Depends on: #69
+- Depends on: #68, #69
 - Spec refs:
-  - `spec/foundation/11-dom-utilities.md` §8 "Modality Manager" (L2531)
-- Goal: track the overlay stack for modal/non-modal overlays.
-- Files to create/modify: `crates/ars-dom/src/modality.rs` (new)
+  - `spec/foundation/05-interactions.md` §12.8 "Nested Overlay Handling" (L4105)
+  - `spec/foundation/11-dom-utilities.md` §6.3 "Usage Pattern" (L2331)
+  - `spec/foundation/11-dom-utilities.md` §6.3.1 "Z-Index Ranges and Adapter Scope" (L2355)
+- Goal: implement the overlay stack registry used to determine topmost overlay ordering and nested overlay dismissal behavior.
+- Files to create/modify: `crates/ars-dom/src/overlay_stack.rs` (new), `crates/ars-dom/src/lib.rs` (wire new module)
 - Tests to add first:
   - Unit tests for push/pop overlay stack operations.
   - Unit tests for modal vs non-modal distinction.
-  - Unit tests for `is_top_modal()` check.
-  - Unit tests for LIFO dismiss ordering.
-  - Unit tests for nested modal scenarios.
+  - Unit tests for topmost overlay detection.
+  - Unit tests for LIFO close ordering.
+  - Unit tests for nested overlay scenarios where child overlays suppress parent dismissal.
 - Acceptance criteria:
-  - Overlay stack tracking (push/pop).
-  - Modal vs non-modal distinction.
-  - `is_top_modal()` check.
-  - LIFO dismiss ordering.
+  - Global overlay stack registration and deregistration API.
+  - Modal vs non-modal overlay metadata.
+  - Topmost overlay lookup for outside-interaction and Escape-key dismissal.
+  - Nested overlay ordering consistent with monotonic z-index allocation.
 - Spec impact: `No spec change required`.
 
 #### W3-4: Implement LiveAnnouncer for screen reader announcements
@@ -900,7 +972,8 @@ Wave 1 (19 pts)
   #55 (leptos attrs, 3)  ──────────────────────────────────┐
   #56 (dioxus attrs, 3)  ──────────────────────────────────┤
   #61 (arrow keys, 1)    ──────────────────────────────────┤
-  #57 (modality, 2)                                        │
+  #57 (superseded, 2)                                      │
+  #90 (shared modality, 5)  ───────────────────────────────┤
     ├─→ #58 (press, 5)   ──────────────────────────────────┤
     ├─→ #59 (hover, 2)   ──────────────────────────────────┤
     └─→ #60 (focus, 3)   ──────────────────────────────────┤
@@ -916,10 +989,12 @@ Wave 2 (29 pts)                              ┌─── Wave 1 complete
     └─→ #69 (portal/inert, 3)
                             │
                             ▼
-Wave 3 (20 pts)            ┌─── Wave 2 complete
+Wave 3 (25 pts)            ┌─── Wave 2 complete
   #70 (type-ahead, 3)      │
   #71 (builder, 3)         │
-  #72 (modality mgr, 3)    │
+  #89 (focus ring, 3)      │
+  #72 (modality mgr, 2)    │
+  #88 (overlay stack, 3)   │
   #73 (announcer, 3)       │
   #74 (scroll view, 3)     │
   #75 (ICU4X locale, 5)    │
@@ -944,15 +1019,15 @@ Wave 4 (50 pts)            ┌─── Wave 3 complete
 
 ## Epic Mapping
 
-| Epic           | Issue | Tasks covered                               |
-| -------------- | ----- | ------------------------------------------- |
-| Interactions   | #4    | #57, #58, #59, #60, #61, #65, #76, #77, #78 |
-| DOM utilities  | #6    | #66, #67, #68, #69, #72, #74, #85           |
-| Leptos adapter | #8    | #55                                         |
-| Dioxus adapter | #9    | #56                                         |
-| A11y           | #3    | #73                                         |
-| Collections    | #53   | #62, #63, #64, #70, #71, #81, #82, #83, #84 |
-| I18n           | #54   | #75, #79, #80                               |
+| Epic           | Issue | Tasks covered                                    |
+| -------------- | ----- | ------------------------------------------------ |
+| Interactions   | #4    | #57, #58, #59, #60, #61, #65, #76, #77, #78, #90 |
+| DOM utilities  | #6    | #66, #67, #68, #69, #72, #74, #85, #88           |
+| Leptos adapter | #8    | #55                                              |
+| Dioxus adapter | #9    | #56                                              |
+| A11y           | #3    | #73, #89                                         |
+| Collections    | #53   | #62, #63, #64, #70, #71, #81, #82, #83, #84      |
+| I18n           | #54   | #75, #79, #80                                    |
 
 ## Post-Foundation Plan
 
@@ -969,6 +1044,6 @@ After all four waves are complete:
 | --------- | ------ | ------- | -------------------------------------------------------- |
 | Wave 1    | 7      | 19      | Button, VisuallyHidden, Separator                        |
 | Wave 2    | 8      | 29      | Select, Combobox, Menu, Listbox, Dialog, Popover         |
-| Wave 3    | 6      | 20      | Tooltip, DatePicker prerequisites, accessibility         |
+| Wave 3    | 8      | 25      | Tooltip, DatePicker prerequisites, accessibility         |
 | Wave 4    | 10     | 50      | All remaining components (Slider, TreeView, Table, etc.) |
-| **Total** | **31** | **118** | **Complete foundation for all 112 components**           |
+| **Total** | **33** | **123** | **Complete foundation for all 112 components**           |

--- a/spec/components/utility/ars-provider.md
+++ b/spec/components/utility/ars-provider.md
@@ -6,12 +6,12 @@ foundation_deps: [architecture, accessibility]
 shared_deps: []
 related: []
 references:
-  ark-ui: Environment
+    ark-ui: Environment
 ---
 
 # ArsProvider
 
-`ArsProvider` is the **single root provider** for the ars-ui library. It supplies shared configuration, platform capabilities, i18n resources, and style strategy to all descendant components. It MUST be rendered at (or near) the application root.
+`ArsProvider` is the **single root provider** for the ars-ui library. It supplies shared configuration, platform capabilities, provider-scoped modality state, i18n resources, and style strategy to all descendant components. It MUST be rendered at (or near) the application root.
 
 `ArsProvider` subsumes the formerly separate `LocaleProvider`, `PlatformEffectsProvider`, `IcuProvider`, `I18nProvider`, and `ArsStyleProvider`.
 
@@ -58,6 +58,10 @@ pub struct Props {
     /// Defaults to `NullPlatformEffects` (no-op) for tests and SSR.
     pub platform: Option<Rc<dyn PlatformEffects>>,
 
+    /// Shared input-modality state for this provider root.
+    /// Defaults to `DefaultModalityContext`.
+    pub modality: Option<Rc<dyn ModalityContext>>,
+
     /// Calendar/locale data provider for date-time components.
     /// Production uses `Icu4xProvider`; tests use `StubIcuProvider`.
     /// Defaults to `StubIcuProvider` (English-only).
@@ -90,6 +94,7 @@ pub struct ArsContext {
     portal_container_id: Option<String>,
     root_node_id: Option<String>,
     platform: Rc<dyn PlatformEffects>,
+    modality: Rc<dyn ModalityContext>,
     icu_provider: Arc<dyn IcuProvider>,
     i18n_registries: Rc<I18nRegistries>,
     style_strategy: StyleStrategy,
@@ -114,6 +119,8 @@ impl ArsContext {
     pub fn root_node_id(&self) -> Option<&str> { self.root_node_id.as_deref() }
     /// Returns the platform capabilities trait object.
     pub fn platform(&self) -> Rc<dyn PlatformEffects> { Rc::clone(&self.platform) }
+    /// Returns the provider-scoped modality context.
+    pub fn modality(&self) -> Rc<dyn ModalityContext> { Rc::clone(&self.modality) }
     /// Returns the ICU calendar/locale data provider.
     pub fn icu_provider(&self) -> Arc<dyn IcuProvider> { Arc::clone(&self.icu_provider) }
     /// Returns the i18n translation registries.
@@ -134,6 +141,7 @@ impl Default for ArsContext {
             portal_container_id: None,
             root_node_id: None,
             platform: Rc::new(NullPlatformEffects),
+            modality: Rc::new(DefaultModalityContext::new()),
             icu_provider: Arc::new(StubIcuProvider),
             i18n_registries: Rc::new(I18nRegistries::new()),
             style_strategy: StyleStrategy::Inline,
@@ -156,6 +164,7 @@ Convenience hooks read from `ArsContext` with fallback defaults:
 
 - `use_locale()` — locale, falls back to `en-US`
 - `use_platform_effects()` — platform capabilities
+- `use_modality_context()` — provider-scoped input-modality state
 - `use_icu_provider()` — calendar/locale data
 - `use_style_strategy()` — CSS style strategy, falls back to `Inline`
 - `resolve_messages::<M>()` — translation registries
@@ -189,6 +198,7 @@ ArsProvider
 | Form field components    | `disabled`, `read_only` — cascade to descendant interactive components                             |
 | Theme-aware components   | `color_mode` — for conditional rendering based on active color mode                                |
 | All effect closures      | `platform` — via `use_platform_effects()` for focus, timers, scroll-lock, positioning, DOM queries |
+| Focus / Hover / Press    | `modality` — via `use_modality_context()` for shared modality and global press state               |
 | Date-time components     | `icu_provider` — via `use_icu_provider()` for calendar data (weekday names, month names, etc.)     |
 | All stateful components  | `i18n_registries` — via `resolve_messages::<M>()` for per-component translation lookups            |
 | All rendered components  | `style_strategy` — via `use_style_strategy()` for CSS injection method                             |

--- a/spec/components/utility/focus-ring.md
+++ b/spec/components/utility/focus-ring.md
@@ -6,7 +6,7 @@ foundation_deps: [architecture, accessibility]
 shared_deps: []
 related: []
 references:
-  react-aria: FocusRing
+    react-aria: FocusRing
 ---
 
 # FocusRing
@@ -126,97 +126,49 @@ FocusRing
 
 > **CSS Selector Performance Note:** The `:has()` pseudo-class (relative selector) has significant performance cost in older Chrome versions (< 105) and can cause style recalculation bottlenecks when used in high-frequency selectors. Prefer attribute selectors like `[data-ars-focus-visible]` over patterns like `:has(:focus-visible)` for focus ring styling. Attribute selectors are O(1) in selector matching, while `:has()` requires ancestor/descendant traversal. The `data-ars-*` attribute system is specifically designed to avoid the need for `:has()` in component styling.
 
-## 4. Global Pointer Tracking
+## 4. Shared Modality Tracking
 
-FocusRing depends on a global module-level pointer tracking effect maintained by `ars-dom`:
+FocusRing no longer depends on a process-global singleton. It consumes the same provider-scoped modality event stream used by `ars_core::ModalityContext`, typically via `ars-dom::ModalityManager`:
 
 ```rust
-// ars-dom/src/focus_visible.rs
+// ars-dom/src/modality.rs
 
-use std::cell::Cell;
+use std::rc::Rc;
+use ars_a11y::FocusRing;
+use ars_core::{KeyboardKey, KeyModifiers, ModalityContext, PointerType};
 
-/// Describes why an element received focus. Replaces the previous boolean
-/// `had_pointer_interaction` flag with a richer enum that distinguishes
-/// keyboard, pointer, and programmatic focus sources.
-#[derive(Clone, Debug, PartialEq)]
-pub enum FocusCause {
-    /// Focus was triggered by keyboard navigation (Tab, Shift+Tab, arrow keys).
-    Keyboard,
-    /// Focus was triggered by pointer interaction (mouse click, touch).
-    Pointer,
-    /// Focus was moved programmatically (e.g., dialog open, focus trap).
-    Programmatic,
+pub struct ModalityManager {
+    modality: Rc<dyn ModalityContext>,
+    focus_ring: FocusRing,
 }
 
-thread_local! {
-    /// Tracks the cause of the most recent focus event.
-    static LAST_FOCUS_CAUSE: Cell<Option<FocusCause>> = Cell::new(None);
-}
+impl ModalityManager {
+    pub fn on_key_down(&self, key: KeyboardKey, modifiers: KeyModifiers) {
+        self.modality.on_key_down(key, modifiers);
+        self.focus_ring.on_key_down(key, modifiers);
+    }
 
-/// Call once at application startup to install the global listeners.
-/// (Called automatically by the ars-leptos / ars-dioxus mount function.)
-///
-/// **Initialization:** `install_focus_visible_tracker()` from `ars-dom` must
-/// be called once at app startup. This is automatically handled by the
-/// `ars-leptos` and `ars-dioxus` mount functions. If using a custom setup,
-/// call it manually before any FocusRing-enabled components mount.
-pub fn install_focus_visible_tracker() {
-    // Install `pointerdown` listener on `window` that sets LAST_FOCUS_CAUSE = Some(Pointer).
-    // Install `keydown` listener on `window` (for Tab, Shift+Tab, arrow keys)
-    //   that sets LAST_FOCUS_CAUSE = Some(Keyboard).
-    // Programmatic focus is detected when neither pointer nor keyboard preceded
-    //   the focus event — the adapter sets LAST_FOCUS_CAUSE = Some(Programmatic)
-    //   when calling element.focus() directly.
+    pub fn on_pointer_down(&self, pointer_type: PointerType) {
+        self.modality.on_pointer_down(pointer_type);
+        self.focus_ring.on_pointer_down();
+    }
+
+    pub fn on_virtual_input(&self) {
+        self.modality.on_virtual_input();
+        self.focus_ring.on_virtual_input();
+    }
 }
 ```
 
-**Cleanup and idempotency:** The function MUST be idempotent — calling it multiple times must not accumulate duplicate listeners. Use a module-level guard:
+Browser listener installation is also owned by `ars-dom`, not by `FocusRing` itself. The web implementation exposes ref-counted `ensure_listeners()` / `remove_listeners()` methods on `ModalityManager` so adapters can install document listeners without creating duplicate registrations.
+
+Individual component focus handlers consult the shared modality context to determine the focus source:
 
 ```rust
-thread_local! {
-    static TRACKER_INSTALLED: Cell<bool> = Cell::new(false);
-}
-
-pub fn install_focus_visible_tracker() {
-    TRACKER_INSTALLED.with(|installed| {
-        if installed.get() { return; }
-        installed.set(true);
-        // ... attach listeners ...
-    });
-}
-```
-
-For Dioxus Desktop hot-reload scenarios, the guard prevents listener accumulation across webview recreations. If full cleanup is needed, the function MAY return a cleanup handle that removes the listeners and resets the guard.
-
-```rust
-/// Returns the cause of the most recent focus event.
-pub fn last_focus_cause() -> Option<FocusCause> {
-    LAST_FOCUS_CAUSE.with(|v| v.get())
-}
-
-/// Whether focus should show a visible focus ring.
-/// Only keyboard-initiated focus triggers the focus ring.
-/// When `is_text_input` is true, `data-ars-focus-visible` is set whenever the
-/// element is focused, regardless of the `FocusCause`. This matches the
-/// convention that text inputs always display a visible focus indicator.
-pub fn is_focus_visible() -> bool {
-    matches!(last_focus_cause(), Some(FocusCause::Keyboard))
-}
-
-/// Legacy compatibility wrapper.
-pub fn had_pointer_interaction() -> bool {
-    matches!(last_focus_cause(), Some(FocusCause::Pointer))
-}
-```
-
-Individual component focus handlers call `last_focus_cause()` to determine the focus source:
-
-```rust
-// Inside any component's focus handler (now a typed method on the Api struct):
-// The adapter calls last_focus_cause() and sends the appropriate event.
+// Inside any component's focus handler:
 // fn on_focus(&self) {
-//     let cause = last_focus_cause().unwrap_or(FocusCause::Programmatic);
-//     let is_keyboard = matches!(cause, FocusCause::Keyboard);
+//     let last_pointer_type = config.modality.last_pointer_type();
+//     let is_keyboard = matches!(last_pointer_type, Some(PointerType::Keyboard));
 //     (self.send)(Event::Focus { is_keyboard });
 // }
 ```
@@ -227,13 +179,13 @@ Individual component focus handlers call `last_focus_cause()` to determine the f
 /* Show visible focus ring only for keyboard navigation */
 [data-ars-focus-visible]:focus,
 [data-ars-focus-visible]:focus-within {
-  outline: 2px solid var(--ars-color-focus);
-  outline-offset: 2px;
+    outline: 2px solid var(--ars-color-focus);
+    outline-offset: 2px;
 }
 
 /* Suppress focus ring for pointer navigation */
 :focus:not([data-ars-focus-visible]) {
-  outline: none;
+    outline: none;
 }
 ```
 

--- a/spec/components/utility/focus-scope.md
+++ b/spec/components/utility/focus-scope.md
@@ -6,7 +6,7 @@ foundation_deps: [architecture, accessibility]
 shared_deps: []
 related: []
 references:
-  react-aria: FocusScope
+    react-aria: FocusScope
 ---
 
 # FocusScope
@@ -292,11 +292,10 @@ impl ars_core::Machine for Machine {
         }
     }
 
-    // **FocusCause coordination:** `platform.focus_element_by_id()` MUST call
-    // `set_last_focus_cause(FocusCause::Programmatic)` before invoking the
-    // element's `.focus()` method. This ensures that FocusRing correctly
-    // evaluates `data-ars-focus-visible` — programmatic focus should NOT show
-    // a focus ring unless the prior interaction was keyboard-initiated.
+    // **Modality coordination:** programmatic focus restoration MUST preserve the
+    // shared `ModalityContext` state rather than forcing pointer modality.
+    // This ensures `data-ars-focus-visible` remains correct — programmatic focus
+    // should only show a focus ring when the prior interaction was not pointer-driven.
 
     fn connect<'a>(
         state: &'a State,
@@ -596,12 +595,12 @@ When a component uses both FocusScope (trapping focus) and Dismissable (providin
 
 ```html
 <div data-ars-scope="dialog">
-  <!-- FocusScope container -->
-  <DismissButton />
-  <!-- Inside trap — reachable -->
-  <div data-ars-part="content">...</div>
-  <DismissButton />
-  <!-- Inside trap — reachable -->
+    <!-- FocusScope container -->
+    <DismissButton />
+    <!-- Inside trap — reachable -->
+    <div data-ars-part="content">...</div>
+    <DismissButton />
+    <!-- Inside trap — reachable -->
 </div>
 ```
 
@@ -611,7 +610,7 @@ When a component uses both FocusScope (trapping focus) and Dismissable (providin
 <DismissButton />
 <!-- Outside trap — unreachable! -->
 <div data-ars-scope="dialog">
-  <div data-ars-part="content">...</div>
+    <div data-ars-part="content">...</div>
 </div>
 ```
 

--- a/spec/foundation/01-architecture.md
+++ b/spec/foundation/01-architecture.md
@@ -1356,6 +1356,8 @@ impl<M: Machine> PendingEffect<M> {
 
 Effect closures must be **platform-agnostic** — they MUST NOT call DOM APIs (`web_sys`, `ars_dom`) directly. Instead, all platform-specific operations (focus, timers, announcements, positioning, scroll lock) go through the `PlatformEffects` trait, resolved from the adapter's framework context.
 
+Ambient input modality tracking is a separate concern. It does **not** belong on `PlatformEffects` because it is shared provider state rather than a machine-triggered side-effect surface. The shared `ModalityContext` lives in `ars-core`, is injected through `ArsProvider`, and is fed by platform-specific listener implementations such as `ars-dom::ModalityManager`.
+
 ```rust
 // ars-core/src/platform.rs
 
@@ -4607,13 +4609,13 @@ Child component (e.g., Trigger):
 ### 6.4 ArsProvider
 
 `ArsProvider` is the **single root provider** for the ars-ui library. It supplies shared
-configuration, platform capabilities, i18n resources, and style strategy to all descendant
+configuration, platform capabilities, provider-scoped modality state, i18n resources, and style strategy to all descendant
 components. It MUST be rendered at (or near) the application root.
 
 `ArsProvider` subsumes the formerly separate `LocaleProvider`, `PlatformEffectsProvider`,
 `IcuProvider`, `I18nProvider`, and `ArsStyleProvider`. Components access configuration
 via `ArsContext` fields and convenience hooks (e.g., `use_locale()`,
-`use_platform_effects()`, `use_style_strategy()`).
+`use_platform_effects()`, `use_modality_context()`, `use_style_strategy()`).
 
 #### 6.4.1 ColorMode
 
@@ -4641,6 +4643,7 @@ pub enum ColorMode {
 | `portal_container_id` | `Option<String>`                            | ID of the container element for portal mounts. `None` means platform default.  |
 | `root_node_id`        | `Option<String>`                            | ID of the root node for focus scope and portal queries. `None` means default.  |
 | `platform`            | `Rc<dyn PlatformEffects>`                   | Platform capabilities for side effects. Defaults to `NullPlatformEffects`.     |
+| `modality`            | `Rc<dyn ModalityContext>`                   | Shared input-modality state for the current provider root.                     |
 | `icu_provider`        | `Arc<dyn IcuProvider>`                      | Calendar/locale data for date-time components. Defaults to `StubIcuProvider`.  |
 | `i18n_registries`     | `Rc<I18nRegistries>`                        | Per-component translation registries. Defaults to empty (English fallbacks).   |
 | `style_strategy`      | `StyleStrategy`                             | CSS style injection strategy. Defaults to `StyleStrategy::Inline`.             |
@@ -4650,6 +4653,7 @@ hooks read from `ArsContext` with fallback defaults:
 
 - `use_locale()` — locale, falls back to `en-US`
 - `use_platform_effects()` — platform capabilities
+- `use_modality_context()` — shared input-modality state
 - `use_icu_provider()` — calendar/locale data
 - `use_style_strategy()` — CSS style strategy, falls back to `Inline`
 - `resolve_messages::<M>()` — translation registries

--- a/spec/foundation/03-accessibility.md
+++ b/spec/foundation/03-accessibility.md
@@ -128,10 +128,10 @@ For each component, execute the following checklist against each screen reader i
 6. **Live region**: Are dynamic content changes announced via `aria-live`?
 7. **Error messages**: Are form errors announced immediately on occurrence?
 8. **Forced colors (WHCM)**: Test on Windows High Contrast Mode:
-   - Focus indicators maintain ≥ 3:1 contrast ratio (use `Highlight` or `ButtonText` system colors).
-   - `data-ars-*` attributes do not hide content — verify `::before`/`::after` state indicators remain visible.
-   - Custom icons with `fill: currentColor` or `forced-color-adjust: auto` inherit system palette correctly.
-   - Component states (selected, checked, disabled, pressed) are distinguishable without author-defined colors.
+    - Focus indicators maintain ≥ 3:1 contrast ratio (use `Highlight` or `ButtonText` system colors).
+    - `data-ars-*` attributes do not hide content — verify `::before`/`::after` state indicators remain visible.
+    - Custom icons with `fill: currentColor` or `forced-color-adjust: auto` inherit system palette correctly.
+    - Component states (selected, checked, disabled, pressed) are distinguishable without author-defined colors.
 
 ---
 
@@ -1597,22 +1597,23 @@ See `FocusStrategy` definition above in §3.2.
 
 /// Tracks whether the most recent interaction was keyboard-driven.
 ///
-/// `FocusRing` is a shared singleton that listens to `pointerdown` and `keydown`
-/// events on the document. After a `keydown`, subsequent `:focus` events are
-/// considered keyboard-initiated and should show the focus ring. After a
-/// `pointerdown`, focus is mouse/touch-initiated and the ring is suppressed.
+/// `FocusRing` is an accessibility-specific heuristic that consumes the same
+/// normalized modality event stream as `ars_core::ModalityContext`. Adapters
+/// typically feed it through `ars-dom::ModalityManager` so focus-visible state
+/// stays aligned with interaction modality without coupling it to
+/// `PlatformEffects`.
 ///
 /// The `data-ars-focus-visible` attribute on focused elements reflects this state
 /// and is the CSS hook for styling focus rings.
 pub struct FocusRing {
     /// True when the most recent interaction was via keyboard.
-    keyboard_modality: bool,
+    keyboard_modality: Cell<bool>,
 }
 
 impl FocusRing {
     /// Process a `pointerdown` event — suppresses keyboard modality.
-    pub fn on_pointer_down(&mut self) {
-        self.keyboard_modality = false;
+    pub fn on_pointer_down(&self) {
+        self.keyboard_modality.set(false);
     }
 
     /// Process a `keydown` event — activates keyboard modality.
@@ -1626,11 +1627,9 @@ impl FocusRing {
     /// The `modifiers` parameter allows filtering out modified key combos
     /// (e.g., Ctrl+Tab switches browser tabs and should not trigger keyboard modality).
     /// Adapters filter platform-consumed combos before calling this method.
-    /// `modifiers` is `ars_a11y::KeyModifiers` (with unified `action` field).
-    /// The adapter MUST convert from raw DOM modifiers using:
-    ///   `ars_a11y::KeyModifiers::from((ars_interactions::KeyModifiers, Platform))`
-    /// before calling this method. See `05-interactions.md` §2.2 for the conversion impl.
-    pub fn on_key_down(&mut self, key: KeyboardKey, modifiers: KeyModifiers) {
+    /// `modifiers` is the raw `ars_core::KeyModifiers` snapshot from the same
+    /// event delivered to `ModalityContext`.
+    pub fn on_key_down(&self, key: KeyboardKey, modifiers: KeyModifiers) {
         // Keys that indicate keyboard navigation intent.
         // F1-F12 are included because they indicate keyboard-driven interaction.
         // If browser-level F-key handling (e.g., F5=refresh) is undesirable,
@@ -1648,21 +1647,26 @@ impl FocusRing {
         // Skip modified combos (e.g., Ctrl+Tab = browser tab switch).
         // The adapter also pre-filters platform-consumed combos, but this
         // guard ensures FocusRing remains correct even without adapter filtering.
-        if modifiers.action || modifiers.alt {
-            // Skip action-modified combos (Ctrl+Tab, Cmd+Tab) and alt-modified
+        if modifiers.ctrl || modifiers.meta || modifiers.alt {
+            // Skip ctrl/meta-modified combos (Ctrl+Tab, Cmd+Tab) and alt-modified
             // combos (Alt+Tab = OS window switch). These are not user keyboard
             // navigation and should not trigger keyboard modality.
             return;
         }
         if NAV_KEYS.contains(&key) {
-            self.keyboard_modality = true;
+            self.keyboard_modality.set(true);
         }
+    }
+
+    /// Process a virtual interaction source (for example assistive-technology navigation).
+    pub fn on_virtual_input(&self) {
+        self.keyboard_modality.set(true);
     }
 
     /// Returns true if the focus ring should be shown for the element
     /// that just received focus.
     pub fn should_show_focus_ring(&self) -> bool {
-        self.keyboard_modality
+        self.keyboard_modality.get()
     }
 
     /// Emit the `data-ars-focus-visible` attribute into AttrMap based on current state.
@@ -1671,7 +1675,7 @@ impl FocusRing {
     /// instead. Direct use of this method is reserved for rare cases where the
     /// `ars-interactions` layer is bypassed. See `05-interactions.md` §4 normative statement.
     pub fn apply_focus_attrs(&self, attrs: &mut AttrMap, is_focused: bool) {
-        if is_focused && self.keyboard_modality {
+        if is_focused && self.keyboard_modality.get() {
             attrs.set_bool(HtmlAttr::Data("ars-focus-visible"), true);
         } else {
             attrs.set(HtmlAttr::Data("ars-focus-visible"), AttrValue::None);
@@ -1735,7 +1739,7 @@ impl FocusRing {
 pub struct FocusRingCssDoc;
 ````
 
-> **Interaction layer:** FocusRing in `ars-a11y` provides the low-level input-modality tracker. The `FocusState` enum in `ars-interactions` (`05-interactions.md` §4) consumes this to drive the `use_focus` hook's focus-visible logic.
+> **Interaction layer:** FocusRing in `ars-a11y` provides the accessibility-focused `focus-visible` heuristic. The `FocusState` enum in `ars-interactions` (`05-interactions.md` §4) reads the shared `ModalityContext`, while adapters feed both through the same `ars-dom::ModalityManager` event stream.
 
 ### 3.5 FocusZone
 
@@ -2034,9 +2038,9 @@ All text input components (TextField, Textarea, Combobox, TagsInput, SearchInput
 
 1. Track `is_composing: bool` in component Context, set to `true` on `compositionstart` and `false` on `compositionend`.
 2. During composition (`is_composing == true`), suppress:
-   - Enter-based actions (tag addition, item selection, form submission)
-   - Filtering/search triggers (Combobox should not filter on intermediate composition text)
-   - Custom keyboard handlers that would interfere with composition
+    - Enter-based actions (tag addition, item selection, form submission)
+    - Filtering/search triggers (Combobox should not filter on intermediate composition text)
+    - Custom keyboard handlers that would interfere with composition
 3. Only process the final committed text on `compositionend`.
 4. When the browser reports `key` as `"Process"` (i.e., `key == KeyboardKey::Process` — Chrome fires this before `compositionstart`), treat as composition-in-progress regardless of the `isComposing` flag value.
 5. **Firefox late-fire workaround:** Firefox fires `compositionend` _after_ `keydown` for Enter, so `is_composing` is still `true` when the Enter `keydown` arrives. The adapter layer MUST schedule a microtask (e.g., `queueMicrotask` / `Promise::resolve().then(...)`) from the Enter `keydown` handler and only process the Enter action in that microtask — by then `compositionend` will have fired and `is_composing` will be `false`. If `is_composing` is still `true` at microtask time, discard the Enter.
@@ -3080,21 +3084,21 @@ Windows High Contrast Mode (WHCM) and CSS `forced-colors` media feature apply a 
 
 /* Ensure focus rings appear in forced-colors mode */
 @media (forced-colors: active) {
-  [data-ars-focus-visible] {
-    outline: 3px solid Highlight;
-    outline-offset: 2px;
-    forced-color-adjust: none;
-  }
+    [data-ars-focus-visible] {
+        outline: 3px solid Highlight;
+        outline-offset: 2px;
+        forced-color-adjust: none;
+    }
 
-  /* Ensure data-attribute-conveyed states remain visible */
-  [data-ars-state~="selected"]::before {
-    content: "✓ ";
-    forced-color-adjust: auto;
-  }
+    /* Ensure data-attribute-conveyed states remain visible */
+    [data-ars-state~="selected"]::before {
+        content: "✓ ";
+        forced-color-adjust: auto;
+    }
 
-  [data-ars-disabled] {
-    color: GrayText;
-  }
+    [data-ars-disabled] {
+        color: GrayText;
+    }
 }
 ```
 
@@ -3152,10 +3156,10 @@ pub fn resolve_opaque_backdrop(override_: Option<bool>) -> bool {
 ```css
 /* CSS pattern for reduced-transparency support */
 @media (prefers-reduced-transparency: reduce) {
-  [data-ars-scope="dialog"] [data-ars-part="backdrop"] {
-    background: rgb(0, 0, 0); /* opaque fallback */
-    backdrop-filter: none; /* remove blur */
-  }
+    [data-ars-scope="dialog"] [data-ars-part="backdrop"] {
+        background: rgb(0, 0, 0); /* opaque fallback */
+        backdrop-filter: none; /* remove blur */
+    }
 }
 ```
 
@@ -3173,24 +3177,24 @@ Recommended defaults (applied via user CSS, documented here for design system au
 ```css
 /* Default focus ring: 3px solid outline with 2px offset (per §3.4 FocusRingCssDoc) */
 [data-ars-focus-visible] {
-  outline: 3px solid #0070f3; /* Must be ≥ 3:1 contrast against background */
-  outline-offset: 2px;
+    outline: 3px solid #0070f3; /* Must be ≥ 3:1 contrast against background */
+    outline-offset: 2px;
 }
 
 /* For dark backgrounds, use a white ring with a dark shadow.
    box-shadow provides contrast halo on normal displays;
    it is stripped in forced-colors mode where outline alone is visible. */
 .dark [data-ars-focus-visible] {
-  outline: 3px solid #ffffff;
-  box-shadow: 0 0 0 4px #000000;
+    outline: 3px solid #ffffff;
+    box-shadow: 0 0 0 4px #000000;
 }
 
 @media (forced-colors: active) {
-  .dark [data-ars-focus-visible] {
-    outline: 3px solid Highlight;
-    outline-offset: 2px;
-    box-shadow: none;
-  }
+    .dark [data-ars-focus-visible] {
+        outline: 3px solid Highlight;
+        outline-offset: 2px;
+        box-shadow: none;
+    }
 }
 ```
 
@@ -3386,12 +3390,12 @@ When `ScrollLock` is active (typically from an open modal Dialog), the `<body>` 
 
 ```css
 @media print {
-  html,
-  body {
-    overflow: visible !important;
-    padding-right: 0 !important;
-    height: auto !important;
-  }
+    html,
+    body {
+        overflow: visible !important;
+        padding-right: 0 !important;
+        height: auto !important;
+    }
 }
 ```
 
@@ -3411,39 +3415,39 @@ The `ars-ui` project should ship a `print.css` file (or `@media print` block wit
 
 ```css
 @media print {
-  /* Hide overlays and backdrops */
-  [data-ars-scope="dialog"]:not([role="alertdialog"]),
-  [data-ars-scope="drawer"],
-  [data-ars-scope="popover"],
-  [data-ars-scope="tooltip"],
-  [data-ars-scope="toast"],
-  [data-ars-backdrop] {
-    display: none !important;
-  }
+    /* Hide overlays and backdrops */
+    [data-ars-scope="dialog"]:not([role="alertdialog"]),
+    [data-ars-scope="drawer"],
+    [data-ars-scope="popover"],
+    [data-ars-scope="tooltip"],
+    [data-ars-scope="toast"],
+    [data-ars-backdrop] {
+        display: none !important;
+    }
 
-  /* Remove scroll lock side-effects */
-  html,
-  body {
-    overflow: visible !important;
-    padding-right: 0 !important;
-    height: auto !important;
-  }
+    /* Remove scroll lock side-effects */
+    html,
+    body {
+        overflow: visible !important;
+        padding-right: 0 !important;
+        height: auto !important;
+    }
 
-  /* Hide portal root (content should be inlined for print) */
-  #ars-portal-root {
-    display: none !important;
-  }
+    /* Hide portal root (content should be inlined for print) */
+    #ars-portal-root {
+        display: none !important;
+    }
 
-  /* Suppress focus indicators */
-  [data-ars-focus-visible] {
-    outline: none !important;
-    box-shadow: none !important;
-  }
+    /* Suppress focus indicators */
+    [data-ars-focus-visible] {
+        outline: none !important;
+        box-shadow: none !important;
+    }
 
-  /* Suppress loading spinners / skeleton screens */
-  [data-ars-state="loading"] {
-    visibility: hidden;
-  }
+    /* Suppress loading spinners / skeleton screens */
+    [data-ars-state="loading"] {
+        visibility: hidden;
+    }
 }
 ```
 

--- a/spec/foundation/05-interactions.md
+++ b/spec/foundation/05-interactions.md
@@ -59,7 +59,7 @@ Composition works at two levels:
 
 **Level 1 — Attrs merging**: Each interaction's `connect` function returns an `AttrMap` set plus typed handler methods. The `merge_attrs` utility (§8) combines multiple `AttrMap` sets onto a single element, unioning data attributes and styles without collision. Event handlers are composed separately via typed methods on per-component `Api` structs.
 
-**Level 2 — Interaction awareness**: Interactions are designed to be mutually aware. For example, `hover` suppresses hover state while a `press` is active (because touch devices fire both `pointerdown` and `mouseover`). `focus_visible` tracks the last pointer type globally to decide whether focus rings should appear. These cross-cutting concerns are handled via shared thread-local state in `ars-interactions`, not by the component author.
+**Level 2 — Interaction awareness**: Interactions are designed to be mutually aware. For example, `hover` suppresses hover state while a `press` is active (because touch devices fire both `pointerdown` and `mouseover`). `focus_visible` consults the shared `ModalityContext` to decide whether focus rings should appear. These cross-cutting concerns are handled via provider-scoped shared state, not by the component author.
 
 ```text
 Button element
@@ -563,27 +563,27 @@ When ars-ui components are used inside Shadow DOM (e.g., web components wrapping
 > ```js
 > // Complete requestIdleCallback polyfill using MessageChannel + requestAnimationFrame fallback.
 > const scheduleIdle = (() => {
->   if (typeof window.requestIdleCallback === "function") {
->     return (fn) => window.requestIdleCallback(fn);
->   }
->   // MessageChannel-based polyfill: posts a message that fires as a macrotask, bypassing the >= 4ms clamping of setTimeout(fn, 0).
->   const channel = new MessageChannel();
->   const queue = [];
->   channel.port1.onmessage = () => {
->     const fn = queue.shift();
->     if (fn) fn({ timeRemaining: () => 0, didTimeout: false });
->   };
->   return (fn) => {
->     queue.push(fn);
->     channel.port2.postMessage(null);
->   };
+>     if (typeof window.requestIdleCallback === "function") {
+>         return (fn) => window.requestIdleCallback(fn);
+>     }
+>     // MessageChannel-based polyfill: posts a message that fires as a macrotask, bypassing the >= 4ms clamping of setTimeout(fn, 0).
+>     const channel = new MessageChannel();
+>     const queue = [];
+>     channel.port1.onmessage = () => {
+>         const fn = queue.shift();
+>         if (fn) fn({ timeRemaining: () => 0, didTimeout: false });
+>     };
+>     return (fn) => {
+>         queue.push(fn);
+>         channel.port2.postMessage(null);
+>     };
 > })();
 >
 > // Cancel polyfill (no-op for MessageChannel variant — the polyfill does not return a cancellable handle.)
 > const cancelIdle =
->   typeof window.cancelIdleCallback === "function"
->     ? (id) => window.cancelIdleCallback(id)
->     : () => {};
+>     typeof window.cancelIdleCallback === "function"
+>         ? (id) => window.cancelIdleCallback(id)
+>         : () => {};
 > ```
 >
 > **Browser Quirk:** `ResizeObserver` can fire a "ResizeObserver loop limit exceeded" error when an observation callback triggers layout changes that in turn trigger additional observations. This is benign in most cases and does not indicate a real error. Adapters should suppress this at the application root: `window.addEventListener('error', (e) => { if (e.message?.includes('ResizeObserver')) e.stopPropagation(); });`. Components using `ResizeObserver` (e.g., positioning engine, overflow detection) should also guard against infinite loops by deferring layout-triggering updates with `requestAnimationFrame`. Components using `ResizeObserver` that trigger layout changes in the callback MUST defer those changes with `requestAnimationFrame` to break the observation→layout→observation loop.
@@ -657,10 +657,10 @@ When ars-ui components are used inside Shadow DOM (e.g., web components wrapping
 >
 > ```js
 > requestAnimationFrame(() => {
->   requestAnimationFrame(() => {
->     const duration = getComputedStyle(el).animationDuration;
->     // Now safe to read
->   });
+>     requestAnimationFrame(() => {
+>         const duration = getComputedStyle(el).animationDuration;
+>         // Now safe to read
+>     });
 > });
 > ```
 >
@@ -880,26 +880,20 @@ impl HoverState {
 
 ### 3.4 Integration with Press
 
-`ars-interactions` maintains thread-local state tracking whether any press interaction is currently active globally (any element on the page). When `HoverState` is `Hovered` and a global press begins — for example, from touch, which fires `pointerover` on iOS before `pointerdown` — the hover interaction immediately transitions to `NotHovered`. This prevents stale hover highlights on mobile.
+`ars-interactions` reads shared instance-scoped modality state from `ars-core::ModalityContext`. When `HoverState` is `Hovered` and a global press begins — for example, from touch, which fires `pointerover` on iOS before `pointerdown` — the hover interaction immediately transitions to `NotHovered`. This prevents stale hover highlights on mobile while keeping the state isolated to a single provider root instead of a process-global singleton.
 
 ```rust
-// Module-level (thread_local) press tracking:
-thread_local! {
-    static GLOBAL_PRESS_ACTIVE: Cell<bool> = Cell::new(false);
-    static LAST_POINTER_TYPE: Cell<PointerType> = Cell::new(PointerType::Mouse);
-    static MODALITY_LISTENERS_INSTALLED: Cell<bool> = Cell::new(false);
-    /// Reference count for modality listener consumers. When this reaches 0,
-    /// `remove_modality_listeners()` detaches all document-level event handlers.
-    static MODALITY_LISTENER_REFCOUNT: Cell<u32> = Cell::new(0);
+use ars_core::ModalityContext;
+
+/// Hover integration reads the shared modality snapshot instead of a thread-local.
+fn should_clear_hover(modality: &dyn ModalityContext) -> bool {
+    modality.is_global_press_active()
 }
 
-/// Returns `true` if the most recent pointer interaction was a mouse, touch, or pen
-/// (as opposed to keyboard). Used by `FocusState::is_focus_visible()` to suppress
-/// the focus ring after pointer-initiated programmatic `.focus()` calls.
-fn had_pointer_interaction() -> bool {
-    LAST_POINTER_TYPE.with(|pt| {
-        matches!(pt.get(), PointerType::Mouse | PointerType::Touch | PointerType::Pen)
-    })
+/// Programmatic focus uses the same shared modality context to decide whether
+/// a preceding interaction came from a pointer device.
+fn had_pointer_interaction(modality: &dyn ModalityContext) -> bool {
+    modality.had_pointer_interaction()
 }
 ```
 
@@ -955,7 +949,8 @@ pub fn use_hover(config: HoverConfig) -> HoverResult {
     // Event handlers are registered as typed methods on the component's Api struct:
     //   pointerenter → NotHovered ──→ Hovered (mouse/pen only; ignores touch)
     //   pointerleave → Hovered ──→ NotHovered
-    // Global press tracking: if GLOBAL_PRESS_ACTIVE becomes true while Hovered,
+    // Shared modality tracking: if config.modality.is_global_press_active()
+    // becomes true while Hovered,
     //   immediately transition to NotHovered (prevents stale hover on mobile).
 
     HoverResult { hovered, state }
@@ -994,9 +989,7 @@ Data attributes:
 
 ## 4. Focus Interaction
 
-> **Cross-ref: FocusRing (ars-a11y §3.4):** FocusState builds on the `FocusRing` modality tracker defined in `ars-a11y` (`03-accessibility.md` §3.4). FocusRing detects whether the last input was pointer or keyboard; FocusState uses that to determine the focus-visible CSS class. See also §4.4 below for adapter wiring that keeps both trackers in sync.
->
-> **Modality contract:** `FocusRing` (ars-a11y) and `FocusState` (ars-interactions) both read from the same shared thread-local state (`LAST_POINTER_TYPE`). `FocusState`'s `had_pointer_interaction()` reads this thread-local directly — it does not delegate to `FocusRing`. The adapter MUST sync both trackers from the same event listener, ensuring the shared thread-local is the single source of truth.
+> **Cross-ref: FocusRing (ars-a11y §3.4):** `FocusState` consumes the shared `ars_core::ModalityContext` while `FocusRing` consumes the same normalized event stream for accessibility-specific focus-visible heuristics. See also §4.4 below for adapter wiring that keeps both consumers synchronized through `ars-dom::ModalityManager`.
 >
 > **Normative:** `FocusState` (ars-interactions) is the consumer-facing API. Components MUST use `FocusResult.current_attrs()` for focus-visible rendering. Components MUST NOT also call `FocusRing.apply_focus_attrs()` on the same element — doing so would produce duplicate or conflicting `data-ars-focus-visible` attributes. `FocusRing` is the low-level tracker used internally by `FocusState`; direct use is reserved for rare cases where the ars-interactions layer is bypassed.
 >
@@ -1014,15 +1007,18 @@ Focus interaction provides normalized `focus` and `blur` events and, critically,
 // ars-interactions/src/focus.rs
 
 use std::{cell::RefCell, rc::Rc};
-use ars_core::AttrMap;
+use ars_core::{AttrMap, DefaultModalityContext, ModalityContext};
 use crate::PointerType;
 
 /// Configuration for focus interaction on a single element.
 // Manual Debug impl omitted for brevity — prints closures as "<closure>"
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct FocusConfig {
     /// Whether the element is disabled.
     pub disabled: bool,
+
+    /// Shared modality context for the current provider root.
+    pub modality: Rc<dyn ModalityContext>,
 
     /// Called when the element receives focus.
     pub on_focus: Option<Rc<dyn Fn(FocusEvent)>>,
@@ -1036,10 +1032,13 @@ pub struct FocusConfig {
 
 /// Configuration for focus-within tracking on a container element.
 // Manual Debug impl omitted for brevity — prints closures as "<closure>"
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct FocusWithinConfig {
     /// Whether the container is disabled.
     pub disabled: bool,
+
+    /// Shared modality context for the current provider root.
+    pub modality: Rc<dyn ModalityContext>,
 
     /// Called when focus enters the container (any descendant focused).
     pub on_focus_within: Option<Rc<dyn Fn(FocusEvent)>>,
@@ -1049,6 +1048,30 @@ pub struct FocusWithinConfig {
 
     /// Called when focus-within-visible state changes.
     pub on_focus_within_visible_change: Option<Rc<dyn Fn(bool)>>,
+}
+
+impl Default for FocusConfig {
+    fn default() -> Self {
+        Self {
+            disabled: false,
+            modality: Rc::new(DefaultModalityContext::new()),
+            on_focus: None,
+            on_blur: None,
+            on_focus_visible_change: None,
+        }
+    }
+}
+
+impl Default for FocusWithinConfig {
+    fn default() -> Self {
+        Self {
+            disabled: false,
+            modality: Rc::new(DefaultModalityContext::new()),
+            on_focus_within: None,
+            on_blur_within: None,
+            on_focus_within_visible_change: None,
+        }
+    }
 }
 
 /// A normalized focus event.
@@ -1101,13 +1124,13 @@ impl FocusState {
     /// Keyboard focus always shows the ring. Programmatic focus only shows
     /// the ring when there was no preceding pointer interaction (i.e., the
     /// document's modality was keyboard before the `.focus()` call).
-    pub fn is_focus_visible(&self) -> bool {
+    pub fn is_focus_visible(&self, modality: &dyn ModalityContext) -> bool {
         match self {
             FocusState::FocusedByKeyboard => true,
-            // Programmatic focus defers to the global modality tracker:
+            // Programmatic focus defers to the shared modality context:
             // show the ring only if the user was NOT using a pointer device
             // immediately before the programmatic `.focus()` call.
-            FocusState::FocusedProgrammatic => !had_pointer_interaction(),
+            FocusState::FocusedProgrammatic => !modality.had_pointer_interaction(),
             _ => false,
         }
     }
@@ -1132,104 +1155,79 @@ Transitions:
     ─[Blur]────────────────────────────→ Unfocused
 ```
 
-### 4.4 Focus Visible Detection: Global Modality Tracking
+### 4.4 Focus Visible Detection: Shared Modality Tracking
 
-The key to `focus-visible` is tracking the most recent input modality at the document level. `ars-interactions` installs a single set of document-level listeners when first used:
+The key to `focus-visible` is tracking the most recent input modality for the active provider root. `ars-core` owns the instance-scoped modality state and `ars-dom` owns the browser listener lifecycle:
 
 ```rust
-/// Installs global modality tracking on the document.
-/// Safe to call multiple times; installs only once per page.
-///
-/// **Web Worker safety:** Thread-local modality tracking is a
-/// no-op in Web Worker contexts, which lack a `document` object. The guard
-/// below ensures no DOM API calls are attempted in worker threads.
-pub fn ensure_modality_listeners() {
-    // Guard: Web Workers have no `document`. Bail out early.
-    // `js_sys::global()` returns the global scope (Window, Worker, etc.).
-    // Design decision: Reflect::has can fail in exotic global scopes (e.g., Service Workers).
-    // Returns false = treat as "no document" = bail early. This is correct behavior since
-    // modality tracking is only meaningful in a browsing context with a document.
-    if !js_sys::Reflect::has(&js_sys::global(), &"document".into()).unwrap_or(false) {
-        return;
-    }
+use std::rc::Rc;
+use ars_a11y::FocusRing;
+use ars_core::{KeyboardKey, KeyModifiers, ModalityContext, PointerType};
 
-    // Increment reference count for every caller (cleanup tracking)
-    MODALITY_LISTENER_REFCOUNT.with(|rc| rc.set(rc.get() + 1));
-
-    MODALITY_LISTENERS_INSTALLED.with(|installed| {
-        if !installed.get() {
-            installed.set(true);
-
-            // On keydown: switch to keyboard modality
-            // On pointerdown/mousedown/touchstart: switch to pointer modality
-            // On focus (capture): read current modality when element focuses
-            //
-            // Tracks via LAST_POINTER_TYPE thread_local:
-            //   Keyboard events → PointerType::Keyboard
-            //   Mouse events → PointerType::Mouse
-            //   Touch events → PointerType::Touch
-            //   Pen events → PointerType::Pen
-        }
-    });
+pub struct ModalityManager {
+    modality: Rc<dyn ModalityContext>,
+    focus_ring: FocusRing,
 }
 
-/// Removes global modality listeners when no consumers remain.
-/// Uses reference counting: each `ensure_modality_listeners()` call increments
-/// the count, and each `remove_modality_listeners()` call decrements it.
-/// Listeners are only detached when the count reaches zero.
-///
-/// Call this in component/interaction cleanup (e.g., `on_cleanup`, `Drop` impl)
-/// to avoid leaked document-level listeners in SPA route transitions.
-pub fn remove_modality_listeners() {
-    // Design decision: Reflect::has can fail in exotic global scopes (e.g., Service Workers).
-    // Returns false = treat as "no document" = bail early. This is correct behavior since
-    // modality tracking is only meaningful in a browsing context with a document.
-    if !js_sys::Reflect::has(&js_sys::global(), &"document".into()).unwrap_or(false) {
-        return;
+impl ModalityManager {
+    /// Safe to call multiple times; attaches one listener set per manager instance.
+    pub fn ensure_listeners(&self) {
+        // Browser-only implementation in ars-dom:
+        // - no-op when no Window/Document is available
+        // - installs keydown, pointerdown, mousedown, touchstart, and focus(capture)
+        // - uses refcounted install/remove semantics
     }
 
-    MODALITY_LISTENER_REFCOUNT.with(|rc| {
-        let count = rc.get();
-        if count > 0 {
-            rc.set(count - 1);
-            if count == 1 {
-                // Last consumer — remove document-level listeners
-                MODALITY_LISTENERS_INSTALLED.with(|installed| {
-                    installed.set(false);
-                });
-                // Remove keydown, pointerdown, mousedown, touchstart,
-                // and focus (capture) listeners from document.
-            }
-        }
-    });
+    pub fn on_key_down(&self, key: KeyboardKey, modifiers: KeyModifiers) {
+        self.modality.on_key_down(key, modifiers);
+        self.focus_ring.on_key_down(key, modifiers);
+    }
+
+    pub fn on_pointer_down(&self, pointer_type: PointerType) {
+        self.modality.on_pointer_down(pointer_type);
+        self.focus_ring.on_pointer_down();
+    }
+
+    pub fn on_virtual_input(&self) {
+        self.modality.on_virtual_input();
+        self.focus_ring.on_virtual_input();
+    }
 }
 ```
 
-> **Modality tracking:** `LAST_POINTER_TYPE` is the modality tracker for `FocusState` in `ars-interactions`. `FocusRing` (from `03-accessibility.md` §3.4) tracks modality independently via its own `on_pointer_down()`/`on_key_down()` methods. To prevent the adapter from accidentally updating only one tracker, `ars-dom` provides `ModalityManager` (`11-dom-utilities.md` §8) which fans out to both atomically. Adapters MUST use `ModalityManager` instead of calling the trackers independently.
+> **Modality tracking:** `ars_core::ModalityContext` is the canonical source of truth for `FocusState` and other interaction consumers. `FocusRing` consumes the same event stream but remains a separate accessibility heuristic. Adapters MUST use `ars-dom::ModalityManager` instead of updating the context and focus ring independently.
 >
 > **Adapter wiring example** — use `ModalityManager` from `ars-dom`:
 >
 > ```rust
-> // Inside ensure_modality_listeners(), after installing the document-level listener:
-> // `modality` is the ModalityManager held in the adapter's state.
+> // `manager` is the ModalityManager held in the adapter's state.
 > //
 > // document.add_event_listener("keydown", move |e: KeyboardEvent| {
 > //     let key = KeyboardKey::from_key_str(&e.key());
-> //     let modifiers = KeyModifiers::from_keyboard_event(&e);
-> //     modality.on_key_down(key, modifiers);
+> //     let modifiers = KeyModifiers {
+> //         shift: e.shift_key(),
+> //         ctrl: e.ctrl_key(),
+> //         alt: e.alt_key(),
+> //         meta: e.meta_key(),
+> //     };
+> //     manager.on_key_down(key, modifiers);
 > // });
 > //
 > // document.add_event_listener("pointerdown", move |e: PointerEvent| {
-> //     let pointer_type = PointerType::from_web(e.pointer_type());
-> //     modality.on_pointer_down(pointer_type);
+> //     let pointer_type = match e.pointer_type().as_str() {
+> //         "touch" => PointerType::Touch,
+> //         "pen" => PointerType::Pen,
+> //         _ => PointerType::Mouse,
+> //     };
+> //     manager.on_pointer_down(pointer_type);
 > // });
 > ```
 
-When a `focus` event fires on an element, `ars-interactions` reads `LAST_POINTER_TYPE`:
+When a `focus` event fires on an element, `ars-interactions` reads `config.modality.last_pointer_type()`:
 
 - If the last interaction was `Keyboard` → state becomes `FocusedByKeyboard`, `data-ars-focus-visible` is set.
 - If the last interaction was `Mouse`, `Touch`, or `Pen` → state becomes `FocusedByPointer`, no `data-ars-focus-visible`.
-- If no prior interaction (programmatic focus) → state becomes `FocusedProgrammatic`, defers to the document's existing modality.
+- If no prior interaction (programmatic focus) → state becomes `FocusedProgrammatic`, defers to the shared modality context.
 
 ### 4.5 Output Props
 
@@ -1238,13 +1236,13 @@ pub fn use_focus(config: FocusConfig) -> FocusResult {
     let state = Rc::new(RefCell::new(FocusState::Unfocused));
 
     let focused = state.borrow().is_focused();
-    let focus_visible = state.borrow().is_focus_visible();
+    let focus_visible = state.borrow().is_focus_visible(config.modality.as_ref());
 
     // Event handlers are registered as typed methods on the component's Api struct:
-    //   focus → reads LAST_POINTER_TYPE to determine modality:
+    //   focus → reads config.modality.last_pointer_type() to determine modality:
     //           Keyboard → FocusedByKeyboard (sets data-ars-focus-visible)
     //           Mouse/Touch/Pen → FocusedByPointer (no focus-visible)
-    //           Programmatic → FocusedProgrammatic (defers to document modality)
+    //           Programmatic → FocusedProgrammatic (defers to shared modality context)
     //   blur  → any focused state ──→ Unfocused
 
     FocusResult { focused, focus_visible, state }
@@ -1279,7 +1277,7 @@ pub fn use_focus_within(config: FocusWithinConfig) -> FocusWithinResult {
     let is_focus_within_visible = *visible.borrow();
 
     // Event handlers are registered as typed methods on the component's Api struct:
-    //   focusin  → set focus_within = true; check LAST_POINTER_TYPE for visibility
+    //   focusin  → set focus_within = true; check config.modality for visibility
     //   focusout → if related_target is outside container, set focus_within = false
     //
     // IMPORTANT — null relatedTarget handling:
@@ -2362,22 +2360,22 @@ Adapter implementations MUST wrap drag effect setup in a try-catch and release p
 ```javascript
 // Adapter pseudocode for pointer-capture-safe drag:
 try {
-  element.setPointerCapture(pointerId);
-  // ... drag processing ...
+    element.setPointerCapture(pointerId);
+    // ... drag processing ...
 } catch (e) {
-  // Ensure pointer capture is released even on error
-  try {
-    element.releasePointerCapture(pointerId);
-  } catch (_) {
-    // releasePointerCapture throws if pointerId was never captured;
-    // this is expected when setPointerCapture itself failed.
-  }
-  console.warn(
-    "ars-interactions: pointer capture released due to error during drag:",
-    e,
-  );
-  // Transition drag state machine back to Idle
-  transition(DragState::Idle);
+    // Ensure pointer capture is released even on error
+    try {
+        element.releasePointerCapture(pointerId);
+    } catch (_) {
+        // releasePointerCapture throws if pointerId was never captured;
+        // this is expected when setPointerCapture itself failed.
+    }
+    console.warn(
+        "ars-interactions: pointer capture released due to error during drag:",
+        e,
+    );
+    // Transition drag state machine back to Idle
+    transition(DragState::Idle);
 }
 ```
 
@@ -2397,16 +2395,16 @@ CSS example for a reorderable list:
 
 ```css
 [data-ars-part="list-item"][data-ars-drop-position="before"]::before {
-  content: "";
-  display: block;
-  height: 2px;
-  background: var(--ars-accent);
+    content: "";
+    display: block;
+    height: 2px;
+    background: var(--ars-accent);
 }
 [data-ars-part="list-item"][data-ars-drop-position="after"]::after {
-  content: "";
-  display: block;
-  height: 2px;
-  background: var(--ars-accent);
+    content: "";
+    display: block;
+    height: 2px;
+    background: var(--ars-accent);
 }
 ```
 
@@ -2783,40 +2781,40 @@ The companion stylesheet (`ars-interactions.css`) MUST include a forced-colors b
 
 ```css
 @media (forced-colors: active) {
-  /* Focus indicators: use transparent outline that becomes visible in forced-colors */
-  [data-ars-focus-visible] {
-    outline: 3px solid Highlight;
-    outline-offset: 2px;
-  }
+    /* Focus indicators: use transparent outline that becomes visible in forced-colors */
+    [data-ars-focus-visible] {
+        outline: 3px solid Highlight;
+        outline-offset: 2px;
+    }
 
-  /* Pressed state: use ButtonText border */
-  [data-ars-pressed] {
-    outline: 3px solid ButtonText;
-  }
+    /* Pressed state: use ButtonText border */
+    [data-ars-pressed] {
+        outline: 3px solid ButtonText;
+    }
 
-  /* Combined focus + pressed: focus ring takes precedence */
-  [data-ars-focus-visible][data-ars-pressed] {
-    outline: 3px solid Highlight;
-    outline-offset: 2px;
-  }
+    /* Combined focus + pressed: focus ring takes precedence */
+    [data-ars-focus-visible][data-ars-pressed] {
+        outline: 3px solid Highlight;
+        outline-offset: 2px;
+    }
 
-  /* Disabled elements */
-  [data-ars-disabled] {
-    color: GrayText;
-    border-color: GrayText;
-  }
+    /* Disabled elements */
+    [data-ars-disabled] {
+        color: GrayText;
+        border-color: GrayText;
+    }
 
-  /* Drag preview */
-  [data-ars-dragging] {
-    outline: 2px solid Highlight;
-  }
+    /* Drag preview */
+    [data-ars-dragging] {
+        outline: 2px solid Highlight;
+    }
 
-  /* Selected items */
-  [data-ars-state~="selected"] {
-    outline: 2px solid Highlight;
-    color: HighlightText;
-    background-color: Highlight;
-  }
+    /* Selected items */
+    [data-ars-state~="selected"] {
+        outline: 2px solid Highlight;
+        color: HighlightText;
+        background-color: Highlight;
+    }
 }
 ```
 
@@ -2872,16 +2870,16 @@ In addition to `forced-colors`, the `prefers-contrast` media query detects user 
 ```css
 /* High contrast preference (not necessarily forced-colors) */
 @media (prefers-contrast: more) {
-  :root {
-    --ars-focus-ring-width: 3px;
-    --ars-border-width: 2px;
-    --ars-focus-ring-offset: 3px;
-  }
+    :root {
+        --ars-focus-ring-width: 3px;
+        --ars-border-width: 2px;
+        --ars-focus-ring-offset: 3px;
+    }
 }
 
 /* Custom contrast preference (forced-colors active) */
 @media (prefers-contrast: custom) {
-  /* Same as forced-colors — system colors in use */
+    /* Same as forced-colors — system colors in use */
 }
 ```
 

--- a/spec/foundation/11-dom-utilities.md
+++ b/spec/foundation/11-dom-utilities.md
@@ -472,60 +472,60 @@ On mobile browsers, the virtual keyboard reduces the visible area without changi
 
 1. **`auto_update()` MUST subscribe to `visualViewport` events** when `window.visualViewport` is available:
 
-   ```rust
-   // In ars-dom auto_update implementation:
-   if let Some(vv) = window.visual_viewport() {
-       // Subscribe to resize (keyboard open/close) and scroll (keyboard pan)
-       vv.add_event_listener_with_callback("resize", reposition_callback.as_ref().unchecked_ref())
-           .expect("addEventListener on VisualViewport");
-       vv.add_event_listener_with_callback("scroll", reposition_callback.as_ref().unchecked_ref())
-           .expect("addEventListener on VisualViewport");
-       // Cleanup must remove both listeners
-   }
-   ```
+    ```rust
+    // In ars-dom auto_update implementation:
+    if let Some(vv) = window.visual_viewport() {
+        // Subscribe to resize (keyboard open/close) and scroll (keyboard pan)
+        vv.add_event_listener_with_callback("resize", reposition_callback.as_ref().unchecked_ref())
+            .expect("addEventListener on VisualViewport");
+        vv.add_event_listener_with_callback("scroll", reposition_callback.as_ref().unchecked_ref())
+            .expect("addEventListener on VisualViewport");
+        // Cleanup must remove both listeners
+    }
+    ```
 
 2. **Boundary height MUST use `visualViewport.height`** when `Boundary::Viewport` is active and the visual viewport API is available. Fallback to `window.innerHeight` when unavailable:
 
-   ```rust
-   fn viewport_width(window: &web_sys::Window) -> f64 {
-       let width = window.visual_viewport()
-           .map(|vv| vv.width())
-           .unwrap_or_else(|| {
-               window.inner_width().ok().and_then(|v| v.as_f64()).unwrap_or(0.0)
-           });
-       #[cfg(debug_assertions)]
-       if width == 0.0 {
-           web_sys::console::warn_1(
-               &"ars-dom: viewport_width() returned 0 — window may not be fully initialized".into(),
-           );
-       }
-       width
-   }
+    ```rust
+    fn viewport_width(window: &web_sys::Window) -> f64 {
+        let width = window.visual_viewport()
+            .map(|vv| vv.width())
+            .unwrap_or_else(|| {
+                window.inner_width().ok().and_then(|v| v.as_f64()).unwrap_or(0.0)
+            });
+        #[cfg(debug_assertions)]
+        if width == 0.0 {
+            web_sys::console::warn_1(
+                &"ars-dom: viewport_width() returned 0 — window may not be fully initialized".into(),
+            );
+        }
+        width
+    }
 
-   fn viewport_height(window: &web_sys::Window) -> f64 {
-       let height = window.visual_viewport()
-           .map(|vv| vv.height())
-           .unwrap_or_else(|| {
-               window.inner_height().ok().and_then(|v| v.as_f64()).unwrap_or(0.0)
-           });
-       #[cfg(debug_assertions)]
-       if height == 0.0 {
-           web_sys::console::warn_1(
-               &"ars-dom: viewport_height() returned 0 — window may not be fully initialized".into(),
-           );
-       }
-       height
-   }
-   ```
+    fn viewport_height(window: &web_sys::Window) -> f64 {
+        let height = window.visual_viewport()
+            .map(|vv| vv.height())
+            .unwrap_or_else(|| {
+                window.inner_height().ok().and_then(|v| v.as_f64()).unwrap_or(0.0)
+            });
+        #[cfg(debug_assertions)]
+        if height == 0.0 {
+            web_sys::console::warn_1(
+                &"ars-dom: viewport_height() returned 0 — window may not be fully initialized".into(),
+            );
+        }
+        height
+    }
+    ```
 
 3. **`keyboard_aware` positioning option**: Add to `PositioningOptions`:
 
-   ```rust
-   /// When true, reposition floating elements in response to virtual keyboard
-   /// open/close events (visualViewport resize). Default: false.
-   /// Enable for floating elements that contain or are triggered by input fields.
-   pub keyboard_aware: bool, // default: false
-   ```
+    ```rust
+    /// When true, reposition floating elements in response to virtual keyboard
+    /// open/close events (visualViewport resize). Default: false.
+    /// Enable for floating elements that contain or are triggered by input fields.
+    pub keyboard_aware: bool, // default: false
+    ```
 
 4. **Scroll lock adjustment**: Dialog scroll lock (see `components/overlay/dialog.md`) MUST account for `visualViewport.offsetTop` when computing the scroll position to preserve. On iOS Safari, `visualViewport.offsetTop` reflects the amount the page has been scrolled to accommodate the keyboard.
 
@@ -1043,20 +1043,20 @@ All positioning calculations use a consistent coordinate system. This section do
 
 - **`position: absolute` positioning (non-portal).** When the floating element uses `Strategy::Absolute` (e.g., it is not portaled and lives inside a positioned ancestor), subtract the offset parent's `getBoundingClientRect()` from the client-space coordinates to produce values relative to the offset parent:
 
-  ```rust
-  let offset_parent_rect = offset_parent.get_bounding_client_rect();
-  let local_x = client_x - offset_parent_rect.x();
-  let local_y = client_y - offset_parent_rect.y();
-  // Apply: element.style.left = local_x; element.style.top = local_y;
-  ```
+    ```rust
+    let offset_parent_rect = offset_parent.get_bounding_client_rect();
+    let local_x = client_x - offset_parent_rect.x();
+    let local_y = client_y - offset_parent_rect.y();
+    // Apply: element.style.left = local_x; element.style.top = local_y;
+    ```
 
 - **Recalculation triggers.** Recalculate the floating element's position on:
-  1. **Scroll events** — any ancestor scroll container between the anchor and the boundary.
-  2. **Resize events** — `window` resize and `ResizeObserver` on both the reference (anchor) and floating elements.
-  3. **`requestAnimationFrame`** — for smooth updates during CSS animations or transitions that change the anchor's geometry.
-  4. **Layout mutations** — when the anchor or floating element's size changes (detected via `ResizeObserver`).
+    1. **Scroll events** — any ancestor scroll container between the anchor and the boundary.
+    2. **Resize events** — `window` resize and `ResizeObserver` on both the reference (anchor) and floating elements.
+    3. **`requestAnimationFrame`** — for smooth updates during CSS animations or transitions that change the anchor's geometry.
+    4. **Layout mutations** — when the anchor or floating element's size changes (detected via `ResizeObserver`).
 
-  The adapter SHOULD debounce scroll/resize recalculations using `requestAnimationFrame` to avoid layout thrashing. At most one position update per animation frame.
+    The adapter SHOULD debounce scroll/resize recalculations using `requestAnimationFrame` to avoid layout thrashing. At most one position update per animation frame.
 
 #### 2.8.1 CSS Transform Ancestor Detection
 
@@ -2157,27 +2157,27 @@ This section provides the complete, authoritative specification for scroll lock 
 
 2. **Apply lock styles (tiered strategy):**
 
-   **Tier 1 — Modern browsers:** Apply to both `<html>` and `<body>`:
+    **Tier 1 — Modern browsers:** Apply to both `<html>` and `<body>`:
 
-   ```css
-   /* <html> */
-   overflow: clip;
-   /* <body> */
-   overscroll-behavior: contain;
-   ```
+    ```css
+    /* <html> */
+    overflow: clip;
+    /* <body> */
+    overscroll-behavior: contain;
+    ```
 
-   `overflow: clip` prevents scrolling without creating a new formatting context (unlike `overflow: hidden`). No scroll position jump. No impact on fixed-position children.
+    `overflow: clip` prevents scrolling without creating a new formatting context (unlike `overflow: hidden`). No scroll position jump. No impact on fixed-position children.
 
-   **Tier 2 — iOS Safari fallback** (when `overflow: clip` is not supported, Safari < 16): Apply to `<body>`:
+    **Tier 2 — iOS Safari fallback** (when `overflow: clip` is not supported, Safari < 16): Apply to `<body>`:
 
-   ```css
-   position: fixed;
-   top: -{savedScrollY}px;
-   width: 100%;
-   overflow: hidden;
-   ```
+    ```css
+    position: fixed;
+    top: -{savedScrollY}px;
+    width: 100%;
+    overflow: hidden;
+    ```
 
-   Setting `position: fixed` on `<body>` removes it from the scroll flow. The `top: -{savedScrollY}px` offset maintains the visual position so the page does not jump to the top. Note: this temporarily breaks other fixed-position elements (see §5.6).
+    Setting `position: fixed` on `<body>` removes it from the scroll flow. The `top: -{savedScrollY}px` offset maintains the visual position so the page does not jump to the top. Note: this temporarily breaks other fixed-position elements (see §5.6).
 
 3. **Scrollbar compensation.** Measure scrollbar width and apply `padding-right` (or `padding-left` in RTL) to prevent layout shift (see §5.7).
 
@@ -2530,40 +2530,52 @@ Usage flow for a modal dialog:
 
 ## 8. Modality Manager
 
-`ars-dom` is the convergence point for `ars-a11y` (FocusRing) and `ars-interactions` (LAST_POINTER_TYPE). To prevent the adapter from accidentally updating only one modality tracker, `ars-dom` provides a single entry point that fans out to both atomically.
+`ars-dom` is the web binding layer for the shared core modality contract. It owns the browser listener lifecycle and fans normalized events out to both `ars_core::ModalityContext` and `ars-a11y::FocusRing` so adapters cannot accidentally update only one side.
 
 ```rust
 // ars-dom/src/modality.rs
 
+use std::rc::Rc;
 use ars_a11y::FocusRing;
-use ars_interactions::{PointerType, KeyboardKey, KeyModifiers};
+use ars_core::{KeyboardKey, KeyModifiers, ModalityContext, PointerType};
 
-/// Unified modality update — ensures ars-a11y and ars-interactions
-/// stay in sync. Adapters MUST call these methods instead of updating
-/// `LAST_POINTER_TYPE` or `FocusRing` independently.
+/// Unified modality update — ensures accessibility and interaction consumers
+/// stay in sync. Adapters MUST call these methods instead of updating the
+/// shared modality context or `FocusRing` independently.
 pub struct ModalityManager {
+    modality: Rc<dyn ModalityContext>,
     focus_ring: FocusRing,
 }
 
 impl ModalityManager {
-    pub fn new() -> Self {
-        Self { focus_ring: FocusRing::new() }
+    pub fn new(modality: Rc<dyn ModalityContext>) -> Self {
+        Self { modality, focus_ring: FocusRing::new() }
     }
 
     /// Call on keydown events. Updates both modality trackers atomically.
-    pub fn on_key_down(&mut self, key: KeyboardKey, modifiers: KeyModifiers) {
-        // 1. ars-interactions: switch to keyboard modality
-        ars_interactions::set_last_pointer_type(PointerType::Keyboard);
-        // 2. ars-a11y: update FocusRing (only nav keys flip keyboard_modality)
+    pub fn on_key_down(&self, key: KeyboardKey, modifiers: KeyModifiers) {
+        self.modality.on_key_down(key, modifiers);
         self.focus_ring.on_key_down(key, modifiers);
     }
 
     /// Call on pointerdown/mousedown/touchstart events.
-    pub fn on_pointer_down(&mut self, pointer_type: PointerType) {
-        // 1. ars-interactions: switch to pointer modality
-        ars_interactions::set_last_pointer_type(pointer_type);
-        // 2. ars-a11y: clear keyboard modality
+    pub fn on_pointer_down(&self, pointer_type: PointerType) {
+        self.modality.on_pointer_down(pointer_type);
         self.focus_ring.on_pointer_down();
+    }
+
+    /// Call on virtual or assistive-technology interactions.
+    pub fn on_virtual_input(&self) {
+        self.modality.on_virtual_input();
+        self.focus_ring.on_virtual_input();
+    }
+
+    /// Install the browser event listeners owned by this manager.
+    pub fn ensure_listeners(&self) {
+        // Browser-only implementation:
+        // - no-op without a document
+        // - attaches keydown, pointerdown, mousedown, touchstart, and focus(capture)
+        // - uses refcounted install/remove semantics
     }
 
     /// Delegate to the inner `FocusRing` for focus-visible checks.
@@ -2573,9 +2585,7 @@ impl ModalityManager {
 }
 ```
 
-> **Note:** `ensure_modality_listeners()` in `ars-interactions` (see `05-interactions.md` §4.4)
-> installs the document-level DOM listeners. The adapter's listener closures should call
-> `ModalityManager::on_key_down()` / `on_pointer_down()` instead of touching the trackers directly.
+> **Note:** `ars-interactions` no longer owns document-level listeners. The adapter's listener closures should call `ModalityManager::on_key_down()` / `on_pointer_down()` / `on_virtual_input()` instead of touching the shared modality context or `FocusRing` directly.
 
 ---
 


### PR DESCRIPTION
## Summary

This PR replaces the old ambient interaction-modality design with a provider-scoped, platform-agnostic `ModalityContext` rooted in `ars-core`.

It also moves web listener ownership into `ars-dom`, aligns `FocusRing` with the shared modality stream, updates the affected foundation specs so they match the new architecture, and adds broader tests around the new modality/focus contracts.

Closes #90.

## What Changed

- added `ars_core::modality` with `PointerType`, `KeyModifiers`, `KeyboardKey`, `ModalitySnapshot`, `ModalityContext`, `DefaultModalityContext`, and `NullModalityContext`
- extended `ArsContext` to carry `Rc<dyn ModalityContext>` alongside `PlatformEffects`
- migrated `ars-interactions` off ambient modality globals and onto injected modality state
- added `ars_dom::ModalityManager` as the web-side listener owner and shared-modality/focus-ring coordinator
- updated `FocusRing` to consume the same normalized modality stream
- fixed the existing wasm-target `scroll_lock` lint blockers so the requested verification path passes again
- synchronized the architecture/interactions/accessibility/dom/provider specs and the foundation roadmap with the new provider-scoped modality model
- expanded coverage for the W3C keyboard key registry, ARIA role mappings, focus helper logic, and modality manager behavior

## Why

The previous approach tied modality tracking to `ars-interactions` globals and browser-specific listener ownership. That made the contract harder to reuse across provider roots and harder to carry forward to non-web platforms.

This change moves the semantic contract into `ars-core`, keeps browser wiring in `ars-dom`, and makes the spec explicit that modality is ambient input state distinct from `PlatformEffects`.

## Impact

- modality state is now instance-scoped per provider root instead of thread-local/global
- future native adapters can implement modality tracking against the shared core contract without depending on DOM-specific behavior
- `FocusRing` and web modality listener wiring now share the same normalized event stream
- the spec and backlog are aligned with the new layering, reducing drift for follow-on work

## Validation

- `cargo test -p ars-core -p ars-a11y -p ars-dom -p ars-interactions`
- `cargo clippy -p ars-core -p ars-a11y -p ars-dom -p ars-interactions --all-targets -- -D warnings`
- `cargo check -p ars-dom -p ars-interactions --target wasm32-unknown-unknown`
- `cargo llvm-cov --workspace --summary-only`

## Coverage Notes

Targeted coverage improved substantially for the main weak spots addressed here:

- `crates/ars-core/src/modality.rs`: `26.68%` -> `99.90%` line coverage
- `crates/ars-a11y/src/aria/role.rs`: `23.13%` -> `98.24%`
- `crates/ars-dom/src/focus.rs`: `34.82%` -> `87.25%`
- `crates/ars-dom/src/modality.rs`: `92.59%` -> `93.44%`

Workspace totals after this batch:

- line coverage: `74.23%`
- region coverage: `76.83%`
- function coverage: `78.04%`
