### PR TITLE
feat: add ICU4X locale-aware case mapping

### DIFF
--- a/crates/ars-i18n/src/case.rs
+++ b/crates/ars-i18n/src/case.rs
@@ -1,0 +1,84 @@
+//! Locale-aware text case transformation helpers.
+//!
+//! Rust's built-in Unicode case conversion is locale-independent, which means
+//! it misses language-sensitive mappings such as Turkish dotted and dotless I
+//! and Greek final sigma handling. These helpers delegate to ICU4X
+//! [`CaseMapper`](icu::casemap::CaseMapper) so components can apply the
+//! spec-defined locale-aware behavior consistently.
+
+use alloc::string::String;
+
+use icu::casemap::CaseMapper;
+
+use crate::Locale;
+
+/// Locale-aware uppercase transformation.
+///
+/// Delegates to ICU4X [`CaseMapper`] so locale-specific mappings such as
+/// Turkish dotted capital I are preserved.
+#[must_use]
+pub fn to_uppercase(text: &str, locale: &Locale) -> String {
+    CaseMapper::new()
+        .uppercase_to_string(text, locale.language_identifier())
+        .into_owned()
+}
+
+/// Locale-aware lowercase transformation.
+///
+/// Delegates to ICU4X [`CaseMapper`] so locale-specific mappings such as
+/// Turkish dotless i and Greek final sigma are preserved.
+#[must_use]
+pub fn to_lowercase(text: &str, locale: &Locale) -> String {
+    CaseMapper::new()
+        .lowercase_to_string(text, locale.language_identifier())
+        .into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{to_lowercase, to_uppercase};
+    use crate::Locale;
+
+    #[test]
+    fn turkish_uppercase_uses_dotted_capital_i() {
+        let locale = Locale::parse("tr").expect("locale should parse");
+
+        assert_eq!(to_uppercase("i", &locale), "İ");
+    }
+
+    #[test]
+    fn turkish_lowercase_uses_dotless_i() {
+        let locale = Locale::parse("tr").expect("locale should parse");
+
+        assert_eq!(to_lowercase("I", &locale), "ı");
+    }
+
+    #[test]
+    fn german_uppercase_expands_sharp_s() {
+        let locale = Locale::parse("de").expect("locale should parse");
+
+        assert_eq!(to_uppercase("ß", &locale), "SS");
+    }
+
+    #[test]
+    fn lithuanian_uppercase_handles_dotted_i() {
+        let locale = Locale::parse("lt").expect("locale should parse");
+
+        assert_eq!(to_uppercase("i\u{307}", &locale), "I");
+    }
+
+    #[test]
+    fn english_round_trips_ascii_text() {
+        let locale = Locale::parse("en-US").expect("locale should parse");
+
+        assert_eq!(to_uppercase("Hello world", &locale), "HELLO WORLD");
+        assert_eq!(to_lowercase("HELLO WORLD", &locale), "hello world");
+    }
+
+    #[test]
+    fn greek_lowercase_applies_final_sigma_rules() {
+        let locale = Locale::parse("el").expect("locale should parse");
+
+        assert_eq!(to_lowercase("ΟΣ", &locale), "ος");
+    }
+}

--- a/crates/ars-i18n/src/case.rs
+++ b/crates/ars-i18n/src/case.rs
@@ -3,42 +3,124 @@
 //! Rust's built-in Unicode case conversion is locale-independent, which means
 //! it misses language-sensitive mappings such as Turkish dotted and dotless I
 //! and Greek final sigma handling. These helpers delegate to ICU4X
-//! [`CaseMapper`](icu::casemap::CaseMapper) so components can apply the
-//! spec-defined locale-aware behavior consistently.
+//! [`CaseMapper`](icu::casemap::CaseMapper) or the browser's locale-aware
+//! string APIs so components can apply the spec-defined behavior consistently
+//! across backends.
 
 use alloc::string::String;
 
