### PR TITLE
[codex] Implement ICU4X-backed Locale and BiDi utilities

### DIFF
--- a/crates/ars-core/src/lib.rs
+++ b/crates/ars-core/src/lib.rs
@@ -51,7 +51,10 @@ pub mod __private {
 #[doc(inline)]
 pub use ars_derive::{ComponentPart, HasId};
 // ── External re-exports ─────────────────────────────────────────────
-pub use ars_i18n::{Direction, IcuProvider, Locale, LocaleParseError, StubIcuProvider};
+pub use ars_i18n::{
+    Direction, IcuProvider, IsolateDirection, Locale, LocaleParseError, StubIcuProvider, Weekday,
+    isolate_text_safe,
+};
 // ── Platform-conditional smart pointers (extracted modules) ─────────
 pub use callback::{Callback, callback};
 // ── DOM attribute / connect primitives ──────────────────────────────
@@ -514,7 +517,7 @@ pub struct Env {
 impl Default for Env {
     fn default() -> Self {
         Self {
-            locale: Locale::parse("en-US").expect("en-US is a valid BCP-47 tag"),
+            locale: ars_i18n::locales::en_us(),
             icu_provider: ArsRc::from_icu_provider(StubIcuProvider),
         }
     }
@@ -1324,7 +1327,7 @@ mod tests {
     #[test]
     fn env_default_has_en_us_locale() {
         let env = Env::default();
-        assert_eq!(env.locale.as_str(), "en-US");
+        assert_eq!(env.locale.to_bcp47(), "en-US");
     }
 
     #[test]

--- a/crates/ars-core/src/message_fn.rs
+++ b/crates/ars-core/src/message_fn.rs
@@ -120,6 +120,8 @@ impl ComponentMessages for () {}
 mod tests {
     use alloc::format;
 
+    use ars_i18n::locales;
+
     use super::*;
 
     #[test]
@@ -145,7 +147,7 @@ mod tests {
     #[test]
     fn message_fn_deref_invokes_closure() {
         let mf = MessageFn::static_str("Dismiss");
-        let locale = Locale::new("en-US");
+        let locale = locales::en_us();
         assert_eq!(mf(&locale), "Dismiss");
     }
 
@@ -153,28 +155,28 @@ mod tests {
     fn message_fn_as_ref_delegates_to_inner() {
         let mf = MessageFn::static_str("Test");
         let f: &(dyn Fn(&Locale) -> String + Send + Sync) = mf.as_ref();
-        assert_eq!(f(&Locale::new("en")), "Test");
+        assert_eq!(f(&locales::en()), "Test");
     }
 
     #[test]
     fn message_fn_from_closure() {
         let mf: MessageFn<dyn Fn(&Locale) -> String + Send + Sync> =
-            MessageFn::from(|locale: &Locale| format!("Close ({})", locale.as_str()));
-        let locale = Locale::new("de-DE");
+            MessageFn::from(|locale: &Locale| format!("Close ({})", locale.to_bcp47()));
+        let locale = locales::de_de();
         assert_eq!(mf(&locale), "Close (de-DE)");
     }
 
     #[test]
     fn message_fn_new_delegates_to_from() {
         let mf: MessageFn<dyn Fn(&Locale) -> String + Send + Sync> =
-            MessageFn::new(|locale: &Locale| format!("Hello {}", locale.as_str()));
-        assert_eq!(mf(&Locale::new("fr-FR")), "Hello fr-FR");
+            MessageFn::new(|locale: &Locale| format!("Hello {}", locale.to_bcp47()));
+        assert_eq!(mf(&locales::fr()), "Hello fr-FR");
     }
 
     #[test]
     fn message_fn_static_str_ignores_locale() {
         let mf = MessageFn::static_str("Dismiss");
-        assert_eq!(mf(&Locale::new("ja-JP")), "Dismiss");
-        assert_eq!(mf(&Locale::new("ar-EG")), "Dismiss");
+        assert_eq!(mf(&locales::ja_jp()), "Dismiss");
+        assert_eq!(mf(&locales::ar_eg()), "Dismiss");
     }
 }

--- a/crates/ars-core/src/provider.rs
+++ b/crates/ars-core/src/provider.rs
@@ -9,7 +9,7 @@ extern crate alloc;
 use alloc::string::String;
 use core::fmt;
 
-use ars_i18n::{Direction, Locale};
+use ars_i18n::{Direction, Locale, locales};
 
 use crate::{
     ArsRc, DefaultModalityContext, ModalityContext, NullPlatformEffects, PlatformEffects,
@@ -152,7 +152,7 @@ impl ArsContext {
 impl Default for ArsContext {
     fn default() -> Self {
         Self {
-            locale: Locale::new("en-US"),
+            locale: locales::en_us(),
             direction: Direction::Ltr,
             color_mode: ColorMode::System,
             disabled: false,
@@ -213,7 +213,7 @@ mod tests {
     fn ars_context_default_uses_default_modality_context() {
         let context = ArsContext::default();
 
-        assert_eq!(context.locale().as_str(), "en-US");
+        assert_eq!(context.locale().to_bcp47(), "en-US");
         assert_eq!(context.direction(), Direction::Ltr);
         assert_eq!(context.color_mode(), ColorMode::System);
         assert_eq!(context.modality().snapshot(), ModalitySnapshot::default());
@@ -222,7 +222,7 @@ mod tests {
     #[test]
     fn ars_context_constructor_preserves_values() {
         let context = ArsContext::new(
-            Locale::new("pt-BR"),
+            locales::br(),
             Direction::Ltr,
             ColorMode::Dark,
             true,
@@ -235,7 +235,7 @@ mod tests {
             StyleStrategy::Cssom,
         );
 
-        assert_eq!(context.locale().as_str(), "pt-BR");
+        assert_eq!(context.locale().to_bcp47(), "pt-BR");
         assert!(context.disabled());
         assert!(context.read_only());
         assert_eq!(context.id_prefix(), Some("prefix"));

--- a/crates/ars-dioxus/src/attrs.rs
+++ b/crates/ars-dioxus/src/attrs.rs
@@ -536,10 +536,10 @@ mod tests {
             use ars_core::{
                 ArsContext, ArsRc, ColorMode, DefaultModalityContext, NullPlatformEffects,
             };
-            use ars_i18n::{Direction, Locale};
+            use ars_i18n::{Direction, locales};
 
             let ctx = ArsContext::new(
-                Locale::new("en-US"),
+                locales::en_us(),
                 Direction::Ltr,
                 ColorMode::System,
                 false,

--- a/crates/ars-forms/src/validation/validator.rs
+++ b/crates/ars-forms/src/validation/validator.rs
@@ -181,7 +181,7 @@ mod tests {
             [("name".to_string(), Value::Text("Alice".to_string()))]
                 .into_iter()
                 .collect();
-        let locale = ars_i18n::Locale::new("en-US");
+        let locale = ars_i18n::locales::en_us();
         let ctx = Context {
             field_name: "name",
             form_values: &values,
@@ -192,7 +192,11 @@ mod tests {
         assert_eq!(owned.field_name, "name");
         assert_eq!(owned.form_values.len(), 1);
         assert_eq!(
-            owned.locale.as_ref().map(ars_i18n::Locale::as_str),
+            owned
+                .locale
+                .as_ref()
+                .map(ars_i18n::Locale::to_bcp47)
+                .as_deref(),
             Some("en-US")
         );
     }
@@ -202,12 +206,15 @@ mod tests {
         let owned = OwnedContext {
             field_name: "email".to_string(),
             form_values: BTreeMap::new(),
-            locale: Some(ars_i18n::Locale::new("fr-FR")),
+            locale: Some(ars_i18n::locales::fr()),
         };
         let borrowed = owned.as_ref();
         assert_eq!(borrowed.field_name, "email");
         assert!(borrowed.form_values.is_empty());
-        assert_eq!(borrowed.locale.map(ars_i18n::Locale::as_str), Some("fr-FR"));
+        assert_eq!(
+            borrowed.locale.map(ars_i18n::Locale::to_bcp47).as_deref(),
+            Some("fr-FR")
+        );
     }
 
     #[test]

--- a/crates/ars-i18n/Cargo.toml
+++ b/crates/ars-i18n/Cargo.toml
@@ -7,6 +7,11 @@ description.workspace  = true
 repository.workspace   = true
 rust-version.workspace = true
 
+[dependencies]
+icu                  = { version = "2.1", default-features = false }
+icu_provider         = { version = "2.1", default-features = false }
+unicode-segmentation = "1.13"
+
 [features]
 default             = ["std", "gregorian", "icu4x"]
 std                 = []

--- a/crates/ars-i18n/src/bidi.rs
+++ b/crates/ars-i18n/src/bidi.rs
@@ -1,0 +1,52 @@
+use alloc::string::String;
+
+use unicode_segmentation::UnicodeSegmentation;
+
+/// `BiDi` isolation direction.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum IsolateDirection {
+    /// Left-to-right isolate.
+    Ltr,
+    /// Right-to-left isolate.
+    Rtl,
+    /// First-strong isolate.
+    FirstStrong,
+}
+
+impl IsolateDirection {
+    const fn opening_mark(self) -> char {
+        // Unicode UAX #9 §2.4 defines these isolate initiators:
+        // LRI U+2066, RLI U+2067, and FSI U+2068.
+        // https://unicode.org/reports/tr9/
+        match self {
+            Self::Ltr => '\u{2066}',
+            Self::Rtl => '\u{2067}',
+            Self::FirstStrong => '\u{2068}',
+        }
+    }
+}
+
+// Unicode UAX #9 §2.5 defines PDI U+2069 as the terminator for the
+// last LRI, RLI, or FSI isolate.
+// https://unicode.org/reports/tr9/
+const PDI: char = '\u{2069}';
+
+/// Wraps text in Unicode bidirectional isolation marks without splitting grapheme clusters.
+#[must_use]
+pub fn isolate_text_safe(text: &str, direction: IsolateDirection) -> String {
+    if text.is_empty() {
+        return String::new();
+    }
+
+    // Reserve space for the original UTF-8 text plus the opening isolate and
+    // closing PDI markers, which are 3 bytes each in UTF-8.
+    let mut out = String::with_capacity(text.len() + 6);
+    out.push(direction.opening_mark());
+
+    for cluster in text.graphemes(true) {
+        out.push_str(cluster);
+    }
+
+    out.push(PDI);
+    out
+}

--- a/crates/ars-i18n/src/lib.rs
+++ b/crates/ars-i18n/src/lib.rs
@@ -10,7 +10,14 @@
 extern crate alloc;
 
 use alloc::string::String;
-use core::fmt;
+
+mod bidi;
+mod locale;
+mod weekday;
+
+pub use bidi::{IsolateDirection, isolate_text_safe};
+pub use locale::{Locale, LocaleParseError, locales};
+pub use weekday::Weekday;
 
 /// Text and layout direction.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -65,92 +72,6 @@ pub enum Orientation {
     /// Children are laid out along the vertical axis.
     Vertical,
 }
-
-/// A BCP 47 locale identifier (e.g. `"en-US"`, `"ar-EG"`).
-///
-/// Wraps a locale string and is used by the environment provider to propagate
-/// locale context to all components for i18n-aware formatting and RTL handling.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct Locale(String);
-
-impl Locale {
-    /// Creates a new locale from a BCP 47 string.
-    #[must_use]
-    pub fn new(value: impl Into<String>) -> Self {
-        Self(value.into())
-    }
-
-    /// Returns the locale as a string slice.
-    #[must_use]
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-
-    /// Parse a BCP 47 locale identifier with structural validation.
-    ///
-    /// Validates that the string follows the basic BCP 47 structure
-    /// (RFC 5646 §2.1): a 2–8 letter language subtag, followed by optional
-    /// hyphen-separated subtags of 1–8 alphanumeric characters each.
-    ///
-    /// This performs **structural** validation only — it does not check whether
-    /// the language, script, or region subtags are registered in the IANA
-    /// subtag registry. Full semantic validation will come with ICU4X.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`LocaleParseError`] if the string is empty, contains invalid
-    /// characters, or violates basic BCP 47 structure.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use ars_i18n::Locale;
-    /// let en = Locale::parse("en-US").expect("valid");
-    /// let ar = Locale::parse("ar").expect("valid");
-    /// let ja = Locale::parse("ja-JP-u-ca-japanese").expect("valid");
-    ///
-    /// assert!(Locale::parse("").is_err());
-    /// assert!(Locale::parse("123").is_err());
-    /// assert!(Locale::parse("-en").is_err());
-    /// ```
-    pub fn parse(s: &str) -> Result<Self, LocaleParseError> {
-        let mut subtags = s.split('-');
-
-        // Language subtag: 2–8 ASCII alphabetic characters (required).
-        let lang = subtags.next().ok_or(LocaleParseError { _private: () })?;
-        if lang.len() < 2 || lang.len() > 8 || !lang.bytes().all(|b| b.is_ascii_alphabetic()) {
-            return Err(LocaleParseError { _private: () });
-        }
-
-        // Subsequent subtags: 1–8 ASCII alphanumeric characters each.
-        for subtag in subtags {
-            if subtag.is_empty()
-                || subtag.len() > 8
-                || !subtag.bytes().all(|b| b.is_ascii_alphanumeric())
-            {
-                return Err(LocaleParseError { _private: () });
-            }
-        }
-
-        Ok(Self(String::from(s)))
-    }
-}
-
-/// Error returned when a locale string fails BCP 47 structural validation.
-///
-/// See [`Locale::parse`] for the validation rules.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct LocaleParseError {
-    _private: (),
-}
-
-impl fmt::Display for LocaleParseError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("invalid BCP 47 locale identifier")
-    }
-}
-
-impl core::error::Error for LocaleParseError {}
 
 // ────────────────────────────────────────────────────────────────────
 // ICU data provider abstraction
@@ -257,7 +178,7 @@ impl DateRange {
 
 #[cfg(test)]
 mod tests {
-    use alloc::string::ToString;
+    use alloc::{string::ToString, vec, vec::Vec};
 
     use super::*;
 
@@ -294,64 +215,292 @@ mod tests {
         assert!(!Direction::Auto.inline_start_is_right());
     }
 
-    // ── Locale::parse tests ────────────────────────────────────────
+    // ── Locale tests ───────────────────────────────────────────────
 
     #[test]
     fn parse_valid_locales() {
-        assert!(Locale::parse("en").is_ok());
-        assert!(Locale::parse("en-US").is_ok());
-        assert!(Locale::parse("zh-Hans-CN").is_ok());
-        assert!(Locale::parse("ja-JP-u-ca-japanese").is_ok());
-        assert!(Locale::parse("ar").is_ok());
-        assert!(Locale::parse("sr-Latn-RS").is_ok());
+        for locale in [
+            "en",
+            "en-US",
+            "zh-Hans-CN",
+            "ja-JP-u-ca-japanese",
+            "en-US-u-fw-mon",
+            "ar",
+            "sr-Latn-RS",
+        ] {
+            assert!(Locale::parse(locale).is_ok(), "{locale} should parse");
+        }
     }
 
     #[test]
     fn parse_invalid_locales() {
-        assert!(Locale::parse("").is_err());
-        assert!(Locale::parse("e").is_err()); // too short
-        assert!(Locale::parse("123").is_err()); // digits in language
-        assert!(Locale::parse("-en").is_err()); // leading hyphen
-        assert!(Locale::parse("en-").is_err()); // trailing hyphen
-        assert!(Locale::parse("en--US").is_err()); // double hyphen
-        assert!(Locale::parse("abcdefghi").is_err()); // language too long (>8)
+        for locale in [
+            "",
+            "e",
+            "123",
+            "-en",
+            "en-",
+            "en--US",
+            "abcdefghi",
+            "en-abcdefghi",
+            "en-US!",
+            "en-\u{00DC}",
+        ] {
+            assert!(
+                Locale::parse(locale).is_err(),
+                "{locale} should be rejected"
+            );
+        }
     }
 
     #[test]
-    fn parse_rejects_invalid_subsequent_subtags() {
-        // Subtag too long in second position
-        assert!(Locale::parse("en-abcdefghi").is_err());
-        // Non-alphanumeric character in subtag
-        assert!(Locale::parse("en-US!").is_err());
-        // Non-ASCII in subtag
-        assert!(Locale::parse("en-Ü").is_err());
+    fn locale_accessors_roundtrip() {
+        let locale = Locale::parse("zh-Hans-CN").expect("zh-Hans-CN is valid");
+        assert_eq!(locale.to_bcp47(), "zh-Hans-CN");
+        assert_eq!(locale.language(), "zh");
+        assert_eq!(locale.script(), Some("Hans"));
+        assert_eq!(locale.region(), Some("CN"));
     }
 
     #[test]
-    fn parse_roundtrips_through_as_str() {
-        let locale = Locale::parse("en-US").expect("valid");
-        assert_eq!(locale.as_str(), "en-US");
+    fn locale_extensions_are_exposed() {
+        let locale =
+            Locale::parse("ja-JP-u-ca-japanese-fw-mon").expect("locale with unicode extensions");
+        assert_eq!(locale.calendar_extension(), Some("japanese"));
+        assert_eq!(locale.first_day_of_week_extension(), Some(Weekday::Monday));
     }
 
     #[test]
-    fn locale_new_creates_unvalidated_locale() {
-        let locale = Locale::new("en-US");
-        assert_eq!(locale.as_str(), "en-US");
-
-        // new() accepts anything — no validation
-        let garbage = Locale::new("not-a-real-locale-!!!");
-        assert_eq!(garbage.as_str(), "not-a-real-locale-!!!");
+    fn locale_accessors_return_none_when_subtags_are_absent() {
+        let locale = Locale::parse("en").expect("en is valid");
+        assert_eq!(locale.script(), None);
+        assert_eq!(locale.region(), None);
+        assert_eq!(locale.calendar_extension(), None);
+        assert_eq!(locale.first_day_of_week_extension(), None);
     }
 
     #[test]
-    fn locale_default_is_empty() {
-        let locale = Locale::default();
-        assert_eq!(locale.as_str(), "");
+    fn locale_from_langid_roundtrips_to_bcp47() {
+        let langid = "en-US"
+            .parse::<icu::locale::LanguageIdentifier>()
+            .expect("en-US langid is valid");
+        let locale = Locale::from_langid(langid);
+        assert_eq!(locale.to_bcp47(), "en-US");
+    }
+
+    #[test]
+    fn locale_to_data_locale_roundtrips_to_string() {
+        let locale = Locale::parse("en-US").expect("en-US is valid");
+        assert_eq!(locale.to_data_locale().to_string(), "en-US");
+    }
+
+    #[test]
+    fn locale_ordering_is_lexical_by_bcp47() {
+        let mut locales = vec![
+            Locale::parse("fr-FR").expect("fr-FR is valid"),
+            Locale::parse("de-DE").expect("de-DE is valid"),
+            Locale::parse("en-US").expect("en-US is valid"),
+        ];
+        locales.sort();
+        let sorted: Vec<_> = locales
+            .into_iter()
+            .map(|locale| locale.to_bcp47())
+            .collect();
+        assert_eq!(sorted, vec!["de-DE", "en-US", "fr-FR"]);
+    }
+
+    #[test]
+    fn locale_direction_detects_rtl_scripts() {
+        for locale in ["ar", "he", "fa", "ar-EG"] {
+            let locale = Locale::parse(locale).expect("locale should parse");
+            assert_eq!(
+                locale.direction(),
+                Direction::Rtl,
+                "{} should be RTL",
+                locale.to_bcp47()
+            );
+            assert!(locale.is_rtl(), "{} should be RTL", locale.to_bcp47());
+        }
+    }
+
+    #[test]
+    fn locale_direction_infers_scripts_for_rtl_languages() {
+        for locale in ["dv", "nqo", "pa-PK", "ku-IQ", "yi", "ks"] {
+            let locale = Locale::parse(locale).expect("locale should parse");
+            assert_eq!(
+                locale.direction(),
+                Direction::Rtl,
+                "{} should be RTL",
+                locale.to_bcp47()
+            );
+            assert!(locale.is_rtl(), "{} should be RTL", locale.to_bcp47());
+        }
+    }
+
+    #[test]
+    fn locale_direction_defaults_to_ltr_when_not_rtl() {
+        let locale = Locale::parse("en-US").expect("en-US is valid");
+        assert_eq!(locale.direction(), Direction::Ltr);
+        assert!(!locale.is_rtl());
     }
 
     #[test]
     fn locale_parse_error_display() {
         let err = Locale::parse("").unwrap_err();
-        assert_eq!(err.to_string(), "invalid BCP 47 locale identifier");
+        assert_eq!(
+            err.to_string(),
+            "ars-ui locale parse error: The given language subtag is invalid"
+        );
+    }
+
+    #[test]
+    fn locale_prelude_constructors_return_expected_tags() {
+        let constructors = [
+            (locales::en(), "en"),
+            (locales::en_us(), "en-US"),
+            (locales::en_gb(), "en-GB"),
+            (locales::ar(), "ar"),
+            (locales::ar_sa(), "ar-SA"),
+            (locales::ar_eg(), "ar-EG"),
+            (locales::he(), "he"),
+            (locales::fa(), "fa"),
+            (locales::de(), "de"),
+            (locales::de_de(), "de-DE"),
+            (locales::fr(), "fr-FR"),
+            (locales::ja(), "ja"),
+            (locales::ja_jp(), "ja-JP"),
+            (locales::zh_hans(), "zh-Hans"),
+            (locales::ko(), "ko"),
+        ];
+
+        for (locale, expected) in constructors {
+            assert_eq!(locale.to_bcp47(), expected);
+        }
+    }
+
+    // ── Weekday tests ──────────────────────────────────────────────
+
+    #[test]
+    fn weekday_from_sunday_zero_wraps() {
+        assert_eq!(Weekday::from_sunday_zero(0), Weekday::Sunday);
+        assert_eq!(Weekday::from_sunday_zero(1), Weekday::Monday);
+        assert_eq!(Weekday::from_sunday_zero(6), Weekday::Saturday);
+        assert_eq!(Weekday::from_sunday_zero(7), Weekday::Sunday);
+    }
+
+    #[test]
+    fn weekday_from_iso_8601_validates_range() {
+        let cases = [
+            (1, Some(Weekday::Monday)),
+            (2, Some(Weekday::Tuesday)),
+            (3, Some(Weekday::Wednesday)),
+            (4, Some(Weekday::Thursday)),
+            (5, Some(Weekday::Friday)),
+            (6, Some(Weekday::Saturday)),
+            (7, Some(Weekday::Sunday)),
+        ];
+
+        for (input, expected) in cases {
+            assert_eq!(Weekday::from_iso_8601(input), expected);
+        }
+
+        assert_eq!(Weekday::from_iso_8601(0), None);
+        assert_eq!(Weekday::from_iso_8601(8), None);
+    }
+
+    #[test]
+    fn weekday_from_icu_str_matches_bcp47_values() {
+        assert_eq!(Weekday::from_icu_str("mon"), Some(Weekday::Monday));
+        assert_eq!(Weekday::from_bcp47_fw("sun"), Some(Weekday::Sunday));
+        assert_eq!(Weekday::from_icu_str("bad"), None);
+    }
+
+    #[test]
+    fn weekday_from_icu_str_covers_all_named_variants() {
+        let cases = [
+            ("mon", Weekday::Monday),
+            ("tue", Weekday::Tuesday),
+            ("wed", Weekday::Wednesday),
+            ("thu", Weekday::Thursday),
+            ("fri", Weekday::Friday),
+            ("sat", Weekday::Saturday),
+            ("sun", Weekday::Sunday),
+        ];
+
+        for (input, expected) in cases {
+            assert_eq!(Weekday::from_icu_str(input), Some(expected));
+            assert_eq!(Weekday::from_bcp47_fw(input), Some(expected));
+        }
+    }
+
+    #[test]
+    fn weekday_from_icu_weekday_covers_all_variants() {
+        let cases = [
+            (icu::calendar::types::Weekday::Monday, Weekday::Monday),
+            (icu::calendar::types::Weekday::Tuesday, Weekday::Tuesday),
+            (icu::calendar::types::Weekday::Wednesday, Weekday::Wednesday),
+            (icu::calendar::types::Weekday::Thursday, Weekday::Thursday),
+            (icu::calendar::types::Weekday::Friday, Weekday::Friday),
+            (icu::calendar::types::Weekday::Saturday, Weekday::Saturday),
+            (icu::calendar::types::Weekday::Sunday, Weekday::Sunday),
+        ];
+
+        for (input, expected) in cases {
+            assert_eq!(Weekday::from_icu_weekday(input), expected);
+        }
+    }
+
+    #[test]
+    fn placeholder_iso_helpers_return_empty_strings() {
+        let date = CalendarDate { _private: () };
+        let time = Time { _private: () };
+        let range = DateRange { _private: () };
+
+        assert_eq!(date.to_iso8601(), "");
+        assert_eq!(time.to_iso8601(), "");
+        assert_eq!(range.to_iso8601(), "");
+    }
+
+    // ── BiDi isolation tests ───────────────────────────────────────
+
+    #[test]
+    fn isolate_text_safe_returns_empty_for_empty_input() {
+        assert_eq!(isolate_text_safe("", IsolateDirection::FirstStrong), "");
+    }
+
+    #[test]
+    fn isolate_text_safe_wraps_text_with_ltr_marks() {
+        assert_eq!(
+            isolate_text_safe("hello", IsolateDirection::Ltr),
+            "\u{2066}hello\u{2069}"
+        );
+    }
+
+    #[test]
+    fn isolate_text_safe_wraps_text_with_rtl_marks() {
+        assert_eq!(
+            isolate_text_safe("مرحبا", IsolateDirection::Rtl),
+            "\u{2067}مرحبا\u{2069}"
+        );
+    }
+
+    #[test]
+    fn isolate_text_safe_wraps_text_with_first_strong_marks() {
+        assert_eq!(
+            isolate_text_safe("abc", IsolateDirection::FirstStrong),
+            "\u{2068}abc\u{2069}"
+        );
+    }
+
+    #[test]
+    fn isolate_text_safe_preserves_zwj_sequences() {
+        let family = "👨‍👩‍👧";
+        let isolated = isolate_text_safe(family, IsolateDirection::FirstStrong);
+        let stripped = isolated
+            .strip_prefix('\u{2068}')
+            .expect("must start with FSI")
+            .strip_suffix('\u{2069}')
+            .expect("must end with PDI");
+        assert_eq!(stripped, family);
     }
 }

--- a/crates/ars-i18n/src/locale.rs
+++ b/crates/ars-i18n/src/locale.rs
@@ -1,0 +1,262 @@
+use alloc::string::String;
+use core::{cmp::Ordering, fmt};
+
+use icu::locale::{LanguageIdentifier, Locale as IcuLocale};
+use icu_provider::DataLocale;
+
+use crate::{Direction, Weekday};
+
+/// A BCP 47 locale identifier.
+///
+/// Wraps ICU4X's locale type with ars-ui-specific helpers for directionality,
+/// Unicode extension access, and provider interop.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Locale(IcuLocale);
+
+impl Locale {
+    /// Parse from a BCP 47 string.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LocaleParseError`] when `s` is not a valid BCP 47 locale tag.
+    pub fn parse(s: &str) -> Result<Self, LocaleParseError> {
+        Ok(Self(s.parse::<IcuLocale>().map_err(LocaleParseError)?))
+    }
+
+    /// Create a locale from a known language identifier.
+    #[must_use]
+    pub fn from_langid(langid: LanguageIdentifier) -> Self {
+        Self(IcuLocale {
+            id: langid,
+            extensions: Default::default(),
+        })
+    }
+
+    /// Returns the text direction for this locale.
+    #[must_use]
+    pub fn direction(&self) -> Direction {
+        if RTL_SCRIPTS.contains(&self.script_or_default()) {
+            Direction::Rtl
+        } else {
+            Direction::Ltr
+        }
+    }
+
+    /// Returns `true` if this locale uses right-to-left text.
+    #[must_use]
+    pub fn is_rtl(&self) -> bool {
+        self.direction() == Direction::Rtl
+    }
+
+    /// Returns the locale's BCP 47 string representation.
+    #[must_use]
+    pub fn to_bcp47(&self) -> String {
+        self.0.to_string()
+    }
+
+    /// Returns the language subtag.
+    #[must_use]
+    pub const fn language(&self) -> &str {
+        self.0.id.language.as_str()
+    }
+
+    /// Returns the optional script subtag.
+    #[must_use]
+    pub fn script(&self) -> Option<&str> {
+        self.0
+            .id
+            .script
+            .as_ref()
+            .map(icu::locale::subtags::Script::as_str)
+    }
+
+    /// Returns the optional region subtag.
+    #[must_use]
+    pub fn region(&self) -> Option<&str> {
+        self.0
+            .id
+            .region
+            .as_ref()
+            .map(icu::locale::subtags::Region::as_str)
+    }
+
+    /// Returns the calendar system requested by the `u-ca-*` Unicode extension.
+    #[must_use]
+    pub fn calendar_extension(&self) -> Option<&str> {
+        self.0
+            .extensions
+            .unicode
+            .keywords
+            .get(&icu::locale::extensions::unicode::key!("ca"))
+            .and_then(|value| {
+                value
+                    .as_single_subtag()
+                    .map(icu::locale::subtags::Subtag::as_str)
+            })
+    }
+
+    /// Returns the first day of week requested by the `u-fw-*` Unicode extension.
+    #[must_use]
+    pub fn first_day_of_week_extension(&self) -> Option<Weekday> {
+        self.0
+            .extensions
+            .unicode
+            .keywords
+            .get(&icu::locale::extensions::unicode::key!("fw"))
+            .and_then(|value| value.as_single_subtag())
+            .and_then(|subtag| Weekday::from_bcp47_fw(subtag.as_str()))
+    }
+
+    /// Converts this locale to the ICU4X provider locale type.
+    #[must_use]
+    pub fn to_data_locale(&self) -> DataLocale {
+        (&self.0).into()
+    }
+
+    fn script_or_default(&self) -> &str {
+        self.script().unwrap_or_else(|| match self.language() {
+            "ar" | "fa" | "ur" | "ps" | "ug" | "sd" | "ks" => "Arab",
+            "he" | "yi" => "Hebr",
+            "dv" => "Thaa",
+            "nqo" => "Nkoo",
+            "pa" if self.region() == Some("PK") => "Arab",
+            "ku" if self.region() == Some("IQ") => "Arab",
+            _ => "Latn",
+        })
+    }
+}
+
+/// Error returned when parsing a locale string fails.
+#[derive(Debug)]
+pub struct LocaleParseError(pub icu::locale::ParseError);
+
+impl fmt::Display for LocaleParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "ars-ui locale parse error: {}", self.0)
+    }
+}
+
+impl core::error::Error for LocaleParseError {}
+
+impl PartialOrd for Locale {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Locale {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.to_bcp47().cmp(&other.to_bcp47())
+    }
+}
+
+/// Scripts that use right-to-left text direction.
+const RTL_SCRIPTS: &[&str] = &[
+    "Arab", "Hebr", "Thaa", "Syrc", "Tfng", "Adlm", "Rohg", "Mand", "Nbat", "Palm", "Nkoo", "Samr",
+];
+
+/// Common pre-defined locales.
+pub mod locales {
+    use super::Locale;
+
+    /// Returns a fallback locale used when a hard-coded locale tag fails to parse.
+    fn fallback() -> Locale {
+        Locale::parse("en-US").expect("en-US must always be a valid locale")
+    }
+
+    /// Returns the canonical Brazilian (A.K.A. Brazilian Portuguese - "pt-BR") locale.
+    #[must_use]
+    pub fn br() -> Locale {
+        Locale::parse("pt-BR").unwrap_or_else(|_| fallback())
+    }
+
+    /// Returns the canonical English language locale.
+    #[must_use]
+    pub fn en() -> Locale {
+        Locale::parse("en").unwrap_or_else(|_| fallback())
+    }
+
+    /// Returns the canonical American English locale.
+    #[must_use]
+    pub fn en_us() -> Locale {
+        Locale::parse("en-US").unwrap_or_else(|_| fallback())
+    }
+
+    /// Returns the canonical British English locale.
+    #[must_use]
+    pub fn en_gb() -> Locale {
+        Locale::parse("en-GB").unwrap_or_else(|_| fallback())
+    }
+
+    /// Returns the Arabic language locale.
+    #[must_use]
+    pub fn ar() -> Locale {
+        Locale::parse("ar").unwrap_or_else(|_| fallback())
+    }
+
+    /// Returns the Saudi Arabic locale.
+    #[must_use]
+    pub fn ar_sa() -> Locale {
+        Locale::parse("ar-SA").unwrap_or_else(|_| fallback())
+    }
+
+    /// Returns the Egyptian Arabic locale.
+    #[must_use]
+    pub fn ar_eg() -> Locale {
+        Locale::parse("ar-EG").unwrap_or_else(|_| fallback())
+    }
+
+    /// Returns the Hebrew language locale.
+    #[must_use]
+    pub fn he() -> Locale {
+        Locale::parse("he").unwrap_or_else(|_| fallback())
+    }
+
+    /// Returns the Persian language locale.
+    #[must_use]
+    pub fn fa() -> Locale {
+        Locale::parse("fa").unwrap_or_else(|_| fallback())
+    }
+
+    /// Returns the German language locale.
+    #[must_use]
+    pub fn de() -> Locale {
+        Locale::parse("de").unwrap_or_else(|_| fallback())
+    }
+
+    /// Returns the canonical German locale.
+    #[must_use]
+    pub fn de_de() -> Locale {
+        Locale::parse("de-DE").unwrap_or_else(|_| fallback())
+    }
+
+    /// Returns the canonical French locale.
+    #[must_use]
+    pub fn fr() -> Locale {
+        Locale::parse("fr-FR").unwrap_or_else(|_| fallback())
+    }
+
+    /// Returns the Japanese language locale.
+    #[must_use]
+    pub fn ja() -> Locale {
+        Locale::parse("ja").unwrap_or_else(|_| fallback())
+    }
+
+    /// Returns the canonical Japanese locale.
+    #[must_use]
+    pub fn ja_jp() -> Locale {
+        Locale::parse("ja-JP").unwrap_or_else(|_| fallback())
+    }
+
+    /// Returns the Simplified Chinese locale.
+    #[must_use]
+    pub fn zh_hans() -> Locale {
+        Locale::parse("zh-Hans").unwrap_or_else(|_| fallback())
+    }
+
+    /// Returns the Korean language locale.
+    #[must_use]
+    pub fn ko() -> Locale {
+        Locale::parse("ko").unwrap_or_else(|_| fallback())
+    }
+}

--- a/crates/ars-i18n/src/weekday.rs
+++ b/crates/ars-i18n/src/weekday.rs
@@ -1,0 +1,88 @@
+use icu::calendar::types::Weekday as IcuWeekday;
+
+/// Canonical ISO 8601 weekday.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Weekday {
+    /// Monday.
+    Monday,
+    /// Tuesday.
+    Tuesday,
+    /// Wednesday.
+    Wednesday,
+    /// Thursday.
+    Thursday,
+    /// Friday.
+    Friday,
+    /// Saturday.
+    Saturday,
+    /// Sunday.
+    Sunday,
+}
+
+impl Weekday {
+    /// Creates a weekday from a Sunday-zero-indexed number.
+    #[must_use]
+    pub fn from_sunday_zero(n: u8) -> Self {
+        const WEEKDAYS: [Weekday; 7] = [
+            Weekday::Sunday,
+            Weekday::Monday,
+            Weekday::Tuesday,
+            Weekday::Wednesday,
+            Weekday::Thursday,
+            Weekday::Friday,
+            Weekday::Saturday,
+        ];
+
+        WEEKDAYS[usize::from(n % 7)]
+    }
+
+    /// Creates a weekday from ISO 8601 numbering.
+    #[must_use]
+    pub const fn from_iso_8601(n: u8) -> Option<Self> {
+        match n {
+            1 => Some(Self::Monday),
+            2 => Some(Self::Tuesday),
+            3 => Some(Self::Wednesday),
+            4 => Some(Self::Thursday),
+            5 => Some(Self::Friday),
+            6 => Some(Self::Saturday),
+            7 => Some(Self::Sunday),
+            _ => None,
+        }
+    }
+
+    /// Parses a weekday from ICU/CLDR short codes such as `"mon"` or `"sun"`.
+    #[must_use]
+    pub fn from_icu_str(s: &str) -> Option<Self> {
+        match s {
+            "mon" => Some(Self::Monday),
+            "tue" => Some(Self::Tuesday),
+            "wed" => Some(Self::Wednesday),
+            "thu" => Some(Self::Thursday),
+            "fri" => Some(Self::Friday),
+            "sat" => Some(Self::Saturday),
+            "sun" => Some(Self::Sunday),
+            _ => None,
+        }
+    }
+
+    /// Parses a weekday from a BCP 47 `-u-fw-` extension value.
+    #[must_use]
+    pub fn from_bcp47_fw(s: &str) -> Option<Self> {
+        Self::from_icu_str(s)
+    }
+
+    /// Converts from ICU4X's weekday enum.
+    #[must_use]
+    pub const fn from_icu_weekday(weekday: IcuWeekday) -> Self {
+        match weekday {
+            IcuWeekday::Monday => Self::Monday,
+            IcuWeekday::Tuesday => Self::Tuesday,
+            IcuWeekday::Wednesday => Self::Wednesday,
+            IcuWeekday::Thursday => Self::Thursday,
+            IcuWeekday::Friday => Self::Friday,
+            IcuWeekday::Saturday => Self::Saturday,
+            IcuWeekday::Sunday => Self::Sunday,
+        }
+    }
+}

--- a/crates/ars-interactions/src/dismissable.rs
+++ b/crates/ars-interactions/src/dismissable.rs
@@ -155,6 +155,7 @@ pub fn dismiss_button_attrs(locale: &Locale, messages: &Messages) -> AttrMap {
 #[cfg(test)]
 mod tests {
     use ars_core::AttrValue;
+    use ars_i18n::locales;
 
     use super::*;
 
@@ -163,14 +164,14 @@ mod tests {
     #[test]
     fn messages_default_close_label_returns_dismiss() {
         let messages = Messages::default();
-        let locale = Locale::new("en-US");
+        let locale = locales::en_us();
         assert_eq!((messages.close_label)(&locale), "Dismiss");
     }
 
     #[test]
     fn messages_default_close_label_ignores_locale() {
         let messages = Messages::default();
-        assert_eq!((messages.close_label)(&Locale::new("ja-JP")), "Dismiss");
+        assert_eq!((messages.close_label)(&locales::ja_jp()), "Dismiss");
     }
 
     #[test]
@@ -319,7 +320,7 @@ mod tests {
     // ── dismiss_button_attrs tests ─────────────────────────────────
 
     fn default_locale() -> Locale {
-        Locale::new("en-US")
+        locales::en_us()
     }
 
     #[test]
@@ -372,14 +373,14 @@ mod tests {
     fn dismiss_button_attrs_uses_locale_in_message_fn() {
         let messages = Messages {
             close_label: MessageFn::from(|locale: &Locale| {
-                if locale.as_str() == "de-DE" {
+                if locale.to_bcp47() == "de-DE" {
                     "Schlie\u{00df}en".into()
                 } else {
                     "Dismiss".into()
                 }
             }),
         };
-        let attrs = dismiss_button_attrs(&Locale::new("de-DE"), &messages);
+        let attrs = dismiss_button_attrs(&locales::de_de(), &messages);
         assert_eq!(
             attrs.get(&HtmlAttr::Aria(AriaAttr::Label)),
             Some("Schlie\u{00df}en")

--- a/crates/ars-leptos/src/attrs.rs
+++ b/crates/ars-leptos/src/attrs.rs
@@ -262,7 +262,7 @@ mod tests {
         let owner = Owner::new();
         owner.with(|| {
             provide_context(ArsContext::new(
-                ars_i18n::Locale::new("en-US"),
+                ars_i18n::locales::en_us(),
                 ars_i18n::Direction::Ltr,
                 ars_core::ColorMode::System,
                 false,

--- a/crates/ars-test-harness/src/lib.rs
+++ b/crates/ars-test-harness/src/lib.rs
@@ -80,9 +80,9 @@ mod tests {
 
     #[test]
     fn test_harness_with_locale() {
-        let harness = TestHarness::with_locale(Locale::new("en-US"));
+        let harness = TestHarness::with_locale(ars_i18n::locales::en_us());
         let locale = harness.locale().expect("locale should be set");
-        assert_eq!(locale.as_str(), "en-US");
+        assert_eq!(locale.to_bcp47(), "en-US");
     }
 
     #[test]

--- a/spec/components/date-time/date-field.md
+++ b/spec/components/date-time/date-field.md
@@ -855,7 +855,7 @@ pub fn segments_for_locale(
     // Language-prefix matching ensures that locale tags without a region
     // (e.g., "de", "fr") and uncommon region variants (e.g., "en-ZA") get
     // appropriate segment orders rather than falling through to the ISO default.
-    let locale_str = locale.as_str();
+    let locale_str = locale.to_bcp47();
     let lang = locale.language();
 
     let base: Vec<DateSegmentKind> = if locale_str == "en-US" || locale_str == "en-PH" || locale_str == "en-CA" || locale_str == "es-MX" {
@@ -953,7 +953,8 @@ pub struct LocaleSeparators {
 impl LocaleSeparators {
     pub fn for_locale(locale: &Locale) -> Self {
         // Production: ICU4X pattern parsing extracts exact separator strings.
-        let seps: Vec<String> = match locale.as_str() {
+        let locale_tag = locale.to_bcp47();
+        let seps: Vec<String> = match locale_tag.as_str() {
             "de-DE" | "de-AT" | "nl-NL" | "pl-PL" | "ru-RU" | "cs-CZ"
             | "sk-SK" | "hr-HR" | "bg-BG" | "ro-RO" =>
                 vec![".".into(), ".".into()],

--- a/spec/components/date-time/date-picker.md
+++ b/spec/components/date-time/date-picker.md
@@ -314,7 +314,8 @@ impl ars_core::Machine for Machine {
         let locale = env.locale.clone();
         let messages = messages.clone();
 
-        let default_format = match locale.as_str() {
+        let locale_tag = locale.to_bcp47();
+        let default_format = match locale_tag.as_str() {
             "en-US" | "en-CA" => "MM/dd/yyyy",
             "en-GB" | "de-DE" | "fr-FR" | "es-ES" | "it-IT" | "ru-RU" => "dd/MM/yyyy",
             "ja-JP" | "zh-CN" | "zh-TW" | "ko-KR" => "yyyy/MM/dd",

--- a/spec/components/date-time/date-time-picker.md
+++ b/spec/components/date-time/date-time-picker.md
@@ -402,7 +402,8 @@ impl Machine {
         }
 
         // Locale-dependent segment order.
-        match locale.as_str() {
+        let locale_tag = locale.to_bcp47();
+        match locale_tag.as_str() {
             "ja-JP" | "zh-CN" | "zh-TW" | "ko-KR" => {
                 segs.push(year_seg);
                 segs.push(DateSegment::new_literal("/"));

--- a/spec/components/utility/ars-provider.md
+++ b/spec/components/utility/ars-provider.md
@@ -24,7 +24,7 @@ references:
 #[derive(Clone, Debug)]
 pub struct Props {
     /// The active locale for i18n message formatting and text direction inference.
-    /// Defaults to `Locale::new("en-US")`.
+    /// Defaults to `Locale::parse("en-US").expect("en-US is always valid")`.
     pub locale: Option<Locale>,
 
     /// Explicit reading direction override. When `None`, direction is inferred
@@ -132,7 +132,7 @@ impl ArsContext {
 impl Default for ArsContext {
     fn default() -> Self {
         Self {
-            locale: Locale::new("en-US").expect("en-US is always valid"),
+            locale: Locale::parse("en-US").expect("en-US is always valid"),
             direction: Direction::Ltr,
             color_mode: ColorMode::System,
             disabled: false,

--- a/spec/foundation/04-internationalization.md
+++ b/spec/foundation/04-internationalization.md
@@ -21,6 +21,12 @@ The `ars-i18n` crate provides complete internationalization support for ars-ui c
 - **`icu4x`** (default): Rust-native ICU4X implementation. Required for SSR, desktop, and non-browser environments. Adds ~100-500KB to WASM binary.
 - **`web-intl`**: Delegates to the browser's `Intl` API via `js-sys`. Zero binary size overhead. WASM client only.
 
+`Locale` parsing, BCP 47 metadata access (`language()`, `script()`, `region()`,
+Unicode extensions), and `DataLocale` conversion are foundational and may rely on
+the lightweight ICU locale/provider crates in all builds, including WASM clients.
+The `icu4x` vs `web-intl` split applies to formatter backends and compiled CLDR
+data, not to the core `Locale` wrapper itself.
+
 ```rust
 #[cfg(feature = "icu4x")]
 pub type DefaultNumberFormatter = icu4x::Icu4xNumberFormatter;
@@ -68,7 +74,7 @@ use icu::locale::{Locale as IcuLocale, locale};
 /// A BCP 47 locale identifier.
 ///
 /// Wraps ICU4X's Locale type with ars-ui-specific helpers.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Locale(IcuLocale);
 
 impl Locale {
@@ -163,6 +169,20 @@ impl Locale {
     }
 }
 
+// ICU4X 2.x does not implement `Ord` on `icu::locale::Locale`, so ars-i18n
+// defines a stable lexical ordering on the canonical BCP 47 string form.
+impl PartialOrd for Locale {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Locale {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.to_bcp47().cmp(&other.to_bcp47())
+    }
+}
+
 /// Scripts that use right-to-left text direction.
 const RTL_SCRIPTS: &[&str] = &[
     "Arab", // Arabic
@@ -235,15 +255,19 @@ pub mod locales {
         Locale::parse("en-US").expect("en-US must always be a valid locale")
     }
 
+    pub fn en() -> Locale { Locale::parse("en").unwrap_or_else(|_| fallback()) }
     pub fn en_us() -> Locale { Locale::parse("en-US").unwrap_or_else(|_| fallback()) }
     pub fn en_gb() -> Locale { Locale::parse("en-GB").unwrap_or_else(|_| fallback()) }
     pub fn ar() -> Locale { Locale::parse("ar").unwrap_or_else(|_| fallback()) }
     pub fn ar_sa() -> Locale { Locale::parse("ar-SA").unwrap_or_else(|_| fallback()) }
+    pub fn ar_eg() -> Locale { Locale::parse("ar-EG").unwrap_or_else(|_| fallback()) }
     pub fn he() -> Locale { Locale::parse("he").unwrap_or_else(|_| fallback()) }
     pub fn fa() -> Locale { Locale::parse("fa").unwrap_or_else(|_| fallback()) }
     pub fn de() -> Locale { Locale::parse("de").unwrap_or_else(|_| fallback()) }
+    pub fn de_de() -> Locale { Locale::parse("de-DE").unwrap_or_else(|_| fallback()) }
     pub fn fr() -> Locale { Locale::parse("fr-FR").unwrap_or_else(|_| fallback()) }
     pub fn ja() -> Locale { Locale::parse("ja").unwrap_or_else(|_| fallback()) }
+    pub fn ja_jp() -> Locale { Locale::parse("ja-JP").unwrap_or_else(|_| fallback()) }
     pub fn zh_hans() -> Locale { Locale::parse("zh-Hans").unwrap_or_else(|_| fallback()) }
     pub fn ko() -> Locale { Locale::parse("ko").unwrap_or_else(|_| fallback()) }
 }
@@ -1449,14 +1473,13 @@ fn platform_today_iso() -> Result<(i32, u8, u8), String> {
     Ok((y, m, d))
 }
 
-// `Weekday` — defined in `shared/date-time-types.md`
-// The following extension methods are provided by `ars-i18n` on the canonical type.
+// `Weekday` — specified in `shared/date-time-types.md` and implemented in `ars-i18n`.
+// The following extension methods are provided on that canonical type.
 
 impl Weekday {
     // `from_sunday_zero()` and `from_iso_8601()` are defined on the canonical
-    // Weekday type in shared/date-time-types.md (ars-core crate). The ars-i18n
-    // crate re-exports Weekday from ars-core, so these methods are available
-    // without redefinition. See shared/date-time-types.md §3.
+    // `Weekday` type in `shared/date-time-types.md`. `ars-core` may re-export
+    // the type for convenience, but `ars-i18n` owns the implementation.
 
     pub fn from_icu_str(s: &str) -> Option<Self> {
         match s {
@@ -2994,6 +3017,8 @@ impl StringCollator {
 [dependencies]
 # Umbrella crate — re-exports icu::calendar, icu::collator, icu::datetime, etc.
 # All code uses icu::* paths; no need for individual icu_* crates in [dependencies].
+# The lightweight locale/provider portions may be used unconditionally because
+# `Locale` parsing and metadata access are part of the core contract on every target.
 icu = { version = "2.1", features = ["serde"] }
 icu_experimental = "0.4"  # Contains relativetime (not yet in umbrella)
 fixed_decimal = "0.7"     # Main type is Decimal (not FixedDecimal)
@@ -3004,6 +3029,9 @@ icu_datagen = { version = "2.1", optional = true }
 
 [features]
 default = ["icu4x", "compiled-data", "gregorian"]
+# `icu4x` enables formatter backends and compiled CLDR data. `Locale` itself may
+# still depend on ICU locale/provider crates even when `web-intl` is the active
+# formatting backend on the client.
 icu4x = ["dep:icu"]
 web-intl = ["dep:wasm-bindgen", "dep:js-sys"]
 compiled-data = ["icu/compiled_data"]

--- a/spec/foundation/06-collections.md
+++ b/spec/foundation/06-collections.md
@@ -4680,7 +4680,7 @@ let state = typeahead::State::default();
 let focus = Some(Key::int(0));
 
 // Type "b" — should jump to Banana (the first item starting with "b" after Apple).
-let locale = Locale::new("en-US").expect("valid locale");
+let locale = Locale::parse("en-US").expect("valid locale");
 let (state, found) = state.process_char('b', 1000, focus.as_ref(), &collection, &locale);
 assert_eq!(found, Some(Key::int(2))); // Banana
 

--- a/spec/shared/date-time-types.md
+++ b/spec/shared/date-time-types.md
@@ -603,6 +603,7 @@ impl core::fmt::Debug for CalendarMessages {
 
 ```rust
 // Canonical Weekday. ISO 8601: Monday=1..Sunday=7.
+// Implemented in `ars_i18n` and re-exported by `ars_core` for convenience.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Weekday {
     Monday,
@@ -671,7 +672,7 @@ pub struct Era {
 /// **Production code MUST use `ars_i18n::Locale` directly.** This placeholder is
 /// `#[cfg(test)]` only — it exists so that unit tests in `date-time-types` can compile
 /// without pulling in the full `ars-i18n` crate. The two types convert via `From`:
-///   `impl From<&ars_i18n::Locale> for Locale { fn from(l) -> Self { Locale(l.to_string()) } }`
+///   `impl From<&ars_i18n::Locale> for Locale { fn from(l) -> Self { Locale(l.to_bcp47()) } }`
 ///   `impl From<&Locale> for ars_i18n::Locale { fn from(l) -> Self { ars_i18n::Locale::parse(l.as_str()).expect("test locale is valid BCP-47") } }`
 #[cfg(test)]
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]


### PR DESCRIPTION
## Summary

Implement the `#75` i18n migration by replacing the stub `Locale(String)` with an ICU4X-backed locale wrapper and adding the supporting BiDi and weekday utilities the spec now expects.

## What Changed

- added ICU4X-backed `Locale`, `LocaleParseError`, `Weekday`, `IsolateDirection`, and `isolate_text_safe` in `ars-i18n`
- split `ars-i18n` into focused `locale`, `weekday`, and `bidi` modules and added coverage for the new API surface
- migrated affected workspace call sites to the new locale API and introduced a few common `locales::*` helpers for repeated defaults
- synchronized the relevant i18n/date-time/provider spec snippets and rationale with the shipped code

## Impact

This brings the workspace onto the spec-aligned locale API needed for future ICU-backed formatting work while keeping browser-facing formatting backend choices separate from the core locale wrapper.

## Validation

- `cargo test -p ars-i18n`
- `cargo test -p ars-core`
- `cargo test -p ars-interactions`

Closes #75