### PR TITLE
docs: A11y spec full audit — 8 new implementation tasks (#150–#157)

### DIFF
--- a/docs/implementation/foundation-completion-roadmap.md
+++ b/docs/implementation/foundation-completion-roadmap.md
@@ -10,18 +10,18 @@ The project needs a fully stable foundation before component work starts. Compon
 
 ### What is built (357 tests passing)
 
-| Crate              | LOC   | Status     | Key surface                                                                                                                                                                                                |
-| ------------------ | ----- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ars-core`         | 4,306 | Solid      | Machine, Service, TransitionPlan, PendingEffect, Bindable, ConnectApi, ComponentPart, AttrMap/AttrValue/UserAttrs, StyleStrategy, Callback, WeakSend, PlatformEffects, Provider (ColorMode), companion CSS |
-| `ars-derive`       | 535   | Complete   | HasId, ComponentPart proc macros with error tests                                                                                                                                                          |
-| `ars-a11y`         | 2,271 | Solid      | AriaRole, AriaAttribute, ComponentIds, ARIA state helpers, FocusScopeBehavior, FocusStrategy                                                                                                               |
-| `ars-forms`        | 4,128 | Solid      | field::State/Value/Context/Descriptors/InputAria, validation::Error/Validator/AsyncValidator, form::Context/Data/Mode, hidden_input, form_submit machine                                                   |
-| `ars-interactions` | 559   | Stubs only | PointerType, PressState, FocusState enums, compose::merge_attrs                                                                                                                                            |
-| `ars-dom`          | 1,777 | Partial    | FocusScope, focus queries, ScrollLockManager                                                                                                                                                               |
-| `ars-leptos`       | 751   | Partial    | use_machine, UseMachineReturn, EphemeralRef, use_id, AdapterCapabilities                                                                                                                                   |
-| `ars-dioxus`       | 762   | Partial    | Same as Leptos adapter                                                                                                                                                                                     |
-| `ars-collections`  | 28    | Stub       | Selection\<T\> only                                                                                                                                                                                        |
-| `ars-i18n`         | 1,928 | Partial    | Locale (ICU4X-backed), Direction, Orientation, NumberFormatter, CurrencyCode, BiDi isolation, Weekday, IcuProvider trait (stub), placeholder date/time types                                               |
+| Crate              | LOC   | Status     | Key surface                                                                                                                                                                                                                                                         |
+| ------------------ | ----- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ars-core`         | 4,306 | Solid      | Machine, Service, TransitionPlan, PendingEffect, Bindable, ConnectApi, ComponentPart, AttrMap/AttrValue/UserAttrs, StyleStrategy, Callback, WeakSend, PlatformEffects, Provider (ColorMode), companion CSS                                                          |
+| `ars-derive`       | 535   | Complete   | HasId, ComponentPart proc macros with error tests                                                                                                                                                                                                                   |
+| `ars-a11y`         | 2,271 | Partial    | AriaRole, AriaAttribute, ComponentIds, ARIA state helpers, FocusScopeBehavior, FocusStrategy, FocusRing. Missing: FocusZone, DomEvent/KeyboardShortcut/Platform, VisuallyHidden, LabelConfig/FieldContext, Announcements, Touch/Mobile, AriaValidator, test helpers |
+| `ars-forms`        | 4,128 | Solid      | field::State/Value/Context/Descriptors/InputAria, validation::Error/Validator/AsyncValidator, form::Context/Data/Mode, hidden_input, form_submit machine                                                                                                            |
+| `ars-interactions` | 559   | Stubs only | PointerType, PressState, FocusState enums, compose::merge_attrs                                                                                                                                                                                                     |
+| `ars-dom`          | 1,777 | Partial    | FocusScope, focus queries, ScrollLockManager                                                                                                                                                                                                                        |
+| `ars-leptos`       | 751   | Partial    | use_machine, UseMachineReturn, EphemeralRef, use_id, AdapterCapabilities                                                                                                                                                                                            |
+| `ars-dioxus`       | 762   | Partial    | Same as Leptos adapter                                                                                                                                                                                                                                              |
+| `ars-collections`  | 28    | Stub       | Selection\<T\> only                                                                                                                                                                                                                                                 |
+| `ars-i18n`         | 1,928 | Partial    | Locale (ICU4X-backed), Direction, Orientation, NumberFormatter, CurrencyCode, BiDi isolation, Weekday, IcuProvider trait (stub), placeholder date/time types                                                                                                        |
 
 ### Architecture spec (01-architecture.md) completion — 2026-04-10 audit
 
@@ -45,7 +45,7 @@ Issues #145 and #146 are trivial and unblocked. #147 is self-contained. #148 dep
 | Collections        | `06-collections.md`          | ~400 lines, 6 sections   | 10%              | Blocks all list-based components                                                                                       |
 | I18n               | `04-internationalization.md` | ~4000 lines, 16 sections | 25%              | Blocks number/date components, RTL. Locale + NumberFormatter done; 16 tasks remaining (48 pts ICU4X + web-intl parity) |
 | DOM utilities      | `11-dom-utilities.md`        | ~400 lines, 8 sections   | 30%              | Blocks all overlay components                                                                                          |
-| Accessibility      | `03-accessibility.md`        | ~300 lines               | 60%              | LiveAnnouncer, FocusRing missing                                                                                       |
+| Accessibility      | `03-accessibility.md`        | ~4000 lines, 14 sections | 30%              | FocusZone, keyboard shortcuts, VisuallyHidden, FieldContext, announcements, touch/mobile, testing infra all missing    |
 | Adapter conversion | `08/09-adapter-*.md` §4/§3   | ~200 lines               | 0%               | Blocks ALL component rendering                                                                                         |
 
 ## Task Waves
@@ -872,8 +872,16 @@ Issues #145 and #146 are trivial and unblocked. #147 is self-contained. #148 dep
 | [#83](https://github.com/fogodev/ars-ui/issues/83)   | Implement TreeCollection in ars-collections                             | 5      | #53  | #63        |
 | [#84](https://github.com/fogodev/ars-ui/issues/84)   | Implement FilteredCollection and SortedCollection in ars-collections    | 3      | #53  | #63        |
 | [#85](https://github.com/fogodev/ars-ui/issues/85)   | Implement media query utilities in ars-dom                              | 2      | #6   | —          |
+| [#150](https://github.com/fogodev/ars-ui/issues/150) | Implement FocusZone for arrow-key navigation in composite widgets       | 5      | #3   | —          |
+| [#151](https://github.com/fogodev/ars-ui/issues/151) | Implement DomEvent trait, KeyboardShortcut, and Platform detection      | 3      | #3   | —          |
+| [#152](https://github.com/fogodev/ars-ui/issues/152) | Implement VisuallyHidden utilities for screen-reader-only content       | 1      | #3   | —          |
+| [#153](https://github.com/fogodev/ars-ui/issues/153) | Implement LabelConfig, DescriptionConfig, and FieldContext              | 3      | #3   | —          |
+| [#154](https://github.com/fogodev/ars-ui/issues/154) | Implement AnnouncementMessages and Announcements helpers                | 2      | #3   | —          |
+| [#155](https://github.com/fogodev/ars-ui/issues/155) | Implement Touch and Mobile accessibility utilities                      | 2      | #3   | #151       |
+| [#156](https://github.com/fogodev/ars-ui/issues/156) | Implement ARIA Validation testing infrastructure                        | 3      | #3   | —          |
+| [#157](https://github.com/fogodev/ars-ui/issues/157) | Implement Keyboard Navigation test helpers                              | 3      | #3   | #150, #151 |
 
-**Total:** 80 points
+**Total:** 102 points
 
 ---
 
@@ -1295,7 +1303,7 @@ Wave 3 (25 pts)            ┌─── Wave 2 complete
   #74 (scroll view, 3)     │
   #75 (ICU4X locale, 5)    │
                            ▼
-Wave 4 (50 pts)            ┌─── Wave 3 complete
+Wave 4 (72 pts)            ┌─── Wave 3 complete
   #76 (long press, 3)      │
   #77 (move, 3)            │
   #78 (drag/drop, 8*)      │  * decompose before pickup
@@ -1306,6 +1314,14 @@ Wave 4 (50 pts)            ┌─── Wave 3 complete
   #83 (tree collection, 5) │
   #84 (filter/sort, 3)     │
   #85 (media query, 2)     │
+  #150 (focus zone, 5)     │  A11y audit additions
+  #151 (dom event, 3)      │
+  #152 (visually hidden, 1)│
+  #153 (field context, 3)  │
+  #154 (announcements, 2)  │
+  #156 (aria validator, 3) │
+    ├─→ #155 (touch, 2)    │  depends on #151
+    └─→ #157 (kbd test, 3) │  depends on #150, #151
                            ▼
 Wave 5 (13 pts)            ┌─── Wave 4 i18n tasks available
   #124 (web number, 5)     │
@@ -1326,7 +1342,7 @@ Wave 5 (13 pts)            ┌─── Wave 4 i18n tasks available
 | DOM utilities       | #6    | #66, #67, #68, #69, #72, #74, #85, #88, #112, #113, #114, #115 |
 | Leptos adapter      | #8    | #55, #105                                                      |
 | Dioxus adapter      | #9    | #56, #106                                                      |
-| A11y                | #3    | #73, #89                                                       |
+| A11y                | #3    | #73, #89, #150, #151, #152, #153, #154, #155, #156, #157       |
 | Collections         | #53   | #62, #63, #64, #70, #71, #81, #82, #83, #84                    |
 | I18n                | #54   | #75, #79, #80, #124, #125, #126                                |
 | First utility slice | #10   | #104                                                           |

--- a/docs/implementation/foundation-gap-audit.md
+++ b/docs/implementation/foundation-gap-audit.md
@@ -360,3 +360,31 @@ The following spec sections are fully implemented and match the spec contract:
 1. #145 and #146 — trivial, unblocked, can land in parallel
 2. #147 — self-contained, adds `log` crate and structured tracing
 3. #148 — largest task, implements WebPlatformEffects with real delegates for existing utilities and documented stubs for methods blocked on other epics
+
+---
+
+## Accessibility Spec Full Audit (2026-04-10)
+
+The original gap matrix listed `ars-a11y` as needing only the ARIA bridge (#33) and state helpers (#34). After those landed along with FocusRing (#89), a full audit of `spec/foundation/03-accessibility.md` (4003 lines, 14 sections) found the original 4-task decomposition covered only **~30%** of the spec's implementable Rust types. The remaining 70% — FocusZone, keyboard shortcuts, VisuallyHidden, FieldContext, announcements, touch/mobile utilities, and testing infrastructure — had no tasks.
+
+### Original gap matrix row (now superseded)
+
+| `ars-a11y` ARIA bridge | Deferred TODO for typed bridge | `AriaAttribute` bridging helpers | Blocks spec-compliant ARIA application | ✅ Resolved by #33 |
+| `ars-a11y` role/state helpers | Missing helper layer | `apply_role`, `set_expanded`, etc. | Blocks reuse of accessibility patterns | ✅ Resolved by #34 |
+
+### New tasks from the audit
+
+Eight new tasks (#150–#157, 22 points) were created under [Epic #3](https://github.com/fogodev/ars-ui/issues/3):
+
+| Issue                                                | Title                                        | Points | Spec Section |
+| ---------------------------------------------------- | -------------------------------------------- | ------ | ------------ |
+| [#150](https://github.com/fogodev/ars-ui/issues/150) | FocusZone (arrow-key navigation engine)      | 5      | §3.5         |
+| [#151](https://github.com/fogodev/ars-ui/issues/151) | DomEvent, KeyboardShortcut, Platform         | 3      | §4.4         |
+| [#152](https://github.com/fogodev/ars-ui/issues/152) | VisuallyHidden utilities                     | 1      | §5.3         |
+| [#153](https://github.com/fogodev/ars-ui/issues/153) | LabelConfig, DescriptionConfig, FieldContext | 3      | §5.4         |
+| [#154](https://github.com/fogodev/ars-ui/issues/154) | AnnouncementMessages + Announcements         | 2      | §5.5         |
+| [#155](https://github.com/fogodev/ars-ui/issues/155) | Touch/Mobile utilities                       | 2      | §7.1–7.4     |
+| [#156](https://github.com/fogodev/ars-ui/issues/156) | ARIA Validator (testing)                     | 3      | §9.1         |
+| [#157](https://github.com/fogodev/ars-ui/issues/157) | Keyboard Navigation Test Helpers             | 3      | §9.2         |
+
+Six of these (#150–#154, #156) are independent; #155 depends on #151 (Platform); #157 depends on #150 (FocusZone) + #151 (DomEvent). All placed in Wave 4 of the [foundation-completion-roadmap](./foundation-completion-roadmap.md).

--- a/docs/implementation/initial-backlog.md
+++ b/docs/implementation/initial-backlog.md
@@ -24,7 +24,7 @@ This backlog is the seed set for the implementation program. It intentionally st
 
 ### Epic: A11y
 
-- Point target: `5`
+- Point target: `25` (revised from `5` after full spec audit — 2026-04-10)
 - Layer: `Subsystem`
 - Framework: `None`
 - Test tier: `Mixed`
@@ -144,7 +144,7 @@ This backlog is the seed set for the implementation program. It intentionally st
 - Acceptance: adapter/component crates can depend on shared a11y types
 - Spec impact: `No spec change required`
 
-Note: this seed task only covered baseline a11y types. The follow-up `AriaAttribute` bridge onto typed `HtmlAttr`/`AttrMap` and the shared role/state helper layer are now tracked as [#33](https://github.com/fogodev/ars-ui/issues/33) and [#34](https://github.com/fogodev/ars-ui/issues/34), and are documented in [foundation-gap-audit.md](/Users/ericson/Workspace/Rust/ars-ui/docs/implementation/foundation-gap-audit.md).
+Note: this seed task only covered baseline a11y types. The follow-up `AriaAttribute` bridge onto typed `HtmlAttr`/`AttrMap` and the shared role/state helper layer landed as [#33](https://github.com/fogodev/ars-ui/issues/33) and [#34](https://github.com/fogodev/ars-ui/issues/34). A full spec audit (2026-04-10) revealed the original 4-task decomposition covered only ~30% of the 4000-line spec. Eight additional tasks (#150–#157, 22 pts) now cover FocusZone, keyboard shortcuts, VisuallyHidden, FieldContext, announcements, touch/mobile, and testing infrastructure. See [Epic #3](https://github.com/fogodev/ars-ui/issues/3) for the full decomposition.
 
 ### #16: Add baseline `ars-interactions` merge and state primitives
 


### PR DESCRIPTION
## Summary

- Full audit of `spec/foundation/03-accessibility.md` (4003 lines, 14 sections) revealed the original 4-task decomposition covered only ~30% of implementable Rust types
- Created 8 new GitHub issues (#150–#157, 22 points) covering the remaining 70%: FocusZone, DomEvent/KeyboardShortcut/Platform, VisuallyHidden, LabelConfig/FieldContext, AnnouncementMessages, Touch/Mobile, AriaValidator, and Keyboard Navigation test helpers
- Updated Epic #3 body with full decomposition plan and dependency graph
- Updated all three implementation roadmap docs to reflect the expanded scope

### New tasks

| Issue | Title | Points | Spec |
|-------|-------|--------|------|
| #150 | FocusZone (arrow-key navigation engine) | 5 | §3.5 |
| #151 | DomEvent, KeyboardShortcut, Platform | 3 | §4.4 |
| #152 | VisuallyHidden utilities | 1 | §5.3 |
| #153 | LabelConfig, DescriptionConfig, FieldContext | 3 | §5.4 |
| #154 | AnnouncementMessages + Announcements | 2 | §5.5 |
| #155 | Touch/Mobile utilities | 2 | §7.1–7.4 |
| #156 | ARIA Validator (testing) | 3 | §9.1 |
| #157 | Keyboard Navigation Test Helpers | 3 | §9.2 |

### Docs updated

- `foundation-completion-roadmap.md` — status table, gap matrix, Wave 4 table (+22 pts), dependency graph, epic mapping
- `foundation-gap-audit.md` — new "Accessibility Spec Full Audit" section
- `initial-backlog.md` — A11y epic point target 5→25, #15 note updated

## Test plan

- [x] Verify all 8 new issues exist and have correct spec refs, acceptance criteria, and dependency links
- [x] Verify Epic #3 body has the complete decomposition checklist
- [x] Verify roadmap docs are internally consistent (point totals, wave assignments, epic mapping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)