### PR TITLE
Implement FocusZone and split ars-a11y focus module

### DIFF
--- a/crates/ars-a11y/src/announcements.rs
+++ b/crates/ars-a11y/src/announcements.rs
@@ -481,6 +481,14 @@ mod tests {
         };
 
         assert_eq!(
+            Announcements::search_results(0, &locale, &messages),
+            "Nenhum resultado (pt-BR)"
+        );
+        assert_eq!(
+            Announcements::search_results(1, &locale, &messages),
+            "1 resultado (pt-BR)"
+        );
+        assert_eq!(
             Announcements::search_results(3, &locale, &messages),
             "3 resultados (pt-BR)"
         );
@@ -489,16 +497,48 @@ mod tests {
             "Item A, selecionado (pt-BR)"
         );
         assert_eq!(
+            Announcements::selection_changed("Item A", false, &locale, &messages),
+            "Item A, desmarcado (pt-BR)"
+        );
+        assert_eq!(
             Announcements::validation_error("Email", "obrigatório", &locale, &messages),
             "Email: obrigatório. Erro (pt-BR)"
+        );
+        assert_eq!(
+            Announcements::loading(&locale, &messages),
+            "Carregando (pt-BR)"
+        );
+        assert_eq!(
+            Announcements::loading_complete(&locale, &messages),
+            "Carregamento concluído (pt-BR)"
         );
         assert_eq!(
             Announcements::item_moved("Linha 3", 2, 10, &locale, &messages),
             "Linha 3 movido para a posição 2 de 10 (pt-BR)"
         );
         assert_eq!(
+            Announcements::item_removed("Linha 3", &locale, &messages),
+            "Linha 3 removido (pt-BR)"
+        );
+        assert_eq!(
+            Announcements::column_sorted("Nome", AriaSort::Ascending, &locale, &messages),
+            "Nome, ordem crescente (pt-BR)"
+        );
+        assert_eq!(
             Announcements::column_sorted("Nome", AriaSort::Descending, &locale, &messages),
             "Nome, ordem decrescente (pt-BR)"
+        );
+        assert_eq!(
+            Announcements::column_sorted("Nome", AriaSort::Other, &locale, &messages),
+            "Nome, ordenado (pt-BR)"
+        );
+        assert_eq!(
+            Announcements::column_sorted("Nome", AriaSort::None, &locale, &messages),
+            "Nome, sem ordenação (pt-BR)"
+        );
+        assert_eq!(
+            Announcements::tree_node_expanded("Pasta", true, &locale, &messages),
+            "Pasta, expandido (pt-BR)"
         );
         assert_eq!(
             Announcements::tree_node_expanded("Pasta", false, &locale, &messages),

--- a/crates/ars-a11y/src/focus/mod.rs
+++ b/crates/ars-a11y/src/focus/mod.rs
@@ -1,0 +1,12 @@
+//! Shared focus-management contracts.
+
+/// Keyboard-modality-based focus-visible tracking.
+pub mod ring;
+/// Focus-scope options and strategy types.
+pub mod scope;
+/// Arrow-key navigation across composite widgets.
+pub mod zone;
+
+pub use ring::FocusRing;
+pub use scope::{FocusScopeBehavior, FocusScopeOptions, FocusStrategy, FocusTarget};
+pub use zone::{FocusZone, FocusZoneDirection, FocusZoneOptions};

--- a/crates/ars-a11y/src/focus/ring.rs
+++ b/crates/ars-a11y/src/focus/ring.rs
@@ -1,94 +1,8 @@
-//! Shared focus-management contracts.
+//! Keyboard-modality tracking for focus-visible styling.
 
 use core::sync::atomic::{AtomicBool, Ordering};
 
 use ars_core::{AttrMap, AttrValue, HtmlAttr, KeyModifiers, KeyboardKey};
-
-/// Options controlling [`FocusScopeBehavior`] implementations.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct FocusScopeOptions {
-    /// If true, Tab and Shift+Tab are prevented from leaving the scope.
-    pub contain: bool,
-    /// If true, focus is restored to the previously focused element when the scope deactivates.
-    pub restore_focus: bool,
-    /// If true, focus moves into the scope when it activates.
-    pub auto_focus: bool,
-}
-
-impl Default for FocusScopeOptions {
-    fn default() -> Self {
-        Self {
-            contain: false,
-            restore_focus: true,
-            auto_focus: true,
-        }
-    }
-}
-
-impl FocusScopeOptions {
-    /// Returns the preset used by modal overlays.
-    #[must_use]
-    pub const fn modal() -> Self {
-        Self {
-            contain: true,
-            restore_focus: true,
-            auto_focus: true,
-        }
-    }
-
-    /// Returns the preset used by non-modal overlays.
-    #[must_use]
-    pub const fn overlay() -> Self {
-        Self {
-            contain: false,
-            restore_focus: true,
-            auto_focus: true,
-        }
-    }
-
-    /// Returns the preset used by inline regions that do not manage focus lifecycle.
-    #[must_use]
-    pub const fn inline() -> Self {
-        Self {
-            contain: false,
-            restore_focus: false,
-            auto_focus: false,
-        }
-    }
-}
-
-/// Trait defining the public interface for focus-scope behavior.
-pub trait FocusScopeBehavior {
-    /// Activates the scope and optionally moves focus according to `focus_target`.
-    fn activate(&mut self, focus_target: FocusTarget);
-    /// Deactivates the scope and releases any focus management behavior.
-    fn deactivate(&mut self);
-    /// Returns whether the scope is currently active.
-    fn is_active(&self) -> bool;
-}
-
-/// Selects which element receives focus when a scope activates.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum FocusTarget {
-    /// Focus the first tabbable element.
-    First,
-    /// Focus the last tabbable element.
-    Last,
-    /// Focus the element explicitly marked for autofocus.
-    AutofocusMarked,
-    /// Focus the element that was previously active inside the scope.
-    PreviouslyActive,
-}
-
-/// Describes how a composite widget manages focus among its items.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub enum FocusStrategy {
-    /// Move DOM focus between items by toggling `tabindex` values.
-    #[default]
-    RovingTabindex,
-    /// Keep DOM focus on the container and expose the active item through `aria-activedescendant`.
-    ActiveDescendant,
-}
 
 /// Tracks whether the current focus should render a visible keyboard ring.
 ///
