### PR TITLE
[codex] Re-export Orientation from ars-core

### DIFF
--- a/crates/ars-core/src/lib.rs
+++ b/crates/ars-core/src/lib.rs
@@ -53,8 +53,8 @@ pub mod __private {
 pub use ars_derive::{ComponentPart, HasId};
 // ── External re-exports ─────────────────────────────────────────────
 pub use ars_i18n::{
-    Direction, IcuProvider, IsolateDirection, Locale, LocaleParseError, StubIcuProvider, Weekday,
-    isolate_text_safe,
+    Direction, IcuProvider, IsolateDirection, Locale, LocaleParseError, Orientation,
+    StubIcuProvider, Weekday, isolate_text_safe,
 };
 // ── Platform-conditional smart pointers (extracted modules) ─────────
 pub use callback::{Callback, callback};

--- a/crates/ars-core/tests/pass/orientation_reexport.rs
+++ b/crates/ars-core/tests/pass/orientation_reexport.rs
@@ -1,0 +1,8 @@
+use ars_core::Orientation as CoreOrientation;
+use ars_i18n::Orientation as I18nOrientation;
+
+fn main() {
+    let core_orientation: CoreOrientation = I18nOrientation::Horizontal;
+    let i18n_orientation: I18nOrientation = core_orientation;
+    let _core_orientation_again: CoreOrientation = i18n_orientation;
+}

--- a/crates/ars-core/tests/reexport_contract.rs
+++ b/crates/ars-core/tests/reexport_contract.rs
@@ -1,0 +1,7 @@
+//! Compile-time contract coverage for crate-root re-exports.
+
+#[test]
+fn orientation_reexport_pass_tests() {
+    let cases = trybuild::TestCases::new();
+    cases.pass("tests/pass/orientation_reexport.rs");
+}


### PR DESCRIPTION
## Summary
- re-export `ars_i18n::Orientation` from `ars-core` crate root
- add a compile-contract test proving `ars_core::Orientation` and `ars_i18n::Orientation` resolve to the same type
- keep the change scoped to issue #146 with no spec or adapter changes

## Why
`Orientation` is defined as a shared cross-crate type in the architecture spec, but `ars-core` only re-exported `Direction`. This made the public API inconsistent across shared types.

## Impact
Consumers can now use `ars_core::Orientation` directly, matching the existing crate-root access pattern for `Direction`.

## Validation
- `cargo test -p ars-core --test reexport_contract`
- `cargo test -p ars-core --tests`
- `cargo doc -p ars-core --no-deps`

Closes #146