### PR TITLE
feat(xtask): add cargo xci local CI runner

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,5 @@
 [alias]
 xtask = "run --package xtask --"
+xci   = "xtask ci"
 xmcp  = "xtask mcp"
 xspec = "xtask spec"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: Cargo fmt
-        run: cargo +nightly fmt --all --check
+      - name: Formatting
+        run: cargo xtask ci fmt
 
   clippy:
     name: Clippy
@@ -36,8 +37,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Install Dioxus desktop system dependencies
         run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev
-      - name: Cargo clippy
-        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+      - name: Clippy
+        run: cargo xtask ci clippy
 
   check:
     name: Workspace Check
@@ -49,8 +50,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Install Dioxus desktop system dependencies
         run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev
-      - name: Cargo check
-        run: cargo check --workspace --all-features
+      - name: Workspace Check
+        run: cargo xtask ci check
 
   unit:
     name: Unit Tests
@@ -60,8 +61,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: Unit test tier
-        run: cargo test -p ars-a11y -p ars-core -p ars-collections -p ars-dom -p ars-interactions -p ars-forms --all-targets --all-features
+      - name: Unit Tests
+        run: cargo xtask ci unit
 
   integration:
     name: Integration Tests
@@ -71,8 +72,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: Integration test tier
-        run: cargo test -p ars-core service_applies_transitions
+      - name: Integration Tests
+        run: cargo xtask ci integration
 
   adapter:
     name: Adapter Tests
@@ -84,8 +85,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Install Dioxus desktop system dependencies
         run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev libxdo-dev
-      - name: Adapter harness tier
-        run: cargo test -p ars-test-harness -p ars-test-harness-leptos -p ars-test-harness-dioxus -p ars-leptos -p ars-dioxus --all-targets --all-features
+      - name: Adapter Tests
+        run: cargo xtask ci adapter
 
   coverage:
     name: Coverage
@@ -98,27 +99,8 @@ jobs:
           components: llvm-tools-preview
       - uses: Swatinem/rust-cache@v2
       - run: cargo install cargo-llvm-cov --locked
-      - name: Generate coverage (lcov)
-        # Exclusions:
-        # - ars-leptos/ars-dioxus: tested via wasm-pack which can't produce lcov;
-        #   coverage is aspirational until WASM instrumentation tooling matures.
-        # - ars-test-harness-*: test infrastructure, not application code; also
-        #   pulls in adapter deps that require system libraries (libgtk, etc.).
-        # - ars-derive: proc-macro crate; runs in the compiler process, not the
-        #   test binary, so cargo-llvm-cov cannot instrument it.
-        # - xtask: build tooling, not shipped code.
-        # See spec/testing/14-ci.md §2 and spec/testing/13-policies.md §4.
-        run: |
-          cargo llvm-cov --workspace \
-            --exclude ars-leptos \
-            --exclude ars-dioxus \
-            --exclude ars-test-harness-leptos \
-            --exclude ars-test-harness-dioxus \
-            --exclude ars-derive \
-            --exclude xtask \
-            --lcov --output-path lcov.info
-      - name: Per-crate threshold checks
-        run: cargo xtask coverage check-all --file lcov.info
+      - name: Coverage
+        run: cargo xtask ci coverage
       - name: Upload to Codecov
         if: always()
         uses: codecov/codecov-action@v4
@@ -137,34 +119,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: feature-flags
-      - name: Check and test feature combinations
-        run: |
-          set -euo pipefail
-          combos=(
-            "-p ars-core --no-default-features"
-            "-p ars-core --features std"
-            "-p ars-core --features serde"
-            "-p ars-core --features debug"
-            "-p ars-core --features ssr"
-            "-p ars-core --features embedded-css"
-            "-p ars-core --features std,ssr"
-            "-p ars-core --features std,serde"
-            "-p ars-core --features std,debug"
-            "-p ars-core --features serde,debug"
-            "-p ars-core --features serde,ssr"
-            "-p ars-core --features debug,ssr"
-            "-p ars-core --features serde,embedded-css"
-            "-p ars-core --features std,serde,debug"
-            "-p ars-core --all-features"
-          )
-          for combo in "${combos[@]}"; do
-            echo "::group::cargo check $combo"
-            cargo check $combo
-            echo "::endgroup::"
-            echo "::group::cargo test $combo --lib"
-            cargo test $combo --lib
-            echo "::endgroup::"
-          done
+      - name: Feature Flags — Core
+        run: cargo xtask ci feature-matrix-core
 
   feature-flags-i18n:
     name: Feature Flags — I18n
@@ -178,32 +134,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: feature-flags
-      - name: Check and test feature combinations
-        run: |
-          set -euo pipefail
-          combos=(
-            "-p ars-i18n --no-default-features --features gregorian,icu4x"
-            "-p ars-i18n --features gregorian,hebrew"
-            "-p ars-i18n --features gregorian,islamic"
-            "-p ars-i18n --features gregorian,hebrew,islamic"
-            "-p ars-i18n --features all-calendars"
-            "-p ars-i18n --features buddhist"
-            "-p ars-i18n --features japanese"
-            "-p ars-i18n --no-default-features --features japanese-extended,icu4x"
-            "-p ars-i18n --features persian"
-            "-p ars-i18n --features chinese"
-            "-p ars-i18n --no-default-features"
-          )
-          for combo in "${combos[@]}"; do
-            echo "::group::cargo check $combo"
-            cargo check $combo
-            echo "::endgroup::"
-            echo "::group::cargo test $combo --lib"
-            cargo test $combo --lib
-            echo "::endgroup::"
-          done
-      - name: Check wasm32 target (no tests)
-        run: cargo check -p ars-i18n --no-default-features --features web-intl --target wasm32-unknown-unknown
+      - name: Feature Flags — I18n
+        run: cargo xtask ci feature-matrix-i18n
 
   feature-flags-subsystems:
     name: Feature Flags — Subsystems
@@ -217,36 +149,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: feature-flags
-      - name: Check and test feature combinations
-        run: |
-          set -euo pipefail
-          combos=(
-            "-p ars-interactions --no-default-features"
-            "-p ars-interactions --features aria-drag-drop-compat"
-            "-p ars-a11y -p ars-interactions --features ars-a11y/aria-drag-drop-compat,ars-interactions/aria-drag-drop-compat"
-            # ars-collections: no-default-features is not tested because
-            # IndexMap requires a hasher (std feature provides RandomState).
-            "-p ars-collections --features i18n"
-            "-p ars-collections --features uuid"
-            "-p ars-collections --features std,uuid"
-            "-p ars-collections --features std,i18n,serde"
-            "-p ars-collections --features std,uuid,i18n"
-            "-p ars-collections --features serde"
-            "-p ars-forms --no-default-features"
-            "-p ars-forms --features serde"
-            "-p ars-dom --no-default-features"
-            "-p ars-dom --features ssr"
-          )
-          for combo in "${combos[@]}"; do
-            echo "::group::cargo check $combo"
-            cargo check $combo
-            echo "::endgroup::"
-            echo "::group::cargo test $combo --lib"
-            cargo test $combo --lib
-            echo "::endgroup::"
-          done
-      - name: Check wasm32 target (no tests)
-        run: cargo check -p ars-dom --features web --target wasm32-unknown-unknown
+      - name: Feature Flags — Subsystems
+        run: cargo xtask ci feature-matrix-subsystems
 
   feature-flags-leptos:
     name: Feature Flags — Leptos
@@ -258,22 +162,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: feature-flags
-      - name: Check and test feature combinations
-        run: |
-          set -euo pipefail
-          combos=(
-            "-p ars-leptos --features ssr"
-            "-p ars-leptos --features hydrate"
-            "-p ars-leptos --features csr"
-          )
-          for combo in "${combos[@]}"; do
-            echo "::group::cargo check $combo"
-            cargo check $combo
-            echo "::endgroup::"
-            echo "::group::cargo test $combo --lib"
-            cargo test $combo --lib
-            echo "::endgroup::"
-          done
+      - name: Feature Flags — Leptos
+        run: cargo xtask ci feature-matrix-leptos
 
   feature-flags-dioxus:
     name: Feature Flags — Dioxus
@@ -289,25 +179,8 @@ jobs:
           shared-key: feature-flags
       - name: Install Dioxus desktop system dependencies
         run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev libxdo-dev
-      - name: Check and test feature combinations
-        run: |
-          set -euo pipefail
-          combos=(
-            "-p ars-dioxus --features desktop"
-            "-p ars-dioxus --features desktop-dom"
-            "-p ars-dioxus --features mobile"
-            "-p ars-dioxus --features ssr"
-          )
-          for combo in "${combos[@]}"; do
-            echo "::group::cargo check $combo"
-            cargo check $combo
-            echo "::endgroup::"
-            echo "::group::cargo test $combo --lib"
-            cargo test $combo --lib
-            echo "::endgroup::"
-          done
-      - name: Check wasm32 target (no tests)
-        run: cargo check -p ars-dioxus --features web --target wasm32-unknown-unknown
+      - name: Feature Flags — Dioxus
+        run: cargo xtask ci feature-matrix-dioxus
 
   feature-flag-check:
     name: Feature Flag Check

