### PR TITLE
[codex] Implement ars-dom scroll_into_view_if_needed

### DIFF
--- a/crates/ars-dom/Cargo.toml
+++ b/crates/ars-dom/Cargo.toml
@@ -10,16 +10,18 @@ rust-version.workspace = true
 [features]
 default = ["web"]
 ssr     = []
-web     = ["dep:wasm-bindgen", "dep:web-sys"]
+web     = ["dep:js-sys", "dep:wasm-bindgen", "dep:web-sys"]
 
 [dependencies]
 ars-a11y         = { path = "../ars-a11y" }
 ars-core         = { path = "../ars-core" }
 ars-i18n         = { path = "../ars-i18n" }
 ars-interactions = { path = "../ars-interactions" }
+js-sys           = { version = "0.3", optional = true }
 wasm-bindgen     = { version = "0.2", optional = true }
 web-sys          = { version = "0.3", optional = true, features = [
     "CssStyleDeclaration",
+    "DomRect",
     "Document",
     "Element",
     "EventTarget",
@@ -32,9 +34,16 @@ web-sys          = { version = "0.3", optional = true, features = [
     "Node",
     "NodeList",
     "PointerEvent",
+    "ScrollBehavior",
+    "ScrollIntoViewOptions",
+    "ScrollLogicalPosition",
+    "ScrollToOptions",
     "TouchEvent",
     "Window",
 ] }
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3"
 
 [lints]
 workspace = true

--- a/crates/ars-dom/src/lib.rs
+++ b/crates/ars-dom/src/lib.rs
@@ -6,6 +6,7 @@
 
 mod focus;
 pub mod modality;
+mod scroll;
 pub mod scroll_lock;
 
 pub use focus::{
@@ -17,6 +18,9 @@ pub use focus::{
     get_html_element_by_id, get_last_focusable,
 };
 pub use modality::ModalityManager;
+pub use scroll::{ScrollIntoViewOptions, ScrollLogicalPosition, supports_scroll_into_view_options};
+#[cfg(feature = "web")]
+pub use scroll::{nearest_scrollable_ancestor, scroll_into_view_if_needed, scrollable_ancestors};
 pub use scroll_lock::{
     ScrollLockManager, acquire, depth, is_locked, prevent_scroll, release, restore_scroll,
 };

--- a/crates/ars-dom/src/scroll.rs
+++ b/crates/ars-dom/src/scroll.rs
@@ -1,0 +1,676 @@
+//! Scroll management utilities for browser-backed adapters.
+
+#[cfg(any(test, all(feature = "web", target_arch = "wasm32")))]
+use core::fmt;
+
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
+use js_sys::Reflect;
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
+use wasm_bindgen::JsValue;
+
+/// Options controlling how an element should be brought into view.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ScrollIntoViewOptions {
+    /// Vertical alignment preference within the scrollable viewport.
+    pub block: Option<ScrollLogicalPosition>,
+    /// Horizontal alignment preference within the scrollable viewport.
+    pub inline: Option<ScrollLogicalPosition>,
+    /// Whether smooth scrolling should be requested when native APIs are available.
+    pub smooth: bool,
+}
+
+impl Default for ScrollIntoViewOptions {
+    fn default() -> Self {
+        Self {
+            block: Some(ScrollLogicalPosition::Nearest),
+            inline: Some(ScrollLogicalPosition::Nearest),
+            smooth: false,
+        }
+    }
+}
+
+/// Logical alignment positions for scrolling an item into view.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ScrollLogicalPosition {
+    /// Align the leading edge of the item with the leading edge of the container.
+    Start,
+    /// Center the item in the container.
+    Center,
+    /// Align the trailing edge of the item with the trailing edge of the container.
+    End,
+    /// Scroll only when needed and only by the minimum required offset.
+    Nearest,
+}
+
+/// Returns whether the current runtime supports `scrollIntoView(options)`.
+#[must_use]
+pub fn supports_scroll_into_view_options() -> bool {
+    supports_scroll_into_view_options_impl()
+}
+
+#[cfg(feature = "web")]
+/// Returns the nearest ancestor that can scroll the given element into view.
+pub fn nearest_scrollable_ancestor(element: &web_sys::Element) -> Option<web_sys::Element> {
+    nearest_scrollable_ancestor_impl(element)
+}
+
+#[cfg(feature = "web")]
+/// Returns all scrollable ancestors from nearest to furthest, including the document root once.
+pub fn scrollable_ancestors(element: &web_sys::Element) -> Vec<web_sys::Element> {
+    scrollable_ancestors_impl(element)
+}
+
+#[cfg(feature = "web")]
+/// Scrolls an element into view, using a manual fallback when native options support is absent.
+pub fn scroll_into_view_if_needed(element: &web_sys::Element, options: ScrollIntoViewOptions) {
+    scroll_into_view_if_needed_impl(element, options);
+}
+
+#[cfg(any(test, all(feature = "web", target_arch = "wasm32")))]
+#[derive(Clone, Copy, PartialEq)]
+struct AxisBounds {
+    start: f64,
+    end: f64,
+}
+
+#[cfg(any(test, all(feature = "web", target_arch = "wasm32")))]
+impl fmt::Debug for AxisBounds {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AxisBounds")
+            .field("start", &self.start)
+            .field("end", &self.end)
+            .finish()
+    }
+}
+
+#[cfg(any(test, all(feature = "web", target_arch = "wasm32")))]
+#[must_use]
+fn is_scrollable_axis_value(value: &str) -> bool {
+    matches!(value.trim(), "auto" | "scroll" | "hidden")
+}
+
+#[cfg(any(test, all(feature = "web", target_arch = "wasm32")))]
+#[must_use]
+fn has_scrollable_overflow(
+    overflow_x: &str,
+    overflow_y: &str,
+    scroll_width: i32,
+    client_width: i32,
+    scroll_height: i32,
+    client_height: i32,
+) -> bool {
+    (is_scrollable_axis_value(overflow_y) && scroll_height > client_height)
+        || (is_scrollable_axis_value(overflow_x) && scroll_width > client_width)
+}
+
+#[cfg(test)]
+fn find_nearest_matching_ancestor(
+    start: usize,
+    parents: &[Option<usize>],
+    matches: &[bool],
+) -> Option<usize> {
+    let mut current = parents[start];
+    while let Some(index) = current {
+        if matches[index] {
+            return Some(index);
+        }
+        current = parents[index];
+    }
+    None
+}
+
+#[cfg(test)]
+fn collect_matching_ancestors(
+    start: usize,
+    parents: &[Option<usize>],
+    matches: &[bool],
+    root: Option<usize>,
+) -> Vec<usize> {
+    let mut ancestors = Vec::new();
+    let mut current = find_nearest_matching_ancestor(start, parents, matches);
+
+    while let Some(index) = current {
+        ancestors.push(index);
+        current = find_nearest_matching_ancestor(index, parents, matches);
+    }
+
+    if let Some(root_index) = root
+        && ancestors.last().copied() != Some(root_index)
+    {
+        ancestors.push(root_index);
+    }
+
+    ancestors
+}
+
+#[cfg(any(test, all(feature = "web", target_arch = "wasm32")))]
+#[must_use]
+fn target_scroll_offset(
+    position: ScrollLogicalPosition,
+    element: AxisBounds,
+    container: AxisBounds,
+    current_scroll: f64,
+) -> Option<f64> {
+    match position {
+        ScrollLogicalPosition::Start => Some(current_scroll + (element.start - container.start)),
+        ScrollLogicalPosition::Center => {
+            let element_center = (element.start + element.end) / 2.0;
+            let container_center = (container.start + container.end) / 2.0;
+            Some(current_scroll + (element_center - container_center))
+        }
+        ScrollLogicalPosition::End => Some(current_scroll + (element.end - container.end)),
+        ScrollLogicalPosition::Nearest => {
+            if element.start < container.start {
+                Some(current_scroll - (container.start - element.start))
+            } else if element.end > container.end {
+                Some(current_scroll + (element.end - container.end))
+            } else {
+                None
+            }
+        }
+    }
+}
+
+#[must_use]
+fn supports_scroll_into_view_options_impl() -> bool {
+    #[cfg(all(feature = "web", target_arch = "wasm32"))]
+    {
+        let Some(document) = web_sys::window().and_then(|window| window.document()) else {
+            return false;
+        };
+        let Ok(_element) = document.create_element("div") else {
+            return false;
+        };
+
+        Reflect::get(
+            &js_sys::global(),
+            &JsValue::from_str("ScrollIntoViewOptions"),
+        )
+        .map(|value| !value.is_undefined())
+        .unwrap_or(false)
+    }
+
+    #[cfg(not(all(feature = "web", target_arch = "wasm32")))]
+    false
+}
+
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
+#[must_use]
+fn nearest_scrollable_ancestor_impl(element: &web_sys::Element) -> Option<web_sys::Element> {
+    let window = web_sys::window()?;
+    let mut current = element.parent_element();
+
+    while let Some(ancestor) = current {
+        let style = window.get_computed_style(&ancestor).ok().flatten()?;
+        let overflow_x = style.get_property_value("overflow-x").unwrap_or_default();
+        let overflow_y = style.get_property_value("overflow-y").unwrap_or_default();
+
+        if has_scrollable_overflow(
+            &overflow_x,
+            &overflow_y,
+            ancestor.scroll_width(),
+            ancestor.client_width(),
+            ancestor.scroll_height(),
+            ancestor.client_height(),
+        ) {
+            return Some(ancestor);
+        }
+
+        current = ancestor.parent_element();
+    }
+
+    None
+}
+
+#[cfg(all(feature = "web", not(target_arch = "wasm32")))]
+#[must_use]
+fn nearest_scrollable_ancestor_impl(_element: &web_sys::Element) -> Option<web_sys::Element> {
+    None
+}
+
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
+#[must_use]
+fn scrollable_ancestors_impl(element: &web_sys::Element) -> Vec<web_sys::Element> {
+    let mut ancestors = Vec::new();
+    let mut current = nearest_scrollable_ancestor_impl(element);
+
+    while let Some(ancestor) = current {
+        ancestors.push(ancestor.clone());
+        current = nearest_scrollable_ancestor_impl(&ancestor);
+    }
+
+    if let Some(document_root) = element
+        .owner_document()
+        .and_then(|document| document.document_element())
+        && ancestors
+            .last()
+            .is_none_or(|last| !last.is_same_node(Some(&document_root)))
+    {
+        ancestors.push(document_root);
+    }
+
+    ancestors
+}
+
+#[cfg(all(feature = "web", not(target_arch = "wasm32")))]
+#[must_use]
+fn scrollable_ancestors_impl(_element: &web_sys::Element) -> Vec<web_sys::Element> {
+    Vec::new()
+}
+
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
+fn scroll_into_view_if_needed_impl(element: &web_sys::Element, options: ScrollIntoViewOptions) {
+    if supports_scroll_into_view_options_impl() {
+        let web_options = web_scroll_into_view_options(options);
+        element.scroll_into_view_with_scroll_into_view_options(&web_options);
+        return;
+    }
+
+    let ancestors = scrollable_ancestors_impl(element);
+    if ancestors.is_empty() {
+        element.scroll_into_view_with_bool(true);
+        return;
+    }
+
+    let block = options.block.unwrap_or(ScrollLogicalPosition::Nearest);
+    let inline = options.inline.unwrap_or(ScrollLogicalPosition::Nearest);
+
+    for ancestor in ancestors {
+        let element_rect = element.get_bounding_client_rect();
+        let ancestor_rect = ancestor.get_bounding_client_rect();
+
+        if let Some(target_top) = target_scroll_offset(
+            block,
+            AxisBounds {
+                start: element_rect.top(),
+                end: element_rect.bottom(),
+            },
+            AxisBounds {
+                start: ancestor_rect.top(),
+                end: ancestor_rect.bottom(),
+            },
+            f64::from(ancestor.scroll_top()),
+        ) {
+            ancestor.set_scroll_top(target_top.round() as i32);
+        }
+
+        if let Some(target_left) = target_scroll_offset(
+            inline,
+            AxisBounds {
+                start: element_rect.left(),
+                end: element_rect.right(),
+            },
+            AxisBounds {
+                start: ancestor_rect.left(),
+                end: ancestor_rect.right(),
+            },
+            f64::from(ancestor.scroll_left()),
+        ) {
+            ancestor.set_scroll_left(target_left.round() as i32);
+        }
+    }
+}
+
+#[cfg(all(feature = "web", not(target_arch = "wasm32")))]
+fn scroll_into_view_if_needed_impl(_element: &web_sys::Element, _options: ScrollIntoViewOptions) {}
+
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
+#[must_use]
+fn web_scroll_into_view_options(options: ScrollIntoViewOptions) -> web_sys::ScrollIntoViewOptions {
+    let web_options = web_sys::ScrollIntoViewOptions::new();
+    web_options.set_behavior(if options.smooth {
+        web_sys::ScrollBehavior::Smooth
+    } else {
+        web_sys::ScrollBehavior::Auto
+    });
+    web_options.set_block(
+        match options.block.unwrap_or(ScrollLogicalPosition::Nearest) {
+            ScrollLogicalPosition::Start => web_sys::ScrollLogicalPosition::Start,
+            ScrollLogicalPosition::Center => web_sys::ScrollLogicalPosition::Center,
+            ScrollLogicalPosition::End => web_sys::ScrollLogicalPosition::End,
+            ScrollLogicalPosition::Nearest => web_sys::ScrollLogicalPosition::Nearest,
+        },
+    );
+    web_options.set_inline(
+        match options.inline.unwrap_or(ScrollLogicalPosition::Nearest) {
+            ScrollLogicalPosition::Start => web_sys::ScrollLogicalPosition::Start,
+            ScrollLogicalPosition::Center => web_sys::ScrollLogicalPosition::Center,
+            ScrollLogicalPosition::End => web_sys::ScrollLogicalPosition::End,
+            ScrollLogicalPosition::Nearest => web_sys::ScrollLogicalPosition::Nearest,
+        },
+    );
+    web_options
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(all(feature = "web", not(target_arch = "wasm32")))]
+    use wasm_bindgen::{JsCast, JsValue};
+
+    use super::*;
+
+    #[test]
+    fn supports_scroll_into_view_options_is_false_without_browser_dom() {
+        assert!(!supports_scroll_into_view_options());
+    }
+
+    #[test]
+    fn scroll_into_view_options_default_matches_spec() {
+        assert_eq!(
+            ScrollIntoViewOptions::default(),
+            ScrollIntoViewOptions {
+                block: Some(ScrollLogicalPosition::Nearest),
+                inline: Some(ScrollLogicalPosition::Nearest),
+                smooth: false,
+            }
+        );
+    }
+
+    #[test]
+    fn nearest_ancestor_finds_first_scrollable_parent() {
+        let parents = [None, Some(0), Some(1), Some(2), Some(2)];
+        let matches = [false, false, true, false, true];
+
+        assert_eq!(
+            find_nearest_matching_ancestor(3, &parents, &matches),
+            Some(2)
+        );
+        assert_eq!(
+            find_nearest_matching_ancestor(4, &parents, &matches),
+            Some(2)
+        );
+    }
+
+    #[test]
+    fn nearest_ancestor_returns_none_without_scrollable_parent() {
+        let parents = [None, Some(0), Some(1), Some(2)];
+        let matches = [false, false, false, false];
+
+        assert_eq!(find_nearest_matching_ancestor(3, &parents, &matches), None);
+    }
+
+    #[test]
+    fn scrollability_requires_overflow_style_and_actual_extra_content() {
+        assert!(has_scrollable_overflow("auto", "visible", 200, 100, 80, 80));
+        assert!(has_scrollable_overflow(
+            "visible", "scroll", 80, 80, 200, 100
+        ));
+        assert!(!has_scrollable_overflow(
+            "visible", "visible", 200, 100, 200, 100
+        ));
+        assert!(!has_scrollable_overflow(
+            "auto", "scroll", 100, 100, 100, 100
+        ));
+    }
+
+    #[test]
+    fn nearest_alignment_scrolls_up_when_item_is_above_viewport() {
+        let result = target_scroll_offset(
+            ScrollLogicalPosition::Nearest,
+            AxisBounds {
+                start: 50.0,
+                end: 80.0,
+            },
+            AxisBounds {
+                start: 100.0,
+                end: 200.0,
+            },
+            150.0,
+        );
+
+        assert_eq!(result, Some(100.0));
+    }
+
+    #[test]
+    fn nearest_alignment_scrolls_down_when_item_is_below_viewport() {
+        let result = target_scroll_offset(
+            ScrollLogicalPosition::Nearest,
+            AxisBounds {
+                start: 240.0,
+                end: 320.0,
+            },
+            AxisBounds {
+                start: 100.0,
+                end: 200.0,
+            },
+            150.0,
+        );
+
+        assert_eq!(result, Some(270.0));
+    }
+
+    #[test]
+    fn nearest_alignment_scrolls_horizontally_when_item_is_outside_viewport() {
+        let result = target_scroll_offset(
+            ScrollLogicalPosition::Nearest,
+            AxisBounds {
+                start: 260.0,
+                end: 340.0,
+            },
+            AxisBounds {
+                start: 100.0,
+                end: 250.0,
+            },
+            30.0,
+        );
+
+        assert_eq!(result, Some(120.0));
+    }
+
+    #[test]
+    fn nearest_alignment_keeps_scroll_position_when_item_is_fully_visible() {
+        let result = target_scroll_offset(
+            ScrollLogicalPosition::Nearest,
+            AxisBounds {
+                start: 120.0,
+                end: 180.0,
+            },
+            AxisBounds {
+                start: 100.0,
+                end: 200.0,
+            },
+            75.0,
+        );
+
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn explicit_alignment_modes_compute_expected_offsets() {
+        let element = AxisBounds {
+            start: 120.0,
+            end: 180.0,
+        };
+        let container = AxisBounds {
+            start: 100.0,
+            end: 300.0,
+        };
+
+        assert_eq!(
+            target_scroll_offset(ScrollLogicalPosition::Start, element, container, 50.0),
+            Some(70.0)
+        );
+        assert_eq!(
+            target_scroll_offset(ScrollLogicalPosition::Center, element, container, 50.0),
+            Some(0.0)
+        );
+        assert_eq!(
+            target_scroll_offset(ScrollLogicalPosition::End, element, container, 50.0),
+            Some(-70.0)
+        );
+    }
+
+    #[test]
+    fn nested_ancestor_collection_preserves_nearest_to_furthest_order_and_appends_root_once() {
+        let parents = [None, Some(0), Some(1), Some(2), Some(3)];
+        let matches = [false, true, false, true, false];
+
+        assert_eq!(
+            collect_matching_ancestors(4, &parents, &matches, Some(0)),
+            vec![3, 1, 0]
+        );
+        assert_eq!(
+            collect_matching_ancestors(4, &parents, &matches, Some(1)),
+            vec![3, 1]
+        );
+    }
+
+    #[test]
+    fn axis_bounds_debug_includes_named_fields() {
+        let debug = format!(
+            "{:?}",
+            AxisBounds {
+                start: 1.0,
+                end: 2.0,
+            }
+        );
+        assert!(debug.contains("AxisBounds"));
+        assert!(debug.contains("start"));
+        assert!(debug.contains("end"));
+    }
+
+    #[cfg(all(feature = "web", not(target_arch = "wasm32")))]
+    fn dummy_element() -> web_sys::Element {
+        JsValue::NULL.unchecked_into()
+    }
+
+    #[cfg(all(feature = "web", not(target_arch = "wasm32")))]
+    #[test]
+    fn non_wasm_web_stubs_are_safe_to_call() {
+        let element = dummy_element();
+
+        assert_eq!(nearest_scrollable_ancestor(&element), None);
+        assert!(scrollable_ancestors(&element).is_empty());
+        scroll_into_view_if_needed(&element, ScrollIntoViewOptions::default());
+    }
+}
+
+#[cfg(all(test, feature = "web", target_arch = "wasm32"))]
+mod wasm_tests {
+    use wasm_bindgen::JsCast;
+    use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+
+    use super::*;
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    fn document() -> web_sys::Document {
+        web_sys::window()
+            .expect("window must exist")
+            .document()
+            .expect("document must exist")
+    }
+
+    fn body() -> web_sys::HtmlElement {
+        document().body().expect("body must exist")
+    }
+
+    fn append_div(parent: &web_sys::Element, style: &str) -> web_sys::HtmlElement {
+        let element = document()
+            .create_element("div")
+            .expect("element creation must succeed")
+            .dyn_into::<web_sys::HtmlElement>()
+            .expect("div must be HtmlElement");
+        element
+            .set_attribute("style", style)
+            .expect("style assignment must succeed");
+        parent
+            .append_child(&element)
+            .expect("append_child must succeed");
+        element
+    }
+
+    fn cleanup(node: &web_sys::HtmlElement) {
+        node.remove();
+    }
+
+    #[wasm_bindgen_test]
+    fn supports_scroll_into_view_options_reports_browser_support() {
+        assert!(supports_scroll_into_view_options());
+    }
+
+    #[wasm_bindgen_test]
+    fn nearest_scrollable_ancestor_finds_the_immediate_scroll_container() {
+        let root = append_div(
+            body().as_ref(),
+            "position:fixed;left:-10000px;top:0;width:300px;height:300px;",
+        );
+        let outer = append_div(
+            root.as_ref(),
+            "width:220px;height:220px;overflow:auto;border:0;padding:0;margin:0;",
+        );
+        let inner = append_div(outer.as_ref(), "width:200px;height:500px;");
+        let target = append_div(inner.as_ref(), "width:100px;height:20px;margin-top:260px;");
+
+        let found = nearest_scrollable_ancestor(target.as_ref()).expect("must find ancestor");
+        assert!(found.is_same_node(Some(outer.as_ref())));
+
+        cleanup(&root);
+    }
+
+    #[wasm_bindgen_test]
+    fn scrollable_ancestors_collects_nearest_first_and_includes_document_root() {
+        let root = append_div(
+            body().as_ref(),
+            "position:fixed;left:-10000px;top:0;width:300px;height:300px;",
+        );
+        let outer = append_div(
+            root.as_ref(),
+            "width:220px;height:220px;overflow:auto;border:0;padding:0;margin:0;",
+        );
+        let inner_scroll = append_div(
+            outer.as_ref(),
+            "width:180px;height:180px;overflow:auto;border:0;padding:0;margin:0;",
+        );
+        let content = append_div(inner_scroll.as_ref(), "width:160px;height:500px;");
+        let target = append_div(
+            content.as_ref(),
+            "width:100px;height:20px;margin-top:260px;",
+        );
+
+        let ancestors = scrollable_ancestors(target.as_ref());
+        assert!(
+            ancestors
+                .first()
+                .is_some_and(|ancestor| ancestor.is_same_node(Some(inner_scroll.as_ref())))
+        );
+        assert!(
+            ancestors
+                .get(1)
+                .is_some_and(|ancestor| ancestor.is_same_node(Some(outer.as_ref())))
+        );
+        let document_root = document()
+            .document_element()
+            .expect("document element must exist");
+        assert!(
+            ancestors
+                .last()
+                .is_some_and(|ancestor| ancestor.is_same_node(Some(document_root.as_ref())))
+        );
+
+        cleanup(&root);
+    }
+
+    #[wasm_bindgen_test]
+    fn scroll_into_view_if_needed_moves_scroll_position() {
+        let root = append_div(
+            body().as_ref(),
+            "position:fixed;left:-10000px;top:0;width:300px;height:300px;",
+        );
+        let outer = append_div(
+            root.as_ref(),
+            "width:220px;height:120px;overflow:auto;border:0;padding:0;margin:0;",
+        );
+        let content = append_div(outer.as_ref(), "width:200px;height:500px;");
+        let target = append_div(
+            content.as_ref(),
+            "width:100px;height:20px;margin-top:320px;",
+        );
+
+        outer.set_scroll_top(0);
+        scroll_into_view_if_needed(target.as_ref(), ScrollIntoViewOptions::default());
+        assert!(outer.scroll_top() > 0);
+
+        cleanup(&root);
+    }
+}

