### PR TITLE
docs: add 8 component category epics (#220–#227) with 74 sub-issues to roadmap

### DIFF
--- a/docs/implementation/initial-backlog.md
+++ b/docs/implementation/initial-backlog.md
@@ -94,6 +94,86 @@ Note: the original 3-task decomposition (#23, #56, #106) covered only ~40% of th
 
 Note: the original "First utility slice" epic scoped only 11 components and had a single decomposition card (#24). A full decomposition (2026-04-10) expanded the epic to cover all 26 utility components as framework-agnostic core implementations. Twenty tasks (#199–#218, 64 pts) organized in 5 dependency waves now cover every component. Issue #24 was closed as superseded. See [Epic #10](https://github.com/fogodev/ars-ui/issues/10) for the full sub-issue breakdown.
 
+### Epic: Agnostic input components
+
+- Point target: `48`
+- Layer: `Component`
+- Framework: `None` (agnostic core only; adapter work tracked under Epics #8/#9)
+- Test tier: `Unit`
+- Spec refs: `spec/components/input/_category.md`, `spec/components/input/*.md`, `spec/foundation/07-forms.md`
+
+All 14 input components (1 stateless, 11 stateful, 2 complex). Twelve tasks (#228–#251, 48 pts) organized in 2 dependency waves. See [Epic #220](https://github.com/fogodev/ars-ui/issues/220) for the full sub-issue breakdown.
+
+### Epic: Agnostic selection components
+
+- Point target: `55`
+- Layer: `Component`
+- Framework: `None` (agnostic core only; adapter work tracked under Epics #8/#9)
+- Test tier: `Unit`
+- Spec refs: `spec/components/selection/_category.md`, `spec/components/selection/*.md`, `spec/shared/selection-patterns.md`
+
+All 9 selection components (2 stateful, 7 complex). Nine tasks (#232–#255, 55 pts) organized in 4 dependency waves. External dep: ars-collections (Epic #53). See [Epic #221](https://github.com/fogodev/ars-ui/issues/221) for the full sub-issue breakdown.
+
+### Epic: Agnostic overlay components
+
+- Point target: `50`
+- Layer: `Component`
+- Framework: `None` (agnostic core only; adapter work tracked under Epics #8/#9)
+- Test tier: `Unit`
+- Spec refs: `spec/components/overlay/_category.md`, `spec/components/overlay/*.md`, `spec/shared/z-index-stacking.md`
+
+All 10 overlay components (4 stateful, 6 complex). Ten tasks (#238–#265, 50 pts) organized in 4 dependency waves. See [Epic #222](https://github.com/fogodev/ars-ui/issues/222) for the full sub-issue breakdown.
+
+### Epic: Agnostic navigation components
+
+- Point target: `33`
+- Layer: `Component`
+- Framework: `None` (agnostic core only; adapter work tracked under Epics #8/#9)
+- Test tier: `Unit`
+- Spec refs: `spec/components/navigation/_category.md`, `spec/components/navigation/*.md`
+
+All 8 navigation components (1 stateless, 4 stateful, 3 complex). Seven tasks (#247–#267, 33 pts) organized in 3 dependency waves. External dep: TreeView depends on ars-collections TreeCollection (#83). See [Epic #223](https://github.com/fogodev/ars-ui/issues/223) for the full sub-issue breakdown.
+
+### Epic: Agnostic date-time components
+
+- Point target: `47`
+- Layer: `Component`
+- Framework: `None` (agnostic core only; adapter work tracked under Epics #8/#9)
+- Test tier: `Unit`
+- Spec refs: `spec/components/date-time/_category.md`, `spec/components/date-time/*.md`, `spec/shared/date-time-types.md`
+
+All 8 date-time components (5 stateful, 3 complex). Eight tasks (#262–#292, 47 pts) organized in 4 dependency waves. External dep: all depend on ars-i18n (Epic #54). See [Epic #224](https://github.com/fogodev/ars-ui/issues/224) for the full sub-issue breakdown.
+
+### Epic: Agnostic data-display components
+
+- Point target: `40`
+- Layer: `Component`
+- Framework: `None` (agnostic core only; adapter work tracked under Epics #8/#9)
+- Test tier: `Unit`
+- Spec refs: `spec/components/data-display/_category.md`, `spec/components/data-display/*.md`
+
+All 11 data-display components (4 stateless, 6 stateful, 1 complex). Nine tasks (#266–#286, 40 pts) organized in 3 dependency waves. External dep: GridList, TagGroup, Table depend on ars-collections (Epic #53). See [Epic #225](https://github.com/fogodev/ars-ui/issues/225) for the full sub-issue breakdown.
+
+### Epic: Agnostic layout components
+
+- Point target: `31`
+- Layer: `Component`
+- Framework: `None` (agnostic core only; adapter work tracked under Epics #8/#9)
+- Test tier: `Unit`
+- Spec refs: `spec/components/layout/_category.md`, `spec/components/layout/*.md`, `spec/shared/layout-shared-types.md`
+
+All 11 layout components (5 stateless, 6 stateful). Eight tasks (#270–#281, 31 pts) in a single wave — no intra-epic dependencies. See [Epic #226](https://github.com/fogodev/ars-ui/issues/226) for the full sub-issue breakdown.
+
+### Epic: Agnostic specialized components
+
+- Point target: `55`
+- Layer: `Component`
+- Framework: `None` (agnostic core only; adapter work tracked under Epics #8/#9)
+- Test tier: `Unit`
+- Spec refs: `spec/components/specialized/_category.md`, `spec/components/specialized/*.md`
+
+All 15 specialized components (3 stateless, 10 stateful, 2 complex). Eleven tasks (#288–#301, 55 pts) organized in 4 dependency waves. External dep: FileUpload depends on DnD interactions (#159–#161). See [Epic #227](https://github.com/fogodev/ars-ui/issues/227) for the full sub-issue breakdown.
+
 ### Epic: Spec synchronization
 
 - Point target: `3`

--- a/docs/implementation/roadmap.md
+++ b/docs/implementation/roadmap.md
@@ -8,7 +8,7 @@ Build `ars-ui` from a spec-only workspace into an implementation workspace with:
 - stable core contracts
 - reusable subsystem primitives
 - framework-agnostic test harnesses
-- the full agnostic utility component layer (26 components)
+- the full agnostic component layer (111 components across 9 categories)
 
 ## Phase Order
 
@@ -107,6 +107,221 @@ Exit criteria:
 - spec and implementation remain aligned; any mismatch resolved in the same task
 
 Status (2026-04-10): Epic repurposed from "First utility slice" (11 components) to cover all 26 agnostic utility components. Issue #24 (decomposition card) closed as superseded. Twenty new task issues (#199–#218) created as sub-issues of Epic #10.
+
+### Phase 5: Agnostic layout components
+
+Scope:
+
+All 11 layout components defined in `spec/components/layout/`, implemented as framework-agnostic core (state machines, ConnectApi, Props/Api/Part types):
+
+**Stateless (5):** AspectRatio, Center, Frame, Grid, Stack
+
+**Stateful (6):** Carousel, Collapsible, Portal, ScrollArea, Splitter, Toolbar
+
+Decomposed into 8 tasks (31 story points) in a single wave — no intra-epic dependencies. See [Epic #226](https://github.com/fogodev/ars-ui/issues/226) for the full task breakdown with sub-issues.
+
+Exit criteria:
+
+- all 11 layout components have agnostic core implementations
+- state machines (stateful components) match their spec §1 exactly
+- ConnectApi implementations produce correct ARIA attributes per spec §2
+- CSS custom property hooks match the spec appendix for each component
+- all public types documented per workspace `missing_docs` lint
+- all tests pass with zero warnings
+- spec and implementation remain aligned; any mismatch resolved in the same task
+
+Status (2026-04-10): Epic #226 created with 8 sub-issue tasks (#270–#281).
+
+### Phase 6: Agnostic input components
+
+Scope:
+
+All 14 input components defined in `spec/components/input/`, implemented as framework-agnostic core (state machines, ConnectApi, Props/Api/Part types):
+
+**Stateless (1):** FileTrigger
+
+**Stateful (11):** Checkbox, CheckboxGroup, Editable, NumberInput, PasswordInput, PinInput, RadioGroup, SearchInput, Switch, TextField, Textarea
+
+**Complex (2):** Slider, RangeSlider
+
+Decomposed into 12 tasks (48 story points) organized in 2 dependency waves. See [Epic #220](https://github.com/fogodev/ars-ui/issues/220) for the full task breakdown with sub-issues.
+
+Exit criteria:
+
+- all 14 input components have agnostic core implementations
+- state machines (stateful components) match their spec §1 exactly
+- ConnectApi implementations produce correct ARIA attributes per spec §2
+- form integration (hidden inputs, validation, field context) matches spec
+- all public types documented per workspace `missing_docs` lint
+- all tests pass with zero warnings
+- spec and implementation remain aligned; any mismatch resolved in the same task
+
+Status (2026-04-10): Epic #220 created with 12 sub-issue tasks (#228–#251).
+
+### Phase 7: Agnostic data-display components
+
+Scope:
+
+All 11 data-display components defined in `spec/components/data-display/`, implemented as framework-agnostic core (state machines, ConnectApi, Props/Api/Part types):
+
+**Stateless (4):** Badge, Meter, Skeleton, Stat
+
+**Stateful (6):** Avatar, GridList, Marquee, Progress, RatingGroup, TagGroup
+
+**Complex (1):** Table
+
+Decomposed into 9 tasks (40 story points) organized in 3 dependency waves. See [Epic #225](https://github.com/fogodev/ars-ui/issues/225) for the full task breakdown with sub-issues.
+
+Exit criteria:
+
+- all 11 data-display components have agnostic core implementations
+- state machines (stateful components) match their spec §1 exactly
+- ConnectApi implementations produce correct ARIA attributes per spec §2
+- collection-dependent components (GridList, TagGroup, Table) use `ars-collections` for item management
+- all public types documented per workspace `missing_docs` lint
+- all tests pass with zero warnings
+- spec and implementation remain aligned; any mismatch resolved in the same task
+
+External deps: GridList, TagGroup, and Table depend on ars-collections (Epic #53).
+
+Status (2026-04-10): Epic #225 created with 9 sub-issue tasks (#266–#286).
+
+### Phase 8: Agnostic overlay components
+
+Scope:
+
+All 10 overlay components defined in `spec/components/overlay/`, implemented as framework-agnostic core (state machines, ConnectApi, Props/Api/Part types):
+
+**Stateful (4):** AlertDialog, Popover, Presence, Tooltip
+
+**Complex (6):** Dialog, Drawer, FloatingPanel, HoverCard, Toast, Tour
+
+Decomposed into 10 tasks (50 story points) organized in 4 dependency waves. See [Epic #222](https://github.com/fogodev/ars-ui/issues/222) for the full task breakdown with sub-issues.
+
+Exit criteria:
+
+- all 10 overlay components have agnostic core implementations
+- state machines (stateful components) match their spec §1 exactly
+- ConnectApi implementations produce correct ARIA attributes per spec §2
+- z-index allocation uses `next_z_index()` from ars-dom for overlay components
+- focus trapping implemented for Dialog and AlertDialog
+- all public types documented per workspace `missing_docs` lint
+- all tests pass with zero warnings
+- spec and implementation remain aligned; any mismatch resolved in the same task
+
+External deps: z-index-stacking (#68, completed). Dialog/AlertDialog depend on FocusScope for focus trapping.
+
+Status (2026-04-10): Epic #222 created with 10 sub-issue tasks (#238–#265).
+
+### Phase 9: Agnostic navigation components
+
+Scope:
+
+All 8 navigation components defined in `spec/components/navigation/`, implemented as framework-agnostic core (state machines, ConnectApi, Props/Api/Part types):
+
+**Stateless (1):** Breadcrumbs
+
+**Stateful (4):** Accordion, Link, Pagination, Steps
+
+**Complex (3):** NavigationMenu, Tabs, TreeView
+
+Decomposed into 7 tasks (33 story points) organized in 3 dependency waves. See [Epic #223](https://github.com/fogodev/ars-ui/issues/223) for the full task breakdown with sub-issues.
+
+Exit criteria:
+
+- all 8 navigation components have agnostic core implementations
+- state machines (stateful components) match their spec §1 exactly
+- ConnectApi implementations produce correct ARIA attributes per spec §2
+- TreeView uses `TreeCollection` from ars-collections for hierarchical navigation
+- all public types documented per workspace `missing_docs` lint
+- all tests pass with zero warnings
+- spec and implementation remain aligned; any mismatch resolved in the same task
+
+External deps: TreeView depends on ars-collections TreeCollection (#83).
+
+Status (2026-04-10): Epic #223 created with 7 sub-issue tasks (#247–#267).
+
+### Phase 10: Agnostic selection components
+
+Scope:
+
+All 9 selection components defined in `spec/components/selection/`, implemented as framework-agnostic core (state machines, ConnectApi, Props/Api/Part types):
+
+**Stateful (2):** Autocomplete, SegmentGroup
+
+**Complex (7):** Combobox, ContextMenu, Listbox, Menu, MenuBar, Select, TagsInput
+
+Decomposed into 9 tasks (55 story points) organized in 4 dependency waves. See [Epic #221](https://github.com/fogodev/ars-ui/issues/221) for the full task breakdown with sub-issues.
+
+Exit criteria:
+
+- all 9 selection components have agnostic core implementations
+- state machines (stateful components) match their spec §1 exactly
+- ConnectApi implementations produce correct ARIA attributes per spec §2
+- collection-dependent components use `ars-collections` Collection trait for navigation and typeahead
+- selection patterns match `shared/selection-patterns.md`
+- all public types documented per workspace `missing_docs` lint
+- all tests pass with zero warnings
+- spec and implementation remain aligned; any mismatch resolved in the same task
+
+External deps: All except SegmentGroup depend on ars-collections (Epic #53).
+
+Status (2026-04-10): Epic #221 created with 9 sub-issue tasks (#232–#255).
+
+### Phase 11: Agnostic specialized components
+
+Scope:
+
+All 15 specialized components defined in `spec/components/specialized/`, implemented as framework-agnostic core (state machines, ConnectApi, Props/Api/Part types):
+
+**Stateless (3):** ColorSwatch, ContextualHelp, QrCode
+
+**Stateful (10):** AngleSlider, Clipboard, ColorArea, ColorField, ColorSlider, ColorSwatchPicker, ColorWheel, ImageCropper, SignaturePad, Timer
+
+**Complex (2):** ColorPicker, FileUpload
+
+Decomposed into 11 tasks (55 story points) organized in 4 dependency waves. See [Epic #227](https://github.com/fogodev/ars-ui/issues/227) for the full task breakdown with sub-issues.
+
+Exit criteria:
+
+- all 15 specialized components have agnostic core implementations
+- state machines (stateful components) match their spec §1 exactly
+- ConnectApi implementations produce correct ARIA attributes per spec §2
+- color components share `ColorValue` type; ColorPicker composes all color primitives
+- all public types documented per workspace `missing_docs` lint
+- all tests pass with zero warnings
+- spec and implementation remain aligned; any mismatch resolved in the same task
+
+External deps: FileUpload depends on DnD interactions (#159–#161).
+
+Status (2026-04-10): Epic #227 created with 11 sub-issue tasks (#288–#301).
+
+### Phase 12: Agnostic date-time components
+
+Scope:
+
+All 8 date-time components defined in `spec/components/date-time/`, implemented as framework-agnostic core (state machines, ConnectApi, Props/Api/Part types):
+
+**Stateful (5):** DateField, DateRangeField, DateRangePicker, RangeCalendar, TimeField
+
+**Complex (3):** Calendar, DatePicker, DateTimePicker
+
+Decomposed into 8 tasks (47 story points) organized in 4 dependency waves. See [Epic #224](https://github.com/fogodev/ars-ui/issues/224) for the full task breakdown with sub-issues.
+
+Exit criteria:
+
+- all 8 date-time components have agnostic core implementations
+- state machines (stateful components) match their spec §1 exactly
+- ConnectApi implementations produce correct ARIA attributes per spec §2
+- calendar correctly uses locale-aware first-day-of-week via WeekInfo
+- date validation respects per-calendar month/day bounds via IcuProvider
+- all public types documented per workspace `missing_docs` lint
+- all tests pass with zero warnings
+- spec and implementation remain aligned; any mismatch resolved in the same task
+
+External deps: All depend on ars-i18n (Epic #54) for CalendarDate, DateFormatter, WeekInfo. Date fields and pickers depend on ars-forms (Epic #5) for form integration.
+
+Status (2026-04-10): Epic #224 created with 8 sub-issue tasks (#262–#292).
 
 ## Spec synchronization rules
 


### PR DESCRIPTION
## Summary

- Create 8 new GitHub epics covering all remaining agnostic component categories (input, selection, overlay, navigation, date-time, data-display, layout, specialized)
- Decompose each epic into task sub-issues with dependency waves, story points, spec refs, and acceptance criteria — 74 sub-issues total (#228–#301)
- Update `docs/implementation/roadmap.md` with Phases 5–12 and expand the objective to cover all 111 components
- Update `docs/implementation/initial-backlog.md` with 8 new epic entries

| Epic | Category | Components | Tasks | Points |
|------|----------|-----------|-------|--------|
| #220 | Input | 14 | 12 | 48 |
| #221 | Selection | 9 | 9 | 55 |
| #222 | Overlay | 10 | 10 | 50 |
| #223 | Navigation | 8 | 7 | 33 |
| #224 | Date-Time | 8 | 8 | 47 |
| #225 | Data-Display | 11 | 9 | 40 |
| #226 | Layout | 11 | 8 | 31 |
| #227 | Specialized | 15 | 11 | 55 |
| **Total** | | **86** | **74** | **359** |

Combined with existing Epic #10 (utility, 26 components, 20 tasks, 64 pts), this brings the full agnostic component backlog to **112 components, 94 tasks, 423 story points**.

## Test plan

- [x] All 8 epics visible at `gh issue list --label epic`
- [x] Sub-issue counts verified per epic (12+9+10+7+8+9+8+11 = 74)
- [x] All sub-issues linked to parent epics via GitHub sub-issue API
- [x] `roadmap.md` Phases 5–12 reference correct epic and issue numbers
- [x] `initial-backlog.md` entries match epic point targets and issue ranges

🤖 Generated with [Claude Code](https://claude.com/claude-code)