@@ -188,100 +102,17 @@ impl FocusRing {
 mod tests {
     use super::*;
 
-    #[derive(Debug, Default)]
-    struct TestFocusScope {
-        active: bool,
-        last_target: Option<FocusTarget>,
-    }
-
-    impl FocusScopeBehavior for TestFocusScope {
-        fn activate(&mut self, focus_target: FocusTarget) {
-            self.active = true;
-            self.last_target = Some(focus_target);
-        }
-
-        fn deactivate(&mut self) {
-            self.active = false;
-        }
-
-        fn is_active(&self) -> bool {
-            self.active
-        }
-    }
-
-    #[test]
-    fn focus_scope_options_default_matches_spec() {
-        assert_eq!(
-            FocusScopeOptions::default(),
-            FocusScopeOptions {
-                contain: false,
-                restore_focus: true,
-                auto_focus: true,
-            }
-        );
-    }
-
-    #[test]
-    fn focus_scope_option_presets_match_spec() {
-        assert_eq!(
-            FocusScopeOptions::modal(),
-            FocusScopeOptions {
-                contain: true,
-                restore_focus: true,
-                auto_focus: true,
-            }
-        );
-        assert_eq!(
-            FocusScopeOptions::overlay(),
-            FocusScopeOptions {
-                contain: false,
-                restore_focus: true,
-                auto_focus: true,
-            }
-        );
-        assert_eq!(
-            FocusScopeOptions::inline(),
-            FocusScopeOptions {
-                contain: false,
-                restore_focus: false,
-                auto_focus: false,
-            }
-        );
-    }
-
-    #[test]
-    fn focus_enums_support_equality_checks() {
-        assert_eq!(FocusTarget::AutofocusMarked, FocusTarget::AutofocusMarked);
-        assert_ne!(FocusTarget::First, FocusTarget::Last);
-        assert_eq!(FocusStrategy::default(), FocusStrategy::RovingTabindex);
-        assert_ne!(
-            FocusStrategy::RovingTabindex,
-            FocusStrategy::ActiveDescendant
-        );
-    }
-
-    #[test]
-    fn focus_scope_behavior_supports_trait_objects() {
-        let mut scope = TestFocusScope::default();
-        let behavior: &mut dyn FocusScopeBehavior = &mut scope;
-
-        behavior.activate(FocusTarget::PreviouslyActive);
-        assert!(behavior.is_active());
-        behavior.deactivate();
-        assert!(!behavior.is_active());
-
-        assert_eq!(scope.last_target, Some(FocusTarget::PreviouslyActive));
-    }
-
     #[test]
     fn focus_ring_starts_hidden() {
         let ring = FocusRing::new();
+
         assert!(!ring.should_show_focus_ring());
     }
 
     #[test]
     fn focus_ring_pointer_down_clears_focus_visible_state() {
         let ring = FocusRing::new();
+
         ring.on_key_down(KeyboardKey::Tab, KeyModifiers::default());
         assert!(ring.should_show_focus_ring());
 
@@ -323,6 +154,7 @@ mod tests {
                 ..KeyModifiers::default()
             },
         );
+
         assert!(!ring.should_show_focus_ring());
 
         ring.on_key_down(
@@ -332,6 +164,7 @@ mod tests {
                 ..KeyModifiers::default()
             },
         );
+
         assert!(!ring.should_show_focus_ring());
 
         ring.on_key_down(
@@ -341,6 +174,7 @@ mod tests {
                 ..KeyModifiers::default()
             },
         );
+
         assert!(!ring.should_show_focus_ring());
     }
 
@@ -353,8 +187,20 @@ mod tests {
     }
 
     #[test]
+    fn cloned_focus_ring_preserves_keyboard_modality_state() {
+        let ring = FocusRing::new();
+
+        ring.on_key_down(KeyboardKey::Tab, KeyModifiers::default());
+
+        let cloned = ring.clone();
+
+        assert!(cloned.should_show_focus_ring());
+    }
+
+    #[test]
     fn apply_focus_attrs_writes_and_clears_attribute_for_visible_focus() {
         let ring = FocusRing::new();
+
         let mut attrs = AttrMap::new();
 
         ring.on_pointer_down();
@@ -375,6 +221,7 @@ mod tests {
     #[test]
     fn apply_focus_attrs_uses_virtual_input_state() {
         let ring = FocusRing::new();
+
         let mut attrs = AttrMap::new();
 
         ring.on_virtual_input();

--- a/crates/ars-a11y/src/focus/scope.rs
+++ b/crates/ars-a11y/src/focus/scope.rs
@@ -1,0 +1,187 @@
+//! Focus-scope contracts shared between adapters and DOM utilities.
+
+/// Options controlling [`FocusScopeBehavior`] implementations.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FocusScopeOptions {
+    /// If true, Tab and Shift+Tab are prevented from leaving the scope.
+    pub contain: bool,
+
+    /// If true, focus is restored to the previously focused element when the scope deactivates.
+    pub restore_focus: bool,
+
+    /// If true, focus moves into the scope when it activates.
+    pub auto_focus: bool,
+}
+
+impl Default for FocusScopeOptions {
+    fn default() -> Self {
+        Self {
+            contain: false,
+            restore_focus: true,
+            auto_focus: true,
+        }
+    }
+}
+
+impl FocusScopeOptions {
+    /// Returns the preset used by modal overlays.
+    #[must_use]
+    pub const fn modal() -> Self {
+        Self {
+            contain: true,
+            restore_focus: true,
+            auto_focus: true,
+        }
+    }
+
+    /// Returns the preset used by non-modal overlays.
+    #[must_use]
+    pub const fn overlay() -> Self {
+        Self {
+            contain: false,
+            restore_focus: true,
+            auto_focus: true,
+        }
+    }
+
+    /// Returns the preset used by inline regions that do not manage focus lifecycle.
+    #[must_use]
+    pub const fn inline() -> Self {
+        Self {
+            contain: false,
+            restore_focus: false,
+            auto_focus: false,
+        }
+    }
+}
+
+/// Trait defining the public interface for focus-scope behavior.
+pub trait FocusScopeBehavior {
+    /// Activates the scope and optionally moves focus according to `focus_target`.
+    fn activate(&mut self, focus_target: FocusTarget);
+
+    /// Deactivates the scope and releases any focus management behavior.
+    fn deactivate(&mut self);
+
+    /// Returns whether the scope is currently active.
+    fn is_active(&self) -> bool;
+}
+
+/// Selects which element receives focus when a scope activates.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FocusTarget {
+    /// Focus the first tabbable element.
+    First,
+
+    /// Focus the last tabbable element.
+    Last,
+
+    /// Focus the element explicitly marked for autofocus.
+    AutofocusMarked,
+
+    /// Focus the element that was previously active inside the scope.
+    PreviouslyActive,
+}
+
+/// Describes how a composite widget manages focus among its items.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum FocusStrategy {
+    /// Move DOM focus between items by toggling `tabindex` values.
+    #[default]
+    RovingTabindex,
+
+    /// Keep DOM focus on the container and expose the active item through `aria-activedescendant`.
+    ActiveDescendant,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, Default)]
+    struct TestFocusScope {
+        active: bool,
+        last_target: Option<FocusTarget>,
+    }
+
+    impl FocusScopeBehavior for TestFocusScope {
+        fn activate(&mut self, focus_target: FocusTarget) {
+            self.active = true;
+            self.last_target = Some(focus_target);
+        }
+
+        fn deactivate(&mut self) {
+            self.active = false;
+        }
+
+        fn is_active(&self) -> bool {
+            self.active
+        }
+    }
+
+    #[test]
+    fn focus_scope_options_default_matches_spec() {
+        assert_eq!(
+            FocusScopeOptions::default(),
+            FocusScopeOptions {
+                contain: false,
+                restore_focus: true,
+                auto_focus: true,
+            }
+        );
+    }
+
+    #[test]
+    fn focus_scope_option_presets_match_spec() {
+        assert_eq!(
+            FocusScopeOptions::modal(),
+            FocusScopeOptions {
+                contain: true,
+                restore_focus: true,
+                auto_focus: true,
+            }
+        );
+        assert_eq!(
+            FocusScopeOptions::overlay(),
+            FocusScopeOptions {
+                contain: false,
+                restore_focus: true,
+                auto_focus: true,
+            }
+        );
+        assert_eq!(
+            FocusScopeOptions::inline(),
+            FocusScopeOptions {
+                contain: false,
+                restore_focus: false,
+                auto_focus: false,
+            }
+        );
+    }
+
+    #[test]
+    fn focus_enums_support_equality_checks() {
+        assert_eq!(FocusTarget::AutofocusMarked, FocusTarget::AutofocusMarked);
+        assert_ne!(FocusTarget::First, FocusTarget::Last);
+        assert_eq!(FocusStrategy::default(), FocusStrategy::RovingTabindex);
+        assert_ne!(
+            FocusStrategy::RovingTabindex,
+            FocusStrategy::ActiveDescendant
+        );
+    }
+
+    #[test]
+    fn focus_scope_behavior_supports_trait_objects() {
+        let mut scope = TestFocusScope::default();
+
+        let behavior: &mut dyn FocusScopeBehavior = &mut scope;
+
+        behavior.activate(FocusTarget::PreviouslyActive);
+        assert!(behavior.is_active());
+
+        behavior.deactivate();
+        assert!(!behavior.is_active());
+
+        assert_eq!(scope.last_target, Some(FocusTarget::PreviouslyActive));
+    }
+}

