### PR TITLE
Repurpose Epic #10 for all 26 agnostic utility components

### DIFF
--- a/docs/implementation/foundation-gap-audit.md
+++ b/docs/implementation/foundation-gap-audit.md
@@ -25,15 +25,15 @@ This audit resets the implementation backlog after the initial seed tasks landed
 | `ars-dom` scroll locking                   | No reference-counted scroll lock implementation exists.                                                                                                                                                                                                                                                             | `ScrollLockManager`, low-level `acquire`/`release`, and public aliases from [`spec/foundation/11-dom-utilities.md`](/Users/ericson/Workspace/Rust/ars-ui/spec/foundation/11-dom-utilities.md):5.2-5.4.                                                   | Not needed for the first utility slice, but required before overlay work starts.                                                                                               | Can wait until later slices                       |
 | Interaction composition depth              | [`crates/ars-interactions/src/lib.rs`](/Users/ericson/Workspace/Rust/ars-ui/crates/ars-interactions/src/lib.rs) only does shallow overwrite merging.                                                                                                                                                                | Token-aware composition behavior expected by [`spec/foundation/05-interactions.md`](/Users/ericson/Workspace/Rust/ars-ui/spec/foundation/05-interactions.md):8.1-8.2 and by `as_child`/button specs.                                                     | Blocks `AsChild`, `Button`, and other composed interactive utilities, but not all utility work.                                                                                | Can land before specific utilities only           |
 
-## Why `#24` Is Blocked
+## ~~Why `#24` Is Blocked~~ (Resolved)
 
-`#24` assumed the first utility slice could be decomposed directly into adapter-facing delivery cards. The audit shows that the current repo still lacks the shared contracts those cards would depend on:
+> **Update (2026-04-10):** Issue #24 has been **closed** as superseded. Epic #10 was repurposed from "First utility slice" to "Agnostic utility components" covering all 26 utility components. Twenty new task issues (#199–#218, 64 pts) replace #24's decomposition role. Each task declares its foundation dependencies via native GitHub issue dependencies, so blocked tasks are explicit. See [Epic #10](https://github.com/fogodev/ars-ui/issues/10) for the full sub-issue breakdown.
+
+The original analysis below remains accurate — the foundation gaps identified here are still the prerequisite contracts that utility component tasks depend on:
 
 - Utility specs already call for typed `HtmlAttr`, `AttrMap::set_bool`, style handling, and part-derived `data_attrs()`.
-- `Field`, `Fieldset`, `Form`, and `ToggleButton` all assume `FormContext`, `FieldCtx`, hidden-input helpers, and submit lifecycle machinery that do not exist yet.
-- `FocusScope` and any effectful component assume DOM focus helpers and `PlatformEffects` integration that are still missing.
-
-Because of that, decomposing the utility slice now would create issue cards that are blocked on unstated prerequisites. `#24` should stay deferred until the replacement foundation tasks below exist as issue-backed work.
+- `Field`, `Fieldset`, `Form`, and `ToggleButton` all assume `FormContext`, `FieldCtx`, hidden-input helpers, and submit lifecycle machinery.
+- `FocusScope` and any effectful component assume DOM focus helpers and `PlatformEffects` integration.
 
 ## Replacement Task Sequence
 