+#[cfg(feature = "icu4x")]
 use icu::casemap::CaseMapper;
+#[cfg(all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")))]
+use js_sys::JsString;
 
 use crate::Locale;
 
 /// Locale-aware uppercase transformation.
 ///
 /// Delegates to ICU4X [`CaseMapper`] so locale-specific mappings such as
-/// Turkish dotted capital I are preserved.
+/// Turkish dotted capital I are preserved. Under the wasm `web-intl` backend,
+/// this delegates to browser `String.prototype.toLocaleUpperCase()`. On
+/// non-wasm builds with `web-intl`, it falls back to Unicode case conversion so
+/// the public API remains available in feature-matrix builds.
 #[must_use]
+#[cfg(feature = "icu4x")]
 pub fn to_uppercase(text: &str, locale: &Locale) -> String {
     CaseMapper::new()
         .uppercase_to_string(text, locale.language_identifier())
         .into_owned()
 }
 
+/// Locale-aware uppercase transformation.
+///
+/// Delegates to browser `String.prototype.toLocaleUpperCase()` on wasm
+/// `web-intl` builds.
+#[must_use]
+#[cfg(all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")))]
+pub fn to_uppercase(text: &str, locale: &Locale) -> String {
+    let locale_tag = locale.to_bcp47();
+    String::from(JsString::from(text).to_locale_upper_case(Some(locale_tag.as_str())))
+}
+
+/// Locale-aware uppercase transformation.
+///
+/// Non-wasm `web-intl` builds cannot access the browser `Intl` APIs, so this
+/// falls back to Rust's Unicode case mapping while preserving the shared public
+/// API surface.
+#[must_use]
+#[cfg(all(
+    feature = "web-intl",
+    not(target_arch = "wasm32"),
+    not(feature = "icu4x")
+))]
+pub fn to_uppercase(text: &str, _locale: &Locale) -> String {
+    text.to_uppercase()
+}
+
 /// Locale-aware lowercase transformation.
 ///
 /// Delegates to ICU4X [`CaseMapper`] so locale-specific mappings such as
-/// Turkish dotless i and Greek final sigma are preserved.
+/// Turkish dotless i and Greek final sigma are preserved. Under the wasm
+/// `web-intl` backend, this delegates to browser
+/// `String.prototype.toLocaleLowerCase()`. On non-wasm builds with `web-intl`,
+/// it falls back to Unicode case conversion so the public API remains
+/// available in feature-matrix builds.
 #[must_use]
+#[cfg(feature = "icu4x")]
 pub fn to_lowercase(text: &str, locale: &Locale) -> String {
     CaseMapper::new()
         .lowercase_to_string(text, locale.language_identifier())
         .into_owned()
 }
 
+/// Locale-aware lowercase transformation.
+///
+/// Delegates to browser `String.prototype.toLocaleLowerCase()` on wasm
+/// `web-intl` builds.
+#[must_use]
+#[cfg(all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")))]
+pub fn to_lowercase(text: &str, locale: &Locale) -> String {
+    let locale_tag = locale.to_bcp47();
+    String::from(JsString::from(text).to_locale_lower_case(Some(locale_tag.as_str())))
+}
+
+/// Locale-aware lowercase transformation.
+///
+/// Non-wasm `web-intl` builds cannot access the browser `Intl` APIs, so this
+/// falls back to Rust's Unicode case mapping while preserving the shared public
+/// API surface.
+#[must_use]
+#[cfg(all(
+    feature = "web-intl",
+    not(target_arch = "wasm32"),
+    not(feature = "icu4x")
+))]
+pub fn to_lowercase(text: &str, _locale: &Locale) -> String {
+    text.to_lowercase()
+}
+
 #[cfg(test)]
 mod tests {
+    #[cfg(any(
+        feature = "icu4x",
+        all(
+            feature = "web-intl",
+            not(target_arch = "wasm32"),
+            not(feature = "icu4x")
+        )
+    ))]
     use super::{to_lowercase, to_uppercase};