--- a/crates/ars-a11y/src/focus/zone.rs
+++ b/crates/ars-a11y/src/focus/zone.rs
@@ -177,19 +177,7 @@ impl FocusZone {
                 if matches!(self.options.direction, FocusZoneDirection::Grid { .. }) =>
             {
                 if let FocusZoneDirection::Grid { cols } = self.options.direction {
-                    let stride = cols.get();
-
-                    let mut candidate = self.active_index.checked_sub(stride);
-
-                    while let Some(target) = candidate {
-                        if !self.options.skip_disabled || !is_disabled(target) {
-                            break;
-                        }
-
-                        candidate = target.checked_sub(stride);
-                    }
-
-                    candidate.filter(|&target| !self.options.skip_disabled || !is_disabled(target))
+                    self.navigate_grid_vertical(cols.get(), false, &is_disabled)
                 } else {
                     None
                 }
@@ -199,24 +187,7 @@ impl FocusZone {
                 if matches!(self.options.direction, FocusZoneDirection::Grid { .. }) =>
             {
                 if let FocusZoneDirection::Grid { cols } = self.options.direction {
-                    let stride = cols.get();
-
-                    let mut target = self.active_index + stride;
-
-                    while target < self.item_count {
-                        if !self.options.skip_disabled || !is_disabled(target) {
-                            break;
-                        }
-                        target += stride;
-                    }
-
-                    if target < self.item_count
-                        && (!self.options.skip_disabled || !is_disabled(target))
-                    {
-                        Some(target)
-                    } else {
-                        None
-                    }
+                    self.navigate_grid_vertical(cols.get(), true, &is_disabled)
                 } else {
                     None
                 }
@@ -283,6 +254,56 @@ impl FocusZone {
             idx += delta;
         }
         None
+    }
+
+    fn navigate_grid_vertical(
+        &self,
+        stride: usize,
+        forward: bool,
+        is_disabled: &impl Fn(usize) -> bool,
+    ) -> Option<usize> {
+        let column = self.active_index % stride;
+        let mut current = self.active_index;
+
+        for _ in 0..self.item_count {
+            let candidate = if forward {
+                let next = current + stride;
+
+                if next < self.item_count {
+                    Some(next)
+                } else if self.options.wrap {
+                    Some(column)
+                } else {
+                    None
+                }
+            } else if current >= stride {
+                Some(current - stride)
+            } else if self.options.wrap {
+                Some(self.last_index_in_column(column, stride))
+            } else {
+                None
+            };
+
+            let candidate = candidate?;
+
+            if !self.options.skip_disabled || !is_disabled(candidate) {
+                return Some(candidate);
+            }
+
+            current = candidate;
+        }
+
+        None
+    }
+
+    const fn last_index_in_column(&self, column: usize, stride: usize) -> usize {
+        let mut index = column;
+
+        while index + stride < self.item_count {
+            index += stride;
+        }
+
+        index
     }
 
     /// Like `find_from`, but tests `start` itself before stepping.
@@ -491,6 +512,68 @@ mod tests {
         assert_eq!(
             zone.handle_key(KeyboardKey::ArrowDown, false, disabled_items(&[])),
             Some(7)
+        );
+    }
+
+    #[test]
+    fn grid_vertical_wrap_navigation_cycles_at_edges() {
+        let downward_zone = FocusZone {
+            options: FocusZoneOptions {
+                direction: FocusZoneDirection::grid(NonZero::new(3).expect("hardcoded nonzero")),
+                ..FocusZoneOptions::default()
+            },
+            active_index: 7,
+            item_count: 9,
+        };
+
+        let upward_zone = FocusZone {
+            options: FocusZoneOptions {
+                direction: FocusZoneDirection::grid(NonZero::new(3).expect("hardcoded nonzero")),
+                ..FocusZoneOptions::default()
+            },
+            active_index: 1,
+            item_count: 9,
+        };
+
+        assert_eq!(
+            downward_zone.handle_key(KeyboardKey::ArrowDown, false, disabled_items(&[])),
+            Some(1)
+        );
+        assert_eq!(
+            upward_zone.handle_key(KeyboardKey::ArrowUp, false, disabled_items(&[])),
+            Some(7)
+        );
+    }
+
+    #[test]
+    fn grid_vertical_no_wrap_returns_none_at_boundary() {
+        let downward_zone = FocusZone {
+            options: FocusZoneOptions {
+                direction: FocusZoneDirection::grid(NonZero::new(3).expect("hardcoded nonzero")),
+                wrap: false,
+                ..FocusZoneOptions::default()
+            },
+            active_index: 7,
+            item_count: 9,
+        };
+
+        let upward_zone = FocusZone {
+            options: FocusZoneOptions {
+                direction: FocusZoneDirection::grid(NonZero::new(3).expect("hardcoded nonzero")),
+                wrap: false,
+                ..FocusZoneOptions::default()
+            },
+            active_index: 1,
+            item_count: 9,
+        };
+
+        assert_eq!(
+            downward_zone.handle_key(KeyboardKey::ArrowDown, false, disabled_items(&[])),
+            None
+        );
+        assert_eq!(
+            upward_zone.handle_key(KeyboardKey::ArrowUp, false, disabled_items(&[])),
+            None
         );
     }
 
@@ -706,6 +789,23 @@ mod tests {
         assert_eq!(
             upward_zone.handle_key(KeyboardKey::ArrowUp, false, disabled_items(&[3])),
             Some(0)
+        );
+    }
+
+    #[test]
+    fn grid_vertical_wrap_skips_disabled_rows_after_wrapping() {
+        let zone = FocusZone {
+            options: FocusZoneOptions {
+                direction: FocusZoneDirection::grid(NonZero::new(3).expect("hardcoded nonzero")),
+                ..FocusZoneOptions::default()
+            },
+            active_index: 7,
+            item_count: 9,
+        };
+
+        assert_eq!(
+            zone.handle_key(KeyboardKey::ArrowDown, false, disabled_items(&[1])),
+            Some(4)
         );
     }
 

--- a/crates/ars-a11y/src/focus/zone.rs
+++ b/crates/ars-a11y/src/focus/zone.rs
@@ -1,0 +1,723 @@
+//! Arrow-key navigation for composite widgets.
+
+use core::num::NonZero;
+
+use ars_core::KeyboardKey;
+
+/// Configuration for a `FocusZone`.
+#[derive(Clone, Debug)]
+pub struct FocusZoneOptions {
+    /// Axis of arrow-key navigation.
+    pub direction: FocusZoneDirection,
+
+    /// If true, pressing ArrowRight/Down at the last item wraps to the first.
+    pub wrap: bool,
+
+    /// If true, use roving tabindex strategy (only one item has tabindex=0).
+    /// If false, use aria-activedescendant strategy.
+    /// Corresponds to `FocusStrategy::RovingTabindex` (true) vs
+    /// `FocusStrategy::ActiveDescendant` (false) — see §3.2.
+    pub roving_tabindex: bool,
+
+    /// If true, Home/End keys move to first/last item.
+    pub home_end: bool,
+
+    /// If true, PageUp/PageDown are active (useful for long lists).
+    pub page_navigation: bool,
+
+    /// Number of items to skip per PageUp/PageDown.
+    pub page_size: NonZero<usize>,
+
+    /// If true, disabled items are skipped during arrow-key navigation within
+    /// the focus zone. Note: this controls arrow-key traversal only — disabled
+    /// items remain in the Tab order per §13 (disabled elements stay focusable).
+    ///
+    /// Per-component guidance:
+    ///   - `RadioGroup`, `Tabs`: SHOULD set `skip_disabled: false` to match APG
+    ///     guidance that disabled options remain discoverable via arrow keys.
+    ///   - Menu, Listbox: MAY keep `true` (default) since disabled items are
+    ///     announced by screen readers but not interactable.
+    pub skip_disabled: bool,
+}
+
+impl Default for FocusZoneOptions {
+    fn default() -> Self {
+        Self {
+            direction: FocusZoneDirection::Vertical,
+            wrap: true,
+            roving_tabindex: true,
+            home_end: true,
+            page_navigation: false,
+            page_size: NonZero::new(10).expect("hardcoded nonzero"),
+            skip_disabled: true,
+        }
+    }
+}
+
+/// Axes supported by the focus-zone navigation engine.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FocusZoneDirection {
+    /// Arrow Up/Down navigate; Arrow Left/Right are not intercepted.
+    Vertical,
+    /// Arrow Left/Right navigate; Arrow Up/Down are not intercepted.
+    Horizontal,
+    /// All four arrow keys navigate in a 2D grid.
+    Grid {
+        /// Number of columns in the grid.
+        cols: NonZero<usize>,
+    },
+    /// Arrow Left/Right AND Up/Down navigate in a single-dimension flat list.
+    /// All four arrow keys step +/- 1, with Left/Right flipped in RTL mode.
+    /// This is NOT a 2D grid — use `Grid { cols }` for 2D navigation.
+    /// Wrapping from the first item on `ArrowUp` to the last item (and vice versa)
+    /// is controlled by `FocusZoneOptions::wrap` and is intentional for flat lists.
+    Both,
+}
+
+impl FocusZoneDirection {
+    /// Creates a `Grid` direction with the given non-zero column count.
+    #[must_use]
+    pub const fn grid(cols: NonZero<usize>) -> Self {
+        Self::Grid { cols }
+    }
+}
+
+/// A managed set of items navigable via arrow keys.
+/// Used in the context of a component's machine context.
+#[derive(Debug)]
+pub struct FocusZone {
+    /// Focus-zone behavior flags and navigation mode.
+    pub options: FocusZoneOptions,
+    /// Index of the currently active/focused item.
+    pub active_index: usize,
+    /// Total number of items (may be computed from a collection).
+    pub item_count: usize,
+}
+
+impl FocusZone {
+    /// Creates a focus zone with the given options and item count.
+    #[must_use]
+    pub const fn new(options: FocusZoneOptions, item_count: usize) -> Self {
+        Self {
+            options,
+            active_index: 0,
+            item_count,
+        }
+    }
+
+    /// Process a navigation key and return the new active index (if changed).
+    ///
+    /// Returns `Some(new_index)` if navigation occurred, `None` if the key is not handled.
+    pub fn handle_key(
+        &self,
+        key: KeyboardKey,
+        is_rtl: bool,
+        is_disabled: impl Fn(usize) -> bool,
+    ) -> Option<usize> {
+        if self.item_count == 0 {
+            return None;
+        }
+
+        let (prev_key, next_key) = match self.options.direction {
+            FocusZoneDirection::Vertical => (KeyboardKey::ArrowUp, KeyboardKey::ArrowDown),
+
+            FocusZoneDirection::Horizontal => {
+                if is_rtl {
+                    (KeyboardKey::ArrowRight, KeyboardKey::ArrowLeft)
+                } else {
+                    (KeyboardKey::ArrowLeft, KeyboardKey::ArrowRight)
+                }
+            }
+
+            FocusZoneDirection::Both | FocusZoneDirection::Grid { .. } => {
+                (KeyboardKey::ArrowUp, KeyboardKey::ArrowDown)
+            }
+        };
+
+        let (h_prev_key, h_next_key) = if is_rtl {
+            (KeyboardKey::ArrowRight, KeyboardKey::ArrowLeft)
+        } else {
+            (KeyboardKey::ArrowLeft, KeyboardKey::ArrowRight)
+        };
+
+        let next = match key {
+            k if k == prev_key
+                && !matches!(self.options.direction, FocusZoneDirection::Grid { .. }) =>
+            {
+                self.navigate(-1, &is_disabled)
+            }
+
+            k if k == next_key
+                && !matches!(self.options.direction, FocusZoneDirection::Grid { .. }) =>
+            {
+                self.navigate(1, &is_disabled)
+            }
+
+            k if matches!(self.options.direction, FocusZoneDirection::Both) && k == h_prev_key => {
+                self.navigate(-1, &is_disabled)
+            }
+
+            k if matches!(self.options.direction, FocusZoneDirection::Both) && k == h_next_key => {
+                self.navigate(1, &is_disabled)
+            }
+
+            k if matches!(self.options.direction, FocusZoneDirection::Grid { .. })
+                && k == h_prev_key =>
+            {
+                self.navigate(-1, &is_disabled)
+            }
+
+            k if matches!(self.options.direction, FocusZoneDirection::Grid { .. })
+                && k == h_next_key =>
+            {
+                self.navigate(1, &is_disabled)
+            }
+
+            KeyboardKey::ArrowUp
+                if matches!(self.options.direction, FocusZoneDirection::Grid { .. }) =>
+            {
+                if let FocusZoneDirection::Grid { cols } = self.options.direction {
+                    let stride = cols.get();
+
+                    let mut candidate = self.active_index.checked_sub(stride);
+
+                    while let Some(target) = candidate {
+                        if !self.options.skip_disabled || !is_disabled(target) {
+                            break;
+                        }
+
+                        candidate = target.checked_sub(stride);
+                    }
+
+                    candidate.filter(|&target| !self.options.skip_disabled || !is_disabled(target))
+                } else {
+                    None
+                }
+            }
+
+            KeyboardKey::ArrowDown
+                if matches!(self.options.direction, FocusZoneDirection::Grid { .. }) =>
+            {
+                if let FocusZoneDirection::Grid { cols } = self.options.direction {
+                    let stride = cols.get();
+
+                    let mut target = self.active_index + stride;
+
+                    while target < self.item_count {
+                        if !self.options.skip_disabled || !is_disabled(target) {
+                            break;
+                        }
+                        target += stride;
+                    }
+
+                    if target < self.item_count
+                        && (!self.options.skip_disabled || !is_disabled(target))
+                    {
+                        Some(target)
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            }
+
+            KeyboardKey::Home if self.options.home_end => {
+                self.find_from_inclusive(0, 1, &is_disabled)
+            }
+
+            KeyboardKey::End if self.options.home_end => {
+                let last = self.item_count.saturating_sub(1);
+
+                self.find_from_inclusive(last, -1, &is_disabled)
+            }
+
+            KeyboardKey::PageDown if self.options.page_navigation => {
+                let target = (self.active_index + self.options.page_size.get())
+                    .min(self.item_count.saturating_sub(1));
+
+                self.find_from_inclusive(target, 1, &is_disabled)
+            }
+
+            KeyboardKey::PageUp if self.options.page_navigation => {
+                let target = self
+                    .active_index
+                    .saturating_sub(self.options.page_size.get());
+
+                self.find_from_inclusive(target, -1, &is_disabled)
+            }
+            _ => None,
+        };
+
+        next.filter(|&idx| idx != self.active_index)
+    }
+
+    fn navigate(&self, delta: i32, is_disabled: &impl Fn(usize) -> bool) -> Option<usize> {
+        self.find_from(self.active_index, delta, is_disabled)
+    }
+
+    fn find_from(
+        &self,
+        start: usize,
+        delta: i32,
+        is_disabled: &impl Fn(usize) -> bool,
+    ) -> Option<usize> {
+        let count =
+            i32::try_from(self.item_count).expect("FocusZone supports up to i32::MAX items");
+
+        let mut idx = start as i32 + delta;
+
+        for _ in 0..self.item_count {
+            if self.options.wrap {
+                idx = idx.rem_euclid(count);
+            } else if idx < 0 || idx >= count {
+                return None;
+            }
+
+            let candidate = idx as usize;
+
+            if !self.options.skip_disabled || !is_disabled(candidate) {
+                return Some(candidate);
+            }
+
+            idx += delta;
+        }
+        None
+    }
+
+    /// Like `find_from`, but tests `start` itself before stepping.
+    /// Used by Home/End to ensure the boundary index is evaluated.
+    fn find_from_inclusive(
+        &self,
+        start: usize,
+        delta: i32,
+        is_disabled: &impl Fn(usize) -> bool,
+    ) -> Option<usize> {
+        if !self.options.skip_disabled || !is_disabled(start) {
+            return Some(start);
+        }
+
+        self.find_from(start, delta, is_disabled)
+    }
+
+    /// Generate tabindex value for an item at the given index.
+    /// In roving tabindex mode: 0 for active, -1 for all others.
+    /// In non-roving mode: all items get tabindex -1 (aria-activedescendant is used).
+    #[must_use]
+    pub const fn tabindex_for(&self, index: usize) -> i32 {
+        if self.options.roving_tabindex {
+            if index == self.active_index { 0 } else { -1 }
+        } else {
+            -1
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn disabled_items(indices: &[usize]) -> impl Fn(usize) -> bool + '_ {
+        move |index| indices.contains(&index)
+    }
+
+    #[test]
+    fn focus_zone_options_default_matches_spec_defaults() {
+        let options = FocusZoneOptions::default();
+
+        assert_eq!(options.direction, FocusZoneDirection::Vertical);
+        assert!(options.wrap);
+        assert!(options.roving_tabindex);
+        assert!(options.home_end);
+        assert!(!options.page_navigation);
+        assert_eq!(options.page_size.get(), 10);
+        assert!(options.skip_disabled);
+    }
+
+    #[test]
+    fn focus_zone_new_starts_at_index_zero() {
+        let options = FocusZoneOptions {
+            direction: FocusZoneDirection::Both,
+            ..FocusZoneOptions::default()
+        };
+
+        let zone = FocusZone::new(options.clone(), 7);
+
+        assert_eq!(zone.options.direction, FocusZoneDirection::Both);
+        assert_eq!(zone.active_index, 0);
+        assert_eq!(zone.item_count, 7);
+    }
+
+    #[test]
+    fn handle_key_returns_none_for_empty_zone() {
+        let zone = FocusZone::new(FocusZoneOptions::default(), 0);
+
+        assert_eq!(
+            zone.handle_key(KeyboardKey::ArrowDown, false, disabled_items(&[])),
+            None
+        );
+    }
+
+    #[test]
+    fn vertical_zone_arrow_keys_move_by_one() {
+        let zone = FocusZone {
+            options: FocusZoneOptions::default(),
+            active_index: 1,
+            item_count: 4,
+        };
+
+        assert_eq!(
+            zone.handle_key(KeyboardKey::ArrowDown, false, disabled_items(&[])),
+            Some(2)
+        );
+        assert_eq!(
+            zone.handle_key(KeyboardKey::ArrowUp, false, disabled_items(&[])),
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn horizontal_zone_is_rtl_aware() {
+        let zone = FocusZone {
+            options: FocusZoneOptions {
+                direction: FocusZoneDirection::Horizontal,
+                ..FocusZoneOptions::default()
+            },
+            active_index: 1,
+            item_count: 4,
+        };
+
+        assert_eq!(
+            zone.handle_key(KeyboardKey::ArrowRight, false, disabled_items(&[])),
+            Some(2)
+        );
+        assert_eq!(
+            zone.handle_key(KeyboardKey::ArrowLeft, false, disabled_items(&[])),
+            Some(0)
+        );
+        assert_eq!(
+            zone.handle_key(KeyboardKey::ArrowLeft, true, disabled_items(&[])),
+            Some(2)
+        );
+        assert_eq!(
+            zone.handle_key(KeyboardKey::ArrowRight, true, disabled_items(&[])),
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn handle_key_returns_none_for_unhandled_key() {
+        let zone = FocusZone::new(FocusZoneOptions::default(), 4);
+
+        assert_eq!(
+            zone.handle_key(KeyboardKey::Enter, false, disabled_items(&[])),
+            None
+        );
+    }
+
+    #[test]
+    fn both_mode_uses_all_four_arrows_as_flat_list_navigation() {
+        let zone = FocusZone {
+            options: FocusZoneOptions {
+                direction: FocusZoneDirection::Both,
+                ..FocusZoneOptions::default()
+            },
+            active_index: 1,
+            item_count: 4,
+        };
+
+        assert_eq!(
+            zone.handle_key(KeyboardKey::ArrowUp, false, disabled_items(&[])),
+            Some(0)
+        );
+        assert_eq!(
+            zone.handle_key(KeyboardKey::ArrowDown, false, disabled_items(&[])),
+            Some(2)
+        );
+        assert_eq!(
+            zone.handle_key(KeyboardKey::ArrowLeft, false, disabled_items(&[])),
+            Some(0)
+        );
+        assert_eq!(
+            zone.handle_key(KeyboardKey::ArrowRight, false, disabled_items(&[])),
+            Some(2)
+        );
+    }
+
+    #[test]
+    fn both_mode_horizontal_keys_flip_in_rtl() {
+        let zone = FocusZone {
+            options: FocusZoneOptions {
+                direction: FocusZoneDirection::Both,
+                ..FocusZoneOptions::default()
+            },
+            active_index: 1,
+            item_count: 4,
+        };
+
+        assert_eq!(
+            zone.handle_key(KeyboardKey::ArrowLeft, true, disabled_items(&[])),
+            Some(2)
+        );
+        assert_eq!(
+            zone.handle_key(KeyboardKey::ArrowRight, true, disabled_items(&[])),
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn grid_mode_uses_horizontal_and_vertical_strides() {
+        let zone = FocusZone {
+            options: FocusZoneOptions {
+                direction: FocusZoneDirection::grid(NonZero::new(3).expect("hardcoded nonzero")),
+                ..FocusZoneOptions::default()
+            },
+            active_index: 4,
+            item_count: 9,
+        };
+
+        assert_eq!(
+            zone.handle_key(KeyboardKey::ArrowLeft, false, disabled_items(&[])),
+            Some(3)
+        );
+        assert_eq!(
+            zone.handle_key(KeyboardKey::ArrowRight, false, disabled_items(&[])),
+            Some(5)
+        );
+        assert_eq!(
+            zone.handle_key(KeyboardKey::ArrowUp, false, disabled_items(&[])),
+            Some(1)
+        );
+        assert_eq!(
+            zone.handle_key(KeyboardKey::ArrowDown, false, disabled_items(&[])),
+            Some(7)
+        );
+    }
+
+    #[test]
+    fn grid_horizontal_keys_flip_in_rtl() {
+        let zone = FocusZone {
+            options: FocusZoneOptions {
+                direction: FocusZoneDirection::grid(NonZero::new(3).expect("hardcoded nonzero")),
+                ..FocusZoneOptions::default()
+            },
+            active_index: 4,
+            item_count: 9,
+        };
+
+        assert_eq!(
+            zone.handle_key(KeyboardKey::ArrowRight, true, disabled_items(&[])),
+            Some(3)
+        );
+        assert_eq!(
+            zone.handle_key(KeyboardKey::ArrowLeft, true, disabled_items(&[])),
+            Some(5)
+        );
+    }
+
+    #[test]
+    fn wrap_navigation_cycles_at_edges() {
+        let zone = FocusZone {
+            options: FocusZoneOptions::default(),
+            active_index: 3,
+            item_count: 4,
+        };
+
+        let reverse_zone = FocusZone {
+            options: FocusZoneOptions::default(),
+            active_index: 0,
+            item_count: 4,
+        };
+
+        assert_eq!(
+            zone.handle_key(KeyboardKey::ArrowDown, false, disabled_items(&[])),
+            Some(0)
+        );
+        assert_eq!(
+            reverse_zone.handle_key(KeyboardKey::ArrowUp, false, disabled_items(&[])),
+            Some(3)
+        );
+    }
+
+    #[test]
+    fn no_wrap_returns_none_at_boundary() {
+        let zone = FocusZone {
+            options: FocusZoneOptions {
+                wrap: false,
+                ..FocusZoneOptions::default()
+            },
+            active_index: 3,
+            item_count: 4,
+        };
+
+        assert_eq!(
+            zone.handle_key(KeyboardKey::ArrowDown, false, disabled_items(&[])),
+            None
+        );
+    }
+
+    #[test]
+    fn handle_key_returns_none_when_navigation_keeps_same_index() {
+        let zone = FocusZone {
+            options: FocusZoneOptions::default(),
+            active_index: 0,
+            item_count: 4,
+        };
+
+        assert_eq!(
+            zone.handle_key(KeyboardKey::Home, false, disabled_items(&[])),
+            None
+        );
+    }
+
+    #[test]
+    fn skip_disabled_traverses_multiple_consecutive_disabled_items() {
+        let zone = FocusZone {
+            options: FocusZoneOptions::default(),
+            active_index: 0,
+            item_count: 5,
+        };
+
+        assert_eq!(
+            zone.handle_key(KeyboardKey::ArrowDown, false, disabled_items(&[1, 2])),
+            Some(3)
+        );
+    }
+
+    #[test]
+    fn returns_none_when_all_reachable_items_are_disabled() {
+        let zone = FocusZone {
+            options: FocusZoneOptions::default(),
+            active_index: 0,
+            item_count: 3,
+        };
+
+        assert_eq!(
+            zone.handle_key(KeyboardKey::ArrowDown, false, disabled_items(&[0, 1, 2])),
+            None
+        );
+    }
+
+    #[test]
+    fn skip_disabled_false_allows_disabled_items_to_receive_focus() {
+        let zone = FocusZone {
+            options: FocusZoneOptions {
+                skip_disabled: false,
+                ..FocusZoneOptions::default()
+            },
+            active_index: 0,
+            item_count: 4,
+        };
+
+        assert_eq!(
+            zone.handle_key(KeyboardKey::ArrowDown, false, disabled_items(&[1])),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn home_and_end_land_on_first_and_last_non_disabled_items() {
+        let zone = FocusZone {
+            options: FocusZoneOptions::default(),
+            active_index: 4,
+            item_count: 5,
+        };
+
+        assert_eq!(
+            zone.handle_key(KeyboardKey::Home, false, disabled_items(&[0, 1])),
+            Some(2)
+        );
+        assert_eq!(
+            zone.handle_key(KeyboardKey::End, false, disabled_items(&[4])),
+            Some(3)
+        );
+    }
+
+    #[test]
+    fn page_navigation_jumps_by_page_size() {
+        let zone = FocusZone {
+            options: FocusZoneOptions {
+                page_navigation: true,
+                page_size: NonZero::new(3).expect("hardcoded nonzero"),
+                ..FocusZoneOptions::default()
+            },
+            active_index: 4,
+            item_count: 10,
+        };
+
+        assert_eq!(
+            zone.handle_key(KeyboardKey::PageDown, false, disabled_items(&[])),
+            Some(7)
+        );
+        assert_eq!(
+            zone.handle_key(KeyboardKey::PageUp, false, disabled_items(&[])),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn tabindex_for_matches_roving_and_activedescendant_modes() {
+        let roving = FocusZone {
+            options: FocusZoneOptions::default(),
+            active_index: 2,
+            item_count: 4,
+        };
+
+        let activedescendant = FocusZone {
+            options: FocusZoneOptions {
+                roving_tabindex: false,
+                ..FocusZoneOptions::default()
+            },
+            active_index: 2,
+            item_count: 4,
+        };
+
+        assert_eq!(roving.tabindex_for(2), 0);
+        assert_eq!(roving.tabindex_for(1), -1);
+        assert_eq!(activedescendant.tabindex_for(2), -1);
+        assert_eq!(activedescendant.tabindex_for(1), -1);
+    }
+
+    #[test]
+    fn grid_vertical_navigation_skips_disabled_rows() {
+        let zone = FocusZone {
+            options: FocusZoneOptions {
+                direction: FocusZoneDirection::grid(NonZero::new(3).expect("hardcoded nonzero")),
+                ..FocusZoneOptions::default()
+            },
+            active_index: 0,
+            item_count: 9,
+        };
+
+        assert_eq!(
+            zone.handle_key(KeyboardKey::ArrowDown, false, disabled_items(&[3, 6])),
+            None
+        );
+
+        let upward_zone = FocusZone {
+            options: FocusZoneOptions {
+                direction: FocusZoneDirection::grid(NonZero::new(3).expect("hardcoded nonzero")),
+                ..FocusZoneOptions::default()
+            },
+            active_index: 6,
+            item_count: 9,
+        };
+
+        assert_eq!(
+            upward_zone.handle_key(KeyboardKey::ArrowUp, false, disabled_items(&[3])),
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn focus_zone_direction_grid_preserves_column_count() {
+        let direction = FocusZoneDirection::grid(NonZero::new(4).expect("hardcoded nonzero"));
+
+        assert_eq!(
+            direction,
+            FocusZoneDirection::Grid {
+                cols: NonZero::new(4).expect("hardcoded nonzero")
+            }
+        );
+    }
+}

--- a/crates/ars-a11y/src/focus/zone.rs
+++ b/crates/ars-a11y/src/focus/zone.rs
@@ -164,13 +164,21 @@ impl FocusZone {
             k if matches!(self.options.direction, FocusZoneDirection::Grid { .. })
                 && k == h_prev_key =>
             {
-                self.navigate(-1, &is_disabled)
+                if let FocusZoneDirection::Grid { cols } = self.options.direction {
+                    self.navigate_grid_horizontal(cols.get(), false, &is_disabled)
+                } else {
+                    None
+                }
             }
 
             k if matches!(self.options.direction, FocusZoneDirection::Grid { .. })
                 && k == h_next_key =>
             {
-                self.navigate(1, &is_disabled)
+                if let FocusZoneDirection::Grid { cols } = self.options.direction {
+                    self.navigate_grid_horizontal(cols.get(), true, &is_disabled)
+                } else {
+                    None
+                }
             }
 
             KeyboardKey::ArrowUp
@@ -296,6 +304,45 @@ impl FocusZone {
         None
     }
 
+    fn navigate_grid_horizontal(
+        &self,
+        stride: usize,
+        forward: bool,
+        is_disabled: &impl Fn(usize) -> bool,
+    ) -> Option<usize> {
+        let row_start = (self.active_index / stride) * stride;
+        let row_end = self.last_index_in_row(row_start, stride);
+        let mut current = self.active_index;
+
+        for _ in row_start..=row_end {
+            let candidate = if forward {
+                if current < row_end {
+                    Some(current + 1)
+                } else if self.options.wrap {
+                    Some(row_start)
+                } else {
+                    None
+                }
+            } else if current > row_start {
+                Some(current - 1)
+            } else if self.options.wrap {
+                Some(row_end)
+            } else {
+                None
+            };
+
+            let candidate = candidate?;
+
+            if !self.options.skip_disabled || !is_disabled(candidate) {
+                return Some(candidate);
+            }
+
+            current = candidate;
+        }
+
+        None
+    }
+
     const fn last_index_in_column(&self, column: usize, stride: usize) -> usize {
         let mut index = column;
 
@@ -304,6 +351,16 @@ impl FocusZone {
         }
 
         index
+    }
+
+    const fn last_index_in_row(&self, row_start: usize, stride: usize) -> usize {
+        let row_end = row_start + stride - 1;
+
+        if row_end < self.item_count {
+            row_end
+        } else {
+            self.item_count - 1
+        }
     }
 
     /// Like `find_from`, but tests `start` itself before stepping.
@@ -595,6 +652,85 @@ mod tests {
         assert_eq!(
             zone.handle_key(KeyboardKey::ArrowLeft, true, disabled_items(&[])),
             Some(5)
+        );
+    }
+
+    #[test]
+    fn grid_horizontal_navigation_stays_within_the_row() {
+        let right_edge = FocusZone {
+            options: FocusZoneOptions {
+                direction: FocusZoneDirection::grid(NonZero::new(3).expect("hardcoded nonzero")),
+                wrap: false,
+                ..FocusZoneOptions::default()
+            },
+            active_index: 2,
+            item_count: 9,
+        };
+
+        let left_edge = FocusZone {
+            options: FocusZoneOptions {
+                direction: FocusZoneDirection::grid(NonZero::new(3).expect("hardcoded nonzero")),
+                wrap: false,
+                ..FocusZoneOptions::default()
+            },
+            active_index: 3,
+            item_count: 9,
+        };
+
+        assert_eq!(
+            right_edge.handle_key(KeyboardKey::ArrowRight, false, disabled_items(&[])),
+            None
+        );
+        assert_eq!(
+            left_edge.handle_key(KeyboardKey::ArrowLeft, false, disabled_items(&[])),
+            None
+        );
+    }
+
+    #[test]
+    fn grid_horizontal_wrap_navigation_cycles_within_the_row() {
+        let right_edge = FocusZone {
+            options: FocusZoneOptions {
+                direction: FocusZoneDirection::grid(NonZero::new(3).expect("hardcoded nonzero")),
+                ..FocusZoneOptions::default()
+            },
+            active_index: 2,
+            item_count: 9,
+        };
+
+        let left_edge = FocusZone {
+            options: FocusZoneOptions {
+                direction: FocusZoneDirection::grid(NonZero::new(3).expect("hardcoded nonzero")),
+                ..FocusZoneOptions::default()
+            },
+            active_index: 3,
+            item_count: 9,
+        };
+
+        assert_eq!(
+            right_edge.handle_key(KeyboardKey::ArrowRight, false, disabled_items(&[])),
+            Some(0)
+        );
+        assert_eq!(
+            left_edge.handle_key(KeyboardKey::ArrowLeft, false, disabled_items(&[])),
+            Some(5)
+        );
+    }
+
+    #[test]
+    fn grid_horizontal_wrap_skips_disabled_cells_within_the_row() {
+        let zone = FocusZone {
+            options: FocusZoneOptions {
+                direction: FocusZoneDirection::grid(NonZero::new(3).expect("hardcoded nonzero")),
+                ..FocusZoneOptions::default()
+            },
+            active_index: 2,
+            item_count: 9,
+        };
+
+        assert_eq!(
+            zone.handle_key(KeyboardKey::ArrowRight, false, disabled_items(&[0])),
+            Some(1)
         );
     }
 

--- a/crates/ars-a11y/src/focus/zone.rs
+++ b/crates/ars-a11y/src/focus/zone.rs
@@ -215,7 +215,7 @@ impl FocusZone {
                 let target = (self.active_index + self.options.page_size.get())
                     .min(self.item_count.saturating_sub(1));
 
-                self.find_from_inclusive(target, 1, &is_disabled)
+                self.find_from_inclusive_no_wrap(target, 1, &is_disabled)
             }
 
             KeyboardKey::PageUp if self.options.page_navigation => {
@@ -223,7 +223,7 @@ impl FocusZone {
                     .active_index
                     .saturating_sub(self.options.page_size.get());
 
-                self.find_from_inclusive(target, -1, &is_disabled)
+                self.find_from_inclusive_no_wrap(target, -1, &is_disabled)
             }
             _ => None,
         };
@@ -376,6 +376,43 @@ impl FocusZone {
         }
 
         self.find_from(start, delta, is_disabled)
+    }
+
+    fn find_from_no_wrap(
+        &self,
+        start: usize,
+        delta: i32,
+        is_disabled: &impl Fn(usize) -> bool,
+    ) -> Option<usize> {
+        let count =
+            i32::try_from(self.item_count).expect("FocusZone supports up to i32::MAX items");
+
+        let mut idx = start as i32 + delta;
+
+        while idx >= 0 && idx < count {
+            let candidate = idx as usize;
+
+            if !self.options.skip_disabled || !is_disabled(candidate) {
+                return Some(candidate);
+            }
+
+            idx += delta;
+        }
+
+        None
+    }
+
+    fn find_from_inclusive_no_wrap(
+        &self,
+        start: usize,
+        delta: i32,
+        is_disabled: &impl Fn(usize) -> bool,
+    ) -> Option<usize> {
+        if !self.options.skip_disabled || !is_disabled(start) {
+            return Some(start);
+        }
+
+        self.find_from_no_wrap(start, delta, is_disabled)
     }
 
     /// Generate tabindex value for an item at the given index.
@@ -871,6 +908,38 @@ mod tests {
         assert_eq!(
             zone.handle_key(KeyboardKey::PageUp, false, disabled_items(&[])),
             Some(1)
+        );
+    }
+
+    #[test]
+    fn page_navigation_does_not_wrap_past_disabled_edges() {
+        let page_down_zone = FocusZone {
+            options: FocusZoneOptions {
+                page_navigation: true,
+                page_size: NonZero::new(3).expect("hardcoded nonzero"),
+                ..FocusZoneOptions::default()
+            },
+            active_index: 2,
+            item_count: 5,
+        };
+
+        let page_up_zone = FocusZone {
+            options: FocusZoneOptions {
+                page_navigation: true,
+                page_size: NonZero::new(3).expect("hardcoded nonzero"),
+                ..FocusZoneOptions::default()
+            },
+            active_index: 2,
+            item_count: 5,
+        };
+
+        assert_eq!(
+            page_down_zone.handle_key(KeyboardKey::PageDown, false, disabled_items(&[4])),
+            None
+        );
+        assert_eq!(
+            page_up_zone.handle_key(KeyboardKey::PageUp, false, disabled_items(&[0])),
+            None
         );
     }
 

--- a/crates/ars-a11y/src/lib.rs
+++ b/crates/ars-a11y/src/lib.rs
@@ -32,7 +32,10 @@ pub use aria::{
     role::AriaRole,
     state::{set_busy, set_checked, set_disabled, set_expanded, set_invalid, set_selected},
 };
-pub use focus::{FocusRing, FocusScopeBehavior, FocusScopeOptions, FocusStrategy, FocusTarget};
+pub use focus::{
+    FocusRing, FocusScopeBehavior, FocusScopeOptions, FocusStrategy, FocusTarget, FocusZone,
+    FocusZoneDirection, FocusZoneOptions,
+};
 pub use keyboard::{DomEvent, KeyModifiers, KeyboardShortcut, Platform};
 pub use label::{DescriptionConfig, FieldContext, LabelConfig};
 pub use visually_hidden::{

--- a/spec/foundation/03-accessibility.md
+++ b/spec/foundation/03-accessibility.md
@@ -1908,12 +1908,16 @@ impl FocusZone {
                 self.navigate(1, &is_disabled)
             }
 
-            // Horizontal axis for Grid mode (Left/Right navigate ±1 within the row)
+            // Horizontal axis for Grid mode (Left/Right navigate within the row)
             k if matches!(self.options.direction, FocusZoneDirection::Grid { .. }) && k == h_prev_key => {
-                self.navigate(-1, &is_disabled)
+                if let FocusZoneDirection::Grid { cols } = self.options.direction {
+                    self.navigate_grid_horizontal(cols.get(), false, &is_disabled)
+                } else { None }
             }
             k if matches!(self.options.direction, FocusZoneDirection::Grid { .. }) && k == h_next_key => {
-                self.navigate(1, &is_disabled)
+                if let FocusZoneDirection::Grid { cols } = self.options.direction {
+                    self.navigate_grid_horizontal(cols.get(), true, &is_disabled)
+                } else { None }
             }
 
             // Grid: Up/Down navigate by ±cols to move between rows.
@@ -2027,6 +2031,45 @@ impl FocusZone {
         None
     }
 
+    fn navigate_grid_horizontal(
+        &self,
+        stride: usize,
+        forward: bool,
+        is_disabled: &impl Fn(usize) -> bool,
+    ) -> Option<usize> {
+        let row_start = (self.active_index / stride) * stride;
+        let row_end = self.last_index_in_row(row_start, stride);
+        let mut current = self.active_index;
+
+        for _ in row_start..=row_end {
+            let candidate = if forward {
+                if current < row_end {
+                    Some(current + 1)
+                } else if self.options.wrap {
+                    Some(row_start)
+                } else {
+                    None
+                }
+            } else if current > row_start {
+                Some(current - 1)
+            } else if self.options.wrap {
+                Some(row_end)
+            } else {
+                None
+            };
+
+            let candidate = candidate?;
+
+            if !self.options.skip_disabled || !is_disabled(candidate) {
+                return Some(candidate);
+            }
+
+            current = candidate;
+        }
+
+        None
+    }
+
     fn last_index_in_column(&self, column: usize, stride: usize) -> usize {
         let mut index = column;
 
@@ -2035,6 +2078,11 @@ impl FocusZone {
         }
 
         index
+    }
+
+    fn last_index_in_row(&self, row_start: usize, stride: usize) -> usize {
+        let row_end = row_start + stride - 1;
+        if row_end < self.item_count { row_end } else { self.item_count - 1 }
     }
 
     /// Like `find_from`, but tests `start` itself before stepping.

--- a/spec/foundation/03-accessibility.md
+++ b/spec/foundation/03-accessibility.md
@@ -1948,13 +1948,13 @@ impl FocusZone {
                     .min(self.item_count.saturating_sub(1));
                 // Search forward (+1) from target (inclusive) to find nearest non-disabled item
                 // at or beyond the page target.
-                self.find_from_inclusive(target, 1, &is_disabled)
+                self.find_from_inclusive_no_wrap(target, 1, &is_disabled)
             }
             KeyboardKey::PageUp if self.options.page_navigation => {
                 let target = self.active_index.saturating_sub(self.options.page_size.get());
                 // Search backward (-1) from target (inclusive) to find nearest non-disabled item
                 // at or before the page target.
-                self.find_from_inclusive(target, -1, &is_disabled)
+                self.find_from_inclusive_no_wrap(target, -1, &is_disabled)
             }
             _ => None,
         };
@@ -2098,6 +2098,39 @@ impl FocusZone {
             return Some(start);
         }
         self.find_from(start, delta, is_disabled)
+    }
+
+    fn find_from_no_wrap(
+        &self,
+        start: usize,
+        delta: i32,
+        is_disabled: &impl Fn(usize) -> bool,
+    ) -> Option<usize> {
+        let count = i32::try_from(self.item_count).expect("FocusZone supports up to i32::MAX items");
+        let mut idx = start as i32 + delta;
+
+        while idx >= 0 && idx < count {
+            let candidate = idx as usize;
+            if !self.options.skip_disabled || !is_disabled(candidate) {
+                return Some(candidate);
+            }
+            idx += delta;
+        }
+
+        None
+    }
+
+    fn find_from_inclusive_no_wrap(
+        &self,
+        start: usize,
+        delta: i32,
+        is_disabled: &impl Fn(usize) -> bool,
+    ) -> Option<usize> {
+        if !self.options.skip_disabled || !is_disabled(start) {
+            return Some(start);
+        }
+
+        self.find_from_no_wrap(start, delta, is_disabled)
     }
 
     /// Generate tabindex value for an item at the given index.

--- a/spec/foundation/03-accessibility.md
+++ b/spec/foundation/03-accessibility.md
@@ -1917,36 +1917,16 @@ impl FocusZone {
             }
 
             // Grid: Up/Down navigate by ±cols to move between rows.
-            // Uses navigate_to_exact to land on the target or skip to next non-disabled.
+            // When wrapping is enabled, vertical navigation wraps within the
+            // current column instead of flattening into linear list order.
             KeyboardKey::ArrowUp if matches!(self.options.direction, FocusZoneDirection::Grid { .. }) => {
                 if let FocusZoneDirection::Grid { cols } = self.options.direction {
-                    let stride = cols.get();
-                    // Loop upward through rows until we find a non-disabled cell or run out
-                    let mut candidate = self.active_index.checked_sub(stride);
-                    while let Some(t) = candidate {
-                        if !self.options.skip_disabled || !is_disabled(t) {
-                            break;
-                        }
-                        candidate = t.checked_sub(stride);
-                    }
-                    candidate.filter(|&t| !self.options.skip_disabled || !is_disabled(t))
+                    self.navigate_grid_vertical(cols.get(), false, &is_disabled)
                 } else { None }
             }
             KeyboardKey::ArrowDown if matches!(self.options.direction, FocusZoneDirection::Grid { .. }) => {
                 if let FocusZoneDirection::Grid { cols } = self.options.direction {
-                    let stride = cols.get();
-                    // Loop downward through rows until we find a non-disabled cell or run out
-                    let mut target = self.active_index + stride;
-                    while target < self.item_count {
-                        if !self.options.skip_disabled || !is_disabled(target) {
-                            break;
-                        }
-                        target += stride;
-                    }
-                    if target < self.item_count
-                        && (!self.options.skip_disabled || !is_disabled(target)) {
-                        Some(target)
-                    } else { None }
+                    self.navigate_grid_vertical(cols.get(), true, &is_disabled)
                 } else { None }
             }
 
@@ -2006,6 +1986,55 @@ impl FocusZone {
             idx += delta;
         }
         None
+    }
+
+    fn navigate_grid_vertical(
+        &self,
+        stride: usize,
+        forward: bool,
+        is_disabled: &impl Fn(usize) -> bool,
+    ) -> Option<usize> {
+        let column = self.active_index % stride;
+        let mut current = self.active_index;
+
+        for _ in 0..self.item_count {
+            let candidate = if forward {
+                let next = current + stride;
+                if next < self.item_count {
+                    Some(next)
+                } else if self.options.wrap {
+                    Some(column)
+                } else {
+                    None
+                }
+            } else if current >= stride {
+                Some(current - stride)
+            } else if self.options.wrap {
+                Some(self.last_index_in_column(column, stride))
+            } else {
+                None
+            };
+
+            let candidate = candidate?;
+
+            if !self.options.skip_disabled || !is_disabled(candidate) {
+                return Some(candidate);
+            }
+
+            current = candidate;
+        }
+
+        None
+    }
+
+    fn last_index_in_column(&self, column: usize, stride: usize) -> usize {
+        let mut index = column;
+
+        while index + stride < self.item_count {
+            index += stride;
+        }
+
+        index
     }
 
     /// Like `find_from`, but tests `start` itself before stepping.

--- a/spec/foundation/03-accessibility.md
+++ b/spec/foundation/03-accessibility.md
@@ -1837,14 +1837,9 @@ pub enum FocusZoneDirection {
 }
 
 impl FocusZoneDirection {
-    /// Creates a `Grid` direction with the given column count.
-    ///
-    /// # Panics
-    /// Panics if `cols` is zero.
-    pub fn grid(cols: usize) -> Self {
-        Self::Grid {
-            cols: NonZero::new(cols).expect("grid must have at least one column"),
-        }
+    /// Creates a `Grid` direction with the given non-zero column count.
+    pub fn grid(cols: NonZero<usize>) -> Self {
+        Self::Grid { cols }
     }
 }
 
@@ -1879,14 +1874,7 @@ impl FocusZone {
             FocusZoneDirection::Horizontal => {
                 if is_rtl { (KeyboardKey::ArrowRight, KeyboardKey::ArrowLeft) } else { (KeyboardKey::ArrowLeft, KeyboardKey::ArrowRight) }
             }
-            FocusZoneDirection::Both => {
-                // Both axes: vertical uses Up/Down, horizontal uses Left/Right with RTL.
-                // Handled below in the extended match.
-                (KeyboardKey::ArrowUp, KeyboardKey::ArrowDown)
-            }
-            FocusZoneDirection::Grid { .. } => {
-                // Grid: vertical uses Up/Down, horizontal uses Left/Right with RTL.
-                // Handled below in the extended match.
+            FocusZoneDirection::Both | FocusZoneDirection::Grid { .. } => {
                 (KeyboardKey::ArrowUp, KeyboardKey::ArrowDown)
             }
         };


### PR DESCRIPTION
## Summary
- split `ars-a11y` focus into `focus/{mod,scope,ring,zone}.rs`
- implement `FocusZone` plus top-level re-exports and spec-aligned API updates
- add focused coverage improvements for focus and announcement paths

## Verification
- `cargo test -p ars-a11y`
- `cargo llvm-cov test -p ars-a11y --summary-only`
- `cargo xci`

Closes #150