### PR TITLE
Implement live announcer core and DOM bootstrap

### DIFF
--- a/crates/ars-a11y/src/announcer.rs
+++ b/crates/ars-a11y/src/announcer.rs
@@ -206,7 +206,10 @@ mod tests {
         announcer.announce_assertive("Critical alert");
 
         assert!(announcer.announcing);
-        assert_eq!(announcer.active_priority, Some(AnnouncementPriority::Assertive));
+        assert_eq!(
+            announcer.active_priority,
+            Some(AnnouncementPriority::Assertive)
+        );
         assert_eq!(announcer.last_message.as_deref(), Some("Critical alert"));
         assert!(announcer.queue.is_empty());
     }
@@ -252,7 +255,10 @@ mod tests {
         announcer.announce_assertive("Critical alert 1");
         announcer.announce_assertive("Critical alert 2");
 
-        assert_eq!(announcer.active_priority, Some(AnnouncementPriority::Assertive));
+        assert_eq!(
+            announcer.active_priority,
+            Some(AnnouncementPriority::Assertive)
+        );
         assert_eq!(announcer.last_message.as_deref(), Some("Critical alert 1"));
         assert_eq!(
             announcer.queue,
@@ -263,16 +269,16 @@ mod tests {
         );
 
         announcer.notify_announced();
-        assert_eq!(announcer.active_priority, Some(AnnouncementPriority::Assertive));
+        assert_eq!(
+            announcer.active_priority,
+            Some(AnnouncementPriority::Assertive)
+        );
         assert_eq!(announcer.last_message.as_deref(), Some("Critical alert 2"));
         assert!(announcer.queue.is_empty());
 
         announcer.notify_announced();
         assert_eq!(announcer.active_priority, None);
-        assert_eq!(
-            announcer.last_message.as_deref(),
-            Some("Critical alert 2")
-        );
+        assert_eq!(announcer.last_message.as_deref(), Some("Critical alert 2"));
     }
 
     #[test]
@@ -280,12 +286,18 @@ mod tests {
         let mut announcer = LiveAnnouncer::new();
 
         announcer.announce("Background update");
-        assert_eq!(announcer.active_priority, Some(AnnouncementPriority::Polite));
+        assert_eq!(
+            announcer.active_priority,
+            Some(AnnouncementPriority::Polite)
+        );
 
         announcer.announce_assertive("Critical alert");
 
         assert!(announcer.announcing);
-        assert_eq!(announcer.active_priority, Some(AnnouncementPriority::Assertive));
+        assert_eq!(
+            announcer.active_priority,
+            Some(AnnouncementPriority::Assertive)
+        );
         assert_eq!(announcer.last_message.as_deref(), Some("Critical alert"));
         assert!(announcer.queue.is_empty());
     }

--- a/crates/ars-a11y/src/announcer.rs
+++ b/crates/ars-a11y/src/announcer.rs
@@ -29,6 +29,8 @@ pub struct LiveAnnouncer {
     queue: Vec<Announcement>,
     /// Whether an announcement is currently being processed.
     announcing: bool,
+    /// Priority of the currently active announcement, if any.
+    active_priority: Option<AnnouncementPriority>,
     /// Toggle bit for `VoiceOver` deduplication workaround.
     voiceover_toggle: bool,
     /// Tracks the last announced message text.
@@ -44,6 +46,7 @@ impl LiveAnnouncer {
         Self {
             queue: Vec::new(),
             announcing: false,
+            active_priority: None,
             voiceover_toggle: false,
             last_message: None,
             clear_delay_ms: 7000,
@@ -78,6 +81,11 @@ impl LiveAnnouncer {
         if priority == AnnouncementPriority::Assertive {
             self.queue
                 .retain(|queued| queued.priority == AnnouncementPriority::Assertive);
+
+            if self.active_priority == Some(AnnouncementPriority::Polite) {
+                self.announcing = false;
+                self.active_priority = None;
+            }
         }
 
         self.queue.push(announcement);
@@ -99,19 +107,13 @@ impl LiveAnnouncer {
 
         let next = self.queue.remove(0);
         self.announcing = true;
+        self.active_priority = Some(next.priority);
 
-        let is_repeat = self.last_message.as_deref() == Some(next.message.as_str());
-        let content = if is_repeat && self.voiceover_toggle {
-            format!("{}\u{200D}", next.message)
-        } else {
-            next.message.clone()
-        };
-
-        if is_repeat {
-            self.voiceover_toggle = !self.voiceover_toggle;
-        } else {
-            self.voiceover_toggle = false;
-        }
+        let content = render_announcement_content(
+            next.message.as_str(),
+            self.last_message.as_deref(),
+            &mut self.voiceover_toggle,
+        );
 
         self.last_message = Some(next.message.clone());
 
@@ -121,6 +123,7 @@ impl LiveAnnouncer {
     /// Called by the ars-dom adapter after the live region update completes.
     pub fn notify_announced(&mut self) {
         self.announcing = false;
+        self.active_priority = None;
         self.process_queue();
     }
 
@@ -156,6 +159,26 @@ impl Default for LiveAnnouncer {
     }
 }
 
+fn render_announcement_content(
+    message: &str,
+    last_message: Option<&str>,
+    voiceover_toggle: &mut bool,
+) -> String {
+    let is_repeat = last_message == Some(message);
+
+    if is_repeat {
+        *voiceover_toggle = !*voiceover_toggle;
+        if *voiceover_toggle {
+            format!("{message}\u{200D}")
+        } else {
+            String::from(message)
+        }
+    } else {
+        *voiceover_toggle = false;
+        String::from(message)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use alloc::vec;
@@ -183,13 +206,9 @@ mod tests {
         announcer.announce_assertive("Critical alert");
 
         assert!(announcer.announcing);
-        assert_eq!(
-            announcer.queue,
-            vec![Announcement {
-                message: String::from("Critical alert"),
-                priority: AnnouncementPriority::Assertive,
-            }]
-        );
+        assert_eq!(announcer.active_priority, Some(AnnouncementPriority::Assertive));
+        assert_eq!(announcer.last_message.as_deref(), Some("Critical alert"));
+        assert!(announcer.queue.is_empty());
     }
 
     #[test]
@@ -233,32 +252,41 @@ mod tests {
         announcer.announce_assertive("Critical alert 1");
         announcer.announce_assertive("Critical alert 2");
 
-        assert_eq!(
-            announcer.queue,
-            vec![
-                Announcement {
-                    message: String::from("Critical alert 1"),
-                    priority: AnnouncementPriority::Assertive,
-                },
-                Announcement {
-                    message: String::from("Critical alert 2"),
-                    priority: AnnouncementPriority::Assertive,
-                },
-            ]
-        );
-
-        announcer.notify_announced();
+        assert_eq!(announcer.active_priority, Some(AnnouncementPriority::Assertive));
         assert_eq!(announcer.last_message.as_deref(), Some("Critical alert 1"));
         assert_eq!(
             announcer.queue,
             vec![Announcement {
                 message: String::from("Critical alert 2"),
                 priority: AnnouncementPriority::Assertive,
-            }]
+            },]
         );
 
         announcer.notify_announced();
+        assert_eq!(announcer.active_priority, Some(AnnouncementPriority::Assertive));
         assert_eq!(announcer.last_message.as_deref(), Some("Critical alert 2"));
+        assert!(announcer.queue.is_empty());
+
+        announcer.notify_announced();
+        assert_eq!(announcer.active_priority, None);
+        assert_eq!(
+            announcer.last_message.as_deref(),
+            Some("Critical alert 2")
+        );
+    }
+
+    #[test]
+    fn assertive_preempts_active_polite_announcement() {
+        let mut announcer = LiveAnnouncer::new();
+
+        announcer.announce("Background update");
+        assert_eq!(announcer.active_priority, Some(AnnouncementPriority::Polite));
+
+        announcer.announce_assertive("Critical alert");
+
+        assert!(announcer.announcing);
+        assert_eq!(announcer.active_priority, Some(AnnouncementPriority::Assertive));
+        assert_eq!(announcer.last_message.as_deref(), Some("Critical alert"));
         assert!(announcer.queue.is_empty());
     }
 
@@ -277,6 +305,19 @@ mod tests {
         announcer.announce("Test message");
 
         assert!(!announcer.voiceover_toggle);
+    }
+
+    #[test]
+    fn voiceover_dedup_marker_is_emitted_on_first_repeat() {
+        let mut toggle = false;
+
+        let first = render_announcement_content("Test message", None, &mut toggle);
+        let second = render_announcement_content("Test message", Some("Test message"), &mut toggle);
+        let third = render_announcement_content("Test message", Some("Test message"), &mut toggle);
+
+        assert_eq!(first, "Test message");
+        assert_eq!(second, "Test message\u{200D}");
+        assert_eq!(third, "Test message");
     }
 
     #[test]
@@ -343,6 +384,7 @@ mod tests {
         let announcer = LiveAnnouncer {
             queue: Vec::new(),
             announcing: false,
+            active_priority: None,
             voiceover_toggle: false,
             last_message: None,
             clear_delay_ms: 1200,
@@ -357,6 +399,7 @@ mod tests {
 
         assert_eq!(announcer.queue, Vec::<Announcement>::new());
         assert!(!announcer.announcing);
+        assert_eq!(announcer.active_priority, None);
         assert!(!announcer.voiceover_toggle);
         assert_eq!(announcer.last_message, None);
         assert_eq!(announcer.clear_delay_ms, 7000);

--- a/crates/ars-a11y/src/announcer.rs
+++ b/crates/ars-a11y/src/announcer.rs
@@ -1,0 +1,364 @@
+//! Screen-reader announcement queue and live-region attribute helpers.
+
+use alloc::{format, string::String, vec::Vec};
+
+use ars_core::{AriaAttr, AttrMap, HtmlAttr};
+
+/// Priority of a live announcement.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum AnnouncementPriority {
+    /// `aria-live="polite"` waits for the user to finish speaking before announcing.
+    Polite,
+    /// `aria-live="assertive"` interrupts the current speech immediately.
+    Assertive,
+}
+
+/// A pending announcement in the queue.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Announcement {
+    /// The text to announce.
+    pub message: String,
+    /// The urgency of the announcement.
+    pub priority: AnnouncementPriority,
+}
+
+/// Service for screen reader announcements, coordinated by the DOM adapter.
+#[derive(Debug)]
+pub struct LiveAnnouncer {
+    /// Queue of pending announcements.
+    queue: Vec<Announcement>,
+    /// Whether an announcement is currently being processed.
+    announcing: bool,
+    /// Toggle bit for `VoiceOver` deduplication workaround.
+    voiceover_toggle: bool,
+    /// Tracks the last announced message text.
+    last_message: Option<String>,
+    /// Delay before clearing the live region content (ms).
+    clear_delay_ms: u32,
+}
+
+impl LiveAnnouncer {
+    /// Create a new `LiveAnnouncer`. Call `ensure_dom()` in `ars-dom` before first use.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            queue: Vec::new(),
+            announcing: false,
+            voiceover_toggle: false,
+            last_message: None,
+            clear_delay_ms: 7000,
+        }
+    }
+
+    /// Announce a message with polite priority.
+    ///
+    /// The message will be announced when the user is idle.
+    pub fn announce(&mut self, message: impl Into<String>) {
+        self.announce_with_priority(message, AnnouncementPriority::Polite);
+    }
+
+    /// Announce a message with assertive priority.
+    ///
+    /// The message will interrupt current screen reader speech.
+    pub fn announce_assertive(&mut self, message: impl Into<String>) {
+        self.announce_with_priority(message, AnnouncementPriority::Assertive);
+    }
+
+    /// Announce with explicit priority.
+    pub fn announce_with_priority(
+        &mut self,
+        message: impl Into<String>,
+        priority: AnnouncementPriority,
+    ) {
+        let announcement = Announcement {
+            message: message.into(),
+            priority,
+        };
+
+        if priority == AnnouncementPriority::Assertive {
+            self.queue
+                .retain(|queued| queued.priority == AnnouncementPriority::Assertive);
+        }
+
+        self.queue.push(announcement);
+        self.process_queue();
+    }
+
+    /// Clear all pending announcements.
+    pub fn clear(&mut self) {
+        self.queue.clear();
+    }
+
+    fn process_queue(&mut self) {
+        if self.announcing || self.queue.is_empty() {
+            return;
+        }
+
+        self.queue
+            .sort_by_key(|announcement| core::cmp::Reverse(announcement.priority));
+
+        let next = self.queue.remove(0);
+        self.announcing = true;
+
+        let is_repeat = self.last_message.as_deref() == Some(next.message.as_str());
+        let content = if is_repeat && self.voiceover_toggle {
+            format!("{}\u{200D}", next.message)
+        } else {
+            next.message.clone()
+        };
+
+        if is_repeat {
+            self.voiceover_toggle = !self.voiceover_toggle;
+        } else {
+            self.voiceover_toggle = false;
+        }
+
+        self.last_message = Some(next.message.clone());
+
+        let _unused = (content, next.priority, self.clear_delay_ms);
+    }
+
+    /// Called by the ars-dom adapter after the live region update completes.
+    pub fn notify_announced(&mut self) {
+        self.announcing = false;
+        self.process_queue();
+    }
+
+    /// Returns `AttrMap` for the polite live region element.
+    #[must_use]
+    pub fn polite_region_attrs() -> AttrMap {
+        let mut attrs = AttrMap::new();
+        attrs.set(HtmlAttr::Id, "ars-live-polite");
+        attrs.set(HtmlAttr::Aria(AriaAttr::Live), "polite");
+        attrs.set(HtmlAttr::Aria(AriaAttr::Atomic), "true");
+        attrs.set(HtmlAttr::Data("ars-part"), "live-region");
+        attrs.set(HtmlAttr::Class, "ars-visually-hidden");
+        attrs
+    }
+
+    /// Returns `AttrMap` for the assertive live region element.
+    ///
+    /// Builds assertive attrs by extending the polite live-region structure and
+    /// overriding the `id`, `aria-live`, and `aria-relevant` values.
+    #[must_use]
+    pub fn assertive_region_attrs() -> AttrMap {
+        let mut attrs = Self::polite_region_attrs();
+        attrs.set(HtmlAttr::Id, "ars-live-assertive");
+        attrs.set(HtmlAttr::Aria(AriaAttr::Live), "assertive");
+        attrs.set(HtmlAttr::Aria(AriaAttr::Relevant), "additions text");
+        attrs
+    }
+}
+
+impl Default for LiveAnnouncer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+
+    use super::*;
+
+    #[test]
+    fn announce_defaults_to_polite_and_begins_processing() {
+        let mut announcer = LiveAnnouncer::new();
+
+        announcer.announce("Polite update");
+
+        assert!(announcer.announcing);
+        assert!(announcer.queue.is_empty());
+        assert_eq!(announcer.last_message.as_deref(), Some("Polite update"));
+        assert!(!announcer.voiceover_toggle);
+    }
+
+    #[test]
+    fn assertive_announcement_prunes_queued_polite_items() {
+        let mut announcer = LiveAnnouncer::new();
+
+        announcer.announce("Current polite");
+        announcer.announce("Queued polite");
+        announcer.announce_assertive("Critical alert");
+
+        assert!(announcer.announcing);
+        assert_eq!(
+            announcer.queue,
+            vec![Announcement {
+                message: String::from("Critical alert"),
+                priority: AnnouncementPriority::Assertive,
+            }]
+        );
+    }
+
+    #[test]
+    fn notify_announced_advances_the_queue() {
+        let mut announcer = LiveAnnouncer::new();
+
+        announcer.announce("First");
+        announcer.announce("Second");
+
+        announcer.notify_announced();
+
+        assert!(announcer.announcing);
+        assert!(announcer.queue.is_empty());
+        assert_eq!(announcer.last_message.as_deref(), Some("Second"));
+    }
+
+    #[test]
+    fn clear_removes_pending_announcements_without_breaking_future_use() {
+        let mut announcer = LiveAnnouncer::new();
+
+        announcer.announce("First");
+        announcer.announce("Queued");
+        announcer.clear();
+
+        assert!(announcer.queue.is_empty());
+        assert!(announcer.announcing);
+
+        announcer.notify_announced();
+        announcer.announce("After clear");
+
+        assert!(announcer.announcing);
+        assert_eq!(announcer.last_message.as_deref(), Some("After clear"));
+    }
+
+    #[test]
+    fn assertive_announcements_preserve_fifo_order_within_priority() {
+        let mut announcer = LiveAnnouncer::new();
+
+        announcer.announce("Current polite");
+        announcer.announce("Queued polite");
+        announcer.announce_assertive("Critical alert 1");
+        announcer.announce_assertive("Critical alert 2");
+
+        assert_eq!(
+            announcer.queue,
+            vec![
+                Announcement {
+                    message: String::from("Critical alert 1"),
+                    priority: AnnouncementPriority::Assertive,
+                },
+                Announcement {
+                    message: String::from("Critical alert 2"),
+                    priority: AnnouncementPriority::Assertive,
+                },
+            ]
+        );
+
+        announcer.notify_announced();
+        assert_eq!(announcer.last_message.as_deref(), Some("Critical alert 1"));
+        assert_eq!(
+            announcer.queue,
+            vec![Announcement {
+                message: String::from("Critical alert 2"),
+                priority: AnnouncementPriority::Assertive,
+            }]
+        );
+
+        announcer.notify_announced();
+        assert_eq!(announcer.last_message.as_deref(), Some("Critical alert 2"));
+        assert!(announcer.queue.is_empty());
+    }
+
+    #[test]
+    fn repeated_identical_messages_toggle_voiceover_deduplication_state() {
+        let mut announcer = LiveAnnouncer::new();
+
+        announcer.announce("Test message");
+        announcer.notify_announced();
+        announcer.announce("Test message");
+
+        assert!(announcer.voiceover_toggle);
+        assert_eq!(announcer.last_message.as_deref(), Some("Test message"));
+
+        announcer.notify_announced();
+        announcer.announce("Test message");
+
+        assert!(!announcer.voiceover_toggle);
+    }
+
+    #[test]
+    fn different_message_resets_voiceover_repeat_state() {
+        let mut announcer = LiveAnnouncer::new();
+
+        announcer.announce("Test message");
+        announcer.notify_announced();
+        announcer.announce("Test message");
+        assert!(announcer.voiceover_toggle);
+
+        announcer.notify_announced();
+        announcer.announce("Different message");
+
+        assert!(!announcer.voiceover_toggle);
+        assert_eq!(announcer.last_message.as_deref(), Some("Different message"));
+
+        announcer.notify_announced();
+        announcer.announce("Test message");
+
+        assert!(!announcer.voiceover_toggle);
+        assert_eq!(announcer.last_message.as_deref(), Some("Test message"));
+    }
+
+    #[test]
+    fn polite_region_attrs_match_spec() {
+        let attrs = LiveAnnouncer::polite_region_attrs();
+
+        assert_eq!(attrs.get(&HtmlAttr::Id), Some("ars-live-polite"));
+        assert_eq!(attrs.get(&HtmlAttr::Aria(AriaAttr::Live)), Some("polite"));
+        assert_eq!(attrs.get(&HtmlAttr::Aria(AriaAttr::Atomic)), Some("true"));
+        assert_eq!(attrs.get(&HtmlAttr::Data("ars-part")), Some("live-region"));
+        assert_eq!(attrs.get(&HtmlAttr::Class), Some("ars-visually-hidden"));
+        assert_eq!(attrs.get(&HtmlAttr::Aria(AriaAttr::Relevant)), None);
+    }
+
+    #[test]
+    fn assertive_region_attrs_match_spec() {
+        let attrs = LiveAnnouncer::assertive_region_attrs();
+
+        assert_eq!(attrs.get(&HtmlAttr::Id), Some("ars-live-assertive"));
+        assert_eq!(
+            attrs.get(&HtmlAttr::Aria(AriaAttr::Live)),
+            Some("assertive")
+        );
+        assert_eq!(attrs.get(&HtmlAttr::Aria(AriaAttr::Atomic)), Some("true"));
+        assert_eq!(
+            attrs.get(&HtmlAttr::Aria(AriaAttr::Relevant)),
+            Some("additions text")
+        );
+        assert_eq!(attrs.get(&HtmlAttr::Data("ars-part")), Some("live-region"));
+        assert_eq!(attrs.get(&HtmlAttr::Class), Some("ars-visually-hidden"));
+    }
+
+    #[test]
+    fn clear_delay_defaults_to_seven_seconds() {
+        let announcer = LiveAnnouncer::new();
+
+        assert_eq!(announcer.clear_delay_ms, 7000);
+    }
+
+    #[test]
+    fn clear_delay_can_be_overridden_in_module_construction() {
+        let announcer = LiveAnnouncer {
+            queue: Vec::new(),
+            announcing: false,
+            voiceover_toggle: false,
+            last_message: None,
+            clear_delay_ms: 1200,
+        };
+
+        assert_eq!(announcer.clear_delay_ms, 1200);
+    }
+
+    #[test]
+    fn default_matches_new() {
+        let announcer = LiveAnnouncer::default();
+
+        assert_eq!(announcer.queue, Vec::<Announcement>::new());
+        assert!(!announcer.announcing);
+        assert!(!announcer.voiceover_toggle);
+        assert_eq!(announcer.last_message, None);
+        assert_eq!(announcer.clear_delay_ms, 7000);
+    }
+}

--- a/crates/ars-a11y/src/lib.rs
+++ b/crates/ars-a11y/src/lib.rs
@@ -11,10 +11,12 @@ extern crate alloc;
 
 use alloc::{format, string::String};
 
+pub mod announcer;
 pub mod aria;
 /// Shared focus management contracts consumed by DOM and adapter layers.
 pub mod focus;
 
+pub use announcer::{Announcement, AnnouncementPriority, LiveAnnouncer};
 #[cfg(feature = "aria-drag-drop-compat")]
 pub use aria::attribute::AriaDropeffect;
 pub use aria::{

--- a/crates/ars-dom/src/announcer.rs
+++ b/crates/ars-dom/src/announcer.rs
@@ -1,0 +1,207 @@
+//! DOM bootstrap for shared live-region announcer nodes.
+
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
+use ars_a11y::LiveAnnouncer;
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
+use ars_core::{AttrMap, AttrValue, HtmlAttr};
+
+/// Ensure the shared live-region DOM nodes exist.
+#[cfg(feature = "web")]
+pub fn ensure_dom() {
+    ensure_dom_impl();
+}
+
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
+fn ensure_dom_impl() {
+    let Some(document) = document() else {
+        return;
+    };
+    let Some(body) = document.body() else {
+        return;
+    };
+
+    ensure_region(
+        &document,
+        body.as_ref(),
+        &LiveAnnouncer::polite_region_attrs(),
+    );
+    ensure_region(
+        &document,
+        body.as_ref(),
+        &LiveAnnouncer::assertive_region_attrs(),
+    );
+}
+
+#[cfg(all(feature = "web", not(target_arch = "wasm32")))]
+fn ensure_dom_impl() {}
+
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
+fn document() -> Option<web_sys::Document> {
+    web_sys::window().and_then(|window| window.document())
+}
+
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
+fn ensure_region(document: &web_sys::Document, parent: &web_sys::Element, attrs: &AttrMap) {
+    let id = attrs
+        .get(&HtmlAttr::Id)
+        .expect("live region attrs must include an id");
+
+    let element = if let Some(existing) = document.get_element_by_id(id) {
+        existing
+    } else {
+        let created = document
+            .create_element("div")
+            .expect("live region creation must succeed");
+        parent
+            .append_child(&created)
+            .expect("live region append must succeed");
+        created
+    };
+
+    apply_attr_map(&element, attrs);
+}
+
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
+fn apply_attr_map(element: &web_sys::Element, attrs: &AttrMap) {
+    for (attr, value) in attrs.attrs() {
+        apply_attr_value(element, *attr, value);
+    }
+}
+
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
+fn apply_attr_value(element: &web_sys::Element, attr: HtmlAttr, value: &AttrValue) {
+    match value {
+        AttrValue::String(value) => {
+            let result = element.set_attribute(&attr.to_string(), value);
+            debug_assert!(
+                result.is_ok(),
+                "live region attribute assignment must succeed"
+            );
+        }
+        AttrValue::Bool(true) => {
+            let result = element.set_attribute(&attr.to_string(), "");
+            debug_assert!(
+                result.is_ok(),
+                "live region boolean attribute assignment must succeed"
+            );
+        }
+        AttrValue::Bool(false) | AttrValue::None => {
+            let result = element.remove_attribute(&attr.to_string());
+            debug_assert!(result.is_ok(), "live region attribute removal must succeed");
+        }
+    }
+}
+
+#[cfg(all(test, feature = "web", not(target_arch = "wasm32")))]
+mod host_tests {
+    use super::*;
+
+    #[test]
+    fn ensure_dom_is_host_safe_and_idempotent() {
+        ensure_dom();
+        ensure_dom();
+    }
+}
+
+#[cfg(all(test, feature = "web", target_arch = "wasm32"))]
+mod wasm_tests {
+    use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+
+    use super::*;
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    fn document() -> web_sys::Document {
+        super::document().expect("document must exist")
+    }
+
+    fn remove_live_regions() {
+        if let Some(region) = document().get_element_by_id("ars-live-polite") {
+            region.remove();
+        }
+        if let Some(region) = document().get_element_by_id("ars-live-assertive") {
+            region.remove();
+        }
+    }
+
+    fn region(id: &str) -> web_sys::Element {
+        document()
+            .get_element_by_id(id)
+            .unwrap_or_else(|| panic!("missing region {id}"))
+    }
+
+    #[wasm_bindgen_test]
+    fn ensure_dom_creates_both_live_regions_under_body() {
+        remove_live_regions();
+
+        ensure_dom();
+
+        let polite = region("ars-live-polite");
+        let assertive = region("ars-live-assertive");
+        let body = document().body().expect("body must exist");
+
+        assert!(body.contains(Some(polite.as_ref())));
+        assert!(body.contains(Some(assertive.as_ref())));
+
+        remove_live_regions();
+    }
+
+    #[wasm_bindgen_test]
+    fn ensure_dom_creates_regions_with_expected_attributes() {
+        remove_live_regions();
+
+        ensure_dom();
+
+        let polite = region("ars-live-polite");
+        let assertive = region("ars-live-assertive");
+
+        assert_eq!(polite.get_attribute("aria-live").as_deref(), Some("polite"));
+        assert_eq!(polite.get_attribute("aria-atomic").as_deref(), Some("true"));
+        assert_eq!(
+            polite.get_attribute("data-ars-part").as_deref(),
+            Some("live-region")
+        );
+        assert_eq!(
+            polite.get_attribute("class").as_deref(),
+            Some("ars-visually-hidden")
+        );
+
+        assert_eq!(
+            assertive.get_attribute("aria-live").as_deref(),
+            Some("assertive")
+        );
+        assert_eq!(
+            assertive.get_attribute("aria-atomic").as_deref(),
+            Some("true")
+        );
+        assert_eq!(
+            assertive.get_attribute("aria-relevant").as_deref(),
+            Some("additions text")
+        );
+        assert_eq!(
+            assertive.get_attribute("data-ars-part").as_deref(),
+            Some("live-region")
+        );
+        assert_eq!(
+            assertive.get_attribute("class").as_deref(),
+            Some("ars-visually-hidden")
+        );
+
+        remove_live_regions();
+    }
+
+    #[wasm_bindgen_test]
+    fn ensure_dom_is_idempotent() {
+        remove_live_regions();
+
+        ensure_dom();
+        ensure_dom();
+
+        let regions = document()
+            .query_selector_all("#ars-live-polite, #ars-live-assertive")
+            .expect("selector must be valid");
+        assert_eq!(regions.length(), 2);
+
+        remove_live_regions();
+    }
+}

--- a/crates/ars-dom/src/lib.rs
+++ b/crates/ars-dom/src/lib.rs
@@ -13,6 +13,7 @@
     reason = "cfg-gated web impls prevent const fn"
 )]
 
+mod announcer;
 mod focus;
 pub mod modality;
 pub mod portal;
@@ -21,6 +22,8 @@ mod scroll;
 pub mod scroll_lock;
 pub mod z_index;
 
+#[cfg(feature = "web")]
+pub use announcer::ensure_dom;
 pub use focus::{
     FocusScope, FocusedElement, focus_body, focus_element_by_id, focus_first_tabbable,
 };

--- a/docs/implementation/foundation-completion-roadmap.md
+++ b/docs/implementation/foundation-completion-roadmap.md
@@ -10,18 +10,18 @@ The project needs a fully stable foundation before component work starts. Compon
 
 ### What is built (357 tests passing)
 
-| Crate              | LOC   | Status   | Key surface                                                                                                                                                                                                                                                                                                                                                                           |
-| ------------------ | ----- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ars-core`         | 4,306 | Solid    | Machine, Service, TransitionPlan, PendingEffect, Bindable, ConnectApi, ComponentPart, AttrMap/AttrValue/UserAttrs, StyleStrategy, Callback, WeakSend, PlatformEffects, Provider (ColorMode), companion CSS                                                                                                                                                                            |
-| `ars-derive`       | 535   | Complete | HasId, ComponentPart proc macros with error tests                                                                                                                                                                                                                                                                                                                                     |
-| `ars-a11y`         | 2,271 | Partial  | AriaRole, AriaAttribute, ComponentIds, ARIA state helpers, FocusScopeBehavior, FocusStrategy, FocusRing. Missing: FocusZone, DomEvent/KeyboardShortcut/Platform, VisuallyHidden, LabelConfig/FieldContext, Announcements, Touch/Mobile, AriaValidator, test helpers                                                                                                                   |
-| `ars-forms`        | 4,128 | Partial  | field::State/Value/Context/Descriptors/InputAria, validation::Error/Validator/AsyncValidator, form::Context/Data/Mode, hidden_input, form_submit machine. Missing: built-in validators, ValidatorsBuilder, FormMessages, DebouncedAsyncValidator, Fieldset/Field/Form machines                                                                                                        |
-| `ars-interactions` | 3,107 | Partial  | Press, Hover, Focus, FocusWithin, InteractOutside, Dismissable, compose::merge_attrs, LogicalDirection. Missing: LongPress, Move, DnD, Keyboard types                                                                                                                                                                                                                                 |
-| `ars-dom`          | 5,880 | Partial  | FocusScope, focus queries, ScrollLockManager, positioning engine (types + compute_position + overflow + VirtualElement), z-index allocator, scroll_into_view, modality manager. Missing: viewport/visualViewport, containing-block detection, auto_update, portal/inert, overlay stack, media queries, URL sanitization, ModalityManager listeners                                    |
-| `ars-leptos`       | 1,195 | Partial  | use_machine, UseMachineReturn, EphemeralRef, use_id, attr_map_to_leptos, use_style_strategy, AdapterCapabilities. Missing: ArsProvider context (#190), reactive props (#190), controlled value helper (#190), emit/emit_map (#191), event mapping (#191), nonce CSS collector (#191), safe event listeners (#191)                                                                     |
-| `ars-dioxus`       | 762   | Partial  | use_machine, UseMachineReturn, EphemeralRef, use_id, attr_map_to_dioxus, use_style_strategy, AdapterCapabilities. Missing: ArsProvider context (#193), reactive props (#193), controlled value helper (#193), emit/emit_map (#194), event mapping (#194), nonce CSS collector (#194), safe event listeners (#194), DioxusPlatform (#195), SSR hydration (#196), error boundary (#197) |
-| `ars-collections`  | 28    | Stub     | Selection\<T\> only                                                                                                                                                                                                                                                                                                                                                                   |
-| `ars-i18n`         | 1,928 | Partial  | Locale (ICU4X-backed), Direction, Orientation, NumberFormatter, CurrencyCode, BiDi isolation, Weekday, IcuProvider trait (stub), placeholder date/time types                                                                                                                                                                                                                          |
+| Crate              | LOC   | Status   | Key surface                                                                                                                                                                                                                                                                                                                                                                                                                |
+| ------------------ | ----- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ars-core`         | 4,306 | Solid    | Machine, Service, TransitionPlan, PendingEffect, Bindable, ConnectApi, ComponentPart, AttrMap/AttrValue/UserAttrs, StyleStrategy, Callback, WeakSend, PlatformEffects, Provider (ColorMode), companion CSS                                                                                                                                                                                                                 |
+| `ars-derive`       | 535   | Complete | HasId, ComponentPart proc macros with error tests                                                                                                                                                                                                                                                                                                                                                                          |
+| `ars-a11y`         | 2,271 | Partial  | AriaRole, AriaAttribute, ComponentIds, ARIA state helpers, FocusScopeBehavior, FocusStrategy, FocusRing. Missing: FocusZone, DomEvent/KeyboardShortcut/Platform, VisuallyHidden, LabelConfig/FieldContext, Announcements, Touch/Mobile, AriaValidator, test helpers                                                                                                                                                        |
+| `ars-forms`        | 4,128 | Partial  | field::State/Value/Context/Descriptors/InputAria, validation::Error/Validator/AsyncValidator, form::Context/Data/Mode, hidden_input, form_submit machine. Missing: built-in validators, ValidatorsBuilder, FormMessages, DebouncedAsyncValidator, Fieldset/Field/Form machines                                                                                                                                             |
+| `ars-interactions` | 3,107 | Partial  | Press, Hover, Focus, FocusWithin, InteractOutside, Dismissable, compose::merge_attrs, LogicalDirection. Missing: LongPress, Move, DnD, Keyboard types                                                                                                                                                                                                                                                                      |
+| `ars-dom`          | 5,880 | Partial  | FocusScope, focus queries, ScrollLockManager, positioning engine (types + compute_position + overflow + VirtualElement), z-index allocator, scroll_into_view, modality manager. Missing: viewport/visualViewport, containing-block detection, auto_update, portal/inert, overlay stack, media queries, URL sanitization, ModalityManager listeners                                                                         |
+| `ars-leptos`       | 1,195 | Partial  | use_machine, UseMachineReturn, EphemeralRef, use_id, attr_map_to_leptos, use_style_strategy, AdapterCapabilities. Missing: ArsProvider context (#190), reactive props (#190), controlled value helper (#190), emit/emit_map (#191), event mapping (#191), nonce CSS collector (#191), safe event listeners (#191), LiveAnnouncer context bridge (#513)                                                                     |
+| `ars-dioxus`       | 762   | Partial  | use_machine, UseMachineReturn, EphemeralRef, use_id, attr_map_to_dioxus, use_style_strategy, AdapterCapabilities. Missing: ArsProvider context (#193), reactive props (#193), controlled value helper (#193), emit/emit_map (#194), event mapping (#194), nonce CSS collector (#194), safe event listeners (#194), LiveAnnouncer context bridge (#512), DioxusPlatform (#195), SSR hydration (#196), error boundary (#197) |
+| `ars-collections`  | 28    | Stub     | Selection\<T\> only                                                                                                                                                                                                                                                                                                                                                                                                        |
+| `ars-i18n`         | 1,928 | Partial  | Locale (ICU4X-backed), Direction, Orientation, NumberFormatter, CurrencyCode, BiDi isolation, Weekday, IcuProvider trait (stub), placeholder date/time types                                                                                                                                                                                                                                                               |
 
 ### Architecture spec (01-architecture.md) completion — 2026-04-10 audit
 
@@ -38,16 +38,16 @@ Issues #145 and #146 are trivial and unblocked. #147 is self-contained. #148 dep
 
 ### Foundation gap matrix
 
-| Foundation area    | Spec file                    | Spec coverage            | Implementation % | Blocking impact                                                                                                                                                                                                                   |
-| ------------------ | ---------------------------- | ------------------------ | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Architecture core  | `01-architecture.md`         | ~5000 lines, 10 sections | 95%              | 4 remaining gaps tracked above; core contract is stable                                                                                                                                                                           |
-| Interactions       | `05-interactions.md`         | ~4000 lines, 12 sections | 60%              | 8 tasks closed; 6 open (#76, #77, #159–#162). Blocks Slider, DnD components, custom keyboard handlers                                                                                                                             |
-| Collections        | `06-collections.md`          | ~400 lines, 6 sections   | 10%              | Blocks all list-based components                                                                                                                                                                                                  |
-| I18n               | `04-internationalization.md` | ~4000 lines, 16 sections | 25%              | Blocks number/date components, RTL. Locale + NumberFormatter done; 16 tasks remaining (48 pts ICU4X + web-intl parity)                                                                                                            |
-| DOM utilities      | `11-dom-utilities.md`        | ~2800 lines, 10 sections | 50%              | 8 tasks closed; 8 open (#69, #72, #85, #88, #112–#114, #176). Blocks all overlay components                                                                                                                                       |
-| Accessibility      | `03-accessibility.md`        | ~4000 lines, 14 sections | 30%              | FocusZone, keyboard shortcuts, VisuallyHidden, FieldContext, announcements, touch/mobile, testing infra all missing                                                                                                               |
-| Forms              | `07-forms.md`                | ~4300 lines, 15 sections | 50%              | 3 tasks closed; 8 open (#164–#171, 26 pts). Blocks Field, Fieldset, Form components and validator builder API                                                                                                                     |
-| Adapter conversion | `08/09-adapter-*.md` §4/§3   | ~200 lines               | 40%              | AttrMap conversion done (#55/#56). Leptos: ArsProvider (#190), utilities (#191). Dioxus: ArsProvider (#193), utilities (#194), DioxusPlatform (#195), SSR hydration (#196), error boundary (#197). Blocks ALL component rendering |
+| Foundation area    | Spec file                    | Spec coverage            | Implementation % | Blocking impact                                                                                                                                                                                                                                                                             |
+| ------------------ | ---------------------------- | ------------------------ | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Architecture core  | `01-architecture.md`         | ~5000 lines, 10 sections | 95%              | 4 remaining gaps tracked above; core contract is stable                                                                                                                                                                                                                                     |
+| Interactions       | `05-interactions.md`         | ~4000 lines, 12 sections | 60%              | 8 tasks closed; 6 open (#76, #77, #159–#162). Blocks Slider, DnD components, custom keyboard handlers                                                                                                                                                                                       |
+| Collections        | `06-collections.md`          | ~400 lines, 6 sections   | 10%              | Blocks all list-based components                                                                                                                                                                                                                                                            |
+| I18n               | `04-internationalization.md` | ~4000 lines, 16 sections | 25%              | Blocks number/date components, RTL. Locale + NumberFormatter done; 16 tasks remaining (48 pts ICU4X + web-intl parity)                                                                                                                                                                      |
+| DOM utilities      | `11-dom-utilities.md`        | ~2800 lines, 10 sections | 50%              | 8 tasks closed; 8 open (#69, #72, #85, #88, #112–#114, #176). Blocks all overlay components                                                                                                                                                                                                 |
+| Accessibility      | `03-accessibility.md`        | ~4000 lines, 14 sections | 30%              | FocusZone, keyboard shortcuts, VisuallyHidden, FieldContext, announcements, touch/mobile, testing infra all missing                                                                                                                                                                         |
+| Forms              | `07-forms.md`                | ~4300 lines, 15 sections | 50%              | 3 tasks closed; 8 open (#164–#171, 26 pts). Blocks Field, Fieldset, Form components and validator builder API                                                                                                                                                                               |
+| Adapter conversion | `08/09-adapter-*.md` §4/§3   | ~200 lines               | 40%              | AttrMap conversion done (#55/#56). Leptos: ArsProvider (#190), utilities (#191), LiveAnnouncer bridge (#513). Dioxus: ArsProvider (#193), utilities (#194), LiveAnnouncer bridge (#512), DioxusPlatform (#195), SSR hydration (#196), error boundary (#197). Blocks ALL component rendering |
 
 ## Task Waves
 
@@ -1440,8 +1440,8 @@ Wave 5 (13 pts)            ┌─── Wave 4 i18n tasks available
 | ------------------- | ----- | -------------------------------------------------------------------- |
 | Interactions        | #4    | #57, #58, #59, #60, #61, #65, #76, #77, #90, #159, #160, #161, #162  |
 | DOM utilities       | #6    | #66, #67, #68, #69, #72, #74, #85, #88, #112, #113, #114, #115, #176 |
-| Leptos adapter      | #8    | #55, #105, #190, #191                                                |
-| Dioxus adapter      | #9    | #56, #106, #193, #194, #195, #196, #197                              |
+| Leptos adapter      | #8    | #55, #105, #190, #191, #513                                          |
+| Dioxus adapter      | #9    | #56, #106, #193, #194, #195, #196, #197, #512                        |
 | A11y                | #3    | #73, #89, #150, #151, #152, #153, #154, #155, #156, #157             |
 | Collections         | #53   | #62, #63, #64, #70, #71, #81, #82, #83, #84                          |
 | I18n                | #54   | #75, #79, #80, #124, #125, #126                                      |
@@ -1569,12 +1569,14 @@ pipeline and do not reopen the full `#24` planning thread.
 
 These cards complete the remaining foundational infrastructure in `ars-leptos` that every
 component will depend on. They were identified by an audit of `spec/foundation/08-adapter-leptos.md`
-against the 3 original Epic #8 tasks (2026-04-10).
+against the 3 original Epic #8 tasks (2026-04-10), plus the adapter-owned live announcer
+follow-up discovered while implementing `#73` (2026-04-11).
 
-| GitHub                                               | Title                                                                                     | Points | Epic | Deps |
-| ---------------------------------------------------- | ----------------------------------------------------------------------------------------- | ------ | ---- | ---- |
-| [#190](https://github.com/fogodev/ars-ui/issues/190) | Implement ArsProvider context, reactive props, and controlled value helper in ars-leptos  | 5      | #8   | —    |
-| [#191](https://github.com/fogodev/ars-ui/issues/191) | Implement Leptos adapter utilities — emit, event mapping, nonce collector, safe listeners | 3      | #8   | #190 |
+| GitHub                                               | Title                                                                                     | Points | Epic | Deps      |
+| ---------------------------------------------------- | ----------------------------------------------------------------------------------------- | ------ | ---- | --------- |
+| [#190](https://github.com/fogodev/ars-ui/issues/190) | Implement ArsProvider context, reactive props, and controlled value helper in ars-leptos  | 5      | #8   | —         |
+| [#191](https://github.com/fogodev/ars-ui/issues/191) | Implement Leptos adapter utilities — emit, event mapping, nonce collector, safe listeners | 3      | #8   | #190      |
+| [#513](https://github.com/fogodev/ars-ui/issues/513) | Implement LiveAnnouncer context bridge in ars-leptos                                      | 2      | #8   | #190, #73 |
 
 #### PF-LA-1: Implement ArsProvider context, reactive props, and controlled value helper in ars-leptos
 
@@ -1633,19 +1635,44 @@ against the 3 original Epic #8 tasks (2026-04-10).
   - `use_safe_event_listener()` with weak-guard, idempotent cleanup, and two-phase lifecycle.
 - Spec impact: `No spec change required`.
 
+#### PF-LA-3: Implement LiveAnnouncer context bridge in ars-leptos
+
+- Points: `2`
+- Layer: `Adapter`
+- Framework: `Leptos`
+- Test tier: `Unit`
+- Depends on: #190, #73
+- Spec refs:
+  - `spec/foundation/03-accessibility.md` §5.1 "LiveAnnouncer"
+  - `spec/foundation/11-dom-utilities.md` announcement helpers
+  - `spec/foundation/08-adapter-leptos.md` §13 "ArsProvider Context"
+- Goal: make announcement ownership adapter-provided rather than global by publishing a shared `Rc<RefCell<ars_a11y::LiveAnnouncer>>` through Leptos context and wiring adapter announcement delivery to that instance.
+- Files to create/modify: `crates/ars-leptos/src/provider.rs` or equivalent adapter context module, any Leptos-side announcement bridge needed to satisfy the spec without globals, related spec text if the cross-crate contract needs clarification
+- Tests to add first:
+  - Unit test that a provided `LiveAnnouncer` context is discoverable from the Leptos adapter surface.
+  - Unit test that missing provider state degrades gracefully without global fallback.
+  - Unit test that repeated announcements reuse the same provided announcer instance instead of hidden singleton state.
+- Acceptance criteria:
+  - The Leptos adapter owns announcer provisioning via context.
+  - No process-global or thread-local singleton is used for announcements.
+  - Runtime announcement flow uses the shared `ars_a11y::LiveAnnouncer` instance rather than duplicating queue state in `ars-dom`.
+  - Any required spec clarification is updated in the same task.
+- Spec impact: `Update shared adapter/DOM wording if the announcement contract needs clarification`.
+
 ### Targeted Follow-On: Dioxus Adapter Foundation Completion
 
-These tasks close the foundation gaps in the Dioxus adapter (Epic #9). The first two
-are symmetric with Leptos #190/#191; the remaining three cover Dioxus-unique sections
+These tasks close the foundation gaps in the Dioxus adapter (Epic #9). The first three
+are symmetric with Leptos #190/#191/#513; the remaining three cover Dioxus-unique sections
 (multi-platform, SSR hydration, error boundary). All are sub-issues of Epic #9.
 
-| GitHub                                               | Title                                                                           | Points | Epic | Deps |
-| ---------------------------------------------------- | ------------------------------------------------------------------------------- | ------ | ---- | ---- |
-| [#193](https://github.com/fogodev/ars-ui/issues/193) | ArsProvider context, reactive props, controlled value helper in ars-dioxus      | 5      | #9   | —    |
-| [#194](https://github.com/fogodev/ars-ui/issues/194) | Dioxus adapter utilities — emit, event mapping, nonce collector, safe listeners | 3      | #9   | #193 |
-| [#195](https://github.com/fogodev/ars-ui/issues/195) | DioxusPlatform trait, platform implementations, use_platform() hook             | 3      | #9   | #193 |
-| [#196](https://github.com/fogodev/ars-ui/issues/196) | SSR Hydration support in ars-dioxus                                             | 3      | #9   | #193 |
-| [#197](https://github.com/fogodev/ars-ui/issues/197) | ArsErrorBoundary component in ars-dioxus                                        | 2      | #9   | —    |
+| GitHub                                               | Title                                                                           | Points | Epic | Deps      |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------- | ------ | ---- | --------- |
+| [#193](https://github.com/fogodev/ars-ui/issues/193) | ArsProvider context, reactive props, controlled value helper in ars-dioxus      | 5      | #9   | —         |
+| [#194](https://github.com/fogodev/ars-ui/issues/194) | Dioxus adapter utilities — emit, event mapping, nonce collector, safe listeners | 3      | #9   | #193      |
+| [#512](https://github.com/fogodev/ars-ui/issues/512) | Implement LiveAnnouncer context bridge in ars-dioxus                            | 2      | #9   | #193, #73 |
+| [#195](https://github.com/fogodev/ars-ui/issues/195) | DioxusPlatform trait, platform implementations, use_platform() hook             | 3      | #9   | #193      |
+| [#196](https://github.com/fogodev/ars-ui/issues/196) | SSR Hydration support in ars-dioxus                                             | 3      | #9   | #193      |
+| [#197](https://github.com/fogodev/ars-ui/issues/197) | ArsErrorBoundary component in ars-dioxus                                        | 2      | #9   | —         |
 
 #### PF-DA-1: Implement ArsProvider context, reactive props, and controlled value helper in ars-dioxus
 
@@ -1703,7 +1730,31 @@ are symmetric with Leptos #190/#191; the remaining three cover Dioxus-unique sec
   - `use_safe_event_listener()` (web feature) with `Signal::try_read()` guard, idempotent cleanup, and two-phase lifecycle.
 - Spec impact: `No spec change required`.
 
-#### PF-DA-3: Implement DioxusPlatform trait, platform implementations, and use_platform() hook
+#### PF-DA-3: Implement LiveAnnouncer context bridge in ars-dioxus
+
+- Points: `2`
+- Layer: `Adapter`
+- Framework: `Dioxus`
+- Test tier: `Unit`
+- Depends on: #193, #73
+- Spec refs:
+  - `spec/foundation/03-accessibility.md` §5.1 "LiveAnnouncer"
+  - `spec/foundation/11-dom-utilities.md` announcement helpers
+  - `spec/foundation/09-adapter-dioxus.md` §16 "ArsProvider Context"
+- Goal: make announcement ownership adapter-provided rather than global by publishing a shared `Rc<RefCell<ars_a11y::LiveAnnouncer>>` through Dioxus context and wiring adapter announcement delivery to that instance across Dioxus targets.
+- Files to create/modify: `crates/ars-dioxus/src/provider.rs` or equivalent adapter context module, any Dioxus-side announcement bridge needed to satisfy the spec without globals, related spec text if the cross-crate contract needs clarification
+- Tests to add first:
+  - Unit test that a provided `LiveAnnouncer` context is discoverable from the Dioxus adapter surface.
+  - Unit test that missing provider state degrades gracefully without global fallback.
+  - Unit test that repeated announcements reuse the same provided announcer instance instead of hidden singleton state.
+- Acceptance criteria:
+  - The Dioxus adapter owns announcer provisioning via context.
+  - No process-global or thread-local singleton is used for announcements.
+  - Runtime announcement flow uses the shared `ars_a11y::LiveAnnouncer` instance rather than duplicating queue state in `ars-dom`.
+  - Any required spec clarification is updated in the same task.
+- Spec impact: `Update shared adapter/DOM wording if the announcement contract needs clarification`.
+
+#### PF-DA-4: Implement DioxusPlatform trait, platform implementations, and use_platform() hook
 
 - Points: `3`
 - Layer: `Adapter`
@@ -1727,7 +1778,7 @@ are symmetric with Leptos #190/#191; the remaining three cover Dioxus-unique sec
   - `use_platform() -> Rc<dyn DioxusPlatform>` with feature-gated fallback.
 - Spec impact: `No spec change required`.
 
-#### PF-DA-4: Implement SSR Hydration support in ars-dioxus
+#### PF-DA-5: Implement SSR Hydration support in ars-dioxus
 
 - Points: `3`
 - Layer: `Adapter`
@@ -1751,7 +1802,7 @@ are symmetric with Leptos #190/#191; the remaining three cover Dioxus-unique sec
   - `use_stable_id(prefix)` with documented hydration-safety caveat.
 - Spec impact: `No spec change required`.
 
-#### PF-DA-5: Implement ArsErrorBoundary component in ars-dioxus
+#### PF-DA-6: Implement ArsErrorBoundary component in ars-dioxus
 
 - Points: `2`
 - Layer: `Adapter`

--- a/docs/implementation/foundation-gap-audit.md
+++ b/docs/implementation/foundation-gap-audit.md
@@ -455,18 +455,31 @@ An audit of Epic #9 (Dioxus adapter) against `spec/foundation/09-adapter-dioxus.
 
 ### Replacement Tasks
 
-Five new tasks close all gaps. All are sub-issues of [Epic #9](https://github.com/fogodev/ars-ui/issues/9).
+Six tasks close all gaps. All are sub-issues of [Epic #9](https://github.com/fogodev/ars-ui/issues/9).
 
-| Issue                                                | Title                                                                    | Points | Deps | Parity                     |
-| ---------------------------------------------------- | ------------------------------------------------------------------------ | ------ | ---- | -------------------------- |
-| [#193](https://github.com/fogodev/ars-ui/issues/193) | ArsProvider context, reactive props, controlled value helper             | 5      | none | Symmetric with Leptos #190 |
-| [#194](https://github.com/fogodev/ars-ui/issues/194) | Adapter utilities — emit, event mapping, nonce collector, safe listeners | 3      | #193 | Symmetric with Leptos #191 |
-| [#195](https://github.com/fogodev/ars-ui/issues/195) | DioxusPlatform trait, platform implementations, use_platform()           | 3      | #193 | Dioxus-unique              |
-| [#196](https://github.com/fogodev/ars-ui/issues/196) | SSR Hydration support                                                    | 3      | #193 | Dioxus-unique              |
-| [#197](https://github.com/fogodev/ars-ui/issues/197) | ArsErrorBoundary component                                               | 2      | none | Dioxus-unique              |
+| Issue                                                | Title                                                                    | Points | Deps      | Parity                     |
+| ---------------------------------------------------- | ------------------------------------------------------------------------ | ------ | --------- | -------------------------- |
+| [#193](https://github.com/fogodev/ars-ui/issues/193) | ArsProvider context, reactive props, controlled value helper             | 5      | none      | Symmetric with Leptos #190 |
+| [#194](https://github.com/fogodev/ars-ui/issues/194) | Adapter utilities — emit, event mapping, nonce collector, safe listeners | 3      | #193      | Symmetric with Leptos #191 |
+| [#512](https://github.com/fogodev/ars-ui/issues/512) | LiveAnnouncer context bridge                                             | 2      | #193, #73 | Symmetric with Leptos #513 |
+| [#195](https://github.com/fogodev/ars-ui/issues/195) | DioxusPlatform trait, platform implementations, use_platform()           | 3      | #193      | Dioxus-unique              |
+| [#196](https://github.com/fogodev/ars-ui/issues/196) | SSR Hydration support                                                    | 3      | #193      | Dioxus-unique              |
+| [#197](https://github.com/fogodev/ars-ui/issues/197) | ArsErrorBoundary component                                               | 2      | none      | Dioxus-unique              |
 
 ### Updated Epic #9 totals
 
-- Point target revised from `8` to `24`.
+- Point target revised from `8` to `29`.
 - Closed: 2 tasks (#23, #56) = 6 pts
-- Open: #106 (5), #193 (5), #194 (3), #195 (3), #196 (3), #197 (2) = 6 tasks, 21 points remaining
+- Open: #106 (5), #193 (5), #194 (3), #512 (2), #195 (3), #196 (3), #197 (2) = 7 tasks, 23 points remaining
+
+## Adapter Announcement Follow-Up (2026-04-11)
+
+Reviewing the initial `#73` implementation showed that live announcement ownership belongs in
+adapter-provided context, not in `ars-dom` singleton state. Two follow-up adapter tasks were
+created so both frameworks wire announcements through the shared `ars_a11y::LiveAnnouncer`
+instance exposed by their provider layer.
+
+| Issue                                                | Title                        | Points | Deps      | Framework |
+| ---------------------------------------------------- | ---------------------------- | ------ | --------- | --------- |
+| [#513](https://github.com/fogodev/ars-ui/issues/513) | LiveAnnouncer context bridge | 2      | #190, #73 | Leptos    |
+| [#512](https://github.com/fogodev/ars-ui/issues/512) | LiveAnnouncer context bridge | 2      | #193, #73 | Dioxus    |

--- a/docs/implementation/roadmap.md
+++ b/docs/implementation/roadmap.md
@@ -70,17 +70,19 @@ Exit criteria:
 
 Status (2026-04-10): Phase 3 crate shells and CI tier split are done (#19, #20). The full harness API, ARIA helpers, snapshot setup, adapter backends, parity types, CI enforcement, mock infrastructure, and nightly pipeline remain as 11 open tasks (#178–#188, 34 pts). See [Epic #7](https://github.com/fogodev/ars-ui/issues/7).
 
-#### Adapter foundation audit (2026-04-10)
+#### Adapter foundation audit (2026-04-10 / 2026-04-11)
 
-An audit of Epic #8 (Leptos adapter) revealed that the original 3 tasks (#22, #55, #105) covered ~40% of the foundational spec sections in `08-adapter-leptos.md`. Two new tasks were added to close the gaps before component work begins:
+An audit of Epic #8 (Leptos adapter) revealed that the original 3 tasks (#22, #55, #105) covered ~40% of the foundational spec sections in `08-adapter-leptos.md`. Three new tasks were added to close the gaps before component work begins:
 
 - [#190](https://github.com/fogodev/ars-ui/issues/190) — ArsProvider context, reactive props, controlled value helper (5 pts)
 - [#191](https://github.com/fogodev/ars-ui/issues/191) — emit/emit_map, event mapping, nonce CSS collector, safe event listeners (3 pts)
+- [#513](https://github.com/fogodev/ars-ui/issues/513) — LiveAnnouncer context bridge owned by `ArsProvider` context (2 pts, depends on #190 and #73)
 
-A symmetric audit of Epic #9 (Dioxus adapter) confirmed the same gaps plus Dioxus-unique sections. Five new tasks were added (16 pts):
+A symmetric audit of Epic #9 (Dioxus adapter) confirmed the same gaps plus Dioxus-unique sections. A later `#73` follow-up also added the adapter-owned announcer bridge task. Six new tasks were added (18 pts):
 
 - [#193](https://github.com/fogodev/ars-ui/issues/193) — ArsProvider context, reactive props, controlled value helper (5 pts, symmetric with #190)
 - [#194](https://github.com/fogodev/ars-ui/issues/194) — emit/emit_map, event mapping, nonce CSS collector, safe event listeners (3 pts, symmetric with #191)
+- [#512](https://github.com/fogodev/ars-ui/issues/512) — LiveAnnouncer context bridge owned by `ArsProvider` context (2 pts, symmetric with #513)
 - [#195](https://github.com/fogodev/ars-ui/issues/195) — DioxusPlatform trait, WebPlatform, DesktopPlatform, NullPlatform, use_platform() (3 pts, Dioxus-unique)
 - [#196](https://github.com/fogodev/ars-ui/issues/196) — SSR Hydration: HydrationSnapshot, FocusScope hydration safety (3 pts)
 - [#197](https://github.com/fogodev/ars-ui/issues/197) — ArsErrorBoundary component (2 pts)

--- a/spec/foundation/03-accessibility.md
+++ b/spec/foundation/03-accessibility.md
@@ -2539,7 +2539,7 @@ pub struct LiveAnnouncer {
 
 impl LiveAnnouncer {
     /// Create a new LiveAnnouncer. Call `ensure_dom()` in ars-dom before first use.
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             queue: Vec::new(),
             announcing: false,

--- a/spec/foundation/03-accessibility.md
+++ b/spec/foundation/03-accessibility.md
@@ -2525,6 +2525,8 @@ pub struct LiveAnnouncer {
     queue: Vec<Announcement>,
     /// Whether an announcement is currently being processed.
     announcing: bool,
+    /// Priority of the currently active announcement, if any.
+    active_priority: Option<AnnouncementPriority>,
     /// Toggle bit for VoiceOver deduplication workaround.
     /// Only toggled when the current message is identical to `last_message`.
     voiceover_toggle: bool,
@@ -2543,6 +2545,7 @@ impl LiveAnnouncer {
         Self {
             queue: Vec::new(),
             announcing: false,
+            active_priority: None,
             voiceover_toggle: false,
             last_message: None,
             clear_delay_ms: 7000,
@@ -2573,6 +2576,14 @@ impl LiveAnnouncer {
         // Assertive messages clear the queue of pending polite messages.
         if priority == AnnouncementPriority::Assertive {
             self.queue.retain(|a| a.priority == AnnouncementPriority::Assertive);
+
+            // Assertive announcements also preempt an in-flight polite
+            // announcement so critical alerts are not delayed behind the
+            // current clear-delay window.
+            if self.active_priority == Some(AnnouncementPriority::Polite) {
+                self.announcing = false;
+                self.active_priority = None;
+            }
         }
 
         self.queue.push(announcement);
@@ -2592,6 +2603,7 @@ impl LiveAnnouncer {
 
         let next = self.queue.remove(0);
         self.announcing = true;
+        self.active_priority = Some(next.priority);
 
         // VoiceOver deduplication: only append a deduplication character when the
         // current message is identical to the last announced message. Uses U+200D
@@ -2599,16 +2611,17 @@ impl LiveAnnouncer {
         // artifacts on braille displays — ZWSP can render as an empty braille cell,
         // whereas ZWJ is reliably invisible.
         let is_repeat = self.last_message.as_deref() == Some(&next.message);
-        let content = if is_repeat && self.voiceover_toggle {
-            format!("{}\u{200D}", next.message)
-        } else {
-            next.message.clone()
-        };
-        if is_repeat {
+        let content = if is_repeat {
             self.voiceover_toggle = !self.voiceover_toggle;
+            if self.voiceover_toggle {
+                format!("{}\u{200D}", next.message)
+            } else {
+                next.message.clone()
+            }
         } else {
             self.voiceover_toggle = false;
-        }
+            next.message.clone()
+        };
         self.last_message = Some(next.message.clone());
 
         // ars-dom implementation (see §5.2 for rationale):
@@ -2627,6 +2640,7 @@ impl LiveAnnouncer {
     /// next queued announcement.
     pub fn notify_announced(&mut self) {
         self.announcing = false;
+        self.active_priority = None;
         self.process_queue();
     }
 
@@ -2680,6 +2694,7 @@ When updating live regions, the **method of DOM mutation** and **timing** critic
 **Priority Guidelines:**
 
 - Use `aria-live="assertive"` **only** for critical alerts that require immediate user attention (e.g., form validation errors that block submission, session timeout warnings).
+- When an assertive announcement arrives while a polite announcement is still in flight, the assertive announcement should preempt the polite one immediately rather than waiting for the polite clear-delay window to elapse.
 - Default to `aria-live="polite"` for all other announcements (selection changes, sort updates, filter results).
 
 **Screen Reader Timing Differences:**


### PR DESCRIPTION
## Summary
- add the `ars-a11y` live announcer core with queueing, priority handling, attr helpers, and focused unit coverage
- add `ars-dom::ensure_dom()` to create and reuse the shared polite/assertive live-region nodes
- update the accessibility spec and implementation roadmap with the adapter-owned announcer follow-up tasks (#512 and #513)

## Verification
- `cargo test -p ars-a11y --lib`
- `cargo test -p ars-a11y -p ars-dom --lib`
- `cargo llvm-cov test -p ars-a11y --lib --summary-only`

## Follow-up
- adapter-owned runtime announcement delivery remains tracked in #512 and #513

Closes #73