### PR TITLE
Implement plural rules in ars-i18n

### DIFF
--- a/crates/ars-i18n/Cargo.toml
+++ b/crates/ars-i18n/Cargo.toml
@@ -10,11 +10,13 @@ rust-version.workspace = true
 [dependencies]
 core_maths           = { version = "0.1", default-features = false }
 fixed_decimal        = { version = "0.7", default-features = false, features = ["ryu"] }
-icu                  = { version = "2.1", default-features = false }
+icu                  = { version = "2.2", default-features = false }
 icu_experimental     = { version = "0.5", default-features = false }
-icu_provider         = { version = "2.1", default-features = false }
+icu_provider         = { version = "2.2", default-features = false }
+js-sys               = { version = "0.3", optional = true }
 tinystr              = { version = "0.8", default-features = false }
 unicode-segmentation = "1.13"
+wasm-bindgen         = { version = "0.2", optional = true }
 
 [features]
 default             = ["std", "gregorian", "icu4x"]
@@ -37,7 +39,10 @@ dangi               = []
 roc                 = []
 all-calendars       = []
 icu4x               = ["icu/compiled_data", "icu_experimental/compiled_data"]
-web-intl            = []
+web-intl            = ["dep:js-sys", "dep:wasm-bindgen"]
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test = "0.3"
 
 [lints]
 workspace = true

--- a/crates/ars-i18n/src/lib.rs
+++ b/crates/ars-i18n/src/lib.rs
@@ -1,12 +1,13 @@
 //! Internationalization types for locale, number formatting, text direction,
-//! layout orientation, and logical-to-physical layout geometry.
+//! layout orientation, plural rules, and logical-to-physical layout geometry.
 //!
 //! This crate provides the core i18n primitives shared across all ars-ui components:
 //! a BCP 47 [`Locale`] wrapper, a locale-aware [`NumberFormatter`], a
 //! [`Direction`] enum for LTR/RTL text flow, an [`Orientation`] enum for
 //! horizontal/vertical layout axes, RTL-aware layout geometry types
 //! ([`LogicalSide`], [`PhysicalSide`], [`LogicalRect`], [`PhysicalRect`]),
-//! and the [`IcuProvider`] trait for calendar/locale data abstraction.
+//! plural and ordinal helpers, and the [`IcuProvider`] trait for
+//! calendar/locale data abstraction.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
@@ -22,6 +23,7 @@ mod layout;
 mod locale;
 mod locale_stack;
 mod number;
+mod plural;
 mod translate;
 mod weekday;
 
@@ -34,6 +36,14 @@ pub use number::get_number_formatter;
 pub use number::{
     CurrencyCode, MeasureUnit, NumberFormatOptions, NumberFormatter, NumberStyle, RoundingMode,
     SignDisplay, UnitDisplay, decimal_and_group_separators, normalize_digits, parse_locale_number,
+};
+#[cfg(feature = "icu4x")]
+pub use plural::{DefaultPluralRules, Icu4xPluralRules};
+#[cfg(feature = "web-intl")]
+pub use plural::{DefaultPluralRules, JsIntlPluralRules};
+pub use plural::{
+    Plural, PluralCategory, PluralRuleType, PluralRulesFormat, format_plural, plural_category,
+    select_plural,
 };
 pub use translate::Translate;
 pub use weekday::Weekday;

--- a/crates/ars-i18n/src/lib.rs
+++ b/crates/ars-i18n/src/lib.rs
@@ -39,7 +39,7 @@ pub use number::{
 };
 #[cfg(feature = "icu4x")]
 pub use plural::{DefaultPluralRules, Icu4xPluralRules};
