### PR TITLE
Implement ICU4X-backed number formatting in ars-i18n

### DIFF
--- a/.agents/skills/icu4x/SKILL.md
+++ b/.agents/skills/icu4x/SKILL.md
@@ -162,11 +162,11 @@ use icu::segmenter::{GraphemeClusterSegmenter, WordSegmenter};
 
 // Infallible, no locale needed
 let segmenter = GraphemeClusterSegmenter::new();
-let breaks: Vec<usize> = segmenter.segment_str("hello").collect();
+let breaks = segmenter.segment_str("hello").collect::<Vec<_>>();
 
 // Word segmenter (auto-selects algorithm)
 let segmenter = WordSegmenter::new_auto(Default::default());
-let breaks: Vec<usize> = segmenter.segment_str("Hello world!").collect();
+let breaks = segmenter.segment_str("Hello world!").collect::<Vec<_>>();
 ```
 
 ## Reference Files

--- a/.agents/skills/icu4x/references/text-processing.md
+++ b/.agents/skills/icu4x/references/text-processing.md
@@ -195,7 +195,7 @@ All segmenters follow an **owned/borrowed** pattern. Constructors often return t
 let segmenter = GraphemeClusterSegmenter::new();  // returns GraphemeClusterSegmenterBorrowed<'static>
 
 // Segment
-let breaks: Vec<usize> = segmenter.segment_str("hello").collect();
+let breaks = segmenter.segment_str("hello").collect::<Vec<_>>();
 ```
 
 ### 4.2 `WordSegmenter`
@@ -209,7 +209,7 @@ let seg = WordSegmenter::new_dictionary(Default::default()); // dictionary model
 // With locale-specific rules (fallible)
 let seg = WordSegmenter::try_new_auto(options)?;  // returns owned WordSegmenter
 let borrowed = seg.as_borrowed();
-let breaks: Vec<usize> = borrowed.segment_str("Hello world!").collect();
+let breaks = borrowed.segment_str("Hello world!").collect::<Vec<_>>();
 ```
 
 ### 4.3 `SentenceSegmenter`
@@ -229,9 +229,9 @@ All `segment_str()` / `segment_utf8()` / `segment_utf16()` methods return iterat
 ```rust
 let segmenter = WordSegmenter::new_auto(Default::default());
 let text = "Hello, world!";
