### PR TITLE
[codex] Implement debug logging and release verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,9 +64,20 @@ jobs:
       - name: Unit Tests
         run: cargo xtask ci unit
 
+  release:
+    name: Release Verification
+    needs: [unit]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Release Verification
+        run: cargo xtask ci release
+
   integration:
     name: Integration Tests
-    needs: [unit]
+    needs: [release]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/crates/ars-core/Cargo.toml
+++ b/crates/ars-core/Cargo.toml
@@ -12,12 +12,13 @@ default      = ["std"]
 std          = []
 serde        = ["dep:serde"]
 ssr          = []
-debug        = []
+debug        = ["dep:log"]
 embedded-css = []
 
 [dependencies]
 ars-derive = { path = "../ars-derive" }
 ars-i18n = { path = "../ars-i18n", default-features = false }
+log      = { version = "0.4", default-features = false, optional = true }
 serde    = { version = "1", default-features = false, features = ["alloc", "derive"], optional = true }
 
 [dev-dependencies]

--- a/crates/ars-core/src/lib.rs
+++ b/crates/ars-core/src/lib.rs
@@ -628,6 +628,40 @@ pub trait Machine: Sized + 'static {
 /// breaking to prevent infinite transition loops.
 const MAX_DRAIN_ITERATIONS: usize = 100;
 
+#[cfg(feature = "debug")]
+fn format_effect_names<M: Machine>(effects: &[PendingEffect<M>]) -> String {
+    let mut formatted = String::from("[");
+    for (index, effect) in effects.iter().enumerate() {
+        if index > 0 {
+            formatted.push_str(", ");
+        }
+        formatted.push_str(effect.name);
+    }
+    formatted.push(']');
+    formatted
+}
+
+#[cfg(feature = "debug")]
+fn format_follow_up_events<Event: Debug>(events: &[Event]) -> String {
+    format!("{events:?}")
+}
+
+#[cfg(feature = "debug")]
+fn format_target_state<State: Debug>(target: Option<&State>) -> String {
+    match target {
+        Some(next) => format!("{next:?}"),
+        None => String::from("(same)"),
+    }
+}
+
+#[cfg(feature = "debug")]
+fn format_apply_description(description: Option<&'static str>) -> String {
+    match description {
+        Some(description) => format!("{description:?}"),
+        None => String::from("\"none\""),
+    }
+}
+
 /// Result of sending an event to the service.
 ///
 /// Contains state/context change flags and pending effects for the adapter.
