### PR TITLE
[codex] implement selection foundation in ars-collections

### DIFF
--- a/crates/ars-collections/src/lib.rs
+++ b/crates/ars-collections/src/lib.rs
@@ -13,7 +13,8 @@
 //! - [`CollectionItem`] — trait for items stored in collections.
 //! - [`CollectionBuilder`] — fluent builder for constructing collections.
 //! - [`StaticCollection`] — in-memory `Collection` implementation.
-//! - [`Selection`] — set of currently selected items.
+//! - [`selection`] — selection enums and state for collection-based components.
+//! - [`navigation`] — disabled-aware navigation helpers for collection widgets.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(clippy::std_instead_of_core)]
@@ -26,32 +27,18 @@ pub mod builder;
 pub mod collection;
 /// Stable node identifiers for collections.
 pub mod key;
+/// Disabled-aware navigation helpers for collection widgets.
+pub mod navigation;
 /// Node types and structural metadata for collection items.
 pub mod node;
+/// Selection enums and state for collection-based components.
+pub mod selection;
 /// In-memory collection backed by `Vec` and `IndexMap`.
 pub mod static_collection;
-
-use alloc::vec::Vec;
 
 pub use builder::CollectionBuilder;
 pub use collection::{Collection, CollectionItem};
 pub use key::Key;
 pub use node::{Node, NodeType};
+pub use selection::DisabledBehavior;
 pub use static_collection::StaticCollection;
-
-/// A set of currently selected items in a collection component.
-///
-/// Tracks which items are selected, supporting single and multiple selection modes.
-/// The item type `T` is typically a [`Key`](ars_core) identifying the selected items.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct Selection<T> {
-    items: Vec<T>,
-}
-
-impl<T> Selection<T> {
-    /// Returns a slice of the currently selected items.
-    #[must_use]
-    pub fn items(&self) -> &[T] {
-        &self.items
-    }
-}