--- a/docs/implementation/initial-backlog.md
+++ b/docs/implementation/initial-backlog.md
@@ -84,13 +84,15 @@ Note: the original 2-task decomposition (#19 harness shell, #20 CI tier split) e
 
 Note: the original 3-task decomposition (#23, #56, #106) covered only ~40% of the foundational spec sections. A full spec audit (2026-04-10) found the same gaps as the Leptos adapter plus Dioxus-unique sections (DioxusPlatform, SSR Hydration, Error Boundary). Five additional tasks (#193–#197, 16 pts) now cover ArsProvider context, adapter utilities, platform abstraction, SSR hydration, and error boundaries. See [Epic #9](https://github.com/fogodev/ars-ui/issues/9) for the full decomposition.
 
-### Epic: First utility slice
+### Epic: Agnostic utility components
 
-- Point target: `8`
+- Point target: `64` (revised from `8` after full decomposition — 2026-04-10)
 - Layer: `Component`
-- Framework: `Both`
-- Test tier: `Mixed`
-- Spec refs: `spec/components/utility/_category.md`
+- Framework: `None` (agnostic core only; adapter work tracked under Epics #8/#9)
+- Test tier: `Unit`
+- Spec refs: `spec/components/utility/_category.md`, `spec/components/utility/*.md`
+
+Note: the original "First utility slice" epic scoped only 11 components and had a single decomposition card (#24). A full decomposition (2026-04-10) expanded the epic to cover all 26 utility components as framework-agnostic core implementations. Twenty tasks (#199–#218, 64 pts) organized in 5 dependency waves now cover every component. Issue #24 was closed as superseded. See [Epic #10](https://github.com/fogodev/ars-ui/issues/10) for the full sub-issue breakdown.
 
 ### Epic: Spec synchronization
 
@@ -318,17 +320,9 @@ Note: this seed task delivered the tier split via xtask CI runner. Additional CI
 - Acceptance: ArsErrorBoundary wrapping Dioxus ErrorBoundary, accessible fallback UI, prelude export
 - Spec impact: `No spec change required`
 
-### #24: Break the first utility slice into per-primitive delivery cards
+### ~~#24: Break the first utility slice into per-primitive delivery cards~~ (CLOSED)
 
-- Points: `2`
-- Layer: `Component`
-- Framework: `Both`
-- Test tier: `Mixed`
-- Depends on: `#21`
-- Spec refs: `spec/components/utility/_category.md`, `spec/components/utility/button.md`, `spec/components/utility/focus-scope.md`, `spec/components/utility/form.md`
-- Tests first: not applicable; verify each card includes tests-first details
-- Acceptance: the first slice is decomposed into component-level or behavior-level cards no larger than `5`
-- Spec impact: `No spec change required`
+Closed (2026-04-10): Superseded by the full decomposition of all 26 agnostic utility components under Epic #10. Twenty task issues (#199–#218) now cover every utility component. See [Epic #10](https://github.com/fogodev/ars-ui/issues/10) sub-issues.
 
 ## Backlog Reset
 

--- a/docs/implementation/project-board.md
+++ b/docs/implementation/project-board.md
@@ -15,7 +15,7 @@ Top-level epics:
 - Test infrastructure
 - Leptos adapter
 - Dioxus adapter
-- First utility slice
+- Agnostic utility components
 - Spec synchronization
 
 ## Required Project fields

--- a/docs/implementation/roadmap.md
+++ b/docs/implementation/roadmap.md
@@ -8,7 +8,7 @@ Build `ars-ui` from a spec-only workspace into an implementation workspace with:
 - stable core contracts
 - reusable subsystem primitives
 - framework-agnostic test harnesses
-- a first shippable utility slice in both Leptos and Dioxus
+- the full agnostic utility component layer (26 components)
 
 ## Phase Order
 
@@ -85,27 +85,28 @@ A symmetric audit of Epic #9 (Dioxus adapter) confirmed the same gaps plus Dioxu
 
 See `foundation-completion-roadmap.md` for full task details and `foundation-gap-audit.md` for the gap matrix.
 
-### Phase 4: First shippable utility slice
+### Phase 4: Agnostic utility components
 
 Scope:
 
-- `ArsProvider`
-- `AsChild`
-- `VisuallyHidden`
-- `FocusRing`
-- `Button`
-- `Toggle`
-- `ToggleButton`
-- `FocusScope`
-- `Field`
-- `Fieldset`
-- `Form`
+All 26 utility components defined in `spec/components/utility/`, implemented as framework-agnostic core (state machines, ConnectApi, Props/Api/Part types):
+
+**Stateless (17):** AsChild, ArsProvider, ClientOnly, Dismissable, DownloadTrigger, Field, Fieldset, FocusRing, Form, Group, Heading, Highlight, Keyboard, Landmark, Separator, VisuallyHidden, ZIndexAllocator
+
+**Stateful (9):** ActionGroup, Button, DropZone, FocusScope, LiveRegion, Swap, Toggle, ToggleButton, ToggleGroup
+
+Decomposed into 20 tasks (64 story points) organized in 5 dependency waves. See [Epic #10](https://github.com/fogodev/ars-ui/issues/10) for the full task breakdown with sub-issues.
 
 Exit criteria:
 
-- all slice components exist in both adapters
-- parity tests cover shared behavior and `data-ars-*`/ARIA output
-- spec and implementation remain aligned for any discovered framework-specific constraints
+- all 26 utility components have agnostic core implementations
+- state machines (stateful components) match their spec §1 exactly
+- ConnectApi implementations produce correct ARIA attributes per spec §2
+- all public types documented per workspace `missing_docs` lint
+- all tests pass with zero warnings
+- spec and implementation remain aligned; any mismatch resolved in the same task
+
+Status (2026-04-10): Epic repurposed from "First utility slice" (11 components) to cover all 26 agnostic utility components. Issue #24 (decomposition card) closed as superseded. Twenty new task issues (#199–#218) created as sub-issues of Epic #10.
 
 ## Spec synchronization rules
 


### PR DESCRIPTION
## Summary

- Repurposed Epic #10 from "First utility slice" (11 components) to "Agnostic utility components" (all 26 utility components)
- Closed issue #24 as superseded; created 20 new task issues (#199–#218, 64 story points) as sub-issues of Epic #10
- Updated all implementation roadmap docs to reflect the expanded scope

## Test plan

- [ ] Verify Epic #10 title and sub-issues on GitHub: `gh api repos/fogodev/ars-ui/issues/10/sub_issues --jq '.[].number'`
- [ ] Verify issue #24 is closed: `gh issue view 24 --json state`
- [ ] Confirm docs render correctly in GitHub markdown preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)