### PR TITLE
[codex] Implement drag/drop state machine snapshots

### DIFF
--- a/crates/ars-interactions/src/drag_drop.rs
+++ b/crates/ars-interactions/src/drag_drop.rs
@@ -409,12 +409,21 @@ impl DragResult {
                 items,
                 pointer_type,
                 ..
-            } => Some(DragState::DragOver {
-                items,
-                pointer_type,
-                target_id: target_id.into(),
-                current_operation,
-            }),
+            } => {
+                if source_allows_operation(&self.config, current_operation) {
+                    Some(DragState::DragOver {
+                        items,
+                        pointer_type,
+                        target_id: target_id.into(),
+                        current_operation,
+                    })
+                } else {
+                    Some(DragState::Dragging {
+                        items,
+                        pointer_type,
+                    })
+                }
+            }
 
             DragState::Idle | DragState::Dropped { .. } => None,
         };
@@ -597,8 +606,7 @@ impl DropResult {
             return DropOperation::Cancel;
         }
 
-        let operation =
-            resolve_drop_operation(&self.config, &items, offered_operation, pointer_type);
+        let operation = resolve_enter_operation(&self.config, &items, offered_operation);
 
         if operation == DropOperation::Cancel {
             self.enter_count = 0;
@@ -647,7 +655,7 @@ impl DropResult {
         }
 
         let operation =
-            resolve_drop_operation(&self.config, items, offered_operation, pointer_type);
+            resolve_drag_over_operation(&self.config, items, offered_operation, pointer_type);
 
         if operation == DropOperation::Cancel {
             self.enter_count = 0;
@@ -850,7 +858,29 @@ fn build_drop_attrs(
     attrs
 }
 
-fn resolve_drop_operation(
+fn resolve_enter_operation(
+    config: &DropConfig,
+    items: &[DragItemPreview],
+    offered_operation: DropOperation,
+) -> DropOperation {
+    if config.disabled || !accepts_preview_items(config, items) {
+        return DropOperation::Cancel;
+    }
+
+    if offered_operation == DropOperation::Cancel {
+        return DropOperation::Cancel;
+    }
+
+    if let Some(accepted_operations) = &config.accepted_operations {
+        if !accepted_operations.contains(&offered_operation) {
+            return DropOperation::Cancel;
+        }
+    }
+
+    offered_operation
+}
+
+fn resolve_drag_over_operation(
     config: &DropConfig,
     items: &[DragItemPreview],
     offered_operation: DropOperation,
@@ -882,6 +912,14 @@ fn resolve_drop_operation(
     }
 
     operation
+}
+
+fn source_allows_operation(config: &DragConfig, operation: DropOperation) -> bool {
+    operation != DropOperation::Cancel
+        && config
+            .allowed_operations
+            .as_ref()
+            .is_none_or(|allowed_operations| allowed_operations.contains(&operation))
 }
 
 fn preview_matches_accepted_types(item: &DragItemPreview, accepted_types: &[String]) -> bool {
@@ -926,6 +964,7 @@ fn accepts_preview_items(config: &DropConfig, items: &[DragItemPreview]) -> bool
 mod tests {
     use std::{
         fmt::Write as _,
+        mem::discriminant,
         sync::{Arc, Mutex},
     };
 
@@ -935,7 +974,7 @@ mod tests {
     use super::{
         DirectoryHandle, DragConfig, DragEndEvent, DragItem, DragItemKind, DragItemPreview,
         DragStartEvent, DragState, DropConfig, DropEvent, DropIndicatorPosition, DropOperation,
-        DropTargetEvent, FileHandle, use_drag, use_drop,
+        DropTargetEvent, FileHandle, build_drop_attrs, use_drag, use_drop,
     };
     use crate::PointerType;
 
@@ -945,6 +984,24 @@ mod tests {
             mime_types: mime_types.iter().map(|mime| (*mime).to_owned()).collect(),
         }
     }
+
+    fn drag_state_is_idle(state: &DragState) -> bool {
+        discriminant(state) == discriminant(&DragState::Idle)
+    }
+
+    fn drag_state_is_dragging(state: &DragState) -> bool {
+        discriminant(state)
+            == discriminant(&DragState::Dragging {
+                items: Vec::new(),
+                pointer_type: PointerType::Mouse,
+            })
+    }
+
+    fn resolve_link_operation(_: DropTargetEvent) -> DropOperation {
+        DropOperation::Link
+    }
+
+    fn ignore_drop_event(_: DropEvent) {}
 
     #[test]
     fn drop_operation_as_drop_effect_returns_html5_values() {
@@ -1298,6 +1355,19 @@ mod tests {
     }
 
     #[test]
+    fn drag_result_start_drag_is_noop_when_already_active() {
+        let mut result = use_drag(DragConfig {
+            items: Some(Arc::new(|| vec![DragItem::Text("payload".into())])),
+            ..DragConfig::default()
+        });
+
+        drop(result.start_drag(PointerType::Mouse));
+
+        assert!(result.start_drag(PointerType::Touch).is_none());
+        assert!(drag_state_is_dragging(&result.current_state()));
+    }
+
+    #[test]
     fn drag_result_enter_target_transitions_dragging_to_drag_over() {
         let mut result = use_drag(DragConfig {
             items: Some(Arc::new(|| vec![DragItem::Text("payload".into())])),
@@ -1386,6 +1456,22 @@ mod tests {
     }
 
     #[test]
+    fn drag_result_enter_target_rejects_operations_outside_allowed_list() {
+        let mut result = use_drag(DragConfig {
+            items: Some(Arc::new(|| vec![DragItem::Text("payload".into())])),
+            allowed_operations: Some(vec![DropOperation::Copy]),
+            ..DragConfig::default()
+        });
+
+        drop(result.start_drag(PointerType::Mouse));
+
+        result.enter_target("target-1", DropOperation::Move);
+
+        assert!(drag_state_is_dragging(&result.current_state()));
+        assert!(result.complete_drop().is_none());
+    }
+
+    #[test]
     fn drag_result_complete_drop_fires_end_callback_with_current_operation() {
         let end_events = Arc::new(Mutex::new(Vec::<DragEndEvent>::new()));
 
@@ -1458,7 +1544,7 @@ mod tests {
         assert_eq!(event.operation, DropOperation::Cancel);
         assert_eq!(event.pointer_type, PointerType::Touch);
         assert!(!event.was_dropped);
-        assert!(matches!(result.current_state(), DragState::Idle));
+        assert!(drag_state_is_idle(&result.current_state()));
         assert!(!result.dragging);
         assert!(!result.attrs.contains(&HtmlAttr::Data("ars-dragging")));
     }
@@ -1508,7 +1594,7 @@ mod tests {
 
         result.reset();
 
-        assert!(matches!(result.current_state(), DragState::Idle));
+        assert!(drag_state_is_idle(&result.current_state()));
         assert!(!result.dragging);
         assert!(!result.attrs.contains(&HtmlAttr::Data("ars-dragging")));
     }
@@ -1570,10 +1656,28 @@ mod tests {
     }
 
     #[test]
+    fn drag_result_start_drag_uses_selected_items_when_primary_items_are_absent() {
+        let mut result = use_drag(DragConfig {
+            get_items: Some(Arc::new(|| vec![DragItem::Text("selected".into())])),
+            ..DragConfig::default()
+        });
+
+        let event = result
+            .start_drag(PointerType::Mouse)
+            .expect("drag should start");
+
+        assert_eq!(event.items.len(), 1);
+
+        match &event.items[0] {
+            DragItem::Text(text) => assert_eq!(text, "selected"),
+            other => panic!("unexpected drag item: {other:?}"),
+        }
+    }
+
+    #[test]
     fn drag_result_disabled_noops_all_transition_helpers() {
         let mut result = use_drag(DragConfig {
             disabled: true,
-            items: Some(Arc::new(|| vec![DragItem::Text("payload".into())])),
             ..DragConfig::default()
         });
 
@@ -1585,7 +1689,7 @@ mod tests {
         assert!(result.complete_drop().is_none());
         assert!(result.cancel_drag().is_none());
 
-        assert!(matches!(result.current_state(), DragState::Idle));
+        assert!(drag_state_is_idle(&result.current_state()));
         assert!(!result.dragging);
         assert!(result.attrs.contains(&HtmlAttr::Draggable));
         assert!(!result.attrs.contains(&HtmlAttr::Data("ars-dragging")));
@@ -1660,6 +1764,48 @@ mod tests {
             result.attrs.get_value(&HtmlAttr::Data("ars-drop-position")),
             Some(AttrValue::String(value)) if value == "before"
         ));
+    }
+
+    #[test]
+    fn drop_result_drag_enter_does_not_invoke_drag_over_callback() {
+        let mut result = use_drop(DropConfig {
+            on_drag_over: Some(Callback::new(resolve_link_operation)),
+            ..DropConfig::default()
+        });
+
+        let operation = result.drag_enter(
+            vec![preview(DragItemKind::Text, &["text/plain"])],
+            DropOperation::Copy,
+            PointerType::Mouse,
+        );
+
+        assert_eq!(operation, DropOperation::Copy);
+    }
+
+    #[test]
+    fn drop_result_drag_over_rejects_operations_outside_accepted_list() {
+        let mut result = use_drop(DropConfig {
+            accepted_operations: Some(vec![DropOperation::Copy]),
+            on_drag_over: Some(Callback::new(resolve_link_operation)),
+            ..DropConfig::default()
+        });
+
+        let _ = result.drag_enter(
+            vec![preview(DragItemKind::Text, &["text/plain"])],
+            DropOperation::Copy,
+            PointerType::Mouse,
+        );
+
+        let operation = result.drag_over(
+            &[preview(DragItemKind::Text, &["text/plain"])],
+            DropOperation::Copy,
+            PointerType::Mouse,
+        );
+
+        assert_eq!(operation, DropOperation::Cancel);
+        assert!(!result.drag_over);
+        assert!(result.drop_operation.is_none());
+        assert!(result.indicator_position.is_none());
     }
 
     #[test]
@@ -1760,7 +1906,7 @@ mod tests {
     #[test]
     fn drop_result_drag_over_updates_operation_and_position_snapshot() {
         let mut result = use_drop(DropConfig {
-            on_drag_over: Some(Callback::new(|_: DropTargetEvent| DropOperation::Link)),
+            on_drag_over: Some(Callback::new(resolve_link_operation)),
             drop_indicator_position: DropIndicatorPosition::After,
             ..DropConfig::default()
         });
@@ -1790,6 +1936,18 @@ mod tests {
         assert!(matches!(
             result.attrs.get_value(&HtmlAttr::Data("ars-drop-position")),
             Some(AttrValue::String(value)) if value == "after"
+        ));
+    }
+
+    #[test]
+    fn build_drop_attrs_omits_operation_when_snapshot_has_no_operation() {
+        let attrs = build_drop_attrs(true, None, Some(DropIndicatorPosition::Before));
+
+        assert!(attrs.contains(&HtmlAttr::Data("ars-drag-over")));
+        assert!(!attrs.contains(&HtmlAttr::Data("ars-drop-operation")));
+        assert!(matches!(
+            attrs.get_value(&HtmlAttr::Data("ars-drop-position")),
+            Some(AttrValue::String(value)) if value == "before"
         ));
     }
 
@@ -1997,6 +2155,27 @@ mod tests {
         assert_eq!(drop_events[0].pointer_type, event.pointer_type);
         assert_eq!(drop_events[0].drop_position, event.drop_position);
         assert_eq!(drop_events[0].items.len(), event.items.len());
+    }
+
+    #[test]
+    fn drop_result_drop_skips_callback_when_operation_is_cancel() {
+        let mut result = use_drop(DropConfig {
+            on_drop: Some(Callback::new(ignore_drop_event)),
+            ..DropConfig::default()
+        });
+
+        result.drag_over = true;
+        result.drop_operation = Some(DropOperation::Cancel);
+        result.indicator_position = Some(DropIndicatorPosition::OnTarget);
+
+        assert!(
+            result
+                .drop(vec![DragItem::Text("payload".into())], PointerType::Mouse)
+                .is_none()
+        );
+        assert!(!result.drag_over);
+        assert!(result.drop_operation.is_none());
+        assert!(result.indicator_position.is_none());
     }
 
     #[test]

--- a/crates/ars-interactions/src/drag_drop.rs
+++ b/crates/ars-interactions/src/drag_drop.rs
@@ -890,6 +890,10 @@ fn resolve_drag_over_operation(
         return DropOperation::Cancel;
     }
 
+    if offered_operation == DropOperation::Cancel {
+        return DropOperation::Cancel;
+    }
+
     let operation = config
         .on_drag_over
         .as_ref()
@@ -1937,6 +1941,44 @@ mod tests {
             result.attrs.get_value(&HtmlAttr::Data("ars-drop-position")),
             Some(AttrValue::String(value)) if value == "after"
         ));
+    }
+
+    #[test]
+    fn drop_result_drag_over_preserves_cancel_offered_operation() {
+        let drag_over_calls = Arc::new(Mutex::new(Vec::<DropTargetEvent>::new()));
+
+        let observed_calls = Arc::clone(&drag_over_calls);
+
+        let mut result = use_drop(DropConfig {
+            on_drag_over: Some(Callback::new(move |event: DropTargetEvent| {
+                observed_calls
+                    .lock()
+                    .expect("drag over calls lock should succeed")
+                    .push(event);
+
+                DropOperation::Link
+            })),
+            ..DropConfig::default()
+        });
+
+        let operation = result.drag_over(
+            &[preview(DragItemKind::Text, &["text/plain"])],
+            DropOperation::Cancel,
+            PointerType::Mouse,
+        );
+
+        assert_eq!(operation, DropOperation::Cancel);
+        assert_eq!(result.enter_count, 0);
+        assert!(!result.drag_over);
+        assert!(result.drop_operation.is_none());
+        assert!(result.indicator_position.is_none());
+        assert!(!result.attrs.contains(&HtmlAttr::Data("ars-drag-over")));
+        assert!(
+            drag_over_calls
+                .lock()
+                .expect("drag over calls lock should succeed")
+                .is_empty()
+        );
     }
 
     #[test]

--- a/crates/ars-interactions/src/drag_drop.rs
+++ b/crates/ars-interactions/src/drag_drop.rs
@@ -601,6 +601,11 @@ impl DropResult {
             resolve_drop_operation(&self.config, &items, offered_operation, pointer_type);
 
         if operation == DropOperation::Cancel {
+            self.enter_count = 0;
+            self.drag_over = false;
+            self.drop_operation = None;
+            self.indicator_position = None;
+
             self.refresh_snapshot();
 
             return DropOperation::Cancel;
@@ -645,6 +650,7 @@ impl DropResult {
             resolve_drop_operation(&self.config, items, offered_operation, pointer_type);
 
         if operation == DropOperation::Cancel {
+            self.enter_count = 0;
             self.drag_over = false;
             self.drop_operation = None;
             self.indicator_position = None;
@@ -654,6 +660,8 @@ impl DropResult {
             return DropOperation::Cancel;
         }
 
+        let was_inactive = self.enter_count == 0 || !self.drag_over;
+
         if self.enter_count == 0 {
             self.enter_count = 1;
         }
@@ -661,6 +669,14 @@ impl DropResult {
         self.drag_over = true;
         self.drop_operation = Some(operation);
         self.indicator_position = Some(self.config.drop_indicator_position);
+
+        if was_inactive && let Some(on_drag_enter) = &self.config.on_drag_enter {
+            on_drag_enter(DropTargetEvent {
+                items: items.to_vec(),
+                operation,
+                pointer_type,
+            });
+        }
 
         self.refresh_snapshot();
 
@@ -1647,6 +1663,37 @@ mod tests {
     }
 
     #[test]
+    fn drop_result_drag_enter_cancel_clears_stale_active_snapshot() {
+        let mut result = use_drop(DropConfig {
+            accepted_operations: Some(vec![DropOperation::Copy]),
+            drop_indicator_position: DropIndicatorPosition::After,
+            ..DropConfig::default()
+        });
+
+        let initial = result.drag_enter(
+            vec![preview(DragItemKind::Text, &["text/plain"])],
+            DropOperation::Copy,
+            PointerType::Mouse,
+        );
+
+        let rejected = result.drag_enter(
+            vec![preview(DragItemKind::Text, &["text/plain"])],
+            DropOperation::Move,
+            PointerType::Mouse,
+        );
+
+        assert_eq!(initial, DropOperation::Copy);
+        assert_eq!(rejected, DropOperation::Cancel);
+        assert_eq!(result.enter_count, 0);
+        assert!(!result.drag_over);
+        assert!(result.drop_operation.is_none());
+        assert!(result.indicator_position.is_none());
+        assert!(!result.attrs.contains(&HtmlAttr::Data("ars-drag-over")));
+        assert!(!result.attrs.contains(&HtmlAttr::Data("ars-drop-operation")));
+        assert!(!result.attrs.contains(&HtmlAttr::Data("ars-drop-position")));
+    }
+
+    #[test]
     fn drop_result_drag_over_recovers_missing_drag_enter() {
         let mut result = use_drop(DropConfig {
             drop_indicator_position: DropIndicatorPosition::After,
@@ -1668,6 +1715,46 @@ mod tests {
             Some(DropIndicatorPosition::After)
         );
         assert!(result.attrs.contains(&HtmlAttr::Data("ars-drag-over")));
+    }
+
+    #[test]
+    fn drop_result_drag_over_recovery_fires_enter_callback_once() {
+        let enter_events = Arc::new(Mutex::new(Vec::<DropTargetEvent>::new()));
+
+        let observed_events = Arc::clone(&enter_events);
+
+        let mut result = use_drop(DropConfig {
+            on_drag_enter: Some(Callback::new(move |event: DropTargetEvent| {
+                observed_events
+                    .lock()
+                    .expect("enter events lock should succeed")
+                    .push(event);
+            })),
+            ..DropConfig::default()
+        });
+
+        let first = result.drag_over(
+            &[preview(DragItemKind::Text, &["text/plain"])],
+            DropOperation::Move,
+            PointerType::Mouse,
+        );
+
+        let second = result.drag_over(
+            &[preview(DragItemKind::Text, &["text/plain"])],
+            DropOperation::Move,
+            PointerType::Mouse,
+        );
+
+        let enter_events = enter_events
+            .lock()
+            .expect("enter events lock should succeed");
+
+        assert_eq!(first, DropOperation::Move);
+        assert_eq!(second, DropOperation::Move);
+        assert_eq!(result.enter_count, 1);
+        assert_eq!(enter_events.len(), 1);
+        assert_eq!(enter_events[0].operation, DropOperation::Move);
+        assert_eq!(enter_events[0].pointer_type, PointerType::Mouse);
     }
 
     #[test]

--- a/crates/ars-interactions/src/drag_drop.rs
+++ b/crates/ars-interactions/src/drag_drop.rs
@@ -1,17 +1,19 @@
-//! Drag-and-drop interaction core types.
+//! Drag-and-drop interaction types, state machines, and snapshot attrs.
 //!
 //! This module defines the framework-agnostic drag payload types, source and
-//! target configuration structs, and the MIME-type acceptance helpers used by
-//! later drag state-machine work.
+//! target configuration structs, state-machine helpers, and MIME-type
+//! acceptance logic used by drag-and-drop-enabled components.
 
 use std::{
+    cell::RefCell,
     fmt::{self, Debug},
+    rc::Rc,
     string::String,
     sync::Arc,
     vec::Vec,
 };
 
-use ars_core::{Callback, MessageFn};
+use ars_core::{AttrMap, Callback, HtmlAttr, MessageFn};
 use ars_i18n::Locale;
 
 use crate::PointerType;
@@ -298,19 +300,584 @@ pub struct DropEvent {
     pub drop_position: DropIndicatorPosition,
 }
 
-#[cfg(test)]
+/// The current state of the drag source state machine.
+///
+/// `DragState` intentionally does not implement `PartialEq` because dragged
+/// payloads may contain opaque file-system handles that do not support value
+/// equality. Callers should pattern-match on the variants they care about.
+#[derive(Clone, Debug)]
+pub enum DragState {
+    /// No drag is active.
+    Idle,
+    /// A drag is active and no drop target is currently hovered.
+    Dragging {
+        /// Items included in the active drag payload.
+        items: Vec<DragItem>,
+        /// Input modality that initiated the drag.
+        pointer_type: PointerType,
+    },
+    /// A drag is active and a valid drop target is currently hovered.
+    DragOver {
+        /// Items included in the active drag payload.
+        items: Vec<DragItem>,
+        /// Input modality that initiated the drag.
+        pointer_type: PointerType,
+        /// Identifier for the currently hovered drop target.
+        target_id: String,
+        /// Operation that would occur if dropped now.
+        current_operation: DropOperation,
+    },
+    /// A drop was accepted and cleanup is pending.
+    Dropped {
+        /// Operation accepted by the drop target.
+        operation: DropOperation,
+    },
+}
+
+/// Snapshot output of [`use_drag`].
+///
+/// Unlike press, hover, and focus interactions, drag attrs are stored as a
+/// stable snapshot and refreshed after each state-machine mutation.
+#[derive(Debug)]
+pub struct DragResult {
+    /// Data attributes to spread onto the draggable element.
+    pub attrs: AttrMap,
+    /// Whether this element is currently being dragged.
+    pub dragging: bool,
+
+    state: Rc<RefCell<DragState>>,
+    config: DragConfig,
+}
+
+impl DragResult {
+    /// Returns the current drag-state snapshot.
+    #[must_use]
+    pub fn current_state(&self) -> DragState {
+        self.state.borrow().clone()
+    }
+
+    /// Starts a drag and returns the emitted start event when the transition succeeds.
+    ///
+    /// This is the adapter-facing entry point for pointer-threshold and
+    /// touch-long-press initiated drags.
+    #[must_use]
+    pub fn start_drag(&mut self, pointer_type: PointerType) -> Option<DragStartEvent> {
+        if self.config.disabled || !matches!(self.current_state(), DragState::Idle) {
+            self.refresh_snapshot();
+
+            return None;
+        }
+
+        let items = collect_drag_items(&self.config);
+
+        let event = DragStartEvent {
+            items: items.clone(),
+            pointer_type,
+        };
+
+        *self.state.borrow_mut() = DragState::Dragging {
+            items,
+            pointer_type,
+        };
+
+        if let Some(on_drag_start) = &self.config.on_drag_start {
+            on_drag_start(event.clone());
+        }
+
+        self.refresh_snapshot();
+
+        Some(event)
+    }
+
+    /// Transitions the active drag into the hovered-target state.
+    ///
+    /// Adapters should call this only after a drop target reports a valid
+    /// target/operation for the current drag payload.
+    pub fn enter_target(&mut self, target_id: impl Into<String>, current_operation: DropOperation) {
+        if self.config.disabled {
+            self.refresh_snapshot();
+
+            return;
+        }
+
+        let next_state = match self.current_state() {
+            DragState::Dragging {
+                items,
+                pointer_type,
+            }
+            | DragState::DragOver {
+                items,
+                pointer_type,
+                ..
+            } => Some(DragState::DragOver {
+                items,
+                pointer_type,
+                target_id: target_id.into(),
+                current_operation,
+            }),
+
+            DragState::Idle | DragState::Dropped { .. } => None,
+        };
+
+        if let Some(next_state) = next_state {
+            *self.state.borrow_mut() = next_state;
+        }
+
+        self.refresh_snapshot();
+    }
+
+    /// Transitions the active drag back to the non-hovered dragging state.
+    ///
+    /// Adapters should call this when the active target's enter/leave nesting
+    /// count reaches zero.
+    pub fn leave_target(&mut self) {
+        if self.config.disabled {
+            self.refresh_snapshot();
+
+            return;
+        }
+
+        let next_state = match self.current_state() {
+            DragState::DragOver {
+                items,
+                pointer_type,
+                ..
+            } => Some(DragState::Dragging {
+                items,
+                pointer_type,
+            }),
+
+            DragState::Idle | DragState::Dragging { .. } | DragState::Dropped { .. } => None,
+        };
+
+        if let Some(next_state) = next_state {
+            *self.state.borrow_mut() = next_state;
+        }
+
+        self.refresh_snapshot();
+    }
+
+    /// Completes the drag with an accepted drop and returns the emitted end event.
+    #[must_use]
+    pub fn complete_drop(&mut self) -> Option<DragEndEvent> {
+        if self.config.disabled {
+            self.refresh_snapshot();
+
+            return None;
+        }
+
+        let (items, pointer_type, operation) = match self.current_state() {
+            DragState::DragOver {
+                items,
+                pointer_type,
+                current_operation,
+                ..
+            } => (items, pointer_type, current_operation),
+
+            DragState::Idle | DragState::Dragging { .. } | DragState::Dropped { .. } => {
+                self.refresh_snapshot();
+                return None;
+            }
+        };
+
+        let event = DragEndEvent {
+            items,
+            operation,
+            pointer_type,
+            was_dropped: true,
+        };
+
+        *self.state.borrow_mut() = DragState::Dropped { operation };
+
+        if let Some(on_drag_end) = &self.config.on_drag_end {
+            on_drag_end(event.clone());
+        }
+
+        self.refresh_snapshot();
+
+        Some(event)
+    }
+
+    /// Cancels the active drag and returns the emitted end event when one existed.
+    ///
+    /// This covers drag-end-without-drop, explicit cancel, and adapter-level
+    /// recovery after pointer-capture or drag setup failures.
+    #[must_use]
+    pub fn cancel_drag(&mut self) -> Option<DragEndEvent> {
+        if self.config.disabled {
+            self.refresh_snapshot();
+
+            return None;
+        }
+
+        let (items, pointer_type) = match self.current_state() {
+            DragState::Dragging {
+                items,
+                pointer_type,
+            }
+            | DragState::DragOver {
+                items,
+                pointer_type,
+                ..
+            } => (items, pointer_type),
+
+            DragState::Idle | DragState::Dropped { .. } => {
+                self.refresh_snapshot();
+                return None;
+            }
+        };
+
+        let event = DragEndEvent {
+            items,
+            operation: DropOperation::Cancel,
+            pointer_type,
+            was_dropped: false,
+        };
+
+        *self.state.borrow_mut() = DragState::Idle;
+
+        if let Some(on_drag_end) = &self.config.on_drag_end {
+            on_drag_end(event.clone());
+        }
+
+        self.refresh_snapshot();
+
+        Some(event)
+    }
+
+    /// Resets the drag source to `Idle` without emitting callbacks.
+    ///
+    /// Adapters use this after post-drop cleanup or forced error recovery.
+    pub fn reset(&mut self) {
+        *self.state.borrow_mut() = DragState::Idle;
+
+        self.refresh_snapshot();
+    }
+
+    fn refresh_snapshot(&mut self) {
+        self.dragging = !matches!(self.current_state(), DragState::Idle);
+        self.attrs = build_drag_attrs(self.dragging);
+    }
+}
+
+/// Snapshot output of [`use_drop`].
+///
+/// `DropResult` keeps the latest drop-target snapshot attrs alongside minimal
+/// adapter-facing state for nested enter/leave tracking.
+#[derive(Debug)]
+pub struct DropResult {
+    /// Data attributes to spread onto the drop target element.
+    pub attrs: AttrMap,
+    /// Whether a dragged item is currently over this target.
+    pub drag_over: bool,
+    /// The operation that will occur if dropped now.
+    pub drop_operation: Option<DropOperation>,
+    /// Where the drop indicator line should appear.
+    pub indicator_position: Option<DropIndicatorPosition>,
+
+    config: DropConfig,
+    enter_count: i32,
+}
+
+impl DropResult {
+    /// Handles a drag-enter event and returns the operation currently accepted.
+    ///
+    /// Nested child enters increment the internal enter count but only the
+    /// initial `0 -> 1` transition fires `on_drag_enter`.
+    #[must_use]
+    pub fn drag_enter(
+        &mut self,
+        items: Vec<DragItemPreview>,
+        offered_operation: DropOperation,
+        pointer_type: PointerType,
+    ) -> DropOperation {
+        if self.config.disabled {
+            self.refresh_snapshot();
+
+            return DropOperation::Cancel;
+        }
+
+        let operation =
+            resolve_drop_operation(&self.config, &items, offered_operation, pointer_type);
+
+        if operation == DropOperation::Cancel {
+            self.refresh_snapshot();
+
+            return DropOperation::Cancel;
+        }
+
+        self.enter_count = self.enter_count.saturating_add(1);
+
+        let was_inactive = !self.drag_over;
+
+        self.drag_over = true;
+        self.drop_operation = Some(operation);
+        self.indicator_position = Some(self.config.drop_indicator_position);
+
+        if was_inactive && let Some(on_drag_enter) = &self.config.on_drag_enter {
+            on_drag_enter(DropTargetEvent {
+                items,
+                operation,
+                pointer_type,
+            });
+        }
+
+        self.refresh_snapshot();
+
+        operation
+    }
+
+    /// Handles a drag-over update and returns the operation currently accepted.
+    #[must_use]
+    pub fn drag_over(
+        &mut self,
+        items: &[DragItemPreview],
+        offered_operation: DropOperation,
+        pointer_type: PointerType,
+    ) -> DropOperation {
+        if self.config.disabled {
+            self.refresh_snapshot();
+
+            return DropOperation::Cancel;
+        }
+
+        let operation =
+            resolve_drop_operation(&self.config, items, offered_operation, pointer_type);
+
+        if operation == DropOperation::Cancel {
+            self.drag_over = false;
+            self.drop_operation = None;
+            self.indicator_position = None;
+
+            self.refresh_snapshot();
+
+            return DropOperation::Cancel;
+        }
+
+        if self.enter_count == 0 {
+            self.enter_count = 1;
+        }
+
+        self.drag_over = true;
+        self.drop_operation = Some(operation);
+        self.indicator_position = Some(self.config.drop_indicator_position);
+
+        self.refresh_snapshot();
+
+        operation
+    }
+
+    /// Handles a drag-leave event, clearing state only when nesting reaches zero.
+    pub fn drag_leave(&mut self, items: &[DragItemPreview], pointer_type: PointerType) {
+        if self.config.disabled {
+            self.refresh_snapshot();
+
+            return;
+        }
+
+        if self.enter_count <= 0 {
+            self.enter_count = 0;
+            self.refresh_snapshot();
+
+            return;
+        }
+
+        self.enter_count -= 1;
+
+        if self.enter_count == 0 {
+            if let Some(on_drag_leave) = &self.config.on_drag_leave {
+                on_drag_leave(DropTargetEvent {
+                    items: items.to_vec(),
+                    operation: self.drop_operation.unwrap_or(DropOperation::Cancel),
+                    pointer_type,
+                });
+            }
+
+            self.drag_over = false;
+            self.drop_operation = None;
+            self.indicator_position = None;
+        }
+
+        self.refresh_snapshot();
+    }
+
+    /// Handles a completed drop and returns the emitted drop event when accepted.
+    #[must_use]
+    pub fn drop(&mut self, items: Vec<DragItem>, pointer_type: PointerType) -> Option<DropEvent> {
+        if self.config.disabled || !self.drag_over {
+            self.reset();
+
+            return None;
+        }
+
+        let operation = self.drop_operation.unwrap_or(DropOperation::Cancel);
+
+        let event = (operation != DropOperation::Cancel).then_some(DropEvent {
+            items,
+            operation,
+            pointer_type,
+            drop_position: self.config.drop_indicator_position,
+        });
+
+        if let Some(on_drop) = &self.config.on_drop {
+            if let Some(event) = &event {
+                on_drop(event.clone());
+            }
+        }
+
+        self.reset();
+
+        event
+    }
+
+    /// Clears all drop-target state without emitting callbacks.
+    pub fn reset(&mut self) {
+        self.enter_count = 0;
+        self.drag_over = false;
+        self.drop_operation = None;
+        self.indicator_position = None;
+
+        self.refresh_snapshot();
+    }
+
+    fn refresh_snapshot(&mut self) {
+        self.attrs = build_drop_attrs(self.drag_over, self.drop_operation, self.indicator_position);
+    }
+}
+
+/// Creates a drag-source state container with snapshot attrs.
+#[must_use]
+pub fn use_drag(config: DragConfig) -> DragResult {
+    let mut result = DragResult {
+        attrs: AttrMap::new(),
+        dragging: false,
+        state: Rc::new(RefCell::new(DragState::Idle)),
+        config,
+    };
+
+    result.refresh_snapshot();
+
+    result
+}
+
+/// Creates a drop-target state container with snapshot attrs.
+#[must_use]
+pub fn use_drop(config: DropConfig) -> DropResult {
+    let mut result = DropResult {
+        attrs: AttrMap::new(),
+        drag_over: false,
+        drop_operation: None,
+        indicator_position: None,
+        config,
+        enter_count: 0,
+    };
+
+    result.refresh_snapshot();
+
+    result
+}
+
+fn collect_drag_items(config: &DragConfig) -> Vec<DragItem> {
+    let mut items = Vec::new();
+
+    if let Some(primary_items) = &config.items {
+        items.extend(primary_items());
+    }
+
+    if let Some(selected_items) = &config.get_items {
+        items.extend(selected_items());
+    }
+
+    items
+}
+
+fn build_drag_attrs(dragging: bool) -> AttrMap {
+    let mut attrs = AttrMap::new();
+
+    attrs.set(HtmlAttr::Draggable, "true");
+
+    if dragging {
+        attrs.set_bool(HtmlAttr::Data("ars-dragging"), true);
+    }
+
+    attrs
+}
+
+fn build_drop_attrs(
+    drag_over: bool,
+    drop_operation: Option<DropOperation>,
+    indicator_position: Option<DropIndicatorPosition>,
+) -> AttrMap {
+    let mut attrs = AttrMap::new();
+
+    if drag_over {
+        attrs.set_bool(HtmlAttr::Data("ars-drag-over"), true);
+
+        if let Some(operation) = drop_operation {
+            attrs.set(
+                HtmlAttr::Data("ars-drop-operation"),
+                operation.as_drop_effect(),
+            );
+        }
+
+        if let Some(position) = indicator_position {
+            attrs.set(
+                HtmlAttr::Data("ars-drop-position"),
+                match position {
+                    DropIndicatorPosition::Before => "before",
+                    DropIndicatorPosition::After => "after",
+                    DropIndicatorPosition::OnTarget => "on",
+                },
+            );
+        }
+    }
+    attrs
+}
+
+fn resolve_drop_operation(
+    config: &DropConfig,
+    items: &[DragItemPreview],
+    offered_operation: DropOperation,
+    pointer_type: PointerType,
+) -> DropOperation {
+    if config.disabled || !accepts_preview_items(config, items) {
+        return DropOperation::Cancel;
+    }
+
+    let operation = config
+        .on_drag_over
+        .as_ref()
+        .map_or(offered_operation, |on_drag_over| {
+            on_drag_over(DropTargetEvent {
+                items: items.to_vec(),
+                operation: offered_operation,
+                pointer_type,
+            })
+        });
+
+    if operation == DropOperation::Cancel {
+        return DropOperation::Cancel;
+    }
+
+    if let Some(accepted_operations) = &config.accepted_operations {
+        if !accepted_operations.contains(&operation) {
+            return DropOperation::Cancel;
+        }
+    }
+
+    operation
+}
+
 fn preview_matches_accepted_types(item: &DragItemPreview, accepted_types: &[String]) -> bool {
     item.mime_types.iter().any(|mime_type| {
-        let normalized_item = normalize_mime_type(mime_type);
         accepted_types
             .iter()
             .map(String::as_str)
             .map(normalize_mime_type)
-            .any(|accepted| mime_type_matches(&accepted, &normalized_item))
+            .any(|accepted| mime_type_matches(&accepted, &normalize_mime_type(mime_type)))
     })
 }
 
-#[cfg(test)]
 fn mime_type_matches(accepted: &str, actual: &str) -> bool {
     if let Some(prefix) = accepted.strip_suffix("/*") {
         actual
@@ -321,7 +888,6 @@ fn mime_type_matches(accepted: &str, actual: &str) -> bool {
     }
 }
 
-#[cfg(test)]
 fn normalize_mime_type(mime_type: &str) -> String {
     let normalized = mime_type.trim().to_ascii_lowercase();
     if normalized == "image/jpg" {
@@ -331,17 +897,29 @@ fn normalize_mime_type(mime_type: &str) -> String {
     }
 }
 
+fn accepts_preview_items(config: &DropConfig, items: &[DragItemPreview]) -> bool {
+    match &config.accepted_types {
+        None => true,
+        Some(accepted_types) => items
+            .iter()
+            .any(|item| preview_matches_accepted_types(item, accepted_types)),
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use std::{fmt::Write as _, sync::Arc};
+    use std::{
+        fmt::Write as _,
+        sync::{Arc, Mutex},
+    };
 
-    use ars_core::{Callback, MessageFn};
+    use ars_core::{AttrValue, Callback, HtmlAttr, MessageFn};
     use ars_i18n::{Locale, locales};
 
     use super::{
         DirectoryHandle, DragConfig, DragEndEvent, DragItem, DragItemKind, DragItemPreview,
-        DragStartEvent, DropConfig, DropEvent, DropIndicatorPosition, DropOperation,
-        DropTargetEvent, FileHandle,
+        DragStartEvent, DragState, DropConfig, DropEvent, DropIndicatorPosition, DropOperation,
+        DropTargetEvent, FileHandle, use_drag, use_drop,
     };
     use crate::PointerType;
 
@@ -411,6 +989,7 @@ mod tests {
             .expect("selection closure should be set")();
 
         assert_eq!(items.len(), 1);
+
         match &items[0] {
             DragItem::Text(text) => assert_eq!(text, "selected"),
             other => panic!("unexpected drag item: {other:?}"),
@@ -429,6 +1008,7 @@ mod tests {
         };
 
         let mut debug = String::new();
+
         write!(&mut debug, "{config:?}").expect("debug write should succeed");
 
         assert!(debug.contains("disabled: false"));
@@ -447,6 +1027,7 @@ mod tests {
         let announcement: Arc<AnnouncementFn> = Arc::new(|items: &[DragItem], locale: &Locale| {
             format!("{} @ {}", items.len(), locale.to_bcp47())
         });
+
         let config = DragConfig {
             drag_start_announcement: Some(MessageFn::new(announcement)),
             ..DragConfig::default()
@@ -474,6 +1055,7 @@ mod tests {
             Arc::new(|event: &DropTargetEvent, locale: &Locale| {
                 format!("{:?} @ {}", event.operation, locale.to_bcp47())
             });
+
         let config = DropConfig {
             drag_enter_announcement: Some(MessageFn::new(announcement)),
             ..DropConfig::default()
@@ -501,6 +1083,7 @@ mod tests {
         let announcement: Arc<AnnouncementFn> = Arc::new(|event: &DropEvent, locale: &Locale| {
             format!("{:?} @ {}", event.drop_position, locale.to_bcp47())
         });
+
         let config = DropConfig {
             drop_announcement: Some(MessageFn::new(announcement)),
             ..DropConfig::default()
@@ -638,5 +1221,781 @@ mod tests {
         assert_eq!(event.pointer_type, PointerType::Mouse);
         assert_eq!(event.drop_position, DropIndicatorPosition::Before);
         assert_eq!(event.items.len(), 1);
+    }
+
+    #[test]
+    fn drag_result_start_drag_transitions_idle_to_dragging() {
+        let mut result = use_drag(DragConfig {
+            items: Some(Arc::new(|| vec![DragItem::Text("payload".into())])),
+            ..DragConfig::default()
+        });
+
+        let event = result
+            .start_drag(PointerType::Mouse)
+            .expect("idle drag should start");
+
+        assert_eq!(event.pointer_type, PointerType::Mouse);
+        assert_eq!(event.items.len(), 1);
+        assert!(result.dragging);
+        assert!(result.attrs.contains(&HtmlAttr::Data("ars-dragging")));
+
+        match result.current_state() {
+            DragState::Dragging {
+                items,
+                pointer_type,
+            } => {
+                assert_eq!(items.len(), 1);
+                assert_eq!(pointer_type, PointerType::Mouse);
+            }
+            state => panic!("unexpected state after start_drag: {state:?}"),
+        }
+    }
+
+    #[test]
+    fn drag_result_start_drag_fires_callback_with_payload() {
+        let start_events = Arc::new(Mutex::new(Vec::<DragStartEvent>::new()));
+
+        let observed_events = Arc::clone(&start_events);
+
+        let mut result = use_drag(DragConfig {
+            items: Some(Arc::new(|| vec![DragItem::Text("payload".into())])),
+            on_drag_start: Some(Callback::new(move |event: DragStartEvent| {
+                observed_events
+                    .lock()
+                    .expect("start events lock should succeed")
+                    .push(event);
+            })),
+            ..DragConfig::default()
+        });
+
+        let event = result
+            .start_drag(PointerType::Pen)
+            .expect("idle drag should start");
+
+        let start_events = start_events
+            .lock()
+            .expect("start events lock should succeed");
+
+        assert_eq!(start_events.len(), 1);
+        assert_eq!(start_events[0].pointer_type, event.pointer_type);
+        assert_eq!(start_events[0].items.len(), event.items.len());
+    }
+
+    #[test]
+    fn drag_result_enter_target_transitions_dragging_to_drag_over() {
+        let mut result = use_drag(DragConfig {
+            items: Some(Arc::new(|| vec![DragItem::Text("payload".into())])),
+            ..DragConfig::default()
+        });
+
+        drop(result.start_drag(PointerType::Mouse));
+
+        result.enter_target("target-1", DropOperation::Copy);
+
+        match result.current_state() {
+            DragState::DragOver {
+                items,
+                pointer_type,
+                target_id,
+                current_operation,
+            } => {
+                assert_eq!(items.len(), 1);
+                assert_eq!(pointer_type, PointerType::Mouse);
+                assert_eq!(target_id, "target-1");
+                assert_eq!(current_operation, DropOperation::Copy);
+            }
+            state => panic!("unexpected state after enter_target: {state:?}"),
+        }
+    }
+
+    #[test]
+    fn drag_result_invalid_source_transitions_are_noops() {
+        let mut result = use_drag(DragConfig {
+            items: Some(Arc::new(|| vec![DragItem::Text("payload".into())])),
+            ..DragConfig::default()
+        });
+
+        result.enter_target("target-1", DropOperation::Move);
+        result.leave_target();
+
+        assert!(result.complete_drop().is_none());
+        assert!(result.cancel_drag().is_none());
+        assert!(matches!(result.current_state(), DragState::Idle));
+
+        drop(result.start_drag(PointerType::Mouse));
+
+        assert!(result.complete_drop().is_none());
+        assert!(matches!(result.current_state(), DragState::Dragging { .. }));
+
+        result.enter_target("target-1", DropOperation::Copy);
+
+        drop(result.complete_drop());
+
+        result.enter_target("target-2", DropOperation::Move);
+        result.leave_target();
+
+        assert!(result.complete_drop().is_none());
+        assert!(result.cancel_drag().is_none());
+        assert!(matches!(
+            result.current_state(),
+            DragState::Dropped {
+                operation: DropOperation::Copy
+            }
+        ));
+    }
+
+    #[test]
+    fn drag_result_leave_target_transitions_drag_over_to_dragging() {
+        let mut result = use_drag(DragConfig {
+            items: Some(Arc::new(|| vec![DragItem::Text("payload".into())])),
+            ..DragConfig::default()
+        });
+
+        drop(result.start_drag(PointerType::Mouse));
+
+        result.enter_target("target-1", DropOperation::Move);
+
+        result.leave_target();
+
+        match result.current_state() {
+            DragState::Dragging {
+                items,
+                pointer_type,
+            } => {
+                assert_eq!(items.len(), 1);
+                assert_eq!(pointer_type, PointerType::Mouse);
+            }
+            state => panic!("unexpected state after leave_target: {state:?}"),
+        }
+    }
+
+    #[test]
+    fn drag_result_complete_drop_fires_end_callback_with_current_operation() {
+        let end_events = Arc::new(Mutex::new(Vec::<DragEndEvent>::new()));
+
+        let observed_events = Arc::clone(&end_events);
+
+        let mut result = use_drag(DragConfig {
+            items: Some(Arc::new(|| vec![DragItem::Text("payload".into())])),
+            on_drag_end: Some(Callback::new(move |event: DragEndEvent| {
+                observed_events
+                    .lock()
+                    .expect("end events lock should succeed")
+                    .push(event);
+            })),
+            ..DragConfig::default()
+        });
+
+        drop(result.start_drag(PointerType::Pen));
+
+        result.enter_target("target-1", DropOperation::Link);
+
+        let event = result
+            .complete_drop()
+            .expect("drag over should complete drop");
+
+        let end_events = end_events.lock().expect("end events lock should succeed");
+
+        assert_eq!(end_events.len(), 1);
+        assert_eq!(end_events[0].operation, event.operation);
+        assert_eq!(end_events[0].pointer_type, event.pointer_type);
+        assert_eq!(end_events[0].items.len(), event.items.len());
+        assert!(end_events[0].was_dropped);
+    }
+
+    #[test]
+    fn drag_result_complete_drop_transitions_drag_over_to_dropped() {
+        let mut result = use_drag(DragConfig {
+            items: Some(Arc::new(|| vec![DragItem::Text("payload".into())])),
+            ..DragConfig::default()
+        });
+
+        drop(result.start_drag(PointerType::Pen));
+
+        result.enter_target("target-1", DropOperation::Link);
+
+        let event = result
+            .complete_drop()
+            .expect("drag over should complete drop");
+
+        assert_eq!(event.operation, DropOperation::Link);
+        assert_eq!(event.pointer_type, PointerType::Pen);
+        assert!(event.was_dropped);
+
+        match result.current_state() {
+            DragState::Dropped { operation } => assert_eq!(operation, DropOperation::Link),
+            state => panic!("unexpected state after complete_drop: {state:?}"),
+        }
+    }
+
+    #[test]
+    fn drag_result_cancel_drag_transitions_to_idle_and_fires_cancel_event() {
+        let mut result = use_drag(DragConfig {
+            items: Some(Arc::new(|| vec![DragItem::Text("payload".into())])),
+            ..DragConfig::default()
+        });
+
+        drop(result.start_drag(PointerType::Touch));
+
+        let event = result.cancel_drag().expect("active drag should cancel");
+
+        assert_eq!(event.operation, DropOperation::Cancel);
+        assert_eq!(event.pointer_type, PointerType::Touch);
+        assert!(!event.was_dropped);
+        assert!(matches!(result.current_state(), DragState::Idle));
+        assert!(!result.dragging);
+        assert!(!result.attrs.contains(&HtmlAttr::Data("ars-dragging")));
+    }
+
+    #[test]
+    fn drag_result_cancel_drag_fires_end_callback_once() {
+        let end_events = Arc::new(Mutex::new(Vec::<DragEndEvent>::new()));
+
+        let observed_events = Arc::clone(&end_events);
+
+        let mut result = use_drag(DragConfig {
+            items: Some(Arc::new(|| vec![DragItem::Text("payload".into())])),
+            on_drag_end: Some(Callback::new(move |event: DragEndEvent| {
+                observed_events
+                    .lock()
+                    .expect("end events lock should succeed")
+                    .push(event);
+            })),
+            ..DragConfig::default()
+        });
+
+        drop(result.start_drag(PointerType::Touch));
+
+        let event = result.cancel_drag().expect("active drag should cancel");
+
+        let end_events = end_events.lock().expect("end events lock should succeed");
+
+        assert_eq!(end_events.len(), 1);
+        assert_eq!(end_events[0].operation, event.operation);
+        assert_eq!(end_events[0].pointer_type, event.pointer_type);
+        assert_eq!(end_events[0].items.len(), event.items.len());
+        assert!(!end_events[0].was_dropped);
+    }
+
+    #[test]
+    fn drag_result_reset_transitions_dropped_to_idle() {
+        let mut result = use_drag(DragConfig {
+            items: Some(Arc::new(|| vec![DragItem::Text("payload".into())])),
+            ..DragConfig::default()
+        });
+
+        drop(result.start_drag(PointerType::Mouse));
+
+        result.enter_target("target-1", DropOperation::Copy);
+
+        drop(result.complete_drop());
+
+        result.reset();
+
+        assert!(matches!(result.current_state(), DragState::Idle));
+        assert!(!result.dragging);
+        assert!(!result.attrs.contains(&HtmlAttr::Data("ars-dragging")));
+    }
+
+    #[test]
+    fn drag_result_attrs_include_draggable_even_when_idle() {
+        let result = use_drag(DragConfig::default());
+
+        assert!(result.attrs.contains(&HtmlAttr::Draggable));
+        assert!(matches!(
+            result.attrs.get_value(&HtmlAttr::Draggable),
+            Some(AttrValue::String(value)) if value == "true"
+        ));
+        assert!(!result.attrs.contains(&HtmlAttr::Data("ars-dragging")));
+    }
+
+    #[test]
+    fn drag_result_multi_item_drag_concatenates_primary_and_selected_items() {
+        let mut result = use_drag(DragConfig {
+            items: Some(Arc::new(|| vec![DragItem::Text("primary".into())])),
+            get_items: Some(Arc::new(|| vec![DragItem::Text("selected".into())])),
+            ..DragConfig::default()
+        });
+
+        let event = result
+            .start_drag(PointerType::Mouse)
+            .expect("drag should start");
+
+        assert_eq!(event.items.len(), 2);
+
+        match &event.items[0] {
+            DragItem::Text(text) => assert_eq!(text, "primary"),
+            other => panic!("unexpected primary drag item: {other:?}"),
+        }
+
+        match &event.items[1] {
+            DragItem::Text(text) => assert_eq!(text, "selected"),
+            other => panic!("unexpected selected drag item: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn drag_result_start_drag_uses_only_primary_items_when_selection_is_none() {
+        let mut result = use_drag(DragConfig {
+            items: Some(Arc::new(|| vec![DragItem::Text("primary".into())])),
+            ..DragConfig::default()
+        });
+
+        let event = result
+            .start_drag(PointerType::Mouse)
+            .expect("drag should start");
+
+        assert_eq!(event.items.len(), 1);
+
+        match &event.items[0] {
+            DragItem::Text(text) => assert_eq!(text, "primary"),
+            other => panic!("unexpected drag item: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn drag_result_disabled_noops_all_transition_helpers() {
+        let mut result = use_drag(DragConfig {
+            disabled: true,
+            items: Some(Arc::new(|| vec![DragItem::Text("payload".into())])),
+            ..DragConfig::default()
+        });
+
+        assert!(result.start_drag(PointerType::Mouse).is_none());
+
+        result.enter_target("target-1", DropOperation::Move);
+        result.leave_target();
+
+        assert!(result.complete_drop().is_none());
+        assert!(result.cancel_drag().is_none());
+
+        assert!(matches!(result.current_state(), DragState::Idle));
+        assert!(!result.dragging);
+        assert!(result.attrs.contains(&HtmlAttr::Draggable));
+        assert!(!result.attrs.contains(&HtmlAttr::Data("ars-dragging")));
+    }
+
+    #[test]
+    fn drop_result_drag_enter_fires_callback_only_on_initial_activation() {
+        let enter_events = Arc::new(Mutex::new(Vec::<DropTargetEvent>::new()));
+
+        let observed_events = Arc::clone(&enter_events);
+
+        let mut result = use_drop(DropConfig {
+            on_drag_enter: Some(Callback::new(move |event: DropTargetEvent| {
+                observed_events
+                    .lock()
+                    .expect("enter events lock should succeed")
+                    .push(event);
+            })),
+            ..DropConfig::default()
+        });
+
+        let first = result.drag_enter(
+            vec![preview(DragItemKind::Text, &["text/plain"])],
+            DropOperation::Move,
+            PointerType::Mouse,
+        );
+
+        let second = result.drag_enter(
+            vec![preview(DragItemKind::Text, &["text/plain"])],
+            DropOperation::Move,
+            PointerType::Mouse,
+        );
+
+        let enter_events = enter_events
+            .lock()
+            .expect("enter events lock should succeed");
+
+        assert_eq!(first, DropOperation::Move);
+        assert_eq!(second, DropOperation::Move);
+        assert_eq!(result.enter_count, 2);
+        assert_eq!(enter_events.len(), 1);
+        assert_eq!(enter_events[0].operation, DropOperation::Move);
+        assert_eq!(enter_events[0].pointer_type, PointerType::Mouse);
+    }
+
+    #[test]
+    fn drop_result_drag_enter_sets_drag_over_and_indicator_snapshot() {
+        let mut result = use_drop(DropConfig {
+            drop_indicator_position: DropIndicatorPosition::Before,
+            ..DropConfig::default()
+        });
+
+        let operation = result.drag_enter(
+            vec![preview(DragItemKind::File, &["image/png"])],
+            DropOperation::Copy,
+            PointerType::Mouse,
+        );
+
+        assert_eq!(operation, DropOperation::Copy);
+        assert!(result.drag_over);
+        assert_eq!(result.drop_operation, Some(DropOperation::Copy));
+        assert_eq!(
+            result.indicator_position,
+            Some(DropIndicatorPosition::Before)
+        );
+        assert!(result.attrs.contains(&HtmlAttr::Data("ars-drag-over")));
+        assert!(matches!(
+            result.attrs.get_value(&HtmlAttr::Data("ars-drop-operation")),
+            Some(AttrValue::String(value)) if value == "copy"
+        ));
+        assert!(matches!(
+            result.attrs.get_value(&HtmlAttr::Data("ars-drop-position")),
+            Some(AttrValue::String(value)) if value == "before"
+        ));
+    }
+
+    #[test]
+    fn drop_result_drag_over_recovers_missing_drag_enter() {
+        let mut result = use_drop(DropConfig {
+            drop_indicator_position: DropIndicatorPosition::After,
+            ..DropConfig::default()
+        });
+
+        let operation = result.drag_over(
+            &[preview(DragItemKind::Text, &["text/plain"])],
+            DropOperation::Copy,
+            PointerType::Mouse,
+        );
+
+        assert_eq!(operation, DropOperation::Copy);
+        assert_eq!(result.enter_count, 1);
+        assert!(result.drag_over);
+        assert_eq!(result.drop_operation, Some(DropOperation::Copy));
+        assert_eq!(
+            result.indicator_position,
+            Some(DropIndicatorPosition::After)
+        );
+        assert!(result.attrs.contains(&HtmlAttr::Data("ars-drag-over")));
+    }
+
+    #[test]
+    fn drop_result_drag_over_updates_operation_and_position_snapshot() {
+        let mut result = use_drop(DropConfig {
+            on_drag_over: Some(Callback::new(|_: DropTargetEvent| DropOperation::Link)),
+            drop_indicator_position: DropIndicatorPosition::After,
+            ..DropConfig::default()
+        });
+
+        let _ = result.drag_enter(
+            vec![preview(DragItemKind::Text, &["text/plain"])],
+            DropOperation::Copy,
+            PointerType::Mouse,
+        );
+
+        let operation = result.drag_over(
+            &[preview(DragItemKind::Text, &["text/plain"])],
+            DropOperation::Copy,
+            PointerType::Mouse,
+        );
+
+        assert_eq!(operation, DropOperation::Link);
+        assert_eq!(result.drop_operation, Some(DropOperation::Link));
+        assert_eq!(
+            result.indicator_position,
+            Some(DropIndicatorPosition::After)
+        );
+        assert!(matches!(
+            result.attrs.get_value(&HtmlAttr::Data("ars-drop-operation")),
+            Some(AttrValue::String(value)) if value == "link"
+        ));
+        assert!(matches!(
+            result.attrs.get_value(&HtmlAttr::Data("ars-drop-position")),
+            Some(AttrValue::String(value)) if value == "after"
+        ));
+    }
+
+    #[test]
+    fn drop_result_rejects_operations_outside_accepted_list() {
+        let mut result = use_drop(DropConfig {
+            accepted_operations: Some(vec![DropOperation::Copy]),
+            ..DropConfig::default()
+        });
+
+        let operation = result.drag_enter(
+            vec![preview(DragItemKind::Text, &["text/plain"])],
+            DropOperation::Move,
+            PointerType::Mouse,
+        );
+
+        assert_eq!(operation, DropOperation::Cancel);
+        assert_eq!(result.enter_count, 0);
+        assert!(!result.drag_over);
+        assert!(result.drop_operation.is_none());
+        assert!(!result.attrs.contains(&HtmlAttr::Data("ars-drag-over")));
+    }
+
+    #[test]
+    fn drop_result_nested_enter_leave_only_clears_on_final_leave() {
+        let mut result = use_drop(DropConfig::default());
+
+        let _ = result.drag_enter(
+            vec![preview(DragItemKind::Text, &["text/plain"])],
+            DropOperation::Move,
+            PointerType::Mouse,
+        );
+
+        let _ = result.drag_enter(
+            vec![preview(DragItemKind::Text, &["text/plain"])],
+            DropOperation::Move,
+            PointerType::Mouse,
+        );
+
+        assert_eq!(result.enter_count, 2);
+        assert!(result.drag_over);
+
+        result.drag_leave(
+            &[preview(DragItemKind::Text, &["text/plain"])],
+            PointerType::Mouse,
+        );
+
+        assert_eq!(result.enter_count, 1);
+        assert!(result.drag_over);
+        assert!(result.attrs.contains(&HtmlAttr::Data("ars-drag-over")));
+
+        result.drag_leave(
+            &[preview(DragItemKind::Text, &["text/plain"])],
+            PointerType::Mouse,
+        );
+
+        assert_eq!(result.enter_count, 0);
+        assert!(!result.drag_over);
+        assert!(!result.attrs.contains(&HtmlAttr::Data("ars-drag-over")));
+    }
+
+    #[test]
+    fn drop_result_drag_leave_saturates_at_zero() {
+        let mut result = use_drop(DropConfig::default());
+
+        result.drag_leave(
+            &[preview(DragItemKind::Text, &["text/plain"])],
+            PointerType::Mouse,
+        );
+
+        assert_eq!(result.enter_count, 0);
+        assert!(!result.drag_over);
+        assert!(result.drop_operation.is_none());
+    }
+
+    #[test]
+    fn drop_result_drag_leave_fires_callback_on_final_leave() {
+        let leave_events = Arc::new(Mutex::new(Vec::<DropTargetEvent>::new()));
+
+        let observed_events = Arc::clone(&leave_events);
+
+        let mut result = use_drop(DropConfig {
+            on_drag_leave: Some(Callback::new(move |event: DropTargetEvent| {
+                observed_events
+                    .lock()
+                    .expect("leave events lock should succeed")
+                    .push(event);
+            })),
+            ..DropConfig::default()
+        });
+
+        let _ = result.drag_enter(
+            vec![preview(DragItemKind::Text, &["text/plain"])],
+            DropOperation::Link,
+            PointerType::Pen,
+        );
+
+        let _ = result.drag_enter(
+            vec![preview(DragItemKind::Text, &["text/plain"])],
+            DropOperation::Link,
+            PointerType::Pen,
+        );
+
+        result.drag_leave(
+            &[preview(DragItemKind::Text, &["text/plain"])],
+            PointerType::Pen,
+        );
+
+        assert!(
+            leave_events
+                .lock()
+                .expect("leave events lock should succeed")
+                .is_empty()
+        );
+
+        result.drag_leave(
+            &[preview(DragItemKind::Text, &["text/plain"])],
+            PointerType::Pen,
+        );
+
+        let leave_events = leave_events
+            .lock()
+            .expect("leave events lock should succeed");
+
+        assert_eq!(leave_events.len(), 1);
+        assert_eq!(leave_events[0].operation, DropOperation::Link);
+        assert_eq!(leave_events[0].pointer_type, PointerType::Pen);
+    }
+
+    #[test]
+    fn drop_result_drop_returns_event_and_resets_state() {
+        let mut result = use_drop(DropConfig {
+            drop_indicator_position: DropIndicatorPosition::OnTarget,
+            ..DropConfig::default()
+        });
+
+        let _ = result.drag_enter(
+            vec![preview(DragItemKind::File, &["image/png"])],
+            DropOperation::Move,
+            PointerType::Pen,
+        );
+
+        let event = result
+            .drop(
+                vec![DragItem::File {
+                    name: "image.png".into(),
+                    mime_type: "image/png".into(),
+                    size: 12,
+                    handle: FileHandle(()),
+                }],
+                PointerType::Pen,
+            )
+            .expect("accepted drop should produce event");
+
+        assert_eq!(event.operation, DropOperation::Move);
+        assert_eq!(event.pointer_type, PointerType::Pen);
+        assert_eq!(event.drop_position, DropIndicatorPosition::OnTarget);
+        assert!(!result.drag_over);
+        assert!(result.drop_operation.is_none());
+        assert!(!result.attrs.contains(&HtmlAttr::Data("ars-drag-over")));
+    }
+
+    #[test]
+    fn drop_result_drop_fires_callback_and_inactive_drop_is_none() {
+        let drop_events = Arc::new(Mutex::new(Vec::<DropEvent>::new()));
+
+        let observed_events = Arc::clone(&drop_events);
+
+        let mut result = use_drop(DropConfig {
+            on_drop: Some(Callback::new(move |event: DropEvent| {
+                observed_events
+                    .lock()
+                    .expect("drop events lock should succeed")
+                    .push(event);
+            })),
+            ..DropConfig::default()
+        });
+
+        assert!(
+            result
+                .drop(vec![DragItem::Text("payload".into())], PointerType::Mouse)
+                .is_none()
+        );
+        assert!(
+            drop_events
+                .lock()
+                .expect("drop events lock should succeed")
+                .is_empty()
+        );
+
+        let _ = result.drag_enter(
+            vec![preview(DragItemKind::Text, &["text/plain"])],
+            DropOperation::Move,
+            PointerType::Mouse,
+        );
+
+        let event = result
+            .drop(vec![DragItem::Text("payload".into())], PointerType::Mouse)
+            .expect("accepted drop should produce event");
+
+        let drop_events = drop_events.lock().expect("drop events lock should succeed");
+
+        assert_eq!(drop_events.len(), 1);
+        assert_eq!(drop_events[0].operation, event.operation);
+        assert_eq!(drop_events[0].pointer_type, event.pointer_type);
+        assert_eq!(drop_events[0].drop_position, event.drop_position);
+        assert_eq!(drop_events[0].items.len(), event.items.len());
+    }
+
+    #[test]
+    fn drop_result_rejected_types_return_cancel_operation() {
+        let mut result = use_drop(DropConfig {
+            accepted_types: Some(vec!["image/*".into()]),
+            ..DropConfig::default()
+        });
+
+        let operation = result.drag_enter(
+            vec![preview(DragItemKind::Text, &["text/plain"])],
+            DropOperation::Copy,
+            PointerType::Mouse,
+        );
+
+        assert_eq!(operation, DropOperation::Cancel);
+        assert!(!result.drag_over);
+        assert!(result.drop_operation.is_none());
+        assert!(result.indicator_position.is_none());
+        assert!(!result.attrs.contains(&HtmlAttr::Data("ars-drag-over")));
+        assert!(!result.attrs.contains(&HtmlAttr::Data("ars-drop-operation")));
+        assert!(!result.attrs.contains(&HtmlAttr::Data("ars-drop-position")));
+    }
+
+    #[test]
+    fn drop_result_drag_over_cancel_clears_active_snapshot() {
+        let mut result = use_drop(DropConfig {
+            on_drag_over: Some(Callback::new(|_: DropTargetEvent| DropOperation::Cancel)),
+            ..DropConfig::default()
+        });
+
+        let _ = result.drag_enter(
+            vec![preview(DragItemKind::Text, &["text/plain"])],
+            DropOperation::Move,
+            PointerType::Mouse,
+        );
+
+        let operation = result.drag_over(
+            &[preview(DragItemKind::Text, &["text/plain"])],
+            DropOperation::Move,
+            PointerType::Mouse,
+        );
+
+        assert_eq!(operation, DropOperation::Cancel);
+        assert!(!result.drag_over);
+        assert!(result.drop_operation.is_none());
+        assert!(result.indicator_position.is_none());
+        assert!(!result.attrs.contains(&HtmlAttr::Data("ars-drag-over")));
+    }
+
+    #[test]
+    fn drop_result_disabled_noops_all_transition_helpers() {
+        let mut result = use_drop(DropConfig {
+            disabled: true,
+            ..DropConfig::default()
+        });
+
+        let operation = result.drag_enter(
+            vec![preview(DragItemKind::Text, &["text/plain"])],
+            DropOperation::Move,
+            PointerType::Mouse,
+        );
+
+        assert_eq!(operation, DropOperation::Cancel);
+        assert_eq!(
+            result.drag_over(
+                &[preview(DragItemKind::Text, &["text/plain"])],
+                DropOperation::Move,
+                PointerType::Mouse,
+            ),
+            DropOperation::Cancel
+        );
+
+        result.drag_leave(
+            &[preview(DragItemKind::Text, &["text/plain"])],
+            PointerType::Mouse,
+        );
+
+        assert!(
+            result
+                .drop(vec![DragItem::Text("payload".into())], PointerType::Mouse)
+                .is_none()
+        );
+
+        assert!(!result.drag_over);
+        assert!(result.drop_operation.is_none());
+        assert!(!result.attrs.contains(&HtmlAttr::Data("ars-drag-over")));
     }
 }

--- a/crates/ars-interactions/src/lib.rs
+++ b/crates/ars-interactions/src/lib.rs
@@ -23,9 +23,9 @@ pub use compose::merge_attrs;
 pub use direction::{LogicalDirection, resolve_arrow_key};
 pub use dismissable::dismiss_button_attrs;
 pub use drag_drop::{
-    DirectoryHandle, DragConfig, DragEndEvent, DragItem, DragItemKind, DragItemPreview,
-    DragStartEvent, DropConfig, DropEvent, DropIndicatorPosition, DropOperation, DropTargetEvent,
-    FileHandle,
+    DirectoryHandle, DragConfig, DragEndEvent, DragItem, DragItemKind, DragItemPreview, DragResult,
+    DragStartEvent, DragState, DropConfig, DropEvent, DropIndicatorPosition, DropOperation,
+    DropResult, DropTargetEvent, FileHandle, use_drag, use_drop,
 };
 pub use focus::{
     FocusConfig, FocusEvent, FocusEventType, FocusResult, FocusState, FocusWithinConfig,

--- a/spec/foundation/05-interactions.md
+++ b/spec/foundation/05-interactions.md
@@ -2370,6 +2370,11 @@ impl DragConfig {
 
 The drag image should reflect the count: when dragging 3 selected items, the ghost image shows a badge "3 items" overlaid.
 
+Because `DragItem` may contain opaque handles without a stable equality
+contract, the payload ordering is defined as **`items()` followed by
+`get_items()`**. Implementations preserve duplicates rather than attempting
+set-style deduplication.
+
 ### 7.10 Drop Indicators and Positioning
 
 > **Design note:** DragResult and DropResult use a snapshot-based `attrs` field rather than the `current_attrs()` pattern used by Press/Hover/Focus/LongPress/Move. This is because drag operations span multiple event cycles and the attrs must remain stable during a drag sequence. Components using DnD should re-call `use_drag`/`use_drop` on each render to refresh the snapshot.
@@ -2398,6 +2403,37 @@ pub struct DragResult {
 
     /// Whether this element is currently being dragged.
     pub dragging: bool,
+}
+
+// Like PressResult and LongPressResult, DnD results expose adapter-facing
+// transition helpers. These methods mutate internal state and rebuild the
+// snapshot fields (`attrs`, `dragging`, `drag_over`, etc.) after each change.
+impl DragResult {
+    pub fn current_state(&self) -> DragState { /* ... */ }
+    pub fn start_drag(&mut self, pointer_type: PointerType) -> Option<DragStartEvent> { /* ... */ }
+    pub fn enter_target(&mut self, target_id: impl Into<String>, current_operation: DropOperation) { /* ... */ }
+    pub fn leave_target(&mut self) { /* ... */ }
+    pub fn complete_drop(&mut self) -> Option<DragEndEvent> { /* ... */ }
+    pub fn cancel_drag(&mut self) -> Option<DragEndEvent> { /* ... */ }
+    pub fn reset(&mut self) { /* ... */ }
+}
+
+impl DropResult {
+    pub fn drag_enter(
+        &mut self,
+        items: Vec<DragItemPreview>,
+        offered_operation: DropOperation,
+        pointer_type: PointerType,
+    ) -> DropOperation { /* ... */ }
+    pub fn drag_over(
+        &mut self,
+        items: &[DragItemPreview],
+        offered_operation: DropOperation,
+        pointer_type: PointerType,
+    ) -> DropOperation { /* ... */ }
+    pub fn drag_leave(&mut self, items: &[DragItemPreview], pointer_type: PointerType) { /* ... */ }
+    pub fn drop(&mut self, items: Vec<DragItem>, pointer_type: PointerType) -> Option<DropEvent> { /* ... */ }
+    pub fn reset(&mut self) { /* ... */ }
 }
 
 pub fn use_drag(config: DragConfig) -> DragResult {
@@ -2452,10 +2488,13 @@ pub fn use_drop(config: DropConfig) -> DropResult {
     }
 
     // Event handlers registered on the component's Api struct:
-    //   dragenter → prevent_default, increment enter_count, set drag_over = true,
-    //               validate accepted_types against DataTransfer.types
+    //   dragenter → prevent_default, validate accepted_types against DataTransfer.types;
+    //               only valid targets enter the active drag_over state
     //   dragleave → decrement enter_count; if 0, set drag_over = false
-    //   dragover  → prevent_default, set drop_effect, compute indicator position
+    //   dragover  → prevent_default, set drop_effect, compute indicator position;
+    //               if the target stops accepting the drop, clear the active snapshot.
+    //               For robustness, adapters may also re-activate the target from dragover
+    //               when native event ordering omits an expected dragenter.
     //   drop      → prevent_default, reset state, extract items, emit on_drop
 
     DropResult {


### PR DESCRIPTION
## Summary
- implement the drag/drop source and target state machines for `ars-interactions`
- add snapshot-based `use_drag` and `use_drop` result surfaces with adapter-facing helper methods
- expand drag/drop tests and align the interaction spec with the helper surface and robustness behavior

## Why
Issue `#160` requires the runtime drag/drop state machines and snapshot attrs needed by adapters. This also closes the remaining code/spec drift around helper methods, accepted target handling, and drag-over recovery behavior.

## Impact
Adapters can now drive drag source and drop target transitions through the public helper surface while reading stable `attrs`, `dragging`, `drag_over`, `drop_operation`, and `indicator_position` snapshots directly from the results.

## Validation
- `cargo test -p ars-interactions drag_drop --offline`
- `cargo test -p ars-interactions --offline`
- `cargo llvm-cov test -p ars-interactions`
- `cargo xci`

Closes #160