--- a/xtask/src/ci/feature_matrix.rs
+++ b/xtask/src/ci/feature_matrix.rs
@@ -1,0 +1,478 @@
+//! Feature-flag combination definitions for CI matrix testing.
+//!
+//! Each group mirrors a `feature-flags-*` job in `.github/workflows/ci.yml`.
+//! Every combo runs `cargo check` then `cargo test --lib`; cross-checks run
+//! `cargo check --target <triple>` without tests.
+
+use super::Error;
+
+/// Feature-flag test groups, matching CI job names.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum Group {
+    /// `ars-core` feature combinations (15 combos).
+    Core,
+    /// `ars-i18n` feature combinations (11 combos + wasm32 cross-check).
+    I18n,
+    /// `ars-interactions`, `ars-collections`, `ars-forms`, `ars-dom` combos
+    /// (12 combos + wasm32 cross-check).
+    Subsystems,
+    /// `ars-leptos` render-mode combos (3 combos).
+    Leptos,
+    /// `ars-dioxus` platform combos (4 combos + wasm32 cross-check).
+    Dioxus,
+}
+
+/// A single feature combination to check and test.
+struct Combo {
+    /// Arguments passed to both `cargo check` and `cargo test ... --lib`.
+    args: &'static [&'static str],
+}
+
+/// A cross-compilation check (no tests).
+struct CrossCheck {
+    /// Arguments passed to `cargo check`.
+    args: &'static [&'static str],
+    /// Target triple (e.g., `wasm32-unknown-unknown`).
+    target: &'static str,
+}
+
+/// Full definition for one feature-flag group.
+struct GroupDef {
+    combos: &'static [Combo],
+    cross_checks: &'static [CrossCheck],
+}
+
+// ---------------------------------------------------------------------------
+// Combo data — mirrors ci.yml exactly
+// ---------------------------------------------------------------------------
+
+static CORE_COMBOS: &[Combo] = &[
+    Combo {
+        args: &["-p", "ars-core", "--no-default-features"],
+    },
+    Combo {
+        args: &["-p", "ars-core", "--features", "std"],
+    },
+    Combo {
+        args: &["-p", "ars-core", "--features", "serde"],
+    },
+    Combo {
+        args: &["-p", "ars-core", "--features", "debug"],
+    },
+    Combo {
+        args: &["-p", "ars-core", "--features", "ssr"],
+    },
+    Combo {
+        args: &["-p", "ars-core", "--features", "embedded-css"],
+    },
+    Combo {
+        args: &["-p", "ars-core", "--features", "std,ssr"],
+    },
+    Combo {
+        args: &["-p", "ars-core", "--features", "std,serde"],
+    },
+    Combo {
+        args: &["-p", "ars-core", "--features", "std,debug"],
+    },
+    Combo {
+        args: &["-p", "ars-core", "--features", "serde,debug"],
+    },
+    Combo {
+        args: &["-p", "ars-core", "--features", "serde,ssr"],
+    },
+    Combo {
+        args: &["-p", "ars-core", "--features", "debug,ssr"],
+    },
+    Combo {
+        args: &["-p", "ars-core", "--features", "serde,embedded-css"],
+    },
+    Combo {
+        args: &["-p", "ars-core", "--features", "std,serde,debug"],
+    },
+    Combo {
+        args: &["-p", "ars-core", "--all-features"],
+    },
+];
+
+static I18N_COMBOS: &[Combo] = &[
+    Combo {
+        args: &[
+            "-p",
+            "ars-i18n",
+            "--no-default-features",
+            "--features",
+            "gregorian,icu4x",
+        ],
+    },
+    Combo {
+        args: &["-p", "ars-i18n", "--features", "gregorian,hebrew"],
+    },
+    Combo {
+        args: &["-p", "ars-i18n", "--features", "gregorian,islamic"],
+    },
+    Combo {
+        args: &["-p", "ars-i18n", "--features", "gregorian,hebrew,islamic"],
+    },
+    Combo {
+        args: &["-p", "ars-i18n", "--features", "all-calendars"],
+    },
+    Combo {
+        args: &["-p", "ars-i18n", "--features", "buddhist"],
+    },
+    Combo {
+        args: &["-p", "ars-i18n", "--features", "japanese"],
+    },
+    Combo {
+        args: &[
+            "-p",
+            "ars-i18n",
+            "--no-default-features",
+            "--features",
+            "japanese-extended,icu4x",
+        ],
+    },
+    Combo {
+        args: &["-p", "ars-i18n", "--features", "persian"],
+    },
+    Combo {
+        args: &["-p", "ars-i18n", "--features", "chinese"],
+    },
+    Combo {
+        args: &["-p", "ars-i18n", "--no-default-features"],
+    },
+];
+
+static I18N_CROSS_CHECKS: &[CrossCheck] = &[CrossCheck {
+    args: &[
+        "-p",
+        "ars-i18n",
+        "--no-default-features",
+        "--features",
+        "web-intl",
+    ],
+    target: "wasm32-unknown-unknown",
+}];
+
+static SUBSYSTEMS_COMBOS: &[Combo] = &[
+    Combo {
+        args: &["-p", "ars-interactions", "--no-default-features"],
+    },
+    Combo {
+        args: &[
+            "-p",
+            "ars-interactions",
+            "--features",
+            "aria-drag-drop-compat",
+        ],
+    },
+    Combo {
+        args: &[
+            "-p",
+            "ars-a11y",
+            "-p",
+            "ars-interactions",
+            "--features",
+            "ars-a11y/aria-drag-drop-compat,ars-interactions/aria-drag-drop-compat",
+        ],
+    },
+    Combo {
+        args: &["-p", "ars-collections", "--features", "i18n"],
+    },
+    Combo {
+        args: &["-p", "ars-collections", "--features", "uuid"],
+    },
+    Combo {
+        args: &["-p", "ars-collections", "--features", "std,uuid"],
+    },
+    Combo {
+        args: &["-p", "ars-collections", "--features", "std,i18n,serde"],
+    },
+    Combo {
+        args: &["-p", "ars-collections", "--features", "std,uuid,i18n"],
+    },
+    Combo {
+        args: &["-p", "ars-collections", "--features", "serde"],
+    },
+    Combo {
+        args: &["-p", "ars-forms", "--no-default-features"],
+    },
+    Combo {
+        args: &["-p", "ars-forms", "--features", "serde"],
+    },
+    Combo {
+        args: &["-p", "ars-dom", "--no-default-features"],
+    },
+    Combo {
+        args: &["-p", "ars-dom", "--features", "ssr"],
+    },
+];
+
+static SUBSYSTEMS_CROSS_CHECKS: &[CrossCheck] = &[CrossCheck {
+    args: &["-p", "ars-dom", "--features", "web"],
+    target: "wasm32-unknown-unknown",
+}];
+
+static LEPTOS_COMBOS: &[Combo] = &[
+    Combo {
+        args: &["-p", "ars-leptos", "--features", "ssr"],
+    },
+    Combo {
+        args: &["-p", "ars-leptos", "--features", "hydrate"],
+    },
+    Combo {
+        args: &["-p", "ars-leptos", "--features", "csr"],
+    },
+];
+
+static DIOXUS_COMBOS: &[Combo] = &[
+    Combo {
+        args: &["-p", "ars-dioxus", "--features", "desktop"],
+    },
+    Combo {
+        args: &["-p", "ars-dioxus", "--features", "desktop-dom"],
+    },
+    Combo {
+        args: &["-p", "ars-dioxus", "--features", "mobile"],
+    },
+    Combo {
+        args: &["-p", "ars-dioxus", "--features", "ssr"],
+    },
+];
+
+static DIOXUS_CROSS_CHECKS: &[CrossCheck] = &[CrossCheck {
+    args: &["-p", "ars-dioxus", "--features", "web"],
+    target: "wasm32-unknown-unknown",
+}];
+
+// ---------------------------------------------------------------------------
+// Lookup
+// ---------------------------------------------------------------------------
+
+fn group_def(group: Group) -> GroupDef {
+    match group {
+        Group::Core => GroupDef {
+            combos: CORE_COMBOS,
+            cross_checks: &[],
+        },
+        Group::I18n => GroupDef {
+            combos: I18N_COMBOS,
+            cross_checks: I18N_CROSS_CHECKS,
+        },
+        Group::Subsystems => GroupDef {
+            combos: SUBSYSTEMS_COMBOS,
+            cross_checks: SUBSYSTEMS_CROSS_CHECKS,
+        },
+        Group::Leptos => GroupDef {
+            combos: LEPTOS_COMBOS,
+            cross_checks: &[],
+        },
+        Group::Dioxus => GroupDef {
+            combos: DIOXUS_COMBOS,
+            cross_checks: DIOXUS_CROSS_CHECKS,
+        },
+    }
+}
+
+/// Map a [`Group`] to the [`CiStep`](super::CiStep) it corresponds to (for
+/// error reporting).
+const fn group_step(group: Group) -> super::Step {
+    match group {
+        Group::Core => super::Step::FeatureMatrixCore,
+        Group::I18n => super::Step::FeatureMatrixI18n,
+        Group::Subsystems => super::Step::FeatureMatrixSubsystems,
+        Group::Leptos => super::Step::FeatureMatrixLeptos,
+        Group::Dioxus => super::Step::FeatureMatrixDioxus,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Preflight
+// ---------------------------------------------------------------------------
+
+/// Verify the `wasm32-unknown-unknown` target is installed.
+fn preflight_wasm32() -> Result<(), Error> {
+    let output = std::process::Command::new("rustup")
+        .args(["target", "list", "--installed"])
+        .output()
+        .map_err(Error::Io)?;
+
+    let installed = String::from_utf8_lossy(&output.stdout);
+    if !installed
+        .lines()
+        .any(|l| l.trim() == "wasm32-unknown-unknown")
+    {
+        return Err(Error::MissingTool {
+            tool: "wasm32-unknown-unknown target".into(),
+            install_hint: "rustup target add wasm32-unknown-unknown".into(),
+        });
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Runner
+// ---------------------------------------------------------------------------
+
+/// Run every combo in `group`: `cargo check` + `cargo test --lib` per combo,
+/// then any cross-compilation checks.
+pub(crate) fn run_group(group: Group) -> Result<(), Error> {
+    let def = group_def(group);
+    let step = group_step(group);
+
+    if !def.cross_checks.is_empty() {
+        preflight_wasm32()?;
+    }
+
+    let total = def.combos.len();
+    for (i, combo) in def.combos.iter().enumerate() {
+        let label = combo.args.join(" ");
+        eprintln!("  [{}/{}] {label}", i + 1, total);
+
+        let mut check_args: Vec<&str> = vec!["check"];
+        check_args.extend_from_slice(combo.args);
+        super::cargo(step, &check_args)?;
+
+        let mut test_args: Vec<&str> = vec!["test"];
+        test_args.extend_from_slice(combo.args);
+        test_args.push("--lib");
+        super::cargo(step, &test_args)?;
+    }
+
+    for cross in def.cross_checks {
+        let label = cross.args.join(" ");
+        eprintln!("  [cross] {label} --target {}", cross.target);
+
+        let mut args: Vec<&str> = vec!["check"];
+        args.extend_from_slice(cross.args);
+        args.extend_from_slice(&["--target", cross.target]);
+        super::cargo(step, &args)?;
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn core_has_15_combos() {
+        assert_eq!(CORE_COMBOS.len(), 15);
+    }
+
+    #[test]
+    fn i18n_has_11_combos_and_1_cross() {
+        assert_eq!(I18N_COMBOS.len(), 11);
+        assert_eq!(I18N_CROSS_CHECKS.len(), 1);
+    }
+
+    #[test]
+    fn subsystems_has_13_combos_and_1_cross() {
+        assert_eq!(SUBSYSTEMS_COMBOS.len(), 13);
+        assert_eq!(SUBSYSTEMS_CROSS_CHECKS.len(), 1);
+    }
+
+    #[test]
+    fn leptos_has_3_combos() {
+        assert_eq!(LEPTOS_COMBOS.len(), 3);
+    }
+
+    #[test]
+    fn dioxus_has_4_combos_and_1_cross() {
+        assert_eq!(DIOXUS_COMBOS.len(), 4);
+        assert_eq!(DIOXUS_CROSS_CHECKS.len(), 1);
+    }
+
+    #[test]
+    fn group_step_mapping_is_exhaustive() {
+        // Ensure every group maps to a distinct step.
+        let groups = [
+            Group::Core,
+            Group::I18n,
+            Group::Subsystems,
+            Group::Leptos,
+            Group::Dioxus,
+        ];
+        let steps: Vec<_> = groups.iter().map(|g| group_step(*g)).collect();
+        for (i, a) in steps.iter().enumerate() {
+            for b in &steps[i + 1..] {
+                assert_ne!(a, b, "duplicate step mapping");
+            }
+        }
+    }
+
+    /// Verify `group_def()` returns the expected data for every group and that
+    /// cross-check counts are consistent with the static arrays.
+    #[test]
+    fn group_def_returns_correct_data() {
+        let cases: &[(Group, usize, usize)] = &[
+            (Group::Core, 15, 0),
+            (Group::I18n, 11, 1),
+            (Group::Subsystems, 13, 1),
+            (Group::Leptos, 3, 0),
+            (Group::Dioxus, 4, 1),
+        ];
+        for &(group, expected_combos, expected_cross) in cases {
+            let def = group_def(group);
+            assert_eq!(
+                def.combos.len(),
+                expected_combos,
+                "{group:?} combo count mismatch"
+            );
+            assert_eq!(
+                def.cross_checks.len(),
+                expected_cross,
+                "{group:?} cross-check count mismatch"
+            );
+        }
+    }
+
+    /// Every cross-check targets wasm32-unknown-unknown.
+    #[test]
+    fn cross_checks_target_wasm32() {
+        let groups = [
+            Group::Core,
+            Group::I18n,
+            Group::Subsystems,
+            Group::Leptos,
+            Group::Dioxus,
+        ];
+        for group in groups {
+            let def = group_def(group);
+            for cross in def.cross_checks {
+                assert_eq!(
+                    cross.target, "wasm32-unknown-unknown",
+                    "{group:?} cross-check has unexpected target: {}",
+                    cross.target
+                );
+            }
+        }
+    }
+
+    /// Every combo has non-empty args starting with `-p`.
+    #[test]
+    fn combo_args_start_with_package_flag() {
+        let groups = [
+            Group::Core,
+            Group::I18n,
+            Group::Subsystems,
+            Group::Leptos,
+            Group::Dioxus,
+        ];
+        for group in groups {
+            let def = group_def(group);
+            for (i, combo) in def.combos.iter().enumerate() {
+                assert!(!combo.args.is_empty(), "{group:?} combo {i} has empty args");
+                assert_eq!(
+                    combo.args[0], "-p",
+                    "{group:?} combo {i} doesn't start with -p: {:?}",
+                    combo.args
+                );
+            }
+        }
+    }
+}

--- a/xtask/src/ci/mod.rs
+++ b/xtask/src/ci/mod.rs
@@ -1,0 +1,613 @@
+//! Local CI pipeline runner.
+//!
+//! Mirrors the jobs declared in `.github/workflows/ci.yml` so that the xtask
+//! crate is the single source of truth for CI commands. Run the full pipeline
+//! with `cargo xci` or pick individual steps with `cargo xci check clippy`.
+
+pub(crate) mod feature_matrix;
+
+use std::{fmt, io, path::Path, process};
+
+/// CI pipeline steps, matching the GitHub Actions job names.
+///
+/// Steps are listed in pipeline dependency order for sequential local
+/// execution. Use [`run`] to execute one or more steps with fail-fast
+/// semantics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, clap::ValueEnum)]
+#[value(rename_all = "kebab-case")]
+pub enum Step {
+    /// `cargo +nightly fmt --all --check`
+    Fmt,
+    /// `cargo check --workspace --all-features`
+    Check,
+    /// `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+    Clippy,
+    /// Unit tests for core crates.
+    Unit,
+    /// Integration tests.
+    Integration,
+    /// Adapter harness tests (Leptos + Dioxus).
+    Adapter,
+    /// Generate coverage and check per-crate thresholds.
+    Coverage,
+    /// Meta-step: run all five feature-matrix groups.
+    FeatureMatrix,
+    /// Feature flags — ars-core (15 combos).
+    FeatureMatrixCore,
+    /// Feature flags — ars-i18n (11 combos + wasm32).
+    FeatureMatrixI18n,
+    /// Feature flags — subsystem crates (13 combos + wasm32).
+    FeatureMatrixSubsystems,
+    /// Feature flags — ars-leptos (3 combos).
+    FeatureMatrixLeptos,
+    /// Feature flags — ars-dioxus (4 combos + wasm32).
+    FeatureMatrixDioxus,
+}
+
+/// Default pipeline order when no steps are specified.
+///
+/// `FeatureMatrix` is intentionally absent — the pipeline runs each sub-group
+/// individually so progress is visible per group.
+const PIPELINE_ORDER: &[Step] = &[
+    Step::Fmt,
+    Step::Check,
+    Step::Clippy,
+    Step::Unit,
+    Step::Integration,
+    Step::Adapter,
+    Step::Coverage,
+    Step::FeatureMatrixCore,
+    Step::FeatureMatrixI18n,
+    Step::FeatureMatrixSubsystems,
+    Step::FeatureMatrixLeptos,
+    Step::FeatureMatrixDioxus,
+];
+
+/// Errors from CI operations.
+#[derive(Debug)]
+pub enum Error {
+    /// A cargo subprocess exited with a non-zero status.
+    StepFailed {
+        /// The step that failed.
+        step: Step,
+        /// The command that was run (for display).
+        command: String,
+        /// Process exit code, if available.
+        code: Option<i32>,
+    },
+    /// A required tool is not installed.
+    MissingTool {
+        /// Human-readable tool name.
+        tool: String,
+        /// How to install it.
+        install_hint: String,
+    },
+    /// IO error spawning a subprocess.
+    Io(io::Error),
+    /// Coverage threshold check failed.
+    Coverage(crate::coverage::Error),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::StepFailed {
+                step,
+                command,
+                code,
+            } => {
+                write!(f, "{} failed", step_name(*step))?;
+                if let Some(code) = code {
+                    write!(f, " (exit code {code})")?;
+                }
+                write!(f, ": {command}")
+            }
+            Self::MissingTool { tool, install_hint } => {
+                write!(
+                    f,
+                    "missing required tool: {tool}\n  install: {install_hint}"
+                )
+            }
+            Self::Io(e) => write!(f, "IO error: {e}"),
+            Self::Coverage(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/// Run the specified CI steps, or the full pipeline if none are given.
+///
+/// Execution is sequential and fail-fast: the first step that fails stops the
+/// pipeline and returns its error.
+///
+/// # Errors
+///
+/// Returns [`CiError`] on the first step that fails — either a subprocess
+/// non-zero exit, a missing tool, or a coverage threshold violation.
+pub fn run(steps: Vec<Step>) -> Result<(), Error> {
+    let steps = resolve_steps(steps);
+
+    for (i, step) in steps.iter().enumerate() {
+        print_header(*step, i + 1, steps.len());
+        run_step(*step)?;
+        print_pass(*step);
+    }
+
+    print_summary(&steps);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Step resolution
+// ---------------------------------------------------------------------------
+
+/// Resolve the user-provided step list into the concrete list to execute.
+///
+/// - Empty input → full [`PIPELINE_ORDER`].
+/// - `FeatureMatrix` → expands to the five individual groups.
+/// - Everything else passes through as-is.
+fn resolve_steps(steps: Vec<Step>) -> Vec<Step> {
+    if steps.is_empty() {
+        return PIPELINE_ORDER.to_vec();
+    }
+
+    let mut resolved = Vec::with_capacity(steps.len());
+    for step in steps {
+        if step == Step::FeatureMatrix {
+            resolved.extend_from_slice(&[
+                Step::FeatureMatrixCore,
+                Step::FeatureMatrixI18n,
+                Step::FeatureMatrixSubsystems,
+                Step::FeatureMatrixLeptos,
+                Step::FeatureMatrixDioxus,
+            ]);
+        } else {
+            resolved.push(step);
+        }
+    }
+    resolved
+}
+
+// ---------------------------------------------------------------------------
+// Step dispatch
+// ---------------------------------------------------------------------------
+
+/// Execute a single CI step.
+fn run_step(step: Step) -> Result<(), Error> {
+    match step {
+        Step::Fmt => run_fmt(),
+        Step::Check => run_check(),
+        Step::Clippy => run_clippy(),
+        Step::Unit => run_unit(),
+        Step::Integration => run_integration(),
+        Step::Adapter => run_adapter(),
+        Step::Coverage => run_coverage(),
+        Step::FeatureMatrix => {
+            unreachable!("FeatureMatrix is expanded by resolve_steps")
+        }
+        Step::FeatureMatrixCore => feature_matrix::run_group(feature_matrix::Group::Core),
+        Step::FeatureMatrixI18n => feature_matrix::run_group(feature_matrix::Group::I18n),
+        Step::FeatureMatrixSubsystems => {
+            feature_matrix::run_group(feature_matrix::Group::Subsystems)
+        }
+        Step::FeatureMatrixLeptos => feature_matrix::run_group(feature_matrix::Group::Leptos),
+        Step::FeatureMatrixDioxus => feature_matrix::run_group(feature_matrix::Group::Dioxus),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Individual step implementations
+// ---------------------------------------------------------------------------
+
+fn run_fmt() -> Result<(), Error> {
+    preflight_nightly()?;
+    cargo(Step::Fmt, &["+nightly", "fmt", "--all", "--check"])
+}
+
+fn run_check() -> Result<(), Error> {
+    cargo(Step::Check, &["check", "--workspace", "--all-features"])
+}
+
+fn run_clippy() -> Result<(), Error> {
+    cargo(
+        Step::Clippy,
+        &[
+            "clippy",
+            "--workspace",
+            "--all-targets",
+            "--all-features",
+            "--",
+            "-D",
+            "warnings",
+        ],
+    )
+}
+
+fn run_unit() -> Result<(), Error> {
+    cargo(
+        Step::Unit,
+        &[
+            "test",
+            "-p",
+            "ars-a11y",
+            "-p",
+            "ars-core",
+            "-p",
+            "ars-collections",
+            "-p",
+            "ars-dom",
+            "-p",
+            "ars-interactions",
+            "-p",
+            "ars-forms",
+            "--all-targets",
+            "--all-features",
+        ],
+    )
+}
+
+fn run_integration() -> Result<(), Error> {
+    cargo(
+        Step::Integration,
+        &["test", "-p", "ars-core", "service_applies_transitions"],
+    )
+}
+
+fn run_adapter() -> Result<(), Error> {
+    cargo(
+        Step::Adapter,
+        &[
+            "test",
+            "-p",
+            "ars-test-harness",
+            "-p",
+            "ars-test-harness-leptos",
+            "-p",
+            "ars-test-harness-dioxus",
+            "-p",
+            "ars-leptos",
+            "-p",
+            "ars-dioxus",
+            "--all-targets",
+            "--all-features",
+        ],
+    )
+}
+
+fn run_coverage() -> Result<(), Error> {
+    preflight_llvm_cov()?;
+
+    // Generate lcov via cargo-llvm-cov.
+    cargo(
+        Step::Coverage,
+        &[
+            "llvm-cov",
+            "--workspace",
+            "--exclude",
+            "ars-leptos",
+            "--exclude",
+            "ars-dioxus",
+            "--exclude",
+            "ars-test-harness-leptos",
+            "--exclude",
+            "ars-test-harness-dioxus",
+            "--exclude",
+            "ars-derive",
+            "--exclude",
+            "xtask",
+            "--lcov",
+            "--output-path",
+            "lcov.info",
+        ],
+    )?;
+
+    // Check thresholds programmatically (reuses coverage module).
+    let thresholds = crate::coverage::default_thresholds();
+    let lcov_path = Path::new("lcov.info");
+    match crate::coverage::check_all(lcov_path, &thresholds) {
+        Ok(output) => {
+            eprint!("{output}");
+            Ok(())
+        }
+        Err(e) => Err(Error::Coverage(e)),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Subprocess helper
+// ---------------------------------------------------------------------------
+
+/// Run `cargo <args>`, inheriting stdout/stderr.
+///
+/// Returns `Ok(())` on exit-code 0, or `CiError::StepFailed` otherwise.
+pub(crate) fn cargo(step: Step, args: &[&str]) -> Result<(), Error> {
+    let display_cmd = format!("cargo {}", args.join(" "));
+    eprintln!("  > {display_cmd}");
+
+    let status = process::Command::new("cargo")
+        .args(args)
+        .status()
+        .map_err(Error::Io)?;
+
+    if status.success() {
+        Ok(())
+    } else {
+        Err(Error::StepFailed {
+            step,
+            command: display_cmd,
+            code: status.code(),
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Preflight checks
+// ---------------------------------------------------------------------------
+
+/// Verify the nightly toolchain is available.
+fn preflight_nightly() -> Result<(), Error> {
+    let output = process::Command::new("rustup")
+        .args(["run", "nightly", "rustc", "--version"])
+        .stdout(process::Stdio::null())
+        .stderr(process::Stdio::null())
+        .status()
+        .map_err(Error::Io)?;
+
+    if !output.success() {
+        return Err(Error::MissingTool {
+            tool: "nightly toolchain".into(),
+            install_hint: "rustup toolchain install nightly".into(),
+        });
+    }
+    Ok(())
+}
+
+/// Verify `cargo-llvm-cov` is installed.
+fn preflight_llvm_cov() -> Result<(), Error> {
+    let output = process::Command::new("cargo")
+        .args(["llvm-cov", "--version"])
+        .stdout(process::Stdio::null())
+        .stderr(process::Stdio::null())
+        .status()
+        .map_err(Error::Io)?;
+
+    if !output.success() {
+        return Err(Error::MissingTool {
+            tool: "cargo-llvm-cov".into(),
+            install_hint: "cargo install cargo-llvm-cov --locked".into(),
+        });
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Output formatting
+// ---------------------------------------------------------------------------
+
+/// Human-readable name for a step (kebab-case).
+const fn step_name(step: Step) -> &'static str {
+    match step {
+        Step::Fmt => "fmt",
+        Step::Check => "check",
+        Step::Clippy => "clippy",
+        Step::Unit => "unit",
+        Step::Integration => "integration",
+        Step::Adapter => "adapter",
+        Step::Coverage => "coverage",
+        Step::FeatureMatrix => "feature-matrix",
+        Step::FeatureMatrixCore => "feature-matrix-core",
+        Step::FeatureMatrixI18n => "feature-matrix-i18n",
+        Step::FeatureMatrixSubsystems => "feature-matrix-subsystems",
+        Step::FeatureMatrixLeptos => "feature-matrix-leptos",
+        Step::FeatureMatrixDioxus => "feature-matrix-dioxus",
+    }
+}
+
+fn print_header(step: Step, current: usize, total: usize) {
+    eprint!("{}", format_header(step, current, total));
+}
+
+fn print_pass(step: Step) {
+    eprint!("{}", format_pass(step));
+}
+
+fn print_summary(steps: &[Step]) {
+    eprint!("{}", format_summary(steps));
+}
+
+/// Format the header banner for a step (testable).
+fn format_header(step: Step, current: usize, total: usize) -> String {
+    format!("\n=== [{current}/{total}] {} ===\n\n", step_name(step))
+}
+
+/// Format the pass message for a step (testable).
+fn format_pass(step: Step) -> String {
+    format!("\n  {} passed\n", step_name(step))
+}
+
+/// Format the final summary (testable).
+fn format_summary(steps: &[Step]) -> String {
+    use fmt::Write as _;
+    let mut out = String::from("\n=== CI Summary ===\n");
+    for step in steps {
+        writeln!(out, "  {}: passed", step_name(*step)).expect("write to String");
+    }
+    writeln!(out, "\nAll {} steps passed.", steps.len()).expect("write to String");
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_steps_resolve_to_pipeline_order() {
+        let resolved = resolve_steps(vec![]);
+        assert_eq!(resolved, PIPELINE_ORDER);
+    }
+
+    #[test]
+    fn explicit_steps_pass_through() {
+        let input = vec![Step::Check, Step::Clippy];
+        let resolved = resolve_steps(input.clone());
+        assert_eq!(resolved, input);
+    }
+
+    #[test]
+    fn feature_matrix_expands_to_five_groups() {
+        let resolved = resolve_steps(vec![Step::FeatureMatrix]);
+        assert_eq!(resolved.len(), 5);
+        assert_eq!(resolved[0], Step::FeatureMatrixCore);
+        assert_eq!(resolved[1], Step::FeatureMatrixI18n);
+        assert_eq!(resolved[2], Step::FeatureMatrixSubsystems);
+        assert_eq!(resolved[3], Step::FeatureMatrixLeptos);
+        assert_eq!(resolved[4], Step::FeatureMatrixDioxus);
+    }
+
+    #[test]
+    fn feature_matrix_expands_in_context() {
+        let resolved = resolve_steps(vec![Step::Fmt, Step::FeatureMatrix, Step::Coverage]);
+        assert_eq!(resolved.len(), 7); // 1 + 5 + 1
+        assert_eq!(resolved[0], Step::Fmt);
+        assert_eq!(resolved[6], Step::Coverage);
+    }
+
+    #[test]
+    fn pipeline_order_does_not_contain_meta_step() {
+        assert!(
+            !PIPELINE_ORDER.contains(&Step::FeatureMatrix),
+            "PIPELINE_ORDER must not include the FeatureMatrix meta-step"
+        );
+    }
+
+    #[test]
+    fn step_names_are_kebab_case() {
+        for &step in PIPELINE_ORDER {
+            let name = step_name(step);
+            assert!(
+                !name.contains('_') && !name.contains(' '),
+                "step name {name:?} is not kebab-case"
+            );
+        }
+    }
+
+    /// Every `CiStep` variant has a non-empty name.
+    #[test]
+    fn step_name_covers_all_variants() {
+        let all = [
+            Step::Fmt,
+            Step::Check,
+            Step::Clippy,
+            Step::Unit,
+            Step::Integration,
+            Step::Adapter,
+            Step::Coverage,
+            Step::FeatureMatrix,
+            Step::FeatureMatrixCore,
+            Step::FeatureMatrixI18n,
+            Step::FeatureMatrixSubsystems,
+            Step::FeatureMatrixLeptos,
+            Step::FeatureMatrixDioxus,
+        ];
+        for step in all {
+            assert!(!step_name(step).is_empty(), "{step:?} has empty name");
+        }
+    }
+
+    // -- CiError::Display tests -----------------------------------------------
+
+    #[test]
+    fn display_step_failed_with_code() {
+        let err = Error::StepFailed {
+            step: Step::Clippy,
+            command: "cargo clippy".into(),
+            code: Some(101),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("clippy failed"), "got: {msg}");
+        assert!(msg.contains("exit code 101"), "got: {msg}");
+        assert!(msg.contains("cargo clippy"), "got: {msg}");
+    }
+
+    #[test]
+    fn display_step_failed_without_code() {
+        let err = Error::StepFailed {
+            step: Step::Fmt,
+            command: "cargo +nightly fmt --all --check".into(),
+            code: None,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("fmt failed"), "got: {msg}");
+        assert!(!msg.contains("exit code"), "got: {msg}");
+    }
+
+    #[test]
+    fn display_missing_tool() {
+        let err = Error::MissingTool {
+            tool: "nightly toolchain".into(),
+            install_hint: "rustup toolchain install nightly".into(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("nightly toolchain"), "got: {msg}");
+        assert!(
+            msg.contains("rustup toolchain install nightly"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn display_io_error() {
+        let err = Error::Io(io::Error::new(io::ErrorKind::NotFound, "no cargo"));
+        let msg = err.to_string();
+        assert!(msg.contains("IO error"), "got: {msg}");
+        assert!(msg.contains("no cargo"), "got: {msg}");
+    }
+
+    #[test]
+    fn display_coverage_error() {
+        let err = Error::Coverage(crate::coverage::Error::NoSourceFiles {
+            package: "ars-core".into(),
+        });
+        let msg = err.to_string();
+        assert!(msg.contains("ars-core"), "got: {msg}");
+    }
+
+    // -- Output formatting tests ----------------------------------------------
+
+    #[test]
+    fn format_header_contains_step_and_progress() {
+        let hdr = format_header(Step::Clippy, 3, 12);
+        assert!(hdr.contains("[3/12]"), "got: {hdr}");
+        assert!(hdr.contains("clippy"), "got: {hdr}");
+    }
+
+    #[test]
+    fn format_pass_contains_step_name() {
+        let msg = format_pass(Step::Unit);
+        assert!(msg.contains("unit passed"), "got: {msg}");
+    }
+
+    #[test]
+    fn format_summary_lists_all_steps() {
+        let steps = vec![Step::Fmt, Step::Check];
+        let summary = format_summary(&steps);
+        assert!(summary.contains("fmt: passed"), "got: {summary}");
+        assert!(summary.contains("check: passed"), "got: {summary}");
+        assert!(summary.contains("All 2 steps passed"), "got: {summary}");
+    }
+
+    #[test]
+    fn format_summary_empty() {
+        let summary = format_summary(&[]);
+        assert!(summary.contains("All 0 steps passed"), "got: {summary}");
+    }
+}

--- a/xtask/src/coverage.rs
+++ b/xtask/src/coverage.rs
@@ -4,7 +4,11 @@
 //! branch coverage against configurable thresholds. Used by CI to gate merges
 //! and by developers for local coverage checks.
 
-use std::{fmt::Write, fs, path::Path};
+use std::{
+    fmt::{self, Write},
+    fs, io,
+    path::Path,
+};
 
 /// Per-crate coverage threshold.
 #[derive(Debug, Clone)]
@@ -73,9 +77,9 @@ pub fn default_thresholds() -> Vec<CrateThreshold> {
 
 /// Errors from coverage operations.
 #[derive(Debug)]
-pub enum CoverageError {
+pub enum Error {
     /// IO error reading the lcov file.
-    Io(std::io::Error),
+    Io(io::Error),
     /// No source files matched the requested package.
     NoSourceFiles {
         /// The package that was looked up.
@@ -88,8 +92,8 @@ pub enum CoverageError {
     },
 }
 
-impl std::fmt::Display for CoverageError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Io(e) => write!(f, "IO error reading lcov file: {e}"),
             Self::NoSourceFiles { package } => {
@@ -104,7 +108,7 @@ impl std::fmt::Display for CoverageError {
     }
 }
 
-impl std::error::Error for CoverageError {}
+impl std::error::Error for Error {}
 
 /// Accumulated coverage counters for a single crate.
 #[derive(Debug, Default)]
@@ -190,13 +194,8 @@ fn parse_package_stats(lcov_content: &str, package: &str) -> CrateStats {
 /// - [`CoverageError::Io`] if the lcov file cannot be read.
 /// - [`CoverageError::NoSourceFiles`] if no source files match the package.
 /// - [`CoverageError::BelowThreshold`] if coverage is below the minimum.
-pub fn check(
-    file: &Path,
-    package: &str,
-    min_line: f64,
-    min_branch: f64,
-) -> Result<String, CoverageError> {
-    let content = fs::read_to_string(file).map_err(CoverageError::Io)?;
+pub fn check(file: &Path, package: &str, min_line: f64, min_branch: f64) -> Result<String, Error> {
+    let content = fs::read_to_string(file).map_err(Error::Io)?;
     check_from_content(&content, package, min_line, min_branch)
 }
 
@@ -207,11 +206,11 @@ fn check_from_content(
     package: &str,
     min_line: f64,
     min_branch: f64,
-) -> Result<String, CoverageError> {
+) -> Result<String, Error> {
     let stats = parse_package_stats(content, package);
 
     if stats.lines_found == 0 {
-        return Err(CoverageError::NoSourceFiles {
+        return Err(Error::NoSourceFiles {
             package: package.to_string(),
         });
     }
@@ -256,7 +255,7 @@ fn check_from_content(
     if line_ok && branch_ok {
         Ok(out)
     } else {
-        Err(CoverageError::BelowThreshold { summary: out })
+        Err(Error::BelowThreshold { summary: out })
     }
 }
 
@@ -269,16 +268,13 @@ fn check_from_content(
 ///
 /// - [`CoverageError::Io`] if the lcov file cannot be read.
 /// - [`CoverageError::BelowThreshold`] if any crate fails its threshold.
-pub fn check_all(file: &Path, thresholds: &[CrateThreshold]) -> Result<String, CoverageError> {
-    let content = fs::read_to_string(file).map_err(CoverageError::Io)?;
+pub fn check_all(file: &Path, thresholds: &[CrateThreshold]) -> Result<String, Error> {
+    let content = fs::read_to_string(file).map_err(Error::Io)?;
     check_all_from_content(&content, thresholds)
 }
 
 /// Inner implementation that operates on lcov content directly.
-fn check_all_from_content(
-    content: &str,
-    thresholds: &[CrateThreshold],
-) -> Result<String, CoverageError> {
+fn check_all_from_content(content: &str, thresholds: &[CrateThreshold]) -> Result<String, Error> {
     let mut out = String::new();
     let mut any_failed = false;
 
@@ -348,7 +344,7 @@ fn check_all_from_content(
             "Coverage check FAILED — one or more crates below threshold."
         )
         .expect("write to String");
-        Err(CoverageError::BelowThreshold { summary: out })
+        Err(Error::BelowThreshold { summary: out })
     } else {
         writeln!(out).expect("write to String");
         writeln!(out, "All crates meet coverage thresholds.").expect("write to String");
@@ -440,7 +436,7 @@ end_of_record
         let result = check_from_content(SAMPLE_LCOV, "ars-core", 90.0, 60.0);
         assert!(result.is_err());
         let err = result.unwrap_err();
-        assert!(matches!(err, CoverageError::BelowThreshold { .. }));
+        assert!(matches!(err, Error::BelowThreshold { .. }));
         assert!(err.to_string().contains("FAIL"));
     }
 
@@ -463,10 +459,7 @@ end_of_record
     fn check_errors_on_missing_package() {
         let result = check_from_content(SAMPLE_LCOV, "ars-nonexistent", 50.0, 50.0);
         assert!(result.is_err());
-        assert!(matches!(
-            result.unwrap_err(),
-            CoverageError::NoSourceFiles { .. }
-        ));
+        assert!(matches!(result.unwrap_err(), Error::NoSourceFiles { .. }));
     }
 
     #[test]

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -1,5 +1,6 @@
 //! ars-ui workspace task runner — library.
 
+pub mod ci;
 pub mod coverage;
 pub mod manifest;
 #[cfg(feature = "mcp")]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,8 +1,9 @@
 //! ars-ui workspace task runner.
 
-use std::{path::PathBuf, process};
+use std::{env, path::PathBuf, process, sync};
 
 use clap::{Parser, Subcommand};
+use xtask::{ci, coverage, manifest, mcp, spec};
 
 /// ars-ui workspace task runner.
 #[derive(Parser)]
@@ -14,6 +15,14 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Command {
+    /// Run CI pipeline steps locally (alias: `cargo xci`).
+    Ci {
+        /// Steps to run (default: all in pipeline order).
+        ///
+        /// Use `feature-matrix` to run all five feature-flag groups at once.
+        #[arg(value_enum)]
+        steps: Vec<ci::Step>,
+    },
     /// Start MCP stdio server exposing all workspace tools.
     #[cfg(feature = "mcp")]
     Mcp,
@@ -130,28 +139,43 @@ enum SpecCommand {
     },
 }
 
-fn main() {
-    let cli = Cli::parse();
-    let cwd = std::env::current_dir().expect("cannot read current directory");
-    let root = match xtask::manifest::SpecRoot::discover(&cwd) {
+/// Discover the spec root or exit with a diagnostic.
+fn discover_spec_root() -> manifest::SpecRoot {
+    let cwd = env::current_dir().expect("cannot read current directory");
+    match manifest::SpecRoot::discover(&cwd) {
         Ok(r) => r,
         Err(e) => {
             eprintln!("error: {e}");
             process::exit(1);
         }
-    };
+    }
+}
 
-    let result = match cli.command {
+fn main() {
+    let cli = Cli::parse();
+
+    match cli.command {
+        // ── CI ────────────────────────────────────────────────────────
+        Command::Ci { steps } => match ci::run(steps) {
+            Ok(()) => {}
+            Err(e) => {
+                eprintln!("error: {e}");
+                process::exit(1);
+            }
+        },
+
+        // ── MCP ───────────────────────────────────────────────────────
         #[cfg(feature = "mcp")]
         Command::Mcp => {
-            let root = std::sync::Arc::new(root);
+            let root = sync::Arc::new(discover_spec_root());
             let rt = tokio::runtime::Runtime::new().expect("cannot create tokio runtime");
-            rt.block_on(xtask::mcp::serve(root)).unwrap_or_else(|e| {
+            rt.block_on(mcp::serve(root)).unwrap_or_else(|e| {
                 eprintln!("error: {e}");
                 process::exit(1);
             });
-            return;
         }
+
+        // ── Coverage ──────────────────────────────────────────────────
         Command::Coverage { cmd } => {
             let result = match cmd {
                 CoverageCommand::Check {
@@ -159,77 +183,71 @@ fn main() {
                     package,
                     min,
                     branch_min,
-                } => xtask::coverage::check(&file, &package, min, branch_min),
+                } => coverage::check(&file, &package, min, branch_min),
                 CoverageCommand::CheckAll { file } => {
-                    let thresholds = xtask::coverage::default_thresholds();
-                    xtask::coverage::check_all(&file, &thresholds)
+                    let thresholds = coverage::default_thresholds();
+                    coverage::check_all(&file, &thresholds)
                 }
             };
             match result {
-                Ok(output) => {
-                    print!("{output}");
-                    return;
-                }
+                Ok(output) => print!("{output}"),
                 Err(e) => {
                     eprintln!("{e}");
                     process::exit(1);
                 }
             }
         }
-        Command::Spec { cmd } => match cmd {
-            SpecCommand::Info { component } => xtask::spec::info::execute(&root, &component),
-            SpecCommand::Deps { component } => xtask::spec::deps::execute(&root, &component),
-            SpecCommand::Category { name } => xtask::spec::category::execute(&root, &name),
-            SpecCommand::Reverse { shared_type } => {
-                xtask::spec::reverse::execute(&root, &shared_type)
-            }
-            SpecCommand::Related { component } => xtask::spec::related::execute(&root, &component),
-            SpecCommand::Profile { name } => xtask::spec::profile::execute(&root, &name),
-            SpecCommand::Toc { file } => xtask::spec::toc::execute(&root, &file),
-            SpecCommand::Validate => {
-                let report = xtask::spec::validate::execute(&root);
-                if let Ok(ref text) = report {
-                    if text.contains("error(s) found:") {
-                        print!("{text}");
-                        process::exit(1);
-                    }
-                }
-                report
-            }
-            SpecCommand::Adapters { framework } => {
-                xtask::spec::adapters::execute(&root, &framework)
-            }
-            SpecCommand::Digest { component } => xtask::spec::digest::execute(&root, &component),
-            SpecCommand::Context {
-                component,
-                framework,
-                include_testing,
-            } => xtask::spec::context::execute(
-                &root,
-                &component,
-                framework.as_deref(),
-                include_testing,
-            ),
-            SpecCommand::Search {
-                query,
-                category,
-                section,
-                tier,
-            } => xtask::spec::search::execute(
-                &root,
-                &query,
-                category.as_deref(),
-                section.as_deref(),
-                tier.as_deref(),
-            ),
-        },
-    };
 
-    match result {
-        Ok(output) => print!("{output}"),
-        Err(e) => {
-            eprintln!("error: {e}");
-            process::exit(1);
+        // ── Spec ──────────────────────────────────────────────────────
+        Command::Spec { cmd } => {
+            let root = discover_spec_root();
+            let result = match cmd {
+                SpecCommand::Info { component } => spec::info::execute(&root, &component),
+                SpecCommand::Deps { component } => spec::deps::execute(&root, &component),
+                SpecCommand::Category { name } => spec::category::execute(&root, &name),
+                SpecCommand::Reverse { shared_type } => spec::reverse::execute(&root, &shared_type),
+                SpecCommand::Related { component } => spec::related::execute(&root, &component),
+                SpecCommand::Profile { name } => spec::profile::execute(&root, &name),
+                SpecCommand::Toc { file } => spec::toc::execute(&root, &file),
+                SpecCommand::Validate => {
+                    let report = spec::validate::execute(&root);
+                    if let Ok(ref text) = report {
+                        if text.contains("error(s) found:") {
+                            print!("{text}");
+                            process::exit(1);
+                        }
+                    }
+                    report
+                }
+                SpecCommand::Adapters { framework } => spec::adapters::execute(&root, &framework),
+                SpecCommand::Digest { component } => spec::digest::execute(&root, &component),
+                SpecCommand::Context {
+                    component,
+                    framework,
+                    include_testing,
+                } => {
+                    spec::context::execute(&root, &component, framework.as_deref(), include_testing)
+                }
+                SpecCommand::Search {
+                    query,
+                    category,
+                    section,
+                    tier,
+                } => spec::search::execute(
+                    &root,
+                    &query,
+                    category.as_deref(),
+                    section.as_deref(),
+                    tier.as_deref(),
+                ),
+            };
+            match result {
+                Ok(output) => print!("{output}"),
+                Err(e) => {
+                    eprintln!("error: {e}");
+                    process::exit(1);
+                }
+            }
         }
     }
 }

--- a/xtask/src/manifest.rs
+++ b/xtask/src/manifest.rs
@@ -2,7 +2,7 @@
 
 use std::{
     collections::BTreeMap,
-    fs,
+    fmt, fs, io,
     path::{Path, PathBuf},
 };
 
@@ -80,11 +80,11 @@ pub struct SpecRoot {
 
 /// Errors from manifest operations.
 #[derive(Debug)]
-pub enum ManifestError {
+pub enum Error {
     /// Could not find `spec/manifest.toml` in any parent directory.
     NotFound,
     /// IO error reading a file.
-    Io(std::io::Error),
+    Io(io::Error),
     /// TOML parse error.
     Parse(toml::de::Error),
     /// Component not found in manifest.
@@ -127,8 +127,8 @@ pub enum ManifestError {
     ),
 }
 
-impl std::fmt::Display for ManifestError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::NotFound => {
                 write!(
@@ -174,7 +174,7 @@ impl std::fmt::Display for ManifestError {
     }
 }
 
-impl std::error::Error for ManifestError {}
+impl std::error::Error for Error {}
 
 impl SpecRoot {
     /// Discover and load the spec root by walking up from `start_dir`.
@@ -184,21 +184,21 @@ impl SpecRoot {
     /// Returns [`ManifestError::NotFound`] if no `spec/manifest.toml` exists in any
     /// ancestor, [`ManifestError::Io`] on read failure, or [`ManifestError::Parse`]
     /// on invalid TOML.
-    pub fn discover(start_dir: &Path) -> Result<Self, ManifestError> {
+    pub fn discover(start_dir: &Path) -> Result<Self, Error> {
         let mut dir = start_dir.to_path_buf();
         loop {
             let candidate = dir.join("spec").join("manifest.toml");
             if candidate.exists() {
                 let spec_path = dir.join("spec");
-                let content = fs::read_to_string(&candidate).map_err(ManifestError::Io)?;
-                let manifest: Manifest = toml::from_str(&content).map_err(ManifestError::Parse)?;
+                let content = fs::read_to_string(&candidate).map_err(Error::Io)?;
+                let manifest: Manifest = toml::from_str(&content).map_err(Error::Parse)?;
                 return Ok(Self {
                     path: spec_path,
                     manifest,
                 });
             }
             if !dir.pop() {
-                return Err(ManifestError::NotFound);
+                return Err(Error::NotFound);
             }
         }
     }
@@ -209,7 +209,7 @@ impl SpecRoot {
 /// # Errors
 ///
 /// Returns [`ManifestError::ComponentNotFound`] if no match exists.
-pub fn find_component_key(manifest: &Manifest, name: &str) -> Result<String, ManifestError> {
+pub fn find_component_key(manifest: &Manifest, name: &str) -> Result<String, Error> {
     let key = name.to_lowercase();
     if manifest.components.contains_key(&key) {
         return Ok(key);
@@ -218,7 +218,7 @@ pub fn find_component_key(manifest: &Manifest, name: &str) -> Result<String, Man
     if manifest.components.contains_key(&alt) {
         return Ok(alt);
     }
-    Err(ManifestError::ComponentNotFound {
+    Err(Error::ComponentNotFound {
         name: name.to_string(),
         available: manifest.components.keys().cloned().collect(),
     })
@@ -232,7 +232,7 @@ pub fn find_component_key(manifest: &Manifest, name: &str) -> Result<String, Man
 pub fn find_component<'a>(
     manifest: &'a Manifest,
     name: &str,
-) -> Result<(&'a str, &'a Component), ManifestError> {
+) -> Result<(&'a str, &'a Component), Error> {
     let key = find_component_key(manifest, name)?;
     let key_ref = manifest
         .components
@@ -280,7 +280,7 @@ pub fn extract_html_comment_header(content: &str) -> Option<String> {
 /// # Errors
 ///
 /// Returns [`ManifestError::FrontmatterError`] on malformed YAML.
-pub fn parse_frontmatter_yaml(yaml_str: &str) -> Result<Frontmatter, ManifestError> {
+pub fn parse_frontmatter_yaml(yaml_str: &str) -> Result<Frontmatter, Error> {
     let mut fm = Frontmatter::default();
     for line in yaml_str.lines() {
         let line = line.trim();

--- a/xtask/src/mcp.rs
+++ b/xtask/src/mcp.rs
@@ -4,7 +4,7 @@
 //! [Model Context Protocol](https://modelcontextprotocol.io/) using JSON-RPC
 //! over stdin/stdout.
 
-use std::sync::Arc;
+use std::{future, sync::Arc};
 
 /// Alias the rmcp protocol type to avoid confusion with our [`crate::tool::Tool`] trait.
 use rmcp::model::Tool as McpTool;
@@ -52,7 +52,7 @@ impl ServerHandler for McpServer {
                 McpTool::new(t.name().to_owned(), t.description().to_owned(), schema_obj)
             })
             .collect();
-        std::future::ready(Ok(ListToolsResult::with_all_items(tools)))
+        future::ready(Ok(ListToolsResult::with_all_items(tools)))
     }
 
     fn call_tool(
@@ -77,7 +77,7 @@ impl ServerHandler for McpServer {
                 None,
             )),
         };
-        std::future::ready(result)
+        future::ready(result)
     }
 }
 

--- a/xtask/src/spec/adapters.rs
+++ b/xtask/src/spec/adapters.rs
@@ -2,19 +2,19 @@
 
 use std::{collections::BTreeMap, fmt::Write};
 
-use crate::manifest::{ManifestError, SpecRoot};
+use crate::manifest::{Error, SpecRoot};
 
 /// Return all adapter files for a framework, grouped by category.
 ///
 /// # Errors
 ///
 /// Returns [`ManifestError::UnknownFramework`] if the framework is not `"leptos"` or `"dioxus"`.
-pub fn execute(root: &SpecRoot, framework: &str) -> Result<String, ManifestError> {
+pub fn execute(root: &SpecRoot, framework: &str) -> Result<String, Error> {
     let m = &root.manifest;
     let adapters = match framework {
         "leptos" => &m.leptos_adapters,
         "dioxus" => &m.dioxus_adapters,
-        _ => return Err(ManifestError::UnknownFramework(framework.to_string())),
+        _ => return Err(Error::UnknownFramework(framework.to_string())),
     };
     if adapters.is_empty() {
         return Ok(format!("No {framework} adapter files registered.\n"));

--- a/xtask/src/spec/category.rs
+++ b/xtask/src/spec/category.rs
@@ -2,14 +2,14 @@
 
 use std::fmt::Write;
 
-use crate::manifest::{self, ManifestError, SpecRoot};
+use crate::manifest::{self, Error, SpecRoot};
 
 /// Return all components in a category with metadata.
 ///
 /// # Errors
 ///
 /// Returns [`ManifestError::CategoryNotFound`] if no components match the category.
-pub fn execute(root: &SpecRoot, name: &str) -> Result<String, ManifestError> {
+pub fn execute(root: &SpecRoot, name: &str) -> Result<String, Error> {
     let m = &root.manifest;
     let components: Vec<_> = m
         .components
@@ -20,7 +20,7 @@ pub fn execute(root: &SpecRoot, name: &str) -> Result<String, ManifestError> {
         let mut cats: Vec<&str> = m.components.values().map(|c| c.category.as_str()).collect();
         cats.sort();
         cats.dedup();
-        return Err(ManifestError::CategoryNotFound {
+        return Err(Error::CategoryNotFound {
             name: name.to_string(),
             available: cats.into_iter().map(String::from).collect(),
         });

--- a/xtask/src/spec/context.rs
+++ b/xtask/src/spec/context.rs
@@ -2,7 +2,7 @@
 
 use std::{fmt::Write, fs, path::Path};
 
-use crate::manifest::{self, ManifestError, SpecRoot};
+use crate::manifest::{self, Error, SpecRoot};
 
 /// Return the full implementation context for a component.
 ///
@@ -17,7 +17,7 @@ pub fn execute(
     component: &str,
     framework: Option<&str>,
     include_testing: bool,
-) -> Result<String, ManifestError> {
+) -> Result<String, Error> {
     let (key, comp) = manifest::find_component(&root.manifest, component)?;
     let m = &root.manifest;
     let mut out = String::new();
@@ -47,7 +47,7 @@ pub fn execute(
         let adapters = match fw {
             "leptos" => &m.leptos_adapters,
             "dioxus" => &m.dioxus_adapters,
-            _ => return Err(ManifestError::UnknownFramework(fw.to_string())),
+            _ => return Err(Error::UnknownFramework(fw.to_string())),
         };
         if let Some(path) = adapters.get(key) {
             append_file(&root.path, path, &mut out);

--- a/xtask/src/spec/deps.rs
+++ b/xtask/src/spec/deps.rs
@@ -2,14 +2,14 @@
 
 use std::fmt::Write;
 
-use crate::manifest::{self, ManifestError, SpecRoot};
+use crate::manifest::{self, Error, SpecRoot};
 
 /// Return the file set for reviewing a component.
 ///
 /// # Errors
 ///
 /// Returns [`ManifestError::ComponentNotFound`] if the component is not in the manifest.
-pub fn execute(root: &SpecRoot, component: &str) -> Result<String, ManifestError> {
+pub fn execute(root: &SpecRoot, component: &str) -> Result<String, Error> {
     let (key, comp) = manifest::find_component(&root.manifest, component)?;
     let m = &root.manifest;
     let mut out = String::new();

--- a/xtask/src/spec/digest.rs
+++ b/xtask/src/spec/digest.rs
@@ -5,7 +5,7 @@
 
 use std::{fmt::Write, fs};
 
-use crate::manifest::{self, ManifestError, SpecRoot};
+use crate::manifest::{self, Error, SpecRoot};
 
 /// Extract a compact digest of a component's key sections.
 ///
@@ -15,10 +15,10 @@ use crate::manifest::{self, ManifestError, SpecRoot};
 /// # Errors
 ///
 /// Returns [`ManifestError`] if the component is not found or the file cannot be read.
-pub fn execute(root: &SpecRoot, component: &str) -> Result<String, ManifestError> {
+pub fn execute(root: &SpecRoot, component: &str) -> Result<String, Error> {
     let (key, comp) = manifest::find_component(&root.manifest, component)?;
     let file_path = root.path.join(&comp.path);
-    let content = fs::read_to_string(&file_path).map_err(ManifestError::Io)?;
+    let content = fs::read_to_string(&file_path).map_err(Error::Io)?;
 
     let mut out = String::new();
     writeln!(out, "# Digest: {component}").expect("write to String");

--- a/xtask/src/spec/info.rs
+++ b/xtask/src/spec/info.rs
@@ -2,14 +2,14 @@
 
 use std::fmt::Write;
 
-use crate::manifest::{self, ManifestError, SpecRoot};
+use crate::manifest::{self, Error, SpecRoot};
 
 /// Return component metadata as text.
 ///
 /// # Errors
 ///
 /// Returns [`ManifestError::ComponentNotFound`] if the component is not in the manifest.
-pub fn execute(root: &SpecRoot, component: &str) -> Result<String, ManifestError> {
+pub fn execute(root: &SpecRoot, component: &str) -> Result<String, Error> {
     let (key, comp) = manifest::find_component(&root.manifest, component)?;
     let mut out = String::new();
     writeln!(out, "component: {component}").expect("write to String");

--- a/xtask/src/spec/profile.rs
+++ b/xtask/src/spec/profile.rs
@@ -2,19 +2,19 @@
 
 use std::fmt::Write;
 
-use crate::manifest::{ManifestError, SpecRoot};
+use crate::manifest::{Error, SpecRoot};
 
 /// Return files in a named review profile.
 ///
 /// # Errors
 ///
 /// Returns [`ManifestError::ProfileNotFound`] if the profile name does not exist.
-pub fn execute(root: &SpecRoot, name: &str) -> Result<String, ManifestError> {
+pub fn execute(root: &SpecRoot, name: &str) -> Result<String, Error> {
     let profiles =
         root.manifest
             .review_profiles
             .as_ref()
-            .ok_or_else(|| ManifestError::ProfileNotFound {
+            .ok_or_else(|| Error::ProfileNotFound {
                 name: name.to_string(),
                 available: vec![],
             })?;
@@ -22,7 +22,7 @@ pub fn execute(root: &SpecRoot, name: &str) -> Result<String, ManifestError> {
         .get(name)
         .or_else(|| profiles.get(&name.replace('-', "_")))
         .or_else(|| profiles.get(&name.replace('_', "-")))
-        .ok_or_else(|| ManifestError::ProfileNotFound {
+        .ok_or_else(|| Error::ProfileNotFound {
             name: name.to_string(),
             available: profiles.keys().cloned().collect(),
         })?;

--- a/xtask/src/spec/related.rs
+++ b/xtask/src/spec/related.rs
@@ -2,14 +2,14 @@
 
 use std::fmt::Write;
 
-use crate::manifest::{self, ManifestError, SpecRoot};
+use crate::manifest::{self, Error, SpecRoot};
 
 /// Return the component and all its related components with deps.
 ///
 /// # Errors
 ///
 /// Returns [`ManifestError::ComponentNotFound`] if the component is not in the manifest.
-pub fn execute(root: &SpecRoot, component: &str) -> Result<String, ManifestError> {
+pub fn execute(root: &SpecRoot, component: &str) -> Result<String, Error> {
     let (_, comp) = manifest::find_component(&root.manifest, component)?;
     let m = &root.manifest;
     let mut out = String::new();

--- a/xtask/src/spec/reverse.rs
+++ b/xtask/src/spec/reverse.rs
@@ -2,17 +2,17 @@
 
 use std::fmt::Write;
 
-use crate::manifest::{ManifestError, SpecRoot};
+use crate::manifest::{Error, SpecRoot};
 
 /// Return components that depend on a shared type.
 ///
 /// # Errors
 ///
 /// Returns [`ManifestError::SharedTypeNotFound`] if the shared type is not in the manifest.
-pub fn execute(root: &SpecRoot, shared_type: &str) -> Result<String, ManifestError> {
+pub fn execute(root: &SpecRoot, shared_type: &str) -> Result<String, Error> {
     let m = &root.manifest;
     if !m.shared.contains_key(shared_type) {
-        return Err(ManifestError::SharedTypeNotFound {
+        return Err(Error::SharedTypeNotFound {
             name: shared_type.to_string(),
             available: m.shared.keys().cloned().collect(),
         });

--- a/xtask/src/spec/search.rs
+++ b/xtask/src/spec/search.rs
@@ -4,7 +4,7 @@ use std::{fmt::Write, fs};
 
 use regex::Regex;
 
-use crate::manifest::{self, ManifestError, SpecRoot};
+use crate::manifest::{self, Error, SpecRoot};
 
 /// Section filter — maps to known heading patterns in the spec template.
 #[derive(Debug, Clone, Copy)]
@@ -81,9 +81,9 @@ pub fn execute(
     category: Option<&str>,
     section: Option<&str>,
     tier: Option<&str>,
-) -> Result<String, ManifestError> {
-    let re = Regex::new(query)
-        .map_err(|e| ManifestError::FrontmatterError(format!("invalid regex: {e}")))?;
+) -> Result<String, Error> {
+    let re =
+        Regex::new(query).map_err(|e| Error::FrontmatterError(format!("invalid regex: {e}")))?;
     let section_filter = section.and_then(SectionFilter::parse);
     let m = &root.manifest;
     let mut hits: Vec<SearchHit> = Vec::new();

--- a/xtask/src/spec/toc.rs
+++ b/xtask/src/spec/toc.rs
@@ -2,20 +2,20 @@
 
 use std::{fmt::Write, fs, path::Path};
 
-use crate::manifest::{self, ManifestError, SpecRoot};
+use crate::manifest::{self, Error, SpecRoot};
 
 /// Return the heading structure (table of contents) of a spec file.
 ///
 /// # Errors
 ///
 /// Returns [`ManifestError::Io`] if the file cannot be read.
-pub fn execute(root: &SpecRoot, file: &str) -> Result<String, ManifestError> {
+pub fn execute(root: &SpecRoot, file: &str) -> Result<String, Error> {
     let file_path = if Path::new(file).is_absolute() || Path::new(file).exists() {
         Path::new(file).to_path_buf()
     } else {
         root.path.join(file)
     };
-    let content = fs::read_to_string(&file_path).map_err(ManifestError::Io)?;
+    let content = fs::read_to_string(&file_path).map_err(Error::Io)?;
     let mut out = String::new();
     for (line_num, line) in content.lines().enumerate() {
         if let Some((level, text)) = manifest::parse_heading(line) {

--- a/xtask/src/spec/validate.rs
+++ b/xtask/src/spec/validate.rs
@@ -2,14 +2,14 @@
 
 use std::{fmt::Write, fs};
 
-use crate::manifest::{self, ManifestError, SpecRoot};
+use crate::manifest::{self, Error, SpecRoot};
 
 /// Validate all spec file frontmatter against manifest entries.
 ///
 /// # Errors
 ///
 /// Returns [`ManifestError::Io`] if a spec file cannot be read.
-pub fn execute(root: &SpecRoot) -> Result<String, ManifestError> {
+pub fn execute(root: &SpecRoot) -> Result<String, Error> {
     let m = &root.manifest;
     let mut errors: Vec<String> = Vec::new();
     let mut checked = 0u32;

--- a/xtask/src/tool.rs
+++ b/xtask/src/tool.rs
@@ -17,8 +17,8 @@ impl std::fmt::Display for ToolError {
 
 impl std::error::Error for ToolError {}
 
-impl From<crate::manifest::ManifestError> for ToolError {
-    fn from(e: crate::manifest::ManifestError) -> Self {
+impl From<crate::manifest::Error> for ToolError {
+    fn from(e: crate::manifest::Error) -> Self {
         Self {
             message: e.to_string(),
         }


### PR DESCRIPTION
## Summary

- **Single source of truth**: CI step definitions moved from shell commands in `ci.yml` into the xtask crate. The YAML now delegates to `cargo xtask ci <step>`.
- **Local CI runner**: `cargo xci` runs the full pipeline locally; `cargo xci check clippy unit` runs specific steps sequentially with fail-fast semantics.
- **Feature matrix locally runnable**: 46 feature-flag combinations across 5 groups (core, i18n, subsystems, leptos, dioxus) can now be validated before pushing via `cargo xci feature-matrix` or individual groups like `cargo xci feature-matrix-core`.

### New commands

```bash
cargo xci                          # all steps, pipeline order, fail-fast
cargo xci check                    # single step
cargo xci check clippy unit        # multiple steps, sequential, fail-fast
cargo xci feature-matrix           # all 5 feature flag groups
cargo xci feature-matrix-core      # just one group
```

### Files changed

- `xtask/src/ci/mod.rs` — Step enum (13 variants), Error type, orchestrator, step implementations, preflight checks, output formatting, 16 unit tests
- `xtask/src/ci/feature_matrix.rs` — combo data (46 combos + 3 cross-checks), group runner, 9 unit tests
- `.cargo/config.toml` — added `xci = "xtask ci"` alias
- `.github/workflows/ci.yml` — all 13 jobs delegate to `cargo xtask ci <step>`
- `xtask/src/{main,lib}.rs` — added Ci command variant, deferred SpecRoot discovery to only branches that need it
- Other xtask files — linter-applied cleanups (import grouping, type renames)

## Test plan

- [x] `cargo clippy -p xtask --all-targets --all-features -- -D warnings` — zero warnings
- [x] `cargo test -p xtask --all-features` — 50 tests pass (25 new CI tests)
- [x] `cargo xci fmt` — smoke test passes
- [x] `cargo xci check` — smoke test passes
- [x] `cargo xci --help` — shows all 13 steps with descriptions
- [ ] CI pipeline passes with all jobs delegating to xtask

🤖 Generated with [Claude Code](https://claude.com/claude-code)