--- a/crates/ars-collections/src/navigation.rs
+++ b/crates/ars-collections/src/navigation.rs
@@ -1,0 +1,389 @@
+use alloc::collections::BTreeSet;
+
+use crate::{Collection, DisabledBehavior, key::Key};
+
+/// Returns the next focusable key, skipping disabled items when configured.
+#[must_use]
+pub fn next_enabled_key<T, C: Collection<T>>(
+    collection: &C,
+    current: &Key,
+    disabled_keys: &BTreeSet<Key>,
+    disabled_behavior: DisabledBehavior,
+    wrap: bool,
+) -> Option<Key> {
+    if disabled_behavior == DisabledBehavior::FocusOnly {
+        let next = if wrap {
+            collection.key_after(current)
+        } else {
+            collection.key_after_no_wrap(current)
+        };
+        return next.cloned();
+    }
+
+    let mut candidate = if wrap {
+        collection.key_after(current)
+    } else {
+        collection.key_after_no_wrap(current)
+    };
+    let start = candidate.cloned();
+
+    loop {
+        match candidate {
+            None => return None,
+            Some(key) if !disabled_keys.contains(key) => return Some(key.clone()),
+            Some(key) => {
+                candidate = if wrap {
+                    collection.key_after(key)
+                } else {
+                    collection.key_after_no_wrap(key)
+                };
+                if candidate.cloned() == start {
+                    return None;
+                }
+            }
+        }
+    }
+}
+
+/// Returns the previous focusable key, skipping disabled items when configured.
+#[must_use]
+pub fn prev_enabled_key<T, C: Collection<T>>(
+    collection: &C,
+    current: &Key,
+    disabled_keys: &BTreeSet<Key>,
+    disabled_behavior: DisabledBehavior,
+    wrap: bool,
+) -> Option<Key> {
+    if disabled_behavior == DisabledBehavior::FocusOnly {
+        let previous = if wrap {
+            collection.key_before(current)
+        } else {
+            collection.key_before_no_wrap(current)
+        };
+        return previous.cloned();
+    }
+
+    let mut candidate = if wrap {
+        collection.key_before(current)
+    } else {
+        collection.key_before_no_wrap(current)
+    };
+    let start = candidate.cloned();
+
+    loop {
+        match candidate {
+            None => return None,
+            Some(key) if !disabled_keys.contains(key) => return Some(key.clone()),
+            Some(key) => {
+                candidate = if wrap {
+                    collection.key_before(key)
+                } else {
+                    collection.key_before_no_wrap(key)
+                };
+                if candidate.cloned() == start {
+                    return None;
+                }
+            }
+        }
+    }
+}
+
+/// Returns the first enabled focusable key in the collection.
+#[must_use]
+pub fn first_enabled_key<T, C: Collection<T>>(
+    collection: &C,
+    disabled_keys: &BTreeSet<Key>,
+    disabled_behavior: DisabledBehavior,
+) -> Option<Key> {
+    if disabled_behavior == DisabledBehavior::FocusOnly {
+        return collection.first_key().cloned();
+    }
+
+    let mut candidate = collection.first_key();
+    while let Some(key) = candidate {
+        if !disabled_keys.contains(key) {
+            return Some(key.clone());
+        }
+        candidate = collection.key_after_no_wrap(key);
+    }
+
+    None
+}
+
+/// Returns the last enabled focusable key in the collection.
+#[must_use]
+pub fn last_enabled_key<T, C: Collection<T>>(
+    collection: &C,
+    disabled_keys: &BTreeSet<Key>,
+    disabled_behavior: DisabledBehavior,
+) -> Option<Key> {
+    if disabled_behavior == DisabledBehavior::FocusOnly {
+        return collection.last_key().cloned();
+    }
+
+    let mut candidate = collection.last_key();
+    while let Some(key) = candidate {
+        if !disabled_keys.contains(key) {
+            return Some(key.clone());
+        }
+        candidate = collection.key_before_no_wrap(key);
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::collections::BTreeSet;
+
+    use super::*;
+    use crate::CollectionBuilder;
+
+    fn fixture_collection() -> crate::StaticCollection<&'static str> {
+        CollectionBuilder::new()
+            .item(Key::int(1), "One", "one")
+            .section(Key::str("group"), "Group")
+            .item(Key::int(2), "Two", "two")
+            .item(Key::int(3), "Three", "three")
+            .separator()
+            .item(Key::int(4), "Four", "four")
+            .end_section()
+            .item(Key::int(5), "Five", "five")
+            .build()
+    }
+
+    #[test]
+    fn next_enabled_key_skips_disabled_with_wrap() {
+        let collection = fixture_collection();
+        let disabled = BTreeSet::from([Key::int(3)]);
+
+        assert_eq!(
+            next_enabled_key(
+                &collection,
+                &Key::int(2),
+                &disabled,
+                DisabledBehavior::Skip,
+                true
+            ),
+            Some(Key::int(4))
+        );
+    }
+
+    #[test]
+    fn next_enabled_key_respects_no_wrap() {
+        let collection = fixture_collection();
+
+        assert_eq!(
+            next_enabled_key(
+                &collection,
+                &Key::int(5),
+                &BTreeSet::new(),
+                DisabledBehavior::Skip,
+                false,
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn next_enabled_key_focus_only_allows_disabled_targets() {
+        let collection = fixture_collection();
+        let disabled = BTreeSet::from([Key::int(3)]);
+
+        assert_eq!(
+            next_enabled_key(
+                &collection,
+                &Key::int(2),
+                &disabled,
+                DisabledBehavior::FocusOnly,
+                true,
+            ),
+            Some(Key::int(3))
+        );
+    }
+
+    #[test]
+    fn next_enabled_key_focus_only_respects_no_wrap() {
+        let collection = fixture_collection();
+
+        assert_eq!(
+            next_enabled_key(
+                &collection,
+                &Key::int(5),
+                &BTreeSet::from([Key::int(5)]),
+                DisabledBehavior::FocusOnly,
+                false,
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn next_enabled_key_skip_no_wrap_stops_after_disabled_tail() {
+        let collection = fixture_collection();
+        let disabled = BTreeSet::from([Key::int(3), Key::int(4), Key::int(5)]);
+
+        assert_eq!(
+            next_enabled_key(
+                &collection,
+                &Key::int(2),
+                &disabled,
+                DisabledBehavior::Skip,
+                false,
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn prev_enabled_key_skips_disabled_with_wrap() {
+        let collection = fixture_collection();
+        let disabled = BTreeSet::from([Key::int(3)]);
+
+        assert_eq!(
+            prev_enabled_key(
+                &collection,
+                &Key::int(4),
+                &disabled,
+                DisabledBehavior::Skip,
+                true
+            ),
+            Some(Key::int(2))
+        );
+    }
+
+    #[test]
+    fn prev_enabled_key_focus_only_allows_disabled_targets() {
+        let collection = fixture_collection();
+        let disabled = BTreeSet::from([Key::int(3)]);
+
+        assert_eq!(
+            prev_enabled_key(
+                &collection,
+                &Key::int(4),
+                &disabled,
+                DisabledBehavior::FocusOnly,
+                true,
+            ),
+            Some(Key::int(3))
+        );
+    }
+
+    #[test]
+    fn prev_enabled_key_focus_only_respects_no_wrap() {
+        let collection = fixture_collection();
+
+        assert_eq!(
+            prev_enabled_key(
+                &collection,
+                &Key::int(1),
+                &BTreeSet::from([Key::int(1)]),
+                DisabledBehavior::FocusOnly,
+                false,
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn prev_enabled_key_skip_no_wrap_stops_after_disabled_head() {
+        let collection = fixture_collection();
+        let disabled = BTreeSet::from([Key::int(1), Key::int(2), Key::int(3)]);
+
+        assert_eq!(
+            prev_enabled_key(
+                &collection,
+                &Key::int(4),
+                &disabled,
+                DisabledBehavior::Skip,
+                false,
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn first_enabled_key_skips_disabled_and_structural_nodes() {
+        let collection = fixture_collection();
+        let disabled = BTreeSet::from([Key::int(1), Key::int(2)]);
+
+        assert_eq!(
+            first_enabled_key(&collection, &disabled, DisabledBehavior::Skip),
+            Some(Key::int(3))
+        );
+    }
+
+    #[test]
+    fn first_enabled_key_focus_only_returns_first_focusable_key() {
+        let collection = fixture_collection();
+        let disabled = BTreeSet::from([Key::int(1), Key::int(2), Key::int(3)]);
+
+        assert_eq!(
+            first_enabled_key(&collection, &disabled, DisabledBehavior::FocusOnly),
+            Some(Key::int(1))
+        );
+    }
+
+    #[test]
+    fn last_enabled_key_skips_disabled_and_structural_nodes() {
+        let collection = fixture_collection();
+        let disabled = BTreeSet::from([Key::int(5), Key::int(4)]);
+
+        assert_eq!(
+            last_enabled_key(&collection, &disabled, DisabledBehavior::Skip),
+            Some(Key::int(3))
+        );
+    }
+
+    #[test]
+    fn last_enabled_key_focus_only_returns_last_focusable_key() {
+        let collection = fixture_collection();
+        let disabled = BTreeSet::from([Key::int(3), Key::int(4), Key::int(5)]);
+
+        assert_eq!(
+            last_enabled_key(&collection, &disabled, DisabledBehavior::FocusOnly),
+            Some(Key::int(5))
+        );
+    }
+
+    #[test]
+    fn all_items_disabled_returns_none_without_looping() {
+        let collection = fixture_collection();
+        let disabled = BTreeSet::from([
+            Key::int(1),
+            Key::int(2),
+            Key::int(3),
+            Key::int(4),
+            Key::int(5),
+        ]);
+
+        assert_eq!(
+            next_enabled_key(
+                &collection,
+                &Key::int(1),
+                &disabled,
+                DisabledBehavior::Skip,
+                true
+            ),
+            None
+        );
+        assert_eq!(
+            prev_enabled_key(
+                &collection,
+                &Key::int(5),
+                &disabled,
+                DisabledBehavior::Skip,
+                true
+            ),
+            None
+        );
+        assert_eq!(
+            first_enabled_key(&collection, &disabled, DisabledBehavior::Skip),
+            None
+        );
+        assert_eq!(
+            last_enabled_key(&collection, &disabled, DisabledBehavior::Skip),
+            None
+        );
+    }
+}

--- a/crates/ars-collections/src/selection.rs
+++ b/crates/ars-collections/src/selection.rs
@@ -1,0 +1,834 @@
+use alloc::{boxed::Box, collections::BTreeSet};
+
+use crate::{Collection, key::Key};
+
+/// Whether and how many items can be selected simultaneously.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum Mode {
+    /// No items can be selected. Focus still moves through the list.
+    #[default]
+    None,
+
+    /// Exactly one item can be selected at a time.
+    Single,
+
+    /// Any number of items may be selected independently.
+    Multiple,
+}
+
+/// Controls how pointer and keyboard selection affect the current selection.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum Behavior {
+    /// Toggling an item preserves the rest of the current selection.
+    #[default]
+    Toggle,
+
+    /// Selecting an item replaces the current selection.
+    Replace,
+}
+
+/// The set of currently selected keys.
+///
+/// `All` represents "every item is selected", including items not yet loaded
+/// in async or paginated collections.
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+#[non_exhaustive]
+pub enum Set {
+    /// No items are selected.
+    #[default]
+    Empty,
+
+    /// Exactly one item is selected.
+    Single(Key),
+
+    /// Multiple items are selected.
+    Multiple(BTreeSet<Key>),
+
+    /// All items are selected.
+    All,
+}
+
+impl Set {
+    /// Returns `true` when `key` is part of this selection.
+    #[must_use]
+    pub fn contains(&self, key: &Key) -> bool {
+        match self {
+            Self::Empty => false,
+            Self::Single(selected) => selected == key,
+            Self::Multiple(selected) => selected.contains(key),
+            Self::All => true,
+        }
+    }
+
+    /// Returns `true` when no items are selected.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        matches!(self, Self::Empty)
+    }
+
+    /// Returns `true` when all items are selected.
+    #[must_use]
+    pub const fn is_all(&self) -> bool {
+        matches!(self, Self::All)
+    }
+
+    /// Returns the first selected key when one is available.
+    #[must_use]
+    pub fn first(&self) -> Option<&Key> {
+        match self {
+            Self::Single(key) => Some(key),
+            Self::Multiple(keys) => keys.first(),
+            Self::Empty | Self::All => None,
+        }
+    }
+
+    /// Returns the number of selected items, or `None` for `All`.
+    #[must_use]
+    pub fn count(&self) -> Option<usize> {
+        match self {
+            Self::Empty => Some(0),
+            Self::Single(_) => Some(1),
+            Self::Multiple(keys) => Some(keys.len()),
+            Self::All => None,
+        }
+    }
+
+    /// Returns the number of selected items.
+    ///
+    /// `All` returns `0`; callers that need to distinguish that case should
+    /// prefer [`Self::count`].
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.count().unwrap_or(0)
+    }
+
+    /// Iterates over the selected keys.
+    ///
+    /// `All` returns an empty iterator because it must be resolved against a
+    /// concrete collection.
+    #[must_use]
+    pub fn keys(&self) -> Box<dyn Iterator<Item = &Key> + '_> {
+        match self {
+            Self::Empty | Self::All => Box::new(core::iter::empty()),
+            Self::Single(key) => Box::new(core::iter::once(key)),
+            Self::Multiple(keys) => Box::new(keys.iter()),
+        }
+    }
+}
+
+/// Controls how disabled items behave in selection contexts.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum DisabledBehavior {
+    /// Disabled items are skipped during keyboard navigation.
+    #[default]
+    Skip,
+
+    /// Disabled items are focusable but not selectable.
+    FocusOnly,
+}
+
+/// The full selection state for a collection-based component.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct State {
+    /// Which items are currently selected.
+    pub selected_keys: Set,
+
+    /// The anchor for range selection.
+    pub anchor_key: Option<Key>,
+
+    /// The item that currently has focus.
+    pub focused_key: Option<Key>,
+
+    /// Keys that are disabled and excluded from selection operations.
+    pub disabled_keys: BTreeSet<Key>,
+
+    /// Controls how disabled items behave.
+    pub disabled_behavior: DisabledBehavior,
+
+    /// Selection mode for this instance.
+    pub mode: Mode,
+
+    /// Selection behavior for this instance.
+    pub behavior: Behavior,
+
+    /// Whether touch-based selection mode is currently active.
+    pub selection_mode_active: bool,
+
+    /// When set, further selections are blocked once the limit is reached.
+    pub max_selection: Option<usize>,
+}
+
+impl State {
+    /// Creates a new selection state with the given mode and behavior.
+    #[must_use]
+    pub fn new(mode: Mode, behavior: Behavior) -> Self {
+        Self {
+            mode,
+            behavior,
+            ..Self::default()
+        }
+    }
+
+    /// Returns `true` when `key` is currently selected.
+    #[must_use]
+    pub fn is_selected(&self, key: &Key) -> bool {
+        self.selected_keys.contains(key)
+    }
+
+    /// Returns `true` when `key` is disabled.
+    #[must_use]
+    pub fn is_disabled(&self, key: &Key) -> bool {
+        self.disabled_keys.contains(key)
+    }
+
+    /// Selects `key`, respecting the current mode and behavior.
+    #[must_use]
+    pub fn select(&self, key: Key) -> Self {
+        if self.mode == Mode::None || self.is_disabled(&key) {
+            return self.clone();
+        }
+
+        let selected_keys = match self.mode {
+            Mode::None => return self.clone(),
+            Mode::Single => Set::Single(key.clone()),
+            Mode::Multiple => match self.behavior {
+                Behavior::Toggle => {
+                    let mut selected = match &self.selected_keys {
+                        Set::Multiple(existing) => existing.clone(),
+                        Set::Single(existing) => {
+                            let mut keys = BTreeSet::new();
+                            keys.insert(existing.clone());
+                            keys
+                        }
+                        Set::All => return self.clone(),
+                        Set::Empty => BTreeSet::new(),
+                    };
+                    selected.insert(key.clone());
+                    Set::Multiple(selected)
+                }
+                Behavior::Replace => {
+                    let mut selected = BTreeSet::new();
+                    selected.insert(key.clone());
+                    Set::Multiple(selected)
+                }
+            },
+        };
+
+        Self {
+            selected_keys,
+            anchor_key: Some(key),
+            ..self.clone()
+        }
+    }
+
+    /// Deselects `key` if it is currently selected.
+    #[must_use]
+    pub fn deselect(&self, key: &Key) -> Self {
+        let selected_keys = match &self.selected_keys {
+            Set::All | Set::Empty => return self.clone(),
+            Set::Single(selected) => {
+                if selected == key {
+                    Set::Empty
+                } else {
+                    return self.clone();
+                }
+            }
+            Set::Multiple(selected) => {
+                let mut next = selected.clone();
+                next.remove(key);
+                if next.is_empty() {
+                    Set::Empty
+                } else {
+                    Set::Multiple(next)
+                }
+            }
+        };
+
+        Self {
+            selected_keys: selected_keys.clone(),
+            selection_mode_active: self.selection_mode_active && !selected_keys.is_empty(),
+            ..self.clone()
+        }
+    }
+
+    /// Deselects `key` when the current selection is [`Set::All`].
+    #[must_use]
+    pub fn deselect_from_all<T, C: Collection<T>>(&self, key: &Key, collection: &C) -> Self {
+        match &self.selected_keys {
+            Set::All => {
+                let remaining = collection
+                    .item_keys()
+                    .filter(|candidate| *candidate != key)
+                    .cloned()
+                    .collect();
+                Self {
+                    selected_keys: Set::Multiple(remaining),
+                    ..self.clone()
+                }
+            }
+            _ => self.deselect(key),
+        }
+    }
+
+    /// Toggles the selection state of `key`.
+    #[must_use]
+    pub fn toggle<T, C: Collection<T>>(&self, key: Key, collection: &C) -> Self {
+        if self.is_selected(&key) {
+            match &self.selected_keys {
+                Set::All => self.deselect_from_all(&key, collection),
+                _ => self.deselect(&key),
+            }
+        } else {
+            self.select(key)
+        }
+    }
+
+    /// Selects all items when the mode is [`Mode::Multiple`].
+    #[must_use]
+    pub fn select_all(&self) -> Self {
+        if self.mode != Mode::Multiple {
+            return self.clone();
+        }
+
+        Self {
+            selected_keys: Set::All,
+            ..self.clone()
+        }
+    }
+
+    /// Clears the selection.
+    #[must_use]
+    pub fn clear(&self) -> Self {
+        Self {
+            selected_keys: Set::Empty,
+            anchor_key: None,
+            selection_mode_active: false,
+            ..self.clone()
+        }
+    }
+
+    /// Extends the selection from the current anchor to `key`.
+    #[must_use]
+    pub fn extend_selection<T: Clone, C: Collection<T>>(&self, key: Key, collection: &C) -> Self {
+        if self.mode == Mode::None {
+            return self.clone();
+        }
+        if self.mode == Mode::Single {
+            return self.select(key);
+        }
+
+        let anchor = match &self.anchor_key {
+            Some(anchor) => anchor.clone(),
+            None => return self.select(key),
+        };
+
+        if !collection.contains_key(&anchor) {
+            return self.select(key);
+        }
+
+        let mut in_range = false;
+        let mut range_keys = BTreeSet::new();
+
+        for node in collection.nodes() {
+            if !node.is_focusable() {
+                continue;
+            }
+
+            let is_anchor = node.key == anchor;
+            let is_target = node.key == key;
+
+            if is_anchor || is_target {
+                in_range = !in_range;
+                if !self.is_disabled(&node.key) {
+                    range_keys.insert(node.key.clone());
+                }
+            } else if in_range && !self.is_disabled(&node.key) {
+                range_keys.insert(node.key.clone());
+            }
+
+            if is_anchor && is_target {
+                break;
+            }
+        }
+
+        let existing = match &self.selected_keys {
+            Set::Multiple(selected) => selected.clone(),
+            _ => BTreeSet::new(),
+        };
+        let merged = existing.into_iter().chain(range_keys).collect();
+
+        Self {
+            selected_keys: Set::Multiple(merged),
+            focused_key: Some(key),
+            ..self.clone()
+        }
+    }
+
+    /// Sets the focused key without changing the selection.
+    #[must_use]
+    pub fn set_focus(&self, key: Key) -> Self {
+        Self {
+            focused_key: Some(key),
+            ..self.clone()
+        }
+    }
+
+    /// Replaces the disabled key set.
+    #[must_use]
+    pub fn with_disabled(self, disabled_keys: BTreeSet<Key>) -> Self {
+        Self {
+            disabled_keys,
+            ..self
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::{collections::BTreeSet, vec, vec::Vec};
+
+    use super::*;
+    use crate::CollectionBuilder;
+
+    fn fixture_collection() -> crate::StaticCollection<&'static str> {
+        CollectionBuilder::new()
+            .item(Key::int(1), "One", "one")
+            .section(Key::str("group"), "Group")
+            .item(Key::int(2), "Two", "two")
+            .item(Key::int(3), "Three", "three")
+            .separator()
+            .item(Key::int(4), "Four", "four")
+            .end_section()
+            .item(Key::int(5), "Five", "five")
+            .build()
+    }
+
+    fn multiple_toggle_state() -> State {
+        State::new(Mode::Multiple, Behavior::Toggle)
+    }
+
+    #[test]
+    fn mode_default_is_none() {
+        assert_eq!(Mode::default(), Mode::None);
+    }
+
+    #[test]
+    fn behavior_default_is_toggle() {
+        assert_eq!(Behavior::default(), Behavior::Toggle);
+    }
+
+    #[test]
+    fn disabled_behavior_default_is_skip() {
+        assert_eq!(DisabledBehavior::default(), DisabledBehavior::Skip);
+    }
+
+    #[test]
+    fn set_helpers_cover_all_variants() {
+        let mut selected = BTreeSet::new();
+        selected.insert(Key::int(1));
+        selected.insert(Key::int(2));
+
+        let empty = Set::Empty;
+        let single = Set::Single(Key::int(3));
+        let multiple = Set::Multiple(selected);
+        let all = Set::All;
+
+        assert!(!empty.contains(&Key::int(1)));
+        assert!(single.contains(&Key::int(3)));
+        assert!(multiple.contains(&Key::int(2)));
+        assert!(all.contains(&Key::int(999)));
+
+        assert!(empty.is_empty());
+        assert!(!single.is_empty());
+        assert!(all.is_all());
+
+        assert_eq!(empty.first(), None);
+        assert_eq!(single.first(), Some(&Key::int(3)));
+        assert_eq!(multiple.first(), Some(&Key::int(1)));
+        assert_eq!(all.first(), None);
+
+        assert_eq!(empty.count(), Some(0));
+        assert_eq!(single.count(), Some(1));
+        assert_eq!(multiple.count(), Some(2));
+        assert_eq!(all.count(), None);
+
+        assert_eq!(all.len(), 0);
+        assert_eq!(single.len(), 1);
+
+        let empty_keys: Vec<_> = empty.keys().cloned().collect();
+        let single_keys: Vec<_> = single.keys().cloned().collect();
+        let multiple_keys: Vec<_> = multiple.keys().cloned().collect();
+        let all_keys: Vec<_> = all.keys().cloned().collect();
+
+        assert!(empty_keys.is_empty());
+        assert_eq!(single_keys, vec![Key::int(3)]);
+        assert_eq!(multiple_keys, vec![Key::int(1), Key::int(2)]);
+        assert!(all_keys.is_empty());
+    }
+
+    #[test]
+    fn state_new_sets_mode_and_behavior() {
+        let state = State::new(Mode::Single, Behavior::Replace);
+        assert_eq!(state.mode, Mode::Single);
+        assert_eq!(state.behavior, Behavior::Replace);
+        assert_eq!(state.selected_keys, Set::Empty);
+        assert_eq!(state.anchor_key, None);
+        assert_eq!(state.focused_key, None);
+        assert_eq!(state.disabled_behavior, DisabledBehavior::Skip);
+        assert!(!state.selection_mode_active);
+        assert_eq!(state.max_selection, None);
+    }
+
+    #[test]
+    fn select_is_noop_in_none_mode() {
+        let state = State::new(Mode::None, Behavior::Toggle);
+        assert_eq!(state.select(Key::int(1)), state);
+    }
+
+    #[test]
+    fn select_replaces_in_single_mode() {
+        let state = State::new(Mode::Single, Behavior::Toggle).select(Key::int(1));
+        let next = state.select(Key::int(2));
+
+        assert_eq!(next.selected_keys, Set::Single(Key::int(2)));
+        assert_eq!(next.anchor_key, Some(Key::int(2)));
+    }
+
+    #[test]
+    fn select_accumulates_in_multiple_toggle_mode() {
+        let state = multiple_toggle_state()
+            .select(Key::int(1))
+            .select(Key::int(2));
+
+        let Set::Multiple(selected) = state.selected_keys else {
+            panic!("expected multiple selection");
+        };
+        assert_eq!(
+            selected.into_iter().collect::<Vec<_>>(),
+            vec![Key::int(1), Key::int(2)]
+        );
+    }
+
+    #[test]
+    fn select_materializes_single_into_multiple_toggle_mode() {
+        let state = State {
+            selected_keys: Set::Single(Key::int(1)),
+            ..multiple_toggle_state()
+        };
+
+        let next = state.select(Key::int(2));
+        let Set::Multiple(selected) = next.selected_keys else {
+            panic!("expected multiple selection");
+        };
+        assert_eq!(
+            selected.into_iter().collect::<Vec<_>>(),
+            vec![Key::int(1), Key::int(2)]
+        );
+    }
+
+    #[test]
+    fn select_is_noop_when_all_is_already_selected() {
+        let state = State {
+            selected_keys: Set::All,
+            anchor_key: Some(Key::int(1)),
+            ..multiple_toggle_state()
+        };
+
+        assert_eq!(state.select(Key::int(3)), state);
+    }
+
+    #[test]
+    fn select_replaces_in_multiple_replace_mode() {
+        let state = State::new(Mode::Multiple, Behavior::Replace)
+            .select(Key::int(1))
+            .select(Key::int(2));
+
+        let Set::Multiple(selected) = state.selected_keys else {
+            panic!("expected multiple selection");
+        };
+        assert_eq!(selected.into_iter().collect::<Vec<_>>(), vec![Key::int(2)]);
+    }
+
+    #[test]
+    fn select_is_noop_for_disabled_key() {
+        let state = State::new(Mode::Multiple, Behavior::Toggle).with_disabled({
+            let mut disabled = BTreeSet::new();
+            disabled.insert(Key::int(2));
+            disabled
+        });
+
+        assert_eq!(state.select(Key::int(2)), state);
+    }
+
+    #[test]
+    fn deselect_clears_selection_mode_when_last_item_removed() {
+        let state = State {
+            selected_keys: Set::Single(Key::int(1)),
+            selection_mode_active: true,
+            ..State::new(Mode::Multiple, Behavior::Toggle)
+        };
+
+        let next = state.deselect(&Key::int(1));
+        assert_eq!(next.selected_keys, Set::Empty);
+        assert!(!next.selection_mode_active);
+    }
+
+    #[test]
+    fn deselect_is_noop_for_empty_and_all_selection() {
+        let empty = multiple_toggle_state();
+        assert_eq!(empty.deselect(&Key::int(1)), empty);
+
+        let all = State {
+            selected_keys: Set::All,
+            ..multiple_toggle_state()
+        };
+        assert_eq!(all.deselect(&Key::int(1)), all);
+    }
+
+    #[test]
+    fn deselect_is_noop_for_nonmatching_single_selection() {
+        let state = State {
+            selected_keys: Set::Single(Key::int(1)),
+            ..multiple_toggle_state()
+        };
+
+        assert_eq!(state.deselect(&Key::int(2)), state);
+    }
+
+    #[test]
+    fn deselect_removes_key_from_multiple_selection() {
+        let state = State {
+            selected_keys: Set::Multiple(BTreeSet::from([Key::int(1), Key::int(2)])),
+            selection_mode_active: true,
+            ..multiple_toggle_state()
+        };
+
+        let next = state.deselect(&Key::int(2));
+        assert_eq!(
+            next.selected_keys,
+            Set::Multiple(BTreeSet::from([Key::int(1)]))
+        );
+        assert!(next.selection_mode_active);
+    }
+
+    #[test]
+    fn deselect_can_empty_multiple_selection() {
+        let state = State {
+            selected_keys: Set::Multiple(BTreeSet::from([Key::int(2)])),
+            selection_mode_active: true,
+            ..multiple_toggle_state()
+        };
+
+        let next = state.deselect(&Key::int(2));
+        assert_eq!(next.selected_keys, Set::Empty);
+        assert!(!next.selection_mode_active);
+    }
+
+    #[test]
+    fn toggle_from_all_uses_collection_complement() {
+        let collection = fixture_collection();
+        let state = State {
+            selected_keys: Set::All,
+            ..multiple_toggle_state()
+        };
+
+        let next = state.toggle(Key::int(3), &collection);
+        let Set::Multiple(selected) = next.selected_keys else {
+            panic!("expected concrete selection");
+        };
+
+        assert!(!selected.contains(&Key::int(3)));
+        assert_eq!(selected.len(), 4);
+    }
+
+    #[test]
+    fn toggle_deselects_selected_key_from_concrete_selection() {
+        let collection = fixture_collection();
+        let state = State {
+            selected_keys: Set::Multiple(BTreeSet::from([Key::int(1), Key::int(2)])),
+            ..multiple_toggle_state()
+        };
+
+        let next = state.toggle(Key::int(2), &collection);
+        assert_eq!(
+            next.selected_keys,
+            Set::Multiple(BTreeSet::from([Key::int(1)]))
+        );
+    }
+
+    #[test]
+    fn toggle_selects_unselected_key() {
+        let collection = fixture_collection();
+        let state = multiple_toggle_state().select(Key::int(1));
+
+        let next = state.toggle(Key::int(2), &collection);
+        assert_eq!(
+            next.selected_keys,
+            Set::Multiple(BTreeSet::from([Key::int(1), Key::int(2)]))
+        );
+    }
+
+    #[test]
+    fn select_all_only_applies_in_multiple_mode() {
+        let single = State::new(Mode::Single, Behavior::Toggle).select_all();
+        let multiple = multiple_toggle_state().select_all();
+
+        assert_eq!(single.selected_keys, Set::Empty);
+        assert_eq!(multiple.selected_keys, Set::All);
+    }
+
+    #[test]
+    fn clear_resets_anchor_and_selection_mode() {
+        let state = State {
+            selected_keys: Set::Single(Key::int(1)),
+            anchor_key: Some(Key::int(1)),
+            selection_mode_active: true,
+            ..multiple_toggle_state()
+        };
+
+        let next = state.clear();
+        assert_eq!(next.selected_keys, Set::Empty);
+        assert_eq!(next.anchor_key, None);
+        assert!(!next.selection_mode_active);
+    }
+
+    #[test]
+    fn extend_selection_collects_focusable_range() {
+        let collection = fixture_collection();
+        let state = State {
+            anchor_key: Some(Key::int(2)),
+            selected_keys: Set::Single(Key::int(2)),
+            ..multiple_toggle_state()
+        };
+
+        let next = state.extend_selection(Key::int(5), &collection);
+        let Set::Multiple(selected) = next.selected_keys else {
+            panic!("expected multiple selection");
+        };
+
+        assert_eq!(
+            selected.into_iter().collect::<Vec<_>>(),
+            vec![Key::int(2), Key::int(3), Key::int(4), Key::int(5)]
+        );
+        assert_eq!(next.focused_key, Some(Key::int(5)));
+        assert_eq!(next.anchor_key, Some(Key::int(2)));
+    }
+
+    #[test]
+    fn extend_selection_is_noop_in_none_mode() {
+        let collection = fixture_collection();
+        let state = State {
+            anchor_key: Some(Key::int(2)),
+            ..State::new(Mode::None, Behavior::Toggle)
+        };
+
+        assert_eq!(state.extend_selection(Key::int(5), &collection), state);
+    }
+
+    #[test]
+    fn extend_selection_delegates_to_select_in_single_mode() {
+        let collection = fixture_collection();
+        let state = State {
+            anchor_key: Some(Key::int(2)),
+            ..State::new(Mode::Single, Behavior::Toggle)
+        };
+
+        let next = state.extend_selection(Key::int(5), &collection);
+        assert_eq!(next.selected_keys, Set::Single(Key::int(5)));
+        assert_eq!(next.anchor_key, Some(Key::int(5)));
+    }
+
+    #[test]
+    fn extend_selection_skips_disabled_keys() {
+        let collection = fixture_collection();
+        let state = State {
+            anchor_key: Some(Key::int(2)),
+            disabled_keys: BTreeSet::from([Key::int(3)]),
+            selected_keys: Set::Single(Key::int(2)),
+            ..multiple_toggle_state()
+        };
+
+        let next = state.extend_selection(Key::int(4), &collection);
+        let Set::Multiple(selected) = next.selected_keys else {
+            panic!("expected multiple selection");
+        };
+
+        assert_eq!(
+            selected.into_iter().collect::<Vec<_>>(),
+            vec![Key::int(2), Key::int(4)]
+        );
+    }
+
+    #[test]
+    fn extend_selection_same_key_yields_single_item_range() {
+        let collection = fixture_collection();
+        let state = State {
+            anchor_key: Some(Key::int(3)),
+            ..multiple_toggle_state()
+        };
+
+        let next = state.extend_selection(Key::int(3), &collection);
+        let Set::Multiple(selected) = next.selected_keys else {
+            panic!("expected multiple selection");
+        };
+
+        assert_eq!(selected.into_iter().collect::<Vec<_>>(), vec![Key::int(3)]);
+    }
+
+    #[test]
+    fn extend_selection_merges_range_with_existing_multiple_selection() {
+        let collection = fixture_collection();
+        let state = State {
+            anchor_key: Some(Key::int(3)),
+            selected_keys: Set::Multiple(BTreeSet::from([Key::int(1)])),
+            ..multiple_toggle_state()
+        };
+
+        let next = state.extend_selection(Key::int(5), &collection);
+        assert_eq!(
+            next.selected_keys,
+            Set::Multiple(BTreeSet::from([
+                Key::int(1),
+                Key::int(3),
+                Key::int(4),
+                Key::int(5),
+            ]))
+        );
+    }
+
+    #[test]
+    fn extend_selection_falls_back_when_anchor_is_stale() {
+        let collection = fixture_collection();
+        let state = State {
+            anchor_key: Some(Key::int(999)),
+            ..multiple_toggle_state()
+        };
+
+        let next = state.extend_selection(Key::int(4), &collection);
+        assert_eq!(
+            next.selected_keys,
+            Set::Multiple(BTreeSet::from([Key::int(4)]))
+        );
+        assert_eq!(next.anchor_key, Some(Key::int(4)));
+    }
+
+    #[test]
+    fn extend_selection_without_anchor_falls_back_to_select() {
+        let collection = fixture_collection();
+        let state = multiple_toggle_state();
+
+        let next = state.extend_selection(Key::int(1), &collection);
+        assert_eq!(
+            next.selected_keys,
+            Set::Multiple(BTreeSet::from([Key::int(1)]))
+        );
+        assert_eq!(next.anchor_key, Some(Key::int(1)));
+    }
+
+    #[test]
+    fn set_focus_updates_only_focus() {
+        let state = multiple_toggle_state().set_focus(Key::int(4));
+        assert_eq!(state.focused_key, Some(Key::int(4)));
+        assert_eq!(state.selected_keys, Set::Empty);
+    }
+}

--- a/crates/ars-forms/Cargo.toml
+++ b/crates/ars-forms/Cargo.toml
@@ -12,10 +12,11 @@ default = []
 serde   = []
 
 [dependencies]
-ars-a11y = { path = "../ars-a11y" }
-ars-core = { path = "../ars-core" }
-ars-i18n = { path = "../ars-i18n" }
-indexmap = "2"
+ars-a11y        = { path = "../ars-a11y" }
+ars-collections = { path = "../ars-collections" }
+ars-core        = { path = "../ars-core" }
+ars-i18n        = { path = "../ars-i18n" }
+indexmap        = "2"
 
 [lints]
 workspace = true

--- a/crates/ars-forms/src/field/value_ext.rs
+++ b/crates/ars-forms/src/field/value_ext.rs
@@ -2,8 +2,9 @@
 //!
 //! [`ValueExt`] provides an `is_empty()` method for [`Value`] and
 //! related types. [`SelectionExt`] and [`CheckboxExt`] are trait
-//! definitions for component-specific emptiness semantics — their
-//! implementations live in the respective component crates.
+//! definitions for component-specific emptiness semantics.
+
+use ars_collections::selection::{Set as SelectionSet, State as SelectionState};
 
 use super::value::Value;
 
@@ -15,8 +16,9 @@ pub trait ValueExt {
 
 /// Trait for types that expose a set of selected keys (e.g., `selection::State`).
 ///
-/// Implemented by the selection module in its own crate to avoid a dependency
-/// cycle where ars-forms would import concrete types from component crates.
+/// `ars-forms` implements this trait for shared foundation types such as
+/// [`ars_collections::selection::State`] so form components can reason about
+/// collection-backed values without redefining selection semantics locally.
 pub trait SelectionExt {
     /// Returns `true` if at least one key is selected.
     fn is_any_selected(&self) -> bool;
@@ -50,6 +52,21 @@ impl ValueExt for Value {
             Value::DateRange(r) => r.is_none(),
             Value::File(f) => f.is_empty(),
             Value::MultipleText(l) => l.is_empty(),
+        }
+    }
+}
+
+impl SelectionExt for SelectionState {
+    fn is_any_selected(&self) -> bool {
+        !self.selected_keys.is_empty()
+    }
+
+    fn is_all_selected(&self, total_items: usize) -> bool {
+        match &self.selected_keys {
+            SelectionSet::All => true,
+            SelectionSet::Single(_) => total_items == 1,
+            SelectionSet::Multiple(keys) => keys.len() == total_items,
+            _ => false,
         }
     }
 }
@@ -113,6 +130,21 @@ mod tests {
     }
 
     #[test]
+    fn date_none_empty() {
+        assert!(Value::Date(None).is_empty());
+    }
+
+    #[test]
+    fn time_none_empty() {
+        assert!(Value::Time(None).is_empty());
+    }
+
+    #[test]
+    fn date_range_none_empty() {
+        assert!(Value::DateRange(None).is_empty());
+    }
+
+    #[test]
     fn calendar_date_none_empty() {
         let date: Option<ars_i18n::CalendarDate> = None;
         assert!(date.is_empty());
@@ -128,5 +160,58 @@ mod tests {
     fn option_f64_some_not_empty() {
         let n: Option<f64> = Some(42.0);
         assert!(!n.is_empty());
+    }
+
+    #[test]
+    fn selection_state_is_any_selected_for_single() {
+        let state = SelectionState {
+            selected_keys: SelectionSet::Single(ars_collections::Key::int(1)),
+            ..SelectionState::default()
+        };
+        assert!(state.is_any_selected());
+    }
+
+    #[test]
+    fn selection_state_is_any_selected_false_for_empty() {
+        assert!(!SelectionState::default().is_any_selected());
+    }
+
+    #[test]
+    fn selection_state_is_all_selected_true_for_all_variant() {
+        let state = SelectionState {
+            selected_keys: SelectionSet::All,
+            ..SelectionState::default()
+        };
+        assert!(state.is_all_selected(5));
+    }
+
+    #[test]
+    fn selection_state_single_is_all_selected_only_for_single_item_collections() {
+        let state = SelectionState {
+            selected_keys: SelectionSet::Single(ars_collections::Key::int(1)),
+            ..SelectionState::default()
+        };
+
+        assert!(state.is_all_selected(1));
+        assert!(!state.is_all_selected(2));
+    }
+
+    #[test]
+    fn selection_state_is_all_selected_counts_materialized_keys() {
+        let state = SelectionState {
+            selected_keys: SelectionSet::Multiple(
+                [
+                    ars_collections::Key::int(1),
+                    ars_collections::Key::int(2),
+                    ars_collections::Key::int(3),
+                ]
+                .into_iter()
+                .collect(),
+            ),
+            ..SelectionState::default()
+        };
+
+        assert!(state.is_all_selected(3));
+        assert!(!state.is_all_selected(4));
     }
 }

--- a/spec/foundation/06-collections.md
+++ b/spec/foundation/06-collections.md
@@ -2367,7 +2367,8 @@ impl State {
                             s.insert(k.clone());
                             s
                         }
-                        _ => BTreeSet::new(),
+                        selection::Set::All => return self.clone(),
+                        selection::Set::Empty => BTreeSet::new(),
                     };
                     s.insert(key.clone());
                     selection::Set::Multiple(s)
@@ -2455,6 +2456,7 @@ impl State {
         Self {
             selected_keys: selection::Set::Empty,
             anchor_key: None,
+            selection_mode_active: false,
             ..self.clone()
         }
     }

--- a/spec/foundation/07-forms.md
+++ b/spec/foundation/07-forms.md
@@ -2161,15 +2161,13 @@ pub trait ValueExt {
     fn is_empty(&self) -> bool;
 }
 
-// NOTE: Extension traits for selection::State and CheckboxState are defined in
-// their respective component modules (shared/selection-patterns.md and
-// components/input/checkbox.md) to avoid a dependency cycle where ars-forms
-// would import concrete types from component crates.
-//
-// ars-forms only defines abstract trait bounds that components can satisfy:
+// NOTE: Checkbox-specific extension impls still live with the checkbox types.
+// `SelectionExt` remains defined in ars-forms, but ars-forms may implement it
+// for shared foundation selection types via an `ars-collections` dependency.
 
 /// Trait for types that expose a set of selected keys (e.g., selection::State).
-/// Implemented by the selection module in its own crate.
+/// Implemented in ars-forms for shared selection types such as
+/// `ars_collections::selection::State`.
 pub trait SelectionExt {
     fn is_any_selected(&self) -> bool;
     fn is_all_selected(&self, total_items: usize) -> bool;


### PR DESCRIPTION
## Summary

Implement the remaining selection foundation in `ars-collections` and wire forms-side selection support to the new API.

## What Changed

- replaced the old public `Selection<T>` stub with the spec-defined `selection` module
- added disabled-aware navigation helpers in `crates/ars-collections/src/navigation.rs`
- re-exported `DisabledBehavior` at the crate root to match the spec examples
- updated `ars-forms` to depend on `ars-collections` and implement `SelectionExt` for `selection::State`
- synced the collections and forms specs with the implemented behavior
- expanded edge-path tests and coverage for selection, navigation, and forms integration

## Why

Issue `#64` called for the spec-defined selection model, including `Set::All`, disabled-aware navigation, and the removal of the old placeholder API. The forms integration and spec updates keep the contract aligned across crates and avoid leaving spec drift behind.

## User Impact

Consumers of `ars-collections` now get the module-based selection API described by the foundation spec, along with explicit disabled-navigation helpers. Forms code can also treat `selection::State` as a first-class selection value through `SelectionExt`.

## Validation

- `cargo test -p ars-collections`
- `cargo test -p ars-forms`
- `cargo clippy -p ars-collections --tests -- -D warnings`
- `cargo clippy -p ars-forms --tests -- -D warnings`
- `cargo llvm-cov test -p ars-collections --lib`
- `cargo llvm-cov test -p ars-forms --lib`

Closes #64