### PR TITLE
docs: add 9 Dioxus adapter category epics with 94 sub-issues to roadmap

### DIFF
--- a/docs/implementation/initial-backlog.md
+++ b/docs/implementation/initial-backlog.md
@@ -78,13 +78,13 @@ Note: the original 3-task decomposition (#22, #55, #105) covered only the adapte
 
 ### Epic: Dioxus adapter
 
-- Point target: `24` (revised from `8` after full spec audit — 2026-04-10)
+- Point target: `292` (revised from `24` after full component adapter decomposition — 2026-04-11)
 - Layer: `Adapter`
 - Framework: `Dioxus`
 - Test tier: `Adapter`
-- Spec refs: `spec/foundation/09-adapter-dioxus.md`
+- Spec refs: `spec/foundation/09-adapter-dioxus.md`, `spec/dioxus-components/`
 
-Note: the original 3-task decomposition (#23, #56, #106) covered only ~40% of the foundational spec sections. A full spec audit (2026-04-10) found the same gaps as the Leptos adapter plus Dioxus-unique sections (DioxusPlatform, SSR Hydration, Error Boundary). Five additional tasks (#193–#197, 16 pts) now cover ArsProvider context, adapter utilities, platform abstraction, SSR hydration, and error boundaries. See [Epic #9](https://github.com/fogodev/ars-ui/issues/9) for the full decomposition.
+Note: the original 3-task decomposition (#23, #56, #106) covered only ~40% of the foundational spec sections. Five additional foundation tasks (#193–#197, 16 pts) close the remaining foundational gaps. Nine category epics (#407–#415, 268 pts) now cover all 112 Dioxus adapter components across 94 tasks organized by category. See [Epic #9](https://github.com/fogodev/ars-ui/issues/9) for the full sub-issue breakdown.
 
 ### Epic: Agnostic utility components
 
@@ -265,6 +265,96 @@ All 11 layout components (5 stateless, 6 stateful). Eight tasks in a single wave
 - Spec refs: `spec/leptos-components/specialized/_category.md`, `spec/leptos-components/specialized/*.md`, `spec/foundation/08-adapter-leptos.md`
 
 All 15 specialized components (3 stateless, 10 stateful, 2 complex). Eleven tasks organized in 4 dependency waves. External dep: FileUpload depends on DnD interactions (#159–#161). See [Epic #311](https://github.com/fogodev/ars-ui/issues/311) for the full sub-issue breakdown.
+
+### Epic: Dioxus utility adapter components
+
+- Point target: `44`
+- Layer: `Adapter`
+- Framework: `Dioxus`
+- Test tier: `Adapter`
+- Spec refs: `spec/dioxus-components/utility/_category.md`, `spec/dioxus-components/utility/*.md`, `spec/foundation/09-adapter-dioxus.md`
+
+All 26 utility components (17 stateless, 9 stateful). Twenty tasks organized in 5 dependency waves. See [Epic #407](https://github.com/fogodev/ars-ui/issues/407) for the full sub-issue breakdown.
+
+### Epic: Dioxus input adapter components
+
+- Point target: `34`
+- Layer: `Adapter`
+- Framework: `Dioxus`
+- Test tier: `Adapter`
+- Spec refs: `spec/dioxus-components/input/_category.md`, `spec/dioxus-components/input/*.md`, `spec/foundation/09-adapter-dioxus.md`
+
+All 14 input components (1 stateless, 11 stateful, 2 complex). Twelve tasks organized in 2 dependency waves. See [Epic #408](https://github.com/fogodev/ars-ui/issues/408) for the full sub-issue breakdown.
+
+### Epic: Dioxus selection adapter components
+
+- Point target: `34`
+- Layer: `Adapter`
+- Framework: `Dioxus`
+- Test tier: `Adapter`
+- Spec refs: `spec/dioxus-components/selection/_category.md`, `spec/dioxus-components/selection/*.md`, `spec/foundation/09-adapter-dioxus.md`
+
+All 9 selection components (2 stateful, 7 complex). Nine tasks organized in 4 dependency waves. See [Epic #409](https://github.com/fogodev/ars-ui/issues/409) for the full sub-issue breakdown.
+
+### Epic: Dioxus overlay adapter components
+
+- Point target: `29`
+- Layer: `Adapter`
+- Framework: `Dioxus`
+- Test tier: `Adapter`
+- Spec refs: `spec/dioxus-components/overlay/_category.md`, `spec/dioxus-components/overlay/*.md`, `spec/foundation/09-adapter-dioxus.md`
+
+All 10 overlay components (4 stateful, 6 complex). Ten tasks organized in 4 dependency waves. See [Epic #410](https://github.com/fogodev/ars-ui/issues/410) for the full sub-issue breakdown.
+
+### Epic: Dioxus navigation adapter components
+
+- Point target: `21`
+- Layer: `Adapter`
+- Framework: `Dioxus`
+- Test tier: `Adapter`
+- Spec refs: `spec/dioxus-components/navigation/_category.md`, `spec/dioxus-components/navigation/*.md`, `spec/foundation/09-adapter-dioxus.md`
+
+All 8 navigation components (1 stateless, 4 stateful, 3 complex). Seven tasks organized in 3 dependency waves. See [Epic #411](https://github.com/fogodev/ars-ui/issues/411) for the full sub-issue breakdown.
+
+### Epic: Dioxus date-time adapter components
+
+- Point target: `29`
+- Layer: `Adapter`
+- Framework: `Dioxus`
+- Test tier: `Adapter`
+- Spec refs: `spec/dioxus-components/date-time/_category.md`, `spec/dioxus-components/date-time/*.md`, `spec/foundation/09-adapter-dioxus.md`
+
+All 8 date-time components (5 stateful, 3 complex). Eight tasks organized in 4 dependency waves. External dep: all depend on ars-i18n (Epic #54). See [Epic #412](https://github.com/fogodev/ars-ui/issues/412) for the full sub-issue breakdown.
+
+### Epic: Dioxus data-display adapter components
+
+- Point target: `24`
+- Layer: `Adapter`
+- Framework: `Dioxus`
+- Test tier: `Adapter`
+- Spec refs: `spec/dioxus-components/data-display/_category.md`, `spec/dioxus-components/data-display/*.md`, `spec/foundation/09-adapter-dioxus.md`
+
+All 11 data-display components (4 stateless, 6 stateful, 1 complex). Nine tasks organized in 3 dependency waves. See [Epic #413](https://github.com/fogodev/ars-ui/issues/413) for the full sub-issue breakdown.
+
+### Epic: Dioxus layout adapter components
+
+- Point target: `21`
+- Layer: `Adapter`
+- Framework: `Dioxus`
+- Test tier: `Adapter`
+- Spec refs: `spec/dioxus-components/layout/_category.md`, `spec/dioxus-components/layout/*.md`, `spec/foundation/09-adapter-dioxus.md`
+
+All 11 layout components (5 stateless, 6 stateful). Eight tasks in a single wave — no intra-epic dependencies. See [Epic #414](https://github.com/fogodev/ars-ui/issues/414) for the full sub-issue breakdown.
+
+### Epic: Dioxus specialized adapter components
+
+- Point target: `32`
+- Layer: `Adapter`
+- Framework: `Dioxus`
+- Test tier: `Adapter`
+- Spec refs: `spec/dioxus-components/specialized/_category.md`, `spec/dioxus-components/specialized/*.md`, `spec/foundation/09-adapter-dioxus.md`
+
+All 15 specialized components (3 stateless, 10 stateful, 2 complex). Eleven tasks organized in 4 dependency waves. External dep: FileUpload depends on DnD interactions (#159–#161). See [Epic #415](https://github.com/fogodev/ars-ui/issues/415) for the full sub-issue breakdown.
 
 ### Epic: Spec synchronization
 

--- a/docs/implementation/roadmap.md
+++ b/docs/implementation/roadmap.md
@@ -10,6 +10,7 @@ Build `ars-ui` from a spec-only workspace into an implementation workspace with:
 - framework-agnostic test harnesses
 - the full agnostic component layer (112 components across 9 categories)
 - the Leptos adapter component layer (112 components across 9 categories)
+- the Dioxus adapter component layer (112 components across 9 categories)
 
 ## Phase Order
 
@@ -551,6 +552,234 @@ Exit criteria:
 External deps: All depend on ars-i18n (Epic #54) for CalendarDate, DateFormatter, WeekInfo. Date fields and pickers depend on ars-forms (Epic #5) for form integration.
 
 Status (2026-04-10): Epic #308 created with 8 sub-issue tasks as a sub-issue of Epic #8.
+
+### Phase 22: Dioxus utility adapter components
+
+Scope:
+
+All 26 utility components defined in `spec/dioxus-components/utility/`, implemented as Dioxus 0.7.x reactive component shells wiring the agnostic core machines to props, slots, context, event mapping, and SSR:
+
+**Stateless (17):** AsChild, ArsProvider, ClientOnly, Dismissable, DownloadTrigger, Field, Fieldset, FocusRing, Form, Group, Heading, Highlight, Keyboard, Landmark, Separator, VisuallyHidden, ZIndexAllocator
+
+**Stateful (9):** ActionGroup, Button, DropZone, FocusScope, LiveRegion, Swap, Toggle, ToggleButton, ToggleGroup
+
+Decomposed into 20 tasks (44 story points) organized in 5 dependency waves. See [Epic #407](https://github.com/fogodev/ars-ui/issues/407) for the full task breakdown with sub-issues.
+
+Exit criteria:
+
+- all 26 utility components have Dioxus adapter implementations
+- each adapter component matches its spec in `spec/dioxus-components/utility/`
+- props, events, context, and attr merge rules match the adapter spec contract
+- SSR produces hydration-stable markup
+- all public types documented per workspace `missing_docs` lint
+- all adapter tests pass with zero warnings
+- spec and implementation remain aligned; any mismatch resolved in the same task
+
+Status (2026-04-11): Epic #407 created with 20 sub-issue tasks as a sub-issue of Epic #9.
+
+### Phase 23: Dioxus layout adapter components
+
+Scope:
+
+All 11 layout components defined in `spec/dioxus-components/layout/`, implemented as Dioxus adapter shells:
+
+**Stateless (5):** AspectRatio, Center, Frame, Grid, Stack
+
+**Stateful (6):** Carousel, Collapsible, Portal, ScrollArea, Splitter, Toolbar
+
+Decomposed into 8 tasks (21 story points) in a single wave — no intra-epic dependencies. See [Epic #414](https://github.com/fogodev/ars-ui/issues/414) for the full task breakdown with sub-issues.
+
+Exit criteria:
+
+- all 11 layout components have Dioxus adapter implementations
+- each adapter component matches its spec in `spec/dioxus-components/layout/`
+- layout measurement and portal patterns match adapter spec
+- SSR produces hydration-stable markup
+- all public types documented per workspace `missing_docs` lint
+- all adapter tests pass with zero warnings
+- spec and implementation remain aligned; any mismatch resolved in the same task
+
+Status (2026-04-11): Epic #414 created with 8 sub-issue tasks as a sub-issue of Epic #9.
+
+### Phase 24: Dioxus input adapter components
+
+Scope:
+
+All 14 input components defined in `spec/dioxus-components/input/`, implemented as Dioxus adapter shells:
+
+**Stateless (1):** FileTrigger
+
+**Stateful (11):** Checkbox, CheckboxGroup, Editable, NumberInput, PasswordInput, PinInput, RadioGroup, SearchInput, Switch, TextField, Textarea
+
+**Complex (2):** Slider, RangeSlider
+
+Decomposed into 12 tasks (34 story points) organized in 2 dependency waves. See [Epic #408](https://github.com/fogodev/ars-ui/issues/408) for the full task breakdown with sub-issues.
+
+Exit criteria:
+
+- all 14 input components have Dioxus adapter implementations
+- each adapter component matches its spec in `spec/dioxus-components/input/`
+- form integration (hidden inputs, validation, field context) matches adapter spec
+- SSR produces hydration-stable markup
+- all public types documented per workspace `missing_docs` lint
+- all adapter tests pass with zero warnings
+- spec and implementation remain aligned; any mismatch resolved in the same task
+
+Status (2026-04-11): Epic #408 created with 12 sub-issue tasks as a sub-issue of Epic #9.
+
+### Phase 25: Dioxus data-display adapter components
+
+Scope:
+
+All 11 data-display components defined in `spec/dioxus-components/data-display/`, implemented as Dioxus adapter shells:
+
+**Stateless (4):** Badge, Meter, Skeleton, Stat
+
+**Stateful (6):** Avatar, GridList, Marquee, Progress, RatingGroup, TagGroup
+
+**Complex (1):** Table
+
+Decomposed into 9 tasks (24 story points) organized in 3 dependency waves. See [Epic #413](https://github.com/fogodev/ars-ui/issues/413) for the full task breakdown with sub-issues.
+
+Exit criteria:
+
+- all 11 data-display components have Dioxus adapter implementations
+- each adapter component matches its spec in `spec/dioxus-components/data-display/`
+- collection-dependent components use collection registration helpers
+- SSR produces hydration-stable markup
+- all public types documented per workspace `missing_docs` lint
+- all adapter tests pass with zero warnings
+- spec and implementation remain aligned; any mismatch resolved in the same task
+
+Status (2026-04-11): Epic #413 created with 9 sub-issue tasks as a sub-issue of Epic #9.
+
+### Phase 26: Dioxus overlay adapter components
+
+Scope:
+
+All 10 overlay components defined in `spec/dioxus-components/overlay/`, implemented as Dioxus adapter shells:
+
+**Stateful (4):** AlertDialog, Popover, Presence, Tooltip
+
+**Complex (6):** Dialog, Drawer, FloatingPanel, HoverCard, Toast, Tour
+
+Decomposed into 10 tasks (29 story points) organized in 4 dependency waves. See [Epic #410](https://github.com/fogodev/ars-ui/issues/410) for the full task breakdown with sub-issues.
+
+Exit criteria:
+
+- all 10 overlay components have Dioxus adapter implementations
+- each adapter component matches its spec in `spec/dioxus-components/overlay/`
+- portal, z-index, focus-scope, and dismissal patterns match adapter spec
+- SSR produces hydration-stable markup
+- all public types documented per workspace `missing_docs` lint
+- all adapter tests pass with zero warnings
+- spec and implementation remain aligned; any mismatch resolved in the same task
+
+Status (2026-04-11): Epic #410 created with 10 sub-issue tasks as a sub-issue of Epic #9.
+
+### Phase 27: Dioxus navigation adapter components
+
+Scope:
+
+All 8 navigation components defined in `spec/dioxus-components/navigation/`, implemented as Dioxus adapter shells:
+
+**Stateless (1):** Breadcrumbs
+
+**Stateful (4):** Accordion, Link, Pagination, Steps
+
+**Complex (3):** NavigationMenu, Tabs, TreeView
+
+Decomposed into 7 tasks (21 story points) organized in 3 dependency waves. See [Epic #411](https://github.com/fogodev/ars-ui/issues/411) for the full task breakdown with sub-issues.
+
+Exit criteria:
+
+- all 8 navigation components have Dioxus adapter implementations
+- each adapter component matches its spec in `spec/dioxus-components/navigation/`
+- roving focus and descendant registration match adapter spec
+- SSR produces hydration-stable markup
+- all public types documented per workspace `missing_docs` lint
+- all adapter tests pass with zero warnings
+- spec and implementation remain aligned; any mismatch resolved in the same task
+
+Status (2026-04-11): Epic #411 created with 7 sub-issue tasks as a sub-issue of Epic #9.
+
+### Phase 28: Dioxus selection adapter components
+
+Scope:
+
+All 9 selection components defined in `spec/dioxus-components/selection/`, implemented as Dioxus adapter shells:
+
+**Stateful (2):** Autocomplete, SegmentGroup
+
+**Complex (7):** Combobox, ContextMenu, Listbox, Menu, MenuBar, Select, TagsInput
+
+Decomposed into 9 tasks (34 story points) organized in 4 dependency waves. See [Epic #409](https://github.com/fogodev/ars-ui/issues/409) for the full task breakdown with sub-issues.
+
+Exit criteria:
+
+- all 9 selection components have Dioxus adapter implementations
+- each adapter component matches its spec in `spec/dioxus-components/selection/`
+- keyed item registration and typeahead bridging match adapter spec
+- SSR produces hydration-stable markup
+- all public types documented per workspace `missing_docs` lint
+- all adapter tests pass with zero warnings
+- spec and implementation remain aligned; any mismatch resolved in the same task
+
+Status (2026-04-11): Epic #409 created with 9 sub-issue tasks as a sub-issue of Epic #9.
+
+### Phase 29: Dioxus specialized adapter components
+
+Scope:
+
+All 15 specialized components defined in `spec/dioxus-components/specialized/`, implemented as Dioxus adapter shells:
+
+**Stateless (3):** ColorSwatch, ContextualHelp, QrCode
+
+**Stateful (10):** AngleSlider, Clipboard, ColorArea, ColorField, ColorSlider, ColorSwatchPicker, ColorWheel, ImageCropper, SignaturePad, Timer
+
+**Complex (2):** ColorPicker, FileUpload
+
+Decomposed into 11 tasks (32 story points) organized in 4 dependency waves. See [Epic #415](https://github.com/fogodev/ars-ui/issues/415) for the full task breakdown with sub-issues.
+
+Exit criteria:
+
+- all 15 specialized components have Dioxus adapter implementations
+- each adapter component matches its spec in `spec/dioxus-components/specialized/`
+- color components share ColorValue type; ColorPicker composes all color primitives
+- SSR produces hydration-stable markup
+- all public types documented per workspace `missing_docs` lint
+- all adapter tests pass with zero warnings
+- spec and implementation remain aligned; any mismatch resolved in the same task
+
+External deps: FileUpload depends on DnD interactions (#159–#161).
+
+Status (2026-04-11): Epic #415 created with 11 sub-issue tasks as a sub-issue of Epic #9.
+
+### Phase 30: Dioxus date-time adapter components
+
+Scope:
+
+All 8 date-time components defined in `spec/dioxus-components/date-time/`, implemented as Dioxus adapter shells:
+
+**Stateful (5):** DateField, DateRangeField, DateRangePicker, RangeCalendar, TimeField
+
+**Complex (3):** Calendar, DatePicker, DateTimePicker
+
+Decomposed into 8 tasks (29 story points) organized in 4 dependency waves. See [Epic #412](https://github.com/fogodev/ars-ui/issues/412) for the full task breakdown with sub-issues.
+
+Exit criteria:
+
+- all 8 date-time components have Dioxus adapter implementations
+- each adapter component matches its spec in `spec/dioxus-components/date-time/`
+- segmented fields and calendar grids match adapter spec
+- SSR produces hydration-stable markup
+- all public types documented per workspace `missing_docs` lint
+- all adapter tests pass with zero warnings
+- spec and implementation remain aligned; any mismatch resolved in the same task
+
+External deps: All depend on ars-i18n (Epic #54) for CalendarDate, DateFormatter, WeekInfo. Date fields and pickers depend on ars-forms (Epic #5) for form integration.
+
+Status (2026-04-11): Epic #412 created with 8 sub-issue tasks as a sub-issue of Epic #9.
 
 ## Spec synchronization rules
 


### PR DESCRIPTION
## Summary

- Add the complete Dioxus 0.7.x adapter component layer to the implementation roadmap, mirroring the Leptos adapter structure (#303–#311)
- 9 category epics (#407–#415) created as sub-issues of Epic #9, with 94 adapter tasks (#416–#509) organized in wave-based dependency order
- `roadmap.md` updated with Phases 22–30 (Dioxus adapter components); `initial-backlog.md` updated with 9 Dioxus category epic entries and Epic #9 point target revised from 24 → 292

Per-category breakdown:

| Epic | Category | Tasks | Points | Waves |
|---|---|---|---|---|
| #407 | Utility | 20 | 44 | 5 |
| #408 | Input | 12 | 34 | 2 |
| #409 | Selection | 9 | 34 | 4 |
| #410 | Overlay | 10 | 29 | 4 |
| #411 | Navigation | 7 | 21 | 3 |
| #412 | Date-Time | 8 | 29 | 4 |
| #413 | Data-Display | 9 | 24 | 3 |
| #414 | Layout | 8 | 21 | 1 |
| #415 | Specialized | 11 | 32 | 4 |
| **Total** | | **94** | **268** | |

## Test plan

- [x] Verified all 9 category epics are sub-issues of Epic #9 (17 total sub-issues)
- [x] Verified per-epic task counts match: 20+12+9+10+7+8+9+8+11 = 94
- [x] Verified all 94 tasks have `task` label, all 9 epics have `epic` label
- [x] Verified `roadmap.md` has 31 phases (0–30)
- [x] Verified `initial-backlog.md` has all 9 Dioxus category epic entries

Closes #406

🤖 Generated with [Claude Code](https://claude.com/claude-code)