### PR TITLE
feat: implement FilteredCollection and SortedCollection

### DIFF
--- a/crates/ars-collections/src/filtered_collection.rs
+++ b/crates/ars-collections/src/filtered_collection.rs
@@ -1,6 +1,9 @@
 // ars-collections/src/filtered_collection.rs
 
-use alloc::{collections::BTreeSet, vec::Vec};
+use alloc::{
+    collections::{BTreeMap, BTreeSet},
+    vec::Vec,
+};
 use core::{
     fmt::{self, Debug},
     marker::PhantomData,
@@ -23,7 +26,18 @@ use crate::{Collection, key::Key, node::Node};
 /// current highlight is not in the new visible set. This prevents
 /// `aria-activedescendant` from referencing a hidden DOM element.
 ///
-/// Clone: the struct stores only indices and a reference — no closures.
+/// ## Coordinate systems
+///
+/// This wrapper maintains two coordinate systems:
+/// - **Base indices** (`node.index`): the stable identity from the underlying
+///   base collection, used for O(log n) membership checks in [`get`] and
+///   [`children_of`].
+/// - **Wrapper positions**: positions into `inner`'s iteration order (i.e.,
+///   arguments to `inner.get_by_index()`), used for [`get_by_index`],
+///   [`nodes`], and navigation. This distinction is critical when `inner`
+///   is itself a wrapper (e.g., [`SortedCollection`]) whose traversal order
+///   differs from base index order.
+///
 /// The predicate is consumed during `new()` and not retained.
 pub struct FilteredCollection<'a, T, C>
 where
@@ -31,17 +45,23 @@ where
 {
     inner: &'a C,
 
-    /// Flat indices of inner nodes that pass the predicate.
-    /// Uses `BTreeSet` for O(log n) `contains()` in `get()`.
-    visible_indices: BTreeSet<usize>,
+    /// Base `node.index` values of visible nodes.
+    /// Used for O(log n) membership checks in `get()` and `children_of()`.
+    visible_base_indices: BTreeSet<usize>,
 
-    /// Ordered list of visible indices for positional access in `get_by_index()`.
-    visible_order: Vec<usize>,
+    /// Wrapper positions (into `inner`) of visible nodes, in traversal order.
+    /// Used by `get_by_index()` and `nodes()` — these are the coordinates
+    /// that `inner.get_by_index()` expects.
+    visible_positions: Vec<usize>,
 
-    /// Cached index of the first visible focusable item.
+    /// Maps base `node.index` → index into `visible_positions`, for O(log n)
+    /// lookup when navigating from a key.
+    base_to_visible_pos: BTreeMap<usize, usize>,
+
+    /// Cached index into `visible_positions` of the first focusable item.
     first_focusable: Option<usize>,
 
-    /// Cached index of the last visible focusable item.
+    /// Cached index into `visible_positions` of the last focusable item.
     last_focusable: Option<usize>,
 
     _phantom: PhantomData<T>,
@@ -53,25 +73,21 @@ impl<'a, T: Clone, C: Collection<T>> FilteredCollection<'a, T, C> {
     /// Section/Header/Separator nodes are included only when at least one of
     /// their children passes the predicate.
     pub fn new(inner: &'a C, predicate: impl Fn(&Node<T>) -> bool) -> Self {
-        // First pass: find all item nodes that pass.
-        // Uses node.index (the stable flat index from the inner collection)
-        // rather than iterator position, so this works correctly when the
-        // inner collection is itself a wrapper (e.g., SortedCollection) whose
-        // traversal order differs from index order.
+        // First pass: find all item nodes that pass, keyed by base index.
         let passing = inner
             .nodes()
             .filter(|n| n.is_focusable() && predicate(n))
             .map(|n| n.index)
             .collect::<BTreeSet<_>>();
 
-        // Second pass: include structural nodes whose section group has passing items.
+        // Second pass: collect (wrapper_position, base_index) for visible nodes.
         // - Section nodes: included when at least one direct child passes.
         // - Header/Separator nodes inside a section: included when their parent
-        //   section has at least one passing child (they have no children of their
-        //   own, so checking `children_of(&header_key)` would always be empty).
-        let visible_order = inner
+        //   section has at least one passing child.
+        let visible_data = inner
             .nodes()
-            .filter(|n| {
+            .enumerate()
+            .filter(|(_, n)| {
                 if n.is_focusable() {
                     passing.contains(&n.index)
                 } else {
@@ -87,26 +103,45 @@ impl<'a, T: Clone, C: Collection<T>> FilteredCollection<'a, T, C> {
                         })
                 }
             })
-            .map(|n| n.index)
+            .map(|(wrapper_pos, n)| (wrapper_pos, n.index))
             .collect::<Vec<_>>();
 
-        let visible_indices = visible_order.iter().copied().collect::<BTreeSet<_>>();
+        let visible_positions = visible_data.iter().map(|&(wp, _)| wp).collect::<Vec<_>>();
 
-        let first_focusable = visible_order
+        let visible_base_indices = visible_data
             .iter()
-            .copied()
-            .find(|&i| inner.get_by_index(i).is_some_and(Node::is_focusable));
+            .map(|&(_, bi)| bi)
+            .collect::<BTreeSet<_>>();
 
-        let last_focusable = visible_order
+        let base_to_visible_pos = visible_data
             .iter()
+            .enumerate()
+            .map(|(vis_idx, &(_, base_idx))| (base_idx, vis_idx))
+            .collect::<BTreeMap<_, _>>();
+
+        let first_focusable = visible_positions.iter().enumerate().find_map(|(vi, &wp)| {
+            inner
+                .get_by_index(wp)
+                .filter(|n| n.is_focusable())
+                .map(|_| vi)
+        });
+
+        let last_focusable = visible_positions
+            .iter()
+            .enumerate()
             .rev()
-            .copied()
-            .find(|&i| inner.get_by_index(i).is_some_and(Node::is_focusable));
+            .find_map(|(vi, &wp)| {
+                inner
+                    .get_by_index(wp)
+                    .filter(|n| n.is_focusable())
+                    .map(|_| vi)
+            });
 
         Self {
             inner,
-            visible_indices,
-            visible_order,
+            visible_base_indices,
+            visible_positions,
+            base_to_visible_pos,
             first_focusable,
             last_focusable,
             _phantom: PhantomData,
@@ -116,13 +151,12 @@ impl<'a, T: Clone, C: Collection<T>> FilteredCollection<'a, T, C> {
 
 impl<'a, T: Clone, C: Collection<T>> Collection<T> for FilteredCollection<'a, T, C> {
     fn size(&self) -> usize {
-        self.visible_indices.len()
+        self.visible_positions.len()
     }
 
     fn get(&self, key: &Key) -> Option<&Node<T>> {
-        // Only return nodes that are in the visible set.
         let node = self.inner.get(key)?;
-        if self.visible_indices.contains(&node.index) {
+        if self.visible_base_indices.contains(&node.index) {
             Some(node)
         } else {
             None
@@ -130,20 +164,22 @@ impl<'a, T: Clone, C: Collection<T>> Collection<T> for FilteredCollection<'a, T,
     }
 
     fn get_by_index(&self, index: usize) -> Option<&Node<T>> {
-        self.visible_order
+        self.visible_positions
             .get(index)
-            .and_then(|&i| self.inner.get_by_index(i))
+            .and_then(|&wp| self.inner.get_by_index(wp))
     }
 
     fn first_key(&self) -> Option<&Key> {
         self.first_focusable
-            .and_then(|i| self.inner.get_by_index(i))
+            .and_then(|vi| self.visible_positions.get(vi))
+            .and_then(|&wp| self.inner.get_by_index(wp))
             .map(|n| &n.key)
     }
 
     fn last_key(&self) -> Option<&Key> {
         self.last_focusable
-            .and_then(|i| self.inner.get_by_index(i))
+            .and_then(|vi| self.visible_positions.get(vi))
+            .and_then(|&wp| self.inner.get_by_index(wp))
             .map(|n| &n.key)
     }
 
@@ -156,35 +192,34 @@ impl<'a, T: Clone, C: Collection<T>> Collection<T> for FilteredCollection<'a, T,
     }
 
     fn key_after_no_wrap(&self, key: &Key) -> Option<&Key> {
-        let current_index = self.inner.get(key)?.index;
+        let node = self.inner.get(key)?;
 
-        let pos = self
-            .visible_order
+        let vis_pos = *self.base_to_visible_pos.get(&node.index)?;
+
+        self.visible_positions[vis_pos + 1..]
             .iter()
-            .position(|&i| i == current_index)?;
-
-        self.visible_order[pos + 1..].iter().find_map(|&i| {
-            self.inner
-                .get_by_index(i)
-                .filter(|n| n.is_focusable())
-                .map(|n| &n.key)
-        })
+            .find_map(|&wp| {
+                self.inner
+                    .get_by_index(wp)
+                    .filter(|n| n.is_focusable())
+                    .map(|n| &n.key)
+            })
     }
 
     fn key_before_no_wrap(&self, key: &Key) -> Option<&Key> {
-        let current_index = self.inner.get(key)?.index;
+        let node = self.inner.get(key)?;
 
-        let pos = self
-            .visible_order
+        let vis_pos = *self.base_to_visible_pos.get(&node.index)?;
+
+        self.visible_positions[..vis_pos]
             .iter()
-            .position(|&i| i == current_index)?;
-
-        self.visible_order[..pos].iter().rev().find_map(|&i| {
-            self.inner
-                .get_by_index(i)
-                .filter(|n| n.is_focusable())
-                .map(|n| &n.key)
-        })
+            .rev()
+            .find_map(|&wp| {
+                self.inner
+                    .get_by_index(wp)
+                    .filter(|n| n.is_focusable())
+                    .map(|n| &n.key)
+            })
     }
 
     fn keys<'b>(&'b self) -> impl Iterator<Item = &'b Key>
@@ -198,13 +233,9 @@ impl<'a, T: Clone, C: Collection<T>> Collection<T> for FilteredCollection<'a, T,
     where
         T: 'b,
     {
-        // Iterate visible_order (Vec) to preserve the inner collection's
-        // traversal order, not visible_indices (BTreeSet) which re-sorts by
-        // numeric index. This ensures nodes()/keys() agree with
-        // get_by_index()/key_after() when wrapping a SortedCollection.
-        self.visible_order
+        self.visible_positions
             .iter()
-            .filter_map(|&i| self.inner.get_by_index(i))
+            .filter_map(|&wp| self.inner.get_by_index(wp))
     }
 
     fn children_of<'b>(&'b self, parent_key: &Key) -> impl Iterator<Item = &'b Node<T>>
@@ -213,7 +244,7 @@ impl<'a, T: Clone, C: Collection<T>> Collection<T> for FilteredCollection<'a, T,
     {
         self.inner
             .children_of(parent_key)
-            .filter(|n| self.visible_indices.contains(&n.index))
+            .filter(|n| self.visible_base_indices.contains(&n.index))
     }
 }
 
@@ -221,7 +252,7 @@ impl<'a, T: Clone, C: Collection<T>> Collection<T> for FilteredCollection<'a, T,
 impl<T, C: Collection<T>> Debug for FilteredCollection<'_, T, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("FilteredCollection")
-            .field("visible", &self.visible_indices.len())
+            .field("visible", &self.visible_positions.len())
             .finish()
     }
 }
@@ -595,5 +626,68 @@ mod tests {
 
         assert!(debug.contains("FilteredCollection"));
         assert!(debug.contains("1"));
+    }
+
+    // ------------------------------------------------------------------ //
+    // Composition: FilteredCollection over SortedCollection               //
+    // ------------------------------------------------------------------ //
+
+    #[test]
+    fn filter_over_sorted_preserves_sorted_order() {
+        use crate::SortedCollection;
+
+        let base = CollectionBuilder::new()
+            .item(Key::int(1), "Cherry", "c")
+            .item(Key::int(2), "Apple", "a")
+            .item(Key::int(3), "Banana", "b")
+            .build();
+
+        let sorted = SortedCollection::new(&base, |a, b| a.text_value.cmp(&b.text_value));
+        // Sorted order: Apple(2), Banana(3), Cherry(1)
+
+        // Filter out Banana — should keep Apple, Cherry in sorted order.
+        let filtered = FilteredCollection::new(&sorted, |n| n.text_value != "Banana");
+
+        assert_eq!(filtered.size(), 2);
+
+        // Apple(2), Cherry(1) — Banana(3) was filtered out.
+        let keys = filtered.keys().collect::<Vec<_>>();
+        assert_eq!(keys, vec![&Key::int(2), &Key::int(1)]);
+
+        // Positional access follows filtered sorted order.
+        assert_eq!(filtered.get_by_index(0).expect("idx 0").text_value, "Apple");
+        assert_eq!(
+            filtered.get_by_index(1).expect("idx 1").text_value,
+            "Cherry"
+        );
+
+        // Navigation follows filtered sorted order.
+        assert_eq!(filtered.first_key(), Some(&Key::int(2))); // Apple
+        assert_eq!(filtered.last_key(), Some(&Key::int(1))); // Cherry
+        assert_eq!(filtered.key_after(&Key::int(2)), Some(&Key::int(1))); // Apple → Cherry
+        assert_eq!(filtered.key_after(&Key::int(1)), Some(&Key::int(2))); // Cherry wraps → Apple
+    }
+
+    #[test]
+    fn filter_all_pass_over_sorted_matches_sorted() {
+        use crate::SortedCollection;
+
+        let base = CollectionBuilder::new()
+            .item(Key::int(1), "Cherry", "c")
+            .item(Key::int(2), "Apple", "a")
+            .item(Key::int(3), "Banana", "b")
+            .build();
+
+        let sorted = SortedCollection::new(&base, |a, b| a.text_value.cmp(&b.text_value));
+        let filtered = FilteredCollection::new(&sorted, |_| true);
+
+        // Should produce identical order as sorted: Apple, Banana, Cherry
+        let texts = filtered
+            .nodes()
+            .map(|n| n.text_value.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(texts, vec!["Apple", "Banana", "Cherry"]);
+
+        assert_eq!(filtered.size(), 3);
     }
 }

--- a/crates/ars-collections/src/filtered_collection.rs
+++ b/crates/ars-collections/src/filtered_collection.rs
@@ -9,7 +9,11 @@ use core::{
     marker::PhantomData,
 };
 
-use crate::{Collection, key::Key, node::Node};
+use crate::{
+    Collection,
+    key::Key,
+    node::{Node, NodeType},
+};
 
 /// A read-only view over another collection with a predicate applied.
 ///
@@ -81,26 +85,32 @@ impl<'a, T: Clone, C: Collection<T>> FilteredCollection<'a, T, C> {
             .collect::<BTreeSet<_>>();
 
         // Second pass: collect (wrapper_position, base_index) for visible nodes.
-        // - Section nodes: included when at least one direct child passes.
-        // - Header/Separator nodes inside a section: included when their parent
-        //   section has at least one passing child.
+        // Structural nodes are included based on the scope they belong to:
+        // - Section nodes: scope is their direct children.
+        // - Header/Separator inside a section: scope is the parent section's
+        //   children (they have no children of their own).
+        // - Top-level Header/Separator: scope is all top-level items. Without
+        //   this branch a no-op predicate (`|_| true`) would drop top-level
+        //   separators and silently change the collection shape.
         let visible_data = inner
             .nodes()
             .enumerate()
             .filter(|(_, n)| {
                 if n.is_focusable() {
-                    passing.contains(&n.index)
-                } else {
-                    // Section nodes own the children — check directly.
-                    inner
+                    return passing.contains(&n.index);
+                }
+                match (&n.parent_key, n.node_type) {
+                    (_, NodeType::Section) => inner
                         .children_of(&n.key)
-                        .any(|child| passing.contains(&child.index))
-                        // Header/Separator nodes: check their parent section's children.
-                        || n.parent_key.as_ref().is_some_and(|pk| {
-                            inner
-                                .children_of(pk)
-                                .any(|child| passing.contains(&child.index))
-                        })
+                        .any(|child| passing.contains(&child.index)),
+
+                    (Some(pk), _) => inner
+                        .children_of(pk)
+                        .any(|child| passing.contains(&child.index)),
+
+                    (None, _) => inner.nodes().any(|m| {
+                        m.is_focusable() && m.parent_key.is_none() && passing.contains(&m.index)
+                    }),
                 }
             })
             .map(|(wrapper_pos, n)| (wrapper_pos, n.index))
@@ -689,5 +699,56 @@ mod tests {
         assert_eq!(texts, vec!["Apple", "Banana", "Cherry"]);
 
         assert_eq!(filtered.size(), 3);
+    }
+
+    #[test]
+    fn no_op_filter_preserves_top_level_separator() {
+        // A no-op predicate must not change the collection's shape, including
+        // top-level separators (which have no children and no parent section).
+        let inner = CollectionBuilder::new()
+            .item(Key::int(1), "Apple", "a")
+            .separator()
+            .item(Key::int(2), "Banana", "b")
+            .build();
+
+        let filtered = FilteredCollection::new(&inner, |_| true);
+
+        assert_eq!(filtered.size(), 3);
+        let types = filtered.nodes().map(|n| n.node_type).collect::<Vec<_>>();
+        assert_eq!(
+            types,
+            vec![NodeType::Item, NodeType::Separator, NodeType::Item]
+        );
+    }
+
+    #[test]
+    fn top_level_separator_preserved_when_top_level_item_passes() {
+        let inner = CollectionBuilder::new()
+            .item(Key::int(1), "Apple", "a")
+            .separator()
+            .item(Key::int(2), "Banana", "b")
+            .build();
+
+        // Filter out Banana; Apple still passes — separator stays.
+        let filtered = FilteredCollection::new(&inner, |n| n.text_value == "Apple");
+
+        assert_eq!(filtered.size(), 2);
+        let types = filtered.nodes().map(|n| n.node_type).collect::<Vec<_>>();
+        assert_eq!(types, vec![NodeType::Item, NodeType::Separator]);
+    }
+
+    #[test]
+    fn top_level_separator_dropped_when_no_top_level_items_pass() {
+        // When no top-level items pass, the separator has no scope to belong
+        // to and is correctly excluded.
+        let inner = CollectionBuilder::new()
+            .item(Key::int(1), "Apple", "a")
+            .separator()
+            .item(Key::int(2), "Banana", "b")
+            .build();
+
+        let filtered = FilteredCollection::new(&inner, |_| false);
+
+        assert_eq!(filtered.size(), 0);
     }
 }

--- a/crates/ars-collections/src/filtered_collection.rs
+++ b/crates/ars-collections/src/filtered_collection.rs
@@ -54,11 +54,14 @@ impl<'a, T: Clone, C: Collection<T>> FilteredCollection<'a, T, C> {
     /// their children passes the predicate.
     pub fn new(inner: &'a C, predicate: impl Fn(&Node<T>) -> bool) -> Self {
         // First pass: find all item nodes that pass.
+        // Uses node.index (the stable flat index from the inner collection)
+        // rather than iterator position, so this works correctly when the
+        // inner collection is itself a wrapper (e.g., SortedCollection) whose
+        // traversal order differs from index order.
         let passing = inner
             .nodes()
-            .enumerate()
-            .filter(|(_, n)| n.is_focusable() && predicate(n))
-            .map(|(i, _)| i)
+            .filter(|n| n.is_focusable() && predicate(n))
+            .map(|n| n.index)
             .collect::<BTreeSet<_>>();
 
         // Second pass: include structural nodes whose section group has passing items.
@@ -195,7 +198,11 @@ impl<'a, T: Clone, C: Collection<T>> Collection<T> for FilteredCollection<'a, T,
     where
         T: 'b,
     {
-        self.visible_indices
+        // Iterate visible_order (Vec) to preserve the inner collection's
+        // traversal order, not visible_indices (BTreeSet) which re-sorts by
+        // numeric index. This ensures nodes()/keys() agree with
+        // get_by_index()/key_after() when wrapping a SortedCollection.
+        self.visible_order
             .iter()
             .filter_map(|&i| self.inner.get_by_index(i))
     }

--- a/crates/ars-collections/src/filtered_collection.rs
+++ b/crates/ars-collections/src/filtered_collection.rs
@@ -1,0 +1,592 @@
+// ars-collections/src/filtered_collection.rs
+
+use alloc::{collections::BTreeSet, vec::Vec};
+use core::{
+    fmt::{self, Debug},
+    marker::PhantomData,
+};
+
+use crate::{Collection, key::Key, node::Node};
+
+/// A read-only view over another collection with a predicate applied.
+///
+/// Items that do not satisfy the predicate are excluded from all iteration
+/// and navigation methods. Selection state (held by the component context)
+/// is unaffected by filtering — selected keys that are currently hidden by
+/// the filter remain in `selection::State::selected_keys`. When the filter is
+/// cleared, those items are still shown as selected.
+///
+/// **Highlight state behavior**: When the filtered set changes (e.g., user
+/// types in a Combobox), the component's `focused_key` may point to an
+/// item that is no longer visible. Components MUST reset `focused_key`
+/// to `filtered.first_key()` whenever the filter predicate changes and the
+/// current highlight is not in the new visible set. This prevents
+/// `aria-activedescendant` from referencing a hidden DOM element.
+///
+/// Clone: the struct stores only indices and a reference — no closures.
+/// The predicate is consumed during `new()` and not retained.
+pub struct FilteredCollection<'a, T, C>
+where
+    C: Collection<T>,
+{
+    inner: &'a C,
+
+    /// Flat indices of inner nodes that pass the predicate.
+    /// Uses `BTreeSet` for O(log n) `contains()` in `get()`.
+    visible_indices: BTreeSet<usize>,
+
+    /// Ordered list of visible indices for positional access in `get_by_index()`.
+    visible_order: Vec<usize>,
+
+    /// Cached index of the first visible focusable item.
+    first_focusable: Option<usize>,
+
+    /// Cached index of the last visible focusable item.
+    last_focusable: Option<usize>,
+
+    _phantom: PhantomData<T>,
+}
+
+impl<'a, T: Clone, C: Collection<T>> FilteredCollection<'a, T, C> {
+    /// Apply `predicate` to each item node in `inner`.
+    ///
+    /// Section/Header/Separator nodes are included only when at least one of
+    /// their children passes the predicate.
+    pub fn new(inner: &'a C, predicate: impl Fn(&Node<T>) -> bool) -> Self {
+        // First pass: find all item nodes that pass.
+        let passing = inner
+            .nodes()
+            .enumerate()
+            .filter(|(_, n)| n.is_focusable() && predicate(n))
+            .map(|(i, _)| i)
+            .collect::<BTreeSet<_>>();
+
+        // Second pass: include structural nodes whose section group has passing items.
+        // - Section nodes: included when at least one direct child passes.
+        // - Header/Separator nodes inside a section: included when their parent
+        //   section has at least one passing child (they have no children of their
+        //   own, so checking `children_of(&header_key)` would always be empty).
+        let visible_order = inner
+            .nodes()
+            .filter(|n| {
+                if n.is_focusable() {
+                    passing.contains(&n.index)
+                } else {
+                    // Section nodes own the children — check directly.
+                    inner
+                        .children_of(&n.key)
+                        .any(|child| passing.contains(&child.index))
+                        // Header/Separator nodes: check their parent section's children.
+                        || n.parent_key.as_ref().is_some_and(|pk| {
+                            inner
+                                .children_of(pk)
+                                .any(|child| passing.contains(&child.index))
+                        })
+                }
+            })
+            .map(|n| n.index)
+            .collect::<Vec<_>>();
+
+        let visible_indices = visible_order.iter().copied().collect::<BTreeSet<_>>();
+
+        let first_focusable = visible_order
+            .iter()
+            .copied()
+            .find(|&i| inner.get_by_index(i).is_some_and(Node::is_focusable));
+
+        let last_focusable = visible_order
+            .iter()
+            .rev()
+            .copied()
+            .find(|&i| inner.get_by_index(i).is_some_and(Node::is_focusable));
+
+        Self {
+            inner,
+            visible_indices,
+            visible_order,
+            first_focusable,
+            last_focusable,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<'a, T: Clone, C: Collection<T>> Collection<T> for FilteredCollection<'a, T, C> {
+    fn size(&self) -> usize {
+        self.visible_indices.len()
+    }
+
+    fn get(&self, key: &Key) -> Option<&Node<T>> {
+        // Only return nodes that are in the visible set.
+        let node = self.inner.get(key)?;
+        if self.visible_indices.contains(&node.index) {
+            Some(node)
+        } else {
+            None
+        }
+    }
+
+    fn get_by_index(&self, index: usize) -> Option<&Node<T>> {
+        self.visible_order
+            .get(index)
+            .and_then(|&i| self.inner.get_by_index(i))
+    }
+
+    fn first_key(&self) -> Option<&Key> {
+        self.first_focusable
+            .and_then(|i| self.inner.get_by_index(i))
+            .map(|n| &n.key)
+    }
+
+    fn last_key(&self) -> Option<&Key> {
+        self.last_focusable
+            .and_then(|i| self.inner.get_by_index(i))
+            .map(|n| &n.key)
+    }
+
+    fn key_after(&self, key: &Key) -> Option<&Key> {
+        self.key_after_no_wrap(key).or_else(|| self.first_key())
+    }
+
+    fn key_before(&self, key: &Key) -> Option<&Key> {
+        self.key_before_no_wrap(key).or_else(|| self.last_key())
+    }
+
+    fn key_after_no_wrap(&self, key: &Key) -> Option<&Key> {
+        let current_index = self.inner.get(key)?.index;
+
+        let pos = self
+            .visible_order
+            .iter()
+            .position(|&i| i == current_index)?;
+
+        self.visible_order[pos + 1..].iter().find_map(|&i| {
+            self.inner
+                .get_by_index(i)
+                .filter(|n| n.is_focusable())
+                .map(|n| &n.key)
+        })
+    }
+
+    fn key_before_no_wrap(&self, key: &Key) -> Option<&Key> {
+        let current_index = self.inner.get(key)?.index;
+
+        let pos = self
+            .visible_order
+            .iter()
+            .position(|&i| i == current_index)?;
+
+        self.visible_order[..pos].iter().rev().find_map(|&i| {
+            self.inner
+                .get_by_index(i)
+                .filter(|n| n.is_focusable())
+                .map(|n| &n.key)
+        })
+    }
+
+    fn keys<'b>(&'b self) -> impl Iterator<Item = &'b Key>
+    where
+        T: 'b,
+    {
+        self.nodes().map(|n| &n.key)
+    }
+
+    fn nodes<'b>(&'b self) -> impl Iterator<Item = &'b Node<T>>
+    where
+        T: 'b,
+    {
+        self.visible_indices
+            .iter()
+            .filter_map(|&i| self.inner.get_by_index(i))
+    }
+
+    fn children_of<'b>(&'b self, parent_key: &Key) -> impl Iterator<Item = &'b Node<T>>
+    where
+        T: 'b,
+    {
+        self.inner
+            .children_of(parent_key)
+            .filter(|n| self.visible_indices.contains(&n.index))
+    }
+}
+
+/// Manual `Debug` avoids requiring `T: Debug`. Prints visible count only.
+impl<T, C: Collection<T>> Debug for FilteredCollection<'_, T, C> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FilteredCollection")
+            .field("visible", &self.visible_indices.len())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{builder::CollectionBuilder, key::Key, node::NodeType};
+
+    // ------------------------------------------------------------------ //
+    // Construction                                                        //
+    // ------------------------------------------------------------------ //
+
+    #[test]
+    fn filter_empty_collection() {
+        let inner = CollectionBuilder::<&str>::new().build();
+
+        let filtered = FilteredCollection::new(&inner, |_| true);
+
+        assert_eq!(filtered.size(), 0);
+        assert!(filtered.is_empty());
+    }
+
+    #[test]
+    fn filter_all_pass() {
+        let inner = CollectionBuilder::new()
+            .item(Key::int(1), "Apple", "a")
+            .item(Key::int(2), "Banana", "b")
+            .item(Key::int(3), "Cherry", "c")
+            .build();
+
+        let filtered = FilteredCollection::new(&inner, |_| true);
+
+        assert_eq!(filtered.size(), 3);
+    }
+
+    #[test]
+    fn filter_none_pass() {
+        let inner = CollectionBuilder::new()
+            .item(Key::int(1), "Apple", "a")
+            .item(Key::int(2), "Banana", "b")
+            .build();
+
+        let filtered = FilteredCollection::new(&inner, |_| false);
+
+        assert_eq!(filtered.size(), 0);
+        assert!(filtered.is_empty());
+    }
+
+    #[test]
+    fn filter_some_items() {
+        let inner = CollectionBuilder::new()
+            .item(Key::int(1), "Apple", "a")
+            .item(Key::int(2), "Banana", "b")
+            .item(Key::int(3), "Cherry", "c")
+            .build();
+
+        let filtered = FilteredCollection::new(&inner, |n| n.text_value.starts_with('A'));
+
+        assert_eq!(filtered.size(), 1);
+
+        let keys = filtered.keys().collect::<Vec<_>>();
+
+        assert_eq!(keys, vec![&Key::int(1)]);
+    }
+
+    #[test]
+    fn filter_preserves_structural_with_passing_children() {
+        let inner = CollectionBuilder::new()
+            .section(Key::str("fruits"), "Fruits")
+            .item(Key::int(1), "Apple", "a")
+            .item(Key::int(2), "Banana", "b")
+            .end_section()
+            .build();
+
+        // Only Apple passes — section and header should still be included.
+        let filtered = FilteredCollection::new(&inner, |n| n.text_value == "Apple");
+
+        // Section + Header + Apple = 3
+        assert_eq!(filtered.size(), 3);
+        assert!(filtered.get(&Key::str("fruits")).is_some());
+        assert!(filtered.get(&Key::str("fruits-header")).is_some());
+        assert!(filtered.get(&Key::int(1)).is_some());
+        assert!(filtered.get(&Key::int(2)).is_none());
+    }
+
+    #[test]
+    fn filter_removes_structural_without_passing_children() {
+        let inner = CollectionBuilder::new()
+            .section(Key::str("fruits"), "Fruits")
+            .item(Key::int(1), "Apple", "a")
+            .end_section()
+            .section(Key::str("vegs"), "Vegetables")
+            .item(Key::int(2), "Carrot", "c")
+            .end_section()
+            .build();
+
+        // Only Apple passes — "Vegetables" section should be removed entirely.
+        let filtered = FilteredCollection::new(&inner, |n| n.text_value == "Apple");
+
+        assert!(filtered.get(&Key::str("fruits")).is_some());
+        assert!(filtered.get(&Key::str("vegs")).is_none());
+        assert!(filtered.get(&Key::int(1)).is_some());
+        assert!(filtered.get(&Key::int(2)).is_none());
+    }
+
+    // ------------------------------------------------------------------ //
+    // Random access                                                       //
+    // ------------------------------------------------------------------ //
+
+    #[test]
+    fn get_returns_none_for_hidden_key() {
+        let inner = CollectionBuilder::new()
+            .item(Key::int(1), "Apple", "a")
+            .item(Key::int(2), "Banana", "b")
+            .build();
+
+        let filtered = FilteredCollection::new(&inner, |n| n.text_value == "Apple");
+
+        assert!(filtered.get(&Key::int(1)).is_some());
+        assert!(filtered.get(&Key::int(2)).is_none());
+    }
+
+    #[test]
+    fn get_by_index_maps_to_visible_order() {
+        let inner = CollectionBuilder::new()
+            .item(Key::int(1), "Apple", "a")
+            .item(Key::int(2), "Banana", "b")
+            .item(Key::int(3), "Cherry", "c")
+            .build();
+
+        // Keep only Apple and Cherry.
+        let filtered = FilteredCollection::new(&inner, |n| n.text_value != "Banana");
+
+        assert_eq!(filtered.size(), 2);
+
+        let first = filtered.get_by_index(0).expect("index 0");
+
+        assert_eq!(first.key, Key::int(1));
+
+        let second = filtered.get_by_index(1).expect("index 1");
+
+        assert_eq!(second.key, Key::int(3));
+        assert!(filtered.get_by_index(2).is_none());
+    }
+
+    #[test]
+    fn contains_key_visible_and_hidden() {
+        let inner = CollectionBuilder::new()
+            .item(Key::int(1), "Apple", "a")
+            .item(Key::int(2), "Banana", "b")
+            .build();
+
+        let filtered = FilteredCollection::new(&inner, |n| n.text_value == "Apple");
+
+        assert!(filtered.contains_key(&Key::int(1)));
+        assert!(!filtered.contains_key(&Key::int(2)));
+    }
+
+    // ------------------------------------------------------------------ //
+    // Boundary navigation                                                 //
+    // ------------------------------------------------------------------ //
+
+    #[test]
+    fn first_key_skips_structural() {
+        let inner = CollectionBuilder::new()
+            .section(Key::str("sec"), "Section")
+            .item(Key::int(1), "Apple", "a")
+            .end_section()
+            .build();
+
+        let filtered = FilteredCollection::new(&inner, |_| true);
+
+        // first_key should be the item, not section or header.
+        assert_eq!(filtered.first_key(), Some(&Key::int(1)));
+    }
+
+    #[test]
+    fn last_key_skips_structural() {
+        let inner = CollectionBuilder::new()
+            .item(Key::int(1), "Apple", "a")
+            .separator()
+            .build();
+
+        let filtered = FilteredCollection::new(&inner, |_| true);
+
+        assert_eq!(filtered.last_key(), Some(&Key::int(1)));
+    }
+
+    #[test]
+    fn first_last_key_on_empty_filtered() {
+        let inner = CollectionBuilder::new()
+            .item(Key::int(1), "Apple", "a")
+            .build();
+
+        let filtered = FilteredCollection::new(&inner, |_| false);
+
+        assert_eq!(filtered.first_key(), None);
+        assert_eq!(filtered.last_key(), None);
+    }
+
+    // ------------------------------------------------------------------ //
+    // Sequential navigation                                               //
+    // ------------------------------------------------------------------ //
+
+    #[test]
+    fn key_after_in_filtered_set() {
+        let inner = CollectionBuilder::new()
+            .item(Key::int(1), "Apple", "a")
+            .item(Key::int(2), "Banana", "b")
+            .item(Key::int(3), "Cherry", "c")
+            .build();
+
+        // Keep Apple and Cherry only.
+        let filtered = FilteredCollection::new(&inner, |n| n.text_value != "Banana");
+
+        assert_eq!(filtered.key_after_no_wrap(&Key::int(1)), Some(&Key::int(3)));
+    }
+
+    #[test]
+    fn key_after_wraps() {
+        let inner = CollectionBuilder::new()
+            .item(Key::int(1), "Apple", "a")
+            .item(Key::int(2), "Banana", "b")
+            .build();
+
+        let filtered = FilteredCollection::new(&inner, |_| true);
+
+        assert_eq!(filtered.key_after(&Key::int(2)), Some(&Key::int(1)));
+    }
+
+    #[test]
+    fn key_before_wraps() {
+        let inner = CollectionBuilder::new()
+            .item(Key::int(1), "Apple", "a")
+            .item(Key::int(2), "Banana", "b")
+            .build();
+
+        let filtered = FilteredCollection::new(&inner, |_| true);
+
+        assert_eq!(filtered.key_before(&Key::int(1)), Some(&Key::int(2)));
+    }
+
+    #[test]
+    fn key_after_no_wrap_at_end() {
+        let inner = CollectionBuilder::new()
+            .item(Key::int(1), "Apple", "a")
+            .item(Key::int(2), "Banana", "b")
+            .build();
+
+        let filtered = FilteredCollection::new(&inner, |_| true);
+
+        assert_eq!(filtered.key_after_no_wrap(&Key::int(2)), None);
+    }
+
+    #[test]
+    fn key_before_no_wrap_at_start() {
+        let inner = CollectionBuilder::new()
+            .item(Key::int(1), "Apple", "a")
+            .item(Key::int(2), "Banana", "b")
+            .build();
+
+        let filtered = FilteredCollection::new(&inner, |_| true);
+
+        assert_eq!(filtered.key_before_no_wrap(&Key::int(1)), None);
+    }
+
+    #[test]
+    fn key_before_no_wrap_finds_previous() {
+        let inner = CollectionBuilder::new()
+            .item(Key::int(1), "Apple", "a")
+            .item(Key::int(2), "Banana", "b")
+            .item(Key::int(3), "Cherry", "c")
+            .build();
+
+        // Keep Apple and Cherry only.
+        let filtered = FilteredCollection::new(&inner, |n| n.text_value != "Banana");
+
+        assert_eq!(
+            filtered.key_before_no_wrap(&Key::int(3)),
+            Some(&Key::int(1))
+        );
+    }
+
+    // ------------------------------------------------------------------ //
+    // Iteration                                                           //
+    // ------------------------------------------------------------------ //
+
+    #[test]
+    fn keys_yields_visible_only() {
+        let inner = CollectionBuilder::new()
+            .item(Key::int(1), "Apple", "a")
+            .item(Key::int(2), "Banana", "b")
+            .item(Key::int(3), "Cherry", "c")
+            .build();
+
+        let filtered = FilteredCollection::new(&inner, |n| n.text_value != "Banana");
+
+        let keys = filtered.keys().collect::<Vec<_>>();
+
+        assert_eq!(keys, vec![&Key::int(1), &Key::int(3)]);
+    }
+
+    #[test]
+    fn nodes_yields_visible_only() {
+        let inner = CollectionBuilder::new()
+            .item(Key::int(1), "Apple", "a")
+            .item(Key::int(2), "Banana", "b")
+            .build();
+
+        let filtered = FilteredCollection::new(&inner, |n| n.text_value == "Banana");
+
+        let nodes = filtered.nodes().collect::<Vec<_>>();
+
+        assert_eq!(nodes.len(), 1);
+        assert_eq!(nodes[0].key, Key::int(2));
+    }
+
+    #[test]
+    fn children_of_filtered() {
+        let inner = CollectionBuilder::new()
+            .section(Key::str("fruits"), "Fruits")
+            .item(Key::int(1), "Apple", "a")
+            .item(Key::int(2), "Banana", "b")
+            .end_section()
+            .build();
+
+        let filtered = FilteredCollection::new(&inner, |n| n.text_value == "Apple");
+
+        let children = filtered
+            .children_of(&Key::str("fruits"))
+            .collect::<Vec<_>>();
+
+        // Header + Apple = 2 (Banana is filtered out).
+        assert_eq!(children.len(), 2);
+        assert_eq!(children[0].node_type, NodeType::Header);
+        assert_eq!(children[1].key, Key::int(1));
+    }
+
+    #[test]
+    fn item_keys_filters_structural_from_visible() {
+        let inner = CollectionBuilder::new()
+            .section(Key::str("sec"), "Section")
+            .item(Key::int(1), "Apple", "a")
+            .item(Key::int(2), "Banana", "b")
+            .end_section()
+            .build();
+
+        let filtered = FilteredCollection::new(&inner, |_| true);
+
+        let item_keys = filtered.item_keys().collect::<Vec<_>>();
+
+        // Should only include item keys, not section/header.
+        assert_eq!(item_keys, vec![&Key::int(1), &Key::int(2)]);
+    }
+
+    // ------------------------------------------------------------------ //
+    // Debug                                                               //
+    // ------------------------------------------------------------------ //
+
+    #[test]
+    fn debug_format() {
+        let inner = CollectionBuilder::new()
+            .item(Key::int(1), "Apple", "a")
+            .item(Key::int(2), "Banana", "b")
+            .build();
+
+        let filtered = FilteredCollection::new(&inner, |n| n.text_value == "Apple");
+
+        let debug = alloc::format!("{filtered:?}");
+
+        assert!(debug.contains("FilteredCollection"));
+        assert!(debug.contains("1"));
+    }
+}

--- a/crates/ars-collections/src/lib.rs
+++ b/crates/ars-collections/src/lib.rs
@@ -21,6 +21,10 @@
 //! - [`AsyncCollection`] — paginated collection that grows as pages are fetched.
 //! - [`AsyncLoader`] — trait for fetching pages of data from an async source.
 //! - [`LoadResult`] — result of a single page fetch.
+//! - [`FilteredCollection`] — predicate-based filtering view.
+//! - [`SortedCollection`] — comparator-based sorting view.
+//! - [`SortDirection`] — ascending or descending sort order.
+//! - [`SortDescriptor`] — column + direction for table sorting.
 //! - [`CollectionError`] — error from an async page load.
 
 #![cfg_attr(not(feature = "std"), no_std)]
@@ -36,6 +40,8 @@ pub mod async_loader;
 pub mod builder;
 /// Core collection traits: [`Collection`] and [`CollectionItem`].
 pub mod collection;
+/// Predicate-based filtering view over a [`Collection`].
+pub mod filtered_collection;
 /// Stable node identifiers for collections.
 pub mod key;
 /// Disabled-aware navigation helpers for collection widgets.
@@ -44,6 +50,8 @@ pub mod navigation;
 pub mod node;
 /// Selection enums and state for collection-based components.
 pub mod selection;
+/// Comparator-based sorting view over a [`Collection`].
+pub mod sorted_collection;
 /// In-memory collection backed by `Vec` and `IndexMap`.
 pub mod static_collection;
 /// Hierarchical collection with expand/collapse for tree-based components.
@@ -53,8 +61,10 @@ pub use async_collection::{AsyncCollection, AsyncLoadingState};
 pub use async_loader::{AsyncLoader, CollectionError, LoadResult};
 pub use builder::CollectionBuilder;
 pub use collection::{Collection, CollectionItem};
+pub use filtered_collection::FilteredCollection;
 pub use key::Key;
 pub use node::{Node, NodeType};
 pub use selection::DisabledBehavior;
+pub use sorted_collection::{SortDescriptor, SortDirection, SortedCollection};
 pub use static_collection::StaticCollection;
 pub use tree_collection::{TreeCollection, TreeItemConfig};

--- a/crates/ars-collections/src/sorted_collection.rs
+++ b/crates/ars-collections/src/sorted_collection.rs
@@ -1,6 +1,9 @@
 // ars-collections/src/sorted_collection.rs
 
-use alloc::{collections::BTreeMap, vec::Vec};
+use alloc::{
+    collections::{BTreeMap, BTreeSet},
+    vec::Vec,
+};
 use core::{
     cmp,
     fmt::{self, Debug, Display},
@@ -103,62 +106,76 @@ impl<'a, T: Clone, C: Collection<T>> SortedCollection<'a, T, C> {
         // For flat (non-sectioned) collections: all nodes are Items, so
         // item_indices IS the final sorted order.
         //
-        // For sectioned collections: sort items within each section while
-        // preserving section order and structural node positions. Algorithm:
-        // 1. Group sorted items by parent_key (section membership).
-        // 2. Walk the original node order. Structural nodes (Section, Header,
-        //    Separator) are emitted in their original positions. When items
-        //    belonging to a section are encountered, emit the section's sorted
-        //    items instead, consuming from the group.
+        // For sectioned or mixed collections: items are sorted within each
+        // contiguous *run* of same-parent items. A new run starts when a
+        // Section node is encountered or an Item's parent_key differs from
+        // the previous Item's parent. Header and Separator nodes do not
+        // break runs — they are emitted in their original positions.
+        //
+        // This run-aware grouping prevents items from migrating across
+        // structural boundaries when top-level items appear in multiple
+        // runs separated by sections.
         let has_sections = inner.nodes().any(Node::is_structural);
 
         let sorted_indices = if has_sections {
-            // Group sorted item indices by parent_key.
-            let mut section_items = BTreeMap::<Option<Key>, Vec<usize>>::new();
-            for &idx in &item_indices {
-                let node = inner
-                    .get_by_index(idx)
-                    .expect("sorted index must be within bounds");
-                section_items
-                    .entry(node.parent_key.clone())
-                    .or_default()
-                    .push(idx);
-            }
-            // Track consumption position per section.
-            let mut section_cursors = BTreeMap::<Option<Key>, usize>::new();
-
-            let mut result = Vec::with_capacity(inner.size());
-            let mut current_section = None::<Key>;
-            let mut items_emitted_for_section = false;
+            // Phase 1: assign each item to a contiguous-run group.
+            let mut item_to_group = BTreeMap::<usize, usize>::new();
+            let mut next_group = 0;
+            let mut current_parent = None::<Option<Key>>;
 
             for node in inner.nodes() {
                 match node.node_type {
                     NodeType::Section => {
-                        current_section = Some(node.key.clone());
-                        items_emitted_for_section = false;
-                        result.push(node.index);
+                        // Section always resets scope — next item starts a new group.
+                        current_parent = None;
                     }
                     NodeType::Header | NodeType::Separator => {
-                        // Emit structural nodes in their original position.
+                        // Structural leaf nodes do not break item groups.
+                    }
+                    NodeType::Item => {
+                        let pk = node.parent_key.clone();
+                        match &current_parent {
+                            Some(existing_pk) if *existing_pk == pk => {
+                                // Same group — no action needed.
+                            }
+                            _ => {
+                                // Different parent or first item after reset — new group.
+                                next_group += 1;
+                                current_parent = Some(pk);
+                            }
+                        }
+                        item_to_group.insert(node.index, next_group);
+                    }
+                }
+            }
+
+            // Phase 2: distribute the globally-sorted item indices into per-group buckets.
+            let mut groups = BTreeMap::<usize, Vec<usize>>::new();
+            for &idx in &item_indices {
+                if let Some(&group) = item_to_group.get(&idx) {
+                    groups.entry(group).or_default().push(idx);
+                }
+            }
+
+            // Phase 3: walk original order, emit structural nodes in place,
+            // emit each group's sorted items on first encounter.
+            let mut group_emitted = BTreeSet::<usize>::new();
+            let mut result = Vec::with_capacity(inner.size());
+
+            for node in inner.nodes() {
+                match node.node_type {
+                    NodeType::Section | NodeType::Header | NodeType::Separator => {
                         result.push(node.index);
                     }
                     NodeType::Item => {
-                        // On first item of this section, emit all sorted items for it.
-                        let section_key = node.parent_key.clone();
-                        if !items_emitted_for_section || section_key != current_section {
-                            if let Some(items) = section_items.get(&section_key) {
-                                let cursor =
-                                    section_cursors.entry(section_key.clone()).or_insert(0);
-                                if *cursor == 0 {
-                                    // First encounter: emit all sorted items for this section.
+                        if let Some(&group) = item_to_group.get(&node.index) {
+                            if group_emitted.insert(group) {
+                                // First encounter — emit all sorted items for this group.
+                                if let Some(items) = groups.get(&group) {
                                     result.extend_from_slice(items);
-                                    *cursor = items.len();
                                 }
                             }
-                            items_emitted_for_section = true;
-                            current_section = section_key;
                         }
-                        // Skip original item indices — already emitted via sorted group.
                     }
                 }
             }
@@ -173,6 +190,7 @@ impl<'a, T: Clone, C: Collection<T>> SortedCollection<'a, T, C> {
             .iter()
             .copied()
             .find(|&i| inner.get_by_index(i).is_some_and(Node::is_focusable));
+
         let last_focusable = sorted_indices
             .iter()
             .rev()
@@ -503,6 +521,58 @@ mod tests {
                 NodeType::Item, // Banana (sorted)
                 NodeType::Separator,
                 NodeType::Item, // Standalone
+            ]
+        );
+    }
+
+    #[test]
+    fn sort_disjoint_top_level_runs_stay_in_place() {
+        // Top-level items separated by a section must NOT merge across
+        // the structural boundary. Each run is sorted independently.
+        //
+        // Original order:
+        //   Item D (top-level)   ← run 1
+        //   Item B (top-level)   ← run 1
+        //   Section "Fruits"
+        //     Item Cherry
+        //     Item Apple
+        //   Item C (top-level)   ← run 2
+        //   Item A (top-level)   ← run 2
+        let inner = CollectionBuilder::new()
+            .item(Key::int(4), "D", "d")
+            .item(Key::int(2), "B", "b")
+            .section(Key::str("fruits"), "Fruits")
+            .item(Key::int(13), "Cherry", "cherry")
+            .item(Key::int(11), "Apple", "apple")
+            .end_section()
+            .item(Key::int(3), "C", "c")
+            .item(Key::int(1), "A", "a")
+            .build();
+
+        let sorted = SortedCollection::new(&inner, |a, b| a.text_value.cmp(&b.text_value));
+
+        let texts = sorted
+            .nodes()
+            .filter(|n| n.is_focusable())
+            .map(|n| n.text_value.as_str())
+            .collect::<Vec<_>>();
+
+        // Run 1 sorted: B, D. Section items sorted: Apple, Cherry. Run 2 sorted: A, C.
+        assert_eq!(texts, vec!["B", "D", "Apple", "Cherry", "A", "C"]);
+
+        // Structural nodes stay in their original positions.
+        let types = sorted.nodes().map(|n| n.node_type).collect::<Vec<_>>();
+        assert_eq!(
+            types,
+            vec![
+                NodeType::Item,    // B (run 1)
+                NodeType::Item,    // D (run 1)
+                NodeType::Section, // Fruits
+                NodeType::Header,  // Fruits header
+                NodeType::Item,    // Apple (section)
+                NodeType::Item,    // Cherry (section)
+                NodeType::Item,    // A (run 2)
+                NodeType::Item,    // C (run 2)
             ]
         );
     }

--- a/crates/ars-collections/src/sorted_collection.rs
+++ b/crates/ars-collections/src/sorted_collection.rs
@@ -59,18 +59,36 @@ pub struct SortDescriptor<K> {
 /// });
 /// ```
 ///
-/// Clone — this struct holds only a reference and sorted indices, no closures.
+/// ## Coordinate systems
+///
+/// This wrapper maintains two coordinate systems:
+/// - **Base indices** (`node.index`): the stable identity from the underlying
+///   base collection, used for key→position lookups during navigation.
+/// - **Wrapper positions**: positions into `inner`'s iteration order (i.e.,
+///   arguments to `inner.get_by_index()`), stored in `sorted_positions`.
+///   This distinction is critical when `inner` is itself a wrapper (e.g.,
+///   [`FilteredCollection`]) whose `get_by_index` expects dense positions,
+///   not sparse base indices.
+///
 /// The comparator is consumed at construction time and not retained.
 pub struct SortedCollection<'a, T, C>
 where
     C: Collection<T>,
 {
     inner: &'a C,
-    /// Sorted flat indices of inner nodes in the new traversal order.
-    sorted_indices: Vec<usize>,
-    /// Cached index of the first focusable item in sorted order.
+
+    /// Wrapper positions (into `inner`) in sorted traversal order.
+    /// These are the coordinates that `inner.get_by_index()` expects.
+    sorted_positions: Vec<usize>,
+
+    /// Maps base `node.index` → index into `sorted_positions`, for O(log n)
+    /// lookup when navigating from a key.
+    base_to_sorted_pos: BTreeMap<usize, usize>,
+
+    /// Cached index into `sorted_positions` of the first focusable item.
     first_focusable: Option<usize>,
-    /// Cached index of the last focusable item in sorted order.
+
+    /// Cached index into `sorted_positions` of the last focusable item.
     last_focusable: Option<usize>,
 
     _phantom: PhantomData<T>,
@@ -84,16 +102,19 @@ impl<'a, T: Clone, C: Collection<T>> SortedCollection<'a, T, C> {
     /// their grouping. For flat (non-sectioned) collections, all nodes are
     /// reordered.
     pub fn new(inner: &'a C, comparator: impl Fn(&Node<T>, &Node<T>) -> cmp::Ordering) -> Self {
-        let mut item_indices = inner
+        // Collect item wrapper positions and sort them by comparator.
+        let mut item_positions = inner
             .nodes()
-            .filter(|n| n.is_focusable())
-            .map(|n| n.index)
+            .enumerate()
+            .filter(|(_, n)| n.is_focusable())
+            .map(|(pos, _)| pos)
             .collect::<Vec<_>>();
 
-        item_indices.sort_by(|&a, &b| {
+        item_positions.sort_by(|&a, &b| {
             let node_a = inner
                 .get_by_index(a)
                 .expect("sort index must be within collection bounds");
+
             let node_b = inner
                 .get_by_index(b)
                 .expect("sort index must be within collection bounds");
@@ -104,7 +125,7 @@ impl<'a, T: Clone, C: Collection<T>> SortedCollection<'a, T, C> {
         // Interleave structural nodes back into sorted order.
         //
         // For flat (non-sectioned) collections: all nodes are Items, so
-        // item_indices IS the final sorted order.
+        // item_positions IS the final sorted order.
         //
         // For sectioned or mixed collections: items are sorted within each
         // contiguous *run* of same-parent items. A new run starts when a
@@ -117,64 +138,65 @@ impl<'a, T: Clone, C: Collection<T>> SortedCollection<'a, T, C> {
         // runs separated by sections.
         let has_sections = inner.nodes().any(Node::is_structural);
 
-        let sorted_indices = if has_sections {
-            // Phase 1: assign each item to a contiguous-run group.
+        let sorted_positions = if has_sections {
+            // Phase 1: assign each item to a contiguous-run group, keyed by
+            // wrapper position.
             let mut item_to_group = BTreeMap::<usize, usize>::new();
             let mut next_group = 0;
             let mut current_parent = None::<Option<Key>>;
 
-            for node in inner.nodes() {
+            for (pos, node) in inner.nodes().enumerate() {
                 match node.node_type {
                     NodeType::Section => {
-                        // Section always resets scope — next item starts a new group.
                         current_parent = None;
                     }
-                    NodeType::Header | NodeType::Separator => {
-                        // Structural leaf nodes do not break item groups.
-                    }
+                    NodeType::Header | NodeType::Separator => {}
                     NodeType::Item => {
                         let pk = node.parent_key.clone();
                         match &current_parent {
-                            Some(existing_pk) if *existing_pk == pk => {
-                                // Same group — no action needed.
-                            }
+                            Some(existing_pk) if *existing_pk == pk => {}
                             _ => {
-                                // Different parent or first item after reset — new group.
                                 next_group += 1;
                                 current_parent = Some(pk);
                             }
                         }
-                        item_to_group.insert(node.index, next_group);
+                        item_to_group.insert(pos, next_group);
                     }
                 }
             }
 
-            // Phase 2: distribute the globally-sorted item indices into per-group buckets.
+            // Phase 2: distribute sorted item wrapper positions into per-group buckets.
+            // Every wrapper position in item_positions was added to item_to_group
+            // in Phase 1 (both iterate focusable items), so the map lookup always
+            // succeeds — `.expect` documents the invariant.
             let mut groups = BTreeMap::<usize, Vec<usize>>::new();
-            for &idx in &item_indices {
-                if let Some(&group) = item_to_group.get(&idx) {
-                    groups.entry(group).or_default().push(idx);
-                }
+            for &wp in &item_positions {
+                let group = *item_to_group
+                    .get(&wp)
+                    .expect("item position must have been assigned a group");
+                groups.entry(group).or_default().push(wp);
             }
 
             // Phase 3: walk original order, emit structural nodes in place,
-            // emit each group's sorted items on first encounter.
+            // emit each group's sorted items on first encounter. Both map
+            // lookups are guaranteed by Phase 1/2 construction invariants.
             let mut group_emitted = BTreeSet::<usize>::new();
             let mut result = Vec::with_capacity(inner.size());
 
-            for node in inner.nodes() {
+            for (pos, node) in inner.nodes().enumerate() {
                 match node.node_type {
                     NodeType::Section | NodeType::Header | NodeType::Separator => {
-                        result.push(node.index);
+                        result.push(pos);
                     }
                     NodeType::Item => {
-                        if let Some(&group) = item_to_group.get(&node.index) {
-                            if group_emitted.insert(group) {
-                                // First encounter — emit all sorted items for this group.
-                                if let Some(items) = groups.get(&group) {
-                                    result.extend_from_slice(items);
-                                }
-                            }
+                        let group = *item_to_group
+                            .get(&pos)
+                            .expect("item position must have been assigned a group");
+                        if group_emitted.insert(group) {
+                            let items = groups
+                                .get(&group)
+                                .expect("group must have been populated in Phase 2");
+                            result.extend_from_slice(items);
                         }
                     }
                 }
@@ -183,23 +205,38 @@ impl<'a, T: Clone, C: Collection<T>> SortedCollection<'a, T, C> {
             result
         } else {
             // Fast path: flat collection — sorted items are the full order.
-            item_indices
+            item_positions
         };
 
-        let first_focusable = sorted_indices
+        // Build reverse map: base node.index → position in sorted_positions.
+        let base_to_sorted_pos = sorted_positions
             .iter()
-            .copied()
-            .find(|&i| inner.get_by_index(i).is_some_and(Node::is_focusable));
+            .enumerate()
+            .filter_map(|(sp_idx, &wp)| inner.get_by_index(wp).map(|n| (n.index, sp_idx)))
+            .collect::<BTreeMap<_, _>>();
 
-        let last_focusable = sorted_indices
+        let first_focusable = sorted_positions.iter().enumerate().find_map(|(si, &wp)| {
+            inner
+                .get_by_index(wp)
+                .filter(|n| n.is_focusable())
+                .map(|_| si)
+        });
+
+        let last_focusable = sorted_positions
             .iter()
+            .enumerate()
             .rev()
-            .copied()
-            .find(|&i| inner.get_by_index(i).is_some_and(Node::is_focusable));
+            .find_map(|(si, &wp)| {
+                inner
+                    .get_by_index(wp)
+                    .filter(|n| n.is_focusable())
+                    .map(|_| si)
+            });
 
         Self {
             inner,
-            sorted_indices,
+            sorted_positions,
+            base_to_sorted_pos,
             first_focusable,
             last_focusable,
             _phantom: PhantomData,
@@ -209,7 +246,7 @@ impl<'a, T: Clone, C: Collection<T>> SortedCollection<'a, T, C> {
 
 impl<'a, T, C: Collection<T>> Collection<T> for SortedCollection<'a, T, C> {
     fn size(&self) -> usize {
-        self.sorted_indices.len()
+        self.sorted_positions.len()
     }
 
     fn get(&self, key: &Key) -> Option<&Node<T>> {
@@ -217,20 +254,22 @@ impl<'a, T, C: Collection<T>> Collection<T> for SortedCollection<'a, T, C> {
     }
 
     fn get_by_index(&self, index: usize) -> Option<&Node<T>> {
-        self.sorted_indices
+        self.sorted_positions
             .get(index)
-            .and_then(|&i| self.inner.get_by_index(i))
+            .and_then(|&wp| self.inner.get_by_index(wp))
     }
 
     fn first_key(&self) -> Option<&Key> {
         self.first_focusable
-            .and_then(|i| self.inner.get_by_index(i))
+            .and_then(|si| self.sorted_positions.get(si))
+            .and_then(|&wp| self.inner.get_by_index(wp))
             .map(|n| &n.key)
     }
 
     fn last_key(&self) -> Option<&Key> {
         self.last_focusable
-            .and_then(|i| self.inner.get_by_index(i))
+            .and_then(|si| self.sorted_positions.get(si))
+            .and_then(|&wp| self.inner.get_by_index(wp))
             .map(|n| &n.key)
     }
 
@@ -243,25 +282,34 @@ impl<'a, T, C: Collection<T>> Collection<T> for SortedCollection<'a, T, C> {
     }
 
     fn key_after_no_wrap(&self, key: &Key) -> Option<&Key> {
-        let current = self.inner.get(key)?.index;
-        let pos = self.sorted_indices.iter().position(|&i| i == current)?;
-        self.sorted_indices[pos + 1..].iter().find_map(|&i| {
-            self.inner
-                .get_by_index(i)
-                .filter(|n| n.is_focusable())
-                .map(|n| &n.key)
-        })
+        let node = self.inner.get(key)?;
+
+        let sorted_pos = *self.base_to_sorted_pos.get(&node.index)?;
+
+        self.sorted_positions[sorted_pos + 1..]
+            .iter()
+            .find_map(|&wp| {
+                self.inner
+                    .get_by_index(wp)
+                    .filter(|n| n.is_focusable())
+                    .map(|n| &n.key)
+            })
     }
 
     fn key_before_no_wrap(&self, key: &Key) -> Option<&Key> {
-        let current = self.inner.get(key)?.index;
-        let pos = self.sorted_indices.iter().position(|&i| i == current)?;
-        self.sorted_indices[..pos].iter().rev().find_map(|&i| {
-            self.inner
-                .get_by_index(i)
-                .filter(|n| n.is_focusable())
-                .map(|n| &n.key)
-        })
+        let node = self.inner.get(key)?;
+
+        let sorted_pos = *self.base_to_sorted_pos.get(&node.index)?;
+
+        self.sorted_positions[..sorted_pos]
+            .iter()
+            .rev()
+            .find_map(|&wp| {
+                self.inner
+                    .get_by_index(wp)
+                    .filter(|n| n.is_focusable())
+                    .map(|n| &n.key)
+            })
     }
 
     fn keys<'b>(&'b self) -> impl Iterator<Item = &'b Key>
@@ -275,9 +323,9 @@ impl<'a, T, C: Collection<T>> Collection<T> for SortedCollection<'a, T, C> {
     where
         T: 'b,
     {
-        self.sorted_indices
+        self.sorted_positions
             .iter()
-            .filter_map(|&i| self.inner.get_by_index(i))
+            .filter_map(|&wp| self.inner.get_by_index(wp))
     }
 
     fn children_of<'b>(&'b self, parent_key: &Key) -> impl Iterator<Item = &'b Node<T>>
@@ -292,7 +340,7 @@ impl<'a, T, C: Collection<T>> Collection<T> for SortedCollection<'a, T, C> {
 impl<T, C: Collection<T>> Debug for SortedCollection<'_, T, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SortedCollection")
-            .field("sorted_count", &self.sorted_indices.len())
+            .field("sorted_count", &self.sorted_positions.len())
             .finish()
     }
 }
@@ -808,5 +856,46 @@ mod tests {
 
         assert!(debug.contains("SortedCollection"));
         assert!(debug.contains("2"));
+    }
+
+    // ------------------------------------------------------------------ //
+    // Composition: SortedCollection over FilteredCollection               //
+    // ------------------------------------------------------------------ //
+
+    #[test]
+    fn sort_over_filtered_uses_wrapper_positions() {
+        use crate::FilteredCollection;
+
+        let base = CollectionBuilder::new()
+            .item(Key::int(1), "Cherry", "c")
+            .item(Key::int(2), "Apple", "a")
+            .item(Key::int(3), "Banana", "b")
+            .item(Key::int(4), "Date", "d")
+            .build();
+
+        // Filter out Apple — leaves Cherry(1), Banana(3), Date(4).
+        let filtered = FilteredCollection::new(&base, |n| n.text_value != "Apple");
+
+        // Sort the filtered view alphabetically.
+        let sorted = SortedCollection::new(&filtered, |a, b| a.text_value.cmp(&b.text_value));
+
+        assert_eq!(sorted.size(), 3);
+
+        let texts = sorted
+            .nodes()
+            .map(|n| n.text_value.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(texts, vec!["Banana", "Cherry", "Date"]);
+
+        // Positional access follows sorted order.
+        assert_eq!(sorted.get_by_index(0).expect("idx 0").text_value, "Banana");
+        assert_eq!(sorted.get_by_index(1).expect("idx 1").text_value, "Cherry");
+        assert_eq!(sorted.get_by_index(2).expect("idx 2").text_value, "Date");
+
+        // Navigation follows sorted order.
+        assert_eq!(sorted.first_key(), Some(&Key::int(3))); // Banana
+        assert_eq!(sorted.last_key(), Some(&Key::int(4))); // Date
+        assert_eq!(sorted.key_after_no_wrap(&Key::int(3)), Some(&Key::int(1))); // Banana → Cherry
+        assert_eq!(sorted.key_before_no_wrap(&Key::int(1)), Some(&Key::int(3))); // Cherry → Banana
     }
 }

--- a/crates/ars-collections/src/sorted_collection.rs
+++ b/crates/ars-collections/src/sorted_collection.rs
@@ -147,10 +147,19 @@ impl<'a, T: Clone, C: Collection<T>> SortedCollection<'a, T, C> {
 
             for (pos, node) in inner.nodes().enumerate() {
                 match node.node_type {
-                    NodeType::Section => {
+                    NodeType::Section | NodeType::Separator => {
+                        // Section and Separator both act as hard run boundaries.
+                        // Items on opposite sides MUST NOT merge into one sorted group,
+                        // even when they share the same parent_key, or sorting would
+                        // pull items across the visual divider.
                         current_parent = None;
                     }
-                    NodeType::Header | NodeType::Separator => {}
+
+                    NodeType::Header => {
+                        // Headers appear immediately after their Section and are
+                        // never run boundaries — the Section already reset scope.
+                    }
+
                     NodeType::Item => {
                         let pk = node.parent_key.clone();
                         match &current_parent {
@@ -897,5 +906,43 @@ mod tests {
         assert_eq!(sorted.last_key(), Some(&Key::int(4))); // Date
         assert_eq!(sorted.key_after_no_wrap(&Key::int(3)), Some(&Key::int(1))); // Banana → Cherry
         assert_eq!(sorted.key_before_no_wrap(&Key::int(1)), Some(&Key::int(3))); // Cherry → Banana
+    }
+
+    #[test]
+    fn sort_respects_separator_as_run_boundary() {
+        // Top-level items with a separator between them must NOT merge into
+        // one group. Each side sorts within itself, separator stays put.
+        //
+        // Original order:
+        //   D, B, Separator, C, A  (all top-level)
+        let inner = CollectionBuilder::new()
+            .item(Key::int(4), "D", "d")
+            .item(Key::int(2), "B", "b")
+            .separator()
+            .item(Key::int(3), "C", "c")
+            .item(Key::int(1), "A", "a")
+            .build();
+
+        let sorted = SortedCollection::new(&inner, |a, b| a.text_value.cmp(&b.text_value));
+
+        let types = sorted.nodes().map(|n| n.node_type).collect::<Vec<_>>();
+        assert_eq!(
+            types,
+            vec![
+                NodeType::Item,      // run 1
+                NodeType::Item,      // run 1
+                NodeType::Separator, // stays in place
+                NodeType::Item,      // run 2
+                NodeType::Item,      // run 2
+            ]
+        );
+
+        let texts = sorted
+            .nodes()
+            .filter(|n| n.is_focusable())
+            .map(|n| n.text_value.as_str())
+            .collect::<Vec<_>>();
+        // Run 1 (D, B) sorted → [B, D]. Run 2 (C, A) sorted → [A, C].
+        assert_eq!(texts, vec!["B", "D", "A", "C"]);
     }
 }

--- a/crates/ars-collections/src/sorted_collection.rs
+++ b/crates/ars-collections/src/sorted_collection.rs
@@ -1,0 +1,742 @@
+// ars-collections/src/sorted_collection.rs
+
+use alloc::{collections::BTreeMap, vec::Vec};
+use core::{
+    cmp,
+    fmt::{self, Debug, Display},
+    marker::PhantomData,
+};
+
+use crate::{
+    Collection,
+    key::Key,
+    node::{Node, NodeType},
+};
+
+/// The direction of a sort.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SortDirection {
+    /// Sort in ascending order (smallest first).
+    Ascending,
+    /// Sort in descending order (largest first).
+    Descending,
+}
+
+impl Display for SortDirection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SortDirection::Ascending => f.write_str("ascending"),
+            SortDirection::Descending => f.write_str("descending"),
+        }
+    }
+}
+
+/// Unified sort state for table columns.
+///
+/// `K` is the column key type — typically the same `Key` used by the
+/// collection, but any type works (e.g., a string column identifier).
+#[derive(Clone, Debug, PartialEq)]
+pub struct SortDescriptor<K> {
+    /// The column (or field) being sorted.
+    pub column: K,
+    /// Whether the sort is ascending or descending.
+    pub direction: SortDirection,
+}
+
+/// A read-only view over another collection with a comparator applied to item
+/// nodes. Structural nodes (sections, headers, separators) retain their
+/// relative order with respect to the items following them.
+///
+/// For locale-aware sorting, integrate `ars_i18n::StringCollator` as the comparator:
+///
+/// ```rust,ignore
+/// let collator = ars_i18n::StringCollator::new(&locale, Default::default());
+/// let sorted = SortedCollection::new(&collection, |a, b| {
+///     collator.compare(&a.text_value, &b.text_value)
+/// });
+/// ```
+///
+/// Clone — this struct holds only a reference and sorted indices, no closures.
+/// The comparator is consumed at construction time and not retained.
+pub struct SortedCollection<'a, T, C>
+where
+    C: Collection<T>,
+{
+    inner: &'a C,
+    /// Sorted flat indices of inner nodes in the new traversal order.
+    sorted_indices: Vec<usize>,
+    /// Cached index of the first focusable item in sorted order.
+    first_focusable: Option<usize>,
+    /// Cached index of the last focusable item in sorted order.
+    last_focusable: Option<usize>,
+
+    _phantom: PhantomData<T>,
+}
+
+impl<'a, T: Clone, C: Collection<T>> SortedCollection<'a, T, C> {
+    /// Construct a sorted view.
+    ///
+    /// `comparator` is called only for `Item` nodes. Section, Header, and
+    /// Separator nodes are left in their original relative positions within
+    /// their grouping. For flat (non-sectioned) collections, all nodes are
+    /// reordered.
+    pub fn new(inner: &'a C, comparator: impl Fn(&Node<T>, &Node<T>) -> cmp::Ordering) -> Self {
+        let mut item_indices = inner
+            .nodes()
+            .filter(|n| n.is_focusable())
+            .map(|n| n.index)
+            .collect::<Vec<_>>();
+
+        item_indices.sort_by(|&a, &b| {
+            let node_a = inner
+                .get_by_index(a)
+                .expect("sort index must be within collection bounds");
+            let node_b = inner
+                .get_by_index(b)
+                .expect("sort index must be within collection bounds");
+
+            comparator(node_a, node_b)
+        });
+
+        // Interleave structural nodes back into sorted order.
+        //
+        // For flat (non-sectioned) collections: all nodes are Items, so
+        // item_indices IS the final sorted order.
+        //
+        // For sectioned collections: sort items within each section while
+        // preserving section order and structural node positions. Algorithm:
+        // 1. Group sorted items by parent_key (section membership).
+        // 2. Walk the original node order. Structural nodes (Section, Header,
+        //    Separator) are emitted in their original positions. When items
+        //    belonging to a section are encountered, emit the section's sorted
+        //    items instead, consuming from the group.
+        let has_sections = inner.nodes().any(Node::is_structural);
+
+        let sorted_indices = if has_sections {
+            // Group sorted item indices by parent_key.
+            let mut section_items = BTreeMap::<Option<Key>, Vec<usize>>::new();
+            for &idx in &item_indices {
+                let node = inner
+                    .get_by_index(idx)
+                    .expect("sorted index must be within bounds");
+                section_items
+                    .entry(node.parent_key.clone())
+                    .or_default()
+                    .push(idx);
+            }
+            // Track consumption position per section.
+            let mut section_cursors = BTreeMap::<Option<Key>, usize>::new();
+
+            let mut result = Vec::with_capacity(inner.size());
+            let mut current_section = None::<Key>;
+            let mut items_emitted_for_section = false;
+
+            for node in inner.nodes() {
+                match node.node_type {
+                    NodeType::Section => {
+                        current_section = Some(node.key.clone());
+                        items_emitted_for_section = false;
+                        result.push(node.index);
+                    }
+                    NodeType::Header | NodeType::Separator => {
+                        // Emit structural nodes in their original position.
+                        result.push(node.index);
+                    }
+                    NodeType::Item => {
+                        // On first item of this section, emit all sorted items for it.
+                        let section_key = node.parent_key.clone();
+                        if !items_emitted_for_section || section_key != current_section {
+                            if let Some(items) = section_items.get(&section_key) {
+                                let cursor =
+                                    section_cursors.entry(section_key.clone()).or_insert(0);
+                                if *cursor == 0 {
+                                    // First encounter: emit all sorted items for this section.
+                                    result.extend_from_slice(items);
+                                    *cursor = items.len();
+                                }
+                            }
+                            items_emitted_for_section = true;
+                            current_section = section_key;
+                        }
+                        // Skip original item indices — already emitted via sorted group.
+                    }
+                }
+            }
+
+            result
+        } else {
+            // Fast path: flat collection — sorted items are the full order.
+            item_indices
+        };
+
+        let first_focusable = sorted_indices
+            .iter()
+            .copied()
+            .find(|&i| inner.get_by_index(i).is_some_and(Node::is_focusable));
+        let last_focusable = sorted_indices
+            .iter()
+            .rev()
+            .copied()
+            .find(|&i| inner.get_by_index(i).is_some_and(Node::is_focusable));
+
+        Self {
+            inner,
+            sorted_indices,
+            first_focusable,
+            last_focusable,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<'a, T, C: Collection<T>> Collection<T> for SortedCollection<'a, T, C> {
+    fn size(&self) -> usize {
+        self.sorted_indices.len()
+    }
+
+    fn get(&self, key: &Key) -> Option<&Node<T>> {
+        self.inner.get(key)
+    }
+
+    fn get_by_index(&self, index: usize) -> Option<&Node<T>> {
+        self.sorted_indices
+            .get(index)
+            .and_then(|&i| self.inner.get_by_index(i))
+    }
+
+    fn first_key(&self) -> Option<&Key> {
+        self.first_focusable
+            .and_then(|i| self.inner.get_by_index(i))
+            .map(|n| &n.key)
+    }
+
+    fn last_key(&self) -> Option<&Key> {
+        self.last_focusable
+            .and_then(|i| self.inner.get_by_index(i))
+            .map(|n| &n.key)
+    }
+
+    fn key_after(&self, key: &Key) -> Option<&Key> {
+        self.key_after_no_wrap(key).or_else(|| self.first_key())
+    }
+
+    fn key_before(&self, key: &Key) -> Option<&Key> {
+        self.key_before_no_wrap(key).or_else(|| self.last_key())
+    }
+
+    fn key_after_no_wrap(&self, key: &Key) -> Option<&Key> {
+        let current = self.inner.get(key)?.index;
+        let pos = self.sorted_indices.iter().position(|&i| i == current)?;
+        self.sorted_indices[pos + 1..].iter().find_map(|&i| {
+            self.inner
+                .get_by_index(i)
+                .filter(|n| n.is_focusable())
+                .map(|n| &n.key)
+        })
+    }
+
+    fn key_before_no_wrap(&self, key: &Key) -> Option<&Key> {
+        let current = self.inner.get(key)?.index;
+        let pos = self.sorted_indices.iter().position(|&i| i == current)?;
+        self.sorted_indices[..pos].iter().rev().find_map(|&i| {
+            self.inner
+                .get_by_index(i)
+                .filter(|n| n.is_focusable())
+                .map(|n| &n.key)
+        })
+    }
+
+    fn keys<'b>(&'b self) -> impl Iterator<Item = &'b Key>
+    where
+        T: 'b,
+    {
+        self.nodes().map(|n| &n.key)
+    }
+
+    fn nodes<'b>(&'b self) -> impl Iterator<Item = &'b Node<T>>
+    where
+        T: 'b,
+    {
+        self.sorted_indices
+            .iter()
+            .filter_map(|&i| self.inner.get_by_index(i))
+    }
+
+    fn children_of<'b>(&'b self, parent_key: &Key) -> impl Iterator<Item = &'b Node<T>>
+    where
+        T: 'b,
+    {
+        self.inner.children_of(parent_key)
+    }
+}
+
+/// Manual `Debug` avoids requiring `T: Debug`. Prints sorted count only.
+impl<T, C: Collection<T>> Debug for SortedCollection<'_, T, C> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SortedCollection")
+            .field("sorted_count", &self.sorted_indices.len())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{builder::CollectionBuilder, key::Key};
+
+    // ------------------------------------------------------------------ //
+    // SortDirection                                                        //
+    // ------------------------------------------------------------------ //
+
+    #[test]
+    fn ascending_display() {
+        assert_eq!(alloc::format!("{}", SortDirection::Ascending), "ascending");
+    }
+
+    #[test]
+    fn descending_display() {
+        assert_eq!(
+            alloc::format!("{}", SortDirection::Descending),
+            "descending"
+        );
+    }
+
+    #[test]
+    fn sort_direction_clone_copy_eq() {
+        let a = SortDirection::Ascending;
+
+        let b = a;
+
+        assert_eq!(a, b);
+    }
+
+    // ------------------------------------------------------------------ //
+    // SortDescriptor                                                      //
+    // ------------------------------------------------------------------ //
+
+    #[test]
+    fn sort_descriptor_creation() {
+        let desc = SortDescriptor {
+            column: Key::str("name"),
+            direction: SortDirection::Ascending,
+        };
+
+        assert_eq!(desc.column, Key::str("name"));
+        assert_eq!(desc.direction, SortDirection::Ascending);
+    }
+
+    #[test]
+    fn sort_descriptor_clone_eq() {
+        let a = SortDescriptor {
+            column: "name",
+            direction: SortDirection::Descending,
+        };
+
+        let b = a.clone();
+
+        assert_eq!(a, b);
+    }
+
+    // ------------------------------------------------------------------ //
+    // Construction (flat collections)                                      //
+    // ------------------------------------------------------------------ //
+
+    #[test]
+    fn sort_empty_collection() {
+        let inner = CollectionBuilder::<&str>::new().build();
+
+        let sorted = SortedCollection::new(&inner, |_, _| cmp::Ordering::Equal);
+
+        assert_eq!(sorted.size(), 0);
+        assert!(sorted.is_empty());
+    }
+
+    #[test]
+    fn sort_single_item() {
+        let inner = CollectionBuilder::new()
+            .item(Key::int(1), "Apple", "a")
+            .build();
+
+        let sorted = SortedCollection::new(&inner, |a, b| a.text_value.cmp(&b.text_value));
+
+        assert_eq!(sorted.size(), 1);
+        assert_eq!(sorted.first_key(), Some(&Key::int(1)));
+    }
+
+    #[test]
+    fn sort_already_sorted() {
+        let inner = CollectionBuilder::new()
+            .item(Key::int(1), "Apple", "a")
+            .item(Key::int(2), "Banana", "b")
+            .item(Key::int(3), "Cherry", "c")
+            .build();
+
+        let sorted = SortedCollection::new(&inner, |a, b| a.text_value.cmp(&b.text_value));
+
+        let keys = sorted.keys().collect::<Vec<_>>();
+
+        assert_eq!(keys, vec![&Key::int(1), &Key::int(2), &Key::int(3)]);
+    }
+
+    #[test]
+    fn sort_reverse_order() {
+        let inner = CollectionBuilder::new()
+            .item(Key::int(1), "Cherry", "c")
+            .item(Key::int(2), "Banana", "b")
+            .item(Key::int(3), "Apple", "a")
+            .build();
+
+        let sorted = SortedCollection::new(&inner, |a, b| a.text_value.cmp(&b.text_value));
+
+        let keys = sorted.keys().collect::<Vec<_>>();
+
+        // Apple (3), Banana (2), Cherry (1)
+        assert_eq!(keys, vec![&Key::int(3), &Key::int(2), &Key::int(1)]);
+    }
+
+    #[test]
+    fn sort_alphabetical_by_text() {
+        let inner = CollectionBuilder::new()
+            .item(Key::int(1), "Delta", "d")
+            .item(Key::int(2), "Alpha", "a")
+            .item(Key::int(3), "Charlie", "c")
+            .item(Key::int(4), "Bravo", "b")
+            .build();
+
+        let sorted = SortedCollection::new(&inner, |a, b| a.text_value.cmp(&b.text_value));
+
+        let texts = sorted
+            .nodes()
+            .map(|n| n.text_value.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(texts, vec!["Alpha", "Bravo", "Charlie", "Delta"]);
+    }
+
+    // ------------------------------------------------------------------ //
+    // Construction (sectioned collections)                                //
+    // ------------------------------------------------------------------ //
+
+    #[test]
+    fn sort_preserves_section_structure() {
+        let inner = CollectionBuilder::new()
+            .section(Key::str("fruits"), "Fruits")
+            .item(Key::int(1), "Cherry", "c")
+            .item(Key::int(2), "Apple", "a")
+            .end_section()
+            .build();
+
+        let sorted = SortedCollection::new(&inner, |a, b| a.text_value.cmp(&b.text_value));
+
+        // Section + Header + 2 items = 4
+        assert_eq!(sorted.size(), 4);
+
+        // Check node order: Section, Header, Apple, Cherry
+        let node_types = sorted.nodes().map(|n| n.node_type).collect::<Vec<_>>();
+
+        assert_eq!(
+            node_types,
+            vec![
+                NodeType::Section,
+                NodeType::Header,
+                NodeType::Item,
+                NodeType::Item,
+            ]
+        );
+
+        let texts = sorted
+            .nodes()
+            .filter(|n| n.is_focusable())
+            .map(|n| n.text_value.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(texts, vec!["Apple", "Cherry"]);
+    }
+
+    #[test]
+    fn sort_within_multiple_sections() {
+        let inner = CollectionBuilder::new()
+            .section(Key::str("fruits"), "Fruits")
+            .item(Key::int(2), "Banana", "b")
+            .item(Key::int(1), "Apple", "a")
+            .end_section()
+            .section(Key::str("vegs"), "Vegetables")
+            .item(Key::int(4), "Carrot", "c")
+            .item(Key::int(3), "Artichoke", "a")
+            .end_section()
+            .build();
+
+        let sorted = SortedCollection::new(&inner, |a, b| a.text_value.cmp(&b.text_value));
+
+        // Each section's items sorted independently.
+        let item_texts = sorted
+            .nodes()
+            .filter(|n| n.is_focusable())
+            .map(|n| n.text_value.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(item_texts, vec!["Apple", "Banana", "Artichoke", "Carrot"]);
+    }
+
+    #[test]
+    fn sort_section_with_separator() {
+        let inner = CollectionBuilder::new()
+            .section(Key::str("sec"), "Section")
+            .item(Key::int(2), "Banana", "b")
+            .item(Key::int(1), "Apple", "a")
+            .end_section()
+            .separator()
+            .item(Key::int(3), "Standalone", "s")
+            .build();
+
+        let sorted = SortedCollection::new(&inner, |a, b| a.text_value.cmp(&b.text_value));
+
+        // Separator stays in its original position.
+        let types = sorted.nodes().map(|n| n.node_type).collect::<Vec<_>>();
+
+        assert_eq!(
+            types,
+            vec![
+                NodeType::Section,
+                NodeType::Header,
+                NodeType::Item, // Apple (sorted)
+                NodeType::Item, // Banana (sorted)
+                NodeType::Separator,
+                NodeType::Item, // Standalone
+            ]
+        );
+    }
+
+    // ------------------------------------------------------------------ //
+    // Random access                                                       //
+    // ------------------------------------------------------------------ //
+
+    #[test]
+    fn get_by_key_unchanged() {
+        let inner = CollectionBuilder::new()
+            .item(Key::int(1), "Cherry", "c")
+            .item(Key::int(2), "Apple", "a")
+            .build();
+
+        let sorted = SortedCollection::new(&inner, |a, b| a.text_value.cmp(&b.text_value));
+
+        // get() by key is unaffected by sort order.
+        let node = sorted.get(&Key::int(1)).expect("key 1");
+
+        assert_eq!(node.text_value, "Cherry");
+    }
+
+    #[test]
+    fn get_by_index_reflects_sorted_order() {
+        let inner = CollectionBuilder::new()
+            .item(Key::int(1), "Cherry", "c")
+            .item(Key::int(2), "Apple", "a")
+            .build();
+
+        let sorted = SortedCollection::new(&inner, |a, b| a.text_value.cmp(&b.text_value));
+
+        // Index 0 should be Apple after sorting.
+        let first = sorted.get_by_index(0).expect("index 0");
+
+        assert_eq!(first.text_value, "Apple");
+
+        let second = sorted.get_by_index(1).expect("index 1");
+
+        assert_eq!(second.text_value, "Cherry");
+    }
+
+    // ------------------------------------------------------------------ //
+    // Boundary navigation                                                 //
+    // ------------------------------------------------------------------ //
+
+    #[test]
+    fn first_key_is_smallest_after_sort() {
+        let inner = CollectionBuilder::new()
+            .item(Key::int(1), "Cherry", "c")
+            .item(Key::int(2), "Apple", "a")
+            .item(Key::int(3), "Banana", "b")
+            .build();
+
+        let sorted = SortedCollection::new(&inner, |a, b| a.text_value.cmp(&b.text_value));
+
+        assert_eq!(sorted.first_key(), Some(&Key::int(2))); // Apple
+    }
+
+    #[test]
+    fn last_key_is_largest_after_sort() {
+        let inner = CollectionBuilder::new()
+            .item(Key::int(1), "Cherry", "c")
+            .item(Key::int(2), "Apple", "a")
+            .item(Key::int(3), "Banana", "b")
+            .build();
+
+        let sorted = SortedCollection::new(&inner, |a, b| a.text_value.cmp(&b.text_value));
+
+        assert_eq!(sorted.last_key(), Some(&Key::int(1))); // Cherry
+    }
+
+    #[test]
+    fn first_key_empty_collection() {
+        let inner = CollectionBuilder::<&str>::new().build();
+
+        let sorted = SortedCollection::new(&inner, |_, _| cmp::Ordering::Equal);
+
+        assert_eq!(sorted.first_key(), None);
+    }
+
+    // ------------------------------------------------------------------ //
+    // Sequential navigation                                               //
+    // ------------------------------------------------------------------ //
+
+    #[test]
+    fn key_after_follows_sorted_order() {
+        let inner = CollectionBuilder::new()
+            .item(Key::int(1), "Cherry", "c")
+            .item(Key::int(2), "Apple", "a")
+            .item(Key::int(3), "Banana", "b")
+            .build();
+
+        let sorted = SortedCollection::new(&inner, |a, b| a.text_value.cmp(&b.text_value));
+
+        // Sorted: Apple(2), Banana(3), Cherry(1)
+        assert_eq!(sorted.key_after_no_wrap(&Key::int(2)), Some(&Key::int(3))); // Apple -> Banana
+        assert_eq!(sorted.key_after_no_wrap(&Key::int(3)), Some(&Key::int(1))); // Banana -> Cherry
+    }
+
+    #[test]
+    fn key_after_wraps() {
+        let inner = CollectionBuilder::new()
+            .item(Key::int(1), "Cherry", "c")
+            .item(Key::int(2), "Apple", "a")
+            .build();
+
+        let sorted = SortedCollection::new(&inner, |a, b| a.text_value.cmp(&b.text_value));
+
+        // Sorted: Apple(2), Cherry(1). After Cherry wraps to Apple.
+        assert_eq!(sorted.key_after(&Key::int(1)), Some(&Key::int(2)));
+    }
+
+    #[test]
+    fn key_before_wraps() {
+        let inner = CollectionBuilder::new()
+            .item(Key::int(1), "Cherry", "c")
+            .item(Key::int(2), "Apple", "a")
+            .build();
+
+        let sorted = SortedCollection::new(&inner, |a, b| a.text_value.cmp(&b.text_value));
+
+        // Sorted: Apple(2), Cherry(1). Before Apple wraps to Cherry.
+        assert_eq!(sorted.key_before(&Key::int(2)), Some(&Key::int(1)));
+    }
+
+    #[test]
+    fn key_after_no_wrap_at_end() {
+        let inner = CollectionBuilder::new()
+            .item(Key::int(1), "Cherry", "c")
+            .item(Key::int(2), "Apple", "a")
+            .build();
+
+        let sorted = SortedCollection::new(&inner, |a, b| a.text_value.cmp(&b.text_value));
+
+        assert_eq!(sorted.key_after_no_wrap(&Key::int(1)), None); // Cherry is last
+    }
+
+    #[test]
+    fn key_before_no_wrap_at_start() {
+        let inner = CollectionBuilder::new()
+            .item(Key::int(1), "Cherry", "c")
+            .item(Key::int(2), "Apple", "a")
+            .build();
+
+        let sorted = SortedCollection::new(&inner, |a, b| a.text_value.cmp(&b.text_value));
+
+        assert_eq!(sorted.key_before_no_wrap(&Key::int(2)), None); // Apple is first
+    }
+
+    #[test]
+    fn key_before_no_wrap_finds_previous() {
+        let inner = CollectionBuilder::new()
+            .item(Key::int(1), "Cherry", "c")
+            .item(Key::int(2), "Apple", "a")
+            .item(Key::int(3), "Banana", "b")
+            .build();
+
+        let sorted = SortedCollection::new(&inner, |a, b| a.text_value.cmp(&b.text_value));
+
+        // Sorted: Apple(2), Banana(3), Cherry(1). Before Cherry is Banana.
+        assert_eq!(sorted.key_before_no_wrap(&Key::int(1)), Some(&Key::int(3)));
+    }
+
+    // ------------------------------------------------------------------ //
+    // Iteration                                                           //
+    // ------------------------------------------------------------------ //
+
+    #[test]
+    fn keys_in_sorted_order() {
+        let inner = CollectionBuilder::new()
+            .item(Key::int(1), "Cherry", "c")
+            .item(Key::int(2), "Apple", "a")
+            .item(Key::int(3), "Banana", "b")
+            .build();
+
+        let sorted = SortedCollection::new(&inner, |a, b| a.text_value.cmp(&b.text_value));
+
+        let keys = sorted.keys().collect::<Vec<_>>();
+
+        assert_eq!(keys, vec![&Key::int(2), &Key::int(3), &Key::int(1)]);
+    }
+
+    #[test]
+    fn nodes_in_sorted_order() {
+        let inner = CollectionBuilder::new()
+            .item(Key::int(1), "Cherry", "c")
+            .item(Key::int(2), "Apple", "a")
+            .build();
+
+        let sorted = SortedCollection::new(&inner, |a, b| a.text_value.cmp(&b.text_value));
+
+        let texts = sorted
+            .nodes()
+            .map(|n| n.text_value.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(texts, vec!["Apple", "Cherry"]);
+    }
+
+    #[test]
+    fn children_of_unchanged() {
+        let inner = CollectionBuilder::new()
+            .section(Key::str("sec"), "Section")
+            .item(Key::int(2), "Banana", "b")
+            .item(Key::int(1), "Apple", "a")
+            .end_section()
+            .build();
+
+        let sorted = SortedCollection::new(&inner, |a, b| a.text_value.cmp(&b.text_value));
+
+        // children_of delegates to inner — original order (Header + 2 items).
+
+        let children = sorted.children_of(&Key::str("sec")).collect::<Vec<_>>();
+
+        assert_eq!(children.len(), 3);
+    }
+
+    // ------------------------------------------------------------------ //
+    // Debug                                                               //
+    // ------------------------------------------------------------------ //
+
+    #[test]
+    fn debug_format() {
+        let inner = CollectionBuilder::new()
+            .item(Key::int(1), "Apple", "a")
+            .item(Key::int(2), "Banana", "b")
+            .build();
+
+        let sorted = SortedCollection::new(&inner, |a, b| a.text_value.cmp(&b.text_value));
+
+        let debug = alloc::format!("{sorted:?}");
+
+        assert!(debug.contains("SortedCollection"));
+        assert!(debug.contains("2"));
+    }
+}

--- a/spec/foundation/06-collections.md
+++ b/spec/foundation/06-collections.md
@@ -4223,17 +4223,23 @@ where
 {
     inner: &'a C,
 
-    /// Flat indices of inner nodes that pass the predicate.
-    /// Uses `BTreeSet` for O(log n) `contains()` in `get()`.
-    visible_indices: alloc::collections::BTreeSet<usize>,
+    /// Base `node.index` values of visible nodes.
+    /// Used for O(log n) membership checks in `get()` and `children_of()`.
+    visible_base_indices: alloc::collections::BTreeSet<usize>,
 
-    /// Ordered list of visible indices for positional access in `get_by_index()`.
-    visible_order: Vec<usize>,
+    /// Wrapper positions (into `inner`) of visible nodes, in traversal order.
+    /// Used by `get_by_index()` and `nodes()` — these are the coordinates
+    /// that `inner.get_by_index()` expects.
+    visible_positions: Vec<usize>,
 
-    /// Cached index of the first visible focusable item.
+    /// Maps base `node.index` → index into `visible_positions`, for O(log n)
+    /// lookup when navigating from a key.
+    base_to_visible_pos: alloc::collections::BTreeMap<usize, usize>,
+
+    /// Cached index into `visible_positions` of the first focusable item.
     first_focusable: Option<usize>,
 
-    /// Cached index of the last visible focusable item.
+    /// Cached index into `visible_positions` of the last focusable item.
     last_focusable: Option<usize>,
 
     _phantom: core::marker::PhantomData<T>,
@@ -4245,57 +4251,54 @@ impl<'a, T: Clone, C: Collection<T>> FilteredCollection<'a, T, C> {
     /// Section/Header/Separator nodes are included only when at least one of
     /// their children passes the predicate.
     pub fn new(inner: &'a C, predicate: impl Fn(&Node<T>) -> bool) -> Self {
-        // First pass: find all item nodes that pass.
-        // Uses node.index (the stable flat index from the inner collection)
-        // rather than iterator position, so this works correctly when the
-        // inner collection is itself a wrapper (e.g., SortedCollection) whose
-        // traversal order differs from index order.
+        // First pass: find all item nodes that pass, keyed by base index.
         let passing: alloc::collections::BTreeSet<usize> = inner
             .nodes()
             .filter(|n| n.is_focusable() && predicate(n))
             .map(|n| n.index)
             .collect();
 
-        // Second pass: include structural nodes whose section group has passing items.
+        // Second pass: collect (wrapper_position, base_index) for visible nodes.
         // - Section nodes: included when at least one direct child passes.
         // - Header/Separator nodes inside a section: included when their parent
-        //   section has at least one passing child (they have no children of their
-        //   own, so checking `children_of(&header_key)` would always be empty).
-        let visible_order: Vec<usize> = inner
+        //   section has at least one passing child.
+        let visible_data: Vec<(usize, usize)> = inner
             .nodes()
-            .filter(|n| {
+            .enumerate()
+            .filter(|(_, n)| {
                 if n.is_focusable() {
                     passing.contains(&n.index)
                 } else {
-                    // Section nodes own the children — check directly.
                     inner.children_of(&n.key).any(|child| passing.contains(&child.index))
-                        // Header/Separator nodes: check their parent section's children.
                         || n.parent_key.as_ref().is_some_and(|pk| {
                             inner.children_of(pk).any(|child| passing.contains(&child.index))
                         })
                 }
             })
-            .map(|n| n.index)
+            .map(|(wrapper_pos, n)| (wrapper_pos, n.index))
             .collect();
 
-        let visible_indices = visible_order.iter().copied().collect();
+        let visible_positions: Vec<usize> = visible_data.iter().map(|&(wp, _)| wp).collect();
+        let visible_base_indices = visible_data.iter().map(|&(_, bi)| bi).collect();
+        let base_to_visible_pos = visible_data.iter().enumerate()
+            .map(|(vis_idx, &(_, base_idx))| (base_idx, vis_idx)).collect();
 
-        let first_focusable = visible_order.iter().copied()
-            .find(|&i| inner.get_by_index(i).is_some_and(|n| n.is_focusable()));
-        let last_focusable = visible_order.iter().rev().copied()
-            .find(|&i| inner.get_by_index(i).is_some_and(|n| n.is_focusable()));
+        let first_focusable = visible_positions.iter().enumerate()
+            .find_map(|(vi, &wp)| inner.get_by_index(wp).filter(|n| n.is_focusable()).map(|_| vi));
+        let last_focusable = visible_positions.iter().enumerate().rev()
+            .find_map(|(vi, &wp)| inner.get_by_index(wp).filter(|n| n.is_focusable()).map(|_| vi));
 
-        Self { inner, visible_indices, visible_order, first_focusable, last_focusable, _phantom: core::marker::PhantomData }
+        Self { inner, visible_base_indices, visible_positions, base_to_visible_pos,
+               first_focusable, last_focusable, _phantom: core::marker::PhantomData }
     }
 }
 
 impl<'a, T: Clone, C: Collection<T>> Collection<T> for FilteredCollection<'a, T, C> {
-    fn size(&self) -> usize { self.visible_indices.len() }
+    fn size(&self) -> usize { self.visible_positions.len() }
 
     fn get(&self, key: &Key) -> Option<&Node<T>> {
-        // Only return nodes that are in the visible set.
         let node = self.inner.get(key)?;
-        if self.visible_indices.contains(&node.index) {
+        if self.visible_base_indices.contains(&node.index) {
             Some(node)
         } else {
             None
@@ -4303,18 +4306,20 @@ impl<'a, T: Clone, C: Collection<T>> Collection<T> for FilteredCollection<'a, T,
     }
 
     fn get_by_index(&self, index: usize) -> Option<&Node<T>> {
-        self.visible_order.get(index).and_then(|&i| self.inner.get_by_index(i))
+        self.visible_positions.get(index).and_then(|&wp| self.inner.get_by_index(wp))
     }
 
     fn first_key(&self) -> Option<&Key> {
         self.first_focusable
-            .and_then(|i| self.inner.get_by_index(i))
+            .and_then(|vi| self.visible_positions.get(vi))
+            .and_then(|&wp| self.inner.get_by_index(wp))
             .map(|n| &n.key)
     }
 
     fn last_key(&self) -> Option<&Key> {
         self.last_focusable
-            .and_then(|i| self.inner.get_by_index(i))
+            .and_then(|vi| self.visible_positions.get(vi))
+            .and_then(|&wp| self.inner.get_by_index(wp))
             .map(|n| &n.key)
     }
 
@@ -4327,20 +4332,20 @@ impl<'a, T: Clone, C: Collection<T>> Collection<T> for FilteredCollection<'a, T,
     }
 
     fn key_after_no_wrap(&self, key: &Key) -> Option<&Key> {
-        let current_index = self.inner.get(key)?.index;
-        let pos = self.visible_order.iter().position(|&i| i == current_index)?;
-        self.visible_order[pos + 1..]
+        let node = self.inner.get(key)?;
+        let &vis_pos = self.base_to_visible_pos.get(&node.index)?;
+        self.visible_positions[vis_pos + 1..]
             .iter()
-            .find_map(|&i| self.inner.get_by_index(i).filter(|n| n.is_focusable()).map(|n| &n.key))
+            .find_map(|&wp| self.inner.get_by_index(wp).filter(|n| n.is_focusable()).map(|n| &n.key))
     }
 
     fn key_before_no_wrap(&self, key: &Key) -> Option<&Key> {
-        let current_index = self.inner.get(key)?.index;
-        let pos = self.visible_order.iter().position(|&i| i == current_index)?;
-        self.visible_order[..pos]
+        let node = self.inner.get(key)?;
+        let &vis_pos = self.base_to_visible_pos.get(&node.index)?;
+        self.visible_positions[..vis_pos]
             .iter()
             .rev()
-            .find_map(|&i| self.inner.get_by_index(i).filter(|n| n.is_focusable()).map(|n| &n.key))
+            .find_map(|&wp| self.inner.get_by_index(wp).filter(|n| n.is_focusable()).map(|n| &n.key))
     }
 
     fn keys(&self) -> impl Iterator<Item = &Key> {
@@ -4348,18 +4353,14 @@ impl<'a, T: Clone, C: Collection<T>> Collection<T> for FilteredCollection<'a, T,
     }
 
     fn nodes(&self) -> impl Iterator<Item = &Node<T>> {
-        // Iterate visible_order (Vec) to preserve the inner collection's
-        // traversal order, not visible_indices (BTreeSet) which re-sorts by
-        // numeric index. This ensures nodes()/keys() agree with
-        // get_by_index()/key_after() when wrapping a SortedCollection.
-        self.visible_order
+        self.visible_positions
             .iter()
-            .filter_map(|&i| self.inner.get_by_index(i))
+            .filter_map(|&wp| self.inner.get_by_index(wp))
     }
 
     fn children_of(&self, parent_key: &Key) -> impl Iterator<Item = &Node<T>> {
         self.inner.children_of(parent_key)
-            .filter(|n| self.visible_indices.contains(&n.index))
+            .filter(|n| self.visible_base_indices.contains(&n.index))
     }
 }
 ```
@@ -4423,11 +4424,13 @@ where
     C: Collection<T>,
 {
     inner: &'a C,
-    /// Sorted flat indices of inner nodes in the new traversal order.
-    sorted_indices: Vec<usize>,
-    /// Cached index of the first focusable item in sorted order.
+    /// Wrapper positions (into `inner`) in sorted traversal order.
+    sorted_positions: Vec<usize>,
+    /// Maps base `node.index` → index into `sorted_positions`.
+    base_to_sorted_pos: alloc::collections::BTreeMap<usize, usize>,
+    /// Cached index into `sorted_positions` of the first focusable item.
     first_focusable: Option<usize>,
-    /// Cached index of the last focusable item in sorted order.
+    /// Cached index into `sorted_positions` of the last focusable item.
     last_focusable: Option<usize>,
     _phantom: core::marker::PhantomData<T>,
 }
@@ -4443,13 +4446,15 @@ impl<'a, T: Clone, C: Collection<T>> SortedCollection<'a, T, C> {
         inner: &'a C,
         comparator: impl Fn(&Node<T>, &Node<T>) -> core::cmp::Ordering,
     ) -> Self {
-        let mut item_indices: Vec<usize> = inner
+        // Collect item wrapper positions and sort them by comparator.
+        let mut item_positions: Vec<usize> = inner
             .nodes()
-            .filter(|n| n.is_focusable())
-            .map(|n| n.index)
+            .enumerate()
+            .filter(|(_, n)| n.is_focusable())
+            .map(|(pos, _)| pos)
             .collect();
 
-        item_indices.sort_by(|&a, &b| {
+        item_positions.sort_by(|&a, &b| {
             let na = inner.get_by_index(a)
                 .expect("sort index must be within collection bounds");
             let nb = inner.get_by_index(b)
@@ -4473,22 +4478,18 @@ impl<'a, T: Clone, C: Collection<T>> SortedCollection<'a, T, C> {
         // runs separated by sections.
         let has_sections = inner.nodes().any(|n| n.is_structural());
 
-        let sorted_indices = if has_sections {
-            // Phase 1: assign each item to a contiguous-run group.
+        let sorted_positions = if has_sections {
+            // Phase 1: assign each item to a contiguous-run group, keyed by
+            // wrapper position.
             let mut item_to_group: alloc::collections::BTreeMap<usize, usize> =
                 alloc::collections::BTreeMap::new();
             let mut next_group: usize = 0;
             let mut current_parent: Option<Option<Key>> = None;
 
-            for node in inner.nodes() {
+            for (pos, node) in inner.nodes().enumerate() {
                 match node.node_type {
-                    NodeType::Section => {
-                        // Section always resets scope — next item starts a new group.
-                        current_parent = None;
-                    }
-                    NodeType::Header | NodeType::Separator => {
-                        // Structural leaf nodes do not break item groups.
-                    }
+                    NodeType::Section => { current_parent = None; }
+                    NodeType::Header | NodeType::Separator => {}
                     NodeType::Item => {
                         let pk = node.parent_key.clone();
                         match &current_parent {
@@ -4498,39 +4499,42 @@ impl<'a, T: Clone, C: Collection<T>> SortedCollection<'a, T, C> {
                                 current_parent = Some(pk);
                             }
                         }
-                        item_to_group.insert(node.index, next_group);
+                        item_to_group.insert(pos, next_group);
                     }
                 }
             }
 
-            // Phase 2: distribute the globally-sorted item indices into per-group buckets.
+            // Phase 2: distribute sorted item wrapper positions into per-group buckets.
+            // Every wrapper position in item_positions was added to item_to_group
+            // in Phase 1 (both iterate focusable items), so the map lookup always
+            // succeeds — `.expect` documents the invariant.
             let mut groups: alloc::collections::BTreeMap<usize, Vec<usize>> =
                 alloc::collections::BTreeMap::new();
-            for &idx in &item_indices {
-                if let Some(&group) = item_to_group.get(&idx) {
-                    groups.entry(group).or_default().push(idx);
-                }
+            for &wp in &item_positions {
+                let group = *item_to_group.get(&wp)
+                    .expect("item position must have been assigned a group");
+                groups.entry(group).or_default().push(wp);
             }
 
             // Phase 3: walk original order, emit structural nodes in place,
-            // emit each group's sorted items on first encounter.
+            // emit each group's sorted items on first encounter. Both map
+            // lookups are guaranteed by Phase 1/2 construction invariants.
             let mut group_emitted: alloc::collections::BTreeSet<usize> =
                 alloc::collections::BTreeSet::new();
             let mut result = Vec::with_capacity(inner.size());
 
-            for node in inner.nodes() {
+            for (pos, node) in inner.nodes().enumerate() {
                 match node.node_type {
                     NodeType::Section | NodeType::Header | NodeType::Separator => {
-                        result.push(node.index);
+                        result.push(pos);
                     }
                     NodeType::Item => {
-                        if let Some(&group) = item_to_group.get(&node.index) {
-                            if group_emitted.insert(group) {
-                                // First encounter — emit all sorted items for this group.
-                                if let Some(items) = groups.get(&group) {
-                                    result.extend_from_slice(items);
-                                }
-                            }
+                        let group = *item_to_group.get(&pos)
+                            .expect("item position must have been assigned a group");
+                        if group_emitted.insert(group) {
+                            let items = groups.get(&group)
+                                .expect("group must have been populated in Phase 2");
+                            result.extend_from_slice(items);
                         }
                     }
                 }
@@ -4539,36 +4543,44 @@ impl<'a, T: Clone, C: Collection<T>> SortedCollection<'a, T, C> {
             result
         } else {
             // Fast path: flat collection — sorted items are the full order.
-            item_indices
+            item_positions
         };
 
-        let first_focusable = sorted_indices.iter().copied()
-            .find(|&i| inner.get_by_index(i).is_some_and(|n| n.is_focusable()));
-        let last_focusable = sorted_indices.iter().rev().copied()
-            .find(|&i| inner.get_by_index(i).is_some_and(|n| n.is_focusable()));
+        // Build reverse map: base node.index → position in sorted_positions.
+        let base_to_sorted_pos: alloc::collections::BTreeMap<usize, usize> = sorted_positions
+            .iter().enumerate()
+            .filter_map(|(sp_idx, &wp)| inner.get_by_index(wp).map(|n| (n.index, sp_idx)))
+            .collect();
 
-        Self { inner, sorted_indices, first_focusable, last_focusable, _phantom: core::marker::PhantomData }
+        let first_focusable = sorted_positions.iter().enumerate()
+            .find_map(|(si, &wp)| inner.get_by_index(wp).filter(|n| n.is_focusable()).map(|_| si));
+        let last_focusable = sorted_positions.iter().enumerate().rev()
+            .find_map(|(si, &wp)| inner.get_by_index(wp).filter(|n| n.is_focusable()).map(|_| si));
+
+        Self { inner, sorted_positions, base_to_sorted_pos, first_focusable, last_focusable, _phantom: core::marker::PhantomData }
     }
 }
 
 impl<'a, T, C: Collection<T>> Collection<T> for SortedCollection<'a, T, C> {
-    fn size(&self) -> usize { self.sorted_indices.len() }
+    fn size(&self) -> usize { self.sorted_positions.len() }
 
     fn get(&self, key: &Key) -> Option<&Node<T>> { self.inner.get(key) }
 
     fn get_by_index(&self, index: usize) -> Option<&Node<T>> {
-        self.sorted_indices.get(index).and_then(|&i| self.inner.get_by_index(i))
+        self.sorted_positions.get(index).and_then(|&wp| self.inner.get_by_index(wp))
     }
 
     fn first_key(&self) -> Option<&Key> {
         self.first_focusable
-            .and_then(|i| self.inner.get_by_index(i))
+            .and_then(|si| self.sorted_positions.get(si))
+            .and_then(|&wp| self.inner.get_by_index(wp))
             .map(|n| &n.key)
     }
 
     fn last_key(&self) -> Option<&Key> {
         self.last_focusable
-            .and_then(|i| self.inner.get_by_index(i))
+            .and_then(|si| self.sorted_positions.get(si))
+            .and_then(|&wp| self.inner.get_by_index(wp))
             .map(|n| &n.key)
     }
 
@@ -4581,18 +4593,18 @@ impl<'a, T, C: Collection<T>> Collection<T> for SortedCollection<'a, T, C> {
     }
 
     fn key_after_no_wrap(&self, key: &Key) -> Option<&Key> {
-        let current = self.inner.get(key)?.index;
-        let pos = self.sorted_indices.iter().position(|&i| i == current)?;
-        self.sorted_indices[pos + 1..].iter().find_map(|&i| {
-            self.inner.get_by_index(i).filter(|n| n.is_focusable()).map(|n| &n.key)
+        let node = self.inner.get(key)?;
+        let &sorted_pos = self.base_to_sorted_pos.get(&node.index)?;
+        self.sorted_positions[sorted_pos + 1..].iter().find_map(|&wp| {
+            self.inner.get_by_index(wp).filter(|n| n.is_focusable()).map(|n| &n.key)
         })
     }
 
     fn key_before_no_wrap(&self, key: &Key) -> Option<&Key> {
-        let current = self.inner.get(key)?.index;
-        let pos = self.sorted_indices.iter().position(|&i| i == current)?;
-        self.sorted_indices[..pos].iter().rev().find_map(|&i| {
-            self.inner.get_by_index(i).filter(|n| n.is_focusable()).map(|n| &n.key)
+        let node = self.inner.get(key)?;
+        let &sorted_pos = self.base_to_sorted_pos.get(&node.index)?;
+        self.sorted_positions[..sorted_pos].iter().rev().find_map(|&wp| {
+            self.inner.get_by_index(wp).filter(|n| n.is_focusable()).map(|n| &n.key)
         })
     }
 
@@ -4601,7 +4613,7 @@ impl<'a, T, C: Collection<T>> Collection<T> for SortedCollection<'a, T, C> {
     }
 
     fn nodes(&self) -> impl Iterator<Item = &Node<T>> {
-        self.sorted_indices.iter().filter_map(|&i| self.inner.get_by_index(i))
+        self.sorted_positions.iter().filter_map(|&wp| self.inner.get_by_index(wp))
     }
 
     fn children_of(&self, parent_key: &Key) -> impl Iterator<Item = &Node<T>> {

--- a/spec/foundation/06-collections.md
+++ b/spec/foundation/06-collections.md
@@ -4246,11 +4246,14 @@ impl<'a, T: Clone, C: Collection<T>> FilteredCollection<'a, T, C> {
     /// their children passes the predicate.
     pub fn new(inner: &'a C, predicate: impl Fn(&Node<T>) -> bool) -> Self {
         // First pass: find all item nodes that pass.
+        // Uses node.index (the stable flat index from the inner collection)
+        // rather than iterator position, so this works correctly when the
+        // inner collection is itself a wrapper (e.g., SortedCollection) whose
+        // traversal order differs from index order.
         let passing: alloc::collections::BTreeSet<usize> = inner
             .nodes()
-            .enumerate()
-            .filter(|(_, n)| n.is_focusable() && predicate(n))
-            .map(|(i, _)| i)
+            .filter(|n| n.is_focusable() && predicate(n))
+            .map(|n| n.index)
             .collect();
 
         // Second pass: include structural nodes whose section group has passing items.
@@ -4345,7 +4348,11 @@ impl<'a, T: Clone, C: Collection<T>> Collection<T> for FilteredCollection<'a, T,
     }
 
     fn nodes(&self) -> impl Iterator<Item = &Node<T>> {
-        self.visible_indices
+        // Iterate visible_order (Vec) to preserve the inner collection's
+        // traversal order, not visible_indices (BTreeSet) which re-sorts by
+        // numeric index. This ensures nodes()/keys() agree with
+        // get_by_index()/key_after() when wrapping a SortedCollection.
+        self.visible_order
             .iter()
             .filter_map(|&i| self.inner.get_by_index(i))
     }
@@ -4455,67 +4462,84 @@ impl<'a, T: Clone, C: Collection<T>> SortedCollection<'a, T, C> {
         // For flat (non-sectioned) collections: all nodes are Items, so
         // item_indices IS the final sorted order.
         //
-        // For sectioned collections: sort items within each section while
-        // preserving section order and structural node positions. Algorithm:
-        // 1. Group sorted items by parent_key (section membership).
-        // 2. Walk the original node order. Structural nodes (Section, Header,
-        //    Separator) are emitted in their original positions. When items
-        //    belonging to a section are encountered, emit the section's sorted
-        //    items instead, consuming from the group.
+        // For sectioned or mixed collections: items are sorted within each
+        // contiguous *run* of same-parent items. A new run starts when a
+        // Section node is encountered or an Item's parent_key differs from
+        // the previous Item's parent. Header and Separator nodes do not
+        // break runs — they are emitted in their original positions.
+        //
+        // This run-aware grouping prevents items from migrating across
+        // structural boundaries when top-level items appear in multiple
+        // runs separated by sections.
         let has_sections = inner.nodes().any(|n| n.is_structural());
 
-        let sorted_indices = if !has_sections {
-            // Fast path: flat collection — sorted items are the full order.
-            item_indices
-        } else {
-            // Group sorted item indices by parent_key.
-            let mut section_items: alloc::collections::BTreeMap<Option<Key>, Vec<usize>> =
+        let sorted_indices = if has_sections {
+            // Phase 1: assign each item to a contiguous-run group.
+            let mut item_to_group: alloc::collections::BTreeMap<usize, usize> =
                 alloc::collections::BTreeMap::new();
-            for &idx in &item_indices {
-                let node = inner.get_by_index(idx)
-                    .expect("sorted index must be within bounds");
-                section_items.entry(node.parent_key.clone()).or_default().push(idx);
-            }
-            // Track consumption position per section.
-            let mut section_cursors: alloc::collections::BTreeMap<Option<Key>, usize> =
-                alloc::collections::BTreeMap::new();
-
-            let mut result = Vec::with_capacity(inner.size());
-            let mut current_section: Option<Key> = None;
-            let mut items_emitted_for_section = false;
+            let mut next_group: usize = 0;
+            let mut current_parent: Option<Option<Key>> = None;
 
             for node in inner.nodes() {
                 match node.node_type {
                     NodeType::Section => {
-                        current_section = Some(node.key.clone());
-                        items_emitted_for_section = false;
-                        result.push(node.index);
+                        // Section always resets scope — next item starts a new group.
+                        current_parent = None;
                     }
                     NodeType::Header | NodeType::Separator => {
-                        // Emit structural nodes in their original position.
+                        // Structural leaf nodes do not break item groups.
+                    }
+                    NodeType::Item => {
+                        let pk = node.parent_key.clone();
+                        match &current_parent {
+                            Some(existing_pk) if *existing_pk == pk => {}
+                            _ => {
+                                next_group += 1;
+                                current_parent = Some(pk);
+                            }
+                        }
+                        item_to_group.insert(node.index, next_group);
+                    }
+                }
+            }
+
+            // Phase 2: distribute the globally-sorted item indices into per-group buckets.
+            let mut groups: alloc::collections::BTreeMap<usize, Vec<usize>> =
+                alloc::collections::BTreeMap::new();
+            for &idx in &item_indices {
+                if let Some(&group) = item_to_group.get(&idx) {
+                    groups.entry(group).or_default().push(idx);
+                }
+            }
+
+            // Phase 3: walk original order, emit structural nodes in place,
+            // emit each group's sorted items on first encounter.
+            let mut group_emitted: alloc::collections::BTreeSet<usize> =
+                alloc::collections::BTreeSet::new();
+            let mut result = Vec::with_capacity(inner.size());
+
+            for node in inner.nodes() {
+                match node.node_type {
+                    NodeType::Section | NodeType::Header | NodeType::Separator => {
                         result.push(node.index);
                     }
                     NodeType::Item => {
-                        // On first item of this section, emit all sorted items for it.
-                        let section_key = node.parent_key.clone();
-                        if !items_emitted_for_section || section_key != current_section {
-                            if let Some(items) = section_items.get(&section_key) {
-                                let cursor = section_cursors.entry(section_key.clone()).or_insert(0);
-                                if *cursor == 0 {
-                                    // First encounter: emit all sorted items for this section.
+                        if let Some(&group) = item_to_group.get(&node.index) {
+                            if group_emitted.insert(group) {
+                                // First encounter — emit all sorted items for this group.
+                                if let Some(items) = groups.get(&group) {
                                     result.extend_from_slice(items);
-                                    *cursor = items.len();
                                 }
                             }
-                            items_emitted_for_section = true;
-                            current_section = section_key;
                         }
-                        // Skip original item indices — already emitted via sorted group.
                     }
                 }
             }
 
             result
+        } else {
+            // Fast path: flat collection — sorted items are the full order.
+            item_indices
         };
 
         let first_focusable = sorted_indices.iter().copied()

--- a/spec/foundation/06-collections.md
+++ b/spec/foundation/06-collections.md
@@ -4230,6 +4230,12 @@ where
     /// Ordered list of visible indices for positional access in `get_by_index()`.
     visible_order: Vec<usize>,
 
+    /// Cached index of the first visible focusable item.
+    first_focusable: Option<usize>,
+
+    /// Cached index of the last visible focusable item.
+    last_focusable: Option<usize>,
+
     _phantom: core::marker::PhantomData<T>,
 }
 
@@ -4247,16 +4253,23 @@ impl<'a, T: Clone, C: Collection<T>> FilteredCollection<'a, T, C> {
             .map(|(i, _)| i)
             .collect();
 
-        // Second pass: include structural nodes only when they have passing children.
-        // (Structural nodes carry their index via node.index.)
+        // Second pass: include structural nodes whose section group has passing items.
+        // - Section nodes: included when at least one direct child passes.
+        // - Header/Separator nodes inside a section: included when their parent
+        //   section has at least one passing child (they have no children of their
+        //   own, so checking `children_of(&header_key)` would always be empty).
         let visible_order: Vec<usize> = inner
             .nodes()
             .filter(|n| {
                 if n.is_focusable() {
                     passing.contains(&n.index)
                 } else {
-                    // Include structural nodes that have at least one visible descendant.
+                    // Section nodes own the children — check directly.
                     inner.children_of(&n.key).any(|child| passing.contains(&child.index))
+                        // Header/Separator nodes: check their parent section's children.
+                        || n.parent_key.as_ref().is_some_and(|pk| {
+                            inner.children_of(pk).any(|child| passing.contains(&child.index))
+                        })
                 }
             })
             .map(|n| n.index)
@@ -4264,7 +4277,12 @@ impl<'a, T: Clone, C: Collection<T>> FilteredCollection<'a, T, C> {
 
         let visible_indices = visible_order.iter().copied().collect();
 
-        Self { inner, visible_indices, visible_order, _phantom: core::marker::PhantomData }
+        let first_focusable = visible_order.iter().copied()
+            .find(|&i| inner.get_by_index(i).is_some_and(|n| n.is_focusable()));
+        let last_focusable = visible_order.iter().rev().copied()
+            .find(|&i| inner.get_by_index(i).is_some_and(|n| n.is_focusable()));
+
+        Self { inner, visible_indices, visible_order, first_focusable, last_focusable, _phantom: core::marker::PhantomData }
     }
 }
 
@@ -4286,16 +4304,15 @@ impl<'a, T: Clone, C: Collection<T>> Collection<T> for FilteredCollection<'a, T,
     }
 
     fn first_key(&self) -> Option<&Key> {
-        self.visible_indices
-            .iter()
-            .find_map(|&i| self.inner.get_by_index(i).filter(|n| n.is_focusable()).map(|n| &n.key))
+        self.first_focusable
+            .and_then(|i| self.inner.get_by_index(i))
+            .map(|n| &n.key)
     }
 
     fn last_key(&self) -> Option<&Key> {
-        self.visible_indices
-            .iter()
-            .rev()
-            .find_map(|&i| self.inner.get_by_index(i).filter(|n| n.is_focusable()).map(|n| &n.key))
+        self.last_focusable
+            .and_then(|i| self.inner.get_by_index(i))
+            .map(|n| &n.key)
     }
 
     fn key_after(&self, key: &Key) -> Option<&Key> {
@@ -4348,12 +4365,14 @@ Sorting produces a view that presents nodes in a different order without modifyi
 // ars-collections/src/sorted_collection.rs
 
 use alloc::vec::Vec;
-use crate::{key::Key, node::Node, Collection};
+use crate::{key::Key, node::{Node, NodeType}, Collection};
 
 /// The direction of a sort.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum SortDirection {
+    /// Sort in ascending order (smallest first).
     Ascending,
+    /// Sort in descending order (largest first).
     Descending,
 }
 
@@ -4367,9 +4386,14 @@ impl core::fmt::Display for SortDirection {
 }
 
 /// Unified sort state for table columns.
+///
+/// `K` is the column key type — typically the same `Key` used by the
+/// collection, but any type works (e.g., a string column identifier).
 #[derive(Clone, Debug, PartialEq)]
 pub struct SortDescriptor<K> {
+    /// The column (or field) being sorted.
     pub column: K,
+    /// Whether the sort is ascending or descending.
     pub direction: SortDirection,
 }
 
@@ -4394,6 +4418,10 @@ where
     inner: &'a C,
     /// Sorted flat indices of inner nodes in the new traversal order.
     sorted_indices: Vec<usize>,
+    /// Cached index of the first focusable item in sorted order.
+    first_focusable: Option<usize>,
+    /// Cached index of the last focusable item in sorted order.
+    last_focusable: Option<usize>,
     _phantom: core::marker::PhantomData<T>,
 }
 
@@ -4490,7 +4518,12 @@ impl<'a, T: Clone, C: Collection<T>> SortedCollection<'a, T, C> {
             result
         };
 
-        Self { inner, sorted_indices, _phantom: core::marker::PhantomData }
+        let first_focusable = sorted_indices.iter().copied()
+            .find(|&i| inner.get_by_index(i).is_some_and(|n| n.is_focusable()));
+        let last_focusable = sorted_indices.iter().rev().copied()
+            .find(|&i| inner.get_by_index(i).is_some_and(|n| n.is_focusable()));
+
+        Self { inner, sorted_indices, first_focusable, last_focusable, _phantom: core::marker::PhantomData }
     }
 }
 
@@ -4504,15 +4537,15 @@ impl<'a, T, C: Collection<T>> Collection<T> for SortedCollection<'a, T, C> {
     }
 
     fn first_key(&self) -> Option<&Key> {
-        self.sorted_indices.iter().find_map(|&i| {
-            self.inner.get_by_index(i).filter(|n| n.is_focusable()).map(|n| &n.key)
-        })
+        self.first_focusable
+            .and_then(|i| self.inner.get_by_index(i))
+            .map(|n| &n.key)
     }
 
     fn last_key(&self) -> Option<&Key> {
-        self.sorted_indices.iter().rev().find_map(|&i| {
-            self.inner.get_by_index(i).filter(|n| n.is_focusable()).map(|n| &n.key)
-        })
+        self.last_focusable
+            .and_then(|i| self.inner.get_by_index(i))
+            .map(|n| &n.key)
     }
 
     fn key_after(&self, key: &Key) -> Option<&Key> {

--- a/spec/foundation/06-collections.md
+++ b/spec/foundation/06-collections.md
@@ -4198,7 +4198,7 @@ Filtering wraps an existing `Collection<T>` implementation and applies a predica
 // ars-collections/src/filtered_collection.rs
 
 use alloc::vec::Vec;
-use crate::{key::Key, node::Node, Collection};
+use crate::{key::Key, node::{Node, NodeType}, Collection};
 
 /// A read-only view over another collection with a predicate applied.
 ///
@@ -4259,20 +4259,32 @@ impl<'a, T: Clone, C: Collection<T>> FilteredCollection<'a, T, C> {
             .collect();
 
         // Second pass: collect (wrapper_position, base_index) for visible nodes.
-        // - Section nodes: included when at least one direct child passes.
-        // - Header/Separator nodes inside a section: included when their parent
-        //   section has at least one passing child.
+        // Structural nodes are included based on the scope they belong to:
+        // - Section nodes: scope is their direct children.
+        // - Header/Separator inside a section: scope is the parent section's
+        //   children (they have no children of their own).
+        // - Top-level Header/Separator: scope is all top-level items. Without
+        //   this branch a no-op predicate (`|_| true`) would drop top-level
+        //   separators and silently change the collection shape.
         let visible_data: Vec<(usize, usize)> = inner
             .nodes()
             .enumerate()
             .filter(|(_, n)| {
                 if n.is_focusable() {
-                    passing.contains(&n.index)
-                } else {
-                    inner.children_of(&n.key).any(|child| passing.contains(&child.index))
-                        || n.parent_key.as_ref().is_some_and(|pk| {
-                            inner.children_of(pk).any(|child| passing.contains(&child.index))
-                        })
+                    return passing.contains(&n.index);
+                }
+                match (&n.parent_key, n.node_type) {
+                    (_, NodeType::Section) => inner
+                        .children_of(&n.key)
+                        .any(|child| passing.contains(&child.index)),
+                    (Some(pk), _) => inner
+                        .children_of(pk)
+                        .any(|child| passing.contains(&child.index)),
+                    (None, _) => inner.nodes().any(|m| {
+                        m.is_focusable()
+                            && m.parent_key.is_none()
+                            && passing.contains(&m.index)
+                    }),
                 }
             })
             .map(|(wrapper_pos, n)| (wrapper_pos, n.index))
@@ -4488,8 +4500,17 @@ impl<'a, T: Clone, C: Collection<T>> SortedCollection<'a, T, C> {
 
             for (pos, node) in inner.nodes().enumerate() {
                 match node.node_type {
-                    NodeType::Section => { current_parent = None; }
-                    NodeType::Header | NodeType::Separator => {}
+                    NodeType::Section | NodeType::Separator => {
+                        // Section and Separator both act as hard run boundaries.
+                        // Items on opposite sides MUST NOT merge into one sorted
+                        // group, even when they share the same parent_key, or
+                        // sorting would pull items across the visual divider.
+                        current_parent = None;
+                    }
+                    NodeType::Header => {
+                        // Headers appear immediately after their Section and are
+                        // never run boundaries — the Section already reset scope.
+                    }
                     NodeType::Item => {
                         let pk = node.parent_key.clone();
                         match &current_parent {


### PR DESCRIPTION
## Summary

- Implement `FilteredCollection<'a, T, C>` — predicate-based filtering view over any `Collection<T>`, with two-pass structural node inclusion and O(1) boundary navigation via cached focusable indices
- Implement `SortedCollection<'a, T, C>` — comparator-based sorting view with fast path for flat collections and section-aware interleaving for grouped collections
- Add `SortDirection` enum and `SortDescriptor<K>` struct for table column sort state
- Fix spec §7.1 algorithm bug: Headers/Separators inside sections were always excluded (now included when parent section has passing children)
- Fix spec §7.2: add missing `NodeType` import, `missing_docs` doc comments, cached `first_focusable`/`last_focusable` fields

Closes #84

## Test plan

- [x] 23 unit tests for `FilteredCollection` — construction (empty, all-pass, none-pass, partial, structural inclusion/exclusion), random access (`get`, `get_by_index`, `contains_key`), boundary navigation, sequential navigation (wrap/no-wrap), iteration (`keys`, `nodes`, `children_of`, `item_keys`), debug format
- [x] 28 unit tests for `SortedCollection` — `SortDirection` display/derives, `SortDescriptor` creation/derives, flat sort (empty, single, already-sorted, reverse, alphabetical), sectioned sort (preserves structure, sorts within sections, separators), random access, boundary/sequential navigation, iteration, debug format
- [x] 346 total crate tests pass
- [x] Clippy clean, docs build, `no_std` clean for new files
- [x] Coverage: `filtered_collection.rs` 100% lines/functions, `sorted_collection.rs` 99.35% lines (1 defensive guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)