-#[cfg(all(feature = "web-intl", target_arch = "wasm32"))]
+#[cfg(all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")))]
 pub use plural::{DefaultPluralRules, JsIntlPluralRules};
 pub use plural::{
     Plural, PluralCategory, PluralRuleType, PluralRulesFormat, format_plural, plural_category,

--- a/crates/ars-i18n/src/lib.rs
+++ b/crates/ars-i18n/src/lib.rs
@@ -39,7 +39,7 @@ pub use number::{
 };
 #[cfg(feature = "icu4x")]
 pub use plural::{DefaultPluralRules, Icu4xPluralRules};
-#[cfg(feature = "web-intl")]
+#[cfg(all(feature = "web-intl", target_arch = "wasm32"))]
 pub use plural::{DefaultPluralRules, JsIntlPluralRules};
 pub use plural::{
     Plural, PluralCategory, PluralRuleType, PluralRulesFormat, format_plural, plural_category,

--- a/crates/ars-i18n/src/locale.rs
+++ b/crates/ars-i18n/src/locale.rs
@@ -264,4 +264,71 @@ pub mod locales {
     pub fn ko() -> Locale {
         Locale::parse("ko").unwrap_or_else(|_| fallback())
     }
+
+    #[cfg(test)]
+    mod tests {
+        use super::{br, fallback};
+
+        #[test]
+        fn fallback_returns_en_us_locale() {
+            assert_eq!(fallback().to_bcp47(), "en-US");
+        }
+
+        #[test]
+        fn br_returns_pt_br_locale() {
+            assert_eq!(br().to_bcp47(), "pt-BR");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use icu::locale::LanguageIdentifier;
+
+    use super::{Locale, RTL_SCRIPTS};
+    use crate::{ResolvedDirection, Weekday};
+
+    #[test]
+    fn locale_accessors_roundtrip_with_extensions() {
+        let locale = Locale::parse("zh-Hans-CN-u-ca-japanese-fw-mon")
+            .expect("locale with extensions should parse");
+
+        assert_eq!(locale.language(), "zh");
+        assert_eq!(locale.script(), Some("Hans"));
+        assert_eq!(locale.region(), Some("CN"));
+        assert_eq!(locale.calendar_extension(), Some("japanese"));
+        assert_eq!(locale.first_day_of_week_extension(), Some(Weekday::Monday));
+    }
+
+    #[test]
+    fn locale_direction_infers_default_scripts_for_rtl_languages() {
+        for tag in ["dv", "nqo", "pa-PK", "ku-IQ", "yi"] {
+            let locale = Locale::parse(tag).expect("RTL locale should parse");
+            assert_eq!(locale.direction(), ResolvedDirection::Rtl);
+            assert!(locale.is_rtl());
+        }
+    }
+
+    #[test]
+    fn locale_direction_defaults_to_ltr_for_non_rtl_languages() {
+        let locale = Locale::parse("en-US").expect("en-US should parse");
+
+        assert_eq!(locale.direction(), ResolvedDirection::Ltr);
+        assert!(!locale.is_rtl());
+    }
+
+    #[test]
+    fn locale_from_langid_roundtrips_without_extensions() {
+        let langid = "fr-CA"
+            .parse::<LanguageIdentifier>()
+            .expect("language identifier should parse");
+
+        assert_eq!(Locale::from_langid(langid).to_bcp47(), "fr-CA");
+    }
+
+    #[test]
+    fn rtl_script_list_contains_core_scripts() {
+        assert!(RTL_SCRIPTS.contains(&"Arab"));
+        assert!(RTL_SCRIPTS.contains(&"Hebr"));
+    }
 }

--- a/crates/ars-i18n/src/number.rs
+++ b/crates/ars-i18n/src/number.rs
@@ -759,6 +759,29 @@ mod tests {
     use super::*;
     use crate::locales;
 
+    #[test]
+    fn currency_code_rejects_invalid_text_and_roundtrips_valid_codes() {
+        assert_eq!(CurrencyCode::from_str("usd"), None);
+        assert_eq!(CurrencyCode::from_str("US"), None);
+        assert_eq!(CurrencyCode::from_str("US1"), None);
+        assert_eq!(
+            CurrencyCode::from_str("USD").map(|code| String::from(code.as_str())),
+            Some(String::from("USD"))
+        );
+    }
+
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn number_formatter_debug_includes_locale_and_separator_fields() {
+        let formatter = NumberFormatter::new(&locales::de_de(), NumberFormatOptions::default());
+        let debug = format!("{formatter:?}");
+
+        assert!(debug.contains("NumberFormatter"));
+        assert!(debug.contains("de-DE"));
+        assert!(debug.contains("decimal_separator"));
+        assert!(debug.contains("grouping_separator"));
+    }
+
     #[cfg(feature = "icu4x")]
     #[test]
     fn formats_en_us_integers_and_decimals() {
@@ -1019,5 +1042,70 @@ mod tests {
         assert_eq!(cached.format(1234.5), direct.format(1234.5));
         assert_eq!(cached.decimal_separator(), direct.decimal_separator());
         assert_eq!(cached.grouping_separator(), direct.grouping_separator());
+    }
+
+    #[cfg(all(feature = "std", feature = "icu4x"))]
+    #[test]
+    fn repeated_cached_formatter_lookups_reuse_existing_entries() {
+        let options = NumberFormatOptions {
+            use_grouping: false,
+            ..NumberFormatOptions::default()
+        };
+
+        let first = get_number_formatter(&locales::en_us(), &options);
+        let second = get_number_formatter(&locales::en_us(), &options);
+
+        assert_eq!(first.format(1234.56), second.format(1234.56));
+        assert_eq!(first.grouping_separator(), second.grouping_separator());
+    }
+
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn format_range_uses_locale_specific_separators() {
+        let formatter = NumberFormatter::new(&locales::en_us(), NumberFormatOptions::default());
+
+        assert_eq!(formatter.format_range(1.0, 2.5, &locales::en_us()), "1–2.5");
+        assert_eq!(formatter.format_range(1.0, 2.5, &locales::fr()), "1 – 2.5");
+        assert_eq!(formatter.format_range(1.0, 2.5, &locales::ja()), "1〜2.5");
+    }
+
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn prepare_decimal_defaults_non_finite_values() {
+        let formatter = NumberFormatter::new(&locales::en_us(), NumberFormatOptions::default());
+
+        assert_eq!(formatter.prepare_decimal(f64::INFINITY), Decimal::default());
+        assert_eq!(
+            formatter.prepare_decimal(f64::NEG_INFINITY),
+            Decimal::default()
+        );
+        assert_eq!(formatter.prepare_decimal(f64::NAN), Decimal::default());
+    }
+
+    #[test]
+    fn choose_decimal_separator_treats_grouping_marks_as_non_decimal() {
+        assert_eq!(choose_decimal_separator("1,234,567", '.', ','), None);
+        assert_eq!(choose_decimal_separator("1.234", ',', '.'), None);
+        assert_eq!(choose_decimal_separator("١٬٢٣٤", '٫', '٬'), None);
+        assert_eq!(choose_decimal_separator("1,234.5", '.', ','), Some('.'));
+    }
+
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn resolve_measure_unit_id_uses_embedded_cldr_id_when_present() {
+        let mut unit =
+            MeasureUnit::try_from_str("kilogram").expect("kilogram is a valid CLDR unit");
+        unit.id = Some("kilogram");
+
+        assert_eq!(
+            resolve_measure_unit_id(&unit),
+            Some(String::from("kilogram"))
+        );
+    }
+
+    #[test]
+    fn round_half_even_rounds_up_when_fraction_exceeds_half() {
+        assert_eq!(round_half_even(1.6), 2.0);
+        assert_eq!(round_half_even(-1.6), -2.0);
     }
 }

--- a/crates/ars-i18n/src/plural.rs
+++ b/crates/ars-i18n/src/plural.rs
@@ -226,8 +226,9 @@ pub const fn plural_category(count: usize, locale: &Locale) -> PluralCategory {
 ///
 /// With `icu4x` or wasm `web-intl`, this uses locale-aware CLDR plural rules.
 /// Without either backend feature, or on non-wasm builds with `web-intl`, it
-/// falls back to English-only behavior: cardinal rules use `One` for exactly
-/// `1.0`, and ordinal rules use the standard English `1st`/`2nd`/`3rd`
+/// falls back to English-only behavior: cardinal rules use `One` for values
+/// whose magnitude is exactly `1.0`, and ordinal rules use the standard English
+/// `1st`/`2nd`/`3rd`
 /// categories.
 #[must_use]
 pub fn select_plural(locale: &Locale, count: f64, rule_type: PluralRuleType) -> PluralCategory {
@@ -322,7 +323,7 @@ fn select_plural_with_backend(
 ) -> PluralCategory {
     match rule_type {
         PluralRuleType::Cardinal => {
-            if count == 1.0 {
+            if count.is_finite() && count.abs() == 1.0 {
                 PluralCategory::One
             } else {
                 PluralCategory::Other
@@ -610,17 +611,21 @@ mod tests {
         assert_eq!(rules.select(4.0), PluralCategory::Other);
     }
 
-    #[cfg(all(
-        feature = "web-intl",
-        not(target_arch = "wasm32"),
-        not(feature = "icu4x")
-    ))]
+    #[cfg(not(any(feature = "icu4x", all(feature = "web-intl", target_arch = "wasm32"))))]
     #[test]
-    fn native_web_intl_feature_uses_english_fallback_rules() {
+    fn fallback_rules_treat_negative_one_as_singular() {
         let locale = Locale::parse("pl").expect("pl should parse");
 
         assert_eq!(plural_category(1, &locale), PluralCategory::One);
         assert_eq!(plural_category(2, &locale), PluralCategory::Other);
+        assert_eq!(
+            select_plural(&locale, -1.0, PluralRuleType::Cardinal),
+            PluralCategory::One
+        );
+        assert_eq!(
+            select_plural(&locale, -2.0, PluralRuleType::Cardinal),
+            PluralCategory::Other
+        );
         assert_eq!(
             select_plural(&locale, 2.0, PluralRuleType::Ordinal),
             PluralCategory::Two

--- a/crates/ars-i18n/src/plural.rs
+++ b/crates/ars-i18n/src/plural.rs
@@ -1,0 +1,712 @@
+//! Plural and ordinal category selection helpers.
+//!
+//! This module exposes the spec-defined `ars-i18n` plural API with backend
+//! selection hidden behind cargo features.
+//!
+//! - `icu4x` uses ICU4X plural rules with CLDR data compiled into the binary.
+//! - `web-intl` uses the browser's `Intl.PluralRules` implementation.
+//! - With neither backend enabled, the public API falls back to English-only
+//!   selection rules so `ars-i18n` still builds in feature-matrix checks and
+//!   backend-free tests.
+
+use alloc::{format, string::String};
+
+use icu::plurals::PluralCategory as IcuPluralCategory;
+#[cfg(feature = "web-intl")]
+use {
+    core::fmt::{self, Debug},
+    js_sys::{Array, Intl::PluralRules as JsPluralRules, Object, Reflect},
+    wasm_bindgen::JsValue,
+};
+#[cfg(feature = "icu4x")]
+use {
+    fixed_decimal::{Decimal, FloatPrecision},
+    icu::plurals::{PluralRules, PluralRulesPreferences},
+};
+
+use crate::Locale;
+
+/// CLDR plural categories.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum PluralCategory {
+    /// Zero quantity.
+    Zero,
+    /// Singular quantity.
+    One,
+    /// Dual quantity.
+    Two,
+    /// Paucal or small quantity.
+    Few,
+    /// Large quantity.
+    Many,
+    /// Required fallback category.
+    Other,
+}
+
+impl PluralCategory {
+    /// Converts an ICU4X plural category into the ars-ui wrapper type.
+    #[must_use]
+    pub const fn from_icu(category: IcuPluralCategory) -> Self {
+        match category {
+            IcuPluralCategory::Zero => Self::Zero,
+            IcuPluralCategory::One => Self::One,
+            IcuPluralCategory::Two => Self::Two,
+            IcuPluralCategory::Few => Self::Few,
+            IcuPluralCategory::Many => Self::Many,
+            IcuPluralCategory::Other => Self::Other,
+        }
+    }
+}
+
+/// A map from plural categories to localized values.
+#[derive(Clone, Debug)]
+pub struct Plural<T: Clone> {
+    /// Value for the `zero` category.
+    pub zero: Option<T>,
+    /// Value for the `one` category.
+    pub one: Option<T>,
+    /// Value for the `two` category.
+    pub two: Option<T>,
+    /// Value for the `few` category.
+    pub few: Option<T>,
+    /// Value for the `many` category.
+    pub many: Option<T>,
+    /// Required fallback value used for `other` and any unset category.
+    pub other: T,
+}
+
+impl<T: Clone> Plural<T> {
+    /// Creates a plural map with only the required `other` value populated.
+    #[must_use]
+    pub const fn from_other(other: T) -> Self {
+        Self {
+            zero: None,
+            one: None,
+            two: None,
+            few: None,
+            many: None,
+            other,
+        }
+    }
+
+    /// Returns the value for the given category, falling back to `other`.
+    #[must_use]
+    pub fn get(&self, category: PluralCategory) -> &T {
+        match category {
+            PluralCategory::Zero => self.zero.as_ref().unwrap_or(&self.other),
+            PluralCategory::One => self.one.as_ref().unwrap_or(&self.other),
+            PluralCategory::Two => self.two.as_ref().unwrap_or(&self.other),
+            PluralCategory::Few => self.few.as_ref().unwrap_or(&self.other),
+            PluralCategory::Many => self.many.as_ref().unwrap_or(&self.other),
+            PluralCategory::Other => &self.other,
+        }
+    }
+}
+
+/// Selects which plural rule system to use.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PluralRuleType {
+    /// Cardinal numbers such as `1 item` or `2 items`.
+    Cardinal,
+    /// Ordinal numbers such as `1st`, `2nd`, or `3rd`.
+    Ordinal,
+}
+
+/// Common interface for plural-rule backends.
+///
+/// Under `icu4x` and `web-intl`, this trait delegates to the active locale-aware
+/// backend. Without either backend feature, the free functions and wrapper types
+/// use the crate's English-only fallback behavior.
+pub trait PluralRulesFormat {
+    /// Selects the CLDR plural category for `number`.
+    fn select(&self, number: f64) -> PluralCategory;
+}
+
+/// ICU4X-backed plural rules wrapper used by the default backend.
+#[cfg(feature = "icu4x")]
+#[derive(Clone, Debug)]
+pub struct Icu4xPluralRules {
+    locale: Locale,
+    rule_type: PluralRuleType,
+}
+
+#[cfg(feature = "icu4x")]
+impl Icu4xPluralRules {
+    /// Creates a new ICU4X-backed plural rules handle.
+    #[must_use]
+    pub fn new(locale: &Locale, rule_type: PluralRuleType) -> Self {
+        Self {
+            locale: locale.clone(),
+            rule_type,
+        }
+    }
+}
+
+#[cfg(feature = "icu4x")]
+impl PluralRulesFormat for Icu4xPluralRules {
+    fn select(&self, number: f64) -> PluralCategory {
+        select_plural(&self.locale, number, self.rule_type)
+    }
+}
+
+/// Default plural-rules backend for the active feature set.
+#[cfg(feature = "icu4x")]
+pub type DefaultPluralRules = Icu4xPluralRules;
+
+/// Browser `Intl.PluralRules` wrapper used by the `web-intl` backend.
+#[cfg(feature = "web-intl")]
+#[derive(Clone)]
+pub struct JsIntlPluralRules {
+    locale: Locale,
+    rule_type: PluralRuleType,
+    inner: JsPluralRules,
+}
+
+#[cfg(feature = "web-intl")]
+impl JsIntlPluralRules {
+    /// Creates a new browser-backed plural rules handle.
+    #[must_use]
+    pub fn new(locale: &Locale, rule_type: PluralRuleType) -> Self {
+        Self {
+            locale: locale.clone(),
+            rule_type,
+            inner: build_js_plural_rules(locale, rule_type),
+        }
+    }
+}
+
+#[cfg(feature = "web-intl")]
+impl Debug for JsIntlPluralRules {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("JsIntlPluralRules")
+            .field("locale", &self.locale)
+            .field("rule_type", &self.rule_type)
+            .finish()
+    }
+}
+
+#[cfg(feature = "web-intl")]
+impl PluralRulesFormat for JsIntlPluralRules {
+    fn select(&self, number: f64) -> PluralCategory {
+        PluralCategory::from_js_category(&self.inner.select(number).as_string().unwrap_or_default())
+    }
+}
+
+/// Default plural-rules backend for the active feature set.
+#[cfg(feature = "web-intl")]
+pub type DefaultPluralRules = JsIntlPluralRules;
+
+/// Returns the CLDR cardinal plural category for an integer count.
+///
+/// With `icu4x` or `web-intl`, this uses locale-aware CLDR cardinal rules.
+/// Without either backend feature, it falls back to English cardinal behavior:
+/// `1 => One`, all other values => `Other`.
+#[must_use]
+#[cfg(any(feature = "icu4x", feature = "web-intl"))]
+pub fn plural_category(count: usize, locale: &Locale) -> PluralCategory {
+    plural_category_with_backend(count, locale)
+}
+
+/// Returns the CLDR cardinal plural category for an integer count.
+///
+/// With `icu4x` or `web-intl`, this uses locale-aware CLDR cardinal rules.
+/// Without either backend feature, it falls back to English cardinal behavior:
+/// `1 => One`, all other values => `Other`.
+#[must_use]
+#[cfg(not(any(feature = "icu4x", feature = "web-intl")))]
+pub const fn plural_category(count: usize, locale: &Locale) -> PluralCategory {
+    plural_category_with_backend(count, locale)
+}
+
+/// Returns the CLDR plural category for a number and rule type.
+///
+/// With `icu4x` or `web-intl`, this uses locale-aware CLDR plural rules.
+/// Without either backend feature, it falls back to English-only behavior:
+/// cardinal rules use `One` for exactly `1.0`, and ordinal rules use the
+/// standard English `1st`/`2nd`/`3rd` categories.
+#[must_use]
+pub fn select_plural(locale: &Locale, count: f64, rule_type: PluralRuleType) -> PluralCategory {
+    select_plural_with_backend(locale, count, rule_type)
+}
+
+/// Formats a pluralized template by selecting the correct category and
+/// replacing `{name}` placeholders from `args`.
+#[must_use]
+pub fn format_plural(
+    locale: &Locale,
+    count: f64,
+    plural: &Plural<&str>,
+    args: &[(&str, &str)],
+) -> String {
+    let category = select_plural(locale, count, PluralRuleType::Cardinal);
+
+    let template = plural.get(category);
+
+    interpolate(template, args)
+}
+
+fn interpolate(template: &str, args: &[(&str, &str)]) -> String {
+    let mut result = String::from(template);
+
+    for (key, value) in args {
+        result = result.replace(&format!("{{{key}}}"), value);
+    }
+
+    result
+}
+
+#[cfg(feature = "icu4x")]
+fn plural_category_with_backend(count: usize, locale: &Locale) -> PluralCategory {
+    let rules = PluralRules::try_new_cardinal(PluralRulesPreferences::from(locale.as_icu()))
+        .expect("compiled_data guarantees plural rules are available for all locales");
+
+    PluralCategory::from_icu(rules.category_for(count))
+}
+
+#[cfg(feature = "web-intl")]
+fn plural_category_with_backend(count: usize, locale: &Locale) -> PluralCategory {
+    select_plural_with_backend(locale, count as f64, PluralRuleType::Cardinal)
+}
+
+#[cfg(not(any(feature = "icu4x", feature = "web-intl")))]
+const fn plural_category_with_backend(count: usize, locale: &Locale) -> PluralCategory {
+    let _ = locale;
+
+    if count == 1 {
+        PluralCategory::One
+    } else {
+        PluralCategory::Other
+    }
+}
+
+#[cfg(feature = "icu4x")]
+fn select_plural_with_backend(
+    locale: &Locale,
+    count: f64,
+    rule_type: PluralRuleType,
+) -> PluralCategory {
+    let rules = match rule_type {
+        PluralRuleType::Cardinal => {
+            PluralRules::try_new_cardinal(PluralRulesPreferences::from(locale.as_icu()))
+        }
+        PluralRuleType::Ordinal => {
+            PluralRules::try_new_ordinal(PluralRulesPreferences::from(locale.as_icu()))
+        }
+    }
+    .expect("compiled_data guarantees plural rules are available for all locales");
+
+    let decimal = Decimal::try_from_f64(count, FloatPrecision::RoundTrip).unwrap_or_default();
+
+    PluralCategory::from_icu(rules.category_for(&decimal))
+}
+
+#[cfg(feature = "web-intl")]
+fn select_plural_with_backend(
+    locale: &Locale,
+    count: f64,
+    rule_type: PluralRuleType,
+) -> PluralCategory {
+    JsIntlPluralRules::new(locale, rule_type).select(count)
+}
+
+#[cfg(not(any(feature = "icu4x", feature = "web-intl")))]
+fn select_plural_with_backend(
+    _locale: &Locale,
+    count: f64,
+    rule_type: PluralRuleType,
+) -> PluralCategory {
+    match rule_type {
+        PluralRuleType::Cardinal => {
+            if count == 1.0 {
+                PluralCategory::One
+            } else {
+                PluralCategory::Other
+            }
+        }
+
+        PluralRuleType::Ordinal => fallback_english_ordinal_category(count),
+    }
+}
+
+#[cfg(feature = "web-intl")]
+fn build_js_plural_rules(locale: &Locale, rule_type: PluralRuleType) -> JsPluralRules {
+    let locales = Array::of1(&JsValue::from_str(&locale.to_bcp47()));
+
+    let options = Object::new();
+
+    Reflect::set(
+        &options,
+        &JsValue::from_str("type"),
+        &JsValue::from_str(rule_type.as_js_str()),
+    )
+    .expect("Reflect::set on Intl.PluralRules options object");
+
+    JsPluralRules::new(&locales, &options)
+}
+
+#[cfg(not(any(feature = "icu4x", feature = "web-intl")))]
+fn fallback_english_ordinal_category(count: f64) -> PluralCategory {
+    if !count.is_finite() || count.fract() != 0.0 {
+        return PluralCategory::Other;
+    }
+
+    let n = count.abs().trunc() as i64;
+
+    let mod10 = n % 10;
+
+    let mod100 = n % 100;
+
+    if (11..=13).contains(&mod100) {
+        return PluralCategory::Other;
+    }
+
+    match mod10 {
+        1 => PluralCategory::One,
+        2 => PluralCategory::Two,
+        3 => PluralCategory::Few,
+        _ => PluralCategory::Other,
+    }
+}
+
+impl PluralCategory {
+    #[cfg(feature = "web-intl")]
+    fn from_js_category(category: &str) -> Self {
+        match category {
+            "zero" => Self::Zero,
+            "one" => Self::One,
+            "two" => Self::Two,
+            "few" => Self::Few,
+            "many" => Self::Many,
+            _ => Self::Other,
+        }
+    }
+}
+
+impl PluralRuleType {
+    #[cfg(feature = "web-intl")]
+    const fn as_js_str(self) -> &'static str {
+        match self {
+            Self::Cardinal => "cardinal",
+            Self::Ordinal => "ordinal",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[cfg(feature = "icu4x")]
+    use crate::locales;
+
+    #[test]
+    fn plural_category_from_icu_maps_exhaustively() {
+        assert_eq!(
+            PluralCategory::from_icu(IcuPluralCategory::Zero),
+            PluralCategory::Zero
+        );
+        assert_eq!(
+            PluralCategory::from_icu(IcuPluralCategory::One),
+            PluralCategory::One
+        );
+        assert_eq!(
+            PluralCategory::from_icu(IcuPluralCategory::Two),
+            PluralCategory::Two
+        );
+        assert_eq!(
+            PluralCategory::from_icu(IcuPluralCategory::Few),
+            PluralCategory::Few
+        );
+        assert_eq!(
+            PluralCategory::from_icu(IcuPluralCategory::Many),
+            PluralCategory::Many
+        );
+        assert_eq!(
+            PluralCategory::from_icu(IcuPluralCategory::Other),
+            PluralCategory::Other
+        );
+    }
+
+    #[test]
+    fn plural_from_other_and_get_fall_back_to_other() {
+        let plural = Plural::from_other("items");
+
+        assert_eq!(plural.get(PluralCategory::One), &"items");
+        assert_eq!(plural.get(PluralCategory::Few), &"items");
+        assert_eq!(plural.get(PluralCategory::Other), &"items");
+    }
+
+    #[test]
+    fn plural_get_prefers_explicit_category_over_other() {
+        let mut plural = Plural::from_other("items");
+
+        plural.one = Some("item");
+        plural.few = Some("items-few");
+
+        assert_eq!(plural.get(PluralCategory::One), &"item");
+        assert_eq!(plural.get(PluralCategory::Few), &"items-few");
+    }
+
+    #[test]
+    fn plural_get_covers_zero_two_and_many_slots() {
+        let mut plural = Plural::from_other("items");
+
+        plural.zero = Some("none");
+        plural.two = Some("pair");
+        plural.many = Some("many-items");
+
+        assert_eq!(plural.get(PluralCategory::Zero), &"none");
+        assert_eq!(plural.get(PluralCategory::Two), &"pair");
+        assert_eq!(plural.get(PluralCategory::Many), &"many-items");
+    }
+
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn plural_category_uses_english_cardinal_rules() {
+        let locale = locales::en();
+
+        assert_eq!(plural_category(0, &locale), PluralCategory::Other);
+        assert_eq!(plural_category(1, &locale), PluralCategory::One);
+    }
+
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn select_plural_uses_english_ordinal_rules() {
+        let locale = locales::en();
+
+        assert_eq!(
+            select_plural(&locale, 1.0, PluralRuleType::Ordinal),
+            PluralCategory::One
+        );
+        assert_eq!(
+            select_plural(&locale, 2.0, PluralRuleType::Ordinal),
+            PluralCategory::Two
+        );
+        assert_eq!(
+            select_plural(&locale, 3.0, PluralRuleType::Ordinal),
+            PluralCategory::Few
+        );
+        assert_eq!(
+            select_plural(&locale, 4.0, PluralRuleType::Ordinal),
+            PluralCategory::Other
+        );
+    }
+
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn select_plural_handles_fractional_english_cardinals() {
+        let locale = locales::en();
+
+        assert_eq!(
+            select_plural(&locale, 1.0, PluralRuleType::Cardinal),
+            PluralCategory::One
+        );
+        assert_eq!(
+            select_plural(&locale, 1.5, PluralRuleType::Cardinal),
+            PluralCategory::Other
+        );
+    }
+
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn select_plural_uses_arabic_cardinal_rules() {
+        let locale = locales::ar();
+
+        assert_eq!(
+            select_plural(&locale, 3.0, PluralRuleType::Cardinal),
+            PluralCategory::Few
+        );
+        assert_eq!(
+            select_plural(&locale, 11.0, PluralRuleType::Cardinal),
+            PluralCategory::Many
+        );
+    }
+
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn select_plural_uses_polish_cardinal_rules() {
+        let locale = Locale::parse("pl").expect("pl is a valid locale");
+
+        assert_eq!(
+            select_plural(&locale, 1.0, PluralRuleType::Cardinal),
+            PluralCategory::One
+        );
+        assert_eq!(
+            select_plural(&locale, 2.0, PluralRuleType::Cardinal),
+            PluralCategory::Few
+        );
+        assert_eq!(
+            select_plural(&locale, 5.0, PluralRuleType::Cardinal),
+            PluralCategory::Many
+        );
+        assert_eq!(
+            select_plural(&locale, 22.0, PluralRuleType::Cardinal),
+            PluralCategory::Few
+        );
+    }
+
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn select_plural_uses_welsh_cardinal_rules() {
+        let locale = Locale::parse("cy").expect("cy is a valid locale");
+
+        assert_eq!(
+            select_plural(&locale, 0.0, PluralRuleType::Cardinal),
+            PluralCategory::Zero
+        );
+        assert_eq!(
+            select_plural(&locale, 1.0, PluralRuleType::Cardinal),
+            PluralCategory::One
+        );
+        assert_eq!(
+            select_plural(&locale, 2.0, PluralRuleType::Cardinal),
+            PluralCategory::Two
+        );
+        assert_eq!(
+            select_plural(&locale, 3.0, PluralRuleType::Cardinal),
+            PluralCategory::Few
+        );
+        assert_eq!(
+            select_plural(&locale, 6.0, PluralRuleType::Cardinal),
+            PluralCategory::Many
+        );
+        assert_eq!(
+            select_plural(&locale, 4.0, PluralRuleType::Cardinal),
+            PluralCategory::Other
+        );
+    }
+
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn format_plural_selects_branch_and_interpolates_arguments() {
+        let locale = locales::en();
+
+        let mut plural = Plural::from_other("{count} items selected");
+
+        plural.one = Some("{count} item selected");
+
+        assert_eq!(
+            format_plural(&locale, 1.0, &plural, &[("count", "1")]),
+            "1 item selected"
+        );
+        assert_eq!(
+            format_plural(&locale, 3.0, &plural, &[("count", "3")]),
+            "3 items selected"
+        );
+    }
+
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn icu4x_plural_rules_wrapper_implements_shared_trait() {
+        let locale = locales::en();
+
+        let rules = Icu4xPluralRules::new(&locale, PluralRuleType::Ordinal);
+
+        assert_eq!(rules.select(1.0), PluralCategory::One);
+        assert_eq!(rules.select(4.0), PluralCategory::Other);
+    }
+}
+
+#[cfg(all(test, feature = "web-intl", target_arch = "wasm32"))]
+mod web_intl_tests {
+    use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+
+    use super::*;
+    use crate::locales;
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    #[wasm_bindgen_test]
+    fn js_intl_plural_rules_wrapper_implements_shared_trait() {
+        let locale = locales::en();
+
+        let rules = JsIntlPluralRules::new(&locale, PluralRuleType::Ordinal);
+
+        assert_eq!(rules.select(1.0), PluralCategory::One);
+        assert_eq!(rules.select(4.0), PluralCategory::Other);
+    }
+
+    #[wasm_bindgen_test]
+    fn js_intl_plural_rules_debug_includes_wrapper_state() {
+        let locale = locales::en();
+
+        let rules = JsIntlPluralRules::new(&locale, PluralRuleType::Ordinal);
+
+        let debug = format!("{rules:?}");
+
+        assert!(debug.contains("JsIntlPluralRules"));
+        assert!(debug.contains("locale"));
+        assert!(debug.contains("rule_type"));
+    }
+
+    #[wasm_bindgen_test]
+    fn web_intl_plural_category_uses_english_cardinal_rules() {
+        let locale = locales::en();
+
+        assert_eq!(plural_category(0, &locale), PluralCategory::Other);
+        assert_eq!(plural_category(1, &locale), PluralCategory::One);
+    }
+
+    #[wasm_bindgen_test]
+    fn web_intl_select_plural_uses_english_ordinal_rules() {
+        let locale = locales::en();
+
+        assert_eq!(
+            select_plural(&locale, 1.0, PluralRuleType::Ordinal),
+            PluralCategory::One
+        );
+        assert_eq!(
+            select_plural(&locale, 2.0, PluralRuleType::Ordinal),
+            PluralCategory::Two
+        );
+        assert_eq!(
+            select_plural(&locale, 3.0, PluralRuleType::Ordinal),
+            PluralCategory::Few
+        );
+        assert_eq!(
+            select_plural(&locale, 4.0, PluralRuleType::Ordinal),
+            PluralCategory::Other
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn web_intl_select_plural_uses_representative_cardinal_locales() {
+        let polish = Locale::parse("pl").expect("pl is a valid locale");
+
+        let welsh = Locale::parse("cy").expect("cy is a valid locale");
+
+        assert_eq!(
+            select_plural(&locales::ar(), 3.0, PluralRuleType::Cardinal),
+            PluralCategory::Few
+        );
+        assert_eq!(
+            select_plural(&locales::ar(), 11.0, PluralRuleType::Cardinal),
+            PluralCategory::Many
+        );
+        assert_eq!(
+            select_plural(&polish, 22.0, PluralRuleType::Cardinal),
+            PluralCategory::Few
+        );
+        assert_eq!(
+            select_plural(&welsh, 6.0, PluralRuleType::Cardinal),
+            PluralCategory::Many
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn web_intl_format_plural_selects_branch_and_interpolates_arguments() {
+        let locale = locales::en();
+
+        let mut plural = Plural::from_other("{count} items selected");
+
+        plural.one = Some("{count} item selected");
+
+        assert_eq!(
+            format_plural(&locale, 1.0, &plural, &[("count", "1")]),
+            "1 item selected"
+        );
+        assert_eq!(
+            format_plural(&locale, 3.0, &plural, &[("count", "3")]),
+            "3 items selected"
+        );
+    }
+}

--- a/crates/ars-i18n/src/plural.rs
+++ b/crates/ars-i18n/src/plural.rs
@@ -4,15 +4,16 @@
 //! selection hidden behind cargo features.
 //!
 //! - `icu4x` uses ICU4X plural rules with CLDR data compiled into the binary.
-//! - `web-intl` uses the browser's `Intl.PluralRules` implementation.
-//! - With neither backend enabled, the public API falls back to English-only
-//!   selection rules so `ars-i18n` still builds in feature-matrix checks and
-//!   backend-free tests.
+//! - `web-intl` uses the browser's `Intl.PluralRules` implementation on
+//!   `wasm32` targets.
+//! - With neither backend enabled, or with `web-intl` enabled on a non-wasm
+//!   target, the public API falls back to English-only selection rules so
+//!   `ars-i18n` still builds in feature-matrix checks and backend-free tests.
 
 use alloc::{format, string::String};
 
 use icu::plurals::PluralCategory as IcuPluralCategory;
-#[cfg(feature = "web-intl")]
+#[cfg(all(feature = "web-intl", target_arch = "wasm32"))]
 use {
     core::fmt::{self, Debug},
     js_sys::{Array, Intl::PluralRules as JsPluralRules, Object, Reflect},
@@ -114,9 +115,10 @@ pub enum PluralRuleType {
 
 /// Common interface for plural-rule backends.
 ///
-/// Under `icu4x` and `web-intl`, this trait delegates to the active locale-aware
-/// backend. Without either backend feature, the free functions and wrapper types
-/// use the crate's English-only fallback behavior.
+/// Under `icu4x` and wasm `web-intl`, this trait delegates to the active
+/// locale-aware backend. Without either backend feature, or on non-wasm builds
+/// with `web-intl`, the free functions and wrapper types use the crate's
+/// English-only fallback behavior.
 pub trait PluralRulesFormat {
     /// Selects the CLDR plural category for `number`.
     fn select(&self, number: f64) -> PluralCategory;
@@ -154,7 +156,7 @@ impl PluralRulesFormat for Icu4xPluralRules {
 pub type DefaultPluralRules = Icu4xPluralRules;
 
 /// Browser `Intl.PluralRules` wrapper used by the `web-intl` backend.
-#[cfg(feature = "web-intl")]
+#[cfg(all(feature = "web-intl", target_arch = "wasm32"))]
 #[derive(Clone)]
 pub struct JsIntlPluralRules {
     locale: Locale,
@@ -162,7 +164,7 @@ pub struct JsIntlPluralRules {
     inner: JsPluralRules,
 }
 
-#[cfg(feature = "web-intl")]
+#[cfg(all(feature = "web-intl", target_arch = "wasm32"))]
 impl JsIntlPluralRules {
     /// Creates a new browser-backed plural rules handle.
     #[must_use]
@@ -175,7 +177,7 @@ impl JsIntlPluralRules {
     }
 }
 
-#[cfg(feature = "web-intl")]
+#[cfg(all(feature = "web-intl", target_arch = "wasm32"))]
 impl Debug for JsIntlPluralRules {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("JsIntlPluralRules")
@@ -185,7 +187,7 @@ impl Debug for JsIntlPluralRules {
     }
 }
 
-#[cfg(feature = "web-intl")]
+#[cfg(all(feature = "web-intl", target_arch = "wasm32"))]
 impl PluralRulesFormat for JsIntlPluralRules {
     fn select(&self, number: f64) -> PluralCategory {
         PluralCategory::from_js_category(&self.inner.select(number).as_string().unwrap_or_default())
@@ -193,37 +195,40 @@ impl PluralRulesFormat for JsIntlPluralRules {
 }
 
 /// Default plural-rules backend for the active feature set.
-#[cfg(feature = "web-intl")]
+#[cfg(all(feature = "web-intl", target_arch = "wasm32"))]
 pub type DefaultPluralRules = JsIntlPluralRules;
 
 /// Returns the CLDR cardinal plural category for an integer count.
 ///
-/// With `icu4x` or `web-intl`, this uses locale-aware CLDR cardinal rules.
-/// Without either backend feature, it falls back to English cardinal behavior:
-/// `1 => One`, all other values => `Other`.
+/// With `icu4x` or wasm `web-intl`, this uses locale-aware CLDR cardinal rules.
+/// Without either backend feature, or on non-wasm builds with `web-intl`, it
+/// falls back to English cardinal behavior: `1 => One`, all other values =>
+/// `Other`.
 #[must_use]
-#[cfg(any(feature = "icu4x", feature = "web-intl"))]
+#[cfg(any(feature = "icu4x", all(feature = "web-intl", target_arch = "wasm32")))]
 pub fn plural_category(count: usize, locale: &Locale) -> PluralCategory {
     plural_category_with_backend(count, locale)
 }
 
 /// Returns the CLDR cardinal plural category for an integer count.
 ///
-/// With `icu4x` or `web-intl`, this uses locale-aware CLDR cardinal rules.
-/// Without either backend feature, it falls back to English cardinal behavior:
-/// `1 => One`, all other values => `Other`.
+/// With `icu4x` or wasm `web-intl`, this uses locale-aware CLDR cardinal rules.
+/// Without either backend feature, or on non-wasm builds with `web-intl`, it
+/// falls back to English cardinal behavior: `1 => One`, all other values =>
+/// `Other`.
 #[must_use]
-#[cfg(not(any(feature = "icu4x", feature = "web-intl")))]
+#[cfg(not(any(feature = "icu4x", all(feature = "web-intl", target_arch = "wasm32"))))]
 pub const fn plural_category(count: usize, locale: &Locale) -> PluralCategory {
     plural_category_with_backend(count, locale)
 }
 
 /// Returns the CLDR plural category for a number and rule type.
 ///
-/// With `icu4x` or `web-intl`, this uses locale-aware CLDR plural rules.
-/// Without either backend feature, it falls back to English-only behavior:
-/// cardinal rules use `One` for exactly `1.0`, and ordinal rules use the
-/// standard English `1st`/`2nd`/`3rd` categories.
+/// With `icu4x` or wasm `web-intl`, this uses locale-aware CLDR plural rules.
+/// Without either backend feature, or on non-wasm builds with `web-intl`, it
+/// falls back to English-only behavior: cardinal rules use `One` for exactly
+/// `1.0`, and ordinal rules use the standard English `1st`/`2nd`/`3rd`
+/// categories.
 #[must_use]
 pub fn select_plural(locale: &Locale, count: f64, rule_type: PluralRuleType) -> PluralCategory {
     select_plural_with_backend(locale, count, rule_type)
@@ -263,12 +268,12 @@ fn plural_category_with_backend(count: usize, locale: &Locale) -> PluralCategory
     PluralCategory::from_icu(rules.category_for(count))
 }
 
-#[cfg(feature = "web-intl")]
+#[cfg(all(feature = "web-intl", target_arch = "wasm32"))]
 fn plural_category_with_backend(count: usize, locale: &Locale) -> PluralCategory {
     select_plural_with_backend(locale, count as f64, PluralRuleType::Cardinal)
 }
 
-#[cfg(not(any(feature = "icu4x", feature = "web-intl")))]
+#[cfg(not(any(feature = "icu4x", all(feature = "web-intl", target_arch = "wasm32"))))]
 const fn plural_category_with_backend(count: usize, locale: &Locale) -> PluralCategory {
     let _ = locale;
 
@@ -300,7 +305,7 @@ fn select_plural_with_backend(
     PluralCategory::from_icu(rules.category_for(&decimal))
 }
 
-#[cfg(feature = "web-intl")]
+#[cfg(all(feature = "web-intl", target_arch = "wasm32"))]
 fn select_plural_with_backend(
     locale: &Locale,
     count: f64,
@@ -309,7 +314,7 @@ fn select_plural_with_backend(
     JsIntlPluralRules::new(locale, rule_type).select(count)
 }
 
-#[cfg(not(any(feature = "icu4x", feature = "web-intl")))]
+#[cfg(not(any(feature = "icu4x", all(feature = "web-intl", target_arch = "wasm32"))))]
 fn select_plural_with_backend(
     _locale: &Locale,
     count: f64,
@@ -328,7 +333,7 @@ fn select_plural_with_backend(
     }
 }
 
-#[cfg(feature = "web-intl")]
+#[cfg(all(feature = "web-intl", target_arch = "wasm32"))]
 fn build_js_plural_rules(locale: &Locale, rule_type: PluralRuleType) -> JsPluralRules {
     let locales = Array::of1(&JsValue::from_str(&locale.to_bcp47()));
 
@@ -344,7 +349,7 @@ fn build_js_plural_rules(locale: &Locale, rule_type: PluralRuleType) -> JsPlural
     JsPluralRules::new(&locales, &options)
 }
 
-#[cfg(not(any(feature = "icu4x", feature = "web-intl")))]
+#[cfg(not(any(feature = "icu4x", all(feature = "web-intl", target_arch = "wasm32"))))]
 fn fallback_english_ordinal_category(count: f64) -> PluralCategory {
     if !count.is_finite() || count.fract() != 0.0 {
         return PluralCategory::Other;
@@ -369,7 +374,7 @@ fn fallback_english_ordinal_category(count: f64) -> PluralCategory {
 }
 
 impl PluralCategory {
-    #[cfg(feature = "web-intl")]
+    #[cfg(all(feature = "web-intl", target_arch = "wasm32"))]
     fn from_js_category(category: &str) -> Self {
         match category {
             "zero" => Self::Zero,
@@ -383,7 +388,7 @@ impl PluralCategory {
 }
 
 impl PluralRuleType {
-    #[cfg(feature = "web-intl")]
+    #[cfg(all(feature = "web-intl", target_arch = "wasm32"))]
     const fn as_js_str(self) -> &'static str {
         match self {
             Self::Cardinal => "cardinal",
@@ -603,6 +608,23 @@ mod tests {
 
         assert_eq!(rules.select(1.0), PluralCategory::One);
         assert_eq!(rules.select(4.0), PluralCategory::Other);
+    }
+
+    #[cfg(all(
+        feature = "web-intl",
+        not(target_arch = "wasm32"),
+        not(feature = "icu4x")
+    ))]
+    #[test]
+    fn native_web_intl_feature_uses_english_fallback_rules() {
+        let locale = Locale::parse("pl").expect("pl should parse");
+
+        assert_eq!(plural_category(1, &locale), PluralCategory::One);
+        assert_eq!(plural_category(2, &locale), PluralCategory::Other);
+        assert_eq!(
+            select_plural(&locale, 2.0, PluralRuleType::Ordinal),
+            PluralCategory::Two
+        );
     }
 }
 

--- a/crates/ars-i18n/src/plural.rs
+++ b/crates/ars-i18n/src/plural.rs
@@ -13,7 +13,7 @@
 use alloc::{format, string::String};
 
 use icu::plurals::PluralCategory as IcuPluralCategory;
-#[cfg(all(feature = "web-intl", target_arch = "wasm32"))]
+#[cfg(all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")))]
 use {
     core::fmt::{self, Debug},
     js_sys::{Array, Intl::PluralRules as JsPluralRules, Object, Reflect},
@@ -156,7 +156,7 @@ impl PluralRulesFormat for Icu4xPluralRules {
 pub type DefaultPluralRules = Icu4xPluralRules;
 
 /// Browser `Intl.PluralRules` wrapper used by the `web-intl` backend.
-#[cfg(all(feature = "web-intl", target_arch = "wasm32"))]
+#[cfg(all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")))]
 #[derive(Clone)]
 pub struct JsIntlPluralRules {
     locale: Locale,
@@ -164,7 +164,7 @@ pub struct JsIntlPluralRules {
     inner: JsPluralRules,
 }
 
-#[cfg(all(feature = "web-intl", target_arch = "wasm32"))]
+#[cfg(all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")))]
 impl JsIntlPluralRules {
     /// Creates a new browser-backed plural rules handle.
     #[must_use]
@@ -177,7 +177,7 @@ impl JsIntlPluralRules {
     }
 }
 
-#[cfg(all(feature = "web-intl", target_arch = "wasm32"))]
+#[cfg(all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")))]
 impl Debug for JsIntlPluralRules {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("JsIntlPluralRules")
@@ -187,7 +187,7 @@ impl Debug for JsIntlPluralRules {
     }
 }
 
-#[cfg(all(feature = "web-intl", target_arch = "wasm32"))]
+#[cfg(all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")))]
 impl PluralRulesFormat for JsIntlPluralRules {
     fn select(&self, number: f64) -> PluralCategory {
         PluralCategory::from_js_category(&self.inner.select(number).as_string().unwrap_or_default())
@@ -195,7 +195,7 @@ impl PluralRulesFormat for JsIntlPluralRules {
 }
 
 /// Default plural-rules backend for the active feature set.
-#[cfg(all(feature = "web-intl", target_arch = "wasm32"))]
+#[cfg(all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")))]
 pub type DefaultPluralRules = JsIntlPluralRules;
 
 /// Returns the CLDR cardinal plural category for an integer count.
@@ -205,7 +205,10 @@ pub type DefaultPluralRules = JsIntlPluralRules;
 /// falls back to English cardinal behavior: `1 => One`, all other values =>
 /// `Other`.
 #[must_use]
-#[cfg(any(feature = "icu4x", all(feature = "web-intl", target_arch = "wasm32")))]
+#[cfg(any(
+    feature = "icu4x",
+    all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x"))
+))]
 pub fn plural_category(count: usize, locale: &Locale) -> PluralCategory {
     plural_category_with_backend(count, locale)
 }
@@ -217,7 +220,10 @@ pub fn plural_category(count: usize, locale: &Locale) -> PluralCategory {
 /// falls back to English cardinal behavior: `1 => One`, all other values =>
 /// `Other`.
 #[must_use]
-#[cfg(not(any(feature = "icu4x", all(feature = "web-intl", target_arch = "wasm32"))))]
+#[cfg(not(any(
+    feature = "icu4x",
+    all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x"))
+)))]
 pub const fn plural_category(count: usize, locale: &Locale) -> PluralCategory {
     plural_category_with_backend(count, locale)
 }
@@ -269,12 +275,15 @@ fn plural_category_with_backend(count: usize, locale: &Locale) -> PluralCategory
     PluralCategory::from_icu(rules.category_for(count))
 }
 
-#[cfg(all(feature = "web-intl", target_arch = "wasm32"))]
+#[cfg(all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")))]
 fn plural_category_with_backend(count: usize, locale: &Locale) -> PluralCategory {
     select_plural_with_backend(locale, count as f64, PluralRuleType::Cardinal)
 }
 
-#[cfg(not(any(feature = "icu4x", all(feature = "web-intl", target_arch = "wasm32"))))]
+#[cfg(not(any(
+    feature = "icu4x",
+    all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x"))
+)))]
 const fn plural_category_with_backend(count: usize, locale: &Locale) -> PluralCategory {
     let _ = locale;
 
@@ -310,7 +319,7 @@ fn select_plural_with_backend(
     PluralCategory::from_icu(rules.category_for(&decimal))
 }
 
-#[cfg(all(feature = "web-intl", target_arch = "wasm32"))]
+#[cfg(all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")))]
 fn select_plural_with_backend(
     locale: &Locale,
     count: f64,
@@ -319,7 +328,10 @@ fn select_plural_with_backend(
     JsIntlPluralRules::new(locale, rule_type).select(count)
 }
 
-#[cfg(not(any(feature = "icu4x", all(feature = "web-intl", target_arch = "wasm32"))))]
+#[cfg(not(any(
+    feature = "icu4x",
+    all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x"))
+)))]
 fn select_plural_with_backend(
     _locale: &Locale,
     count: f64,
@@ -338,7 +350,7 @@ fn select_plural_with_backend(
     }
 }
 
-#[cfg(all(feature = "web-intl", target_arch = "wasm32"))]
+#[cfg(all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")))]
 fn build_js_plural_rules(locale: &Locale, rule_type: PluralRuleType) -> JsPluralRules {
     let locales = Array::of1(&JsValue::from_str(&locale.to_bcp47()));
 
@@ -354,7 +366,10 @@ fn build_js_plural_rules(locale: &Locale, rule_type: PluralRuleType) -> JsPlural
     JsPluralRules::new(&locales, &options)
 }
 
-#[cfg(not(any(feature = "icu4x", all(feature = "web-intl", target_arch = "wasm32"))))]
+#[cfg(not(any(
+    feature = "icu4x",
+    all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x"))
+)))]
 fn fallback_english_ordinal_category(count: f64) -> PluralCategory {
     if !count.is_finite() || count.fract() != 0.0 {
         return PluralCategory::Other;
@@ -379,7 +394,7 @@ fn fallback_english_ordinal_category(count: f64) -> PluralCategory {
 }
 
 impl PluralCategory {
-    #[cfg(all(feature = "web-intl", target_arch = "wasm32"))]
+    #[cfg(all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")))]
     fn from_js_category(category: &str) -> Self {
         match category {
             "zero" => Self::Zero,
@@ -393,7 +408,7 @@ impl PluralCategory {
 }
 
 impl PluralRuleType {
-    #[cfg(all(feature = "web-intl", target_arch = "wasm32"))]
+    #[cfg(all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")))]
     const fn as_js_str(self) -> &'static str {
         match self {
             Self::Cardinal => "cardinal",
@@ -634,7 +649,10 @@ mod tests {
         assert_eq!(rules.select(4.0), PluralCategory::Other);
     }
 
-    #[cfg(not(any(feature = "icu4x", all(feature = "web-intl", target_arch = "wasm32"))))]
+    #[cfg(not(any(
+        feature = "icu4x",
+        all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x"))
+    )))]
     #[test]
     fn fallback_rules_treat_negative_one_as_singular() {
         let locale = Locale::parse("pl").expect("pl should parse");
@@ -656,7 +674,12 @@ mod tests {
     }
 }
 
-#[cfg(all(test, feature = "web-intl", target_arch = "wasm32"))]
+#[cfg(all(
+    test,
+    feature = "web-intl",
+    target_arch = "wasm32",
+    not(feature = "icu4x")
+))]
 mod web_intl_tests {
     use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
 

--- a/crates/ars-i18n/src/plural.rs
+++ b/crates/ars-i18n/src/plural.rs
@@ -291,6 +291,10 @@ fn select_plural_with_backend(
     count: f64,
     rule_type: PluralRuleType,
 ) -> PluralCategory {
+    if !count.is_finite() {
+        return PluralCategory::Other;
+    }
+
     let rules = match rule_type {
         PluralRuleType::Cardinal => {
             PluralRules::try_new_cardinal(PluralRulesPreferences::from(locale.as_icu()))
@@ -508,6 +512,25 @@ mod tests {
         );
         assert_eq!(
             select_plural(&locale, 1.5, PluralRuleType::Cardinal),
+            PluralCategory::Other
+        );
+    }
+
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn select_plural_returns_other_for_non_finite_icu4x_inputs() {
+        let locale = locales::ar();
+
+        assert_eq!(
+            select_plural(&locale, f64::NAN, PluralRuleType::Cardinal),
+            PluralCategory::Other
+        );
+        assert_eq!(
+            select_plural(&locale, f64::INFINITY, PluralRuleType::Cardinal),
+            PluralCategory::Other
+        );
+        assert_eq!(
+            select_plural(&locale, f64::NEG_INFINITY, PluralRuleType::Cardinal),
             PluralCategory::Other
         );
     }

--- a/spec/components/data-display/rating-group.md
+++ b/spec/components/data-display/rating-group.md
@@ -525,13 +525,12 @@ RatingGroup uses one of two ARIA patterns depending on whether half-ratings are 
 - Star labels use `PluralCategory` from `ars-i18n` for correct singular/plural forms:
 
 ```rust
-use ars_i18n::{PluralRules, PluralCategory};
+use ars_i18n::{select_plural, PluralCategory, PluralRuleType};
 
 /// Returns the default item label for the rating group.
-fn default_item_label(locale: &Locale) -> MessageFn<dyn Fn(f64) -> String + Send + Sync> {
-    let rules = PluralRules::new(locale, PluralType::Cardinal);
-    MessageFn::new(move |value: f64| {
-        let category = rules.category_for(value);
+fn default_item_label() -> MessageFn<dyn Fn(f64, &Locale) -> String + Send + Sync> {
+    MessageFn::new(move |value: f64, locale: &Locale| {
+        let category = select_plural(locale, value, PluralRuleType::Cardinal);
         match category {
             PluralCategory::One => format!("{} star", value),
             _                   => format!("{} stars", value),

--- a/spec/foundation/04-internationalization.md
+++ b/spec/foundation/04-internationalization.md
@@ -2268,6 +2268,9 @@ visible trailing-zero precision such as `1` versus `1.0`. The ars-i18n API
 normalizes category names across backends, but precision-sensitive CLDR edge
 cases follow the capabilities of the active backend.
 
+Across all backends, non-finite numeric inputs (`NaN`, `+∞`, `-∞`) select
+`PluralCategory::Other` rather than being coerced into a numeric plural class.
+
 With neither `icu4x` nor wasm `web-intl` enabled, `select_plural()` falls back
 to English-only behavior. This also applies to non-wasm builds compiled with
 the `web-intl` feature flag, because the browser `Intl` backend is only

--- a/spec/foundation/04-internationalization.md
+++ b/spec/foundation/04-internationalization.md
@@ -2271,8 +2271,8 @@ cases follow the capabilities of the active backend.
 With neither `icu4x` nor wasm `web-intl` enabled, `select_plural()` falls back
 to English-only behavior. This also applies to non-wasm builds compiled with
 the `web-intl` feature flag, because the browser `Intl` backend is only
-available on `wasm32`: cardinal rules use `One` for exactly `1.0` and `Other`
-otherwise, while ordinal rules use the standard English
+available on `wasm32`: cardinal rules use `One` for values whose magnitude is
+exactly `1.0` and `Other` otherwise, while ordinal rules use the standard English
 `1st`/`2nd`/`3rd` categories and map all other values to `Other`.
 
 ### 6.2 ICU MessageFormat Plural Syntax

--- a/spec/foundation/04-internationalization.md
+++ b/spec/foundation/04-internationalization.md
@@ -3310,7 +3310,7 @@ pub type DefaultDateFormatter = web_intl::JsIntlDateFormatter;
 // ── Plural rules ──
 #[cfg(feature = "icu4x")]
 pub type DefaultPluralRules = icu4x::Icu4xPluralRules;
-#[cfg(all(feature = "web-intl", target_arch = "wasm32"))]
+#[cfg(all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")))]
 pub type DefaultPluralRules = web_intl::JsIntlPluralRules;
 
 // ── Collation ──

--- a/spec/foundation/04-internationalization.md
+++ b/spec/foundation/04-internationalization.md
@@ -1315,6 +1315,13 @@ pub fn plural_category(count: usize, locale: &Locale) -> PluralCategory {
 }
 ```
 
+When either plural backend is enabled, `plural_category()` uses locale-aware CLDR
+cardinal rules from that backend. With neither `icu4x` nor `web-intl` enabled,
+`ars-i18n` still exposes the function but falls back to English cardinal behavior:
+`1 => One`, all other integer counts => `Other`. This fallback exists so
+backend-free feature-matrix builds can compile without introducing a separate
+conditional public API.
+
 ---
 
 ## 5. Date and Time Formatting
@@ -2211,8 +2218,8 @@ pub fn select_plural(
     // rules depend on trailing zeros: "1.0" is "other" in English, not "one". Decimal
     // preserves the original precision from f64. In contrast, plural_category(usize)
     // (§4.3) can pass usize directly since integers have no trailing-zero ambiguity.
-    let fd = fixed_decimal::Decimal::try_from_f64(count, fixed_decimal::FloatPrecision::Floating).unwrap_or_default();
-    PluralCategory::from_icu(rules.category_for(fd))
+    let fd = fixed_decimal::Decimal::try_from_f64(count, fixed_decimal::FloatPrecision::RoundTrip).unwrap_or_default();
+    PluralCategory::from_icu(rules.category_for(&fd))
 }
 
 /// Format a count with the appropriate plural form.
@@ -2253,6 +2260,17 @@ fn interpolate(template: &str, args: &[(&str, &str)]) -> String {
     result
 }
 ````
+
+Under the `web-intl` backend, `select_plural()` delegates to `Intl.PluralRules::select(number)`.
+That API observes the numeric value only, not the original source formatting, so browser builds
+cannot distinguish visible trailing-zero precision such as `1` versus `1.0`. The ars-i18n API
+normalizes category names across backends, but precision-sensitive CLDR edge cases follow the
+capabilities of the active backend.
+
+With neither `icu4x` nor `web-intl` enabled, `select_plural()` falls back to
+English-only behavior: cardinal rules use `One` for exactly `1.0` and `Other`
+otherwise, while ordinal rules use the standard English `1st`/`2nd`/`3rd`
+categories and map all other values to `Other`.
 
 ### 6.2 ICU MessageFormat Plural Syntax
 
@@ -3390,6 +3408,10 @@ impl CollationFormat for StringCollator {
 | WASM client (offline) | `icu4x`    | Needs built-in ICU data                   |
 
 > **Note**: `parse()` (string -> number/date) is not available via the browser `Intl` API. Applications that need parsing must use the `icu4x` backend even on the client.
+>
+> For plural rules, omitting both `icu4x` and `web-intl` leaves the free-function
+> API available with an English-only fallback. That configuration is supported
+> for backend-free builds and tests, not for full locale-aware production i18n.
 
 ### 9.5 Calendar/Locale Provider Trait (`IcuProvider`)
 

--- a/spec/foundation/04-internationalization.md
+++ b/spec/foundation/04-internationalization.md
@@ -2261,16 +2261,19 @@ fn interpolate(template: &str, args: &[(&str, &str)]) -> String {
 }
 ````
 
-Under the `web-intl` backend, `select_plural()` delegates to `Intl.PluralRules::select(number)`.
-That API observes the numeric value only, not the original source formatting, so browser builds
-cannot distinguish visible trailing-zero precision such as `1` versus `1.0`. The ars-i18n API
-normalizes category names across backends, but precision-sensitive CLDR edge cases follow the
-capabilities of the active backend.
+Under the `web-intl` backend on `wasm32`, `select_plural()` delegates to
+`Intl.PluralRules::select(number)`. That API observes the numeric value only,
+not the original source formatting, so browser builds cannot distinguish
+visible trailing-zero precision such as `1` versus `1.0`. The ars-i18n API
+normalizes category names across backends, but precision-sensitive CLDR edge
+cases follow the capabilities of the active backend.
 
-With neither `icu4x` nor `web-intl` enabled, `select_plural()` falls back to
-English-only behavior: cardinal rules use `One` for exactly `1.0` and `Other`
-otherwise, while ordinal rules use the standard English `1st`/`2nd`/`3rd`
-categories and map all other values to `Other`.
+With neither `icu4x` nor wasm `web-intl` enabled, `select_plural()` falls back
+to English-only behavior. This also applies to non-wasm builds compiled with
+the `web-intl` feature flag, because the browser `Intl` backend is only
+available on `wasm32`: cardinal rules use `One` for exactly `1.0` and `Other`
+otherwise, while ordinal rules use the standard English
+`1st`/`2nd`/`3rd` categories and map all other values to `Other`.
 
 ### 6.2 ICU MessageFormat Plural Syntax
 
@@ -3278,7 +3281,11 @@ pub fn get_number_formatter(locale: &Locale, options: &NumberFormatOptions) -> N
 
 ### 9.4 Browser Intl API Feature Flag (`web-intl`)
 
-For WASM client builds, the browser's `Intl` API provides the same formatting capabilities as ICU4X with zero bundle size overhead. The `web-intl` feature flag enables this backend.
+For WASM client builds, the browser's `Intl` API provides the same formatting
+capabilities as ICU4X with zero bundle size overhead. The `web-intl` feature
+flag enables this backend on `wasm32`; non-wasm builds that enable the feature
+continue to use the documented English fallback behavior for APIs that depend
+on browser `Intl`.
 
 #### 9.4.1 Feature-flagged type aliases
 
@@ -3300,7 +3307,7 @@ pub type DefaultDateFormatter = web_intl::JsIntlDateFormatter;
 // ── Plural rules ──
 #[cfg(feature = "icu4x")]
 pub type DefaultPluralRules = icu4x::Icu4xPluralRules;
-#[cfg(feature = "web-intl")]
+#[cfg(all(feature = "web-intl", target_arch = "wasm32"))]
 pub type DefaultPluralRules = web_intl::JsIntlPluralRules;
 
 // ── Collation ──

--- a/spec/testing/14-ci.md
+++ b/spec/testing/14-ci.md
@@ -375,7 +375,9 @@ coverage:
    `cargo-nextest` and exports real branch records in the lcov tracefile.
 2. Generate per-package wasm lcov with `cargo xtask coverage wasm` for every
    browser-test crate in `xtask/src/coverage.rs :: default_wasm_coverage_targets()`.
-   At the time of writing this is `ars-dom` with `--features web`.
+   At the time of writing this includes:
+   - `ars-dom` with `--features web`
+   - `ars-i18n` with `--no-default-features --features web-intl`
 3. Merge the native and wasm lcov tracefiles with `cargo xtask coverage merge`
    so duplicate file records are unioned instead of double-counted.
 
@@ -387,7 +389,10 @@ coverage:
 > exports `WASM_COVERAGE_CLANG` so the recompile step does not accidentally
 > pick an older system `clang`. The installed `wasm-bindgen-cli` /
 > `wasm-bindgen-test-runner` version MUST match the workspace `wasm-bindgen`
-> crate version in `Cargo.lock`.
+> crate version in `Cargo.lock`. When the wasm exporter emits `BRDA` records
+> with `taken = -`, `cargo xtask coverage` treats them as "no branch data"
+> rather than failed branches, so merged branch thresholds are not artificially
+> penalized by exporter omissions.
 > Native coverage also requires nightly Rust and `cargo-nextest`, because
 > branch coverage is unstable in `cargo-llvm-cov` and native execution is
 > delegated through `cargo llvm-cov nextest`.

--- a/xtask/src/ci/mod.rs
+++ b/xtask/src/ci/mod.rs
@@ -382,7 +382,7 @@ fn run_coverage() -> Result<(), Error> {
                 .iter()
                 .map(|feature| (*feature).to_owned())
                 .collect(),
-            no_default_features: false,
+            no_default_features: target.no_default_features,
             extra_test_args: Vec::new(),
         })
         .map_err(Error::Coverage)?;

--- a/xtask/src/coverage.rs
+++ b/xtask/src/coverage.rs
@@ -294,14 +294,24 @@ pub struct WasmCoverageTarget {
     pub package: &'static str,
     /// Cargo features required for the browser test build.
     pub features: &'static [&'static str],
+    /// Whether CI coverage must disable the crate's default features.
+    pub no_default_features: bool,
 }
 
 /// Browser-test packages whose `web`/`wasm32` code paths are merged into CI coverage.
 pub const fn default_wasm_coverage_targets() -> &'static [WasmCoverageTarget] {
-    &[WasmCoverageTarget {
-        package: "ars-dom",
-        features: &["web"],
-    }]
+    &[
+        WasmCoverageTarget {
+            package: "ars-dom",
+            features: &["web"],
+            no_default_features: false,
+        },
+        WasmCoverageTarget {
+            package: "ars-i18n",
+            features: &["web-intl"],
+            no_default_features: true,
+        },
+    ]
 }
 
 /// Parse lcov content into per-file line/branch hit maps.
@@ -356,7 +366,12 @@ fn parse_lcov_records(content: &str) -> BTreeMap<String, FileCoverage> {
             let Some(taken) = parts.next() else {
                 continue;
             };
-            let hit = taken != "-" && taken.parse::<u64>().ok().is_some_and(|count| count > 0);
+            if taken == "-" {
+                // Some wasm lcov exporters emit branch records without taken counts.
+                // Treat those as "no branch data" instead of uncovered branches.
+                continue;
+            }
+            let hit = taken.parse::<u64>().ok().is_some_and(|count| count > 0);
             file.record_branch(
                 BranchKey {
                     line: line_no,
@@ -896,6 +911,15 @@ BRDA:2,0,1,0
 end_of_record
 ";
 
+    const NO_BRANCH_DATA_LCOV: &str = "\
+SF:crates/ars-i18n/src/plural.rs
+DA:1,1
+DA:2,1
+BRDA:2,0,0,-
+BRDA:2,0,1,-
+end_of_record
+";
+
     #[test]
     fn parse_stats_aggregates_across_files() {
         let stats = parse_package_stats(SAMPLE_LCOV, "ars-core");
@@ -938,6 +962,15 @@ end_of_record
         assert_eq!(stats.lines_hit, 1);
         assert_eq!(stats.branches_found, 2);
         assert_eq!(stats.branches_hit, 1);
+    }
+
+    #[test]
+    fn parse_stats_ignores_branch_records_without_taken_counts() {
+        let stats = parse_package_stats(NO_BRANCH_DATA_LCOV, "ars-i18n");
+        assert_eq!(stats.lines_found, 2);
+        assert_eq!(stats.lines_hit, 2);
+        assert_eq!(stats.branches_found, 0);
+        assert_eq!(stats.branches_hit, 0);
     }
 
     #[test]
@@ -1127,6 +1160,42 @@ version = "0.2.118"
         let flags = coverage_rustflags();
         assert!(flags.contains("-Cinstrument-coverage"));
         assert!(flags.contains("-Zcoverage-options=branch"));
+    }
+
+    #[test]
+    fn default_wasm_coverage_targets_include_web_intl_ars_i18n() {
+        let targets = default_wasm_coverage_targets();
+
+        assert!(targets.iter().any(|target| {
+            target.package == "ars-dom" && target.features == ["web"] && !target.no_default_features
+        }));
+        assert!(targets.iter().any(|target| {
+            target.package == "ars-i18n"
+                && target.features == ["web-intl"]
+                && target.no_default_features
+        }));
+    }
+
+    #[test]
+    fn base_wasm_cargo_args_respects_no_default_features_and_features() {
+        let args = base_wasm_cargo_args(&WasmCoverageOptions {
+            package: "ars-i18n".into(),
+            output: PathBuf::from("/tmp/ars-i18n-web-intl.lcov"),
+            features: vec!["web-intl".into()],
+            no_default_features: true,
+            extra_test_args: Vec::new(),
+        });
+        let args = args
+            .into_iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+
+        assert!(args.windows(2).any(|pair| pair == ["-p", "ars-i18n"]));
+        assert!(args.contains(&"--no-default-features".to_owned()));
+        assert!(
+            args.windows(2)
+                .any(|pair| pair == ["--features", "web-intl"])
+        );
     }
 }
 


### PR DESCRIPTION
## Summary
- add the spec-defined plural and ordinal API in `ars-i18n` with shared ICU4X and `web-intl` backends
- add runtime and coverage support for the `web-intl` path, including merged wasm coverage in `xtask`
- sync the affected i18n, rating-group, and CI spec/docs to the implemented contract

## Verification
- `cargo xci`

Closes #126
Closes #131