### PR TITLE
[codex] implement InteractOutside core types in ars-interactions

### DIFF
--- a/crates/ars-interactions/src/interact_outside.rs
+++ b/crates/ars-interactions/src/interact_outside.rs
@@ -1,0 +1,274 @@
+//! Outside-interaction configuration and event types.
+//!
+//! This module defines the adapter-facing data model for "interact outside"
+//! behavior used by overlays and dismissable surfaces. It intentionally stays
+//! free of DOM or framework types so the detection policy can be tested with
+//! pure unit tests.
+
+use std::{string::String, vec::Vec};
+
+use ars_core::{Callback, PointerType};
+
+/// Configuration for outside-interaction detection.
+///
+/// This composable configuration controls whether detection is enabled and
+/// whether focus transitions outside the boundary should also be reported.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct InteractOutsideConfig {
+    /// Whether outside-interaction detection is disabled.
+    pub disabled: bool,
+
+    /// Whether focus moving outside the boundary should also be reported.
+    ///
+    /// When `false`, only pointer-originated outside interactions are
+    /// considered. Overlay components typically set this to `true`.
+    pub detect_focus: bool,
+}
+
+/// Standalone registration payload for outside-interaction detection.
+///
+/// Framework adapters use this value to register an interaction boundary,
+/// additional portal-owner IDs that should still count as "inside" for
+/// teleported content, and the callback to invoke when an outside interaction
+/// is detected.
+#[derive(Clone, Debug, PartialEq)]
+pub struct InteractOutsideStandalone {
+    /// The ID of the primary element whose boundary is being monitored.
+    pub target_id: String,
+
+    /// Portal-owner IDs that should be treated as inside.
+    ///
+    /// These IDs correspond to `data-ars-portal-owner` markers applied by the
+    /// adapter to teleported content. They are not arbitrary DOM element IDs.
+    pub portal_owner_ids: Vec<String>,
+
+    /// Callback invoked when an outside interaction is detected.
+    pub on_interact_outside: Option<Callback<dyn Fn(InteractOutsideEvent)>>,
+
+    /// Whether outside-interaction detection is active for this registration.
+    pub enabled: bool,
+
+    /// Optional grace period in milliseconds before pointer-outside dismissal.
+    ///
+    /// Adapters may use this for submenu-style pointer grace handling.
+    pub pointer_gracing: Option<u32>,
+}
+
+/// A normalized outside-interaction event.
+#[derive(Clone, Debug, PartialEq)]
+pub enum InteractOutsideEvent {
+    /// A pointer interaction occurred outside the registered boundary.
+    PointerOutside {
+        /// Client-space X coordinate of the pointer event.
+        client_x: f64,
+        /// Client-space Y coordinate of the pointer event.
+        client_y: f64,
+        /// The type of pointer that triggered the event.
+        pointer_type: PointerType,
+    },
+
+    /// Focus moved outside the registered boundary.
+    FocusOutside,
+
+    /// The Escape key was pressed while the overlay had focus.
+    EscapeKey,
+}
+
+/// Returns whether outside-interaction detection should currently be active.
+#[cfg(test)]
+#[must_use]
+fn detection_is_active(
+    config: &InteractOutsideConfig,
+    standalone: &InteractOutsideStandalone,
+) -> bool {
+    !config.disabled && standalone.enabled
+}
+
+/// Returns whether a resolved portal-owner ID should count as inside.
+#[cfg(test)]
+#[must_use]
+fn portal_owner_id_is_inside(
+    standalone: &InteractOutsideStandalone,
+    resolved_owner_id: Option<&str>,
+) -> bool {
+    let Some(resolved_owner_id) = resolved_owner_id else {
+        return false;
+    };
+
+    standalone
+        .portal_owner_ids
+        .iter()
+        .any(|owner_id| owner_id == resolved_owner_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use ars_core::PointerType;
+
+    use super::*;
+
+    fn sample_standalone() -> InteractOutsideStandalone {
+        InteractOutsideStandalone {
+            target_id: "popover-1".into(),
+            portal_owner_ids: vec!["portal-1".into(), "portal-2".into()],
+            on_interact_outside: None,
+            enabled: true,
+            pointer_gracing: Some(250),
+        }
+    }
+
+    #[test]
+    fn interact_outside_config_defaults() {
+        let config = InteractOutsideConfig::default();
+        assert!(!config.disabled);
+        assert!(!config.detect_focus);
+    }
+
+    #[test]
+    fn pointer_outside_event_compares_fields() {
+        let event = InteractOutsideEvent::PointerOutside {
+            client_x: 10.0,
+            client_y: 20.0,
+            pointer_type: PointerType::Mouse,
+        };
+
+        assert_eq!(
+            event,
+            InteractOutsideEvent::PointerOutside {
+                client_x: 10.0,
+                client_y: 20.0,
+                pointer_type: PointerType::Mouse,
+            }
+        );
+    }
+
+    #[test]
+    fn focus_outside_event_is_constructible() {
+        assert_eq!(
+            InteractOutsideEvent::FocusOutside,
+            InteractOutsideEvent::FocusOutside
+        );
+    }
+
+    #[test]
+    fn escape_key_event_is_constructible() {
+        assert_eq!(
+            InteractOutsideEvent::EscapeKey,
+            InteractOutsideEvent::EscapeKey
+        );
+    }
+
+    #[test]
+    fn standalone_clone_preserves_fields_and_callback_identity() {
+        let standalone = InteractOutsideStandalone {
+            on_interact_outside: Some(Callback::new(|_: InteractOutsideEvent| {})),
+            ..sample_standalone()
+        };
+
+        let cloned = standalone.clone();
+
+        assert_eq!(standalone.target_id, cloned.target_id);
+        assert_eq!(standalone.portal_owner_ids, cloned.portal_owner_ids);
+        assert_eq!(standalone.enabled, cloned.enabled);
+        assert_eq!(standalone.pointer_gracing, cloned.pointer_gracing);
+        assert_eq!(standalone.on_interact_outside, cloned.on_interact_outside);
+    }
+
+    #[test]
+    fn standalone_debug_redacts_callback_body() {
+        let standalone = InteractOutsideStandalone {
+            on_interact_outside: Some(Callback::new(|_: InteractOutsideEvent| {})),
+            ..sample_standalone()
+        };
+
+        let debug = format!("{standalone:?}");
+        assert!(debug.contains("target_id: \"popover-1\""));
+        assert!(debug.contains("on_interact_outside: Some(Callback(..))"));
+        assert!(debug.contains("pointer_gracing: Some(250)"));
+    }
+
+    #[test]
+    fn standalone_partial_eq_uses_callback_pointer_identity() {
+        let callback = Callback::new(|_: InteractOutsideEvent| {});
+        let left = InteractOutsideStandalone {
+            on_interact_outside: Some(callback.clone()),
+            ..sample_standalone()
+        };
+        let right = InteractOutsideStandalone {
+            on_interact_outside: Some(callback),
+            ..sample_standalone()
+        };
+        let different = InteractOutsideStandalone {
+            on_interact_outside: Some(Callback::new(|_: InteractOutsideEvent| {})),
+            ..sample_standalone()
+        };
+
+        assert_eq!(left, right);
+        assert_ne!(left, different);
+    }
+
+    #[test]
+    fn detection_is_inactive_when_config_is_disabled() {
+        let config = InteractOutsideConfig {
+            disabled: true,
+            detect_focus: true,
+        };
+
+        assert!(!detection_is_active(&config, &sample_standalone()));
+    }
+
+    #[test]
+    fn detection_is_inactive_when_standalone_is_disabled() {
+        let config = InteractOutsideConfig::default();
+        let standalone = InteractOutsideStandalone {
+            enabled: false,
+            ..sample_standalone()
+        };
+
+        assert!(!detection_is_active(&config, &standalone));
+    }
+
+    #[test]
+    fn detection_is_active_when_both_config_and_registration_are_enabled() {
+        assert!(detection_is_active(
+            &InteractOutsideConfig::default(),
+            &sample_standalone()
+        ));
+    }
+
+    #[test]
+    fn target_id_is_not_treated_as_a_portal_owner_id() {
+        let standalone = sample_standalone();
+        assert!(!portal_owner_id_is_inside(&standalone, Some("popover-1")));
+    }
+
+    #[test]
+    fn portal_owner_ids_count_as_inside() {
+        let standalone = sample_standalone();
+        assert!(portal_owner_id_is_inside(&standalone, Some("portal-2")));
+    }
+
+    #[test]
+    fn unrelated_owner_id_is_outside() {
+        let standalone = sample_standalone();
+        assert!(!portal_owner_id_is_inside(
+            &standalone,
+            Some("other-overlay")
+        ));
+    }
+
+    #[test]
+    fn missing_owner_id_is_outside() {
+        let standalone = sample_standalone();
+        assert!(!portal_owner_id_is_inside(&standalone, None));
+    }
+
+    #[test]
+    fn pointer_gracing_is_preserved_without_affecting_boundary_matching() {
+        let standalone = sample_standalone();
+
+        assert_eq!(standalone.pointer_gracing, Some(250));
+        assert!(portal_owner_id_is_inside(&standalone, Some("portal-1")));
+        assert!(!portal_owner_id_is_inside(&standalone, Some("outside")));
+    }
+}

--- a/crates/ars-interactions/src/lib.rs
+++ b/crates/ars-interactions/src/lib.rs
@@ -8,6 +8,7 @@ pub mod compose;
 pub mod direction;
 pub mod focus;
 pub mod hover;
+pub mod interact_outside;
 pub mod press;
 
 pub use ars_core::{
@@ -21,4 +22,7 @@ pub use focus::{
     FocusWithinResult, use_focus, use_focus_within,
 };
 pub use hover::{HoverConfig, HoverEvent, HoverEventType, HoverResult, HoverState, use_hover};
+pub use interact_outside::{
+    InteractOutsideConfig, InteractOutsideEvent, InteractOutsideStandalone,
+};
 pub use press::{PressConfig, PressEvent, PressEventType, PressResult, PressState, use_press};

--- a/docs/implementation/foundation-completion-roadmap.md
+++ b/docs/implementation/foundation-completion-roadmap.md
@@ -370,10 +370,10 @@ The project needs a fully stable foundation before component work starts. Compon
   - Unit tests for portal-aware detection design using `data-ars-portal-owner`.
 - Acceptance criteria:
   - `InteractOutsideConfig` with `disabled`, `detect_focus`.
-  - `InteractOutsideStandalone` with `target_id`, `owner_ids`, `on_interact_outside`, `enabled`, `pointer_gracing`.
+  - `InteractOutsideStandalone` with `target_id`, `portal_owner_ids`, `on_interact_outside`, `enabled`, `pointer_gracing`.
   - `InteractOutsideEvent` enum with `PointerOutside`, `FocusOutside`, `EscapeKey`.
   - Portal-aware detection design.
-- Spec impact: `No spec change required`.
+- Spec impact: clarify that portal-aware boundary registration uses portal-owner IDs rather than arbitrary element IDs.
 
 #### W2-5: Implement positioning engine types in ars-dom
 
@@ -1019,15 +1019,16 @@ Wave 4 (50 pts)            ┌─── Wave 3 complete
 
 ## Epic Mapping
 
-| Epic           | Issue | Tasks covered                                    |
-| -------------- | ----- | ------------------------------------------------ |
-| Interactions   | #4    | #57, #58, #59, #60, #61, #65, #76, #77, #78, #90 |
-| DOM utilities  | #6    | #66, #67, #68, #69, #72, #74, #85, #88           |
-| Leptos adapter | #8    | #55                                              |
-| Dioxus adapter | #9    | #56                                              |
-| A11y           | #3    | #73, #89                                         |
-| Collections    | #53   | #62, #63, #64, #70, #71, #81, #82, #83, #84      |
-| I18n           | #54   | #75, #79, #80                                    |
+| Epic                | Issue | Tasks covered                                    |
+| ------------------- | ----- | ------------------------------------------------ |
+| Interactions        | #4    | #57, #58, #59, #60, #61, #65, #76, #77, #78, #90 |
+| DOM utilities       | #6    | #66, #67, #68, #69, #72, #74, #85, #88           |
+| Leptos adapter      | #8    | #55, #105                                        |
+| Dioxus adapter      | #9    | #56, #106                                        |
+| A11y                | #3    | #73, #89                                         |
+| Collections         | #53   | #62, #63, #64, #70, #71, #81, #82, #83, #84      |
+| I18n                | #54   | #75, #79, #80                                    |
+| First utility slice | #10   | #104                                             |
 
 ## Post-Foundation Plan
 
@@ -1037,6 +1038,114 @@ After all four waves are complete:
 2. Decompose the first utility slice (Button, VisuallyHidden, Separator, FocusScope, Toggle, Field, Form) into agent-ready component tasks.
 3. Component work can proceed in parallel across both adapters without foundation merge conflicts.
 4. Each component task references the now-stable foundation APIs by crate path and spec section.
+
+### Targeted Follow-On: Full Outside-Interaction Delivery
+
+These cards intentionally carve out the remaining work needed to turn the foundation-level
+`InteractOutside` substrate into a full shared `Dismissable` primitive before the broader
+utility-slice decomposition resumes. They are narrowly scoped to the outside-interaction
+pipeline and do not reopen the full `#24` planning thread.
+
+| GitHub                                               | Title                                                                         | Points | Epic | Deps                |
+| ---------------------------------------------------- | ----------------------------------------------------------------------------- | ------ | ---- | ------------------- |
+| [#104](https://github.com/fogodev/ars-ui/issues/104) | Implement Dismissable core props and dismiss-button attrs in ars-interactions | 3      | #10  | #65                 |
+| [#105](https://github.com/fogodev/ars-ui/issues/105) | Implement use_dismissable and DismissableRegion in ars-leptos                 | 5      | #8   | #65, #69, #88, #104 |
+| [#106](https://github.com/fogodev/ars-ui/issues/106) | Implement use_dismissable and DismissableRegion in ars-dioxus                 | 5      | #9   | #65, #69, #88, #104 |
+
+#### PF-IO-1: Implement Dismissable core props and dismiss-button attrs in ars-interactions
+
+- Points: `3`
+- Layer: `Component`
+- Framework: `None`
+- Test tier: `Unit`
+- Depends on: #65
+- Spec refs:
+  - `spec/components/utility/dismissable.md` §1 "API"
+  - `spec/components/utility/dismissable.md` §4 "Internationalization"
+  - `spec/components/utility/dismissable.md` §5 "Behavior"
+  - `spec/foundation/05-interactions.md` §12 "InteractOutside Interaction"
+  - `spec/foundation/04-internationalization.md` §7 "Messages"
+- Goal: implement the shared `Dismissable` contract so both adapters consume the same props, messages, parts, and dismiss-button attr helper.
+- Files to create/modify: `crates/ars-interactions/src/dismissable.rs` (new), `crates/ars-interactions/src/lib.rs` (wire new module)
+- Tests to add first:
+  - Unit tests for `dismissable::Props` defaults and debug output.
+  - Unit tests for callback-bearing `Props` clone/partial-eq pointer identity semantics.
+  - Unit tests for `dismissable::Messages` default close label.
+  - Unit tests for `dismissable::dismiss_button_attrs()` producing scope/part data attrs, native button semantics, visually-hidden marker, and localized `aria-label`.
+  - Unit tests for `exclude_ids` and `disable_outside_pointer_events` config preservation.
+- Acceptance criteria:
+  - `dismissable::Props` with `on_interact_outside`, `on_escape_key_down`, `on_dismiss`, `disable_outside_pointer_events`, `exclude_ids`, `messages`, and `locale`.
+  - `dismissable::Messages` with default English close label following the shared `MessageFn` pattern.
+  - `dismissable::Part` with `Root` and `DismissButton`.
+  - `dismiss_button_attrs(&Props) -> AttrMap` matching the spec.
+  - No document listeners or framework-specific containment logic in this task.
+- Spec impact: `No spec change required`.
+
+#### PF-IO-2: Implement use_dismissable and DismissableRegion in ars-leptos
+
+- Points: `5`
+- Layer: `Adapter`
+- Framework: `Leptos`
+- Test tier: `Adapter`
+- Depends on: #65, #69, #88, #104
+- Spec refs:
+  - `spec/leptos-components/utility/dismissable.md`
+  - `spec/components/utility/dismissable.md`
+  - `spec/foundation/05-interactions.md` §12 "InteractOutside Interaction"
+  - `spec/testing/10-keyboard-focus.md` §13.2 "InteractOutside Tests"
+  - `docs/implementation/adapter-contract.md`
+- Goal: implement the Leptos adapter-owned `Dismissable` hook and region wrapper with client-only listeners, portal-aware containment, and topmost-overlay dismissal behavior.
+- Files to create/modify: `crates/ars-leptos/src/dismissable.rs` (new), `crates/ars-leptos/src/lib.rs` (wire new module)
+- Tests to add first:
+  - Adapter tests for outside `pointerdown` calling `on_interact_outside` then `on_dismiss`.
+  - Adapter tests for outside `focusin` calling `on_interact_outside` then `on_dismiss`.
+  - Adapter tests for Escape dismissal firing `on_escape_key_down` then `on_dismiss`.
+  - Adapter tests for `exclude_ids` and additional inside boundaries suppressing dismissal.
+  - Adapter tests for portal-aware containment using `data-ars-portal-owner`.
+  - Adapter tests for topmost-overlay-only dismissal using the overlay stack.
+  - Adapter tests for SSR safety and cleanup removing listeners / pending retries.
+  - Adapter tests for both dismiss buttons invoking dismiss behavior.
+- Acceptance criteria:
+  - `use_dismissable(root_ref, props, inside_boundaries) -> DismissableHandle` implemented per spec.
+  - `DismissableRegion` renders both native dismiss buttons around consumer content.
+  - Client-only `pointerdown`, `focusin`, and Escape listeners with proper cleanup.
+  - Portal-aware containment and overlay-stack-aware topmost dismissal behavior.
+  - `disable_outside_pointer_events` behavior supported without breaking keyboard dismissal.
+  - Adapter behavior and cleanup ordering match the spec and adapter contract.
+- Spec impact: `No spec change required`.
+
+#### PF-IO-3: Implement use_dismissable and DismissableRegion in ars-dioxus
+
+- Points: `5`
+- Layer: `Adapter`
+- Framework: `Dioxus`
+- Test tier: `Adapter`
+- Depends on: #65, #69, #88, #104
+- Spec refs:
+  - `spec/dioxus-components/utility/dismissable.md`
+  - `spec/components/utility/dismissable.md`
+  - `spec/foundation/05-interactions.md` §12 "InteractOutside Interaction"
+  - `spec/testing/10-keyboard-focus.md` §13.2 "InteractOutside Tests"
+  - `docs/implementation/adapter-contract.md`
+- Goal: implement the Dioxus adapter-owned `Dismissable` hook and region wrapper with client-only listeners, portal-aware containment, and topmost-overlay dismissal behavior across Dioxus targets.
+- Files to create/modify: `crates/ars-dioxus/src/dismissable.rs` (new), `crates/ars-dioxus/src/lib.rs` (wire new module)
+- Tests to add first:
+  - Adapter tests for outside `pointerdown` calling `on_interact_outside` then `on_dismiss`.
+  - Adapter tests for outside `focusin` calling `on_interact_outside` then `on_dismiss`.
+  - Adapter tests for Escape dismissal firing `on_escape_key_down` then `on_dismiss`.
+  - Adapter tests for `exclude_ids` and additional inside boundaries suppressing dismissal.
+  - Adapter tests for portal-aware containment using `data-ars-portal-owner`.
+  - Adapter tests for topmost-overlay-only dismissal using the overlay stack.
+  - Adapter tests for web/Desktop-safe cleanup removing listeners / pending retries.
+  - Adapter tests for both dismiss buttons invoking dismiss behavior.
+- Acceptance criteria:
+  - `use_dismissable(root_id, props, inside_boundaries) -> DismissableHandle` implemented per spec.
+  - `DismissableRegion` renders both native dismiss buttons around consumer content.
+  - Client-only `pointerdown`, `focusin`, and Escape listeners with proper cleanup.
+  - Portal-aware containment and overlay-stack-aware topmost dismissal behavior.
+  - `disable_outside_pointer_events` behavior supported without breaking keyboard dismissal.
+  - Dioxus Web/Desktop behavior and cleanup ordering match the spec and adapter contract.
+- Spec impact: `No spec change required`.
 
 ## Summary
 

--- a/spec/foundation/05-interactions.md
+++ b/spec/foundation/05-interactions.md
@@ -4013,12 +4013,14 @@ Currently each overlay component re-implements this logic independently. `Intera
 ```rust
 // ars-interactions/src/interact_outside.rs
 
+use ars_core::{Callback, PointerType};
+
 /// Standalone interaction primitive for detecting clicks/interactions outside a target element.
 /// Used independently of DismissableLayer for custom components.
 ///
 /// Configuration:
-/// - `target_ref`: The element to monitor for outside interactions
-/// - `owner_ids`: Additional element IDs considered "inside" (e.g., portal content)
+/// - `target_id`: The element to monitor for outside interactions
+/// - `portal_owner_ids`: Additional portal-owner IDs considered "inside"
 /// - `on_interact_outside`: Callback when interaction outside is detected
 /// - `enabled`: Whether detection is active
 /// - `pointer_gracing`: Grace period (ms) after pointer leaves before triggering (for submenus)
@@ -4027,8 +4029,10 @@ pub struct InteractOutsideStandalone {
     /// Uses a String ID (not ElementRef) because InteractOutside is in
     /// ars-interactions, which is below ars-dom in the dependency graph.
     pub target_id: String,
-    pub owner_ids: Vec<String>,
-    pub on_interact_outside: Option<Rc<dyn Fn(InteractOutsideEvent)>>,
+    /// Portal-owner IDs corresponding to `data-ars-portal-owner` markers that
+    /// should be treated as inside this interaction boundary.
+    pub portal_owner_ids: Vec<String>,
+    pub on_interact_outside: Option<Callback<dyn Fn(InteractOutsideEvent)>>,
     pub enabled: bool,
     pub pointer_gracing: Option<u32>,
 }
@@ -4064,7 +4068,7 @@ The adapter implements outside detection by:
 
 ### 12.4 Edge Cases
 
-- **Portaled content**: When content is rendered in a `Portal` (e.g., a dropdown menu), the adapter must consider portal children as "inside" the interaction boundary. This is achieved by maintaining a set of related element references.
+- **Portaled content**: When content is rendered in a `Portal` (e.g., a dropdown menu), the adapter must consider portal children as "inside" the interaction boundary. This is achieved by maintaining the relevant portal-owner IDs and matching them against `data-ars-portal-owner`.
 - **Nested overlays**: If a click occurs inside a child overlay (e.g., a tooltip inside a popover), it should NOT trigger an outside interaction on the parent. The overlay stacking context must be consulted.
 
 > **Portal-aware outside detection.** Since portal content is DOM-detached from the component
@@ -4143,7 +4147,7 @@ Portal-rendered content is DOM-detached from the component tree. The detection a
 2. Check `element.contains(resolved)` for direct DOM containment.
 3. If not contained, walk up from the resolved element checking for `[data-ars-portal-owner="COMPONENT_ID"]` attributes.
 4. Any element with a matching `data-ars-portal-owner` is considered "inside" the interaction boundary.
-5. The `owner_ids` field in `InteractOutsideStandalone` allows additional element IDs to be registered as "inside" for custom portal-like patterns.
+5. The `portal_owner_ids` field in `InteractOutsideStandalone` stores those portal-owner IDs. It does not store arbitrary DOM element IDs; direct DOM containment remains the responsibility of step 2.
 
 ### 12.8 Nested Overlay Handling
 


### PR DESCRIPTION
## Summary

- add the `InteractOutside` module to `ars-interactions` with config, standalone registration payload, event enum, and unit-tested pure helpers
- re-export the new interaction types from `ars-interactions` and sync the foundation spec to the shipped `Callback`-based API plus explicit portal-owner semantics
- record the remaining dismissable follow-on tasks in the implementation roadmap and tighten epic linkage for the related DOM overlay-stack task

## Why

This lands the shared adapter-facing core for outside-interaction dismissal without pulling DOM concerns into `ars-interactions`. It also removes the ambiguity between direct DOM containment and portal-owner matching so later adapter work has a clear contract boundary.

## Validation

- `cargo check -p ars-interactions`
- `cargo test -p ars-interactions interact_outside`
- `cargo test -p ars-interactions --lib`
- `cargo llvm-cov test -p ars-interactions --lib`

Closes #65