-let words: Vec<&str> = {
-    let breaks: Vec<usize> = segmenter.segment_str(text).collect();
-    breaks.windows(2).map(|w| &text[w[0]..w[1]]).collect()
+let words = {
+    let breaks = segmenter.segment_str(text).collect::<Vec<_>>();
+    breaks.windows(2).map(|w| &text[w[0]..w[1]]).collect::<Vec<_>>()
 };
 ```
 

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,6 @@
 [alias]
-xtask = "run --package xtask --"
-xci   = "xtask ci"
-xmcp  = "xtask mcp"
-xspec = "xtask spec"
+xtask   = "run --package xtask --"
+xci     = "xtask ci"
+xclippy = "xtask clippy"
+xmcp    = "xtask mcp"
+xspec   = "xtask spec"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+  "rust-analyzer.check.overrideCommand": [
+    "cargo",
+    "xclippy",
+    "--message-format=json"
+  ],
+  "rust-analyzer.rustfmt.extraArgs": ["+nightly"],
+  "[rust]": {
+    "editor.defaultFormatter": "rust-lang.rust-analyzer",
+    "editor.formatOnSave": true
+  }
+}

--- a/crates/ars-a11y/src/aria/attribute.rs
+++ b/crates/ars-a11y/src/aria/attribute.rs
@@ -300,7 +300,7 @@ pub struct AriaRelevant {
 
 impl core::fmt::Display for AriaRelevant {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let mut parts: Vec<&str> = Vec::new();
+        let mut parts = Vec::new();
         if self.additions {
             parts.push("additions");
         }

--- a/crates/ars-collections/src/async_collection.rs
+++ b/crates/ars-collections/src/async_collection.rs
@@ -90,7 +90,7 @@ impl<T: Clone> AsyncCollection<T> {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            inner: StaticCollection::from_vec(Vec::new()),
+            inner: StaticCollection::default(),
             next_cursor: None,
             has_more: true,
             loading_state: AsyncLoadingState::Idle,
@@ -128,7 +128,7 @@ impl<T: Clone> AsyncCollection<T> {
     ) -> Self {
         let has_more = next_cursor.is_some();
         // Merge existing items with the new page.
-        let mut merged: Vec<(Key, String, T)> = self
+        let mut merged = self
             .inner
             .nodes()
             .filter_map(|n| {
@@ -136,11 +136,11 @@ impl<T: Clone> AsyncCollection<T> {
                     .as_ref()
                     .map(|v| (n.key.clone(), n.text_value.clone(), v.clone()))
             })
-            .collect();
+            .collect::<Vec<_>>();
         merged.extend(new_items);
 
         Self {
-            inner: StaticCollection::from_vec(merged),
+            inner: merged.into(),
             next_cursor,
             has_more,
             loading_state: AsyncLoadingState::Loaded,
@@ -527,20 +527,20 @@ mod tests {
     #[test]
     fn collection_delegation_keys_iterator() {
         let c = loaded_collection();
-        let keys: Vec<_> = c.keys().collect();
+        let keys = c.keys().collect::<Vec<_>>();
         assert_eq!(keys, vec![&Key::int(1), &Key::int(2), &Key::int(3)]);
 
-        let nodes: Vec<_> = c.nodes().map(|n| n.text_value.as_str()).collect();
+        let nodes = c.nodes().map(|n| n.text_value.as_str()).collect::<Vec<_>>();
         assert_eq!(nodes, vec!["Apple", "Banana", "Cherry"]);
 
-        let item_keys: Vec<_> = c.item_keys().collect();
+        let item_keys = c.item_keys().collect::<Vec<_>>();
         assert_eq!(item_keys, vec![&Key::int(1), &Key::int(2), &Key::int(3)]);
     }
 
     #[test]
     fn collection_delegation_children_of_empty() {
         let c = loaded_collection();
-        let children: Vec<_> = c.children_of(&Key::str("nonexistent")).collect();
+        let children = c.children_of(&Key::str("nonexistent")).collect::<Vec<_>>();
         assert!(children.is_empty());
     }
 

--- a/crates/ars-collections/src/builder.rs
+++ b/crates/ars-collections/src/builder.rs
@@ -173,7 +173,7 @@ mod tests {
 
     #[test]
     fn builder_empty() {
-        let c: StaticCollection<String> = CollectionBuilder::new().build();
+        let c = CollectionBuilder::<String>::new().build();
         assert_eq!(c.size(), 0);
         assert!(c.is_empty());
     }
@@ -203,7 +203,7 @@ mod tests {
             .build();
 
         assert_eq!(c.size(), 3);
-        let keys: Vec<_> = c.keys().collect();
+        let keys = c.keys().collect::<Vec<_>>();
         assert_eq!(keys, vec![&Key::int(1), &Key::int(2), &Key::int(3)]);
 
         // Verify indices
@@ -279,8 +279,8 @@ mod tests {
 
     #[test]
     fn builder_default_equals_new() {
-        let a: CollectionBuilder<String> = CollectionBuilder::new();
-        let b: CollectionBuilder<String> = CollectionBuilder::default();
+        let a = CollectionBuilder::<String>::new();
+        let b = CollectionBuilder::<String>::default();
         assert_eq!(a.build().size(), b.build().size());
     }
 

--- a/crates/ars-collections/src/collection.rs
+++ b/crates/ars-collections/src/collection.rs
@@ -93,7 +93,7 @@ pub trait Collection<T> {
     ///
     /// **Callers that need to store keys across mutations MUST clone:**
     /// ```rust,ignore
-    /// let key: Key = collection.first_key().cloned().expect("collection is non-empty");
+    /// let key = collection.first_key().cloned().expect("collection is non-empty");
     /// // `key` is now owned — safe across mutations
     /// ```
     ///

--- a/crates/ars-collections/src/key.rs
+++ b/crates/ars-collections/src/key.rs
@@ -214,31 +214,31 @@ mod tests {
 
     #[test]
     fn key_from_str_ref() {
-        let key: Key = Key::from("hello");
+        let key = Key::from("hello");
         assert_eq!(key, Key::String("hello".into()));
     }
 
     #[test]
     fn key_from_string() {
-        let key: Key = Key::from(String::from("x"));
+        let key = Key::from(String::from("x"));
         assert_eq!(key, Key::String("x".into()));
     }
 
     #[test]
     fn key_from_u64() {
-        let key: Key = Key::from(42u64);
+        let key = Key::from(42u64);
         assert_eq!(key, Key::Int(42));
     }
 
     #[test]
     fn key_from_u32() {
-        let key: Key = Key::from(7u32);
+        let key = Key::from(7u32);
         assert_eq!(key, Key::Int(7));
     }
 
     #[test]
     fn key_from_usize() {
-        let key: Key = Key::from(3usize);
+        let key = Key::from(3usize);
         assert_eq!(key, Key::Int(3));
     }
 
@@ -303,7 +303,7 @@ mod tests {
         set.insert(Key::str("a"));
         set.insert(Key::Int(1));
 
-        let keys: Vec<_> = set.into_iter().collect();
+        let keys = set.into_iter().collect::<Vec<_>>();
         assert_eq!(
             keys,
             vec![Key::Int(1), Key::Int(2), Key::str("a"), Key::str("z")]
@@ -400,7 +400,7 @@ mod tests {
         #[test]
         fn uuid_from_impl() {
             let id = sample_uuid_a();
-            let key: Key = Key::from(id);
+            let key = Key::from(id);
             assert_eq!(key, Key::Uuid(id));
         }
 
@@ -459,7 +459,7 @@ mod tests {
             set.insert(Key::str("a"));
             set.insert(Key::Int(2));
 
-            let keys: Vec<_> = set.into_iter().collect();
+            let keys = set.into_iter().collect::<Vec<_>>();
             assert_eq!(
                 keys,
                 vec![

--- a/crates/ars-collections/src/node.rs
+++ b/crates/ars-collections/src/node.rs
@@ -317,7 +317,7 @@ mod tests {
 
     #[test]
     fn node_with_tree_fields() {
-        let node: Node<String> = Node {
+        let node = Node {
             key: Key::str("child-1"),
             node_type: NodeType::Item,
             value: Some("child".to_string()),

--- a/crates/ars-collections/src/selection.rs
+++ b/crates/ars-collections/src/selection.rs
@@ -455,10 +455,10 @@ mod tests {
         assert_eq!(all.len(), 0);
         assert_eq!(single.len(), 1);
 
-        let empty_keys: Vec<_> = empty.keys().cloned().collect();
-        let single_keys: Vec<_> = single.keys().cloned().collect();
-        let multiple_keys: Vec<_> = multiple.keys().cloned().collect();
-        let all_keys: Vec<_> = all.keys().cloned().collect();
+        let empty_keys = empty.keys().cloned().collect::<Vec<_>>();
+        let single_keys = single.keys().cloned().collect::<Vec<_>>();
+        let multiple_keys = multiple.keys().cloned().collect::<Vec<_>>();
+        let all_keys = all.keys().cloned().collect::<Vec<_>>();
 
         assert!(empty_keys.is_empty());
         assert_eq!(single_keys, vec![Key::int(3)]);

--- a/crates/ars-collections/src/static_collection.rs
+++ b/crates/ars-collections/src/static_collection.rs
@@ -40,20 +40,24 @@ impl<T: Clone> StaticCollection<T> {
         }
     }
 
-    /// Construct from a `Vec` of `(Key, text_value, T)` tuples.
+    /// Construct from any iterator of `(Key, text_value, T)` tuples.
     #[must_use]
-    pub fn new(items: Vec<(Key, String, T)>) -> Self {
-        Self::from_vec(items)
+    pub fn new(items: impl IntoIterator<Item = (Key, String, T)>) -> Self {
+        Self::from_iter(items)
     }
+}
 
-    /// Convenience constructor from a `Vec` of `(Key, label, data)` tuples.
-    #[must_use]
-    pub fn from_vec(items: Vec<(Key, String, T)>) -> Self {
-        let mut builder = CollectionBuilder::new();
-        for (key, text, value) in items {
-            builder = builder.item(key, text, value);
-        }
-        builder.build()
+/// Construct an empty collection.
+impl<T: Clone> Default for StaticCollection<T> {
+    fn default() -> Self {
+        Self::new([])
+    }
+}
+
+/// Construct from a `Vec` of `(Key, text_value, T)` tuples.
+impl<T: Clone> From<Vec<(Key, String, T)>> for StaticCollection<T> {
+    fn from(items: Vec<(Key, String, T)>) -> Self {
+        Self::from_iter(items)
     }
 }
 
@@ -61,7 +65,11 @@ impl<T: Clone> StaticCollection<T> {
 /// to build a collection from an iterator of `(Key, text_value, T)` tuples.
 impl<T: Clone> FromIterator<(Key, String, T)> for StaticCollection<T> {
     fn from_iter<I: IntoIterator<Item = (Key, String, T)>>(iter: I) -> Self {
-        Self::from_vec(iter.into_iter().collect())
+        let mut builder = CollectionBuilder::new();
+        for (key, text, value) in iter {
+            builder = builder.item(key, text, value);
+        }
+        builder.build()
     }
 }
 
@@ -292,7 +300,7 @@ mod tests {
     // ---------------------------------------------------------------
 
     fn three_items() -> StaticCollection<&'static str> {
-        StaticCollection::from_vec(vec![
+        StaticCollection::new([
             (Key::int(1), "Apple".to_string(), "a"),
             (Key::int(2), "Banana".to_string(), "b"),
             (Key::int(3), "Cherry".to_string(), "c"),
@@ -312,18 +320,18 @@ mod tests {
 
     #[test]
     fn from_vec_empty() {
-        let c = StaticCollection::<String>::from_vec(vec![]);
+        let c = StaticCollection::<String>::default();
         assert_eq!(c.size(), 0);
         assert!(c.is_empty());
     }
 
     #[test]
     fn new_delegates_to_from_vec() {
-        let a = StaticCollection::new(vec![
+        let a = StaticCollection::new([
             (Key::int(1), "X".to_string(), 10),
             (Key::int(2), "Y".to_string(), 20),
         ]);
-        let b = StaticCollection::from_vec(vec![
+        let b = StaticCollection::new([
             (Key::int(1), "X".to_string(), 10),
             (Key::int(2), "Y".to_string(), 20),
         ]);
@@ -332,11 +340,11 @@ mod tests {
 
     #[test]
     fn from_iterator() {
-        let items = vec![
+        let items = [
             (Key::int(1), "A".to_string(), "a"),
             (Key::int(2), "B".to_string(), "b"),
         ];
-        let c: StaticCollection<&str> = items.into_iter().collect();
+        let c = items.into_iter().collect::<StaticCollection<_>>();
         assert_eq!(c.size(), 2);
     }
 
@@ -412,7 +420,7 @@ mod tests {
 
     #[test]
     fn first_key_empty() {
-        let c = StaticCollection::<String>::from_vec(vec![]);
+        let c = StaticCollection::<String>::default();
         assert_eq!(c.first_key(), None);
     }
 
@@ -445,7 +453,7 @@ mod tests {
 
     #[test]
     fn first_and_last_key_only_structural() {
-        let c: StaticCollection<String> = CollectionBuilder::new().separator().build();
+        let c = CollectionBuilder::<String>::new().separator().build();
         assert_eq!(c.first_key(), None);
         assert_eq!(c.last_key(), None);
     }
@@ -588,14 +596,14 @@ mod tests {
     #[test]
     fn keys_iterator() {
         let c = three_items();
-        let keys: Vec<_> = c.keys().collect();
+        let keys = c.keys().collect::<Vec<_>>();
         assert_eq!(keys, vec![&Key::int(1), &Key::int(2), &Key::int(3)]);
     }
 
     #[test]
     fn nodes_iterator() {
         let c = three_items();
-        let text_values: Vec<_> = c.nodes().map(|n| n.text_value.as_str()).collect();
+        let text_values = c.nodes().map(|n| n.text_value.as_str()).collect::<Vec<_>>();
         assert_eq!(text_values, vec!["Apple", "Banana", "Cherry"]);
     }
 
@@ -609,7 +617,7 @@ mod tests {
             .item(Key::int(2), "B", "b")
             .build();
         // item_keys should only return focusable items
-        let item_keys: Vec<_> = c.item_keys().collect();
+        let item_keys = c.item_keys().collect::<Vec<_>>();
         assert_eq!(item_keys, vec![&Key::int(1), &Key::int(2)]);
     }
 
@@ -627,7 +635,7 @@ mod tests {
             .item(Key::int(3), "Other", "o")
             .build();
 
-        let children: Vec<_> = c.children_of(&Key::str("fruits")).collect();
+        let children = c.children_of(&Key::str("fruits")).collect::<Vec<_>>();
         // Header + 2 items are children of the section
         assert_eq!(children.len(), 3);
         assert_eq!(children[0].node_type, NodeType::Header);
@@ -638,7 +646,7 @@ mod tests {
     #[test]
     fn children_of_no_match() {
         let c = three_items();
-        let children: Vec<_> = c.children_of(&Key::str("nonexistent")).collect();
+        let children = c.children_of(&Key::str("nonexistent")).collect::<Vec<_>>();
         assert!(children.is_empty());
     }
 
@@ -687,14 +695,14 @@ mod tests {
     #[test]
     fn partial_eq_different_size() {
         let a = three_items();
-        let b = StaticCollection::from_vec(vec![(Key::int(1), "Apple".to_string(), "a")]);
+        let b = StaticCollection::new([(Key::int(1), "Apple".to_string(), "a")]);
         assert_ne!(a, b);
     }
 
     #[test]
     fn partial_eq_different_values() {
-        let a = StaticCollection::from_vec(vec![(Key::int(1), "Apple".to_string(), "a")]);
-        let b = StaticCollection::from_vec(vec![(Key::int(1), "Apple".to_string(), "z")]);
+        let a = StaticCollection::new([(Key::int(1), "Apple".to_string(), "a")]);
+        let b = StaticCollection::new([(Key::int(1), "Apple".to_string(), "z")]);
         assert_ne!(a, b);
     }
 
@@ -809,7 +817,7 @@ mod tests {
 
     #[test]
     fn single_item_wrapping_navigation() {
-        let c = StaticCollection::from_vec(vec![(Key::int(1), "Only".to_string(), "x")]);
+        let c = StaticCollection::new([(Key::int(1), "Only".to_string(), "x")]);
         // key_after wraps to itself
         assert_eq!(c.key_after(&Key::int(1)), Some(&Key::int(1)));
         // key_before wraps to itself
@@ -825,7 +833,7 @@ mod tests {
 
     #[test]
     fn empty_collection_navigation() {
-        let c = StaticCollection::<String>::from_vec(vec![]);
+        let c = StaticCollection::<String>::default();
         assert_eq!(c.first_key(), None);
         assert_eq!(c.last_key(), None);
         assert_eq!(c.key_after(&Key::int(1)), None);

--- a/crates/ars-core/src/lib.rs
+++ b/crates/ars-core/src/lib.rs
@@ -790,7 +790,7 @@ impl<M: Machine> Service<M> {
         )]
         let mut truncated = false;
         let mut iterations = 0;
-        let mut context_change_count: usize = 0;
+        let mut context_change_count = 0;
 
         while let Some(event) = self.event_queue.pop_front() {
             iterations += 1;

--- a/crates/ars-core/src/message_fn.rs
+++ b/crates/ars-core/src/message_fn.rs
@@ -160,16 +160,14 @@ mod tests {
 
     #[test]
     fn message_fn_from_closure() {
-        let mf: MessageFn<dyn Fn(&Locale) -> String + Send + Sync> =
-            MessageFn::from(|locale: &Locale| format!("Close ({})", locale.to_bcp47()));
+        let mf = MessageFn::from(|locale: &Locale| format!("Close ({})", locale.to_bcp47()));
         let locale = locales::de_de();
         assert_eq!(mf(&locale), "Close (de-DE)");
     }
 
     #[test]
     fn message_fn_new_delegates_to_from() {
-        let mf: MessageFn<dyn Fn(&Locale) -> String + Send + Sync> =
-            MessageFn::new(|locale: &Locale| format!("Hello {}", locale.to_bcp47()));
+        let mf = MessageFn::new(|locale: &Locale| format!("Hello {}", locale.to_bcp47()));
         assert_eq!(mf(&locales::fr()), "Hello fr-FR");
     }
 

--- a/crates/ars-core/src/shared_ptr.rs
+++ b/crates/ars-core/src/shared_ptr.rs
@@ -150,17 +150,17 @@ mod tests {
 
     #[test]
     fn ars_rc_from_modality_creates_trait_object() {
-        use crate::{DefaultModalityContext, ModalityContext, ModalitySnapshot};
+        use crate::{DefaultModalityContext, ModalitySnapshot};
 
-        let rc: ArsRc<dyn ModalityContext> = ArsRc::from_modality(DefaultModalityContext::new());
+        let rc = ArsRc::from_modality(DefaultModalityContext::new());
         assert_eq!(rc.snapshot(), ModalitySnapshot::default());
     }
 
     #[test]
     fn ars_rc_from_platform_creates_trait_object() {
-        use crate::{NullPlatformEffects, PlatformEffects};
+        use crate::NullPlatformEffects;
 
-        let rc: ArsRc<dyn PlatformEffects> = ArsRc::from_platform(NullPlatformEffects);
+        let rc = ArsRc::from_platform(NullPlatformEffects);
         rc.focus_element_by_id("test");
     }
 

--- a/crates/ars-core/src/shared_state.rs
+++ b/crates/ars-core/src/shared_state.rs
@@ -169,7 +169,7 @@ mod tests {
 
     #[test]
     fn shared_state_default() {
-        let state: SharedState<u32> = SharedState::default();
+        let state = SharedState::<u32>::default();
         assert_eq!(state.get(), 0);
     }
 

--- a/crates/ars-derive/src/lib.rs
+++ b/crates/ars-derive/src/lib.rs
@@ -8,7 +8,7 @@ use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
 use syn::{
-    Data, DeriveInput, Expr, Fields, Generics, Ident, Lit, LitStr, Meta, Type, Variant, Visibility,
+    Data, DeriveInput, Expr, Fields, Generics, Lit, LitStr, Meta, Type, Variant, Visibility,
     parse_macro_input, parse_quote,
 };
 
@@ -365,9 +365,9 @@ fn clone_arm(variant: &Variant) -> TokenStream2 {
     match &variant.fields {
         Fields::Unit => quote!(Self::#ident => Self::#ident),
         Fields::Unnamed(fields) => {
-            let bindings: Vec<_> = (0..fields.unnamed.len())
+            let bindings = (0..fields.unnamed.len())
                 .map(|index| format_ident!("field_{index}"))
-                .collect();
+                .collect::<Vec<_>>();
             let clones = bindings
                 .iter()
                 .map(|binding| quote!(::core::clone::Clone::clone(#binding)));
@@ -375,11 +375,11 @@ fn clone_arm(variant: &Variant) -> TokenStream2 {
             quote!(Self::#ident(#(#bindings),*) => Self::#ident(#(#clones),*))
         }
         Fields::Named(fields) => {
-            let bindings: Vec<_> = fields
+            let bindings = fields
                 .named
                 .iter()
                 .map(|field| field.ident.as_ref().expect("named field").clone())
-                .collect();
+                .collect::<Vec<_>>();
             let clones = bindings
                 .iter()
                 .map(|binding| quote!(#binding: ::core::clone::Clone::clone(#binding)));
@@ -396,9 +396,9 @@ fn debug_arm(variant: &Variant) -> TokenStream2 {
     match &variant.fields {
         Fields::Unit => quote!(Self::#ident => f.write_str(#debug_name)),
         Fields::Unnamed(fields) => {
-            let bindings: Vec<_> = (0..fields.unnamed.len())
+            let bindings = (0..fields.unnamed.len())
                 .map(|index| format_ident!("field_{index}"))
-                .collect();
+                .collect::<Vec<_>>();
             let field_calls = bindings
                 .iter()
                 .map(|binding| quote!(debug.field(#binding);));
@@ -412,11 +412,11 @@ fn debug_arm(variant: &Variant) -> TokenStream2 {
             }
         }
         Fields::Named(fields) => {
-            let bindings: Vec<_> = fields
+            let bindings = fields
                 .named
                 .iter()
                 .map(|field| field.ident.as_ref().expect("named field").clone())
-                .collect();
+                .collect::<Vec<_>>();
             let field_calls = bindings.iter().map(|binding| {
                 let name = LitStr::new(&binding.to_string(), binding.span());
                 quote!(debug.field(#name, #binding);)
@@ -439,12 +439,12 @@ fn partial_eq_arm(_index: usize, variant: &Variant) -> TokenStream2 {
     match &variant.fields {
         Fields::Unit => quote!((Self::#ident, Self::#ident) => true),
         Fields::Unnamed(fields) => {
-            let lefts: Vec<_> = (0..fields.unnamed.len())
+            let lefts = (0..fields.unnamed.len())
                 .map(|index| format_ident!("left_{index}"))
-                .collect();
-            let rights: Vec<_> = (0..fields.unnamed.len())
+                .collect::<Vec<_>>();
+            let rights = (0..fields.unnamed.len())
                 .map(|index| format_ident!("right_{index}"))
-                .collect();
+                .collect::<Vec<_>>();
             let comparisons = lefts
                 .iter()
                 .zip(rights.iter())
@@ -453,16 +453,16 @@ fn partial_eq_arm(_index: usize, variant: &Variant) -> TokenStream2 {
             quote!((Self::#ident(#(#lefts),*), Self::#ident(#(#rights),*)) => true #(&& #comparisons)*)
         }
         Fields::Named(fields) => {
-            let lefts: Vec<_> = fields
+            let lefts = fields
                 .named
                 .iter()
                 .map(|field| format_ident!("left_{}", field.ident.as_ref().expect("named field")))
-                .collect();
-            let rights: Vec<_> = fields
+                .collect::<Vec<_>>();
+            let rights = fields
                 .named
                 .iter()
                 .map(|field| format_ident!("right_{}", field.ident.as_ref().expect("named field")))
-                .collect();
+                .collect::<Vec<_>>();
             let left_pattern = fields.named.iter().zip(lefts.iter()).map(|(field, left)| {
                 let ident = field.ident.as_ref().expect("named field");
                 quote!(#ident: #left)
@@ -500,9 +500,9 @@ fn hash_arm(index: usize, variant: &Variant) -> TokenStream2 {
             }
         },
         Fields::Unnamed(fields) => {
-            let bindings: Vec<_> = (0..fields.unnamed.len())
+            let bindings = (0..fields.unnamed.len())
                 .map(|field_index| format_ident!("field_{field_index}"))
-                .collect();
+                .collect::<Vec<_>>();
             let hashes = bindings
                 .iter()
                 .map(|binding| quote!(::core::hash::Hash::hash(#binding, state);));
@@ -515,11 +515,11 @@ fn hash_arm(index: usize, variant: &Variant) -> TokenStream2 {
             }
         }
         Fields::Named(fields) => {
-            let bindings: Vec<Ident> = fields
+            let bindings = fields
                 .named
                 .iter()
                 .map(|field| field.ident.as_ref().expect("named field").clone())
-                .collect();
+                .collect::<Vec<_>>();
             let hashes = bindings
                 .iter()
                 .map(|binding| quote!(::core::hash::Hash::hash(#binding, state);));

--- a/crates/ars-dioxus/src/attrs.rs
+++ b/crates/ars-dioxus/src/attrs.rs
@@ -77,7 +77,7 @@ pub fn attr_map_to_dioxus(
 ) -> DioxusAttrResult {
     let AttrMapParts { attrs, styles } = map.into_parts();
 
-    let mut result: Vec<Attribute> = attrs
+    let mut result = attrs
         .into_iter()
         .filter_map(|(key, val)| match val {
             AttrValue::String(s) => Some(Attribute::new(
@@ -94,7 +94,7 @@ pub fn attr_map_to_dioxus(
             )),
             AttrValue::Bool(false) | AttrValue::None => None,
         })
-        .collect();
+        .collect::<Vec<_>>();
 
     let mut cssom_styles = Vec::new();
     let mut nonce_css = String::new();
@@ -102,7 +102,7 @@ pub fn attr_map_to_dioxus(
     match strategy {
         StyleStrategy::Inline => {
             if !styles.is_empty() {
-                let style_str: String = styles
+                let style_str = styles
                     .into_iter()
                     .map(|(prop, val)| format!("{prop}: {val};"))
                     .collect::<Vec<_>>()
@@ -160,10 +160,10 @@ pub fn apply_styles_cssom(el: &web_sys::HtmlElement, styles: &[(CssProperty, Str
 
 /// Convert styles to a CSS rule string for nonce-based injection.
 fn styles_to_nonce_css(id: &str, styles: &[(CssProperty, String)]) -> String {
-    let decls: Vec<String> = styles
+    let decls = styles
         .iter()
         .map(|(prop, val)| format!("  {prop}: {val};"))
-        .collect();
+        .collect::<Vec<_>>();
     format!("[data-ars-style-id=\"{id}\"] {{\n{}\n}}", decls.join("\n"))
 }
 

--- a/crates/ars-dioxus/src/use_machine.rs
+++ b/crates/ars-dioxus/src/use_machine.rs
@@ -224,11 +224,11 @@ where
     // Create a signal tracking the current state.
     // Use .peek() to avoid subscribing the component to service_signal changes.
     let initial_state = service_signal.peek().state().clone();
-    let mut state_signal: Signal<M::State> = use_signal(|| initial_state);
+    let mut state_signal = use_signal::<M::State>(|| initial_state);
 
     // Context version counter — incremented on every context change so that
     // derive() memos re-run even when state itself hasn't changed.
-    let mut context_version: Signal<u64> = use_signal(|| 0u64);
+    let mut context_version = use_signal(|| 0u64);
 
     // Build the send callback. When an event is sent:
     // 1. Snapshot the old state for comparison

--- a/crates/ars-forms/src/field/value_ext.rs
+++ b/crates/ars-forms/src/field/value_ext.rs
@@ -146,19 +146,19 @@ mod tests {
 
     #[test]
     fn calendar_date_none_empty() {
-        let date: Option<ars_i18n::CalendarDate> = None;
+        let date = None::<ars_i18n::CalendarDate>;
         assert!(date.is_empty());
     }
 
     #[test]
     fn option_f64_none_empty() {
-        let n: Option<f64> = None;
+        let n = None::<f64>;
         assert!(n.is_empty());
     }
 
     #[test]
     fn option_f64_some_not_empty() {
-        let n: Option<f64> = Some(42.0);
+        let n = Some(42.0);
         assert!(!n.is_empty());
     }
 

--- a/crates/ars-forms/src/form/context.rs
+++ b/crates/ars-forms/src/form/context.rs
@@ -367,7 +367,7 @@ impl Context {
 
     /// Validate all fields. Returns `true` if the form is valid.
     pub fn validate_all(&mut self) -> bool {
-        let names: Vec<String> = self.fields.keys().cloned().collect();
+        let names = self.fields.keys().cloned().collect::<Vec<_>>();
         let mut valid = true;
         for name in names {
             self.run_field_validation(&name);
@@ -386,13 +386,14 @@ impl Context {
     ///
     /// Old server errors are removed first, then new server errors are appended.
     /// Preserves client-side errors from `validate_all()`.
-    pub fn set_server_errors(&mut self, errors: BTreeMap<String, Vec<String>>) {
+    pub fn set_server_errors(&mut self, errors: impl Into<BTreeMap<String, Vec<String>>>) {
+        let errors = errors.into();
         for (name, messages) in &errors {
             if let Some(field) = self.fields.get_mut(name) {
                 field.touched = true; // Show errors immediately
-                let server_errs: Vec<Error> = messages.iter().map(Error::server).collect();
+                let server_errs = messages.iter().map(Error::server).collect::<Vec<_>>();
                 // Merge: keep existing client-side errors, replace server errors
-                let mut client_errs: Vec<Error> = match &field.validation {
+                let mut client_errs = match &field.validation {
                     Err(Errors(errs)) => errs.iter().filter(|e| !e.is_server()).cloned().collect(),
                     _ => vec![],
                 };
@@ -435,7 +436,7 @@ impl Context {
             None => return,
         };
 
-        let all_values: BTreeMap<String, Value> = self
+        let all_values = self
             .fields
             .iter()
             .map(|(k, v)| (k.clone(), v.value.clone()))
@@ -667,7 +668,7 @@ mod tests {
         ctx.register("email", text(""), None, None);
         ctx.register("age", Value::Number(None), None, None);
 
-        let keys: Vec<&String> = ctx.fields.keys().collect();
+        let keys = ctx.fields.keys().collect::<Vec<_>>();
         assert_eq!(keys, vec!["name", "email", "age"]);
     }
 
@@ -713,11 +714,7 @@ mod tests {
         ctx.register("email", text(""), None, None);
         assert!(!ctx.field("email").expect("exists").touched);
 
-        let errors: BTreeMap<String, Vec<String>> =
-            [("email".to_string(), vec!["Already exists".to_string()])]
-                .into_iter()
-                .collect();
-        ctx.set_server_errors(errors);
+        ctx.set_server_errors([("email".to_string(), vec!["Already exists".to_string()])]);
         assert!(ctx.field("email").expect("exists").touched);
     }
 
@@ -726,11 +723,7 @@ mod tests {
         let mut ctx = Context::new(Mode::on_submit());
         ctx.register("email", text(""), None, None);
 
-        let errors: BTreeMap<String, Vec<String>> =
-            [("email".to_string(), vec!["Already exists".to_string()])]
-                .into_iter()
-                .collect();
-        ctx.set_server_errors(errors);
+        ctx.set_server_errors([("email".to_string(), vec!["Already exists".to_string()])]);
 
         let field = ctx.field("email").expect("exists");
         assert!(field.show_error());
@@ -742,11 +735,7 @@ mod tests {
         let mut ctx = Context::new(Mode::on_submit());
         ctx.register("email", text(""), None, None);
 
-        let errors: BTreeMap<String, Vec<String>> =
-            [("email".to_string(), vec!["Taken".to_string()])]
-                .into_iter()
-                .collect();
-        ctx.set_server_errors(errors);
+        ctx.set_server_errors([("email".to_string(), vec!["Taken".to_string()])]);
         assert!(ctx.field("email").expect("exists").validation.is_err());
 
         // Change clears server error
@@ -765,11 +754,7 @@ mod tests {
         assert!(ctx.field("email").expect("exists").validation.is_err());
 
         // Now inject server errors — client errors should be preserved
-        let errors: BTreeMap<String, Vec<String>> =
-            [("email".to_string(), vec!["Already exists".to_string()])]
-                .into_iter()
-                .collect();
-        ctx.set_server_errors(errors);
+        ctx.set_server_errors([("email".to_string(), vec!["Already exists".to_string()])]);
 
         let field = ctx.field("email").expect("exists");
         let all_errors = field.validation.errors().expect("has errors");
@@ -1054,11 +1039,7 @@ mod tests {
         let mut ctx = Context::new(Mode::on_submit());
         ctx.register("email", text(""), None, None);
 
-        let errors: BTreeMap<String, Vec<String>> =
-            [("email".to_string(), vec!["Taken".to_string()])]
-                .into_iter()
-                .collect();
-        ctx.set_server_errors(errors);
+        ctx.set_server_errors([("email".to_string(), vec!["Taken".to_string()])]);
         assert!(ctx.field("email").expect("exists").validation.is_err());
 
         ctx.on_input("email", text("new"));
@@ -1117,11 +1098,7 @@ mod tests {
         let mut ctx = Context::new(Mode::on_submit());
         ctx.register("name", text(""), None, None);
 
-        let errors: BTreeMap<String, Vec<String>> =
-            [("nonexistent".to_string(), vec!["err".to_string()])]
-                .into_iter()
-                .collect();
-        ctx.set_server_errors(errors);
+        ctx.set_server_errors([("nonexistent".to_string(), vec!["err".to_string()])]);
 
         // The known field is unaffected
         assert!(ctx.field("name").expect("exists").validation.is_ok());
@@ -1193,11 +1170,7 @@ mod tests {
         let mut ctx = Context::new(Mode::on_submit());
         ctx.register("email", text(""), None, None);
 
-        let errors: BTreeMap<String, Vec<String>> =
-            [("email".to_string(), vec!["Taken".to_string()])]
-                .into_iter()
-                .collect();
-        ctx.set_server_errors(errors);
+        ctx.set_server_errors([("email".to_string(), vec!["Taken".to_string()])]);
         assert!(!ctx.server_errors.is_empty());
 
         ctx.reset();

--- a/crates/ars-forms/src/validation/result.rs
+++ b/crates/ars-forms/src/validation/result.rs
@@ -8,7 +8,7 @@
 //! The [`ResultExt`] extension trait adds domain-specific helpers like
 //! [`merge`](ResultExt::merge) and [`without_server_errors`](ResultExt::without_server_errors).
 
-use super::error::{Error, ErrorCode, Errors};
+use super::error::{ErrorCode, Errors};
 
 /// The result of validating a field value.
 ///
@@ -67,12 +67,12 @@ impl ResultExt for Result {
         match self {
             Ok(()) => Ok(()),
             Err(errors) => {
-                let filtered: Vec<Error> = errors
+                let filtered = errors
                     .0
                     .iter()
                     .filter(|e| !matches!(&e.code, ErrorCode::Server(_) | ErrorCode::Async(_)))
                     .cloned()
-                    .collect();
+                    .collect::<Vec<_>>();
                 if filtered.is_empty() {
                     Ok(())
                 } else {
@@ -86,17 +86,17 @@ impl ResultExt for Result {
 #[cfg(test)]
 mod tests {
 
-    use super::*;
+    use super::{super::Error, *};
 
     #[test]
     fn valid_result_is_ok() {
-        let result: Result = Ok(());
+        let result = Result::Ok(());
         assert!(result.is_ok());
     }
 
     #[test]
     fn invalid_result_is_err() {
-        let result: Result = Err(Errors(vec![Error {
+        let result = Result::Err(Errors(vec![Error {
             code: ErrorCode::Required,
             message: "This field is required".to_string(),
         }]));
@@ -111,7 +111,7 @@ mod tests {
 
     #[test]
     fn merge_first_invalid() {
-        let invalid: Result = Err(Errors(vec![Error {
+        let invalid = Result::Err(Errors(vec![Error {
             code: ErrorCode::Required,
             message: "required".to_string(),
         }]));
@@ -122,7 +122,7 @@ mod tests {
 
     #[test]
     fn merge_second_invalid() {
-        let invalid: Result = Err(Errors(vec![Error {
+        let invalid = Result::Err(Errors(vec![Error {
             code: ErrorCode::Email,
             message: "bad email".to_string(),
         }]));
@@ -133,11 +133,11 @@ mod tests {
 
     #[test]
     fn merge_both_invalid_combines_errors() {
-        let a: Result = Err(Errors(vec![Error {
+        let a = Result::Err(Errors(vec![Error {
             code: ErrorCode::Required,
             message: "required".to_string(),
         }]));
-        let b: Result = Err(Errors(vec![Error {
+        let b = Result::Err(Errors(vec![Error {
             code: ErrorCode::Email,
             message: "bad email".to_string(),
         }]));
@@ -147,13 +147,13 @@ mod tests {
 
     #[test]
     fn first_error_message_valid() {
-        let result: Result = Ok(());
+        let result = Result::Ok(());
         assert_eq!(result.first_error_message(), None);
     }
 
     #[test]
     fn first_error_message_invalid() {
-        let result: Result = Err(Errors(vec![Error {
+        let result = Result::Err(Errors(vec![Error {
             code: ErrorCode::Required,
             message: "required".to_string(),
         }]));
@@ -162,7 +162,7 @@ mod tests {
 
     #[test]
     fn without_server_errors_keeps_client() {
-        let result: Result = Err(Errors(vec![
+        let result = Result::Err(Errors(vec![
             Error {
                 code: ErrorCode::Required,
                 message: "required".to_string(),
@@ -178,7 +178,7 @@ mod tests {
 
     #[test]
     fn without_server_errors_removes_all_server() {
-        let result: Result = Err(Errors(vec![
+        let result = Result::Err(Errors(vec![
             Error::server("err1"),
             Error {
                 code: ErrorCode::Async("check".to_string()),
@@ -191,7 +191,7 @@ mod tests {
 
     #[test]
     fn without_server_errors_valid_stays_valid() {
-        let result: Result = Ok(());
+        let result = Result::Ok(());
         assert!(result.without_server_errors().is_ok());
     }
 }

--- a/crates/ars-forms/src/validation/validator.rs
+++ b/crates/ars-forms/src/validation/validator.rs
@@ -177,10 +177,9 @@ mod tests {
 
     #[test]
     fn snapshot_produces_owned_context() {
-        let values: BTreeMap<String, Value> =
-            [("name".to_string(), Value::Text("Alice".to_string()))]
-                .into_iter()
-                .collect();
+        let values = [("name".to_string(), Value::Text("Alice".to_string()))]
+            .into_iter()
+            .collect();
         let locale = ars_i18n::locales::en_us();
         let ctx = Context {
             field_name: "name",

--- a/crates/ars-i18n/Cargo.toml
+++ b/crates/ars-i18n/Cargo.toml
@@ -8,8 +8,11 @@ repository.workspace   = true
 rust-version.workspace = true
 
 [dependencies]
+fixed_decimal        = { version = "0.7", default-features = false, features = ["ryu"] }
 icu                  = { version = "2.1", default-features = false }
+icu_experimental     = { version = "0.5", default-features = false }
 icu_provider         = { version = "2.1", default-features = false }
+tinystr              = { version = "0.8", default-features = false }
 unicode-segmentation = "1.13"
 
 [features]
@@ -32,7 +35,7 @@ coptic              = []
 dangi               = []
 roc                 = []
 all-calendars       = []
-icu4x               = []
+icu4x               = ["icu/compiled_data", "icu_experimental/compiled_data"]
 web-intl            = []
 
 [lints]

--- a/crates/ars-i18n/src/lib.rs
+++ b/crates/ars-i18n/src/lib.rs
@@ -1,11 +1,16 @@
-//! Internationalization types for locale, text direction, and layout orientation.
+//! Internationalization types for locale, number formatting, text direction, and
+//! layout orientation.
 //!
 //! This crate provides the core i18n primitives shared across all ars-ui components:
-//! a BCP 47 [`Locale`] wrapper, a [`Direction`] enum for LTR/RTL text flow, an
-//! [`Orientation`] enum for horizontal/vertical layout axes, and the [`IcuProvider`]
-//! trait for calendar/locale data abstraction.
+//! a BCP 47 [`Locale`] wrapper, a locale-aware [`NumberFormatter`], a
+//! [`Direction`] enum for LTR/RTL text flow, an [`Orientation`] enum for
+//! horizontal/vertical layout axes, and the [`IcuProvider`] trait for
+//! calendar/locale data abstraction.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(all(feature = "icu4x", feature = "web-intl"))]
+compile_error!("features `icu4x` and `web-intl` are mutually exclusive");
 
 extern crate alloc;
 
@@ -13,10 +18,17 @@ use alloc::string::String;
 
 mod bidi;
 mod locale;
+mod number;
 mod weekday;
 
 pub use bidi::{IsolateDirection, isolate_text_safe};
 pub use locale::{Locale, LocaleParseError, locales};
+#[cfg(feature = "std")]
+pub use number::get_number_formatter;
+pub use number::{
+    CurrencyCode, MeasureUnit, NumberFormatOptions, NumberFormatter, NumberStyle, RoundingMode,
+    SignDisplay, UnitDisplay, decimal_and_group_separators, normalize_digits, parse_locale_number,
+};
 pub use weekday::Weekday;
 
 /// Text and layout direction.
@@ -302,10 +314,10 @@ mod tests {
             Locale::parse("en-US").expect("en-US is valid"),
         ];
         locales.sort();
-        let sorted: Vec<_> = locales
+        let sorted = locales
             .into_iter()
             .map(|locale| locale.to_bcp47())
-            .collect();
+            .collect::<Vec<_>>();
         assert_eq!(sorted, vec!["de-DE", "en-US", "fr-FR"]);
     }
 

--- a/crates/ars-i18n/src/locale.rs
+++ b/crates/ars-i18n/src/locale.rs
@@ -113,6 +113,11 @@ impl Locale {
         (&self.0).into()
     }
 
+    #[cfg(feature = "icu4x")]
+    pub(crate) const fn as_icu(&self) -> &IcuLocale {
+        &self.0
+    }
+
     fn script_or_default(&self) -> &str {
         self.script().unwrap_or_else(|| match self.language() {
             "ar" | "fa" | "ur" | "ps" | "ug" | "sd" | "ks" => "Arab",

--- a/crates/ars-i18n/src/number.rs
+++ b/crates/ars-i18n/src/number.rs
@@ -1,0 +1,1003 @@
+use alloc::{format, rc::Rc, string::String};
+use core::{fmt, num::NonZeroU8, str::FromStr};
+
+use fixed_decimal::{Decimal, SignDisplay as FixedSignDisplay};
+use icu::decimal::DecimalFormatter;
+pub use icu_experimental::measure::measureunit::MeasureUnit;
+#[cfg(feature = "std")]
+use {alloc::collections::BTreeMap, std::cell::RefCell};
+#[cfg(feature = "icu4x")]
+use {
+    icu::decimal::{
+        DecimalFormatterPreferences,
+        options::{DecimalFormatterOptions, GroupingStrategy},
+    },
+    icu_experimental::{
+        dimension::{
+            currency::{
+                CurrencyCode as IcuCurrencyCode,
+                formatter::{
+                    CurrencyFormatter as IcuCurrencyFormatter, CurrencyFormatterPreferences,
+                },
+                options::CurrencyFormatterOptions,
+            },
+            percent::{
+                formatter::{PercentFormatter, PercentFormatterPreferences},
+                options::PercentFormatterOptions,
+            },
+            units::{
+                formatter::{UnitsFormatter, UnitsFormatterPreferences},
+                options::{UnitsFormatterOptions, Width},
+            },
+        },
+        measure::parser::ids::CLDR_IDS_TRIE,
+    },
+    tinystr::TinyAsciiStr,
+};
+
+use crate::Locale;
+
+/// Options controlling locale-aware number formatting.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NumberFormatOptions {
+    /// The high-level number style to format.
+    pub style: NumberStyle,
+    /// The display width to use when formatting [`NumberStyle::Unit`] values.
+    pub unit_display: UnitDisplay,
+    /// The minimum number of digits to display before the decimal separator.
+    pub min_integer_digits: NonZeroU8,
+    /// The minimum number of digits to display after the decimal separator.
+    pub min_fraction_digits: u8,
+    /// The maximum number of digits to display after the decimal separator.
+    pub max_fraction_digits: u8,
+    /// Whether locale-appropriate grouping separators should be emitted.
+    pub use_grouping: bool,
+    /// How positive, negative, and zero values should display a sign.
+    pub sign_display: SignDisplay,
+    /// The rounding rule to apply before the number is formatted.
+    pub rounding_mode: RoundingMode,
+}
+
+/// The overall presentation style for formatted numbers.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum NumberStyle {
+    /// A plain decimal number.
+    Decimal,
+    /// A percentage value.
+    Percent,
+    /// A monetary value in the given ISO 4217 currency.
+    Currency(CurrencyCode),
+    /// A measurement value in the given CLDR unit.
+    Unit(MeasureUnit),
+}
+
+/// The width used when formatting measurement units.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum UnitDisplay {
+    /// Locale-appropriate long unit names.
+    Long,
+    /// Locale-appropriate short unit names.
+    #[default]
+    Short,
+    /// Locale-appropriate narrow unit names.
+    Narrow,
+}
+
+/// Sign display policy for formatted numbers.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SignDisplay {
+    /// Show a sign only for negative values.
+    Auto,
+    /// Always show a sign for non-negative and negative values.
+    Always,
+    /// Never show a sign.
+    Never,
+    /// Show a sign for non-zero values only.
+    ExceptZero,
+    /// Show only the negative sign.
+    Negative,
+}
+
+/// Rounding mode used before formatting a value.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum RoundingMode {
+    /// Round to nearest, with ties resolved to the nearest even digit.
+    #[default]
+    HalfEven,
+    /// Round to nearest, with ties resolved away from zero.
+    HalfUp,
+    /// Round to nearest, with ties resolved toward zero.
+    HalfDown,
+    /// Round toward positive infinity.
+    Ceiling,
+    /// Round toward negative infinity.
+    Floor,
+    /// Round toward zero.
+    Truncate,
+}
+
+/// An ISO 4217 currency code.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct CurrencyCode(
+    /// Uppercase ASCII bytes encoding the currency identifier.
+    pub [u8; 3],
+);
+
+impl CurrencyCode {
+    /// United States Dollar.
+    pub const USD: Self = Self(*b"USD");
+    /// Euro.
+    pub const EUR: Self = Self(*b"EUR");
+    /// British Pound Sterling.
+    pub const GBP: Self = Self(*b"GBP");
+    /// Japanese Yen.
+    pub const JPY: Self = Self(*b"JPY");
+    /// Chinese Yuan Renminbi.
+    pub const CNY: Self = Self(*b"CNY");
+
+    /// Parse an ISO 4217 currency code from uppercase ASCII text.
+    #[must_use]
+    #[expect(
+        clippy::should_implement_trait,
+        reason = "API matches the specification"
+    )]
+    pub fn from_str(s: &str) -> Option<Self> {
+        let bytes = s.as_bytes();
+        if bytes.len() != 3 || !bytes.iter().all(u8::is_ascii_uppercase) {
+            return None;
+        }
+
+        Some(Self([bytes[0], bytes[1], bytes[2]]))
+    }
+
+    /// Return this currency code as text.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        core::str::from_utf8(&self.0).expect("CurrencyCode contains valid ASCII")
+    }
+
+    #[cfg(feature = "icu4x")]
+    fn as_icu(self) -> IcuCurrencyCode {
+        let code = TinyAsciiStr::<3>::try_from_utf8(self.as_str().as_bytes())
+            .expect("CurrencyCode contains a valid TinyAsciiStr");
+        IcuCurrencyCode(code)
+    }
+}
+
+impl Default for NumberFormatOptions {
+    fn default() -> Self {
+        Self {
+            style: NumberStyle::Decimal,
+            unit_display: UnitDisplay::Short,
+            min_integer_digits: NonZeroU8::new(1).expect("hardcoded nonzero"),
+            min_fraction_digits: 0,
+            max_fraction_digits: 3,
+            use_grouping: true,
+            sign_display: SignDisplay::Auto,
+            rounding_mode: RoundingMode::HalfEven,
+        }
+    }
+}
+
+/// A locale-aware formatter for decimals, percents, currencies, and units.
+#[derive(Clone)]
+pub struct NumberFormatter {
+    locale: Locale,
+    options: NumberFormatOptions,
+    decimal_separator: char,
+    grouping_separator: Option<char>,
+    backend: FormatterBackend,
+}
+
+#[derive(Clone)]
+enum FormatterBackend {
+    Decimal(Rc<DecimalFormatter>),
+    #[cfg(feature = "icu4x")]
+    Percent(Rc<PercentFormatter<DecimalFormatter>>),
+    #[cfg(not(feature = "icu4x"))]
+    Percent,
+    #[cfg(feature = "icu4x")]
+    Currency(Rc<IcuCurrencyFormatter>),
+    #[cfg(not(feature = "icu4x"))]
+    Currency,
+    #[cfg(feature = "icu4x")]
+    Unit(Rc<UnitsFormatter>),
+    #[cfg(not(feature = "icu4x"))]
+    Unit,
+}
+
+impl fmt::Debug for NumberFormatter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("NumberFormatter")
+            .field("locale", &self.locale)
+            .field("options", &self.options)
+            .field("decimal_separator", &self.decimal_separator)
+            .field("grouping_separator", &self.grouping_separator)
+            .finish()
+    }
+}
+
+#[cfg(feature = "std")]
+thread_local! {
+    static NUMBER_FORMATTER_CACHE: RefCell<BTreeMap<String, NumberFormatter>> =
+        const { RefCell::new(BTreeMap::new()) };
+}
+
+/// Return a cached formatter for the given locale and options.
+///
+/// On `std` builds ars-i18n keeps a process-local cache keyed by locale and
+/// format options so repeated formatter construction can be avoided.
+#[cfg(feature = "std")]
+#[must_use]
+pub fn get_number_formatter(locale: &Locale, options: &NumberFormatOptions) -> NumberFormatter {
+    let key = format!("{:?}-{:?}", locale.to_bcp47(), options);
+    NUMBER_FORMATTER_CACHE.with(|cache| {
+        let mut cache = cache.borrow_mut();
+        if let Some(existing) = cache.get(&key) {
+            return existing.clone();
+        }
+
+        let formatter = NumberFormatter::new(locale, options.clone());
+        cache.insert(key, formatter.clone());
+        formatter
+    })
+}
+
+impl NumberFormatter {
+    /// Create a new locale-aware formatter for the given locale and options.
+    #[must_use]
+    pub fn new(locale: &Locale, options: NumberFormatOptions) -> Self {
+        let options = normalize_style_defaults(options);
+        let (decimal_separator, grouping_separator) = decimal_and_group_separators(locale);
+        let backend = FormatterBackend::for_locale_and_style(locale, &options);
+
+        Self {
+            locale: locale.clone(),
+            options,
+            decimal_separator,
+            grouping_separator: Some(grouping_separator),
+            backend,
+        }
+    }
+
+    /// Format a numeric value according to this formatter's locale and style.
+    #[must_use]
+    pub fn format(&self, value: f64) -> String {
+        let decimal = self.prepare_decimal(value);
+
+        match &self.backend {
+            FormatterBackend::Decimal(formatter) => formatter.format(&decimal).to_string(),
+            #[cfg(feature = "icu4x")]
+            FormatterBackend::Percent(formatter) => formatter.format(&decimal).to_string(),
+            #[cfg(not(feature = "icu4x"))]
+            FormatterBackend::Percent => fallback_format(&decimal, self),
+            #[cfg(feature = "icu4x")]
+            FormatterBackend::Currency(formatter) => {
+                #[cfg(not(feature = "std"))]
+                use alloc::string::ToString as _;
+
+                let NumberStyle::Currency(code) = self.options.style else {
+                    unreachable!("currency backend must match currency style");
+                };
+                formatter
+                    .format_fixed_decimal(&decimal, &code.as_icu())
+                    .to_string()
+            }
+            #[cfg(not(feature = "icu4x"))]
+            FormatterBackend::Currency => fallback_format(&decimal, self),
+            #[cfg(feature = "icu4x")]
+            FormatterBackend::Unit(formatter) => {
+                formatter.format_fixed_decimal(&decimal).to_string()
+            }
+            #[cfg(not(feature = "icu4x"))]
+            FormatterBackend::Unit => fallback_format(&decimal, self),
+        }
+    }
+
+    /// Parse a locale-formatted number back into a numeric value.
+    pub fn parse(&self, input: &str) -> Option<f64> {
+        let parsed = parse_locale_number(input, &self.locale)?;
+        if matches!(self.options.style, NumberStyle::Percent) {
+            Some(parsed / 100.0)
+        } else {
+            Some(parsed)
+        }
+    }
+
+    /// Return this formatter's decimal separator.
+    #[must_use]
+    pub const fn decimal_separator(&self) -> char {
+        self.decimal_separator
+    }
+
+    /// Return this formatter's grouping separator, when one is known.
+    #[must_use]
+    pub const fn grouping_separator(&self) -> Option<char> {
+        self.grouping_separator
+    }
+
+    /// Format a monetary amount using the given ISO 4217 currency code.
+    #[must_use]
+    pub fn format_currency(&self, amount: f64, currency_code: &str) -> String {
+        let code = CurrencyCode::from_str(currency_code).expect("invalid ISO 4217 currency code");
+        let precision = iso4217_minor_units(code);
+
+        let mut options = self.options.clone();
+        options.style = NumberStyle::Currency(code);
+        options.min_fraction_digits = precision;
+        options.max_fraction_digits = precision;
+
+        Self::new(&self.locale, options).format(amount)
+    }
+
+    /// Format a fractional value as a percentage.
+    #[must_use]
+    pub fn format_percent(&self, value: f64, max_fraction_digits: Option<u8>) -> String {
+        let mut options = self.options.clone();
+        options.style = NumberStyle::Percent;
+        options.min_fraction_digits = 0;
+        options.max_fraction_digits = max_fraction_digits.unwrap_or(0);
+
+        Self::new(&self.locale, options).format(value)
+    }
+
+    /// Format a start/end numeric range using a locale-sensitive separator.
+    #[must_use]
+    pub fn format_range(&self, start: f64, end: f64, locale: &Locale) -> String {
+        let separator = match locale.language() {
+            "fr" => " – ",
+            "ja" | "zh" | "ko" => "〜",
+            _ => "–",
+        };
+
+        format!("{}{}{}", self.format(start), separator, self.format(end))
+    }
+
+    fn prepare_decimal(&self, value: f64) -> Decimal {
+        let scaled = if matches!(self.options.style, NumberStyle::Percent) {
+            value * 100.0
+        } else {
+            value
+        };
+
+        if !scaled.is_finite() {
+            return Decimal::default();
+        }
+
+        let rounded = round_value(
+            scaled,
+            self.options.max_fraction_digits,
+            self.options.rounding_mode,
+        );
+        let precision = usize::from(self.options.max_fraction_digits);
+        let decimal_literal = if precision == 0 {
+            format!("{rounded:.0}")
+        } else {
+            format!("{rounded:.precision$}")
+        };
+
+        let mut decimal = Decimal::from_str(&decimal_literal).unwrap_or_default();
+        decimal.absolute.trim_end();
+        decimal
+            .absolute
+            .pad_end(-i16::from(self.options.min_fraction_digits));
+        decimal
+            .absolute
+            .pad_start(i16::from(self.options.min_integer_digits.get()));
+        decimal.apply_sign_display(self.options.sign_display.into_fixed_decimal());
+        decimal
+    }
+}
+
+impl FormatterBackend {
+    fn for_locale_and_style(locale: &Locale, options: &NumberFormatOptions) -> Self {
+        match &options.style {
+            NumberStyle::Decimal => {
+                Self::Decimal(Rc::new(build_decimal_formatter(locale, options)))
+            }
+            #[cfg(feature = "icu4x")]
+            NumberStyle::Percent => {
+                let formatter = PercentFormatter::try_new(
+                    PercentFormatterPreferences::from(locale.as_icu()),
+                    PercentFormatterOptions::default(),
+                )
+                .expect("compiled_data guarantees percent formatter availability");
+                Self::Percent(Rc::new(formatter))
+            }
+            #[cfg(not(feature = "icu4x"))]
+            NumberStyle::Percent => Self::Percent,
+            #[cfg(feature = "icu4x")]
+            NumberStyle::Currency(_) => {
+                let formatter = IcuCurrencyFormatter::try_new(
+                    CurrencyFormatterPreferences::from(locale.as_icu()),
+                    CurrencyFormatterOptions::default(),
+                )
+                .expect("compiled_data guarantees currency formatter availability");
+                Self::Currency(Rc::new(formatter))
+            }
+            #[cfg(not(feature = "icu4x"))]
+            NumberStyle::Currency(_) => Self::Currency,
+            #[cfg(feature = "icu4x")]
+            NumberStyle::Unit(unit) => {
+                let unit_id = resolve_measure_unit_id(unit)
+                    .expect("unit formatter requires a resolvable CLDR unit id");
+                let mut formatter_options = UnitsFormatterOptions::default();
+                formatter_options.width = options.unit_display.into_icu_width();
+                let formatter = UnitsFormatter::try_new(
+                    UnitsFormatterPreferences::from(locale.as_icu()),
+                    &unit_id,
+                    formatter_options,
+                )
+                .expect("compiled_data guarantees unit formatter availability");
+                Self::Unit(Rc::new(formatter))
+            }
+            #[cfg(not(feature = "icu4x"))]
+            NumberStyle::Unit(_) => Self::Unit,
+        }
+    }
+}
+
+/// Normalize non-Latin decimal digits into ASCII digits.
+#[must_use]
+pub fn normalize_digits(input: &str) -> String {
+    input
+        .chars()
+        .map(|c| {
+            if c.is_ascii_digit() {
+                c
+            } else if ('\u{0660}'..='\u{0669}').contains(&c) {
+                char::from(b'0' + (c as u32 - 0x0660) as u8)
+            } else if ('\u{06F0}'..='\u{06F9}').contains(&c) {
+                char::from(b'0' + (c as u32 - 0x06F0) as u8)
+            } else if ('\u{0966}'..='\u{096F}').contains(&c) {
+                char::from(b'0' + (c as u32 - 0x0966) as u8)
+            } else if ('\u{09E6}'..='\u{09EF}').contains(&c) {
+                char::from(b'0' + (c as u32 - 0x09E6) as u8)
+            } else {
+                c
+            }
+        })
+        .collect()
+}
+
+/// Parse a locale-aware numeric string.
+pub fn parse_locale_number(input: &str, locale: &Locale) -> Option<f64> {
+    let transliterated = normalize_digits(input);
+    let (decimal_sep, group_sep) = decimal_and_group_separators(locale);
+    let filtered = filter_numeric_characters(&transliterated, decimal_sep, group_sep);
+    let chosen_decimal = choose_decimal_separator(&filtered, decimal_sep, group_sep);
+    let normalized = normalize_numeric_syntax(&filtered, chosen_decimal);
+    normalized.parse::<f64>().ok()
+}
+
+/// Determine the decimal and grouping separators for a locale.
+#[must_use]
+pub fn decimal_and_group_separators(locale: &Locale) -> (char, char) {
+    #[cfg(feature = "icu4x")]
+    {
+        let formatter = DecimalFormatter::try_new(
+            DecimalFormatterPreferences::from(locale.as_icu()),
+            DecimalFormatterOptions::default(),
+        )
+        .expect("compiled_data guarantees decimal formatter availability");
+        let formatted = formatter
+            .format(&Decimal::from_str("12345.6").expect("static decimal string must parse"))
+            .to_string();
+
+        parse_separators(&formatted)
+    }
+
+    #[cfg(not(feature = "icu4x"))]
+    {
+        fallback_separators(locale)
+    }
+}
+
+fn filter_numeric_characters(input: &str, decimal_sep: char, group_sep: char) -> String {
+    input
+        .chars()
+        .filter(|c| {
+            c.is_ascii_digit()
+                || matches!(*c, '+' | '-' | '.' | ',')
+                || matches!(*c, '\u{066B}' | '\u{066C}' | '\u{00A0}' | '\u{202F}')
+                || c.is_ascii_whitespace()
+                || *c == decimal_sep
+                || *c == group_sep
+        })
+        .collect()
+}
+
+fn normalize_numeric_syntax(input: &str, decimal_separator: Option<char>) -> String {
+    let mut normalized = String::with_capacity(input.len());
+    let mut seen_sign = false;
+
+    for c in input.chars() {
+        if c.is_ascii_digit() {
+            normalized.push(c);
+        } else if matches!(c, '+' | '-') && !seen_sign && normalized.is_empty() {
+            normalized.push(c);
+            seen_sign = true;
+        } else if Some(c) == decimal_separator {
+            normalized.push('.');
+        }
+    }
+
+    normalized
+}
+
+fn choose_decimal_separator(input: &str, locale_decimal: char, locale_group: char) -> Option<char> {
+    let locale_decimal_occurs = input.contains(locale_decimal);
+    if locale_decimal_occurs {
+        return Some(locale_decimal);
+    }
+
+    if input.contains('\u{066B}') {
+        return Some('\u{066B}');
+    }
+
+    let last = input
+        .char_indices()
+        .rev()
+        .find(|(_, c)| matches!(*c, '.' | ',' | '\u{066B}'));
+    let (idx, separator) = last?;
+
+    let digits_after = input[idx + separator.len_utf8()..]
+        .chars()
+        .filter(char::is_ascii_digit)
+        .count();
+    let occurrences = input.chars().filter(|c| *c == separator).count();
+    let other_separator_present = input
+        .chars()
+        .any(|c| matches!(c, '.' | ',' | '\u{066B}') && c != separator);
+
+    if separator == '\u{066C}' {
+        return None;
+    }
+
+    if separator == locale_group && digits_after == 3 && !other_separator_present {
+        return None;
+    }
+
+    if occurrences > 1 && digits_after == 3 && !other_separator_present {
+        return None;
+    }
+
+    Some(separator)
+}
+
+#[cfg(feature = "icu4x")]
+fn parse_separators(formatted: &str) -> (char, char) {
+    let mut decimal_sep = '.';
+    let mut group_sep = ',';
+
+    if let Some((idx, ch)) = formatted
+        .char_indices()
+        .rev()
+        .find(|(_, c)| !c.is_numeric() && !matches!(*c, '+' | '-'))
+    {
+        let has_digit_after = formatted[idx + ch.len_utf8()..]
+            .chars()
+            .any(char::is_numeric);
+        if has_digit_after {
+            decimal_sep = ch;
+        }
+    }
+
+    let integer_part = formatted.split(decimal_sep).next().unwrap_or(formatted);
+    if let Some(ch) = integer_part
+        .chars()
+        .find(|c| !c.is_numeric() && !matches!(*c, '+' | '-'))
+    {
+        group_sep = ch;
+    }
+
+    (decimal_sep, group_sep)
+}
+
+fn normalize_style_defaults(mut options: NumberFormatOptions) -> NumberFormatOptions {
+    if options.min_fraction_digits == 0 && options.max_fraction_digits == 3 {
+        match options.style {
+            NumberStyle::Percent => {
+                options.max_fraction_digits = 0;
+            }
+            NumberStyle::Currency(code) => {
+                let precision = iso4217_minor_units(code);
+                options.min_fraction_digits = precision;
+                options.max_fraction_digits = precision;
+            }
+            NumberStyle::Decimal | NumberStyle::Unit(_) => {}
+        }
+    }
+
+    options
+}
+
+fn iso4217_minor_units(code: CurrencyCode) -> u8 {
+    match code.as_str() {
+        "BHD" | "KWD" | "OMR" | "IQD" | "LYD" | "TND" => 3,
+        "CLF" | "UYW" => 4,
+        "JPY" | "KRW" | "VND" | "ISK" | "CLP" | "UGX" | "GNF" | "XOF" | "XAF" | "XPF" | "RWF"
+        | "DJF" | "KMF" | "VUV" | "PYG" => 0,
+        _ => 2,
+    }
+}
+
+#[cfg(feature = "icu4x")]
+fn resolve_measure_unit_id(unit: &MeasureUnit) -> Option<String> {
+    #[cfg(not(feature = "std"))]
+    use alloc::borrow::ToOwned as _;
+
+    if let Some(id) = unit.id {
+        return Some(id.to_owned());
+    }
+
+    for (candidate, _) in CLDR_IDS_TRIE.iter() {
+        let Ok(parsed) = MeasureUnit::try_from_str(&candidate) else {
+            continue;
+        };
+        if parsed == *unit {
+            return Some(candidate);
+        }
+    }
+
+    None
+}
+
+#[cfg(feature = "icu4x")]
+fn build_decimal_formatter(locale: &Locale, options: &NumberFormatOptions) -> DecimalFormatter {
+    let mut formatter_options = DecimalFormatterOptions::default();
+    formatter_options.grouping_strategy = Some(if options.use_grouping {
+        GroupingStrategy::Auto
+    } else {
+        GroupingStrategy::Never
+    });
+
+    DecimalFormatter::try_new(
+        DecimalFormatterPreferences::from(locale.as_icu()),
+        formatter_options,
+    )
+    .expect("compiled_data guarantees decimal formatter availability")
+}
+
+#[cfg(not(feature = "icu4x"))]
+fn build_decimal_formatter(_locale: &Locale, _options: &NumberFormatOptions) -> DecimalFormatter {
+    unreachable!("decimal formatters are only constructed when the icu4x feature is enabled")
+}
+
+fn round_value(value: f64, fraction_digits: u8, mode: RoundingMode) -> f64 {
+    let factor = 10_f64.powi(i32::from(fraction_digits));
+    let scaled = value * factor;
+    let rounded = match mode {
+        RoundingMode::HalfEven => scaled.round_ties_even(),
+        RoundingMode::HalfUp => round_half_away_from_zero(scaled),
+        RoundingMode::HalfDown => round_half_toward_zero(scaled),
+        RoundingMode::Ceiling => scaled.ceil(),
+        RoundingMode::Floor => scaled.floor(),
+        RoundingMode::Truncate => scaled.trunc(),
+    };
+
+    rounded / factor
+}
+
+fn round_half_away_from_zero(value: f64) -> f64 {
+    let abs = value.abs();
+    let floor = abs.floor();
+    let fraction = abs - floor;
+    let rounded = if fraction >= 0.5 { floor + 1.0 } else { floor };
+    rounded.copysign(value)
+}
+
+fn round_half_toward_zero(value: f64) -> f64 {
+    let abs = value.abs();
+    let floor = abs.floor();
+    let fraction = abs - floor;
+    let rounded = if fraction > 0.5 { floor + 1.0 } else { floor };
+    rounded.copysign(value)
+}
+
+#[cfg(not(feature = "icu4x"))]
+fn fallback_separators(locale: &Locale) -> (char, char) {
+    match locale.language() {
+        "de" | "pt" => (',', '.'),
+        "fr" => (',', ' '),
+        "ar" => ('٫', '٬'),
+        _ => ('.', ','),
+    }
+}
+
+#[cfg(not(feature = "icu4x"))]
+fn fallback_format(decimal: &Decimal, formatter: &NumberFormatter) -> String {
+    let mut output = decimal.to_string();
+    if formatter.decimal_separator != '.' {
+        output = output.replace('.', &String::from(formatter.decimal_separator));
+    }
+    output
+}
+
+impl SignDisplay {
+    const fn into_fixed_decimal(self) -> FixedSignDisplay {
+        match self {
+            Self::Auto => FixedSignDisplay::Auto,
+            Self::Always => FixedSignDisplay::Always,
+            Self::Never => FixedSignDisplay::Never,
+            Self::ExceptZero => FixedSignDisplay::ExceptZero,
+            Self::Negative => FixedSignDisplay::Negative,
+        }
+    }
+}
+
+impl UnitDisplay {
+    #[cfg(feature = "icu4x")]
+    const fn into_icu_width(self) -> Width {
+        match self {
+            Self::Long => Width::Long,
+            Self::Short => Width::Short,
+            Self::Narrow => Width::Narrow,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::locales;
+
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn formats_en_us_integers_and_decimals() {
+        let formatter = NumberFormatter::new(&locales::en_us(), NumberFormatOptions::default());
+
+        assert_eq!(formatter.format(1234.0), "1,234");
+        assert_eq!(formatter.format(1234.56), "1,234.56");
+    }
+
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn formats_grouping_and_decimal_separators_for_en_us_and_de_de() {
+        let en_us = NumberFormatter::new(&locales::en_us(), NumberFormatOptions::default());
+        let de_de = NumberFormatter::new(&locales::de_de(), NumberFormatOptions::default());
+
+        assert_eq!(en_us.format(1234.56), "1,234.56");
+        assert_eq!(de_de.format(1234.56), "1.234,56");
+    }
+
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn round_trips_parse_for_en_us_and_de_de() {
+        let en_us = NumberFormatter::new(&locales::en_us(), NumberFormatOptions::default());
+        let de_de = NumberFormatter::new(&locales::de_de(), NumberFormatOptions::default());
+
+        assert_eq!(en_us.parse("1,234.56"), Some(1234.56));
+        assert_eq!(de_de.parse("1.234,56"), Some(1234.56));
+        assert_eq!(de_de.parse("1.5"), Some(1.5));
+    }
+
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn exposes_decimal_and_grouping_separator_accessors() {
+        let en_us = NumberFormatter::new(&locales::en_us(), NumberFormatOptions::default());
+        let de_de = NumberFormatter::new(&locales::de_de(), NumberFormatOptions::default());
+
+        assert_eq!(en_us.decimal_separator(), '.');
+        assert_eq!(en_us.grouping_separator(), Some(','));
+        assert_eq!(de_de.decimal_separator(), ',');
+        assert_eq!(de_de.grouping_separator(), Some('.'));
+    }
+
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn formats_percent_from_fractional_input() {
+        let options = NumberFormatOptions {
+            style: NumberStyle::Percent,
+            ..NumberFormatOptions::default()
+        };
+        let en_us = NumberFormatter::new(&locales::en_us(), options.clone());
+        let de_de = NumberFormatter::new(&locales::de_de(), options);
+
+        assert_eq!(en_us.format(0.47), "47%");
+        assert_eq!(de_de.format(0.47), "47 %");
+        assert_eq!(en_us.format_percent(0.475, Some(1)), "47.5%");
+    }
+
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn parses_percent_back_to_fraction() {
+        let options = NumberFormatOptions {
+            style: NumberStyle::Percent,
+            ..NumberFormatOptions::default()
+        };
+        let formatter = NumberFormatter::new(&locales::en_us(), options);
+
+        assert_eq!(formatter.parse("47%"), Some(0.47));
+    }
+
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn formats_currency_with_locale_correct_symbol_placement() {
+        let base = NumberFormatter::new(&locales::en_us(), NumberFormatOptions::default());
+        let de = NumberFormatter::new(&locales::de_de(), NumberFormatOptions::default());
+        let ja = NumberFormatter::new(&locales::ja_jp(), NumberFormatOptions::default());
+
+        assert_eq!(base.format_currency(1234.5, "USD"), "$1,234.50");
+        assert_eq!(de.format_currency(1234.5, "EUR"), "1.234,50 €");
+        assert_eq!(ja.format_currency(1234.5, "JPY"), "￥1,234");
+    }
+
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn formats_unit_values_for_multiple_widths() {
+        let unit = MeasureUnit::try_from_str("kilogram").expect("kilogram is a valid CLDR unit");
+
+        let long = NumberFormatter::new(
+            &locales::en_us(),
+            NumberFormatOptions {
+                style: NumberStyle::Unit(unit.clone()),
+                unit_display: UnitDisplay::Long,
+                ..NumberFormatOptions::default()
+            },
+        )
+        .format(5.0);
+        let short = NumberFormatter::new(
+            &locales::en_us(),
+            NumberFormatOptions {
+                style: NumberStyle::Unit(unit.clone()),
+                unit_display: UnitDisplay::Short,
+                ..NumberFormatOptions::default()
+            },
+        )
+        .format(5.0);
+        let narrow = NumberFormatter::new(
+            &locales::en_us(),
+            NumberFormatOptions {
+                style: NumberStyle::Unit(unit),
+                unit_display: UnitDisplay::Narrow,
+                ..NumberFormatOptions::default()
+            },
+        )
+        .format(5.0);
+
+        assert_ne!(long, short);
+        assert_ne!(short, narrow);
+        assert!(long.contains("kil"));
+        assert!(short.contains("kg"));
+    }
+
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn parses_numeric_core_from_currency_or_unit_affixed_strings() {
+        let currency = NumberFormatter::new(&locales::en_us(), NumberFormatOptions::default());
+        let unit = MeasureUnit::try_from_str("celsius").expect("celsius is a valid CLDR unit");
+        let unit_formatter = NumberFormatter::new(
+            &locales::de_de(),
+            NumberFormatOptions {
+                style: NumberStyle::Unit(unit),
+                unit_display: UnitDisplay::Short,
+                min_fraction_digits: 1,
+                max_fraction_digits: 1,
+                ..NumberFormatOptions::default()
+            },
+        );
+
+        let currency_text = currency.format_currency(1234.5, "USD");
+        let unit_text = unit_formatter.format(37.0);
+
+        assert_eq!(currency.parse(&currency_text), Some(1234.5));
+        assert_eq!(unit_formatter.parse(&unit_text), Some(37.0));
+    }
+
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn normalizes_arabic_indic_digits_during_parse() {
+        let locale = locales::ar();
+        let formatter = NumberFormatter::new(&locale, NumberFormatOptions::default());
+
+        assert_eq!(formatter.parse("١٬٢٣٤٫٥٦"), Some(1234.56));
+    }
+
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn respects_non_uniform_grouping() {
+        let locale = Locale::parse("en-IN").expect("en-IN is a valid locale");
+        let formatter = NumberFormatter::new(&locale, NumberFormatOptions::default());
+
+        assert_eq!(formatter.format(1234567.0), "12,34,567");
+    }
+
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn formats_without_grouping_when_disabled() {
+        let formatter = NumberFormatter::new(
+            &locales::en_us(),
+            NumberFormatOptions {
+                use_grouping: false,
+                ..NumberFormatOptions::default()
+            },
+        );
+
+        assert_eq!(formatter.format(1234.56), "1234.56");
+    }
+
+    #[test]
+    fn rounds_values_for_all_rounding_modes() {
+        assert_eq!(round_value(1.25, 1, RoundingMode::HalfEven), 1.2);
+        assert_eq!(round_value(-1.25, 1, RoundingMode::HalfUp), -1.3);
+        assert_eq!(round_value(-1.25, 1, RoundingMode::HalfDown), -1.2);
+        assert_eq!(round_value(1.21, 1, RoundingMode::Ceiling), 1.3);
+        assert_eq!(round_value(-1.21, 1, RoundingMode::Floor), -1.3);
+        assert_eq!(round_value(-1.29, 1, RoundingMode::Truncate), -1.2);
+    }
+
+    #[test]
+    fn sign_display_variants_map_to_fixed_decimal_policies() {
+        assert_eq!(
+            SignDisplay::Auto.into_fixed_decimal(),
+            FixedSignDisplay::Auto
+        );
+        assert_eq!(
+            SignDisplay::Always.into_fixed_decimal(),
+            FixedSignDisplay::Always
+        );
+        assert_eq!(
+            SignDisplay::Never.into_fixed_decimal(),
+            FixedSignDisplay::Never
+        );
+        assert_eq!(
+            SignDisplay::ExceptZero.into_fixed_decimal(),
+            FixedSignDisplay::ExceptZero
+        );
+        assert_eq!(
+            SignDisplay::Negative.into_fixed_decimal(),
+            FixedSignDisplay::Negative
+        );
+    }
+
+    #[test]
+    fn normalizes_currency_style_defaults_from_minor_units() {
+        let bhd = normalize_style_defaults(NumberFormatOptions {
+            style: NumberStyle::Currency(CurrencyCode::from_str("BHD").expect("valid code")),
+            ..NumberFormatOptions::default()
+        });
+        let clf = normalize_style_defaults(NumberFormatOptions {
+            style: NumberStyle::Currency(CurrencyCode::from_str("CLF").expect("valid code")),
+            ..NumberFormatOptions::default()
+        });
+        let jpy = normalize_style_defaults(NumberFormatOptions {
+            style: NumberStyle::Currency(CurrencyCode::JPY),
+            ..NumberFormatOptions::default()
+        });
+
+        assert_eq!((bhd.min_fraction_digits, bhd.max_fraction_digits), (3, 3));
+        assert_eq!((clf.min_fraction_digits, clf.max_fraction_digits), (4, 4));
+        assert_eq!((jpy.min_fraction_digits, jpy.max_fraction_digits), (0, 0));
+        assert_eq!(iso4217_minor_units(CurrencyCode::USD), 2);
+    }
+
+    #[test]
+    fn parses_signed_and_grouped_numbers_with_locale_heuristics() {
+        let en_us = locales::en_us();
+        let de_de = locales::de_de();
+        let ar = locales::ar();
+
+        assert_eq!(parse_locale_number("-1,234.56", &en_us), Some(-1234.56));
+        assert_eq!(parse_locale_number("+1,234,567", &en_us), Some(1234567.0));
+        assert_eq!(parse_locale_number("+1.234", &de_de), Some(1234.0));
+        assert_eq!(parse_locale_number("١٬٢٣٤", &ar), Some(1234.0));
+    }
+
+    #[cfg(all(feature = "std", feature = "icu4x"))]
+    #[test]
+    fn caches_number_formatters_by_locale_and_options() {
+        let options = NumberFormatOptions {
+            min_fraction_digits: 2,
+            max_fraction_digits: 2,
+            ..NumberFormatOptions::default()
+        };
+
+        let cached = get_number_formatter(&locales::en_us(), &options);
+        let direct = NumberFormatter::new(&locales::en_us(), options);
+
+        assert_eq!(cached.format(1234.5), direct.format(1234.5));
+        assert_eq!(cached.decimal_separator(), direct.decimal_separator());
+        assert_eq!(cached.grouping_separator(), direct.grouping_separator());
+    }
+}

--- a/crates/ars-interactions/src/compose.rs
+++ b/crates/ars-interactions/src/compose.rs
@@ -138,7 +138,7 @@ mod tests {
 
         // All unique tokens present, duplicates removed.
         let class = merged.get(&HtmlAttr::Class).expect("class should be set");
-        let tokens: Vec<&str> = class.split_whitespace().collect();
+        let tokens = class.split_whitespace().collect::<Vec<_>>();
         assert!(tokens.contains(&"base"), "missing 'base': {class}");
         assert!(tokens.contains(&"pressed"), "missing 'pressed': {class}");
         assert!(tokens.contains(&"hovered"), "missing 'hovered': {class}");

--- a/crates/ars-leptos/src/attrs.rs
+++ b/crates/ars-leptos/src/attrs.rs
@@ -32,7 +32,7 @@ pub fn attr_map_to_leptos(
     element_id: Option<&str>,
 ) -> LeptosAttrResult {
     let parts = map.into_parts();
-    let mut attrs: Vec<(String, String)> = parts
+    let mut attrs = parts
         .attrs
         .into_iter()
         .filter_map(|(key, value)| match value {
@@ -40,7 +40,7 @@ pub fn attr_map_to_leptos(
             AttrValue::Bool(true) => Some((key.to_string(), String::new())),
             AttrValue::Bool(false) | AttrValue::None => None,
         })
-        .collect();
+        .collect::<Vec<_>>();
 
     let mut cssom_styles = Vec::new();
     let mut nonce_css = String::new();

--- a/crates/ars-leptos/src/use_machine.rs
+++ b/crates/ars-leptos/src/use_machine.rs
@@ -241,7 +241,7 @@ where
     // 2. Forward the event to Service::send()
     // 3. Update signals if state/context changed
     //
-    let send: Callback<M::Event> = Callback::new(move |event: M::Event| {
+    let send = Callback::new(move |event: M::Event| {
         // StoredValue::update_value returns (), so extract result via side-channel.
         let mut state_changed = false;
         let mut context_changed = false;

--- a/docs/implementation/README.md
+++ b/docs/implementation/README.md
@@ -18,4 +18,4 @@ Start with:
 4. The GitHub Project and initial issue backlog are expected to be kept in sync with these docs.
 5. [adapter-contract.md](./adapter-contract.md) for adapter work obligations and spec-sync checklist.
 6. [foundation-gap-audit.md](./foundation-gap-audit.md) for the backlog reset that defers `#24` and promotes the missing foundation contracts into issue-ready follow-on tasks.
-7. [foundation-completion-roadmap.md](./foundation-completion-roadmap.md) for the remaining foundation work (interactions, collections, DOM positioning, i18n) organized into four delivery waves before component work begins.
+7. [foundation-completion-roadmap.md](./foundation-completion-roadmap.md) for the remaining foundation work (interactions, collections, DOM positioning, i18n, and browser `web-intl` follow-ons) organized into five delivery waves before component work begins.

--- a/docs/implementation/foundation-completion-roadmap.md
+++ b/docs/implementation/foundation-completion-roadmap.md
@@ -851,6 +851,22 @@ The project needs a fully stable foundation before component work starts. Compon
 
 ---
 
+### Wave 5: Browser Intl Backends
+
+**Goal:** Complete the `web-intl` i18n backend so WASM client builds can rely on browser `Intl` services behind the same public `ars-i18n` API surface established by the ICU4X tasks.
+
+**Depends on:** `#75` plus the relevant Wave 4 i18n foundation tasks.
+
+| GitHub                                               | Title                                                                          | Points | Epic | Deps      |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------ | ------ | ---- | --------- |
+| [#124](https://github.com/fogodev/ars-ui/issues/124) | Implement web-intl NumberFormatter backend in ars-i18n                         | 5      | #54  | #75, #79  |
+| [#125](https://github.com/fogodev/ars-ui/issues/125) | Implement web-intl DateFormatter and RelativeTimeFormatter backend in ars-i18n | 5      | #54  | #75, #80  |
+| [#126](https://github.com/fogodev/ars-ui/issues/126) | Implement web-intl plural and ordinal rules backend in ars-i18n                | 3      | #54  | #75       |
+
+**Total:** 13 points
+
+---
+
 ### Wave 4 Task Details
 
 #### W4-1: Implement LongPress interaction in ars-interactions
@@ -1067,6 +1083,105 @@ The project needs a fully stable foundation before component work starts. Compon
 
 ---
 
+### Wave 5 Task Details
+
+#### W5-1: Implement web-intl NumberFormatter backend in ars-i18n
+
+- Points: `5`
+- Layer: `Subsystem`
+- Framework: `None`
+- Test tier: `Unit`
+- Depends on: #75, #79
+- Spec refs:
+  - `spec/foundation/04-internationalization.md`
+  - `spec/testing/14-ci.md`
+- Goal: implement the browser `Intl.NumberFormat` backend behind the existing `ars-i18n::NumberFormatter` public API.
+- Files to create/modify:
+  - `crates/ars-i18n/Cargo.toml`
+  - `crates/ars-i18n/src/lib.rs`
+  - `crates/ars-i18n/src/number.rs` or `crates/ars-i18n/src/web_intl/number.rs`
+  - `spec/foundation/04-internationalization.md`
+  - `spec/testing/14-ci.md` only if checks/spec drift need sync
+- Tests to add first:
+  - Feature-gated compile coverage proving `ars-i18n` builds with `--no-default-features --features web-intl --target wasm32-unknown-unknown`.
+  - Tests for option mapping of decimal, percent, and currency formatting.
+  - Tests proving `icu4x` and `web-intl` are mutually exclusive.
+  - Tests or smoke coverage for locale separator extraction and parsing behavior under `web-intl`.
+- Acceptance criteria:
+  - `web-intl` is a real backend, not an empty feature flag.
+  - `NumberFormatter` keeps the same public API under both `icu4x` and `web-intl`.
+  - Browser builds use `Intl.NumberFormat` for decimal, percent, and currency formatting.
+  - `format_percent(0.47, None)` preserves ars-ui fractional semantics and formats as `47%`.
+  - `format_currency()` preserves ISO-4217 minor-unit defaults.
+  - `decimal_separator()` and `grouping_separator()` work under `web-intl`.
+  - `parse()` remains locale-aware for browser-backed formatting.
+  - `icu4x` and `web-intl` cannot be enabled together.
+  - CI and verification include the wasm `web-intl` cargo check path required by the spec.
+- Spec impact: `Likely yes` to remove stale backend-specific public wrapper sketches if the concrete `NumberFormatter` API remains canonical.
+
+#### W5-2: Implement web-intl DateFormatter and RelativeTimeFormatter backend in ars-i18n
+
+- Points: `5`
+- Layer: `Subsystem`
+- Framework: `None`
+- Test tier: `Unit`
+- Depends on: #75, #80
+- Spec refs:
+  - `spec/foundation/04-internationalization.md`
+  - `spec/shared/date-time-types.md`
+  - `spec/testing/14-ci.md`
+- Goal: implement browser `Intl.DateTimeFormat` and `Intl.RelativeTimeFormat` backends for the existing `ars-i18n` date and relative-time public APIs.
+- Files to create/modify:
+  - `crates/ars-i18n/Cargo.toml`
+  - `crates/ars-i18n/src/lib.rs`
+  - `crates/ars-i18n/src/date.rs` and/or `crates/ars-i18n/src/web_intl/date.rs`
+  - `spec/foundation/04-internationalization.md`
+  - `spec/testing/14-ci.md` only if checks/spec drift need sync
+- Tests to add first:
+  - Feature-gated compile coverage proving `ars-i18n` builds with `--no-default-features --features web-intl --target wasm32-unknown-unknown`.
+  - Tests for representative date formatting under locale-sensitive browser patterns.
+  - Tests for relative time formatting via browser `Intl.RelativeTimeFormat`.
+  - Tests proving `icu4x` and `web-intl` are mutually exclusive.
+- Acceptance criteria:
+  - `web-intl` is a real backend for the public date and relative-time formatter surface.
+  - Browser builds use `Intl.DateTimeFormat` for date and time formatting where the spec maps cleanly to browser capabilities.
+  - Browser builds use `Intl.RelativeTimeFormat` for relative time output.
+  - The public `DateFormatter` and related API stay stable across `icu4x` and `web-intl` builds.
+  - Unsupported browser gaps are handled explicitly in code and spec rather than silently changing semantics.
+  - CI and verification include the wasm `web-intl` cargo check path required by the spec.
+- Spec impact: `Likely yes` if browser APIs cannot exactly match every ICU4X-oriented option or calendar behavior currently described.
+
+#### W5-3: Implement web-intl plural and ordinal rules backend in ars-i18n
+
+- Points: `3`
+- Layer: `Subsystem`
+- Framework: `None`
+- Test tier: `Unit`
+- Depends on: #75
+- Spec refs:
+  - `spec/foundation/04-internationalization.md`
+  - `spec/testing/14-ci.md`
+- Goal: implement browser `Intl.PluralRules` support for plural and ordinal category selection behind the existing `ars-i18n` contract.
+- Files to create/modify:
+  - `crates/ars-i18n/Cargo.toml`
+  - `crates/ars-i18n/src/lib.rs`
+  - `crates/ars-i18n/src/plural.rs` and/or `crates/ars-i18n/src/web_intl/plural.rs`
+  - `spec/foundation/04-internationalization.md`
+  - `spec/testing/14-ci.md` only if checks/spec drift need sync
+- Tests to add first:
+  - Feature-gated compile coverage proving `ars-i18n` builds with `--no-default-features --features web-intl --target wasm32-unknown-unknown`.
+  - Tests for representative cardinal and ordinal category selection across multiple locales.
+  - Tests proving `icu4x` and `web-intl` are mutually exclusive.
+- Acceptance criteria:
+  - `web-intl` is a real backend for plural and ordinal rules.
+  - Browser builds use `Intl.PluralRules` for cardinal and ordinal category selection.
+  - The public plural-category API stays stable across `icu4x` and `web-intl` builds.
+  - Any browser and ICU naming or behavior mismatches are normalized at the `ars-i18n` API boundary.
+  - CI and verification include the wasm `web-intl` cargo check path required by the spec.
+- Spec impact: `Potentially yes` if the current spec still assumes ICU4X-only plural-rule abstractions.
+
+---
+
 ## Dependency Graph
 
 ```diagram
@@ -1117,6 +1232,11 @@ Wave 4 (50 pts)            ┌─── Wave 3 complete
   #84 (filter/sort, 3)     │
   #85 (media query, 2)     │
                            ▼
+Wave 5 (13 pts)            ┌─── Wave 4 i18n tasks available
+  #124 (web number, 5)     │
+  #125 (web date/rtf, 5)   │
+  #126 (web plural, 3)     │
+                           ▼
             ┌─── All waves complete
             │
             ▼
@@ -1133,12 +1253,12 @@ Wave 4 (50 pts)            ┌─── Wave 3 complete
 | Dioxus adapter      | #9    | #56, #106                                                      |
 | A11y                | #3    | #73, #89                                                       |
 | Collections         | #53   | #62, #63, #64, #70, #71, #81, #82, #83, #84                    |
-| I18n                | #54   | #75, #79, #80                                                  |
+| I18n                | #54   | #75, #79, #80, #124, #125, #126                                |
 | First utility slice | #10   | #104                                                           |
 
 ## Post-Foundation Plan
 
-After all four waves are complete:
+After all five waves are complete:
 
 1. Close or supersede `#24` ("Break the first utility slice into agent-ready delivery cards").
 2. Decompose the first utility slice (Button, VisuallyHidden, Separator, FocusScope, Toggle, Field, Form) into agent-ready component tasks.

--- a/spec/components/data-display/avatar.md
+++ b/spec/components/data-display/avatar.md
@@ -154,7 +154,7 @@ impl Default for Messages {
     fn default() -> Self {
         Self {
             initials_fn: MessageFn::new(|name, _locale| {
-                let parts: Vec<&str> = name.split_whitespace().collect();
+                let parts = name.split_whitespace().collect::<Vec<_>>();
                 match parts.as_slice() {
                     [] => String::new(),
                     [single] => single.chars().next()

--- a/spec/components/data-display/stat.md
+++ b/spec/components/data-display/stat.md
@@ -114,8 +114,11 @@ impl<'a> Api<'a> {
     pub fn formatted_change(&self) -> Option<String> {
         let change = self.props.change?;
         let locale = &self.locale;
-        let fmt = NumberFormatter::new(locale, self.props.format_options.as_ref());
-        let pct = fmt.format_percent(change.abs() / 100.0);
+        let fmt = NumberFormatter::new(
+            locale,
+            self.props.format_options.clone().unwrap_or_default(),
+        );
+        let pct = fmt.format_percent(change.abs() / 100.0, None);
         let msgs = &self.messages;
         let label = match self.resolved_trend() {
             Some(Trend::Up)      => format!("{} {}", (msgs.increase_prefix)(locale), pct),
@@ -338,50 +341,30 @@ impl ComponentMessages for Messages {}
 ### 4.2 Currency and Unit Formatting
 
 When `Stat` displays monetary or unit values, the `value` prop MUST be pre-formatted
-by the host application using the appropriate formatter. `ars-i18n` provides wrappers
-for locale-correct formatting:
+by the host application using `ars-i18n::NumberFormatter`. Currency and measurement
+formatting are selected through `NumberStyle` rather than separate wrapper types:
 
 ```rust
-/// Formats a currency value with locale-correct symbol placement and grouping.
-///
-/// Uses ICU4X `DecimalFormatter` + `CurrencyFormatter` under the hood.
-///
-/// Symbol placement varies by locale:
-/// - `en-US`: "$1,234.56" (symbol before, comma grouping, period decimal)
-/// - `de-DE`: "1.234,56 €" (symbol after with space, period grouping, comma decimal)
-/// - `ja-JP`: "￥1,234" (symbol before, no decimal for JPY)
-/// - `ar-SA`: "١٬٢٣٤٫٥٦ ر.س." (Arabic-Indic numerals, symbol after)
-pub struct CurrencyFormatter {
-    locale: Locale,
-    currency_code: String, // ISO 4217, e.g. "USD", "EUR", "JPY"
+pub fn format_currency_value(locale: &Locale, code: CurrencyCode, value: f64) -> String {
+    NumberFormatter::new(locale, NumberFormatOptions::default())
+        .format_currency(value, code.as_str())
 }
 
-impl CurrencyFormatter {
-    pub fn new(locale: &Locale, currency_code: &str) -> Self { /* ... */ }
-    pub fn format(&self, value: f64) -> String { /* ... */ }
-}
-
-/// Formats a value with a measurement unit, respecting locale conventions.
-///
-/// Uses ICU4X `MeasureUnit` for placement rules.
-///
-/// Placement varies by locale:
-/// - `en-US`: "98.6°F", "5 lbs"
-/// - `de-DE`: "37 °C", "2,3 kg"
-/// - `ja-JP`: "37°C", "5kg"
-/// - RTL locales: unit suffix ordering follows bidi algorithm
-pub struct UnitFormatter {
-    locale: Locale,
-    unit: String,          // CLDR unit ID, e.g. "temperature-celsius"
-    unit_display: UnitDisplay, // Long, Short, Narrow
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum UnitDisplay { Long, Short, Narrow }
-
-impl UnitFormatter {
-    pub fn new(locale: &Locale, unit: &str, display: UnitDisplay) -> Self { /* ... */ }
-    pub fn format(&self, value: f64) -> String { /* ... */ }
+pub fn format_unit_value(
+    locale: &Locale,
+    unit: MeasureUnit,
+    display: UnitDisplay,
+    value: f64,
+) -> String {
+    NumberFormatter::new(
+        locale,
+        NumberFormatOptions {
+            style: NumberStyle::Unit(unit),
+            unit_display: display,
+            ..NumberFormatOptions::default()
+        },
+    )
+    .format(value)
 }
 ```
 
@@ -391,7 +374,7 @@ use ICU MessageFormat-style interpolation for locale-aware string building.
 
 ### 4.3 Currency Symbol Placement
 
-The `CurrencyFormatter` trait defined above handles locale-aware currency symbol placement. To streamline currency display in Stat, Progress, and Meter components:
+`NumberFormatter` with `NumberStyle::Currency` handles locale-aware currency symbol placement. To streamline currency display in Stat, Progress, and Meter components:
 
 **Stat `currency` Prop:**
 
@@ -400,13 +383,9 @@ pub struct Props {
     // ... existing fields ...
     /// Optional ISO 4217 currency code (e.g., "USD", "EUR", "JPY").
     /// When set, the `value` field is interpreted as a raw numeric value
-    /// and formatted using `CurrencyFormatter::new(&locale, &currency_code)`.
+    /// and formatted using `NumberFormatter::format_currency()`.
     pub currency: Option<CurrencyCode>,
 }
-
-/// ISO 4217 currency code wrapper.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct CurrencyCode(pub String);
 ```
 
 **Symbol Placement Rules** (determined entirely by locale ICU data):
@@ -415,7 +394,7 @@ pub struct CurrencyCode(pub String);
 - Spacing between symbol and value is locale-dependent (e.g., `€1.00` in `en-IE` vs `1,00 €` in `de-DE`).
 - Narrow symbol variants (e.g., `$` vs `US$`) are selected automatically when the currency is unambiguous in the locale context.
 
-**Progress/Meter**: These components do not directly format currency values. When used to display monetary progress (e.g., fundraising), the application MUST pre-format `value_label` using `CurrencyFormatter` and pass it as a string prop.
+**Progress/Meter**: These components do not directly format currency values. When used to display monetary progress (e.g., fundraising), the application MUST pre-format `value_label` using `NumberFormatter` and pass it as a string prop.
 
 ## 5. Library Parity
 

--- a/spec/components/data-display/table.md
+++ b/spec/components/data-display/table.md
@@ -1116,7 +1116,7 @@ fn build_sort_announcement(
         };
     }
     // Multi-column: build comma-separated list.
-    let parts: Vec<String> = sort_descriptors.iter().map(|desc| {
+    let parts = sort_descriptors.iter().map(|desc| {
         let col_name = columns.iter()
             .find(|c| c.key == desc.column_key)
             .map(|c| c.header_text.as_str())
@@ -1126,7 +1126,7 @@ fn build_sort_announcement(
             SortDirection::Descending => "descending",
         };
         format!("{col_name} {dir}")
-    }).collect();
+    }).collect::<Vec<_>>();
     messages.multi_sort_changed.replace("{columns}", &parts.join(", "))
 }
 ```

--- a/spec/components/date-time/date-field.md
+++ b/spec/components/date-time/date-field.md
@@ -858,7 +858,7 @@ pub fn segments_for_locale(
     let locale_str = locale.to_bcp47();
     let lang = locale.language();
 
-    let base: Vec<DateSegmentKind> = if locale_str == "en-US" || locale_str == "en-PH" || locale_str == "en-CA" || locale_str == "es-MX" {
+    let base = if locale_str == "en-US" || locale_str == "en-PH" || locale_str == "en-CA" || locale_str == "es-MX" {
         // United States / Canada / Philippines: M/D/Y
         vec![
             DateSegmentKind::Month,
@@ -954,7 +954,7 @@ impl LocaleSeparators {
     pub fn for_locale(locale: &Locale) -> Self {
         // Production: ICU4X pattern parsing extracts exact separator strings.
         let locale_tag = locale.to_bcp47();
-        let seps: Vec<String> = match locale_tag.as_str() {
+        let seps = match locale_tag.as_str() {
             "de-DE" | "de-AT" | "nl-NL" | "pl-PL" | "ru-RU" | "cs-CZ"
             | "sk-SK" | "hr-HR" | "bg-BG" | "ro-RO" =>
                 vec![".".into(), ".".into()],
@@ -1433,10 +1433,10 @@ impl ars_core::Machine for Machine {
                 if ctx.readonly { return None; }
                 Some(TransitionPlan::to(State::Idle)
                     .apply(|ctx| {
-                        let editable: Vec<_> = ctx.segments.iter()
+                        let editable = ctx.segments.iter()
                             .filter(|s| s.is_editable)
                             .map(|s| s.kind)
-                            .collect();
+                            .collect::<Vec<_>>();
                         for k in editable { ctx.clear_segment_value(k); }
                         ctx.value.set(None);
                         ctx.type_buffer.clear();
@@ -2137,7 +2137,7 @@ mod tests {
     #[test]
     fn en_us_segment_order_is_month_day_year() {
         let svc = make_service(DateGranularity::Day);
-        let kinds: Vec<_> = svc.context().segments.iter().map(|s| s.kind).collect();
+        let kinds = svc.context().segments.iter().map(|s| s.kind).collect::<Vec<_>>();
         assert_eq!(kinds, vec![
             DateSegmentKind::Month,
             DateSegmentKind::Literal,
@@ -2151,7 +2151,7 @@ mod tests {
     fn de_de_segment_order_is_day_month_year() {
         let env = Env { locale: Locale::parse("de-DE").expect("valid locale"), ..Env::default() };
         let svc = Service::new(Props { granularity: DateGranularity::Day, ..Props::default() }, env, Default::default());
-        let kinds: Vec<_> = svc.context().segments.iter().map(|s| s.kind).collect();
+        let kinds = svc.context().segments.iter().map(|s| s.kind).collect::<Vec<_>>();
         assert_eq!(kinds, vec![
             DateSegmentKind::Day,
             DateSegmentKind::Literal,

--- a/spec/components/date-time/date-picker.md
+++ b/spec/components/date-time/date-picker.md
@@ -135,7 +135,7 @@ fn format_date(date: &CalendarDate, format: &str, locale: &Locale) -> String {
 fn parse_date(text: &str, format: &str, locale: &Locale) -> Option<CalendarDate> {
     // Production: ICU4X DateTimeParser.
     // Simplified placeholder for the spec:
-    let parts: Vec<&str> = text.split('/').collect();
+    let parts = text.split('/').collect::<Vec<_>>();
     if parts.len() != 3 { return None; }
     let month = parts[0].parse::<u8>().ok()?;
     let day   = parts[1].parse::<u8>().ok()?;

--- a/spec/components/date-time/date-time-picker.md
+++ b/spec/components/date-time/date-time-picker.md
@@ -148,7 +148,7 @@ impl Context {
     /// Find the next editable segment after the given segment, crossing the
     /// date-to-time boundary when the current segment is the last date segment.
     pub fn next_editable_after(&self, kind: DateSegmentKind) -> Option<DateSegmentKind> {
-        let all: Vec<_> = self.all_segments().collect();
+        let all = self.all_segments().collect::<Vec<_>>();
         let idx = all.iter().position(|s| s.kind == kind)?;
         all[idx + 1..].iter().find(|s| s.is_editable).map(|s| s.kind)
     }
@@ -156,7 +156,7 @@ impl Context {
     /// Find the previous editable segment before the given segment, crossing
     /// the time-to-date boundary when the current segment is the first time segment.
     pub fn prev_editable_before(&self, kind: DateSegmentKind) -> Option<DateSegmentKind> {
-        let all: Vec<_> = self.all_segments().collect();
+        let all = self.all_segments().collect::<Vec<_>>();
         let idx = all.iter().position(|s| s.kind == kind)?;
         all[..idx].iter().rev().find(|s| s.is_editable).map(|s| s.kind)
     }
@@ -834,11 +834,11 @@ impl ars_core::Machine for Machine {
                 if is_readonly(ctx) { return None; }
                 Some(TransitionPlan::to(State::Idle)
                     .apply(|ctx| {
-                        let date_editable: Vec<_> = ctx.date_segments.iter()
-                            .filter(|s| s.is_editable).map(|s| s.kind).collect();
+                        let date_editable = ctx.date_segments.iter()
+                            .filter(|s| s.is_editable).map(|s| s.kind).collect::<Vec<_>>();
                         for k in date_editable { ctx.clear_segment_value(k); }
-                        let time_editable: Vec<_> = ctx.time_segments.iter()
-                            .filter(|s| s.is_editable).map(|s| s.kind).collect();
+                        let time_editable = ctx.time_segments.iter()
+                            .filter(|s| s.is_editable).map(|s| s.kind).collect::<Vec<_>>();
                         for k in time_editable { ctx.clear_segment_value(k); }
                         ctx.date_value = None;
                         ctx.time_value = None;

--- a/spec/components/date-time/time-field.md
+++ b/spec/components/date-time/time-field.md
@@ -429,10 +429,10 @@ fn day_period_from_cjk_buffer(
     };
 
     // Normalize: strip combining marks for tone-mark resilience.
-    let normalized: String = buffer
+    let normalized = buffer
         .nfd()
         .filter(|c| !c.is_combining_mark())
-        .collect();
+        .collect::<String>();
 
     // Full or prefix match against AM/PM labels.
     if entry.am_label.starts_with(&normalized) && !entry.pm_label.starts_with(&normalized) {
@@ -795,10 +795,10 @@ impl ars_core::Machine for Machine {
                 if ctx.readonly { return None; }
                 Some(TransitionPlan::to(State::Idle)
                     .apply(|ctx| {
-                        let editable: Vec<_> = ctx.segments.iter()
+                        let editable = ctx.segments.iter()
                             .filter(|s| s.is_editable)
                             .map(|s| s.kind)
-                            .collect();
+                            .collect::<Vec<_>>();
                         for k in editable { ctx.clear_segment_value(k); }
                         ctx.value.set(None);
                         ctx.type_buffer.clear();

--- a/spec/components/input/checkbox-group.md
+++ b/spec/components/input/checkbox-group.md
@@ -308,7 +308,7 @@ impl ars_core::Machine for Machine {
                 Some(TransitionPlan::context_only(move |ctx| {
                     match max {
                         Some(n) => {
-                            let truncated: BTreeSet<Key> = all.into_iter().take(n).collect();
+                            let truncated = all.into_iter().take(n).collect::<BTreeSet<_>>();
                             ctx.value.set(truncated);
                         }
                         None => ctx.value.set(all),

--- a/spec/components/input/pin-input.md
+++ b/spec/components/input/pin-input.md
@@ -322,7 +322,7 @@ impl ars_core::Machine for Machine {
                 vals[i] = c.to_string();
 
                 if vals.iter().all(|v| !v.is_empty()) {
-                    let combined: String = vals.iter().map(|v| v.as_str()).collect();
+                    let combined = vals.iter().map(|v| v.as_str()).collect::<String>();
                     let blur = ctx.blur_on_complete;
                     let mut plan = TransitionPlan::to(State::Completed).apply(move |ctx| {
                         ctx.value.set(vals);
@@ -388,7 +388,7 @@ impl ars_core::Machine for Machine {
             // ── Paste ─────────────────────────────────────────────
             (_, Event::Paste(text)) => {
                 let mode = ctx.mode.clone();
-                let chars: Vec<char> = text.chars()
+                let chars = text.chars::<Vec<_>>()
                     .filter(|c| match mode {
                         Mode::Numeric => c.is_ascii_digit(),
                         Mode::Alphanumeric => c.is_alphanumeric(),
@@ -404,7 +404,7 @@ impl ars_core::Machine for Machine {
                 }
 
                 if vals.iter().all(|v| !v.is_empty()) {
-                    let combined: String = vals.iter().map(|v| v.as_str()).collect();
+                    let combined = vals.iter().map(|v| v.as_str()).collect::<String>();
                     let blur = ctx.blur_on_complete;
                     let mut plan = TransitionPlan::to(State::Completed).apply(move |ctx| {
                         ctx.value.set(vals);
@@ -582,7 +582,7 @@ impl<'a> Api<'a> {
         attrs.set(scope_attr, scope_val);
         attrs.set(part_attr, part_val);
         attrs.set(HtmlAttr::Type, "hidden");
-        let combined: String = self.ctx.value.get().iter().map(|v| v.as_str()).collect();
+        let combined = self.ctx.value.get().iter().map(|v| v.as_str()).collect::<String>();
         attrs.set(HtmlAttr::Value, combined);
         if let Some(ref name) = self.ctx.name { attrs.set(HtmlAttr::Name, name); }
         if let Some(ref form) = self.props.form { attrs.set(HtmlAttr::Form, form); }

--- a/spec/components/input/radio-group.md
+++ b/spec/components/input/radio-group.md
@@ -6,9 +6,9 @@ foundation_deps: [architecture, accessibility, interactions, forms]
 shared_deps: []
 related: []
 references:
-  ark-ui: RadioGroup
-  radix-ui: RadioGroup
-  react-aria: RadioGroup
+    ark-ui: RadioGroup
+    radix-ui: RadioGroup
+    react-aria: RadioGroup
 ---
 
 # RadioGroup
@@ -358,7 +358,7 @@ fn navigate_items(
     direction: i32,
     wrap: bool,
 ) -> Option<Key> {
-    let enabled: Vec<&Radio> = items.iter().filter(|i| !i.disabled).collect();
+    let enabled = items.iter().filter(|i| !i.disabled).collect::<Vec<_>>();
     if enabled.is_empty() { return None; }
 
     let current_idx = current.as_ref()

--- a/spec/components/navigation/accordion.md
+++ b/spec/components/navigation/accordion.md
@@ -348,14 +348,14 @@ impl ars_core::Machine for Machine {
                 if ctx.disabled { return None; }
                 if !ctx.multiple { return None; }
                 // Filter out items that are individually disabled.
-                let expandable_items: BTreeSet<Key> = ctx.items.iter()
+                let expandable_items = ctx.items.iter()
                     .filter(|id| !*ctx.disabled_items.get(*id).unwrap_or(&false))
                     .cloned()
-                    .collect();
+                    .collect::<BTreeSet<_>>();
                 // Merge with currently open items (disabled items that are already
                 // open remain open; we just don't add new disabled items).
                 let current = ctx.value.get().clone();
-                let merged: BTreeSet<Key> = current.union(&expandable_items).cloned().collect();
+                let merged = current.union(&expandable_items).cloned().collect::<BTreeSet<_>>();
                 Some(TransitionPlan::context_only(move |ctx| {
                     ctx.value.set(merged);
                 }))

--- a/spec/components/navigation/pagination.md
+++ b/spec/components/navigation/pagination.md
@@ -83,7 +83,7 @@ impl Context {
         let show_left_ellipsis  = left_start > 2;
         let show_right_ellipsis = right_end < total.saturating_sub(1);
 
-        let mut pages: Vec<Option<u32>> = vec![Some(1)];
+        let mut pages = vec![Some(1)];
 
         if show_left_ellipsis {
             pages.push(None); // ellipsis

--- a/spec/components/navigation/tree-view.md
+++ b/spec/components/navigation/tree-view.md
@@ -445,10 +445,10 @@ impl ars_core::Machine for Machine {
             // ── Expand/Collapse All ────────────────────────────────────
             // ExpandAll — expand every expandable node
             Event::ExpandAll => {
-                let expandable: Vec<String> = ctx.items.nodes()
+                let expandable = ctx.items.nodes()
                     .filter(|n| n.has_children)
                     .map(|n| n.key.to_string())
-                    .collect();
+                    .collect::<Vec<_>>();
                 Some(TransitionPlan::context_only(move |ctx| {
                     let mut exp = ctx.expanded.get().clone();
                     for key in expandable {

--- a/spec/components/selection/combobox.md
+++ b/spec/components/selection/combobox.md
@@ -292,7 +292,7 @@ impl ars_core::Machine for Machine {
         };
 
         let ctx = Context {
-            items: StaticCollection::from_vec(Vec::new()),
+            items: StaticCollection::default(),
             input_value: match &props.input_value {
                 Some(v) => Bindable::controlled(v.clone()),
                 None => Bindable::uncontrolled(props.default_input_value.clone()),

--- a/spec/components/selection/context-menu.md
+++ b/spec/components/selection/context-menu.md
@@ -184,7 +184,7 @@ impl ars_core::Machine for Machine {
 
     fn init(props: &Props, _env: &Env, _messages: &Messages) -> (State, Context) {
         let ctx = Context {
-            items: StaticCollection::empty(),
+            items: StaticCollection::default(),
             open: false,
             highlighted_key: None,
             focus_visible: false,

--- a/spec/components/selection/listbox.md
+++ b/spec/components/selection/listbox.md
@@ -242,7 +242,7 @@ impl ars_core::Machine for Machine {
         let messages = messages.clone();
         let ctx = Context {
             locale,
-            items: StaticCollection::from_vec(Vec::new()),
+            items: StaticCollection::default(),
             selection: match &props.value {
                 Some(v) => Bindable::controlled(v.clone()),
                 None => Bindable::uncontrolled(props.default_value.clone()),

--- a/spec/components/selection/menu-bar.md
+++ b/spec/components/selection/menu-bar.md
@@ -145,7 +145,7 @@ impl ars_core::Machine for Machine {
         let messages = messages.clone();
         let ctx = Context {
             locale,
-            menus: StaticCollection::empty(),
+            menus: StaticCollection::default(),
             active_menu: None,
             focused_item: None,
             focus_visible: false,

--- a/spec/components/selection/menu.md
+++ b/spec/components/selection/menu.md
@@ -276,7 +276,7 @@ impl ars_core::Machine for Machine {
 
     fn init(props: &Self::Props, _env: &Env, _messages: &Self::Messages) -> (Self::State, Self::Context) {
         let ctx = Context {
-            items: StaticCollection::empty(),
+            items: StaticCollection::default(),
             open: false,
             highlighted_key: None,
             focused: false,

--- a/spec/components/selection/select.md
+++ b/spec/components/selection/select.md
@@ -313,7 +313,7 @@ impl ars_core::Machine for Machine {
         let messages = messages.clone();
         let ctx = Context {
             locale,
-            items: StaticCollection::from_vec(Vec::new()),
+            items: StaticCollection::default(),
             selection: match &props.value {
                 Some(v) => Bindable::controlled(v.clone()),
                 None => Bindable::uncontrolled(props.default_value.clone()),

--- a/spec/foundation/04-internationalization.md
+++ b/spec/foundation/04-internationalization.md
@@ -34,7 +34,7 @@ pub type DefaultNumberFormatter = icu4x::Icu4xNumberFormatter;
 pub type DefaultNumberFormatter = web_intl::JsIntlNumberFormatter;
 ```
 
-Both backends implement the same formatter traits. Components are backend-agnostic.
+Both backends expose the same concrete formatter surface. Components are backend-agnostic.
 
 #### 1.1.1 Number Formatter Context Propagation
 
@@ -48,17 +48,27 @@ Numeric components (NumberInput, Slider, RangeSlider, Progress, Meter) MUST reso
 All numeric components MUST accept a `number_formatter: Option<NumberFormatter>` prop. If not provided, a default `NumberFormatter` is constructed from the resolved locale.
 
 ```rust
-/// Trait for locale-aware number formatting and parsing.
-pub trait NumberFormatter {
-    /// Format a numeric value for display (e.g., 1234.5 -> "1,234.5" in en-US, "1.234,5" in de-DE).
-    fn format(&self, value: f64) -> String;
-    /// Parse a locale-formatted string back to a number. Accepts both canonical ("1.5") and
-    /// locale-specific ("1,5" in de-DE) formats. Returns None if unparseable.
-    fn parse(&self, input: &str) -> Option<f64>;
-    /// Return the decimal separator for the current locale (e.g., '.' for en-US, ',' for de-DE).
-    fn decimal_separator(&self) -> char;
-    /// Return the grouping separator for the current locale (e.g., ',' for en-US, '.' for de-DE).
-    fn grouping_separator(&self) -> Option<char>;
+pub struct NumberFormatter {
+    /* private fields */
+}
+
+impl NumberFormatter {
+    /// Create a locale-aware formatter with the requested options.
+    pub fn new(locale: &Locale, options: NumberFormatOptions) -> Self;
+    /// Format a numeric value for display.
+    pub fn format(&self, value: f64) -> String;
+    /// Parse a locale-formatted string back to a number.
+    pub fn parse(&self, input: &str) -> Option<f64>;
+    /// Return the decimal separator for the current locale.
+    pub fn decimal_separator(&self) -> char;
+    /// Return the grouping separator for the current locale.
+    pub fn grouping_separator(&self) -> Option<char>;
+    /// Format a monetary amount using the supplied ISO 4217 currency code.
+    pub fn format_currency(&self, amount: f64, currency_code: &str) -> String;
+    /// Format a fractional value such as `0.47` as a localized percentage.
+    pub fn format_percent(&self, value: f64, max_fraction_digits: Option<u8>) -> String;
+    /// Format a numeric range using locale-appropriate range punctuation.
+    pub fn format_range(&self, start: f64, end: f64, locale: &Locale) -> String;
 }
 ```
 
@@ -735,14 +745,20 @@ Overlay components use `Placement` from `11-dom-utilities.md` §2.2, which inclu
 ### 4.1 NumberFormatter
 
 ````rust
-use icu::decimal::DecimalFormatter;
+use core::num::NonZeroU8;
+
 use fixed_decimal::Decimal;
+use icu::decimal::DecimalFormatter;
+// ICU4X 2.1 currently exposes MeasureUnit and related formatter APIs through
+// `icu_experimental`, not an `icu::experimental` umbrella path.
+pub use icu_experimental::measure::measureunit::MeasureUnit;
 
 /// Options for formatting numbers.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct NumberFormatOptions {
     pub style: NumberStyle,
-    pub min_integer_digits: NonZero<u8>,
+    pub unit_display: UnitDisplay,
+    pub min_integer_digits: NonZeroU8,
     pub min_fraction_digits: u8,
     pub max_fraction_digits: u8,
     pub use_grouping: bool,
@@ -756,7 +772,7 @@ pub struct NumberFormatOptions {
 //
 // The `max_fraction_digits` for currency formatting MUST default to the
 // ISO 4217 standard fraction digits for the given currency code. The
-// `NumberFormatter` resolves this via ICU4X `CurrencyInfo`.
+// `NumberFormatter` resolves this via ars-i18n's ISO 4217 helper table.
 //
 // | Currency Code | Currency Name           | Fraction Digits |
 // |---------------|-------------------------|-----------------|
@@ -792,7 +808,7 @@ pub struct NumberFormatOptions {
 //
 // This minimizes cumulative rounding bias in financial calculations.
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum NumberStyle {
     Decimal,
     Percent,
@@ -800,7 +816,15 @@ pub enum NumberStyle {
     Unit(MeasureUnit),
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum UnitDisplay {
+    Long,
+    #[default]
+    Short,
+    Narrow,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum SignDisplay {
     Auto,       // negative only
     Always,     // always show sign
@@ -851,7 +875,7 @@ pub enum RoundingMode {
 /// | KWD           | Kuwaiti Dinar           | 3               |
 /// | OMR           | Omani Rial              | 3               |
 /// | CLF           | Chilean UF              | 4               |
-fn iso4217_minor_units(code: &CurrencyCode) -> u8 {
+fn iso4217_minor_units(code: CurrencyCode) -> u8 {
     match code.as_str() {
         "BHD" | "KWD" | "OMR" | "IQD" | "LYD" | "TND" => 3,
         "CLF" | "UYW" => 4,
@@ -862,8 +886,9 @@ fn iso4217_minor_units(code: &CurrencyCode) -> u8 {
     }
 }
 
-// Currency, percent, and rounding helpers are inherent methods on NumberFormatter
-// (no separate trait — these are not used polymorphically).
+// Currency, percent, unit, and range helpers are inherent methods on
+// NumberFormatter. ars-i18n does not define separate CurrencyFormatter or
+// UnitFormatter wrapper types.
 
 impl NumberFormatter {
     /// Format a monetary amount using the ISO 4217 precision for the
@@ -876,13 +901,13 @@ impl NumberFormatter {
     /// ```
     /// let fmt = NumberFormatter::new(&locale_en_us, opts);
     /// assert_eq!(fmt.format_currency(1234.5, "USD"), "$1,234.50");
-    /// assert_eq!(fmt.format_currency(1234.5, "JPY"), "¥1,235");
+    /// assert_eq!(fmt.format_currency(1234.5, "JPY"), "￥1,234");
     /// assert_eq!(fmt.format_currency(1234.5, "KWD"), "KWD 1,234.500");
     /// ```
     pub fn format_currency(&self, amount: f64, currency_code: &str) -> String {
         let code = CurrencyCode::from_str(currency_code)
             .expect("invalid ISO 4217 currency code");
-        let precision = iso4217_minor_units(&code);
+        let precision = iso4217_minor_units(code);
 
         let mut opts = self.options.clone();
         opts.style = NumberStyle::Currency(code);
@@ -892,6 +917,12 @@ impl NumberFormatter {
         NumberFormatter::new(&self.locale, opts).format(amount)
     }
 
+    /// Format a fractional value as a percentage.
+    ///
+    /// ars-ui percent formatting accepts fractional inputs such as `0.47`
+    /// for `47%`. The formatter scales by `100` before delegating to ICU4X's
+    /// percent formatter so that locale-specific percent symbols, placement,
+    /// and spacing still come from CLDR data.
     pub fn format_percent(&self, value: f64, max_fraction_digits: Option<u8>) -> String {
         let frac = max_fraction_digits.unwrap_or(0);
 
@@ -900,13 +931,7 @@ impl NumberFormatter {
         opts.min_fraction_digits = 0;
         opts.max_fraction_digits = frac;
 
-        // ICU4X Percent style handles the ×100 conversion internally;
-        // pass the raw fraction (e.g., 0.75 for 75%).
         NumberFormatter::new(&self.locale, opts).format(value)
-    }
-
-    fn rounding_mode(&self) -> RoundingMode {
-        self.options.rounding_mode
     }
 }
 
@@ -943,7 +968,8 @@ impl Default for NumberFormatOptions {
     fn default() -> Self {
         Self {
             style: NumberStyle::Decimal,
-            min_integer_digits: NonZero::new(1).expect("hardcoded nonzero"),
+            unit_display: UnitDisplay::Short,
+            min_integer_digits: NonZeroU8::new(1).expect("hardcoded nonzero"),
             min_fraction_digits: 0,
             max_fraction_digits: 3,
             use_grouping: true,
@@ -956,52 +982,49 @@ impl Default for NumberFormatOptions {
 /// A locale-aware number formatter.
 ///
 /// `Clone` is derived to support caching in `NUMBER_FORMATTER_CACHE` (§9.3).
-/// The inner `DecimalFormatter` is wrapped in `Arc` so cloning is cheap.
+/// The formatter stores precomputed separators and delegates formatting to a
+/// style-specific ICU4X backend selected from `NumberStyle`.
 #[derive(Clone)]
 pub struct NumberFormatter {
     locale: Locale,
     options: NumberFormatOptions,
-    formatter: Arc<DecimalFormatter>,
+    decimal_separator: char,
+    grouping_separator: Option<char>,
+    /* style-specific backend */
 }
 
 impl NumberFormatter {
     /// Create a new locale-aware number formatter.
-    ///
-    /// With the `compiled_data` feature (our default), `DecimalFormatter::try_new()`
-    /// cannot fail — CLDR data is baked into the binary for all locales.
     pub fn new(locale: &Locale, options: NumberFormatOptions) -> Self {
-        let mut dec_opts = DecimalFormatterOptions::default();
-        dec_opts.grouping_strategy = if options.use_grouping {
-            Some(GroupingStrategy::Auto)
-        } else {
-            Some(GroupingStrategy::Never)
-        };
-        let formatter = DecimalFormatter::try_new((&locale.0).into(), dec_opts)
-            .expect("compiled_data guarantees decimal formatter is available for all locales");
-
-        Self {
-            locale: locale.clone(),
-            options,
-            formatter: Arc::new(formatter),
-        }
+        /* normalize defaults, precompute separators, and build a style-specific backend */
     }
 
     /// Format an f64 value.
     pub fn format(&self, value: f64) -> String {
-        // Note: Decimal::try_from_f64 returns Ok(Decimal::default()) for NaN/Inf inputs,
-        // silently formatting them as "0". This is intentional — callers should validate
-        // inputs before formatting if special NaN/Inf display is needed.
-        let mut fd = Decimal::try_from_f64(value, fixed_decimal::FloatPrecision::Floating)
-            .unwrap_or_default();
+        /* convert to Decimal, apply rounding/sign rules, and format with the backend */
+    }
 
-        // Apply max fraction digits (truncate beyond the limit)
-        fd.trunc(-(self.options.max_fraction_digits as i16));
-        // Apply min fraction digits (pad trailing zeros)
-        // Decimal = Signed<UnsignedDecimal>; .absolute accesses the unsigned inner
-        fd.absolute.pad_end(-(self.options.min_fraction_digits as i16));
+    /// Parse a locale-formatted number string back to f64.
+    ///
+    /// Parsing normalizes non-Latin digits, strips currency/unit affixes, and
+    /// accepts locale-specific decimal and grouping separators.
+    pub fn parse(&self, input: &str) -> Option<f64> {
+        let parsed = parse_locale_number(input, &self.locale)?;
+        if matches!(self.options.style, NumberStyle::Percent) {
+            Some(parsed / 100.0)
+        } else {
+            Some(parsed)
+        }
+    }
 
-        let formatted = self.formatter.format(&fd);
-        formatted.to_string()
+    /// Return this formatter's decimal separator.
+    pub const fn decimal_separator(&self) -> char {
+        self.decimal_separator
+    }
+
+    /// Return this formatter's grouping separator, when one is known.
+    pub const fn grouping_separator(&self) -> Option<char> {
+        self.grouping_separator
     }
 
     /// Format a range (for sliders with min-max display).
@@ -1034,15 +1057,6 @@ impl NumberFormatter {
         format!("{}{}{}", self.format(start), separator, self.format(end))
     }
 
-    /// Parse a locale-formatted number string back to f64.
-    ///
-    /// Before parsing, all Unicode Nd (decimal digit) characters are normalized
-    /// to ASCII 0-9 via `normalize_digits()`, enabling seamless input from
-    /// non-Latin numeral systems.
-    pub fn parse(&self, input: &str) -> Option<f64> {
-        let normalized = normalize_digits(input);
-        parse_locale_number(&normalized, &self.locale)
-    }
 }
 ````
 
@@ -1090,7 +1104,8 @@ pub fn normalize_digits(input: &str) -> String {
 /// Parse a locale-aware number string to f64.
 ///
 /// Handles locale-specific decimal separators (`.` vs `,`) and grouping,
-/// as well as non-Latin numeral systems (Arabic-Indic, Devanagari, Bengali, etc.).
+/// strips currency/unit affixes, and normalizes non-Latin numeral systems
+/// (Arabic-Indic, Devanagari, Bengali, etc.).
 ///
 /// # Examples
 /// - `"1,234.56"` (en-US) → `Some(1234.56)`
@@ -1098,18 +1113,11 @@ pub fn normalize_digits(input: &str) -> String {
 /// - `"1 234,56"` (fr-FR) → `Some(1234.56)`
 /// - `"١٬٢٣٤٫٥٦"` (ar) → `Some(1234.56)` (Arabic-Indic numerals)
 pub fn parse_locale_number(input: &str, locale: &Locale) -> Option<f64> {
-    // Step 1: Transliterate non-Latin digits to Western Arabic (0-9).
     let transliterated = normalize_digits(input);
-
     let (decimal_sep, group_sep) = decimal_and_group_separators(locale);
-
-    // Step 2: Strip grouping separators, replace decimal separator with '.'
-    let normalized: String = transliterated
-        .chars()
-        .filter(|&c| c != group_sep)
-        .map(|c| if c == decimal_sep { '.' } else { c })
-        .collect();
-
+    let filtered = filter_numeric_characters(&transliterated, decimal_sep, group_sep);
+    let chosen_decimal = choose_decimal_separator(&filtered, decimal_sep, group_sep);
+    let normalized = normalize_numeric_syntax(&filtered, chosen_decimal);
     normalized.parse::<f64>().ok()
 }
 
@@ -1186,17 +1194,15 @@ pub fn decimal_and_group_separators(locale: &Locale) -> (char, char) {
 
 ```rust
 impl NumberFormatter {
-    /// Format as a percentage (0.0-1.0 or 0.0-100.0 based on options).
+    /// Format a fractional value such as `0.47` as a localized percentage.
     ///
-    /// Production: Use ICU4X `DecimalFormatter` with `NumberStyle::Percent`.
-    /// ICU4X handles locale-specific percent symbols (Arabic: ٪ U+066A),
-    /// placement (before vs after number), and spacing.
+    /// Production: Use ICU4X's percent formatter for locale-specific percent
+    /// symbols (Arabic: ٪ U+066A), placement (before vs after number), and
+    /// spacing.
     ///
-    /// The `format_percent` function MUST use locale-aware spacing between
-    /// the number and percent symbol. Per CLDR, many locales require a
-    /// non-breaking space (e.g., French: "75 %", German: "75 %"). The
-    /// function should use ICU4X's percent formatter for full locale support.
-    /// At minimum, check the locale's percent pattern for spacing requirements.
+    /// ars-ui percent formatting treats the input as a fraction, not a raw
+    /// percent. `0.47` therefore formats as `47%`, and `parse()` divides by
+    /// `100` to round-trip the original fractional value.
 }
 ```
 
@@ -3019,22 +3025,24 @@ impl StringCollator {
 # All code uses icu::* paths; no need for individual icu_* crates in [dependencies].
 # The lightweight locale/provider portions may be used unconditionally because
 # `Locale` parsing and metadata access are part of the core contract on every target.
-icu = { version = "2.1", features = ["serde"] }
-icu_experimental = "0.4"  # Contains relativetime (not yet in umbrella)
-fixed_decimal = "0.7"     # Main type is Decimal (not FixedDecimal)
+icu = { version = "2.1", default-features = false }
+icu_experimental = { version = "0.4", default-features = false }
+fixed_decimal = { version = "0.7", default-features = false, features = ["ryu"] }
+tinystr = { version = "0.8", default-features = false }
 
 # Infrastructure crates — not re-exported by the umbrella
-icu_provider = "2.1"
+icu_provider = { version = "2.1", default-features = false }
 icu_datagen = { version = "2.1", optional = true }
 
 [features]
-default = ["icu4x", "compiled-data", "gregorian"]
-# `icu4x` enables formatter backends and compiled CLDR data. `Locale` itself may
-# still depend on ICU locale/provider crates even when `web-intl` is the active
-# formatting backend on the client.
-icu4x = ["dep:icu"]
+default = ["std", "gregorian", "icu4x"]
+# `icu4x` enables formatter backends and compiled CLDR data. ICU4X 2.1's
+# experimental measurement, currency, and percent formatters are provided by
+# the direct `icu_experimental` dependency rather than the umbrella crate.
+# This is an intentional implementation detail of the current ICU4X release,
+# not a public ars-i18n API distinction.
+icu4x = ["icu/compiled_data", "icu_experimental/compiled_data"]
 web-intl = ["dep:wasm-bindgen", "dep:js-sys"]
-compiled-data = ["icu/compiled_data"]
 
 # Calendar feature flags — include only what you need
 gregorian = []     # Always included
@@ -3060,7 +3068,7 @@ all-calendars = ["buddhist", "japanese", "hebrew", "islamic", "persian", "ethiop
 // In a build.rs (optional — for custom locale data sets):
 // icu_datagen generates a Rust file with embedded data.
 
-// Usage (automatically used when "compiled-data" feature is on):
+// Usage (automatically used when the `icu4x` feature enables compiled data):
 // ICU4X formatters use compiled baked data internally (via each crate's `compiled_data` feature).
 
 // Estimate WASM binary size impact:
@@ -3075,24 +3083,29 @@ all-calendars = ["buddhist", "japanese", "hebrew", "islamic", "persian", "ethiop
 ```rust
 /// Cache formatters keyed by locale + options to avoid re-creation.
 ///
-/// Note: This cache uses `std::sync::Mutex`, which requires `std`.
-/// On `no_std` targets (bare `alloc`), formatters must be constructed
-/// per-call or cached by the application using thread-local storage.
+/// Note: ICU4X formatter handles used inside `NumberFormatter` are not
+/// `Send`, so ars-i18n uses a `std` thread-local cache rather than a process-
+/// wide `Mutex`-guarded static. On `no_std` targets (bare `alloc`),
+/// formatters must be constructed per-call or cached by the application.
 #[cfg(feature = "std")]
-static NUMBER_FORMATTER_CACHE: std::sync::LazyLock<
-    std::sync::Mutex<alloc::collections::BTreeMap<String, NumberFormatter>>
-> = std::sync::LazyLock::new(Default::default);
+thread_local! {
+    static NUMBER_FORMATTER_CACHE:
+        std::cell::RefCell<alloc::collections::BTreeMap<String, NumberFormatter>> =
+            std::cell::RefCell::new(alloc::collections::BTreeMap::new());
+}
 
 #[cfg(feature = "std")]
 pub fn get_number_formatter(locale: &Locale, options: &NumberFormatOptions) -> NumberFormatter {
     let key = format!("{:?}-{:?}", locale.to_bcp47(), options);
-    let mut cache = NUMBER_FORMATTER_CACHE.lock().expect("NumberFormatter cache lock poisoned");
-    if let Some(existing) = cache.get(&key) {
-        return existing.clone();
-    }
-    let formatter = NumberFormatter::new(locale, options.clone());
-    cache.insert(key, formatter.clone());
-    formatter
+    NUMBER_FORMATTER_CACHE.with(|cache| {
+        let mut cache = cache.borrow_mut();
+        if let Some(existing) = cache.get(&key) {
+            return existing.clone();
+        }
+        let formatter = NumberFormatter::new(locale, options.clone());
+        cache.insert(key, formatter.clone());
+        formatter
+    })
 }
 ```
 
@@ -3973,4 +3986,4 @@ Adapter styling guidance must account for text expansion ratios across locales (
 
 ## 16. Currency Formatting for Mixed LTR/RTL Content
 
-Currency formatting in mixed-direction content must wrap formatted values in Unicode BiDi isolates (U+2066 LRI ... U+2069 PDI) or HTML `<bdi>` elements. `CurrencyFormatter` output includes directional isolates by default. Components displaying monetary values in RTL contexts must not rely on CSS `direction` alone — explicit BiDi isolation prevents digit reordering.
+Currency formatting in mixed-direction content must wrap formatted values in Unicode BiDi isolates (U+2066 LRI ... U+2069 PDI) or HTML `<bdi>` elements. `NumberFormatter` output does not implicitly insert directional isolates. Components displaying monetary values in RTL contexts must not rely on CSS `direction` alone — explicit BiDi isolation prevents digit reordering.

--- a/spec/foundation/06-collections.md
+++ b/spec/foundation/06-collections.md
@@ -32,10 +32,10 @@ The `ars-collections` crate lives at layer three of the dependency graph, above 
 
 ```rust
 // CORRECT: RwSignal wraps the entire collection
-let items = RwSignal::new(StaticCollection::from_vec(vec![item1, item2]));
+let items = RwSignal::new(StaticCollection::new([item1, item2]));
 
 // WRONG: Do not use Signal<Rc<RefCell<Collection>>>
-// let items = RwSignal::new(Rc::new(RefCell::new(StaticCollection::from_vec(...))));
+// let items = RwSignal::new(Rc::new(RefCell::new(StaticCollection::new(...))));
 ```
 
 **Async loading safe pattern:** For collections populated asynchronously, use `Signal<Option<Collection<T>>>` to represent the loading state, or use `AsyncCollection<T>` (§5) which manages loading state internally:
@@ -45,7 +45,7 @@ let items = RwSignal::new(StaticCollection::from_vec(vec![item1, item2]));
 let items: RwSignal<Option<ListCollection<MyItem>>> = RwSignal::new(None);
 
 // After async load completes:
-items.set(Some(StaticCollection::from_vec(loaded_data)));
+items.set(Some(StaticCollection::new(loaded_data)));
 ```
 
 When the signal updates, the framework adapter triggers a re-render with the new collection. The old collection is dropped when no longer referenced.
@@ -1180,33 +1180,39 @@ impl<T: Clone> StaticCollection<T> {
 
     /// Construct from a `Vec` of `(Key, text_value, T)` tuples.
     #[must_use]
-    pub fn new(items: Vec<(Key, String, T)>) -> Self {
-        Self::from_vec(items)
+    pub fn new(items: impl IntoIterator<Item = (Key, String, T)>) -> Self {
+        Self::from_iter(items)
     }
+}
 
-    /// Convenience constructor from a `Vec` of `(Key, label, data)` tuples.
-    #[must_use]
-    pub fn from_vec(items: Vec<(Key, String, T)>) -> Self {
-        let mut builder = CollectionBuilder::new();
-        for (key, text, value) in items {
-            builder = builder.item(key, text, value);
-        }
-        builder.build()
+/// Construct an empty collection.
+impl<T: Clone> Default for StaticCollection<T> {
+    fn default() -> Self {
+        Self::new([])
     }
+}
 
+/// Construct from a `Vec` of `(Key, text_value, T)` tuples.
+impl<T: Clone> From<Vec<(Key, String, T)>> for StaticCollection<T> {
+    fn from(items: Vec<(Key, String, T)>) -> Self {
+        Self::from_iter(items)
+    }
 }
 
 /// Enables `iterator.collect::<StaticCollection<T>>()` as the idiomatic way
 /// to build a collection from an iterator of `(Key, text_value, T)` tuples.
-/// This replaces the inherent `from_iter()` method, which is now deprecated.
 impl<T: Clone> FromIterator<(Key, String, T)> for StaticCollection<T> {
     fn from_iter<I: IntoIterator<Item = (Key, String, T)>>(iter: I) -> Self {
-        Self::from_vec(iter.into_iter().collect())
+        let mut builder = CollectionBuilder::new();
+        for (key, text, value) in iter {
+            builder = builder.item(key, text, value);
+        }
+        builder.build()
     }
 }
 
 // Note: Clone bound on the trait impl is intentional — StaticCollection stores owned T values
-// and its constructors (from_vec, from_parts) require Clone for ergonomic initialization.
+// and its constructors (new, from_parts) require Clone for ergonomic initialization.
 // The Collection<T> trait itself has no bounds on T (read-only access), but this impl
 // inherits the Clone bound from the struct's constructors for simplicity.
 impl<T: Clone> Collection<T> for StaticCollection<T> {
@@ -3006,7 +3012,7 @@ impl<T: Clone> AsyncCollection<T> {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            inner: StaticCollection::from_vec(Vec::new()),
+            inner: StaticCollection::default(),
             next_cursor: None,
             has_more: true,
             loading_state: AsyncLoadingState::Idle,
@@ -3049,7 +3055,7 @@ impl<T: Clone> AsyncCollection<T> {
         merged.extend(new_items);
 
         Self {
-            inner: StaticCollection::from_vec(merged),
+            inner: StaticCollection::new(merged),
             next_cursor,
             has_more,
             loading_state: AsyncLoadingState::Loaded,
@@ -4668,7 +4674,7 @@ assert!(collapsed.nodes().all(|n| n.key != Key::str("apple"))); // not in visibl
 ```rust
 use ars_collections::{typeahead, StaticCollection, Key};
 
-let collection = StaticCollection::from_vec(vec![
+let collection = StaticCollection::new([
     (Key::int(0), "Apple".into(),      ()),
     (Key::int(1), "Avocado".into(),    ()),
     (Key::int(2), "Banana".into(),     ()),

--- a/spec/testing/02-integration-tests.md
+++ b/spec/testing/02-integration-tests.md
@@ -1416,7 +1416,7 @@ use ars_collections::{StaticCollection, CollectionBuilder, Collection, Key, Node
 
 #[test]
 fn empty_collection_returns_none_for_all_queries() {
-    let col = StaticCollection::<()>::from_vec(vec![]);
+    let col = StaticCollection::<()>::default();
     assert!(col.first_key().is_none(), "empty collection must return None for first_key");
     assert!(col.last_key().is_none(), "empty collection must return None for last_key");
     assert!(col.get_by_index(0).is_none(), "empty collection must return None for get_by_index(0)");

--- a/xtask/src/ci/feature_matrix.rs
+++ b/xtask/src/ci/feature_matrix.rs
@@ -328,11 +328,11 @@ pub(crate) fn run_group(group: Group) -> Result<(), Error> {
         let label = combo.args.join(" ");
         eprintln!("  [{}/{}] {label}", i + 1, total);
 
-        let mut check_args: Vec<&str> = vec!["check"];
+        let mut check_args = vec!["check"];
         check_args.extend_from_slice(combo.args);
         super::cargo(step, &check_args)?;
 
-        let mut test_args: Vec<&str> = vec!["test"];
+        let mut test_args = vec!["test"];
         test_args.extend_from_slice(combo.args);
         test_args.push("--lib");
         super::cargo(step, &test_args)?;
@@ -342,7 +342,7 @@ pub(crate) fn run_group(group: Group) -> Result<(), Error> {
         let label = cross.args.join(" ");
         eprintln!("  [cross] {label} --target {}", cross.target);
 
-        let mut args: Vec<&str> = vec!["check"];
+        let mut args = vec!["check"];
         args.extend_from_slice(cross.args);
         args.extend_from_slice(&["--target", cross.target]);
         super::cargo(step, &args)?;
@@ -397,7 +397,7 @@ mod tests {
             Group::Leptos,
             Group::Dioxus,
         ];
-        let steps: Vec<_> = groups.iter().map(|g| group_step(*g)).collect();
+        let steps = groups.iter().map(|g| group_step(*g)).collect::<Vec<_>>();
         for (i, a) in steps.iter().enumerate() {
             for b in &steps[i + 1..] {
                 assert_ne!(a, b, "duplicate step mapping");
@@ -409,7 +409,7 @@ mod tests {
     /// cross-check counts are consistent with the static arrays.
     #[test]
     fn group_def_returns_correct_data() {
-        let cases: &[(Group, usize, usize)] = &[
+        let cases = &[
             (Group::Core, 15, 0),
             (Group::I18n, 11, 1),
             (Group::Subsystems, 13, 1),

--- a/xtask/src/ci/mod.rs
+++ b/xtask/src/ci/mod.rs
@@ -6,7 +6,7 @@
 
 pub(crate) mod feature_matrix;
 
-use std::{fmt, io, path::Path, process};
+use std::{fmt, fs, io, path::Path, process};
 
 /// CI pipeline steps, matching the GitHub Actions job names.
 ///
@@ -42,6 +42,47 @@ pub enum Step {
     FeatureMatrixLeptos,
     /// Feature flags — ars-dioxus (4 combos + wasm32).
     FeatureMatrixDioxus,
+}
+
+/// The two mutually exclusive `ars-i18n` backend features.
+const I18N_BACKENDS: [&str; 2] = ["icu4x", "web-intl"];
+
+/// Read `crates/ars-i18n/Cargo.toml` and build two comma-separated feature
+/// lists — one per backend — that together cover every feature.
+///
+/// Each list contains all features except `default` and the *other* backend,
+/// so new features added to the crate are picked up automatically.
+fn i18n_feature_lists() -> Result<[String; 2], Error> {
+    let path = Path::new("crates/ars-i18n/Cargo.toml");
+    let content = fs::read_to_string(path).map_err(Error::Io)?;
+    let doc = content.parse::<toml::Table>().map_err(|e| {
+        Error::Io(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("{path:?}: {e}"),
+        ))
+    })?;
+
+    let features = doc
+        .get("features")
+        .and_then(toml::Value::as_table)
+        .ok_or_else(|| {
+            Error::Io(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("{path:?}: missing [features] table"),
+            ))
+        })?;
+
+    let common = features
+        .keys()
+        .map(String::as_str)
+        .filter(|k| *k != "default" && !I18N_BACKENDS.contains(k))
+        .collect::<Vec<_>>();
+
+    Ok(I18N_BACKENDS.map(|backend| {
+        let mut all = common.clone();
+        all.push(backend);
+        all.join(",")
+    }))
 }
 
 /// Default pipeline order when no steps are specified.
@@ -129,12 +170,12 @@ impl std::error::Error for Error {}
 ///
 /// Returns [`CiError`] on the first step that fails — either a subprocess
 /// non-zero exit, a missing tool, or a coverage threshold violation.
-pub fn run(steps: Vec<Step>) -> Result<(), Error> {
+pub fn run(steps: Vec<Step>, message_format: Option<&str>) -> Result<(), Error> {
     let steps = resolve_steps(steps);
 
     for (i, step) in steps.iter().enumerate() {
         print_header(*step, i + 1, steps.len());
-        run_step(*step)?;
+        run_step(*step, message_format)?;
         print_pass(*step);
     }
 
@@ -178,11 +219,11 @@ fn resolve_steps(steps: Vec<Step>) -> Vec<Step> {
 // ---------------------------------------------------------------------------
 
 /// Execute a single CI step.
-fn run_step(step: Step) -> Result<(), Error> {
+fn run_step(step: Step, message_format: Option<&str>) -> Result<(), Error> {
     match step {
         Step::Fmt => run_fmt(),
-        Step::Check => run_check(),
-        Step::Clippy => run_clippy(),
+        Step::Check => run_check(message_format),
+        Step::Clippy => run_clippy(message_format),
         Step::Unit => run_unit(),
         Step::Integration => run_integration(),
         Step::Adapter => run_adapter(),
@@ -209,23 +250,88 @@ fn run_fmt() -> Result<(), Error> {
     cargo(Step::Fmt, &["+nightly", "fmt", "--all", "--check"])
 }
 
-fn run_check() -> Result<(), Error> {
-    cargo(Step::Check, &["check", "--workspace", "--all-features"])
+fn run_check(message_format: Option<&str>) -> Result<(), Error> {
+    // Exclude ars-i18n: its `icu4x` and `web-intl` features are mutually
+    // exclusive, so `--all-features` would trigger a compile_error!.
+    // Instead, check ars-i18n twice — once per backend — to cover all features.
+    cargo_with_format(
+        Step::Check,
+        &[
+            "check",
+            "--workspace",
+            "--all-features",
+            "--exclude",
+            "ars-i18n",
+        ],
+        message_format,
+    )?;
+
+    let [icu4x_features, web_intl_features] = i18n_feature_lists()?;
+    for features in [&icu4x_features, &web_intl_features] {
+        cargo_with_format(
+            Step::Check,
+            &[
+                "check",
+                "-p",
+                "ars-i18n",
+                "--all-targets",
+                "--no-default-features",
+                "--features",
+                features,
+            ],
+            message_format,
+        )?;
+    }
+    Ok(())
 }
 
-fn run_clippy() -> Result<(), Error> {
-    cargo(
-        Step::Clippy,
-        &[
+fn run_clippy(message_format: Option<&str>) -> Result<(), Error> {
+    clippy_workspace(message_format, true)
+}
+
+/// Run workspace-wide clippy with ars-i18n backend splitting.
+///
+/// Used by both the CI `clippy` step (`deny_warnings = true`) and
+/// `cargo xclippy` for development (`deny_warnings = false`).
+///
+/// # Errors
+///
+/// Returns [`Error::StepFailed`] if any clippy invocation exits non-zero,
+/// or [`Error::Io`] if `crates/ars-i18n/Cargo.toml` cannot be read.
+pub fn clippy_workspace(message_format: Option<&str>, deny_warnings: bool) -> Result<(), Error> {
+    // Exclude ars-i18n: its `icu4x` and `web-intl` features are mutually
+    // exclusive, so `--all-features` would trigger a compile_error!.
+    // Instead, lint ars-i18n twice — once per backend — to cover all features.
+    let mut workspace_args = vec![
+        "clippy",
+        "--workspace",
+        "--all-targets",
+        "--all-features",
+        "--exclude",
+        "ars-i18n",
+    ];
+    if deny_warnings {
+        workspace_args.extend_from_slice(&["--", "-D", "warnings"]);
+    }
+    cargo_with_format(Step::Clippy, &workspace_args, message_format)?;
+
+    let [icu4x_features, web_intl_features] = i18n_feature_lists()?;
+    for features in [&icu4x_features, &web_intl_features] {
+        let mut args = vec![
             "clippy",
-            "--workspace",
+            "-p",
+            "ars-i18n",
             "--all-targets",
-            "--all-features",
-            "--",
-            "-D",
-            "warnings",
-        ],
-    )
+            "--no-default-features",
+            "--features",
+            features.as_str(),
+        ];
+        if deny_warnings {
+            args.extend_from_slice(&["--", "-D", "warnings"]);
+        }
+        cargo_with_format(Step::Clippy, &args, message_format)?;
+    }
+    Ok(())
 }
 
 fn run_unit() -> Result<(), Error> {
@@ -321,6 +427,33 @@ fn run_coverage() -> Result<(), Error> {
 // ---------------------------------------------------------------------------
 // Subprocess helper
 // ---------------------------------------------------------------------------
+
+/// Run `cargo <args>` with an optional `--message-format` flag injected.
+///
+/// The flag is inserted before `--` if present, otherwise appended. This
+/// lets rust-analyzer's `overrideCommand` request JSON diagnostics via
+/// `cargo xtask ci clippy --message-format=json`.
+fn cargo_with_format(step: Step, args: &[&str], message_format: Option<&str>) -> Result<(), Error> {
+    match message_format {
+        None => cargo(step, args),
+        Some(fmt) => {
+            let fmt_flag = format!("--message-format={fmt}");
+            let mut full_args = Vec::with_capacity(args.len() + 1);
+            let mut inserted = false;
+            for &arg in args {
+                if arg == "--" && !inserted {
+                    full_args.push(fmt_flag.as_str());
+                    inserted = true;
+                }
+                full_args.push(arg);
+            }
+            if !inserted {
+                full_args.push(fmt_flag.as_str());
+            }
+            cargo(step, &full_args)
+        }
+    }
+}
 
 /// Run `cargo <args>`, inheriting stdout/stderr.
 ///

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -22,6 +22,21 @@ enum Command {
         /// Use `feature-matrix` to run all five feature-flag groups at once.
         #[arg(value_enum)]
         steps: Vec<ci::Step>,
+
+        /// Forward `--message-format` to cargo check/clippy (e.g. `json` for
+        /// rust-analyzer's `overrideCommand`).
+        #[arg(long)]
+        message_format: Option<String>,
+    },
+    /// Run workspace clippy without `-D warnings` (alias: `cargo xclippy`).
+    ///
+    /// Same ars-i18n backend splitting as `cargo xci clippy`, but warnings
+    /// stay as warnings — suitable for rust-analyzer and interactive use.
+    Clippy {
+        /// Forward `--message-format` to cargo clippy (e.g. `json` for
+        /// rust-analyzer's `overrideCommand`).
+        #[arg(long)]
+        message_format: Option<String>,
     },
     /// Start MCP stdio server exposing all workspace tools.
     #[cfg(feature = "mcp")]
@@ -156,13 +171,27 @@ fn main() {
 
     match cli.command {
         // ── CI ────────────────────────────────────────────────────────
-        Command::Ci { steps } => match ci::run(steps) {
+        Command::Ci {
+            steps,
+            message_format,
+        } => match ci::run(steps, message_format.as_deref()) {
             Ok(()) => {}
             Err(e) => {
                 eprintln!("error: {e}");
                 process::exit(1);
             }
         },
+
+        // ── Clippy (dev) ─────────────────────────────────────────────
+        Command::Clippy { message_format } => {
+            match ci::clippy_workspace(message_format.as_deref(), false) {
+                Ok(()) => {}
+                Err(e) => {
+                    eprintln!("error: {e}");
+                    process::exit(1);
+                }
+            }
+        }
 
         // ── MCP ───────────────────────────────────────────────────────
         #[cfg(feature = "mcp")]

--- a/xtask/src/manifest.rs
+++ b/xtask/src/manifest.rs
@@ -191,7 +191,7 @@ impl SpecRoot {
             if candidate.exists() {
                 let spec_path = dir.join("spec");
                 let content = fs::read_to_string(&candidate).map_err(Error::Io)?;
-                let manifest: Manifest = toml::from_str(&content).map_err(Error::Parse)?;
+                let manifest = toml::from_str::<Manifest>(&content).map_err(Error::Parse)?;
                 return Ok(Self {
                     path: spec_path,
                     manifest,

--- a/xtask/src/mcp.rs
+++ b/xtask/src/mcp.rs
@@ -42,13 +42,13 @@ impl ServerHandler for McpServer {
         _request: Option<PaginatedRequestParams>,
         _context: RequestContext<RoleServer>,
     ) -> impl Future<Output = Result<ListToolsResult, ErrorData>> + Send + '_ {
-        let tools: Vec<McpTool> = self
+        let tools = self
             .registry
             .tools()
             .iter()
             .map(|t| {
                 let schema = t.input_schema();
-                let schema_obj: JsonObject = serde_json::from_value(schema).unwrap_or_default();
+                let schema_obj = serde_json::from_value::<JsonObject>(schema).unwrap_or_default();
                 McpTool::new(t.name().to_owned(), t.description().to_owned(), schema_obj)
             })
             .collect();

--- a/xtask/src/spec/adapters.rs
+++ b/xtask/src/spec/adapters.rs
@@ -19,7 +19,7 @@ pub fn execute(root: &SpecRoot, framework: &str) -> Result<String, Error> {
     if adapters.is_empty() {
         return Ok(format!("No {framework} adapter files registered.\n"));
     }
-    let mut by_category: BTreeMap<String, Vec<(&String, &String)>> = BTreeMap::new();
+    let mut by_category = BTreeMap::<_, Vec<_>>::new();
     for (name, path) in adapters {
         let category = m
             .components

--- a/xtask/src/spec/category.rs
+++ b/xtask/src/spec/category.rs
@@ -11,13 +11,17 @@ use crate::manifest::{self, Error, SpecRoot};
 /// Returns [`ManifestError::CategoryNotFound`] if no components match the category.
 pub fn execute(root: &SpecRoot, name: &str) -> Result<String, Error> {
     let m = &root.manifest;
-    let components: Vec<_> = m
+    let components = m
         .components
         .iter()
         .filter(|(_, c)| c.category == name)
-        .collect();
+        .collect::<Vec<_>>();
     if components.is_empty() {
-        let mut cats: Vec<&str> = m.components.values().map(|c| c.category.as_str()).collect();
+        let mut cats = m
+            .components
+            .values()
+            .map(|c| c.category.as_str())
+            .collect::<Vec<_>>();
         cats.sort();
         cats.dedup();
         return Err(Error::CategoryNotFound {

--- a/xtask/src/spec/digest.rs
+++ b/xtask/src/spec/digest.rs
@@ -65,9 +65,9 @@ pub fn execute(root: &SpecRoot, component: &str) -> Result<String, Error> {
 
 /// Extract content under a section heading until the next heading of equal or higher level.
 fn extract_section(content: &str, heading_prefixes: &[&str]) -> Option<String> {
-    let lines: Vec<&str> = content.lines().collect();
+    let lines = content.lines().collect::<Vec<_>>();
     let mut start_idx = None;
-    let mut start_level: u8 = 0;
+    let mut start_level = 0;
 
     for (i, line) in lines.iter().enumerate() {
         if let Some((level, text)) = manifest::parse_heading(line) {
@@ -91,7 +91,7 @@ fn extract_section(content: &str, heading_prefixes: &[&str]) -> Option<String> {
         }
     }
 
-    let section: String = lines[start..end].join("\n");
+    let section = lines[start..end].join("\n");
     let trimmed = section.trim();
     if trimmed.is_empty() {
         None

--- a/xtask/src/spec/reverse.rs
+++ b/xtask/src/spec/reverse.rs
@@ -17,11 +17,11 @@ pub fn execute(root: &SpecRoot, shared_type: &str) -> Result<String, Error> {
             available: m.shared.keys().cloned().collect(),
         });
     }
-    let dependents: Vec<_> = m
+    let dependents = m
         .components
         .iter()
         .filter(|(_, c)| c.shared_deps.iter().any(|d| d == shared_type))
-        .collect();
+        .collect::<Vec<_>>();
     let mut out = String::new();
     writeln!(out, "# Components depending on shared/{shared_type}").expect("write to String");
     writeln!(out).expect("write to String");

--- a/xtask/src/spec/search.rs
+++ b/xtask/src/spec/search.rs
@@ -86,14 +86,14 @@ pub fn execute(
         Regex::new(query).map_err(|e| Error::FrontmatterError(format!("invalid regex: {e}")))?;
     let section_filter = section.and_then(SectionFilter::parse);
     let m = &root.manifest;
-    let mut hits: Vec<SearchHit> = Vec::new();
+    let mut hits = Vec::new();
 
-    let files: Vec<(&str, &str)> = m
+    let files = m
         .components
         .iter()
         .filter(|(_, c)| category.is_none() || category == Some(c.category.as_str()))
         .map(|(name, c)| (name.as_str(), c.path.as_str()))
-        .collect();
+        .collect::<Vec<_>>();
 
     for (_name, rel_path) in &files {
         let file_path = root.path.join(rel_path);
@@ -119,7 +119,7 @@ pub fn execute(
 
         let mut current_section = String::new();
         let mut in_matching_section = section_filter.is_none();
-        let mut section_level: u8 = 0;
+        let mut section_level = 0;
 
         for (line_idx, line) in content.lines().enumerate() {
             if let Some((level, text)) = manifest::parse_heading(line) {

--- a/xtask/src/spec/validate.rs
+++ b/xtask/src/spec/validate.rs
@@ -11,7 +11,7 @@ use crate::manifest::{self, Error, SpecRoot};
 /// Returns [`ManifestError::Io`] if a spec file cannot be read.
 pub fn execute(root: &SpecRoot) -> Result<String, Error> {
     let m = &root.manifest;
-    let mut errors: Vec<String> = Vec::new();
+    let mut errors = Vec::new();
     let mut checked = 0u32;
     for (name, comp) in &m.components {
         let file_path = root.path.join(&comp.path);


### PR DESCRIPTION
## Summary
- add the concrete ICU4X-backed `NumberFormatter` API to `ars-i18n`, including percent, currency, unit, parsing, separator, and cache helpers
- enforce `icu4x`/`web-intl` mutual exclusion and sync the i18n/stat specs with the implemented formatter behavior
- add roadmap follow-up entries for the `web-intl` i18n backend work and strengthen formatter coverage with targeted tests

## Verification
- `cargo test -p ars-i18n`
- `cargo test -p ars-i18n --doc`
- `cargo check -p ars-i18n --no-default-features`
- `cargo check -p ars-i18n --features icu4x,web-intl` (fails as intended)
- `cargo llvm-cov test -p ars-i18n --summary-only`
- `cargo xci`

Closes #79