@@ -777,6 +811,12 @@ impl<M: Machine> Service<M> {
     pub fn send(&mut self, event: M::Event) -> SendResult<M> {
         debug_assert!(!self.unmounted, "send() called after unmount()");
         if self.unmounted {
+            #[cfg(feature = "debug")]
+            log::debug!(
+                "[ars:{}] dropped event after unmount: {:?}",
+                self.props.id(),
+                event
+            );
             return SendResult {
                 state_changed: false,
                 context_changed: false,
@@ -796,9 +836,12 @@ impl<M: Machine> Service<M> {
         let mut cancel_effects = Vec::new();
         let mut state_changed = false;
         let mut context_changed = false;
-        #[expect(
-            unused_mut,
-            reason = "only mutated in release builds (debug panics first)"
+        #[cfg_attr(
+            debug_assertions,
+            expect(
+                unused_mut,
+                reason = "only mutated in release builds (debug panics first)"
+            )
         )]
         let mut truncated = false;
         let mut iterations = 0;
@@ -806,6 +849,10 @@ impl<M: Machine> Service<M> {
 
         while let Some(event) = self.event_queue.pop_front() {
             iterations += 1;
+            #[cfg(feature = "debug")]
+            let state_before = format!("{:?}", self.state);
+            #[cfg(feature = "debug")]
+            let event_repr = format!("{event:?}");
             if iterations > MAX_DRAIN_ITERATIONS {
                 #[cfg(debug_assertions)]
                 panic!(
@@ -814,12 +861,27 @@ impl<M: Machine> Service<M> {
                 );
                 #[cfg(not(debug_assertions))]
                 {
+                    #[cfg(feature = "debug")]
+                    log::warn!(
+                        "drain_queue: event queue exceeded {MAX_DRAIN_ITERATIONS} iterations, \
+                         truncating. This likely indicates an infinite loop in state machine \
+                         transitions."
+                    );
                     truncated = true;
                     break;
                 }
             }
 
             if let Some(plan) = M::transition(&self.state, &event, &self.context, &self.props) {
+                #[cfg(feature = "debug")]
+                let target_state = format_target_state(plan.target.as_ref());
+                #[cfg(feature = "debug")]
+                let effect_names = format_effect_names(&plan.effects);
+                #[cfg(feature = "debug")]
+                let apply_description = format_apply_description(plan.apply_description);
+                #[cfg(feature = "debug")]
+                let follow_up_events = format_follow_up_events(&plan.then_send);
+
                 // Apply context mutation.
                 if let Some(apply) = plan.apply {
                     apply(&mut self.context);
@@ -829,12 +891,32 @@ impl<M: Machine> Service<M> {
                 // Track context-only iterations for diagnostics.
                 if plan.target.is_none() {
                     context_change_count += 1;
+                    if context_change_count >= MAX_DRAIN_ITERATIONS {
+                        #[cfg(debug_assertions)]
+                        panic!(
+                            "drain_queue: {context_change_count} consecutive context_only \
+                             iterations without a state change — likely an infinite \
+                             context_only + then_send loop"
+                        );
+                        #[cfg(not(debug_assertions))]
+                        {
+                            #[cfg(feature = "debug")]
+                            log::warn!(
+                                "drain_queue: {context_change_count} context_only iterations \
+                                 without state change — possible infinite loop, truncating."
+                            );
+                            truncated = true;
+                            break;
+                        }
+                    }
                 } else {
                     context_change_count = 0;
                 }
 
                 // Enqueue follow-up events.
                 self.event_queue.extend(plan.then_send);
+                #[cfg(feature = "debug")]
+                let queue_depth = self.event_queue.len();
 
                 // Apply state change.
                 if let Some(next) = plan.target {
@@ -851,6 +933,27 @@ impl<M: Machine> Service<M> {
                     e.target_state = Some(target.clone());
                     e
                 }));
+
+                #[cfg(feature = "debug")]
+                {
+                    let component_id = self.props.id();
+                    log::trace!(
+                        "[ars:{component_id}] {state_before} + {event_repr} → {target_state} \
+                         (guard: pass, effects: {effect_names})"
+                    );
+                    log::trace!(
+                        "[ars:{component_id}]   apply: {apply_description}, then_send: \
+                         {follow_up_events}, iteration: {iterations}, queue_depth: {queue_depth}"
+                    );
+                }
+            } else {
+                #[cfg(feature = "debug")]
+                log::trace!(
+                    "[ars:{}] {} + {} → (same) (guard: reject, effects: [])",
+                    self.props.id(),
+                    state_before,
+                    event_repr
+                );
             }
         }
 
@@ -924,6 +1027,8 @@ impl<M: Machine> Service<M> {
 #[cfg(test)]
 mod tests {
     use alloc::vec;
+    #[cfg(feature = "debug")]
+    use std::sync::{Mutex, Once};
 
     use super::*;
 
@@ -931,6 +1036,81 @@ mod tests {
     enum ToggleState {
         Off,
         On,
+    }
+
+    #[cfg(feature = "debug")]
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    struct CapturedLog {
+        level: log::Level,
+        message: String,
+    }
+
+    #[cfg(feature = "debug")]
+    struct TestLogger {
+        records: Mutex<Vec<CapturedLog>>,
+    }
+
+    #[cfg(feature = "debug")]
+    static TEST_LOGGER: TestLogger = TestLogger {
+        records: Mutex::new(Vec::new()),
+    };
+
+    #[cfg(feature = "debug")]
+    static LOGGER_INIT: Once = Once::new();
+
+    #[cfg(feature = "debug")]
+    static CAPTURE_LOCK: Mutex<()> = Mutex::new(());
+
+    #[cfg(feature = "debug")]
+    impl log::Log for TestLogger {
+        fn enabled(&self, metadata: &log::Metadata<'_>) -> bool {
+            metadata.level() <= log::Level::Trace
+        }
+
+        fn log(&self, record: &log::Record<'_>) {
+            if self.enabled(record.metadata()) {
+                self.records
+                    .lock()
+                    .expect("test logger mutex poisoned")
+                    .push(CapturedLog {
+                        level: record.level(),
+                        message: format!("{}", record.args()),
+                    });
+            }
+        }
+
+        fn flush(&self) {}
+    }
+
+    #[cfg(feature = "debug")]
+    fn init_test_logger() {
+        LOGGER_INIT.call_once(|| {
+            log::set_logger(&TEST_LOGGER).expect("test logger should install once");
+            log::set_max_level(log::LevelFilter::Trace);
+        });
+    }
+
+    #[cfg(feature = "debug")]
+    fn capture_logs(run: impl FnOnce()) -> Vec<CapturedLog> {
+        init_test_logger();
+        let _capture_guard = CAPTURE_LOCK.lock().expect("capture mutex poisoned");
+        TEST_LOGGER
+            .records
+            .lock()
+            .expect("test logger mutex poisoned")
+            .clear();
+        run();
+        let records = TEST_LOGGER
+            .records
+            .lock()
+            .expect("test logger mutex poisoned")
+            .clone();
+        TEST_LOGGER
+            .records
+            .lock()
+            .expect("test logger mutex poisoned")
+            .clear();
+        records
     }
 
     #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -1329,6 +1509,7 @@ mod tests {
         assert_eq!(service.state(), &ToggleState::On);
     }
 
+    #[cfg(debug_assertions)]
     #[test]
     #[should_panic(expected = "Props::id must not be empty")]
     fn service_new_panics_on_empty_id_in_debug() {
@@ -1359,6 +1540,709 @@ mod tests {
             Bindable::uncontrolled(String::default())
         );
         assert_eq!(Bindable::<bool>::default(), Bindable::uncontrolled(false));
+    }
+
+    #[cfg(feature = "debug")]
+    #[test]
+    fn send_emits_trace_log_for_processed_event() {
+        let logs = capture_logs(|| {
+            let mut service = Service::<ToggleMachine>::new(
+                ToggleProps {
+                    id: String::from("toggle#btn-1"),
+                },
+                &Env::default(),
+                &(),
+            );
+
+            let _result = service.send(ToggleEvent::Toggle);
+        });
+
+        assert!(
+            logs.iter().any(|record| record.level == log::Level::Trace),
+            "expected at least one trace log, got {logs:?}"
+        );
+    }
+
+    #[cfg(feature = "debug")]
+    #[test]
+    fn trace_log_formats_multiple_effect_names() {
+        #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+        enum MultiEffectEvent {
+            Trigger,
+        }
+
+        struct MultiEffectMachine;
+
+        impl Machine for MultiEffectMachine {
+            type State = ToggleState;
+            type Event = MultiEffectEvent;
+            type Context = ToggleContext;
+            type Props = ToggleProps;
+            type Messages = ();
+            type Api<'a> = ToggleApi;
+
+            fn init(
+                _props: &Self::Props,
+                _env: &Env,
+                _messages: &Self::Messages,
+            ) -> (Self::State, Self::Context) {
+                (ToggleState::Off, ToggleContext)
+            }
+
+            fn transition(
+                state: &Self::State,
+                event: &Self::Event,
+                _context: &Self::Context,
+                _props: &Self::Props,
+            ) -> Option<TransitionPlan<Self>> {
+                match (state, event) {
+                    (ToggleState::Off, MultiEffectEvent::Trigger) => Some(
+                        TransitionPlan::to(ToggleState::On)
+                            .with_effect(PendingEffect::named("focus"))
+                            .with_effect(PendingEffect::named("announce")),
+                    ),
+                    _ => None,
+                }
+            }
+
+            fn connect<'a>(
+                _state: &'a Self::State,
+                _context: &'a Self::Context,
+                _props: &'a Self::Props,
+                _send: &'a dyn Fn(Self::Event),
+            ) -> Self::Api<'a> {
+                ToggleApi
+            }
+        }
+
+        let logs = capture_logs(|| {
+            let mut service = Service::<MultiEffectMachine>::new(
+                ToggleProps {
+                    id: String::from("menu#item-1"),
+                },
+                &Env::default(),
+                &(),
+            );
+
+            let _result = service.send(MultiEffectEvent::Trigger);
+        });
+
+        let transition = logs
+            .iter()
+            .find(|record| record.message.contains("[ars:menu#item-1]"))
+            .expect("expected transition log");
+        assert!(
+            transition.message.contains("effects: [focus, announce]"),
+            "expected comma-joined effect names: {transition:?}"
+        );
+    }
+
+    #[cfg(feature = "debug")]
+    #[test]
+    fn trace_log_includes_required_structured_fields() {
+        #[derive(Clone, Debug, PartialEq, Eq)]
+        struct DebugContext {
+            pressed: bool,
+        }
+
+        #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+        enum DebugEvent {
+            Toggle,
+            Notify,
+        }
+
+        struct DebugMachine;
+
+        impl Machine for DebugMachine {
+            type State = ToggleState;
+            type Event = DebugEvent;
+            type Context = DebugContext;
+            type Props = ToggleProps;
+            type Messages = ();
+            type Api<'a> = ToggleApi;
+
+            fn init(
+                _props: &Self::Props,
+                _env: &Env,
+                _messages: &Self::Messages,
+            ) -> (Self::State, Self::Context) {
+                (ToggleState::Off, DebugContext { pressed: false })
+            }
+
+            fn transition(
+                state: &Self::State,
+                event: &Self::Event,
+                _context: &Self::Context,
+                _props: &Self::Props,
+            ) -> Option<TransitionPlan<Self>> {
+                match (state, event) {
+                    (ToggleState::Off, DebugEvent::Toggle) => {
+                        let mut plan = TransitionPlan::to(ToggleState::On)
+                            .apply(|ctx: &mut DebugContext| ctx.pressed = true)
+                            .then(DebugEvent::Notify)
+                            .with_effect(PendingEffect::named("notify_change"));
+                        plan.apply_description = Some("set pressed = true");
+                        Some(plan)
+                    }
+                    (ToggleState::On, DebugEvent::Notify) => Some(TransitionPlan::new()),
+                    _ => None,
+                }
+            }
+
+            fn connect<'a>(
+                _state: &'a Self::State,
+                _context: &'a Self::Context,
+                _props: &'a Self::Props,
+                _send: &'a dyn Fn(Self::Event),
+            ) -> Self::Api<'a> {
+                ToggleApi
+            }
+        }
+
+        let logs = capture_logs(|| {
+            let mut service = Service::<DebugMachine>::new(
+                ToggleProps {
+                    id: String::from("toggle#btn-1"),
+                },
+                &Env::default(),
+                &(),
+            );
+
+            let _result = service.send(DebugEvent::Toggle);
+        });
+
+        let transition = logs
+            .iter()
+            .find(|record| {
+                record
+                    .message
+                    .contains("[ars:toggle#btn-1] Off + Toggle → On")
+            })
+            .expect("expected transition log");
+        assert_eq!(transition.level, log::Level::Trace);
+        assert!(
+            transition.message.contains("guard: pass"),
+            "missing guard result: {transition:?}"
+        );
+        assert!(
+            transition.message.contains("effects: [notify_change]"),
+            "missing effect names: {transition:?}"
+        );
+
+        let detail = logs
+            .iter()
+            .find(|record| {
+                record
+                    .message
+                    .contains("[ars:toggle#btn-1]   apply: \"set pressed = true\"")
+            })
+            .expect("expected detail log");
+        assert!(
+            detail.message.contains("then_send: [Notify]"),
+            "missing follow-up events: {detail:?}"
+        );
+        assert!(
+            detail.message.contains("iteration: 1"),
+            "missing iteration counter: {detail:?}"
+        );
+        assert!(
+            detail.message.contains("queue_depth: 1"),
+            "missing queue depth: {detail:?}"
+        );
+    }
+
+    #[cfg(feature = "debug")]
+    #[test]
+    fn rejected_event_logs_guard_reject() {
+        #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+        enum RejectEvent {
+            Ignore,
+        }
+
+        struct RejectMachine;
+
+        impl Machine for RejectMachine {
+            type State = ToggleState;
+            type Event = RejectEvent;
+            type Context = ToggleContext;
+            type Props = ToggleProps;
+            type Messages = ();
+            type Api<'a> = ToggleApi;
+
+            fn init(
+                _props: &Self::Props,
+                _env: &Env,
+                _messages: &Self::Messages,
+            ) -> (Self::State, Self::Context) {
+                (ToggleState::Off, ToggleContext)
+            }
+
+            fn transition(
+                _state: &Self::State,
+                _event: &Self::Event,
+                _context: &Self::Context,
+                _props: &Self::Props,
+            ) -> Option<TransitionPlan<Self>> {
+                None
+            }
+
+            fn connect<'a>(
+                _state: &'a Self::State,
+                _context: &'a Self::Context,
+                _props: &'a Self::Props,
+                _send: &'a dyn Fn(Self::Event),
+            ) -> Self::Api<'a> {
+                ToggleApi
+            }
+        }
+
+        let logs = capture_logs(|| {
+            let mut service = Service::<RejectMachine>::new(
+                ToggleProps {
+                    id: String::from("combobox#cb-1"),
+                },
+                &Env::default(),
+                &(),
+            );
+
+            let _result = service.send(RejectEvent::Ignore);
+        });
+
+        let rejected = logs
+            .iter()
+            .find(|record| record.message.contains("[ars:combobox#cb-1]"))
+            .expect("expected rejected transition log");
+        assert!(
+            rejected.message.contains("guard: reject"),
+            "missing guard reject marker: {rejected:?}"
+        );
+        assert!(
+            rejected.message.contains("→ (same)"),
+            "missing same-state marker: {rejected:?}"
+        );
+    }
+
+    #[cfg(feature = "debug")]
+    #[test]
+    fn multi_step_drain_cycle_logs_each_iteration_with_queue_depth() {
+        #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+        enum ChainEvent {
+            Start,
+            Continue,
+        }
+
+        struct ChainMachine;
+
+        impl Machine for ChainMachine {
+            type State = ToggleState;
+            type Event = ChainEvent;
+            type Context = ToggleContext;
+            type Props = ToggleProps;
+            type Messages = ();
+            type Api<'a> = ToggleApi;
+
+            fn init(
+                _props: &Self::Props,
+                _env: &Env,
+                _messages: &Self::Messages,
+            ) -> (Self::State, Self::Context) {
+                (ToggleState::Off, ToggleContext)
+            }
+
+            fn transition(
+                state: &Self::State,
+                event: &Self::Event,
+                _context: &Self::Context,
+                _props: &Self::Props,
+            ) -> Option<TransitionPlan<Self>> {
+                match (state, event) {
+                    (ToggleState::Off, ChainEvent::Start) => {
+                        Some(TransitionPlan::to(ToggleState::On).then(ChainEvent::Continue))
+                    }
+                    (ToggleState::On, ChainEvent::Continue) => {
+                        Some(TransitionPlan::to(ToggleState::Off))
+                    }
+                    _ => None,
+                }
+            }
+
+            fn connect<'a>(
+                _state: &'a Self::State,
+                _context: &'a Self::Context,
+                _props: &'a Self::Props,
+                _send: &'a dyn Fn(Self::Event),
+            ) -> Self::Api<'a> {
+                ToggleApi
+            }
+        }
+
+        let logs = capture_logs(|| {
+            let mut service = Service::<ChainMachine>::new(
+                ToggleProps {
+                    id: String::from("dialog#dlg-1"),
+                },
+                &Env::default(),
+                &(),
+            );
+
+            let _result = service.send(ChainEvent::Start);
+        });
+
+        let iteration_one = logs
+            .iter()
+            .find(|record| {
+                record
+                    .message
+                    .contains("[ars:dialog#dlg-1]   apply: \"none\"")
+                    && record.message.contains("iteration: 1")
+            })
+            .expect("expected first detail log");
+        assert!(
+            iteration_one.message.contains("queue_depth: 1"),
+            "expected queued follow-up event after first iteration: {iteration_one:?}"
+        );
+
+        let iteration_two = logs
+            .iter()
+            .find(|record| {
+                record
+                    .message
+                    .contains("[ars:dialog#dlg-1]   apply: \"none\"")
+                    && record.message.contains("iteration: 2")
+            })
+            .expect("expected second detail log");
+        assert!(
+            iteration_two.message.contains("queue_depth: 0"),
+            "expected queue to be drained after second iteration: {iteration_two:?}"
+        );
+    }
+
+    #[cfg(all(feature = "debug", debug_assertions))]
+    #[test]
+    #[should_panic(expected = "Event queue exceeded 100 iterations")]
+    fn drain_queue_panics_on_iteration_limit_in_debug_builds() {
+        #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+        enum LoopEvent {
+            Continue,
+        }
+
+        struct IterationLoopMachine;
+
+        impl Machine for IterationLoopMachine {
+            type State = ToggleState;
+            type Event = LoopEvent;
+            type Context = ToggleContext;
+            type Props = ToggleProps;
+            type Messages = ();
+            type Api<'a> = ToggleApi;
+
+            fn init(
+                _props: &Self::Props,
+                _env: &Env,
+                _messages: &Self::Messages,
+            ) -> (Self::State, Self::Context) {
+                (ToggleState::Off, ToggleContext)
+            }
+
+            fn transition(
+                state: &Self::State,
+                event: &Self::Event,
+                _context: &Self::Context,
+                _props: &Self::Props,
+            ) -> Option<TransitionPlan<Self>> {
+                match (state, event) {
+                    (ToggleState::Off, LoopEvent::Continue) => {
+                        Some(TransitionPlan::to(ToggleState::On).then(LoopEvent::Continue))
+                    }
+                    (ToggleState::On, LoopEvent::Continue) => {
+                        Some(TransitionPlan::to(ToggleState::Off).then(LoopEvent::Continue))
+                    }
+                }
+            }
+
+            fn connect<'a>(
+                _state: &'a Self::State,
+                _context: &'a Self::Context,
+                _props: &'a Self::Props,
+                _send: &'a dyn Fn(Self::Event),
+            ) -> Self::Api<'a> {
+                ToggleApi
+            }
+        }
+
+        let mut service = Service::<IterationLoopMachine>::new(
+            ToggleProps {
+                id: String::from("loop#iteration"),
+            },
+            &Env::default(),
+            &(),
+        );
+
+        let _result = service.send(LoopEvent::Continue);
+    }
+
+    #[cfg(all(feature = "debug", debug_assertions))]
+    #[test]
+    #[should_panic(expected = "consecutive context_only iterations")]
+    fn drain_queue_panics_on_context_only_loop_in_debug_builds() {
+        #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+        enum LoopEvent {
+            Continue,
+        }
+
+        #[derive(Clone, Debug, PartialEq, Eq)]
+        struct LoopContext {
+            ticks: usize,
+        }
+
+        struct ContextLoopMachine;
+
+        impl Machine for ContextLoopMachine {
+            type State = ToggleState;
+            type Event = LoopEvent;
+            type Context = LoopContext;
+            type Props = ToggleProps;
+            type Messages = ();
+            type Api<'a> = ToggleApi;
+
+            fn init(
+                _props: &Self::Props,
+                _env: &Env,
+                _messages: &Self::Messages,
+            ) -> (Self::State, Self::Context) {
+                (ToggleState::Off, LoopContext { ticks: 0 })
+            }
+
+            fn transition(
+                _state: &Self::State,
+                event: &Self::Event,
+                _context: &Self::Context,
+                _props: &Self::Props,
+            ) -> Option<TransitionPlan<Self>> {
+                match event {
+                    LoopEvent::Continue => Some(
+                        TransitionPlan::context_only(|ctx: &mut LoopContext| ctx.ticks += 1)
+                            .then(LoopEvent::Continue),
+                    ),
+                }
+            }
+
+            fn connect<'a>(
+                _state: &'a Self::State,
+                _context: &'a Self::Context,
+                _props: &'a Self::Props,
+                _send: &'a dyn Fn(Self::Event),
+            ) -> Self::Api<'a> {
+                ToggleApi
+            }
+        }
+
+        let mut service = Service::<ContextLoopMachine>::new(
+            ToggleProps {
+                id: String::from("loop#context"),
+            },
+            &Env::default(),
+            &(),
+        );
+
+        let _result = service.send(LoopEvent::Continue);
+    }
+
+    #[cfg(all(feature = "debug", not(debug_assertions)))]
+    #[test]
+    fn send_after_unmount_emits_debug_log() {
+        let mut service = Service::<ToggleMachine>::new(
+            ToggleProps {
+                id: String::from("toggle#btn-1"),
+            },
+            &Env::default(),
+            &(),
+        );
+        service.unmount(Vec::new());
+
+        let logs = capture_logs(|| {
+            let result = service.send(ToggleEvent::Toggle);
+            assert!(!result.state_changed);
+            assert!(!result.context_changed);
+            assert!(result.pending_effects.is_empty());
+            assert!(result.cancel_effects.is_empty());
+            assert!(!result.truncated);
+            assert_eq!(result.context_change_count, 0);
+        });
+
+        let dropped = logs
+            .iter()
+            .find(|record| record.level == log::Level::Debug)
+            .expect("expected dropped-event debug log");
+        assert!(
+            dropped
+                .message
+                .contains("[ars:toggle#btn-1] dropped event after unmount: Toggle"),
+            "missing dropped-event diagnostic: {dropped:?}"
+        );
+    }
+
+    #[cfg(all(feature = "debug", not(debug_assertions)))]
+    #[test]
+    fn iteration_limit_truncation_emits_warning_in_release_builds() {
+        #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+        enum LoopEvent {
+            Continue,
+        }
+
+        struct IterationLoopMachine;
+
+        impl Machine for IterationLoopMachine {
+            type State = ToggleState;
+            type Event = LoopEvent;
+            type Context = ToggleContext;
+            type Props = ToggleProps;
+            type Messages = ();
+            type Api<'a> = ToggleApi;
+
+            fn init(
+                _props: &Self::Props,
+                _env: &Env,
+                _messages: &Self::Messages,
+            ) -> (Self::State, Self::Context) {
+                (ToggleState::Off, ToggleContext)
+            }
+
+            fn transition(
+                state: &Self::State,
+                event: &Self::Event,
+                _context: &Self::Context,
+                _props: &Self::Props,
+            ) -> Option<TransitionPlan<Self>> {
+                match (state, event) {
+                    (ToggleState::Off, LoopEvent::Continue) => {
+                        Some(TransitionPlan::to(ToggleState::On).then(LoopEvent::Continue))
+                    }
+                    (ToggleState::On, LoopEvent::Continue) => {
+                        Some(TransitionPlan::to(ToggleState::Off).then(LoopEvent::Continue))
+                    }
+                }
+            }
+
+            fn connect<'a>(
+                _state: &'a Self::State,
+                _context: &'a Self::Context,
+                _props: &'a Self::Props,
+                _send: &'a dyn Fn(Self::Event),
+            ) -> Self::Api<'a> {
+                ToggleApi
+            }
+        }
+
+        let mut service = Service::<IterationLoopMachine>::new(
+            ToggleProps {
+                id: String::from("loop#iteration"),
+            },
+            &Env::default(),
+            &(),
+        );
+
+        let logs = capture_logs(|| {
+            let result = service.send(LoopEvent::Continue);
+            assert!(result.truncated);
+            assert!(result.state_changed);
+            assert!(!result.context_changed);
+            assert_eq!(result.context_change_count, 0);
+        });
+
+        let warning = logs
+            .iter()
+            .find(|record| record.level == log::Level::Warn)
+            .expect("expected truncation warning log");
+        assert!(
+            warning
+                .message
+                .contains("event queue exceeded 100 iterations, truncating"),
+            "missing iteration-limit warning: {warning:?}"
+        );
+    }
+
+    #[cfg(all(feature = "debug", not(debug_assertions)))]
+    #[test]
+    fn context_only_truncation_emits_warning_in_release_builds() {
+        #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+        enum LoopEvent {
+            Continue,
+        }
+
+        #[derive(Clone, Debug, PartialEq, Eq)]
+        struct LoopContext {
+            ticks: usize,
+        }
+
+        struct ContextLoopMachine;
+
+        impl Machine for ContextLoopMachine {
+            type State = ToggleState;
+            type Event = LoopEvent;
+            type Context = LoopContext;
+            type Props = ToggleProps;
+            type Messages = ();
+            type Api<'a> = ToggleApi;
+
+            fn init(
+                _props: &Self::Props,
+                _env: &Env,
+                _messages: &Self::Messages,
+            ) -> (Self::State, Self::Context) {
+                (ToggleState::Off, LoopContext { ticks: 0 })
+            }
+
+            fn transition(
+                _state: &Self::State,
+                event: &Self::Event,
+                _context: &Self::Context,
+                _props: &Self::Props,
+            ) -> Option<TransitionPlan<Self>> {
+                match event {
+                    LoopEvent::Continue => Some(
+                        TransitionPlan::context_only(|ctx: &mut LoopContext| ctx.ticks += 1)
+                            .then(LoopEvent::Continue),
+                    ),
+                }
+            }
+
+            fn connect<'a>(
+                _state: &'a Self::State,
+                _context: &'a Self::Context,
+                _props: &'a Self::Props,
+                _send: &'a dyn Fn(Self::Event),
+            ) -> Self::Api<'a> {
+                ToggleApi
+            }
+        }
+
+        let mut service = Service::<ContextLoopMachine>::new(
+            ToggleProps {
+                id: String::from("loop#context"),
+            },
+            &Env::default(),
+            &(),
+        );
+
+        let logs = capture_logs(|| {
+            let result = service.send(LoopEvent::Continue);
+            assert!(result.truncated);
+            assert!(!result.state_changed);
+            assert!(result.context_changed);
+            assert_eq!(result.context_change_count, 100);
+        });
+
+        let warning = logs
+            .iter()
+            .find(|record| record.level == log::Level::Warn)
+            .expect("expected context_only truncation warning");
+        assert!(
+            warning
+                .message
+                .contains("100 context_only iterations without state change"),
+            "missing context_only warning: {warning:?}"
+        );
     }
 
     #[test]