--- a/crates/ars-dom/src/scroll_lock.rs
+++ b/crates/ars-dom/src/scroll_lock.rs
@@ -577,7 +577,7 @@ fn reset_global_state() {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::MutexGuard;
+    use std::sync::{Mutex, MutexGuard};
 
     use super::*;
 

--- a/spec/foundation/01-architecture.md
+++ b/spec/foundation/01-architecture.md
@@ -4572,7 +4572,7 @@ See `11-dom-utilities.md` for all details:
 
 - **Positioning Engine** (§2) — `compute_position()`, `auto_update()`, all positioning types
 - **Focus Utilities** (§3) — `get_focusable_elements()`, `focus_element()`, `FocusScope`
-- **Scroll Management** (§4) — `scroll_into_view()`, `nearest_scrollable_ancestor()`
+- **Scroll Management** (§4) — `scroll_into_view_if_needed()`, `nearest_scrollable_ancestor()`
 - **Scroll Locking** (§5) — `ScrollLockManager`, `prevent_scroll()`/`restore_scroll()`
 - **Z-Index Management** (§6) — `next_z_index()`, `ZIndexAllocator`
 - **Portal Root** (§7) — `get_or_create_portal_root()`, `set_background_inert()`

--- a/spec/foundation/05-interactions.md
+++ b/spec/foundation/05-interactions.md
@@ -612,7 +612,7 @@ When ars-ui components are used inside Shadow DOM (e.g., web components wrapping
 >
 > /// Scroll an element into its nearest scrollable ancestor's viewport.
 > /// Handles Safari <15.4 fallback, horizontal scrolling, and nested containers.
-> pub fn scroll_into_view_if_needed(element: &HtmlElement, options: ScrollIntoViewOptions) {
+> pub fn scroll_into_view_if_needed(element: &Element, options: ScrollIntoViewOptions) {
 >     if supports_scroll_into_view_options() {
 >         element.scroll_into_view_with_scroll_into_view_options(&options);
 >     } else {

--- a/spec/foundation/11-dom-utilities.md
+++ b/spec/foundation/11-dom-utilities.md
@@ -4,7 +4,9 @@
 
 The `ars-dom` crate provides browser DOM utilities shared by all framework adapters (Leptos, Dioxus). It serves as the convergence layer between the framework-agnostic core crates (`ars-core`, `ars-a11y`, `ars-interactions`) and the actual browser DOM. Components never touch `web_sys` directly — they delegate through `ars-dom` APIs for positioning, focus management, scroll control, z-index allocation, portal management, modality tracking, media queries, and URL sanitization.
 
-`ars-dom` depends on: `ars-core`, `ars-a11y`, `ars-i18n`, `ars-interactions`, `web-sys`, `js-sys`. It is always `std`-enabled because `web-sys` requires it. The crate exposes two feature flags: `web` (default, enables `web_sys` bindings for all DOM functions) and `ssr` (server-side rendering stubs — all DOM functions become no-ops or return sensible defaults, enabling the same adapter code to compile for both client and server targets).
+`ars-dom` depends on: `ars-core`, `ars-a11y`, `ars-i18n`, `ars-interactions`, `web-sys`, `js-sys`. It is always `std`-enabled because `web-sys` requires it. The crate exposes two feature flags: `web` (default, enables the DOM-backed APIs that expose raw `web_sys` types) and `ssr` (server-side rendering support for the cross-build subset of `ars-dom`).
+
+**Feature-surface rule:** any public API that mentions `web_sys` types in its signature is **web-only** and may be omitted entirely when the `web` feature is disabled. Only the cross-build subset of `ars-dom` participates in the `ssr` contract, where functions return safe defaults or no-op instead of touching the DOM. Adapters and components must treat raw DOM-typed helpers as browser-only APIs and gate their usage accordingly.
 
 On `wasm32` targets the crate uses `thread_local!` with `Cell`/`RefCell` for mutable global state, consistent with the library's single-threaded WASM-first design. On native targets (Dioxus Desktop), most utilities follow the same pattern, with one exception: Scroll Locking (§5.3) uses `AtomicU32`/`Mutex` where thread safety is needed because Dioxus Desktop runs the event loop and rendering on separate threads.
 
@@ -1583,6 +1585,8 @@ impl Drop for FocusScope {
 
 ### 4.1 Scroll Into View
 
+The scroll-management APIs in this section operate on raw DOM elements and are therefore part of the **web-only** surface of `ars-dom`. They are available when the `web` feature is enabled and are not part of the `ssr` stub contract.
+
 ```rust
 /// Options for scrolling an element into view within a scrollable container.
 pub struct ScrollIntoViewOptions {
@@ -1603,8 +1607,8 @@ pub enum ScrollLogicalPosition {
     Nearest,
 }
 
-/// Scroll an element into view within a scrollable container.
-pub fn scroll_into_view(element: &web_sys::Element, options: ScrollIntoViewOptions) {
+/// Scroll an element into view within a scrollable container when needed.
+pub fn scroll_into_view_if_needed(element: &web_sys::Element, options: ScrollIntoViewOptions) {
     let rect = element.get_bounding_client_rect();
     let parent = nearest_scrollable_ancestor(element);
 

--- a/spec/testing/07-ssr-hydration.md
+++ b/spec/testing/07-ssr-hydration.md
@@ -771,13 +771,17 @@ async fn suspense_boundary_shows_fallback_then_content() {
 
 ## 8. SSR Smoke Tests for ars-dom Utilities
 
-Per [11-dom-utilities.md](../foundation/11-dom-utilities.md), all DOM utility functions are gated with `#[cfg(not(feature = "ssr"))]`. Under the `ssr` feature, these functions must return safe defaults without attempting DOM access.
+Per [11-dom-utilities.md](../foundation/11-dom-utilities.md), `ars-dom` has two surfaces:
+
+- raw DOM-typed APIs, which are `web`-only and are not available under pure `ssr` builds
+- cross-build utilities, which remain available under `ssr` and must return safe defaults without attempting DOM access
+
+The smoke tests in this section cover only the cross-build `ssr` surface.
 
 ```rust
 #[cfg(feature = "ssr")]
 mod ssr_dom_smoke_tests {
     use ars_dom::positioning::{compute_position, PositioningOptions, Rect};
-    use ars_dom::focus::get_focusable_elements;
     use ars_dom::scroll::ScrollLockManager;
 
     #[test]
@@ -802,12 +806,8 @@ mod ssr_dom_smoke_tests {
         manager.unlock("test-component");
     }
 
-    #[test]
-    fn get_focusable_elements_returns_empty_under_ssr() {
-        // get_focusable_elements is cfg-gated out under SSR (no DOM access).
-        // Verify the SSR stub returns an empty Vec.
-        let elements = get_focusable_elements(&web_sys::HtmlElement::new().expect("SSR stub"));
-        assert!(elements.is_empty(), "SSR stub must return empty Vec");
-    }
+    // Raw DOM-typed helpers such as `get_focusable_elements`,
+    // `scroll_into_view_if_needed`, and `nearest_scrollable_ancestor`
+    // are part of the `web` surface and are intentionally not exercised here.
 }
 ```

--- a/spec/testing/13-policies.md
+++ b/spec/testing/13-policies.md
@@ -276,13 +276,14 @@ fn form_context_round_trips_via_serde() {
 #[cfg(feature = "web")]
 #[test]
 fn dom_queries_work_in_wasm() {
-    // ars-dom web feature requires wasm32; SSR feature compiles on any target
+    // Raw DOM-typed ars-dom APIs belong to the web-only surface.
 }
 
 #[cfg(feature = "ssr")]
 #[test]
 fn ssr_dom_abstraction_available() {
-    // Verify SSR DOM abstraction compiles and basic operations work
+    // Verify only the cross-build ars-dom surface compiles.
+    // Raw web_sys-typed functions are not part of the SSR contract.
 }
 ```
 


### PR DESCRIPTION
## Summary
- add `ars-dom` scroll utilities for `scroll_into_view_if_needed`, scroll ancestor discovery, and native-options detection
- provide a manual Safari-safe fallback for nested vertical and horizontal scrolling
- sync the foundation and testing specs to mark raw `web_sys` DOM helpers as `web`-only and standardize on `Element`

## Validation
- `cargo test -p ars-dom --quiet`
- `cargo clippy -p ars-dom --all-targets -- -D warnings`
- `cargo llvm-cov report -p ars-dom --summary-only`
- `cargo test -p ars-dom --features web --target wasm32-unknown-unknown --no-run`

Closes #74