### PR TITLE
Implement announcement message helpers in ars-a11y

### DIFF
--- a/crates/ars-a11y/src/announcements.rs
+++ b/crates/ars-a11y/src/announcements.rs
@@ -61,6 +61,9 @@ pub struct Messages {
     /// Message used when a column is sorted descending.
     pub sorted_descending: MessageFn<LabelLocaleMessage>,
 
+    /// Message used when a column is sorted in a non-standard order.
+    pub sorted_other: MessageFn<LabelLocaleMessage>,
+
     /// Message used when a column is not sorted.
     pub not_sorted: MessageFn<LabelLocaleMessage>,
 
@@ -112,6 +115,10 @@ impl Default for Messages {
 
             sorted_descending: MessageFn::new(Arc::new(|column: &str, _locale: &Locale| {
                 format!("{column}, sorted descending.")
+            }) as Arc<LabelLocaleMessage>),
+
+            sorted_other: MessageFn::new(Arc::new(|column: &str, _locale: &Locale| {
+                format!("{column}, sorted.")
             }) as Arc<LabelLocaleMessage>),
 
             not_sorted: MessageFn::new(Arc::new(|column: &str, _locale: &Locale| {
@@ -217,7 +224,8 @@ impl Announcements {
         let message = match direction {
             AriaSort::Ascending => &messages.sorted_ascending,
             AriaSort::Descending => &messages.sorted_descending,
-            AriaSort::None | AriaSort::Other => &messages.not_sorted,
+            AriaSort::Other => &messages.sorted_other,
+            AriaSort::None => &messages.not_sorted,
         };
 
         message(column, locale)
@@ -281,6 +289,7 @@ mod tests {
             (messages.sorted_descending)("Name", &locale),
             "Name, sorted descending."
         );
+        assert_eq!((messages.sorted_other)("Name", &locale), "Name, sorted.");
         assert_eq!((messages.not_sorted)("Name", &locale), "Name, not sorted.");
         assert_eq!(
             (messages.tree_expanded)("Folder", &locale),
@@ -395,7 +404,7 @@ mod tests {
         );
         assert_eq!(
             Announcements::column_sorted("Name", AriaSort::Other, &locale, &messages),
-            "Name, not sorted."
+            "Name, sorted."
         );
     }
 
@@ -438,12 +447,12 @@ mod tests {
                 format!("Carregando ({})", locale.to_bcp47())
             }),
             loading_complete: MessageFn::new(|locale: &Locale| {
-                format!("Carregamento concluido ({})", locale.to_bcp47())
+                format!("Carregamento concluído ({})", locale.to_bcp47())
             }),
             item_moved: MessageFn::new(Arc::new(
                 |label: &str, position: usize, total: usize, locale: &Locale| {
                     format!(
-                        "{label} movido para a posicao {position} de {total} ({})",
+                        "{label} movido para a posição {position} de {total} ({})",
                         locale.to_bcp47()
                     )
                 },
@@ -457,8 +466,11 @@ mod tests {
             sorted_descending: MessageFn::new(Arc::new(|column: &str, locale: &Locale| {
                 format!("{column}, ordem decrescente ({})", locale.to_bcp47())
             }) as Arc<LabelLocaleMessage>),
+            sorted_other: MessageFn::new(Arc::new(|column: &str, locale: &Locale| {
+                format!("{column}, ordenado ({})", locale.to_bcp47())
+            }) as Arc<LabelLocaleMessage>),
             not_sorted: MessageFn::new(Arc::new(|column: &str, locale: &Locale| {
-                format!("{column}, sem ordenacao ({})", locale.to_bcp47())
+                format!("{column}, sem ordenação ({})", locale.to_bcp47())
             }) as Arc<LabelLocaleMessage>),
             tree_expanded: MessageFn::new(Arc::new(|label: &str, locale: &Locale| {
                 format!("{label}, expandido ({})", locale.to_bcp47())
@@ -477,12 +489,12 @@ mod tests {
             "Item A, selecionado (pt-BR)"
         );
         assert_eq!(
-            Announcements::validation_error("Email", "obrigatorio", &locale, &messages),
-            "Email: obrigatorio. Erro (pt-BR)"
+            Announcements::validation_error("Email", "obrigatório", &locale, &messages),
+            "Email: obrigatório. Erro (pt-BR)"
         );
         assert_eq!(
             Announcements::item_moved("Linha 3", 2, 10, &locale, &messages),
-            "Linha 3 movido para a posicao 2 de 10 (pt-BR)"
+            "Linha 3 movido para a posição 2 de 10 (pt-BR)"
         );
         assert_eq!(
             Announcements::column_sorted("Nome", AriaSort::Descending, &locale, &messages),

--- a/crates/ars-a11y/src/announcements.rs
+++ b/crates/ars-a11y/src/announcements.rs
@@ -1,0 +1,560 @@
+//! Localizable screen-reader announcement message helpers.
+
+use alloc::{
+    format,
+    string::{String, ToString},
+    sync::Arc,
+};
+
+use ars_core::{ComponentMessages, Locale, MessageFn};
+
+use crate::aria::attribute::AriaSort;
+
+type LocaleMessage = dyn Fn(&Locale) -> String + Send + Sync;
+
+type CountLocaleMessage = dyn Fn(usize, &Locale) -> String + Send + Sync;
+
+type LabelLocaleMessage = dyn Fn(&str, &Locale) -> String + Send + Sync;
+
+type FieldErrorLocaleMessage = dyn Fn(&str, &str, &Locale) -> String + Send + Sync;
+
+type MoveLocaleMessage = dyn Fn(&str, usize, usize, &Locale) -> String + Send + Sync;
+
+/// Localizable announcement templates for common component state changes.
+///
+/// Announcement helpers follow the shared `ComponentMessages` pattern: each
+/// field is a [`MessageFn`] that receives the active locale when the helper is
+/// invoked, allowing the adapter to supply locale-sensitive strings and
+/// pluralization rules without hardcoding English in the subsystem layer.
+#[derive(Clone, Debug)]
+pub struct Messages {
+    /// Message used when a search yields any number of results.
+    ///
+    /// The default English implementation branches on `count`, while
+    /// locale-specific implementations can use richer pluralization rules.
+    pub search_results: MessageFn<CountLocaleMessage>,
+
+    /// Message used when an item becomes selected.
+    pub selected: MessageFn<LabelLocaleMessage>,
+
+    /// Message used when an item becomes deselected.
+    pub deselected: MessageFn<LabelLocaleMessage>,
+
+    /// Message used when a field has a validation error.
+    pub validation_error: MessageFn<FieldErrorLocaleMessage>,
+
+    /// Message used while content is loading.
+    pub loading: MessageFn<LocaleMessage>,
+
+    /// Message used when loading finishes.
+    pub loading_complete: MessageFn<LocaleMessage>,
+
+    /// Message used when an item is moved to a new position.
+    pub item_moved: MessageFn<MoveLocaleMessage>,
+
+    /// Message used when an item is removed.
+    pub item_removed: MessageFn<LabelLocaleMessage>,
+
+    /// Message used when a column is sorted ascending.
+    pub sorted_ascending: MessageFn<LabelLocaleMessage>,
+
+    /// Message used when a column is sorted descending.
+    pub sorted_descending: MessageFn<LabelLocaleMessage>,
+
+    /// Message used when a column is not sorted.
+    pub not_sorted: MessageFn<LabelLocaleMessage>,
+
+    /// Message used when a tree node expands.
+    pub tree_expanded: MessageFn<LabelLocaleMessage>,
+
+    /// Message used when a tree node collapses.
+    pub tree_collapsed: MessageFn<LabelLocaleMessage>,
+}
+
+impl Default for Messages {
+    fn default() -> Self {
+        Self {
+            search_results: MessageFn::new(Arc::new(|count: usize, _locale: &Locale| match count {
+                0 => String::from("No results found."),
+                1 => String::from("1 result found."),
+                _ => format!("{count} results found."),
+            }) as Arc<CountLocaleMessage>),
+
+            selected: MessageFn::new(Arc::new(|label: &str, _locale: &Locale| {
+                format!("{label}, selected.")
+            }) as Arc<LabelLocaleMessage>),
+
+            deselected: MessageFn::new(Arc::new(|label: &str, _locale: &Locale| {
+                format!("{label}, deselected.")
+            }) as Arc<LabelLocaleMessage>),
+
+            validation_error: MessageFn::new(Arc::new(
+                |field: &str, error: &str, _locale: &Locale| format!("{field}: {error}. Error."),
+            ) as Arc<FieldErrorLocaleMessage>),
+
+            loading: MessageFn::static_str("Loading."),
+
+            loading_complete: MessageFn::static_str("Loading complete."),
+
+            item_moved: MessageFn::new(Arc::new(
+                |label: &str, position: usize, total: usize, _locale: &Locale| {
+                    format!("{label} moved to position {position} of {total}.")
+                },
+            ) as Arc<MoveLocaleMessage>),
+
+            item_removed: MessageFn::new(Arc::new(|label: &str, _locale: &Locale| {
+                format!("{label} removed.")
+            }) as Arc<LabelLocaleMessage>),
+
+            sorted_ascending: MessageFn::new(Arc::new(|column: &str, _locale: &Locale| {
+                format!("{column}, sorted ascending.")
+            }) as Arc<LabelLocaleMessage>),
+
+            sorted_descending: MessageFn::new(Arc::new(|column: &str, _locale: &Locale| {
+                format!("{column}, sorted descending.")
+            }) as Arc<LabelLocaleMessage>),
+
+            not_sorted: MessageFn::new(Arc::new(|column: &str, _locale: &Locale| {
+                format!("{column}, not sorted.")
+            }) as Arc<LabelLocaleMessage>),
+
+            tree_expanded: MessageFn::new(Arc::new(|label: &str, _locale: &Locale| {
+                format!("{label}, expanded.")
+            }) as Arc<LabelLocaleMessage>),
+
+            tree_collapsed: MessageFn::new(Arc::new(|label: &str, _locale: &Locale| {
+                format!("{label}, collapsed.")
+            }) as Arc<LabelLocaleMessage>),
+        }
+    }
+}
+
+impl ComponentMessages for Messages {}
+
+/// Helpers that render localized announcement strings for common UI changes.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Announcements;
+
+impl Announcements {
+    /// Announces the number of search results.
+    #[must_use]
+    pub fn search_results(count: usize, locale: &Locale, messages: &Messages) -> String {
+        (messages.search_results)(count, locale)
+    }
+
+    /// Announces a selection change in a collection widget.
+    #[must_use]
+    pub fn selection_changed(
+        label: &str,
+        selected: bool,
+        locale: &Locale,
+        messages: &Messages,
+    ) -> String {
+        let message = if selected {
+            &messages.selected
+        } else {
+            &messages.deselected
+        };
+
+        message(label, locale)
+    }
+
+    /// Announces a toast notification.
+    #[must_use]
+    pub fn toast(message: &str) -> String {
+        message.to_string()
+    }
+
+    /// Announces a form validation error.
+    #[must_use]
+    pub fn validation_error(
+        field_label: &str,
+        error: &str,
+        locale: &Locale,
+        messages: &Messages,
+    ) -> String {
+        (messages.validation_error)(field_label, error, locale)
+    }
+
+    /// Announces that loading has started.
+    #[must_use]
+    pub fn loading(locale: &Locale, messages: &Messages) -> String {
+        (messages.loading)(locale)
+    }
+
+    /// Announces that loading has completed.
+    #[must_use]
+    pub fn loading_complete(locale: &Locale, messages: &Messages) -> String {
+        (messages.loading_complete)(locale)
+    }
+
+    /// Announces that an item moved within a collection.
+    #[must_use]
+    pub fn item_moved(
+        label: &str,
+        position: usize,
+        total: usize,
+        locale: &Locale,
+        messages: &Messages,
+    ) -> String {
+        (messages.item_moved)(label, position, total, locale)
+    }
+
+    /// Announces that an item was removed.
+    #[must_use]
+    pub fn item_removed(label: &str, locale: &Locale, messages: &Messages) -> String {
+        (messages.item_removed)(label, locale)
+    }
+
+    /// Announces a column sorting change.
+    #[must_use]
+    pub fn column_sorted(
+        column: &str,
+        direction: AriaSort,
+        locale: &Locale,
+        messages: &Messages,
+    ) -> String {
+        let message = match direction {
+            AriaSort::Ascending => &messages.sorted_ascending,
+            AriaSort::Descending => &messages.sorted_descending,
+            AriaSort::None | AriaSort::Other => &messages.not_sorted,
+        };
+
+        message(column, locale)
+    }
+
+    /// Announces a tree node expanding or collapsing.
+    #[must_use]
+    pub fn tree_node_expanded(
+        label: &str,
+        expanded: bool,
+        locale: &Locale,
+        messages: &Messages,
+    ) -> String {
+        let message = if expanded {
+            &messages.tree_expanded
+        } else {
+            &messages.tree_collapsed
+        };
+
+        message(label, locale)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn locale() -> Locale {
+        Locale::parse("en-US").expect("test locale must parse")
+    }
+
+    #[test]
+    fn announcement_messages_default_provides_spec_english_templates() {
+        let messages = Messages::default();
+        let locale = locale();
+
+        assert_eq!((messages.search_results)(0, &locale), "No results found.");
+        assert_eq!((messages.search_results)(1, &locale), "1 result found.");
+        assert_eq!((messages.search_results)(42, &locale), "42 results found.");
+        assert_eq!((messages.selected)("Item A", &locale), "Item A, selected.");
+        assert_eq!(
+            (messages.deselected)("Item A", &locale),
+            "Item A, deselected."
+        );
+        assert_eq!(
+            (messages.validation_error)("Email", "is required", &locale),
+            "Email: is required. Error."
+        );
+        assert_eq!((messages.loading)(&locale), "Loading.");
+        assert_eq!((messages.loading_complete)(&locale), "Loading complete.");
+        assert_eq!(
+            (messages.item_moved)("Row 3", 2, 10, &locale),
+            "Row 3 moved to position 2 of 10."
+        );
+        assert_eq!((messages.item_removed)("Tag X", &locale), "Tag X removed.");
+        assert_eq!(
+            (messages.sorted_ascending)("Name", &locale),
+            "Name, sorted ascending."
+        );
+        assert_eq!(
+            (messages.sorted_descending)("Name", &locale),
+            "Name, sorted descending."
+        );
+        assert_eq!((messages.not_sorted)("Name", &locale), "Name, not sorted.");
+        assert_eq!(
+            (messages.tree_expanded)("Folder", &locale),
+            "Folder, expanded."
+        );
+        assert_eq!(
+            (messages.tree_collapsed)("Folder", &locale),
+            "Folder, collapsed."
+        );
+    }
+
+    #[test]
+    fn search_results_uses_count_aware_template() {
+        let messages = Messages::default();
+        let locale = locale();
+
+        assert_eq!(
+            Announcements::search_results(0, &locale, &messages),
+            "No results found."
+        );
+        assert_eq!(
+            Announcements::search_results(1, &locale, &messages),
+            "1 result found."
+        );
+        assert_eq!(
+            Announcements::search_results(42, &locale, &messages),
+            "42 results found."
+        );
+    }
+
+    #[test]
+    fn selection_changed_uses_selected_and_deselected_templates() {
+        let messages = Messages::default();
+        let locale = locale();
+
+        assert_eq!(
+            Announcements::selection_changed("Item A", true, &locale, &messages),
+            "Item A, selected."
+        );
+        assert_eq!(
+            Announcements::selection_changed("Item A", false, &locale, &messages),
+            "Item A, deselected."
+        );
+    }
+
+    #[test]
+    fn toast_returns_message_as_is() {
+        assert_eq!(Announcements::toast("Hello"), "Hello");
+    }
+
+    #[test]
+    fn validation_error_replaces_field_and_error_placeholders() {
+        let messages = Messages::default();
+        let locale = locale();
+
+        assert_eq!(
+            Announcements::validation_error("Email", "is required", &locale, &messages),
+            "Email: is required. Error."
+        );
+    }
+
+    #[test]
+    fn loading_helpers_invoke_locale_aware_templates() {
+        let messages = Messages::default();
+        let locale = locale();
+
+        assert_eq!(Announcements::loading(&locale, &messages), "Loading.");
+        assert_eq!(
+            Announcements::loading_complete(&locale, &messages),
+            "Loading complete."
+        );
+    }
+
+    #[test]
+    fn item_moved_replaces_all_placeholders() {
+        let messages = Messages::default();
+        let locale = locale();
+
+        assert_eq!(
+            Announcements::item_moved("Row 3", 2, 10, &locale, &messages),
+            "Row 3 moved to position 2 of 10."
+        );
+    }
+
+    #[test]
+    fn item_removed_replaces_label_placeholder() {
+        let messages = Messages::default();
+        let locale = locale();
+
+        assert_eq!(
+            Announcements::item_removed("Tag X", &locale, &messages),
+            "Tag X removed."
+        );
+    }
+
+    #[test]
+    fn column_sorted_handles_all_direction_branches() {
+        let messages = Messages::default();
+        let locale = locale();
+
+        assert_eq!(
+            Announcements::column_sorted("Name", AriaSort::Ascending, &locale, &messages),
+            "Name, sorted ascending."
+        );
+        assert_eq!(
+            Announcements::column_sorted("Name", AriaSort::Descending, &locale, &messages),
+            "Name, sorted descending."
+        );
+        assert_eq!(
+            Announcements::column_sorted("Name", AriaSort::None, &locale, &messages),
+            "Name, not sorted."
+        );
+        assert_eq!(
+            Announcements::column_sorted("Name", AriaSort::Other, &locale, &messages),
+            "Name, not sorted."
+        );
+    }
+
+    #[test]
+    fn tree_node_expanded_uses_expanded_and_collapsed_templates() {
+        let messages = Messages::default();
+        let locale = locale();
+
+        assert_eq!(
+            Announcements::tree_node_expanded("Folder", true, &locale, &messages),
+            "Folder, expanded."
+        );
+        assert_eq!(
+            Announcements::tree_node_expanded("Folder", false, &locale, &messages),
+            "Folder, collapsed."
+        );
+    }
+
+    #[test]
+    fn custom_localized_templates_are_used_without_hardcoded_english() {
+        let locale = Locale::parse("pt-BR").expect("test locale must parse");
+        let messages = Messages {
+            search_results: MessageFn::new(Arc::new(|count: usize, locale: &Locale| match count {
+                0 => format!("Nenhum resultado ({})", locale.to_bcp47()),
+                1 => format!("1 resultado ({})", locale.to_bcp47()),
+                _ => format!("{count} resultados ({})", locale.to_bcp47()),
+            }) as Arc<CountLocaleMessage>),
+            selected: MessageFn::new(Arc::new(|label: &str, locale: &Locale| {
+                format!("{label}, selecionado ({})", locale.to_bcp47())
+            }) as Arc<LabelLocaleMessage>),
+            deselected: MessageFn::new(Arc::new(|label: &str, locale: &Locale| {
+                format!("{label}, desmarcado ({})", locale.to_bcp47())
+            }) as Arc<LabelLocaleMessage>),
+            validation_error: MessageFn::new(Arc::new(
+                |field: &str, error: &str, locale: &Locale| {
+                    format!("{field}: {error}. Erro ({})", locale.to_bcp47())
+                },
+            ) as Arc<FieldErrorLocaleMessage>),
+            loading: MessageFn::new(|locale: &Locale| {
+                format!("Carregando ({})", locale.to_bcp47())
+            }),
+            loading_complete: MessageFn::new(|locale: &Locale| {
+                format!("Carregamento concluido ({})", locale.to_bcp47())
+            }),
+            item_moved: MessageFn::new(Arc::new(
+                |label: &str, position: usize, total: usize, locale: &Locale| {
+                    format!(
+                        "{label} movido para a posicao {position} de {total} ({})",
+                        locale.to_bcp47()
+                    )
+                },
+            ) as Arc<MoveLocaleMessage>),
+            item_removed: MessageFn::new(Arc::new(|label: &str, locale: &Locale| {
+                format!("{label} removido ({})", locale.to_bcp47())
+            }) as Arc<LabelLocaleMessage>),
+            sorted_ascending: MessageFn::new(Arc::new(|column: &str, locale: &Locale| {
+                format!("{column}, ordem crescente ({})", locale.to_bcp47())
+            }) as Arc<LabelLocaleMessage>),
+            sorted_descending: MessageFn::new(Arc::new(|column: &str, locale: &Locale| {
+                format!("{column}, ordem decrescente ({})", locale.to_bcp47())
+            }) as Arc<LabelLocaleMessage>),
+            not_sorted: MessageFn::new(Arc::new(|column: &str, locale: &Locale| {
+                format!("{column}, sem ordenacao ({})", locale.to_bcp47())
+            }) as Arc<LabelLocaleMessage>),
+            tree_expanded: MessageFn::new(Arc::new(|label: &str, locale: &Locale| {
+                format!("{label}, expandido ({})", locale.to_bcp47())
+            }) as Arc<LabelLocaleMessage>),
+            tree_collapsed: MessageFn::new(Arc::new(|label: &str, locale: &Locale| {
+                format!("{label}, recolhido ({})", locale.to_bcp47())
+            }) as Arc<LabelLocaleMessage>),
+        };
+
+        assert_eq!(
+            Announcements::search_results(3, &locale, &messages),
+            "3 resultados (pt-BR)"
+        );
+        assert_eq!(
+            Announcements::selection_changed("Item A", true, &locale, &messages),
+            "Item A, selecionado (pt-BR)"
+        );
+        assert_eq!(
+            Announcements::validation_error("Email", "obrigatorio", &locale, &messages),
+            "Email: obrigatorio. Erro (pt-BR)"
+        );
+        assert_eq!(
+            Announcements::item_moved("Linha 3", 2, 10, &locale, &messages),
+            "Linha 3 movido para a posicao 2 de 10 (pt-BR)"
+        );
+        assert_eq!(
+            Announcements::column_sorted("Nome", AriaSort::Descending, &locale, &messages),
+            "Nome, ordem decrescente (pt-BR)"
+        );
+        assert_eq!(
+            Announcements::tree_node_expanded("Pasta", false, &locale, &messages),
+            "Pasta, recolhido (pt-BR)"
+        );
+    }
+
+    #[test]
+    fn search_results_can_vary_by_locale() {
+        let en_locale = Locale::parse("en-US").expect("test locale must parse");
+        let pt_locale = Locale::parse("pt-BR").expect("test locale must parse");
+        let messages = Messages {
+            search_results: MessageFn::new(Arc::new(|count: usize, locale: &Locale| {
+                match locale.to_bcp47().as_str() {
+                    "pt-BR" if count == 0 => String::from("Nenhum resultado encontrado."),
+                    "pt-BR" => format!("{count} resultados encontrados."),
+                    _ if count == 0 => String::from("No results found."),
+                    _ => format!("{count} results found."),
+                }
+            }) as Arc<CountLocaleMessage>),
+            ..Messages::default()
+        };
+
+        assert_eq!(
+            Announcements::search_results(0, &en_locale, &messages),
+            "No results found."
+        );
+        assert_eq!(
+            Announcements::search_results(2, &en_locale, &messages),
+            "2 results found."
+        );
+        assert_eq!(
+            Announcements::search_results(0, &pt_locale, &messages),
+            "Nenhum resultado encontrado."
+        );
+        assert_eq!(
+            Announcements::search_results(2, &pt_locale, &messages),
+            "2 resultados encontrados."
+        );
+    }
+
+    #[test]
+    fn messages_satisfies_component_messages_contract() {
+        fn clone_messages<M: ComponentMessages + Clone + Default>(messages: &M) -> M {
+            messages.clone()
+        }
+
+        let messages = Messages::default();
+        let cloned = clone_messages(&messages);
+        let locale = locale();
+
+        assert_eq!((cloned.search_results)(0, &locale), "No results found.");
+        assert_eq!(Announcements::loading(&locale, &cloned), "Loading.");
+    }
+
+    #[test]
+    fn cloned_messages_preserve_custom_message_functions() {
+        let locale = Locale::parse("pt-BR").expect("test locale must parse");
+        let messages = Messages {
+            loading: MessageFn::new(|locale: &Locale| format!("Carregando {}", locale.to_bcp47())),
+            ..Messages::default()
+        };
+        let cloned = messages.clone();
+
+        assert_eq!(
+            Announcements::loading(&locale, &messages),
+            "Carregando pt-BR"
+        );
+        assert_eq!(Announcements::loading(&locale, &cloned), "Carregando pt-BR");
+    }
+}

--- a/crates/ars-a11y/src/lib.rs
+++ b/crates/ars-a11y/src/lib.rs
@@ -8,6 +8,7 @@
 
 extern crate alloc;
 
+pub mod announcements;
 pub mod announcer;
 pub mod aria;
 /// Shared focus management contracts consumed by DOM and adapter layers.
@@ -16,6 +17,7 @@ pub mod focus;
 pub mod keyboard;
 pub mod visually_hidden;
 
+pub use announcements::Announcements;
 pub use announcer::{Announcement, AnnouncementPriority, LiveAnnouncer};
 #[cfg(feature = "aria-drag-drop-compat")]
 pub use aria::attribute::AriaDropeffect;
@@ -68,5 +70,21 @@ mod tests {
     #[test]
     fn data_ars_state_constant_value() {
         assert_eq!(DATA_ARS_STATE, "data-ars-state");
+    }
+
+    #[test]
+    fn announcements_messages_are_available_via_module_path() {
+        fn assert_component_messages<M: ars_core::ComponentMessages + Clone + Default>(
+            messages: &M,
+        ) -> M {
+            messages.clone()
+        }
+
+        let messages = announcements::Messages::default();
+        let cloned = assert_component_messages(&messages);
+        let locale = ars_core::Locale::parse("en-US").expect("test locale must parse");
+
+        assert_eq!((cloned.loading)(&locale), "Loading.");
+        assert_eq!(Announcements::loading(&locale, &messages), "Loading.");
     }
 }

--- a/spec/foundation/03-accessibility.md
+++ b/spec/foundation/03-accessibility.md
@@ -2987,72 +2987,89 @@ Patterns for specific dynamic content scenarios:
 /// Localizable announcement templates for common component state changes.
 ///
 /// Per §2.8: NO hardcoded English strings in ARIA labels or announcements.
-/// All announcement text is provided via the `AnnouncementMessages` struct,
-/// which implements `ComponentMessages` with English defaults. Consumers
-/// supply a locale-appropriate instance through the adapter's context provider.
-///
-/// **Design note — String vs MessageFn pattern:** This struct uses pre-localized `String`
-/// fields (with `{placeholder}` interpolation) rather than the `MessageFn` closure pattern
-/// used by `DragAnnouncements` (in `ars-interactions`). This is because `ars-a11y` depends
-/// only on `ars-core` and cannot reference `Locale` from `ars-i18n`. The adapter is
-/// responsible for constructing the correct locale-specific `AnnouncementMessages` instance.
+/// All announcement text follows the shared `ComponentMessages` pattern:
+/// each field is a `MessageFn` that receives the active locale, allowing
+/// adapters to resolve locale-aware strings and pluralization consistently
+/// across components.
 #[derive(Clone, Debug)]
-pub struct AnnouncementMessages {
-    pub search_results_zero: String,    // "No results found."
-    pub search_results_one: String,     // "1 result found."
-    pub search_results_other: String,   // "{count} results found."
-    pub selected: String,               // "{label}, selected."
-    pub deselected: String,             // "{label}, deselected."
-    pub validation_error: String,       // "{field}: {error}. Error."
-    pub loading: String,                // "Loading."
-    pub loading_complete: String,       // "Loading complete."
-    pub item_moved: String,             // "{label} moved to position {position} of {total}."
-    pub item_removed: String,           // "{label} removed."
-    pub sorted_ascending: String,       // "{column}, sorted ascending."
-    pub sorted_descending: String,      // "{column}, sorted descending."
-    pub not_sorted: String,             // "{column}, not sorted."
-    pub tree_expanded: String,          // "{label}, expanded."
-    pub tree_collapsed: String,         // "{label}, collapsed."
+pub struct Messages {
+    pub search_results: MessageFn<dyn Fn(usize, &Locale) -> String + Send + Sync>,
+    pub selected: MessageFn<dyn Fn(&str, &Locale) -> String + Send + Sync>,
+    pub deselected: MessageFn<dyn Fn(&str, &Locale) -> String + Send + Sync>,
+    pub validation_error: MessageFn<dyn Fn(&str, &str, &Locale) -> String + Send + Sync>,
+    pub loading: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
+    pub loading_complete: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
+    pub item_moved: MessageFn<dyn Fn(&str, usize, usize, &Locale) -> String + Send + Sync>,
+    pub item_removed: MessageFn<dyn Fn(&str, &Locale) -> String + Send + Sync>,
+    pub sorted_ascending: MessageFn<dyn Fn(&str, &Locale) -> String + Send + Sync>,
+    pub sorted_descending: MessageFn<dyn Fn(&str, &Locale) -> String + Send + Sync>,
+    pub not_sorted: MessageFn<dyn Fn(&str, &Locale) -> String + Send + Sync>,
+    pub tree_expanded: MessageFn<dyn Fn(&str, &Locale) -> String + Send + Sync>,
+    pub tree_collapsed: MessageFn<dyn Fn(&str, &Locale) -> String + Send + Sync>,
 }
 
-impl Default for AnnouncementMessages {
+impl Default for Messages {
     fn default() -> Self {
         Self {
-            search_results_zero: "No results found.".into(),
-            search_results_one: "1 result found.".into(),
-            search_results_other: "{count} results found.".into(),
-            selected: "{label}, selected.".into(),
-            deselected: "{label}, deselected.".into(),
-            validation_error: "{field}: {error}. Error.".into(),
-            loading: "Loading.".into(),
-            loading_complete: "Loading complete.".into(),
-            item_moved: "{label} moved to position {position} of {total}.".into(),
-            item_removed: "{label} removed.".into(),
-            sorted_ascending: "{column}, sorted ascending.".into(),
-            sorted_descending: "{column}, sorted descending.".into(),
-            not_sorted: "{column}, not sorted.".into(),
-            tree_expanded: "{label}, expanded.".into(),
-            tree_collapsed: "{label}, collapsed.".into(),
+            search_results: MessageFn::new(|count: usize, _locale: &Locale| match count {
+                0 => "No results found.".into(),
+                1 => "1 result found.".into(),
+                _ => format!("{count} results found."),
+            }),
+            selected: MessageFn::new(|label: &str, _locale: &Locale| {
+                format!("{label}, selected.")
+            }),
+            deselected: MessageFn::new(|label: &str, _locale: &Locale| {
+                format!("{label}, deselected.")
+            }),
+            validation_error: MessageFn::new(
+                |field: &str, error: &str, _locale: &Locale| {
+                    format!("{field}: {error}. Error.")
+                },
+            ),
+            loading: MessageFn::static_str("Loading."),
+            loading_complete: MessageFn::static_str("Loading complete."),
+            item_moved: MessageFn::new(
+                |label: &str, position: usize, total: usize, _locale: &Locale| {
+                    format!("{label} moved to position {position} of {total}.")
+                },
+            ),
+            item_removed: MessageFn::new(|label: &str, _locale: &Locale| {
+                format!("{label} removed.")
+            }),
+            sorted_ascending: MessageFn::new(|column: &str, _locale: &Locale| {
+                format!("{column}, sorted ascending.")
+            }),
+            sorted_descending: MessageFn::new(|column: &str, _locale: &Locale| {
+                format!("{column}, sorted descending.")
+            }),
+            not_sorted: MessageFn::new(|column: &str, _locale: &Locale| {
+                format!("{column}, not sorted.")
+            }),
+            tree_expanded: MessageFn::new(|label: &str, _locale: &Locale| {
+                format!("{label}, expanded.")
+            }),
+            tree_collapsed: MessageFn::new(|label: &str, _locale: &Locale| {
+                format!("{label}, collapsed.")
+            }),
         }
     }
 }
+
+impl ComponentMessages for Messages {}
 
 pub struct Announcements;
 
 impl Announcements {
     /// Announce the number of search results.
-    pub fn search_results(count: usize, messages: &AnnouncementMessages) -> String {
-        match count {
-            0 => messages.search_results_zero.clone(),
-            1 => messages.search_results_one.clone(),
-            n => messages.search_results_other.replace("{count}", &n.to_string()),
-        }
+    pub fn search_results(count: usize, locale: &Locale, messages: &Messages) -> String {
+        (messages.search_results)(count, locale)
     }
 
     /// Announce a selection change in a listbox.
-    pub fn selection_changed(label: &str, selected: bool, messages: &AnnouncementMessages) -> String {
-        let template = if selected { &messages.selected } else { &messages.deselected };
-        template.replace("{label}", label)
+    pub fn selection_changed(label: &str, selected: bool, locale: &Locale, messages: &Messages) -> String {
+        let message = if selected { &messages.selected } else { &messages.deselected };
+        message(label, locale)
     }
 
     /// Announce a toast notification.
@@ -3061,41 +3078,38 @@ impl Announcements {
     }
 
     /// Announce a form validation error.
-    pub fn validation_error(field_label: &str, error: &str, messages: &AnnouncementMessages) -> String {
-        messages.validation_error.replace("{field}", field_label).replace("{error}", error)
+    pub fn validation_error(field_label: &str, error: &str, locale: &Locale, messages: &Messages) -> String {
+        (messages.validation_error)(field_label, error, locale)
     }
 
     /// Announce loading state.
-    pub fn loading(messages: &AnnouncementMessages) -> String { messages.loading.clone() }
-    pub fn loading_complete(messages: &AnnouncementMessages) -> String { messages.loading_complete.clone() }
+    pub fn loading(locale: &Locale, messages: &Messages) -> String { (messages.loading)(locale) }
+    pub fn loading_complete(locale: &Locale, messages: &Messages) -> String { (messages.loading_complete)(locale) }
 
     /// Announce item moved in a drag-and-drop list.
-    pub fn item_moved(label: &str, position: usize, total: usize, messages: &AnnouncementMessages) -> String {
-        messages.item_moved
-            .replace("{label}", label)
-            .replace("{position}", &position.to_string())
-            .replace("{total}", &total.to_string())
+    pub fn item_moved(label: &str, position: usize, total: usize, locale: &Locale, messages: &Messages) -> String {
+        (messages.item_moved)(label, position, total, locale)
     }
 
     /// Announce item removed.
-    pub fn item_removed(label: &str, messages: &AnnouncementMessages) -> String {
-        messages.item_removed.replace("{label}", label)
+    pub fn item_removed(label: &str, locale: &Locale, messages: &Messages) -> String {
+        (messages.item_removed)(label, locale)
     }
 
     /// Announce sorted column.
-    pub fn column_sorted(column: &str, direction: AriaSort, messages: &AnnouncementMessages) -> String {
-        let template = match direction {
+    pub fn column_sorted(column: &str, direction: AriaSort, locale: &Locale, messages: &Messages) -> String {
+        let message = match direction {
             AriaSort::Ascending => &messages.sorted_ascending,
             AriaSort::Descending => &messages.sorted_descending,
             _ => &messages.not_sorted,
         };
-        template.replace("{column}", column)
+        message(column, locale)
     }
 
     /// Announce tree node expanded/collapsed.
-    pub fn tree_node_expanded(label: &str, expanded: bool, messages: &AnnouncementMessages) -> String {
-        let template = if expanded { &messages.tree_expanded } else { &messages.tree_collapsed };
-        template.replace("{label}", label)
+    pub fn tree_node_expanded(label: &str, expanded: bool, locale: &Locale, messages: &Messages) -> String {
+        let message = if expanded { &messages.tree_expanded } else { &messages.tree_collapsed };
+        message(label, locale)
     }
 }
 ```

--- a/spec/foundation/03-accessibility.md
+++ b/spec/foundation/03-accessibility.md
@@ -2984,6 +2984,18 @@ Patterns for specific dynamic content scenarios:
 ```rust
 // ars-a11y/src/announcements.rs
 
+use alloc::{format, string::String, sync::Arc};
+
+use ars_core::{ComponentMessages, Locale, MessageFn};
+
+use crate::aria::attribute::AriaSort;
+
+type LocaleMessage = dyn Fn(&Locale) -> String + Send + Sync;
+type CountLocaleMessage = dyn Fn(usize, &Locale) -> String + Send + Sync;
+type LabelLocaleMessage = dyn Fn(&str, &Locale) -> String + Send + Sync;
+type FieldErrorLocaleMessage = dyn Fn(&str, &str, &Locale) -> String + Send + Sync;
+type MoveLocaleMessage = dyn Fn(&str, usize, usize, &Locale) -> String + Send + Sync;
+
 /// Localizable announcement templates for common component state changes.
 ///
 /// Per §2.8: NO hardcoded English strings in ARIA labels or announcements.
@@ -2993,65 +3005,69 @@ Patterns for specific dynamic content scenarios:
 /// across components.
 #[derive(Clone, Debug)]
 pub struct Messages {
-    pub search_results: MessageFn<dyn Fn(usize, &Locale) -> String + Send + Sync>,
-    pub selected: MessageFn<dyn Fn(&str, &Locale) -> String + Send + Sync>,
-    pub deselected: MessageFn<dyn Fn(&str, &Locale) -> String + Send + Sync>,
-    pub validation_error: MessageFn<dyn Fn(&str, &str, &Locale) -> String + Send + Sync>,
-    pub loading: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
-    pub loading_complete: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
-    pub item_moved: MessageFn<dyn Fn(&str, usize, usize, &Locale) -> String + Send + Sync>,
-    pub item_removed: MessageFn<dyn Fn(&str, &Locale) -> String + Send + Sync>,
-    pub sorted_ascending: MessageFn<dyn Fn(&str, &Locale) -> String + Send + Sync>,
-    pub sorted_descending: MessageFn<dyn Fn(&str, &Locale) -> String + Send + Sync>,
-    pub not_sorted: MessageFn<dyn Fn(&str, &Locale) -> String + Send + Sync>,
-    pub tree_expanded: MessageFn<dyn Fn(&str, &Locale) -> String + Send + Sync>,
-    pub tree_collapsed: MessageFn<dyn Fn(&str, &Locale) -> String + Send + Sync>,
+    pub search_results: MessageFn<CountLocaleMessage>,
+    pub selected: MessageFn<LabelLocaleMessage>,
+    pub deselected: MessageFn<LabelLocaleMessage>,
+    pub validation_error: MessageFn<FieldErrorLocaleMessage>,
+    pub loading: MessageFn<LocaleMessage>,
+    pub loading_complete: MessageFn<LocaleMessage>,
+    pub item_moved: MessageFn<MoveLocaleMessage>,
+    pub item_removed: MessageFn<LabelLocaleMessage>,
+    pub sorted_ascending: MessageFn<LabelLocaleMessage>,
+    pub sorted_descending: MessageFn<LabelLocaleMessage>,
+    pub sorted_other: MessageFn<LabelLocaleMessage>,
+    pub not_sorted: MessageFn<LabelLocaleMessage>,
+    pub tree_expanded: MessageFn<LabelLocaleMessage>,
+    pub tree_collapsed: MessageFn<LabelLocaleMessage>,
 }
 
 impl Default for Messages {
     fn default() -> Self {
         Self {
-            search_results: MessageFn::new(|count: usize, _locale: &Locale| match count {
+            search_results: MessageFn::new(Arc::new(|count: usize, _locale: &Locale| match count {
                 0 => "No results found.".into(),
                 1 => "1 result found.".into(),
                 _ => format!("{count} results found."),
-            }),
-            selected: MessageFn::new(|label: &str, _locale: &Locale| {
+            }) as Arc<CountLocaleMessage>),
+            selected: MessageFn::new(Arc::new(|label: &str, _locale: &Locale| {
                 format!("{label}, selected.")
-            }),
-            deselected: MessageFn::new(|label: &str, _locale: &Locale| {
+            }) as Arc<LabelLocaleMessage>),
+            deselected: MessageFn::new(Arc::new(|label: &str, _locale: &Locale| {
                 format!("{label}, deselected.")
-            }),
-            validation_error: MessageFn::new(
+            }) as Arc<LabelLocaleMessage>),
+            validation_error: MessageFn::new(Arc::new(
                 |field: &str, error: &str, _locale: &Locale| {
                     format!("{field}: {error}. Error.")
                 },
-            ),
+            ) as Arc<FieldErrorLocaleMessage>),
             loading: MessageFn::static_str("Loading."),
             loading_complete: MessageFn::static_str("Loading complete."),
-            item_moved: MessageFn::new(
+            item_moved: MessageFn::new(Arc::new(
                 |label: &str, position: usize, total: usize, _locale: &Locale| {
                     format!("{label} moved to position {position} of {total}.")
                 },
-            ),
-            item_removed: MessageFn::new(|label: &str, _locale: &Locale| {
+            ) as Arc<MoveLocaleMessage>),
+            item_removed: MessageFn::new(Arc::new(|label: &str, _locale: &Locale| {
                 format!("{label} removed.")
-            }),
-            sorted_ascending: MessageFn::new(|column: &str, _locale: &Locale| {
+            }) as Arc<LabelLocaleMessage>),
+            sorted_ascending: MessageFn::new(Arc::new(|column: &str, _locale: &Locale| {
                 format!("{column}, sorted ascending.")
-            }),
-            sorted_descending: MessageFn::new(|column: &str, _locale: &Locale| {
+            }) as Arc<LabelLocaleMessage>),
+            sorted_descending: MessageFn::new(Arc::new(|column: &str, _locale: &Locale| {
                 format!("{column}, sorted descending.")
-            }),
-            not_sorted: MessageFn::new(|column: &str, _locale: &Locale| {
+            }) as Arc<LabelLocaleMessage>),
+            sorted_other: MessageFn::new(Arc::new(|column: &str, _locale: &Locale| {
+                format!("{column}, sorted.")
+            }) as Arc<LabelLocaleMessage>),
+            not_sorted: MessageFn::new(Arc::new(|column: &str, _locale: &Locale| {
                 format!("{column}, not sorted.")
-            }),
-            tree_expanded: MessageFn::new(|label: &str, _locale: &Locale| {
+            }) as Arc<LabelLocaleMessage>),
+            tree_expanded: MessageFn::new(Arc::new(|label: &str, _locale: &Locale| {
                 format!("{label}, expanded.")
-            }),
-            tree_collapsed: MessageFn::new(|label: &str, _locale: &Locale| {
+            }) as Arc<LabelLocaleMessage>),
+            tree_collapsed: MessageFn::new(Arc::new(|label: &str, _locale: &Locale| {
                 format!("{label}, collapsed.")
-            }),
+            }) as Arc<LabelLocaleMessage>),
         }
     }
 }
@@ -3101,7 +3117,8 @@ impl Announcements {
         let message = match direction {
             AriaSort::Ascending => &messages.sorted_ascending,
             AriaSort::Descending => &messages.sorted_descending,
-            _ => &messages.not_sorted,
+            AriaSort::Other => &messages.sorted_other,
+            AriaSort::None => &messages.not_sorted,
         };
         message(column, locale)
     }


### PR DESCRIPTION
Closes #154

## Summary
- add `ars-a11y::announcements` with locale-aware `Messages` and `Announcements` helpers
- align the search results API with the shared `MessageFn` architecture and update the accessibility spec example
- expand tests to cover locale-aware message behavior, `ComponentMessages`, and the intended module path

## Verification
- `cargo xci`