--- a/crates/ars-core/src/platform.rs
+++ b/crates/ars-core/src/platform.rs
@@ -339,16 +339,16 @@ impl PlatformEffects for NullPlatformEffects {
 pub struct MissingProviderEffects;
 
 impl MissingProviderEffects {
-    #[cfg(all(debug_assertions, feature = "std"))]
+    #[cfg(feature = "debug")]
     #[inline]
     fn warn(method: &str) {
-        eprintln!(
+        log::warn!(
             "[ars-ui] {method}() called without ArsProvider. \
              Platform effects are disabled. Wrap your app root in <ArsProvider>."
         );
     }
 
-    #[cfg(not(all(debug_assertions, feature = "std")))]
+    #[cfg(not(feature = "debug"))]
     #[inline]
     const fn warn(_method: &str) {}
 }

--- a/crates/ars-dioxus/Cargo.toml
+++ b/crates/ars-dioxus/Cargo.toml
@@ -9,6 +9,7 @@ rust-version.workspace = true
 
 [features]
 default     = []
+debug       = ["dep:log", "ars-core/debug", "ars-interactions/debug", "ars-dom?/debug"]
 web         = ["dioxus/web", "dep:ars-dom", "ars-dom/web", "dep:web-sys"]
 desktop     = ["dioxus/desktop"]
 desktop-dom = ["desktop", "dep:ars-dom"]
@@ -23,6 +24,7 @@ ars-dom          = { path = "../ars-dom", optional = true, default-features = fa
 ars-forms        = { path = "../ars-forms" }
 ars-i18n         = { path = "../ars-i18n" }
 ars-interactions = { path = "../ars-interactions" }
+log              = { version = "0.4", default-features = false, optional = true }
 
 [dependencies.dioxus]
 version          = "0.7"

--- a/crates/ars-dioxus/src/attrs.rs
+++ b/crates/ars-dioxus/src/attrs.rs
@@ -212,17 +212,17 @@ pub fn append_nonce_css(css: String) {
 
 /// Emit a debug-mode warning when a hook is called without an `ArsProvider`
 /// ancestor in the component tree.
-#[cfg(debug_assertions)]
+#[cfg(feature = "debug")]
 fn warn_missing_provider(hook: &str) {
-    eprintln!(
+    log::warn!(
         "[ars-ui] {hook}() called without ArsProvider. \
          Returning default value. Wrap your app root in <ArsProvider>."
     );
 }
 
 /// No-op in release builds.
-#[cfg(not(debug_assertions))]
-fn warn_missing_provider(_hook: &str) {}
+#[cfg(not(feature = "debug"))]
+const fn warn_missing_provider(_hook: &str) {}
 
 /// Read the current style strategy from Dioxus context.
 ///

--- a/crates/ars-dom/Cargo.toml
+++ b/crates/ars-dom/Cargo.toml
@@ -9,6 +9,7 @@ rust-version.workspace = true
 
 [features]
 default = ["web"]
+debug   = ["dep:log", "ars-core/debug", "ars-interactions/debug"]
 ssr     = []
 web     = ["dep:js-sys", "dep:wasm-bindgen", "dep:web-sys"]
 
@@ -18,8 +19,13 @@ ars-core         = { path = "../ars-core" }
 ars-i18n         = { path = "../ars-i18n" }
 ars-interactions = { path = "../ars-interactions" }
 js-sys           = { version = "0.3", optional = true }
+log              = { version = "0.4", default-features = false, optional = true }
 wasm-bindgen     = { version = "0.2", optional = true }
-web-sys          = { version = "0.3", optional = true, features = [
+
+[dependencies.web-sys]
+version = "0.3"
+optional = true
+features = [
     "CssStyleDeclaration",
     "DomRect",
     "Document",
@@ -39,8 +45,8 @@ web-sys          = { version = "0.3", optional = true, features = [
     "ScrollLogicalPosition",
     "ScrollToOptions",
     "TouchEvent",
-    "Window",
-] }
+    "Window"
+]
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/crates/ars-dom/src/z_index.rs
+++ b/crates/ars-dom/src/z_index.rs
@@ -75,8 +75,8 @@ pub fn next_z_index() -> u32 {
             // this call receives the fresh base and the next call advances.
             // Reset to base — existing overlays at high z-indexes will still
             // render above normal content; new overlays start fresh.
-            #[cfg(debug_assertions)]
-            eprintln!(
+            #[cfg(feature = "debug")]
+            log::warn!(
                 "[ars-dom] z-index counter reached ceiling ({Z_INDEX_CEILING}), \
                  resetting to base ({Z_INDEX_BASE})"
             );

--- a/crates/ars-i18n/Cargo.toml
+++ b/crates/ars-i18n/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace   = true
 rust-version.workspace = true
 
 [dependencies]
+core_maths           = { version = "0.1", default-features = false }
 fixed_decimal        = { version = "0.7", default-features = false, features = ["ryu"] }
 icu                  = { version = "2.1", default-features = false }
 icu_experimental     = { version = "0.5", default-features = false }

--- a/crates/ars-i18n/src/number.rs
+++ b/crates/ars-i18n/src/number.rs
@@ -665,23 +665,40 @@ fn build_decimal_formatter(_locale: &Locale, _options: &NumberFormatOptions) -> 
 }
 
 fn round_value(value: f64, fraction_digits: u8, mode: RoundingMode) -> f64 {
-    let factor = 10_f64.powi(i32::from(fraction_digits));
+    let factor = core_maths::CoreFloat::powi(10_f64, i32::from(fraction_digits));
     let scaled = value * factor;
     let rounded = match mode {
-        RoundingMode::HalfEven => scaled.round_ties_even(),
+        RoundingMode::HalfEven => round_half_even(scaled),
         RoundingMode::HalfUp => round_half_away_from_zero(scaled),
         RoundingMode::HalfDown => round_half_toward_zero(scaled),
-        RoundingMode::Ceiling => scaled.ceil(),
-        RoundingMode::Floor => scaled.floor(),
-        RoundingMode::Truncate => scaled.trunc(),
+        RoundingMode::Ceiling => core_maths::CoreFloat::ceil(scaled),
+        RoundingMode::Floor => core_maths::CoreFloat::floor(scaled),
+        RoundingMode::Truncate => core_maths::CoreFloat::trunc(scaled),
     };
 
     rounded / factor
 }
 
+fn round_half_even(value: f64) -> f64 {
+    let abs = value.abs();
+    let floor = core_maths::CoreFloat::floor(abs);
+    let fraction = abs - floor;
+    let rounded = if fraction < 0.5 {
+        floor
+    } else if fraction > 0.5 {
+        floor + 1.0
+    } else if core_maths::CoreFloat::rem_euclid(floor, 2.0) == 0.0 {
+        floor
+    } else {
+        floor + 1.0
+    };
+
+    rounded.copysign(value)
+}
+
 fn round_half_away_from_zero(value: f64) -> f64 {
     let abs = value.abs();
-    let floor = abs.floor();
+    let floor = core_maths::CoreFloat::floor(abs);
     let fraction = abs - floor;
     let rounded = if fraction >= 0.5 { floor + 1.0 } else { floor };
     rounded.copysign(value)
@@ -689,7 +706,7 @@ fn round_half_away_from_zero(value: f64) -> f64 {
 
 fn round_half_toward_zero(value: f64) -> f64 {
     let abs = value.abs();
-    let floor = abs.floor();
+    let floor = core_maths::CoreFloat::floor(abs);
     let fraction = abs - floor;
     let rounded = if fraction > 0.5 { floor + 1.0 } else { floor };
     rounded.copysign(value)
@@ -920,6 +937,9 @@ mod tests {
     #[test]
     fn rounds_values_for_all_rounding_modes() {
         assert_eq!(round_value(1.25, 1, RoundingMode::HalfEven), 1.2);
+        assert_eq!(round_value(1.35, 1, RoundingMode::HalfEven), 1.4);
+        assert_eq!(round_value(2.5, 0, RoundingMode::HalfEven), 2.0);
+        assert_eq!(round_value(3.5, 0, RoundingMode::HalfEven), 4.0);
         assert_eq!(round_value(-1.25, 1, RoundingMode::HalfUp), -1.3);
         assert_eq!(round_value(-1.25, 1, RoundingMode::HalfDown), -1.2);
         assert_eq!(round_value(1.21, 1, RoundingMode::Ceiling), 1.3);

--- a/crates/ars-interactions/Cargo.toml
+++ b/crates/ars-interactions/Cargo.toml
@@ -10,10 +10,12 @@ rust-version.workspace = true
 [features]
 default               = ["aria-drag-drop-compat"]
 aria-drag-drop-compat = []
+debug                 = ["dep:log", "ars-core/debug"]
 
 [dependencies]
 ars-core = { path = "../ars-core" }
 ars-i18n = { path = "../ars-i18n" }
+log      = { version = "0.4", default-features = false, optional = true }
 
 [lints]
 workspace = true

--- a/crates/ars-interactions/src/compose.rs
+++ b/crates/ars-interactions/src/compose.rs
@@ -43,13 +43,13 @@ where
 {
     let mut merged = AttrMap::new();
     for attrs in attrs_iter {
-        // In debug builds, warn when the same CSS property is set by multiple
-        // interaction sources with different values.
-        #[cfg(debug_assertions)]
+        // When the optional debug feature is enabled, warn when the same CSS
+        // property is set by multiple interaction sources with different values.
+        #[cfg(feature = "debug")]
         for (prop, new_value) in attrs.iter_styles() {
             if let Ok(idx) = merged.styles().binary_search_by(|(k, _)| k.cmp(prop)) {
                 if merged.styles()[idx].1 != *new_value {
-                    eprintln!(
+                    log::warn!(
                         "ars-interactions: style property '{prop}' set by multiple interactions \
                          (existing: '{}', new: '{new_value}'). Last write wins.",
                         merged.styles()[idx].1

--- a/crates/ars-leptos/Cargo.toml
+++ b/crates/ars-leptos/Cargo.toml
@@ -9,6 +9,7 @@ rust-version.workspace = true
 
 [features]
 default = []
+debug   = ["dep:log", "ars-core/debug", "ars-dom/debug", "ars-interactions/debug"]
 ssr     = ["leptos/ssr", "ars-dom/ssr"]
 hydrate = ["leptos/hydrate"]
 csr     = ["leptos/csr"]
@@ -22,6 +23,7 @@ ars-forms        = { path = "../ars-forms" }
 ars-i18n         = { path = "../ars-i18n" }
 ars-interactions = { path = "../ars-interactions" }
 leptos           = { version = "0.8", default-features = false }
+log              = { version = "0.4", default-features = false, optional = true }
 
 [lints]
 workspace = true

--- a/crates/ars-leptos/src/attrs.rs
+++ b/crates/ars-leptos/src/attrs.rs
@@ -108,16 +108,16 @@ fn styles_to_nonce_css(id: &str, styles: &[(CssProperty, String)]) -> String {
     format!("[data-ars-style-id=\"{id}\"] {{\n{declarations}\n}}")
 }
 
-#[cfg(debug_assertions)]
+#[cfg(feature = "debug")]
 fn warn_missing_provider(hook_name: &str) {
-    eprintln!(
+    log::warn!(
         "[ars-ui] {hook_name}: No ArsProvider found in the component tree. \
         Falling back to defaults."
     );
 }
 
-#[cfg(not(debug_assertions))]
-fn warn_missing_provider(_hook_name: &str) {}
+#[cfg(not(feature = "debug"))]
+const fn warn_missing_provider(_hook_name: &str) {}
 
 #[cfg(test)]
 mod tests {

--- a/spec/foundation/01-architecture.md
+++ b/spec/foundation/01-architecture.md
@@ -94,17 +94,20 @@ web-intl = ["dep:js-sys"]      # Browser Intl API via wasm-bindgen (WASM-only)
 [features]
 default = ["aria-drag-drop-compat"]
 aria-drag-drop-compat = []        # Emit deprecated aria-grabbed/aria-dropeffect for legacy AT
+debug = ["dep:log", "ars-core/debug"]  # Dev-time warnings for interaction attr conflicts
 
 # ars-dom/Cargo.toml
 # Non-feature deps: ars-core, ars-a11y, ars-i18n, ars-interactions (always included)
 [features]
 default = ["web"]
+debug = ["dep:log", "ars-core/debug", "ars-interactions/debug"]  # Dev-time DOM/platform diagnostics
 ssr = []                          # Server-side rendering support (no web-sys)
 web = ["dep:web-sys", "dep:wasm-bindgen", "dep:js-sys"]  # Browser DOM access
 
 # ars-leptos/Cargo.toml
 [features]
 default = []
+debug = ["dep:log", "ars-core/debug", "ars-dom/debug", "ars-interactions/debug"]
 ssr = ["leptos/ssr", "ars-dom/ssr"]
 hydrate = ["leptos/hydrate"]
 csr = ["leptos/csr"]
@@ -132,6 +135,7 @@ serde = ["dep:serde"]          # Serialization for form data
 # ars-dioxus/Cargo.toml
 [features]
 default = []
+debug = ["dep:log", "ars-core/debug", "ars-interactions/debug", "ars-dom?/debug"]
 web = ["dioxus/web", "dep:ars-dom", "ars-dom/web"]
 desktop = ["dioxus/desktop"]
 desktop-dom = ["desktop", "dep:ars-dom"]  # ars-dom declared with default-features = false; no web-sys on desktop
@@ -1568,8 +1572,8 @@ impl TimerHandle {
 /// Resolve platform effects from ArsProvider context.
 /// ArsProvider is the single root provider that bundles configuration,
 /// platform capabilities, i18n, and style strategy.
-/// Falls back to `NullPlatformEffects` with debug-mode warnings if no
-/// ArsProvider is found.
+/// Falls back to `NullPlatformEffects` with `log::warn!` diagnostics when
+/// the `ars-core/debug` feature is enabled and no ArsProvider is found.
 fn use_platform_effects() -> ArsRc<dyn PlatformEffects> {
     use_context::<ArsContext>()
         .map(|ctx| ctx.platform())
@@ -1614,22 +1618,23 @@ method call so the developer sees exactly which platform operations are silently
 
 ```rust
 /// Fallback PlatformEffects used when no ArsProvider is in the component tree.
-/// Behaves identically to NullPlatformEffects but emits debug warnings per call.
+/// Behaves identically to NullPlatformEffects but emits `log::warn!` diagnostics
+/// per call when the `ars-core/debug` feature is enabled.
 /// This is NOT used in tests — only in the `use_platform_effects()` fallback path
 /// inside adapters.
 pub struct MissingProviderEffects;
 
 impl MissingProviderEffects {
-    #[cfg(all(debug_assertions, feature = "std"))]
+    #[cfg(feature = "debug")]
     #[inline]
     fn warn(method: &str) {
-        eprintln!(
+        log::warn!(
             "[ars-ui] {method}() called without ArsProvider. \
              Platform effects are disabled. Wrap your app root in <ArsProvider>."
         );
     }
 
-    #[cfg(not(all(debug_assertions, feature = "std")))]
+    #[cfg(not(feature = "debug"))]
     #[inline]
     fn warn(_method: &str) {}
 }
@@ -2658,18 +2663,18 @@ All transition log lines follow a single structured format for machine-parseable
 
 **Field definitions (tracing-compatible span/event fields):**
 
-| Field          | Type     | Description                                                                         |
-| -------------- | -------- | ----------------------------------------------------------------------------------- |
-| `component_id` | `String` | The `Props::id()` value, e.g. `"toggle#btn-1"`                                      |
-| `state`        | `String` | `Debug` representation of the current state before transition                       |
-| `event`        | `String` | `Debug` representation of the incoming event                                        |
-| `target_state` | `String` | `Debug` representation of the state after transition; `"(same)"` if no state change |
-| `guard`        | `String` | `"pass"` if transition matched, `"reject"` if no transition plan was returned       |
-| `effects`      | `String` | Comma-separated list of effect names from `PendingEffect::name`, or `"none"`        |
-| `apply`        | `String` | The `apply_description` from `TransitionPlan`, or `"none"`                          |
-| `then_send`    | `String` | Comma-separated list of follow-up events, or `"none"`                               |
-| `iteration`    | `u32`    | 1-based index within the current `drain_queue()` cycle                              |
-| `queue_depth`  | `u32`    | Number of events remaining in the queue after this iteration                        |
+| Field          | Type     | Description                                                                                    |
+| -------------- | -------- | ---------------------------------------------------------------------------------------------- |
+| `component_id` | `String` | The `Props::id()` value, e.g. `"toggle#btn-1"`                                                 |
+| `state`        | `String` | `Debug` representation of the current state before transition                                  |
+| `event`        | `String` | `Debug` representation of the incoming event                                                   |
+| `target_state` | `String` | `Debug` representation of the state after transition; `"(same)"` if no state change            |
+| `guard`        | `String` | `"pass"` if transition matched, `"reject"` if no transition plan was returned                  |
+| `effects`      | `String` | Bracketed list of effect names from `PendingEffect::name`, for example `[focus]` or `[]`       |
+| `apply`        | `String` | The `apply_description` from `TransitionPlan`, or `"none"`                                     |
+| `then_send`    | `String` | Bracketed list of follow-up events using their `Debug` form, for example `[FocusTrap]` or `[]` |
+| `iteration`    | `u32`    | 1-based index within the current `drain_queue()` cycle                                         |
+| `queue_depth`  | `u32`    | Number of events remaining in the queue after this iteration                                   |
 
 **Example output for a complete transition cycle:**
 

--- a/spec/foundation/04-internationalization.md
+++ b/spec/foundation/04-internationalization.md
@@ -409,23 +409,24 @@ context and passes them to core code via the `Env` struct and `Messages` paramet
 (see `01-architecture.md` §2.1 for the `Env` definition).
 
 **Missing provider warning:** All adapter context hooks (`use_locale()`, `use_icu_provider()`,
-`use_style_strategy()`) emit a debug-mode warning when no `ArsProvider` is found.
-This helps developers catch missing provider setup during development. The warning
-is compiled out in release builds.
+`use_style_strategy()`) emit a `log::warn!` diagnostic when the adapter crate's
+`debug` feature is enabled and no `ArsProvider` is found. This helps developers
+catch missing provider setup during development while keeping diagnostics routed
+through the application's configured logger.
 
 ```rust
-/// Emit a debug-mode warning when ArsProvider context is missing.
-/// Compiled out in release builds (zero-cost).
-#[cfg(debug_assertions)]
+/// Emit a warning when ArsProvider context is missing.
+/// Compiled out unless the adapter crate's `debug` feature is enabled.
+#[cfg(feature = "debug")]
 fn warn_missing_provider(hook_name: &str) {
-    eprintln!(
+    log::warn!(
         "[ars-ui] {hook_name}: No ArsProvider found in the component tree. \
          Falling back to defaults."
     );
 }
 
-#[cfg(not(debug_assertions))]
-fn warn_missing_provider(_hook_name: &str) {}
+#[cfg(not(feature = "debug"))]
+const fn warn_missing_provider(_hook_name: &str) {}
 ```
 
 The adapter resolves locale through a three-level chain:

--- a/spec/foundation/05-interactions.md
+++ b/spec/foundation/05-interactions.md
@@ -2634,19 +2634,19 @@ Note: Class deduplication is handled by `AttrMap::set()` — space-separated tok
 list attributes (including `class`) are automatically appended with dedup.
 See `SPACE_SEPARATED` in `01-architecture.md`.
 
-**Dev-mode `style` conflict warning:** When `cfg!(debug_assertions)` is enabled, `merge_attrs` SHOULD emit a `console.warn` if the same CSS property is set by two different interaction `AttrMap` sources with different values. This helps component authors detect unintentional style conflicts during development:
+**Dev-mode `style` conflict warning:** When the `ars-interactions/debug` feature is enabled, `merge_attrs` SHOULD emit a `log::warn!` if the same CSS property is set by two different interaction `AttrMap` sources with different values. This helps component authors detect unintentional style conflicts during development while keeping diagnostics routed through the application's logger setup:
 
 ```rust
-// In merge_attrs, during style merging (debug builds only):
-#[cfg(debug_assertions)]
+// In merge_attrs, during style merging (debug feature only):
+#[cfg(feature = "debug")]
 if let Some(existing_value) = merged.iter_styles().find(|(k, _)| k == &property).map(|(_, v)| v) {
     if existing_value != &value {
-        web_sys::console::warn_1(
-            &format!(
-                "ars-interactions: style property '{}' set by multiple interactions \
-                 (existing: '{}', new: '{}'). Last write wins.",
-                property, existing_value, value
-            ).into()
+        log::warn!(
+            "ars-interactions: style property '{}' set by multiple interactions \
+             (existing: '{}', new: '{}'). Last write wins.",
+            property,
+            existing_value,
+            value
         );
     }
 }

--- a/spec/foundation/08-adapter-leptos.md
+++ b/spec/foundation/08-adapter-leptos.md
@@ -33,9 +33,11 @@ ars-collections = { workspace = true }
 ars-forms = { workspace = true }
 ars-dom = { workspace = true }
 leptos = "0.8"
+log = { version = "0.4", default-features = false, optional = true }
 
 [features]
 default = []
+debug = ["dep:log", "ars-core/debug", "ars-dom/debug", "ars-interactions/debug"]
 ssr = ["leptos/ssr", "ars-dom/ssr"]
 hydrate = ["leptos/hydrate"]
 csr = ["leptos/csr"]
@@ -820,6 +822,10 @@ pub fn use_style_strategy() -> StyleStrategy {
         })
 }
 ```
+
+`warn_missing_provider()` is an adapter-private helper. It emits `log::warn!`
+messages only when the `ars-leptos/debug` feature is enabled; otherwise these
+fallback paths remain silent.
 
 #### 4.5.1 Nonce CSS Collector
 

--- a/spec/foundation/09-adapter-dioxus.md
+++ b/spec/foundation/09-adapter-dioxus.md
@@ -40,9 +40,11 @@ ars-collections = { workspace = true }
 ars-forms = { workspace = true }
 ars-dom = { workspace = true, optional = true }
 dioxus = { version = "0.7" }
+log = { version = "0.4", default-features = false, optional = true }
 
 [features]
 default = []
+debug = ["dep:log", "ars-core/debug", "ars-interactions/debug", "ars-dom?/debug"]
 web = ["dioxus/web", "dep:ars-dom", "ars-dom/web"]
 desktop = ["dioxus/desktop"]
 desktop-dom = ["desktop", "dep:ars-dom"]
@@ -850,6 +852,10 @@ pub fn use_style_strategy() -> StyleStrategy {
         })
 }
 ```
+
+`warn_missing_provider()` is adapter-private. It emits `log::warn!` messages
+only when the `ars-dioxus/debug` feature is enabled; otherwise these fallback
+paths are silent.
 
 > **Note:** `ArsStyleProvider` and `ArsStyleCtx` have been removed. The style strategy is
 > now provided by `ArsProvider` (§16) via the `style_strategy` field on `ArsContext`.
@@ -2216,6 +2222,11 @@ The Dioxus adapter resolves `platform` via feature flags: `WebPlatformEffects` (
 `DesktopPlatformEffects` (desktop), `NullPlatformEffects` (SSR/tests/mobile fallback).
 
 ### 16.1 use_locale()
+
+All ArsProvider fallback helpers in this section (`use_locale()`,
+`use_icu_provider()`, `t()`, and `use_platform()`) route through
+`warn_missing_provider()`. That helper emits `log::warn!` only when the
+`ars-dioxus/debug` feature is enabled.
 
 ```rust
 /// Returns the current locale signal. The returned signal is **read-only in practice**:

--- a/spec/foundation/11-dom-utilities.md
+++ b/spec/foundation/11-dom-utilities.md
@@ -2324,8 +2324,8 @@ pub fn next_z_index() -> u32 {
             // allocation continues from the new sequence without repeating BASE.
             // Reset to base — existing overlays at high z-indexes will still
             // render above normal content; new overlays start fresh.
-            #[cfg(debug_assertions)]
-            eprintln!(
+            #[cfg(feature = "debug")]
+            log::warn!(
                 "[ars-dom] z-index counter reached ceiling ({Z_INDEX_CEILING}), \
                  resetting to base ({Z_INDEX_BASE})"
             );

--- a/spec/testing/14-ci.md
+++ b/spec/testing/14-ci.md
@@ -11,8 +11,9 @@ branch protection).
 
 Every pull request MUST pass all jobs in this pipeline before merge is allowed.
 The pipeline is intentionally staged so cheap deterministic gates fail first:
-formatting, then compile checks, then linting, then unit and integration tests,
-then adapter coverage, and only then the expensive feature-flag matrix.
+formatting, then compile checks, then linting, then unit tests, then release
+verification, then integration tests, then adapter coverage, and only then the
+expensive feature-flag matrix.
 
 ### 1.1 Formatting
 
@@ -76,7 +77,36 @@ core-tests:
     - run: cargo test --workspace --exclude ars-leptos --exclude ars-dioxus
 ```
 
-### 1.4 Adapter Tests
+### 1.4 Release Verification
+
+Release-mode regressions MUST be caught in CI, even when the debug-profile
+pipeline stays green. This job exercises the `ars-i18n` bare `no_std` release
+compile path, its default release tests, and the same non-adapter library set
+covered by the unit-test stage under `--release`.
+
+```yaml
+release:
+  name: Release Verification
+  needs: [core-tests]
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@stable
+    - uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-
+    - run: cargo check -p ars-i18n --release --all-targets --no-default-features --features icu4x
+    - run: cargo test -p ars-i18n --lib --release
+    - run: cargo test -p ars-a11y -p ars-core -p ars-collections -p ars-dom -p ars-interactions -p ars-forms --all-targets --all-features --release
+```
+
+### 1.5 Adapter Tests
 
 Both adapters are tested under `wasm-pack` on every PR.
 
@@ -109,7 +139,7 @@ adapter-tests:
     - run: wasm-pack test --headless --chrome crates/${{ matrix.crate }}
 ```
 
-### 1.5 Feature Flag Matrix
+### 1.6 Feature Flag Matrix
 
 Relocated from 13-policies.md. Every supported feature-flag combination MUST
 compile and pass library tests.
@@ -222,7 +252,7 @@ feature-flag-check:
 
 > **Calendar coverage:** Individual calendar features not listed here (`islamic-civil`, `islamic-umm-al-qura`, `ethiopic`, `ethiopic-amete-alem`, `indian`, `coptic`, `dangi`, `roc`) are covered by the `all-calendars` matrix entry. `japanese-extended` is tested individually because it differs from `japanese` (includes era dates before Meiji).
 
-### 1.6 Adapter Parity Enforcement
+### 1.7 Adapter Parity Enforcement
 
 The parity script validates per-component test counts and snapshot equivalence
 between the Leptos and Dioxus adapters. See [13-policies.md](13-policies.md) for

--- a/xtask/src/ci/mod.rs
+++ b/xtask/src/ci/mod.rs
@@ -24,6 +24,8 @@ pub enum Step {
     Clippy,
     /// Unit tests for core crates.
     Unit,
+    /// Release-profile compile and test smoke checks.
+    Release,
     /// Integration tests.
     Integration,
     /// Adapter harness tests (Leptos + Dioxus).
@@ -94,6 +96,7 @@ const PIPELINE_ORDER: &[Step] = &[
     Step::Check,
     Step::Clippy,
     Step::Unit,
+    Step::Release,
     Step::Integration,
     Step::Adapter,
     Step::Coverage,
@@ -225,6 +228,7 @@ fn run_step(step: Step, message_format: Option<&str>) -> Result<(), Error> {
         Step::Check => run_check(message_format),
         Step::Clippy => run_clippy(message_format),
         Step::Unit => run_unit(),
+        Step::Release => run_release(),
         Step::Integration => run_integration(),
         Step::Adapter => run_adapter(),
         Step::Coverage => run_coverage(),
@@ -353,6 +357,47 @@ fn run_unit() -> Result<(), Error> {
             "ars-forms",
             "--all-targets",
             "--all-features",
+        ],
+    )
+}
+
+fn run_release() -> Result<(), Error> {
+    cargo(
+        Step::Release,
+        &[
+            "check",
+            "-p",
+            "ars-i18n",
+            "--release",
+            "--all-targets",
+            "--no-default-features",
+            "--features",
+            "icu4x",
+        ],
+    )?;
+    cargo(
+        Step::Release,
+        &["test", "-p", "ars-i18n", "--lib", "--release"],
+    )?;
+    cargo(
+        Step::Release,
+        &[
+            "test",
+            "-p",
+            "ars-a11y",
+            "-p",
+            "ars-core",
+            "-p",
+            "ars-collections",
+            "-p",
+            "ars-dom",
+            "-p",
+            "ars-interactions",
+            "-p",
+            "ars-forms",
+            "--all-targets",
+            "--all-features",
+            "--release",
         ],
     )
 }
@@ -529,6 +574,7 @@ const fn step_name(step: Step) -> &'static str {
         Step::Check => "check",
         Step::Clippy => "clippy",
         Step::Unit => "unit",
+        Step::Release => "release",
         Step::Integration => "integration",
         Step::Adapter => "adapter",
         Step::Coverage => "coverage",
@@ -641,6 +687,7 @@ mod tests {
             Step::Check,
             Step::Clippy,
             Step::Unit,
+            Step::Release,
             Step::Integration,
             Step::Adapter,
             Step::Coverage,


### PR DESCRIPTION
## Summary

- implement structured debug logging in `ars-core::Service` and add debug-feature logging tests
- replace library/runtime `eprintln!` diagnostics with `log`-based warnings across runtime crates
- fix the `ars-i18n` release/clippy float-path regression and add broader release verification in CI

## Why

This issue started with the `ars-core` logging contract from the architecture spec, but the follow-up work exposed a real release-only verification gap. `ars-core` release tests were blocked by an `ars-i18n` float-operation path that only failed under the release/clippy configuration, and CI was not exercising that path.

## What Changed

- wired `ars-core`'s `debug` feature to the optional `log` dependency and emitted structured trace/debug/warn logs from `Service`
- added crate-local log capture tests for accepted transitions, rejected transitions, queue-depth logging, multi-effect formatting, unmounted sends, and truncation behavior
- migrated library diagnostics in `ars-interactions`, `ars-dom`, `ars-leptos`, and `ars-dioxus` from `eprintln!` to `log`
- updated the relevant foundation specs to match the logging behavior
- switched `ars-i18n` rounding helpers to a `no_std`-safe float path and added stronger half-even assertions
- added a `release` CI step in `xtask` and GitHub Actions covering `ars-i18n` release checks plus the full non-adapter library release test set

## Impact

- debug logging is now consistent, structured, and spec-aligned across the core runtime path
- release-mode regressions in the non-adapter library stack now have an explicit CI gate
- the previously failing `ars-i18n` release/clippy configuration now compiles cleanly

## Validation

- `cargo clippy -p ars-i18n --release --all-targets --no-default-features --features icu4x -- -D warnings`
- `cargo test -p ars-i18n --lib`
- `cargo test -p ars-i18n --lib --release`
- `cargo test -p ars-core --lib --features debug`
- `cargo test -p ars-core --lib --features debug --release`
- `cargo xtask ci release`
- `cargo xtask spec validate`

Closes #147