+    #[cfg(any(
+        feature = "icu4x",
+        all(
+            feature = "web-intl",
+            not(target_arch = "wasm32"),
+            not(feature = "icu4x")
+        )
+    ))]
     use crate::Locale;
 
+    #[cfg(feature = "icu4x")]
     #[test]
     fn turkish_uppercase_uses_dotted_capital_i() {
         let locale = Locale::parse("tr").expect("locale should parse");
@@ -46,6 +128,7 @@ mod tests {
         assert_eq!(to_uppercase("i", &locale), "İ");
     }
 
+    #[cfg(feature = "icu4x")]
     #[test]
     fn turkish_lowercase_uses_dotless_i() {
         let locale = Locale::parse("tr").expect("locale should parse");
@@ -53,6 +136,7 @@ mod tests {
         assert_eq!(to_lowercase("I", &locale), "ı");
     }
 
+    #[cfg(feature = "icu4x")]
     #[test]
     fn german_uppercase_expands_sharp_s() {
         let locale = Locale::parse("de").expect("locale should parse");
@@ -60,6 +144,7 @@ mod tests {
         assert_eq!(to_uppercase("ß", &locale), "SS");
     }
 
+    #[cfg(feature = "icu4x")]
     #[test]
     fn lithuanian_uppercase_handles_dotted_i() {
         let locale = Locale::parse("lt").expect("locale should parse");
@@ -67,6 +152,14 @@ mod tests {
         assert_eq!(to_uppercase("i\u{307}", &locale), "I");
     }
 
+    #[cfg(any(
+        feature = "icu4x",
+        all(
+            feature = "web-intl",
+            not(target_arch = "wasm32"),
+            not(feature = "icu4x")
+        )
+    ))]
     #[test]
     fn english_round_trips_ascii_text() {
         let locale = Locale::parse("en-US").expect("locale should parse");
@@ -75,8 +168,80 @@ mod tests {
         assert_eq!(to_lowercase("HELLO WORLD", &locale), "hello world");
     }
 
+    #[cfg(feature = "icu4x")]
     #[test]
     fn greek_lowercase_applies_final_sigma_rules() {
+        let locale = Locale::parse("el").expect("locale should parse");
+
+        assert_eq!(to_lowercase("ΟΣ", &locale), "ος");
+    }
+
+    #[cfg(all(
+        feature = "web-intl",
+        not(target_arch = "wasm32"),
+        not(feature = "icu4x")
+    ))]
+    #[test]
+    fn non_wasm_web_intl_keeps_case_api_available() {
+        let locale = Locale::parse("tr").expect("locale should parse");
+
+        assert_eq!(to_uppercase("Hello world", &locale), "HELLO WORLD");
+        assert_eq!(to_lowercase("HELLO WORLD", &locale), "hello world");
+    }
+}
+
+#[cfg(all(
+    test,
+    feature = "web-intl",
+    target_arch = "wasm32",
+    not(feature = "icu4x")
+))]
+mod web_intl_tests {
+    use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+
+    use super::{to_lowercase, to_uppercase};
+    use crate::Locale;
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    #[wasm_bindgen_test]
+    fn web_intl_turkish_uppercase_uses_dotted_capital_i() {
+        let locale = Locale::parse("tr").expect("locale should parse");
+
+        assert_eq!(to_uppercase("i", &locale), "İ");
+    }
+
+    #[wasm_bindgen_test]
+    fn web_intl_turkish_lowercase_uses_dotless_i() {
+        let locale = Locale::parse("tr").expect("locale should parse");
+
+        assert_eq!(to_lowercase("I", &locale), "ı");
+    }
+
+    #[wasm_bindgen_test]
+    fn web_intl_german_uppercase_expands_sharp_s() {
+        let locale = Locale::parse("de").expect("locale should parse");
+
+        assert_eq!(to_uppercase("ß", &locale), "SS");
+    }
+
+    #[wasm_bindgen_test]
+    fn web_intl_lithuanian_uppercase_handles_dotted_i() {
+        let locale = Locale::parse("lt").expect("locale should parse");
+
+        assert_eq!(to_uppercase("i\u{307}", &locale), "I");
+    }
+
+    #[wasm_bindgen_test]
+    fn web_intl_english_round_trips_ascii_text() {
+        let locale = Locale::parse("en-US").expect("locale should parse");
+
+        assert_eq!(to_uppercase("Hello world", &locale), "HELLO WORLD");
+        assert_eq!(to_lowercase("HELLO WORLD", &locale), "hello world");
+    }
+
+    #[wasm_bindgen_test]
+    fn web_intl_greek_lowercase_applies_final_sigma_rules() {
         let locale = Locale::parse("el").expect("locale should parse");
 
         assert_eq!(to_lowercase("ΟΣ", &locale), "ος");

--- a/crates/ars-i18n/src/lib.rs
+++ b/crates/ars-i18n/src/lib.rs
@@ -21,7 +21,7 @@ extern crate alloc;
 use alloc::string::String;
 
 mod bidi;
-#[cfg(feature = "icu4x")]
+#[cfg(any(feature = "icu4x", feature = "web-intl"))]
 mod case;
 mod layout;
 mod locale;
@@ -32,7 +32,7 @@ mod translate;
 mod weekday;
 
 pub use bidi::{IsolateDirection, isolate_text_safe};
-#[cfg(feature = "icu4x")]
+#[cfg(any(feature = "icu4x", feature = "web-intl"))]
 pub use case::{to_lowercase, to_uppercase};
 pub use layout::{LogicalRect, LogicalSide, PhysicalRect, PhysicalSide};
 pub use locale::{Locale, LocaleParseError, locales};

--- a/crates/ars-i18n/src/lib.rs
+++ b/crates/ars-i18n/src/lib.rs
@@ -1,13 +1,15 @@
 //! Internationalization types for locale, number formatting, text direction,
-//! layout orientation, plural rules, and logical-to-physical layout geometry.
+//! layout orientation, plural rules, locale-aware case mapping, and
+//! logical-to-physical layout geometry.
 //!
 //! This crate provides the core i18n primitives shared across all ars-ui components:
 //! a BCP 47 [`Locale`] wrapper, a locale-aware [`NumberFormatter`], a
 //! [`Direction`] enum for LTR/RTL text flow, an [`Orientation`] enum for
 //! horizontal/vertical layout axes, RTL-aware layout geometry types
 //! ([`LogicalSide`], [`PhysicalSide`], [`LogicalRect`], [`PhysicalRect`]),
-//! plural and ordinal helpers, and the [`IcuProvider`] trait for
-//! calendar/locale data abstraction.
+//! plural and ordinal helpers, locale-aware [`to_uppercase`] and
+//! [`to_lowercase`] helpers, and the [`IcuProvider`] trait for calendar/locale
+//! data abstraction.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
@@ -19,6 +21,8 @@ extern crate alloc;
 use alloc::string::String;
 
 mod bidi;
+#[cfg(feature = "icu4x")]
+mod case;
 mod layout;
 mod locale;
 mod locale_stack;
@@ -28,6 +32,8 @@ mod translate;
 mod weekday;
 
 pub use bidi::{IsolateDirection, isolate_text_safe};
+#[cfg(feature = "icu4x")]
+pub use case::{to_lowercase, to_uppercase};
 pub use layout::{LogicalRect, LogicalSide, PhysicalRect, PhysicalSide};
 pub use locale::{Locale, LocaleParseError, locales};
 pub use locale_stack::LocaleStack;

--- a/crates/ars-i18n/src/locale.rs
+++ b/crates/ars-i18n/src/locale.rs
@@ -336,6 +336,13 @@ mod tests {
     }
 
     #[test]
+    fn locale_language_identifier_roundtrips() {
+        let locale = Locale::parse("sr-Latn-RS").expect("locale should parse");
+
+        assert_eq!(locale.language_identifier().to_string(), "sr-Latn-RS");
+    }
+
+    #[test]
     fn rtl_script_list_contains_core_scripts() {
         assert!(RTL_SCRIPTS.contains(&"Arab"));
         assert!(RTL_SCRIPTS.contains(&"Hebr"));

--- a/crates/ars-i18n/src/locale_stack.rs
+++ b/crates/ars-i18n/src/locale_stack.rs
@@ -109,6 +109,14 @@ mod tests {
     }
 
     #[test]
+    fn locale_stack_builds_script_only_fallback_chain() {
+        let stack = LocaleStack::new(Locale::parse("zh-Hant").expect("locale should parse"));
+
+        let tags = stack.iter().map(Locale::to_bcp47).collect::<Vec<_>>();
+        assert_eq!(tags, vec!["zh-Hant", "zh"]);
+    }
+
+    #[test]
     fn locale_stack_keeps_single_language_locale() {
         let stack = LocaleStack::new(Locale::parse("en").expect("locale should parse"));
 

--- a/crates/ars-i18n/src/number.rs
+++ b/crates/ars-i18n/src/number.rs
@@ -927,6 +927,14 @@ mod tests {
 
     #[cfg(feature = "icu4x")]
     #[test]
+    fn parse_returns_none_when_numeric_core_is_missing() {
+        let formatter = NumberFormatter::new(&locales::en_us(), NumberFormatOptions::default());
+
+        assert_eq!(formatter.parse("not a number"), None);
+    }
+
+    #[cfg(feature = "icu4x")]
+    #[test]
     fn normalizes_arabic_indic_digits_during_parse() {
         let locale = locales::ar();
         let formatter = NumberFormatter::new(&locale, NumberFormatOptions::default());
@@ -1087,7 +1095,15 @@ mod tests {
         assert_eq!(choose_decimal_separator("1,234,567", '.', ','), None);
         assert_eq!(choose_decimal_separator("1.234", ',', '.'), None);
         assert_eq!(choose_decimal_separator("١٬٢٣٤", '٫', '٬'), None);
+        assert_eq!(choose_decimal_separator("1.234.567", ',', ' '), None);
         assert_eq!(choose_decimal_separator("1,234.5", '.', ','), Some('.'));
+    }
+
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn parse_separators_handles_suffixes_and_plain_digits() {
+        assert_eq!(parse_separators("37 kg"), ('.', ' '));
+        assert_eq!(parse_separators("1234"), ('.', ','));
     }
 
     #[cfg(feature = "icu4x")]
@@ -1107,5 +1123,11 @@ mod tests {
     fn round_half_even_rounds_up_when_fraction_exceeds_half() {
         assert_eq!(round_half_even(1.6), 2.0);
         assert_eq!(round_half_even(-1.6), -2.0);
+    }
+
+    #[test]
+    fn round_half_up_and_half_down_cover_non_tie_paths() {
+        assert_eq!(round_half_away_from_zero(1.4), 1.0);
+        assert_eq!(round_half_toward_zero(1.6), 2.0);
     }
 }


### PR DESCRIPTION
## Summary
- add locale-aware `to_uppercase` and `to_lowercase` to `ars-i18n` under both ICU4X and `web-intl`
- cover ICU4X and browser-backed locale-sensitive mappings, including Turkish, German, Lithuanian, Greek, and English
- add browser-executed wasm coverage for the `web-intl` case-mapping path

## Verification
- `cargo test -p ars-i18n`
- `cargo test -p ars-i18n --no-default-features --features web-intl`
- `cargo test -p ars-i18n --no-default-features --features web-intl --target wasm32-unknown-unknown --no-run`
- `cargo xtask coverage wasm --package ars-i18n --file /tmp/ars-i18n-web-intl-case.lcov --feature web-intl --no-default-features`
- `cargo xci`

Closes #133
Closes #142