### PR TITLE
Implement virtualizer core in ars-collections

### DIFF
--- a/crates/ars-collections/src/lib.rs
+++ b/crates/ars-collections/src/lib.rs
@@ -27,6 +27,11 @@
 //! - [`SortDescriptor`] — column + direction for table sorting.
 //! - [`CollectionError`] — error from an async page load.
 //! - [`typeahead`] — type-ahead / type-select state machine for keyboard search.
+//! - [`Virtualizer`] — visible-range and scroll math for virtualized rendering.
+//! - [`LayoutStrategy`] — sizing strategy used by [`Virtualizer`].
+//! - [`ScrollAlign`] — alignment mode for programmatic scrolling.
+//! - [`VirtualLayout`] — extension trait for custom vertical layout engines.
+//! - [`HorizontalVirtualLayout`] — optional extension trait for horizontal layout engines.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(clippy::std_instead_of_core)]
@@ -59,6 +64,10 @@ pub mod static_collection;
 pub mod tree_collection;
 /// Type-ahead / type-select state machine for keyboard search in collections.
 pub mod typeahead;
+/// Extension trait for custom virtualization layout engines.
+pub mod virtual_layout;
+/// Virtualized rendering range and scroll math.
+pub mod virtualization;
 
 pub use async_collection::{AsyncCollection, AsyncLoadingState};
 pub use async_loader::{AsyncLoader, CollectionError, LoadResult};
@@ -71,3 +80,5 @@ pub use selection::DisabledBehavior;
 pub use sorted_collection::{SortDescriptor, SortDirection, SortedCollection};
 pub use static_collection::StaticCollection;
 pub use tree_collection::{TreeCollection, TreeItemConfig};
+pub use virtual_layout::{HorizontalVirtualLayout, VirtualLayout};
+pub use virtualization::{LayoutStrategy, ScrollAlign, Virtualizer};

--- a/crates/ars-collections/src/virtual_layout.rs
+++ b/crates/ars-collections/src/virtual_layout.rs
@@ -51,11 +51,14 @@ pub trait HorizontalVirtualLayout: VirtualLayout {
 
 #[cfg(test)]
 mod tests {
-    use core::ops::Range;
+    use core::{cell::Cell, ops::Range};
 
     use super::{HorizontalVirtualLayout, VirtualLayout};
 
-    struct DummyLayout;
+    #[derive(Default)]
+    struct DummyLayout {
+        last_height_report: Cell<Option<(usize, f64)>>,
+    }
 
     impl VirtualLayout for DummyLayout {
         fn visible_range(&self, scroll_offset: f64, viewport_height: f64) -> Range<usize> {
@@ -72,7 +75,7 @@ mod tests {
         }
 
         fn report_item_height(&mut self, index: usize, height: f64) {
-            let _ = (index, height);
+            self.last_height_report.set(Some((index, height)));
         }
 
         fn item_count(&self) -> usize {
@@ -80,7 +83,10 @@ mod tests {
         }
     }
 
-    struct DummyHorizontalLayout;
+    #[derive(Default)]
+    struct DummyHorizontalLayout {
+        last_width_report: Cell<Option<(usize, f64)>>,
+    }
 
     impl VirtualLayout for DummyHorizontalLayout {
         fn visible_range(&self, scroll_offset: f64, viewport_height: f64) -> Range<usize> {
@@ -97,7 +103,7 @@ mod tests {
         }
 
         fn report_item_height(&mut self, index: usize, height: f64) {
-            let _ = (index, height);
+            self.last_width_report.set(Some((index, height)));
         }
 
         fn item_count(&self) -> usize {
@@ -124,34 +130,129 @@ mod tests {
         }
     }
 
+    fn top_offset_for<T: VirtualLayout>(layout: &T, index: usize) -> f64 {
+        layout.scroll_to_index(index)
+    }
+
+    fn horizontal_window_for<T: HorizontalVirtualLayout>(
+        layout: &T,
+        scroll_offset: f64,
+        viewport_width: f64,
+    ) -> Range<usize> {
+        layout.visible_range_horizontal(scroll_offset, viewport_width)
+    }
+
+    fn vertical_window_for<T: VirtualLayout>(
+        layout: &T,
+        scroll_offset: f64,
+        viewport_height: f64,
+    ) -> Range<usize> {
+        layout.visible_range(scroll_offset, viewport_height)
+    }
+
     #[test]
     fn default_scroll_to_index_uses_item_offset() {
-        let layout = DummyLayout;
+        let layout = DummyLayout::default();
         assert_eq!(layout.scroll_to_index(4), 40.0);
     }
 
     #[test]
     fn default_report_item_width_is_no_op() {
-        let mut layout = DummyHorizontalLayout;
+        let mut layout = DummyHorizontalLayout::default();
         layout.report_item_width(2, 88.0);
         assert_eq!(layout.item_count(), 6);
+        assert_eq!(layout.last_width_report.get(), None);
+    }
+
+    #[test]
+    fn vertical_layout_reports_visible_range() {
+        let layout = DummyLayout::default();
+        assert_eq!(layout.visible_range(12.0, 48.0), 1..3);
+    }
+
+    #[test]
+    fn vertical_layout_reports_total_height() {
+        let layout = DummyLayout::default();
+        assert_eq!(layout.total_height(), 100.0);
+    }
+
+    #[test]
+    fn vertical_layout_reports_item_count() {
+        let layout = DummyLayout::default();
+        assert_eq!(layout.item_count(), 10);
+    }
+
+    #[test]
+    fn vertical_layout_records_reported_item_height() {
+        let mut layout = DummyLayout::default();
+        layout.report_item_height(3, 44.0);
+        assert_eq!(layout.last_height_report.get(), Some((3, 44.0)));
     }
 
     #[test]
     fn horizontal_layout_reports_visible_range() {
-        let layout = DummyHorizontalLayout;
+        let layout = DummyHorizontalLayout::default();
         assert_eq!(layout.visible_range_horizontal(16.0, 48.0), 2..5);
     }
 
     #[test]
+    fn horizontal_layout_also_reports_vertical_visible_range() {
+        let layout = DummyHorizontalLayout::default();
+        assert_eq!(layout.visible_range(10.0, 24.0), 0..2);
+    }
+
+    #[test]
     fn horizontal_layout_reports_item_offset_x() {
-        let layout = DummyHorizontalLayout;
+        let layout = DummyHorizontalLayout::default();
         assert_eq!(layout.item_offset_x(3), 36.0);
     }
 
     #[test]
+    fn horizontal_layout_also_reports_vertical_item_offset() {
+        let layout = DummyHorizontalLayout::default();
+        assert_eq!(layout.item_offset(4), 32.0);
+    }
+
+    #[test]
     fn horizontal_layout_reports_total_width() {
-        let layout = DummyHorizontalLayout;
+        let layout = DummyHorizontalLayout::default();
         assert_eq!(layout.total_width(), 120.0);
+    }
+
+    #[test]
+    fn horizontal_layout_also_reports_total_height() {
+        let layout = DummyHorizontalLayout::default();
+        assert_eq!(layout.total_height(), 80.0);
+    }
+
+    #[test]
+    fn horizontal_layout_records_reported_item_height() {
+        let mut layout = DummyHorizontalLayout::default();
+        layout.report_item_height(1, 22.0);
+        assert_eq!(layout.last_width_report.get(), Some((1, 22.0)));
+    }
+
+    #[test]
+    fn horizontal_layout_reports_item_count() {
+        let layout = DummyHorizontalLayout::default();
+        assert_eq!(layout.item_count(), 6);
+    }
+
+    #[test]
+    fn virtual_layout_trait_bound_uses_default_scroll_helper() {
+        let layout = DummyLayout::default();
+        assert_eq!(top_offset_for(&layout, 5), 50.0);
+    }
+
+    #[test]
+    fn horizontal_virtual_layout_trait_bound_uses_horizontal_range() {
+        let layout = DummyHorizontalLayout::default();
+        assert_eq!(horizontal_window_for(&layout, 24.0, 60.0), 2..5);
+    }
+
+    #[test]
+    fn horizontal_layout_also_satisfies_vertical_trait_bound() {
+        let layout = DummyHorizontalLayout::default();
+        assert_eq!(vertical_window_for(&layout, 12.0, 24.0), 0..2);
     }
 }

--- a/crates/ars-collections/src/virtual_layout.rs
+++ b/crates/ars-collections/src/virtual_layout.rs
@@ -1,0 +1,157 @@
+use core::ops::Range;
+
+/// A layout algorithm that maps collection indices to vertical pixel coordinates.
+///
+/// The [`crate::Virtualizer`] type provides built-in strategies for the
+/// standard layouts defined by the spec. This trait exists as an extension
+/// point for layouts that need custom vertical range or positioning logic.
+pub trait VirtualLayout {
+    /// Returns the visible item range `[start, end)` for the given vertical
+    /// scroll state.
+    fn visible_range(&self, scroll_offset: f64, viewport_height: f64) -> Range<usize>;
+
+    /// Returns the Y-axis pixel offset for the item at `index`.
+    fn item_offset(&self, index: usize) -> f64;
+
+    /// Returns the total scrollable height of the layout.
+    fn total_height(&self) -> f64;
+
+    /// Reports the measured height for an item.
+    fn report_item_height(&mut self, index: usize, height: f64);
+
+    /// Returns the scroll position that aligns the item to the viewport top.
+    fn scroll_to_index(&self, index: usize) -> f64 {
+        self.item_offset(index)
+    }
+
+    /// Returns the total number of items known to the layout.
+    fn item_count(&self) -> usize;
+}
+
+/// An optional horizontal extension for layouts that support inline-axis virtualization.
+///
+/// Layouts for carousels, horizontal grid lists, or bidirectional scrollers
+/// implement this trait in addition to [`VirtualLayout`].
+pub trait HorizontalVirtualLayout: VirtualLayout {
+    /// Returns the visible item range `[start, end)` for the given horizontal
+    /// scroll state.
+    fn visible_range_horizontal(&self, scroll_offset: f64, viewport_width: f64) -> Range<usize>;
+
+    /// Returns the X-axis pixel offset for the item at `index`.
+    fn item_offset_x(&self, index: usize) -> f64;
+
+    /// Returns the total scrollable width of the layout.
+    fn total_width(&self) -> f64;
+
+    /// Reports the measured width for an item.
+    fn report_item_width(&mut self, index: usize, width: f64) {
+        let _ = (index, width);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::ops::Range;
+
+    use super::{HorizontalVirtualLayout, VirtualLayout};
+
+    struct DummyLayout;
+
+    impl VirtualLayout for DummyLayout {
+        fn visible_range(&self, scroll_offset: f64, viewport_height: f64) -> Range<usize> {
+            let _ = (scroll_offset, viewport_height);
+            1..3
+        }
+
+        fn item_offset(&self, index: usize) -> f64 {
+            index as f64 * 10.0
+        }
+
+        fn total_height(&self) -> f64 {
+            100.0
+        }
+
+        fn report_item_height(&mut self, index: usize, height: f64) {
+            let _ = (index, height);
+        }
+
+        fn item_count(&self) -> usize {
+            10
+        }
+    }
+
+    struct DummyHorizontalLayout;
+
+    impl VirtualLayout for DummyHorizontalLayout {
+        fn visible_range(&self, scroll_offset: f64, viewport_height: f64) -> Range<usize> {
+            let _ = (scroll_offset, viewport_height);
+            0..2
+        }
+
+        fn item_offset(&self, index: usize) -> f64 {
+            index as f64 * 8.0
+        }
+
+        fn total_height(&self) -> f64 {
+            80.0
+        }
+
+        fn report_item_height(&mut self, index: usize, height: f64) {
+            let _ = (index, height);
+        }
+
+        fn item_count(&self) -> usize {
+            6
+        }
+    }
+
+    impl HorizontalVirtualLayout for DummyHorizontalLayout {
+        fn visible_range_horizontal(
+            &self,
+            scroll_offset: f64,
+            viewport_width: f64,
+        ) -> Range<usize> {
+            let _ = (scroll_offset, viewport_width);
+            2..5
+        }
+
+        fn item_offset_x(&self, index: usize) -> f64 {
+            index as f64 * 12.0
+        }
+
+        fn total_width(&self) -> f64 {
+            120.0
+        }
+    }
+
+    #[test]
+    fn default_scroll_to_index_uses_item_offset() {
+        let layout = DummyLayout;
+        assert_eq!(layout.scroll_to_index(4), 40.0);
+    }
+
+    #[test]
+    fn default_report_item_width_is_no_op() {
+        let mut layout = DummyHorizontalLayout;
+        layout.report_item_width(2, 88.0);
+        assert_eq!(layout.item_count(), 6);
+    }
+
+    #[test]
+    fn horizontal_layout_reports_visible_range() {
+        let layout = DummyHorizontalLayout;
+        assert_eq!(layout.visible_range_horizontal(16.0, 48.0), 2..5);
+    }
+
+    #[test]
+    fn horizontal_layout_reports_item_offset_x() {
+        let layout = DummyHorizontalLayout;
+        assert_eq!(layout.item_offset_x(3), 36.0);
+    }
+
+    #[test]
+    fn horizontal_layout_reports_total_width() {
+        let layout = DummyHorizontalLayout;
+        assert_eq!(layout.total_width(), 120.0);
+    }
+}

--- a/crates/ars-collections/src/virtualization.rs
+++ b/crates/ars-collections/src/virtualization.rs
@@ -196,36 +196,42 @@ impl Virtualizer {
     /// Returns the rendered range `[start, end)` including overscan.
     #[must_use]
     pub fn visible_range(&self) -> Range<usize> {
-        if self.total_count == 0 || self.viewport_height == 0.0 {
+        let viewport_extent = self.viewport_extent();
+
+        if self.total_count == 0 || viewport_extent == 0.0 {
             return 0..0;
         }
 
+        let scroll_offset = self.clamped_scroll_offset(viewport_extent);
+
         let (first_visible, last_visible) = match &self.layout {
             LayoutStrategy::FixedHeight { item_height } => {
-                let first = (self.scroll_top / item_height).floor() as usize;
-                let last = ((self.scroll_top + self.viewport_height) / item_height).ceil() as usize;
+                let first = (scroll_offset / item_height).floor() as usize;
+                let last = ((scroll_offset + viewport_extent) / item_height).ceil() as usize;
+
                 (first, last)
             }
 
             LayoutStrategy::VariableHeight {
                 estimated_item_height,
-            } => self.variable_height_range(*estimated_item_height),
+            } => self.variable_height_range(*estimated_item_height, scroll_offset, viewport_extent),
 
             LayoutStrategy::Grid {
                 item_height,
                 columns,
             } => {
-                let row_start = (self.scroll_top / item_height).floor() as usize;
-                let row_end =
-                    ((self.scroll_top + self.viewport_height) / item_height).ceil() as usize;
+                let row_start = (scroll_offset / item_height).floor() as usize;
+                let row_end = ((scroll_offset + viewport_extent) / item_height).ceil() as usize;
                 let cols = columns.get();
+
                 (row_start * cols, (row_end * cols).min(self.total_count))
             }
 
             _ => {
                 let estimated = self.layout.estimated_item_height();
-                let first = (self.scroll_top / estimated).floor() as usize;
-                let last = ((self.scroll_top + self.viewport_height) / estimated).ceil() as usize;
+                let first = (scroll_offset / estimated).floor() as usize;
+                let last = ((scroll_offset + viewport_extent) / estimated).ceil() as usize;
+
                 (first, last)
             }
         };
@@ -367,7 +373,32 @@ impl Virtualizer {
         key_to_index(key).map(|index| self.scroll_to_index(index, align))
     }
 
-    fn variable_height_range(&self, estimated: f64) -> (usize, usize) {
+    const fn viewport_extent(&self) -> f64 {
+        match self.orientation {
+            Orientation::Vertical => self.viewport_height,
+            Orientation::Horizontal => self.viewport_width,
+        }
+    }
+
+    const fn scroll_offset(&self) -> f64 {
+        match self.orientation {
+            Orientation::Vertical => self.scroll_top,
+            Orientation::Horizontal => self.scroll_left,
+        }
+    }
+
+    fn clamped_scroll_offset(&self, viewport_extent: f64) -> f64 {
+        let max_scroll = (self.total_height_px() - viewport_extent).max(0.0);
+
+        self.scroll_offset().clamp(0.0, max_scroll)
+    }
+
+    fn variable_height_range(
+        &self,
+        estimated: f64,
+        scroll_offset: f64,
+        viewport_extent: f64,
+    ) -> (usize, usize) {
         let mut cumulative = 0.0_f64;
 
         let mut first = 0;
@@ -383,14 +414,14 @@ impl Virtualizer {
                 .copied()
                 .unwrap_or(estimated);
 
-            if cumulative + height > self.scroll_top && !found_first {
+            if cumulative + height > scroll_offset && !found_first {
                 first = index;
                 found_first = true;
             }
 
             cumulative += height;
 
-            if cumulative >= self.scroll_top + self.viewport_height {
+            if cumulative >= scroll_offset + viewport_extent {
                 last = index + 1;
 
                 break;
@@ -612,11 +643,26 @@ mod tests {
             },
         );
 
-        virt.set_scroll_state_mut(70.0, 0.0, 500.0, 0.0);
+        virt.set_scroll_state_mut(70.0, 0.0, 100.0, 0.0);
         virt.overscan = 0;
         virt.report_item_height_mut(0, 60.0);
 
         assert_eq!(virt.visible_range(), 1..4);
+    }
+
+    #[test]
+    fn variable_height_visible_range_clamps_when_scrolled_past_end() {
+        let mut virt = Virtualizer::new(
+            4,
+            LayoutStrategy::VariableHeight {
+                estimated_item_height: 40.0,
+            },
+        );
+
+        virt.set_scroll_state_mut(500.0, 0.0, 50.0, 0.0);
+        virt.overscan = 0;
+
+        assert_eq!(virt.visible_range(), 2..4);
     }
 
     #[test]
@@ -660,6 +706,27 @@ mod tests {
         assert_eq!(virt.item_offset_px(7), 60.0);
         assert_eq!(virt.total_height_px(), 120.0);
         assert_eq!(virt.scroll_to_index(7, ScrollAlign::Top), 60.0);
+    }
+
+    #[test]
+    fn horizontal_visible_range_uses_scroll_left_and_viewport_width() {
+        let mut virt = fixed_height_virt();
+
+        virt.orientation = Orientation::Horizontal;
+        virt.overscan = 0;
+        virt.set_scroll_state_mut(400.0, 120.0, 40.0, 80.0);
+
+        assert_eq!(virt.visible_range(), 3..5);
+    }
+
+    #[test]
+    fn fixed_height_visible_range_clamps_when_scrolled_past_end() {
+        let mut virt = Virtualizer::new(4, LayoutStrategy::FixedHeight { item_height: 40.0 });
+
+        virt.set_scroll_state_mut(500.0, 0.0, 50.0, 0.0);
+        virt.overscan = 0;
+
+        assert_eq!(virt.visible_range(), 2..4);
     }
 
     #[test]

--- a/crates/ars-collections/src/virtualization.rs
+++ b/crates/ars-collections/src/virtualization.rs
@@ -329,7 +329,7 @@ impl Virtualizer {
         }
     }
 
-    /// Returns the total scrollable height for the current layout.
+    /// Returns the total scrollable extent for the current layout.
     #[must_use]
     pub fn total_height_px(&self) -> f64 {
         match &self.layout {
@@ -355,7 +355,7 @@ impl Virtualizer {
                 rows as f64 * item_height
             }
 
-            _ => self.total_count as f64 * self.layout.estimated_item_height(),
+            _ => self.total_count as f64 * self.layout.estimated_item_extent(self.orientation),
         }
     }
 
@@ -953,6 +953,7 @@ mod tests {
 
         assert_eq!(virt.visible_range(), 2..3);
         assert_eq!(virt.scroll_to_index(2, ScrollAlign::Top), 240.0);
+        assert_eq!(virt.total_height_px(), 2400.0);
     }
 
     #[test]
@@ -977,6 +978,23 @@ mod tests {
     }
 
     #[test]
+    fn waterfall_layout_fallback_uses_inline_axis_estimate_when_horizontal() {
+        let mut virt = Virtualizer::new(
+            20,
+            LayoutStrategy::WaterfallLayout {
+                min_item_width: 120.0,
+                max_item_width: 240.0,
+                min_item_height: 45.0,
+                gap: 12.0,
+            },
+        );
+
+        virt.orientation = Orientation::Horizontal;
+
+        assert_eq!(virt.total_height_px(), 2400.0);
+    }
+
+    #[test]
     fn table_layout_fallback_uses_estimated_height_math() {
         let mut virt = Virtualizer::new(
             8,
@@ -995,6 +1013,23 @@ mod tests {
         assert_eq!(virt.item_offset_px(3), 105.0);
         assert_eq!(virt.total_height_px(), 280.0);
         assert_eq!(virt.scroll_to_index(3, ScrollAlign::Bottom), 70.0);
+    }
+
+    #[test]
+    fn table_layout_fallback_uses_inline_axis_estimate_when_horizontal() {
+        let mut virt = Virtualizer::new(
+            8,
+            LayoutStrategy::TableLayout {
+                row_height: 35.0,
+                header_height: 24.0,
+                column_widths: vec![120.0, 160.0],
+                row_gap: 4.0,
+            },
+        );
+
+        virt.orientation = Orientation::Horizontal;
+
+        assert_eq!(virt.total_height_px(), 960.0);
     }
 
     #[test]

--- a/crates/ars-collections/src/virtualization.rs
+++ b/crates/ars-collections/src/virtualization.rs
@@ -209,6 +209,32 @@ impl Virtualizer {
         updated
     }
 
+    /// Applies a collection update that may have changed flat item indices.
+    ///
+    /// Because measured heights are keyed by flat index, any insert, removal,
+    /// filter, or reorder can make cached measurements point at the wrong
+    /// items. This method updates the tracked item count, clears the measured
+    /// height cache, and drops an out-of-bounds focused index.
+    pub fn apply_collection_change_mut(&mut self, total_count: usize) {
+        self.total_count = total_count;
+
+        self.measured_heights.clear();
+
+        if self.focused_index.is_some_and(|index| index >= total_count) {
+            self.focused_index = None;
+        }
+    }
+
+    /// Returns a cloned virtualizer with a collection update applied.
+    #[must_use]
+    pub fn apply_collection_change(&self, total_count: usize) -> Self {
+        let mut updated = self.clone();
+
+        updated.apply_collection_change_mut(total_count);
+
+        updated
+    }
+
     /// Returns the rendered range `[start, end)` including overscan.
     #[must_use]
     pub fn visible_range(&self) -> Range<usize> {
@@ -636,6 +662,59 @@ mod tests {
 
         assert_eq!(updated, mutated);
         assert_ne!(baseline, updated);
+    }
+
+    #[test]
+    fn apply_collection_change_mut_clears_index_based_measurements_even_when_count_is_unchanged() {
+        let mut virt = Virtualizer::new(
+            4,
+            LayoutStrategy::VariableHeight {
+                estimated_item_height: 40.0,
+            },
+        );
+
+        virt.report_item_height_mut(0, 60.0);
+        virt.report_item_height_mut(1, 50.0);
+
+        assert_eq!(virt.total_height_px(), 190.0);
+
+        virt.apply_collection_change_mut(4);
+
+        assert_eq!(virt.total_height_px(), 160.0);
+    }
+
+    #[test]
+    fn apply_collection_change_updates_total_count_and_focus() {
+        let mut virt = fixed_height_virt();
+
+        virt.focused_index = Some(8);
+        virt.apply_collection_change_mut(3);
+
+        assert_eq!(virt.total_count, 3);
+        assert_eq!(virt.focused_index, None);
+    }
+
+    #[test]
+    fn apply_collection_change_returns_new_virtualizer() {
+        let mut baseline = Virtualizer::new(
+            4,
+            LayoutStrategy::VariableHeight {
+                estimated_item_height: 40.0,
+            },
+        );
+
+        baseline.focused_index = Some(1);
+        baseline.report_item_height_mut(0, 60.0);
+
+        let updated = baseline.apply_collection_change(6);
+
+        assert_eq!(baseline.total_count, 4);
+        assert_eq!(baseline.focused_index, Some(1));
+        assert_eq!(baseline.total_height_px(), 180.0);
+
+        assert_eq!(updated.total_count, 6);
+        assert_eq!(updated.focused_index, Some(1));
+        assert_eq!(updated.total_height_px(), 240.0);
     }
 
     #[test]

--- a/crates/ars-collections/src/virtualization.rs
+++ b/crates/ars-collections/src/virtualization.rs
@@ -90,6 +90,22 @@ impl LayoutStrategy {
             Self::TableLayout { row_height, .. } => *row_height,
         }
     }
+
+    fn estimated_item_extent(&self, orientation: Orientation) -> f64 {
+        match orientation {
+            Orientation::Vertical => self.estimated_item_height(),
+            Orientation::Horizontal => match self {
+                Self::GridLayout { min_item_width, .. }
+                | Self::WaterfallLayout { min_item_width, .. } => *min_item_width,
+                Self::TableLayout {
+                    row_height,
+                    column_widths,
+                    ..
+                } => column_widths.first().copied().unwrap_or(*row_height),
+                _ => self.estimated_item_height(),
+            },
+        }
+    }
 }
 
 /// Aligns a target item within the viewport during programmatic scrolling.
@@ -228,7 +244,7 @@ impl Virtualizer {
             }
 
             _ => {
-                let estimated = self.layout.estimated_item_height();
+                let estimated = self.layout.estimated_item_extent(self.orientation);
                 let first = (scroll_offset / estimated).floor() as usize;
                 let last = ((scroll_offset + viewport_extent) / estimated).ceil() as usize;
 
@@ -281,7 +297,7 @@ impl Virtualizer {
                 columns,
             } => (index / columns.get()) as f64 * item_height,
 
-            _ => index as f64 * self.layout.estimated_item_height(),
+            _ => index as f64 * self.layout.estimated_item_extent(self.orientation),
         }
     }
 
@@ -315,12 +331,12 @@ impl Virtualizer {
         }
     }
 
-    /// Returns the scroll top needed to bring `index` into view.
+    /// Returns the scroll offset needed to bring `index` into view.
     #[must_use]
     pub fn scroll_top_for_index(&self, index: usize, align: ScrollAlign) -> f64 {
         let offset = self.item_offset_px(index);
 
-        let height = match &self.layout {
+        let item_extent = match &self.layout {
             LayoutStrategy::FixedHeight { item_height }
             | LayoutStrategy::Grid { item_height, .. } => *item_height,
 
@@ -332,27 +348,29 @@ impl Virtualizer {
                 .copied()
                 .unwrap_or(*estimated_item_height),
 
-            _ => self.layout.estimated_item_height(),
+            _ => self.layout.estimated_item_extent(self.orientation),
         };
 
-        let item_bottom = offset + height;
+        let viewport_extent = self.viewport_extent();
+        let scroll_offset = self.scroll_offset();
+        let item_end = offset + item_extent;
 
         match align {
             ScrollAlign::Auto => {
-                if offset < self.scroll_top {
+                if offset < scroll_offset {
                     offset
-                } else if item_bottom > self.scroll_top + self.viewport_height {
-                    item_bottom - self.viewport_height
+                } else if item_end > scroll_offset + viewport_extent {
+                    item_end - viewport_extent
                 } else {
-                    self.scroll_top
+                    scroll_offset
                 }
             }
 
             ScrollAlign::Top => offset,
 
-            ScrollAlign::Bottom => (item_bottom - self.viewport_height).max(0.0),
+            ScrollAlign::Bottom => (item_end - viewport_extent).max(0.0),
 
-            ScrollAlign::Center => (offset - (self.viewport_height - height) / 2.0).max(0.0),
+            ScrollAlign::Center => (offset - (viewport_extent - item_extent) / 2.0).max(0.0),
         }
     }
 
@@ -388,9 +406,23 @@ impl Virtualizer {
     }
 
     fn clamped_scroll_offset(&self, viewport_extent: f64) -> f64 {
-        let max_scroll = (self.total_height_px() - viewport_extent).max(0.0);
+        let max_scroll = (self.total_main_axis_extent() - viewport_extent).max(0.0);
 
         self.scroll_offset().clamp(0.0, max_scroll)
+    }
+
+    fn total_main_axis_extent(&self) -> f64 {
+        match self.orientation {
+            Orientation::Vertical => self.total_height_px(),
+            Orientation::Horizontal => match &self.layout {
+                LayoutStrategy::GridLayout { .. }
+                | LayoutStrategy::WaterfallLayout { .. }
+                | LayoutStrategy::TableLayout { .. } => {
+                    self.total_count as f64 * self.layout.estimated_item_extent(self.orientation)
+                }
+                _ => self.total_height_px(),
+            },
+        }
     }
 
     fn variable_height_range(
@@ -720,6 +752,18 @@ mod tests {
     }
 
     #[test]
+    fn horizontal_scroll_to_index_uses_scroll_left_and_viewport_width() {
+        let mut virt = fixed_height_virt();
+
+        virt.orientation = Orientation::Horizontal;
+        virt.set_scroll_state_mut(400.0, 80.0, 40.0, 80.0);
+
+        assert_eq!(virt.scroll_to_index(4, ScrollAlign::Auto), 120.0);
+        assert_eq!(virt.scroll_to_index(4, ScrollAlign::Bottom), 120.0);
+        assert_eq!(virt.scroll_to_index(4, ScrollAlign::Center), 140.0);
+    }
+
+    #[test]
     fn fixed_height_visible_range_clamps_when_scrolled_past_end() {
         let mut virt = Virtualizer::new(4, LayoutStrategy::FixedHeight { item_height: 40.0 });
 
@@ -756,6 +800,27 @@ mod tests {
         assert_eq!(virt.item_offset_px(3), 150.0);
         assert_eq!(virt.total_height_px(), 1000.0);
         assert_eq!(virt.scroll_to_index(3, ScrollAlign::Top), 150.0);
+    }
+
+    #[test]
+    fn grid_layout_fallback_uses_inline_axis_estimate_when_horizontal() {
+        let mut virt = Virtualizer::new(
+            20,
+            LayoutStrategy::GridLayout {
+                min_item_width: 120.0,
+                max_item_width: 240.0,
+                min_item_height: 50.0,
+                max_item_height: Some(200.0),
+                gap: 12.0,
+            },
+        );
+
+        virt.orientation = Orientation::Horizontal;
+        virt.overscan = 0;
+        virt.set_scroll_state_mut(0.0, 240.0, 40.0, 120.0);
+
+        assert_eq!(virt.visible_range(), 2..3);
+        assert_eq!(virt.scroll_to_index(2, ScrollAlign::Top), 240.0);
     }
 
     #[test]

--- a/crates/ars-collections/src/virtualization.rs
+++ b/crates/ars-collections/src/virtualization.rs
@@ -213,16 +213,15 @@ impl Virtualizer {
     ///
     /// Because measured heights are keyed by flat index, any insert, removal,
     /// filter, or reorder can make cached measurements point at the wrong
-    /// items. This method updates the tracked item count, clears the measured
-    /// height cache, and drops an out-of-bounds focused index.
+    /// items. The tracked focused index is also invalid after any such update,
+    /// because it may now identify a different item even when it remains
+    /// in-bounds. This method updates the tracked item count, clears the
+    /// measured height cache, and clears the focused index.
     pub fn apply_collection_change_mut(&mut self, total_count: usize) {
         self.total_count = total_count;
 
         self.measured_heights.clear();
-
-        if self.focused_index.is_some_and(|index| index >= total_count) {
-            self.focused_index = None;
-        }
+        self.focused_index = None;
     }
 
     /// Returns a cloned virtualizer with a collection update applied.
@@ -715,7 +714,7 @@ mod tests {
     }
 
     #[test]
-    fn apply_collection_change_updates_total_count_and_focus() {
+    fn apply_collection_change_updates_total_count_and_clears_focus() {
         let mut virt = fixed_height_virt();
 
         virt.focused_index = Some(8);
@@ -744,8 +743,18 @@ mod tests {
         assert_eq!(baseline.total_height_px(), 180.0);
 
         assert_eq!(updated.total_count, 6);
-        assert_eq!(updated.focused_index, Some(1));
+        assert_eq!(updated.focused_index, None);
         assert_eq!(updated.total_height_px(), 240.0);
+    }
+
+    #[test]
+    fn apply_collection_change_clears_focus_even_when_count_is_unchanged() {
+        let mut virt = fixed_height_virt();
+
+        virt.focused_index = Some(5);
+        virt.apply_collection_change_mut(100);
+
+        assert_eq!(virt.focused_index, None);
     }
 
     #[test]

--- a/crates/ars-collections/src/virtualization.rs
+++ b/crates/ars-collections/src/virtualization.rs
@@ -254,7 +254,9 @@ impl Virtualizer {
 
         let mut start = first_visible.saturating_sub(self.overscan);
 
-        let mut end = (last_visible + self.overscan).min(self.total_count);
+        let mut end = last_visible
+            .saturating_add(self.overscan)
+            .min(self.total_count);
 
         if let Some(focused_index) = self.focused_index {
             if focused_index < self.total_count {
@@ -771,6 +773,16 @@ mod tests {
         virt.overscan = 0;
 
         assert_eq!(virt.visible_range(), 2..4);
+    }
+
+    #[test]
+    fn visible_range_end_uses_saturating_add_for_large_overscan() {
+        let mut virt = fixed_height_virt();
+
+        virt.viewport_height = 50.0;
+        virt.overscan = usize::MAX;
+
+        assert_eq!(virt.visible_range(), 0..100);
     }
 
     #[test]

--- a/crates/ars-collections/src/virtualization.rs
+++ b/crates/ars-collections/src/virtualization.rs
@@ -1,0 +1,804 @@
+use alloc::{collections::BTreeMap, vec::Vec};
+use core::{num::NonZeroUsize, ops::Range};
+
+pub use ars_core::{Direction, Orientation};
+
+use crate::key::Key;
+
+/// The number of items to render beyond the visible range on each side.
+pub const DEFAULT_OVERSCAN: usize = 5;
+
+/// How item sizes are determined for virtualization math.
+#[derive(Clone, Debug, PartialEq)]
+pub enum LayoutStrategy {
+    /// Every item has the same pixel height.
+    FixedHeight {
+        /// Pixel height of each item.
+        item_height: f64,
+    },
+
+    /// Items use measured heights with an estimate for unmeasured rows.
+    VariableHeight {
+        /// Estimated height used for items without a measurement.
+        estimated_item_height: f64,
+    },
+
+    /// Items are arranged in a grid with a fixed row height.
+    Grid {
+        /// Pixel height of each row.
+        item_height: f64,
+        /// Number of columns in the grid.
+        columns: NonZeroUsize,
+    },
+
+    /// Equal-sized items in responsive columns.
+    GridLayout {
+        /// Minimum item width in pixels.
+        min_item_width: f64,
+        /// Maximum item width in pixels.
+        max_item_width: f64,
+        /// Minimum item height in pixels.
+        min_item_height: f64,
+        /// Optional maximum item height in pixels.
+        max_item_height: Option<f64>,
+        /// Gap between items in pixels.
+        gap: f64,
+    },
+
+    /// Waterfall or masonry layout using responsive columns.
+    WaterfallLayout {
+        /// Minimum item width in pixels.
+        min_item_width: f64,
+        /// Maximum item width in pixels.
+        max_item_width: f64,
+        /// Minimum item height in pixels.
+        min_item_height: f64,
+        /// Gap between items in pixels.
+        gap: f64,
+    },
+
+    /// Table-specific virtualization layout.
+    TableLayout {
+        /// Estimated height of each data row in pixels.
+        row_height: f64,
+        /// Height of the sticky header row in pixels.
+        header_height: f64,
+        /// Width of each visible column in pixels.
+        column_widths: Vec<f64>,
+        /// Vertical gap between rows in pixels.
+        row_gap: f64,
+    },
+}
+
+impl LayoutStrategy {
+    /// Returns the estimated height for a single item in this layout.
+    #[must_use]
+    pub const fn estimated_item_height(&self) -> f64 {
+        match self {
+            Self::VariableHeight {
+                estimated_item_height,
+            } => *estimated_item_height,
+
+            Self::FixedHeight { item_height } | Self::Grid { item_height, .. } => *item_height,
+
+            Self::GridLayout {
+                min_item_height, ..
+            }
+            | Self::WaterfallLayout {
+                min_item_height, ..
+            } => *min_item_height,
+            Self::TableLayout { row_height, .. } => *row_height,
+        }
+    }
+}
+
+/// Aligns a target item within the viewport during programmatic scrolling.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum ScrollAlign {
+    /// Scroll only when the item is outside the viewport.
+    #[default]
+    Auto,
+
+    /// Align the item to the top of the viewport.
+    Top,
+
+    /// Align the item to the bottom of the viewport.
+    Bottom,
+
+    /// Center the item within the viewport.
+    Center,
+}
+
+/// Computes visible range and scroll math for a virtualized collection.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Virtualizer {
+    /// Total logical item count in the collection.
+    pub total_count: usize,
+
+    /// Layout strategy that drives height estimation.
+    pub layout: LayoutStrategy,
+
+    /// Height of the viewport in pixels.
+    pub viewport_height: f64,
+
+    /// Width of the viewport in pixels.
+    pub viewport_width: f64,
+
+    /// Current vertical scroll position in pixels.
+    pub scroll_top: f64,
+
+    /// Current horizontal scroll position in pixels.
+    pub scroll_left: f64,
+
+    /// Active scroll orientation.
+    pub orientation: Orientation,
+
+    /// Active text direction.
+    pub dir: Direction,
+
+    /// Overscan count applied on both sides of the visible range.
+    pub overscan: usize,
+
+    /// Currently focused index, if any.
+    pub focused_index: Option<usize>,
+
+    measured_heights: BTreeMap<usize, f64>,
+}
+
+impl Virtualizer {
+    /// Creates a new virtualizer with the given item count and layout strategy.
+    #[must_use]
+    pub const fn new(total_count: usize, layout: LayoutStrategy) -> Self {
+        Self {
+            total_count,
+            layout,
+            viewport_height: 0.0,
+            viewport_width: 0.0,
+            scroll_top: 0.0,
+            scroll_left: 0.0,
+            orientation: Orientation::Vertical,
+            dir: Direction::Ltr,
+            overscan: DEFAULT_OVERSCAN,
+            focused_index: None,
+            measured_heights: BTreeMap::new(),
+        }
+    }
+
+    /// Updates the tracked scroll position and viewport dimensions.
+    pub const fn set_scroll_state_mut(
+        &mut self,
+        scroll_top: f64,
+        scroll_left: f64,
+        viewport_height: f64,
+        viewport_width: f64,
+    ) {
+        self.scroll_top = scroll_top;
+        self.scroll_left = scroll_left;
+        self.viewport_height = viewport_height;
+        self.viewport_width = viewport_width;
+    }
+
+    /// Records a measured height for a specific item.
+    pub fn report_item_height_mut(&mut self, index: usize, height: f64) {
+        self.measured_heights.insert(index, height);
+    }
+
+    /// Returns a cloned virtualizer with an updated measured height.
+    #[must_use]
+    pub fn report_item_height(&self, index: usize, height: f64) -> Self {
+        let mut updated = self.clone();
+
+        updated.report_item_height_mut(index, height);
+
+        updated
+    }
+
+    /// Returns the rendered range `[start, end)` including overscan.
+    #[must_use]
+    pub fn visible_range(&self) -> Range<usize> {
+        if self.total_count == 0 || self.viewport_height == 0.0 {
+            return 0..0;
+        }
+
+        let (first_visible, last_visible) = match &self.layout {
+            LayoutStrategy::FixedHeight { item_height } => {
+                let first = (self.scroll_top / item_height).floor() as usize;
+                let last = ((self.scroll_top + self.viewport_height) / item_height).ceil() as usize;
+                (first, last)
+            }
+
+            LayoutStrategy::VariableHeight {
+                estimated_item_height,
+            } => self.variable_height_range(*estimated_item_height),
+
+            LayoutStrategy::Grid {
+                item_height,
+                columns,
+            } => {
+                let row_start = (self.scroll_top / item_height).floor() as usize;
+                let row_end =
+                    ((self.scroll_top + self.viewport_height) / item_height).ceil() as usize;
+                let cols = columns.get();
+                (row_start * cols, (row_end * cols).min(self.total_count))
+            }
+
+            _ => {
+                let estimated = self.layout.estimated_item_height();
+                let first = (self.scroll_top / estimated).floor() as usize;
+                let last = ((self.scroll_top + self.viewport_height) / estimated).ceil() as usize;
+                (first, last)
+            }
+        };
+
+        let mut start = first_visible.saturating_sub(self.overscan);
+
+        let mut end = (last_visible + self.overscan).min(self.total_count);
+
+        if let Some(focused_index) = self.focused_index {
+            if focused_index < self.total_count {
+                start = start.min(focused_index);
+                end = end.max(focused_index + 1);
+            }
+        }
+
+        start..end
+    }
+
+    /// Returns a cloned virtualizer with the focused index updated.
+    #[must_use]
+    pub fn set_focused_index(&self, index: Option<usize>) -> Self {
+        Self {
+            focused_index: index,
+            ..self.clone()
+        }
+    }
+
+    /// Returns the Y-axis offset for the item at `index`.
+    #[must_use]
+    pub fn item_offset_px(&self, index: usize) -> f64 {
+        match &self.layout {
+            LayoutStrategy::FixedHeight { item_height } => index as f64 * item_height,
+
+            LayoutStrategy::VariableHeight {
+                estimated_item_height,
+            } => (0..index)
+                .map(|item_index| {
+                    self.measured_heights
+                        .get(&item_index)
+                        .copied()
+                        .unwrap_or(*estimated_item_height)
+                })
+                .sum(),
+
+            LayoutStrategy::Grid {
+                item_height,
+                columns,
+            } => (index / columns.get()) as f64 * item_height,
+
+            _ => index as f64 * self.layout.estimated_item_height(),
+        }
+    }
+
+    /// Returns the total scrollable height for the current layout.
+    #[must_use]
+    pub fn total_height_px(&self) -> f64 {
+        match &self.layout {
+            LayoutStrategy::FixedHeight { item_height } => self.total_count as f64 * item_height,
+
+            LayoutStrategy::VariableHeight {
+                estimated_item_height,
+            } => (0..self.total_count)
+                .map(|item_index| {
+                    self.measured_heights
+                        .get(&item_index)
+                        .copied()
+                        .unwrap_or(*estimated_item_height)
+                })
+                .sum(),
+
+            LayoutStrategy::Grid {
+                item_height,
+                columns,
+            } => {
+                let cols = columns.get();
+                let rows = self.total_count.div_ceil(cols);
+                rows as f64 * item_height
+            }
+
+            _ => self.total_count as f64 * self.layout.estimated_item_height(),
+        }
+    }
+
+    /// Returns the scroll top needed to bring `index` into view.
+    #[must_use]
+    pub fn scroll_top_for_index(&self, index: usize, align: ScrollAlign) -> f64 {
+        let offset = self.item_offset_px(index);
+
+        let height = match &self.layout {
+            LayoutStrategy::FixedHeight { item_height }
+            | LayoutStrategy::Grid { item_height, .. } => *item_height,
+
+            LayoutStrategy::VariableHeight {
+                estimated_item_height,
+            } => self
+                .measured_heights
+                .get(&index)
+                .copied()
+                .unwrap_or(*estimated_item_height),
+
+            _ => self.layout.estimated_item_height(),
+        };
+
+        let item_bottom = offset + height;
+
+        match align {
+            ScrollAlign::Auto => {
+                if offset < self.scroll_top {
+                    offset
+                } else if item_bottom > self.scroll_top + self.viewport_height {
+                    item_bottom - self.viewport_height
+                } else {
+                    self.scroll_top
+                }
+            }
+
+            ScrollAlign::Top => offset,
+
+            ScrollAlign::Bottom => (item_bottom - self.viewport_height).max(0.0),
+
+            ScrollAlign::Center => (offset - (self.viewport_height - height) / 2.0).max(0.0),
+        }
+    }
+
+    /// Convenience wrapper around [`Self::scroll_top_for_index`].
+    #[must_use]
+    pub fn scroll_to_index(&self, index: usize, align: ScrollAlign) -> f64 {
+        self.scroll_top_for_index(index, align)
+    }
+
+    /// Resolves a key to an index, then scrolls to that item if found.
+    #[must_use]
+    pub fn scroll_to_key(
+        &self,
+        key: &Key,
+        align: ScrollAlign,
+        key_to_index: impl Fn(&Key) -> Option<usize>,
+    ) -> Option<f64> {
+        key_to_index(key).map(|index| self.scroll_to_index(index, align))
+    }
+
+    fn variable_height_range(&self, estimated: f64) -> (usize, usize) {
+        let mut cumulative = 0.0_f64;
+
+        let mut first = 0;
+
+        let mut found_first = false;
+
+        let mut last = self.total_count;
+
+        for index in 0..self.total_count {
+            let height = self
+                .measured_heights
+                .get(&index)
+                .copied()
+                .unwrap_or(estimated);
+
+            if cumulative + height > self.scroll_top && !found_first {
+                first = index;
+                found_first = true;
+            }
+
+            cumulative += height;
+
+            if cumulative >= self.scroll_top + self.viewport_height {
+                last = index + 1;
+
+                break;
+            }
+        }
+
+        (first, last)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+
+    use super::*;
+
+    fn fixed_height_virt() -> Virtualizer {
+        let mut virt = Virtualizer::new(100, LayoutStrategy::FixedHeight { item_height: 40.0 });
+
+        virt.viewport_height = 200.0;
+        virt.overscan = 3;
+
+        virt
+    }
+
+    fn grid_virt() -> Virtualizer {
+        let mut virt = Virtualizer::new(
+            10,
+            LayoutStrategy::Grid {
+                item_height: 30.0,
+                columns: NonZeroUsize::new(3).expect("non-zero columns"),
+            },
+        );
+
+        virt.viewport_height = 60.0;
+        virt.overscan = 1;
+
+        virt
+    }
+
+    #[test]
+    fn visible_range_for_fixed_height_items() {
+        let virt = fixed_height_virt();
+
+        let range = virt.visible_range();
+
+        assert_eq!(range.start, 0);
+        assert_eq!(range.end, 8);
+    }
+
+    #[test]
+    fn empty_collection_has_empty_visible_range() {
+        let virt = Virtualizer::new(0, LayoutStrategy::FixedHeight { item_height: 40.0 });
+
+        assert_eq!(virt.visible_range(), 0..0);
+    }
+
+    #[test]
+    fn zero_viewport_has_empty_visible_range() {
+        let virt = Virtualizer::new(10, LayoutStrategy::FixedHeight { item_height: 40.0 });
+
+        assert_eq!(virt.visible_range(), 0..0);
+    }
+
+    #[test]
+    fn scroll_to_index_top_returns_correct_offset() {
+        let virt = fixed_height_virt();
+
+        assert_eq!(virt.scroll_to_index(10, ScrollAlign::Top), 400.0);
+    }
+
+    #[test]
+    fn scroll_to_index_bottom_returns_correct_offset() {
+        let virt = fixed_height_virt();
+
+        assert_eq!(virt.scroll_to_index(10, ScrollAlign::Bottom), 240.0);
+    }
+
+    #[test]
+    fn scroll_to_index_center_returns_correct_offset() {
+        let virt = fixed_height_virt();
+
+        assert_eq!(virt.scroll_to_index(10, ScrollAlign::Center), 320.0);
+    }
+
+    #[test]
+    fn scroll_to_index_auto_scrolls_when_item_is_below_viewport() {
+        let virt = fixed_height_virt();
+
+        assert_eq!(virt.scroll_to_index(10, ScrollAlign::Auto), 240.0);
+    }
+
+    #[test]
+    fn scroll_to_index_auto_scrolls_when_item_is_above_viewport() {
+        let mut virt = fixed_height_virt();
+
+        virt.set_scroll_state_mut(500.0, 0.0, 200.0, 0.0);
+
+        assert_eq!(virt.scroll_to_index(10, ScrollAlign::Auto), 400.0);
+    }
+
+    #[test]
+    fn scroll_to_index_auto_keeps_visible_item_stationary() {
+        let mut virt = fixed_height_virt();
+
+        virt.set_scroll_state_mut(360.0, 0.0, 200.0, 0.0);
+
+        assert_eq!(virt.scroll_to_index(10, ScrollAlign::Auto), 360.0);
+    }
+
+    #[test]
+    fn scroll_to_key_delegates_through_closure() {
+        let virt = fixed_height_virt();
+
+        let offset = virt.scroll_to_key(&Key::from("item-10"), ScrollAlign::Top, |key| {
+            if key == &Key::from("item-10") {
+                Some(10)
+            } else {
+                None
+            }
+        });
+
+        assert_eq!(offset, Some(400.0));
+    }
+
+    #[test]
+    fn scroll_to_unknown_key_returns_none() {
+        let virt = fixed_height_virt();
+
+        assert_eq!(
+            virt.scroll_to_key(&Key::from("missing"), ScrollAlign::Top, |_| None),
+            None
+        );
+    }
+
+    #[test]
+    fn report_item_height_mut_updates_variable_height_calculations() {
+        let mut virt = Virtualizer::new(
+            100,
+            LayoutStrategy::VariableHeight {
+                estimated_item_height: 40.0,
+            },
+        );
+
+        virt.viewport_height = 170.0;
+        virt.overscan = 3;
+
+        let range_before = virt.visible_range();
+
+        let height_before = virt.total_height_px();
+
+        virt.report_item_height_mut(0, 60.0);
+
+        let range_after = virt.visible_range();
+
+        let height_after = virt.total_height_px();
+
+        assert_ne!(range_before, range_after);
+        assert_eq!(height_before + 20.0, height_after);
+    }
+
+    #[test]
+    fn report_item_height_returns_new_equivalent_state() {
+        let mut baseline = Virtualizer::new(
+            100,
+            LayoutStrategy::VariableHeight {
+                estimated_item_height: 40.0,
+            },
+        );
+
+        baseline.viewport_height = 200.0;
+
+        let updated = baseline.report_item_height(2, 64.0);
+
+        let mut mutated = baseline.clone();
+
+        mutated.report_item_height_mut(2, 64.0);
+
+        assert_eq!(updated, mutated);
+        assert_ne!(baseline, updated);
+    }
+
+    #[test]
+    fn variable_height_affects_item_offset() {
+        let mut virt = Virtualizer::new(
+            100,
+            LayoutStrategy::VariableHeight {
+                estimated_item_height: 40.0,
+            },
+        );
+
+        virt.report_item_height_mut(0, 60.0);
+
+        assert_eq!(virt.item_offset_px(1), 60.0);
+    }
+
+    #[test]
+    fn variable_height_scroll_top_for_index_uses_measured_height() {
+        let mut virt = Virtualizer::new(
+            10,
+            LayoutStrategy::VariableHeight {
+                estimated_item_height: 40.0,
+            },
+        );
+
+        virt.viewport_height = 100.0;
+        virt.report_item_height_mut(0, 60.0);
+        virt.report_item_height_mut(1, 50.0);
+
+        assert_eq!(virt.scroll_to_index(1, ScrollAlign::Bottom), 10.0);
+    }
+
+    #[test]
+    fn variable_height_visible_range_can_extend_to_collection_end() {
+        let mut virt = Virtualizer::new(
+            4,
+            LayoutStrategy::VariableHeight {
+                estimated_item_height: 40.0,
+            },
+        );
+
+        virt.set_scroll_state_mut(70.0, 0.0, 500.0, 0.0);
+        virt.overscan = 0;
+        virt.report_item_height_mut(0, 60.0);
+
+        assert_eq!(virt.visible_range(), 1..4);
+    }
+
+    #[test]
+    fn focused_index_before_range_expands_start() {
+        let mut virt = fixed_height_virt();
+
+        virt.set_scroll_state_mut(200.0, 0.0, 200.0, 0.0);
+
+        let range = virt.set_focused_index(Some(1)).visible_range();
+
+        assert_eq!(range.start, 1);
+    }
+
+    #[test]
+    fn focused_index_after_range_expands_end() {
+        let mut virt = fixed_height_virt();
+
+        virt.set_scroll_state_mut(0.0, 0.0, 200.0, 0.0);
+
+        let range = virt.set_focused_index(Some(20)).visible_range();
+
+        assert_eq!(range.end, 21);
+    }
+
+    #[test]
+    fn out_of_bounds_focused_index_is_ignored() {
+        let mut virt = fixed_height_virt();
+
+        virt.set_scroll_state_mut(0.0, 0.0, 200.0, 0.0);
+
+        assert_eq!(virt.set_focused_index(Some(200)).visible_range(), 0..8);
+    }
+
+    #[test]
+    fn grid_layout_computes_visible_range_offsets_and_total_height() {
+        let mut virt = grid_virt();
+
+        virt.set_scroll_state_mut(30.0, 0.0, 60.0, 0.0);
+
+        assert_eq!(virt.visible_range(), 2..10);
+        assert_eq!(virt.item_offset_px(7), 60.0);
+        assert_eq!(virt.total_height_px(), 120.0);
+        assert_eq!(virt.scroll_to_index(7, ScrollAlign::Top), 60.0);
+    }
+
+    #[test]
+    fn fixed_height_total_height_matches_item_count() {
+        let virt = Virtualizer::new(7, LayoutStrategy::FixedHeight { item_height: 22.0 });
+
+        assert_eq!(virt.total_height_px(), 154.0);
+    }
+
+    #[test]
+    fn grid_layout_fallback_uses_estimated_height_math() {
+        let mut virt = Virtualizer::new(
+            20,
+            LayoutStrategy::GridLayout {
+                min_item_width: 120.0,
+                max_item_width: 240.0,
+                min_item_height: 50.0,
+                max_item_height: Some(200.0),
+                gap: 12.0,
+            },
+        );
+
+        virt.set_scroll_state_mut(100.0, 0.0, 125.0, 0.0);
+        virt.overscan = 2;
+
+        assert_eq!(virt.visible_range(), 0..7);
+        assert_eq!(virt.item_offset_px(3), 150.0);
+        assert_eq!(virt.total_height_px(), 1000.0);
+        assert_eq!(virt.scroll_to_index(3, ScrollAlign::Top), 150.0);
+    }
+
+    #[test]
+    fn waterfall_layout_fallback_uses_estimated_height_math() {
+        let mut virt = Virtualizer::new(
+            20,
+            LayoutStrategy::WaterfallLayout {
+                min_item_width: 120.0,
+                max_item_width: 240.0,
+                min_item_height: 45.0,
+                gap: 12.0,
+            },
+        );
+
+        virt.set_scroll_state_mut(90.0, 0.0, 90.0, 0.0);
+        virt.overscan = 1;
+
+        assert_eq!(virt.visible_range(), 1..5);
+        assert_eq!(virt.item_offset_px(4), 180.0);
+        assert_eq!(virt.total_height_px(), 900.0);
+        assert_eq!(virt.scroll_to_index(4, ScrollAlign::Center), 157.5);
+    }
+
+    #[test]
+    fn table_layout_fallback_uses_estimated_height_math() {
+        let mut virt = Virtualizer::new(
+            8,
+            LayoutStrategy::TableLayout {
+                row_height: 35.0,
+                header_height: 24.0,
+                column_widths: vec![120.0, 160.0],
+                row_gap: 4.0,
+            },
+        );
+
+        virt.set_scroll_state_mut(70.0, 0.0, 70.0, 0.0);
+        virt.overscan = 1;
+
+        assert_eq!(virt.visible_range(), 1..5);
+        assert_eq!(virt.item_offset_px(3), 105.0);
+        assert_eq!(virt.total_height_px(), 280.0);
+        assert_eq!(virt.scroll_to_index(3, ScrollAlign::Bottom), 70.0);
+    }
+
+    #[test]
+    fn layout_strategy_estimated_height_matches_variant() {
+        assert_eq!(
+            LayoutStrategy::FixedHeight { item_height: 12.0 }.estimated_item_height(),
+            12.0
+        );
+        assert_eq!(
+            LayoutStrategy::VariableHeight {
+                estimated_item_height: 13.0,
+            }
+            .estimated_item_height(),
+            13.0
+        );
+        assert_eq!(
+            LayoutStrategy::Grid {
+                item_height: 14.0,
+                columns: NonZeroUsize::new(2).expect("non-zero columns"),
+            }
+            .estimated_item_height(),
+            14.0
+        );
+        assert_eq!(
+            LayoutStrategy::GridLayout {
+                min_item_width: 100.0,
+                max_item_width: 200.0,
+                min_item_height: 15.0,
+                max_item_height: Some(250.0),
+                gap: 8.0,
+            }
+            .estimated_item_height(),
+            15.0
+        );
+        assert_eq!(
+            LayoutStrategy::WaterfallLayout {
+                min_item_width: 100.0,
+                max_item_width: 200.0,
+                min_item_height: 16.0,
+                gap: 8.0,
+            }
+            .estimated_item_height(),
+            16.0
+        );
+        assert_eq!(
+            LayoutStrategy::TableLayout {
+                row_height: 17.0,
+                header_height: 24.0,
+                column_widths: vec![100.0, 120.0],
+                row_gap: 4.0,
+            }
+            .estimated_item_height(),
+            17.0
+        );
+    }
+
+    #[test]
+    fn scroll_align_default_is_auto() {
+        assert_eq!(ScrollAlign::default(), ScrollAlign::Auto);
+    }
+
+    #[test]
+    fn new_virtualizer_uses_spec_defaults() {
+        let virt = Virtualizer::new(5, LayoutStrategy::FixedHeight { item_height: 20.0 });
+
+        assert_eq!(virt.orientation, Orientation::Vertical);
+        assert_eq!(virt.dir, Direction::Ltr);
+        assert_eq!(virt.overscan, DEFAULT_OVERSCAN);
+        assert_eq!(virt.focused_index, None);
+    }
+}

--- a/crates/ars-collections/src/virtualization.rs
+++ b/crates/ars-collections/src/virtualization.rs
@@ -380,17 +380,17 @@ impl Virtualizer {
         };
 
         let viewport_extent = self.viewport_extent();
-        let scroll_offset = self.scroll_offset();
+        let clamped_scroll_offset = self.clamped_scroll_offset(viewport_extent);
         let item_end = offset + item_extent;
 
         match align {
             ScrollAlign::Auto => {
-                if offset < scroll_offset {
+                if offset < clamped_scroll_offset {
                     offset
-                } else if item_end > scroll_offset + viewport_extent {
+                } else if item_end > clamped_scroll_offset + viewport_extent {
                     item_end - viewport_extent
                 } else {
-                    scroll_offset
+                    clamped_scroll_offset
                 }
             }
 
@@ -590,6 +590,16 @@ mod tests {
         virt.set_scroll_state_mut(360.0, 0.0, 200.0, 0.0);
 
         assert_eq!(virt.scroll_to_index(10, ScrollAlign::Auto), 360.0);
+    }
+
+    #[test]
+    fn scroll_to_index_auto_clamps_stale_scroll_before_visibility_check() {
+        let mut virt = Virtualizer::new(4, LayoutStrategy::FixedHeight { item_height: 40.0 });
+
+        virt.set_scroll_state_mut(500.0, 0.0, 50.0, 0.0);
+        virt.overscan = 0;
+
+        assert_eq!(virt.scroll_to_index(3, ScrollAlign::Auto), 110.0);
     }
 
     #[test]

--- a/crates/ars-collections/src/virtualization.rs
+++ b/crates/ars-collections/src/virtualization.rs
@@ -380,10 +380,11 @@ impl Virtualizer {
         };
 
         let viewport_extent = self.viewport_extent();
+        let max_scroll = (self.total_main_axis_extent() - viewport_extent).max(0.0);
         let clamped_scroll_offset = self.clamped_scroll_offset(viewport_extent);
         let item_end = offset + item_extent;
 
-        match align {
+        let target_offset = match align {
             ScrollAlign::Auto => {
                 if offset < clamped_scroll_offset {
                     offset
@@ -399,7 +400,9 @@ impl Virtualizer {
             ScrollAlign::Bottom => (item_end - viewport_extent).max(0.0),
 
             ScrollAlign::Center => (offset - (viewport_extent - item_extent) / 2.0).max(0.0),
-        }
+        };
+
+        target_offset.clamp(0.0, max_scroll)
     }
 
     /// Convenience wrapper around [`Self::scroll_top_for_index`].
@@ -565,6 +568,24 @@ mod tests {
         let virt = fixed_height_virt();
 
         assert_eq!(virt.scroll_to_index(10, ScrollAlign::Center), 320.0);
+    }
+
+    #[test]
+    fn scroll_to_index_top_clamps_to_scrollable_extent() {
+        let mut virt = Virtualizer::new(4, LayoutStrategy::FixedHeight { item_height: 40.0 });
+
+        virt.set_scroll_state_mut(0.0, 0.0, 50.0, 0.0);
+
+        assert_eq!(virt.scroll_to_index(3, ScrollAlign::Top), 110.0);
+    }
+
+    #[test]
+    fn scroll_to_index_center_clamps_to_scrollable_extent() {
+        let mut virt = Virtualizer::new(4, LayoutStrategy::FixedHeight { item_height: 40.0 });
+
+        virt.set_scroll_state_mut(0.0, 0.0, 50.0, 0.0);
+
+        assert_eq!(virt.scroll_to_index(3, ScrollAlign::Center), 110.0);
     }
 
     #[test]
@@ -852,6 +873,16 @@ mod tests {
         assert_eq!(virt.scroll_to_index(4, ScrollAlign::Auto), 120.0);
         assert_eq!(virt.scroll_to_index(4, ScrollAlign::Bottom), 120.0);
         assert_eq!(virt.scroll_to_index(4, ScrollAlign::Center), 140.0);
+    }
+
+    #[test]
+    fn horizontal_scroll_to_index_top_clamps_to_scrollable_extent() {
+        let mut virt = Virtualizer::new(4, LayoutStrategy::FixedHeight { item_height: 40.0 });
+
+        virt.orientation = Orientation::Horizontal;
+        virt.set_scroll_state_mut(0.0, 0.0, 40.0, 50.0);
+
+        assert_eq!(virt.scroll_to_index(3, ScrollAlign::Top), 110.0);
     }
 
     #[test]

--- a/spec/foundation/06-collections.md
+++ b/spec/foundation/06-collections.md
@@ -3585,6 +3585,21 @@ impl LayoutStrategy {
             LayoutStrategy::TableLayout { row_height, .. }      => *row_height,
         }
     }
+
+    /// Estimated size of a single item along the active scroll axis.
+    pub fn estimated_item_extent(&self, orientation: Orientation) -> f64 {
+        match orientation {
+            Orientation::Vertical => self.estimated_item_height(),
+            Orientation::Horizontal => match self {
+                LayoutStrategy::GridLayout { min_item_width, .. }
+                | LayoutStrategy::WaterfallLayout { min_item_width, .. } => *min_item_width,
+                LayoutStrategy::TableLayout { row_height, column_widths, .. } => {
+                    column_widths.first().copied().unwrap_or(*row_height)
+                }
+                _ => self.estimated_item_height(),
+            },
+        }
+    }
 }
 ```
 
@@ -3848,7 +3863,7 @@ impl Virtualizer {
             return 0..0;
         }
 
-        let max_scroll = (self.total_height_px() - viewport_extent).max(0.0);
+        let max_scroll = (self.total_main_axis_extent() - viewport_extent).max(0.0);
         let scroll_offset = match self.orientation {
             Orientation::Vertical => self.scroll_top,
             Orientation::Horizontal => self.scroll_left,
@@ -3870,9 +3885,9 @@ impl Virtualizer {
                 (row_start * cols, (row_end * cols).min(self.total_count))
             }
             // GridLayout, WaterfallLayout, TableLayout: delegate to
-            // estimated_item_height() for uniform range estimation.
+            // an axis-specific estimate until specialized geometry lands.
             _ => {
-                let est = self.layout.estimated_item_height();
+                let est = self.layout.estimated_item_extent(self.orientation);
                 let first = (scroll_offset / est).floor() as usize;
                 let last  = ((scroll_offset + viewport_extent) / est).ceil() as usize;
                 (first, last)
@@ -3923,10 +3938,10 @@ impl Virtualizer {
                 (index / columns.get()) as f64 * item_height
             }
             // GridLayout, WaterfallLayout, TableLayout: estimate using
-            // uniform item height. Production layouts should override
+            // the active-axis item size. Production layouts should override
             // with measured positions.
             _ => {
-                index as f64 * self.layout.estimated_item_height()
+                index as f64 * self.layout.estimated_item_extent(self.orientation)
             }
         }
     }
@@ -3962,7 +3977,7 @@ impl Virtualizer {
         }
     }
 
-    /// Compute the `scroll_top` value needed to bring item `index` into view.
+    /// Compute the scroll offset needed to bring item `index` into view.
     /// Used by `scroll_to_index` and `scroll_to_key` (after resolving key →
     /// index via the collection).
     ///
@@ -3970,33 +3985,32 @@ impl Virtualizer {
     /// when the item is not already visible.
     pub fn scroll_top_for_index(&self, index: usize, align: ScrollAlign) -> f64 {
         let offset = self.item_offset_px(index);
-        let height = match &self.layout {
+        let extent = match &self.layout {
             LayoutStrategy::FixedHeight { item_height }              => *item_height,
             LayoutStrategy::Grid { item_height, .. }                 => *item_height,
             LayoutStrategy::VariableHeight { estimated_item_height } => {
                 self.measured_heights.get(&index).copied().unwrap_or(*estimated_item_height)
             }
-            // GridLayout, WaterfallLayout, TableLayout: use estimated height.
-            _ => self.layout.estimated_item_height(),
+            // GridLayout, WaterfallLayout, TableLayout: use active-axis estimate.
+            _ => self.layout.estimated_item_extent(self.orientation),
         };
-        let item_bottom = offset + height;
+        let viewport_extent = self.viewport_extent();
+        let scroll_offset = self.scroll_offset();
+        let item_end = offset + extent;
 
         match align {
             ScrollAlign::Auto => {
-                if offset < self.scroll_top {
-                    // Item is above viewport — scroll up.
+                if offset < scroll_offset {
                     offset
-                } else if item_bottom > self.scroll_top + self.viewport_height {
-                    // Item is below viewport — scroll down.
-                    item_bottom - self.viewport_height
+                } else if item_end > scroll_offset + viewport_extent {
+                    item_end - viewport_extent
                 } else {
-                    // Already visible.
-                    self.scroll_top
+                    scroll_offset
                 }
             }
             ScrollAlign::Top    => offset,
-            ScrollAlign::Bottom => (item_bottom - self.viewport_height).max(0.0),
-            ScrollAlign::Center => (offset - (self.viewport_height - height) / 2.0).max(0.0),
+            ScrollAlign::Bottom => (item_end - viewport_extent).max(0.0),
+            ScrollAlign::Center => (offset - (viewport_extent - extent) / 2.0).max(0.0),
         }
     }
 
@@ -4032,6 +4046,34 @@ impl Virtualizer {
         key_to_index: impl Fn(&Key) -> Option<usize>,
     ) -> Option<f64> {
         key_to_index(key).map(|index| self.scroll_to_index(index, align))
+    }
+
+    fn viewport_extent(&self) -> f64 {
+        match self.orientation {
+            Orientation::Vertical => self.viewport_height,
+            Orientation::Horizontal => self.viewport_width,
+        }
+    }
+
+    fn scroll_offset(&self) -> f64 {
+        match self.orientation {
+            Orientation::Vertical => self.scroll_top,
+            Orientation::Horizontal => self.scroll_left,
+        }
+    }
+
+    fn total_main_axis_extent(&self) -> f64 {
+        match self.orientation {
+            Orientation::Vertical => self.total_height_px(),
+            Orientation::Horizontal => match &self.layout {
+                LayoutStrategy::GridLayout { .. }
+                | LayoutStrategy::WaterfallLayout { .. }
+                | LayoutStrategy::TableLayout { .. } => {
+                    self.total_count as f64 * self.layout.estimated_item_extent(self.orientation)
+                }
+                _ => self.total_height_px(),
+            },
+        }
     }
 
     fn variable_height_range(

--- a/spec/foundation/06-collections.md
+++ b/spec/foundation/06-collections.md
@@ -3681,18 +3681,18 @@ pub struct Virtualizer {
 
 #### 6.3.1 VirtualLayout Trait
 
-The `VirtualLayout` trait abstracts layout calculations so that components can swap between fixed-height, variable-height, and grid strategies without changing their scroll-handling logic. Custom layout implementations (e.g., masonry, sticky headers) implement this trait and plug into the `Virtualizer`.
+The `VirtualLayout` trait abstracts vertical layout calculations so that components can swap between fixed-height, variable-height, and grid strategies without changing their scroll-handling logic. Custom layout implementations (e.g., masonry, sticky headers) implement this trait and plug into the `Virtualizer`.
 
-> **Note:** The built-in `LayoutStrategy` enum variants use inline implementations within the `Virtualizer` methods. The `VirtualLayout` trait is an extension point for custom layouts that don't fit the built-in strategies.
+> **Note:** The built-in `LayoutStrategy` enum variants use inline implementations within the `Virtualizer` methods. The `VirtualLayout` trait is an extension point for custom vertical layouts that don't fit the built-in strategies. Layouts that also support horizontal virtualization implement the separate `HorizontalVirtualLayout` trait instead of relying on panic-prone default methods.
 
 ````rust
 // ars-collections/src/virtual_layout.rs
 
 use core::ops::Range;
 
-/// A layout algorithm that maps a flat collection of items to pixel positions
-/// within a scroll container. The `Virtualizer` delegates all geometric
-/// queries to its `VirtualLayout` implementation.
+/// A layout algorithm that maps a flat collection of items to vertical pixel
+/// positions within a scroll container. The `Virtualizer` delegates all
+/// vertical geometric queries to its `VirtualLayout` implementation.
 pub trait VirtualLayout {
     /// Returns the range of item indices `[start, end)` that are visible
     /// (or partially visible) given the current scroll state.
@@ -3744,34 +3744,26 @@ pub trait VirtualLayout {
     /// The total number of items known to the layout. Must match the
     /// collection size (or estimated total for async collections).
     fn item_count(&self) -> usize;
+}
 
-    // ── Horizontal layout methods ──────────────────────────────────────
-    // These mirror the vertical methods for horizontal virtualization.
-    // Default implementations panic — only layouts that support horizontal
-    // scrolling (e.g., Carousel) need to override them.
+/// Optional horizontal extension implemented by layouts that support
+/// inline-axis virtualization.
+pub trait HorizontalVirtualLayout: VirtualLayout {
 
     /// Returns the range of item indices visible given horizontal scroll state.
-    fn visible_range_horizontal(&self, scroll_offset: f64, viewport_width: f64) -> Range<usize> {
-        let _ = (scroll_offset, viewport_width);
-        unimplemented!("this layout does not support horizontal virtualization")
-    }
+    fn visible_range_horizontal(&self, scroll_offset: f64, viewport_width: f64) -> Range<usize>;
 
     /// Returns the X-axis pixel offset for the item at `index`, measured from
     /// the inline-start edge of the scroll content area.
-    fn item_offset_x(&self, index: usize) -> f64 {
-        let _ = index;
-        unimplemented!("this layout does not support horizontal virtualization")
-    }
+    fn item_offset_x(&self, index: usize) -> f64;
 
     /// Returns the total scrollable width of the content area.
-    fn total_width(&self) -> f64 {
-        unimplemented!("this layout does not support horizontal virtualization")
-    }
+    fn total_width(&self) -> f64;
 
     /// Reports the actual measured pixel width of the item at `index`.
     fn report_item_width(&mut self, index: usize, width: f64) {
         let _ = (index, width);
-        // No-op for layouts that don't support horizontal variable widths.
+        // No-op for layouts that don't use horizontal variable widths.
     }
 }
 ````

--- a/spec/foundation/06-collections.md
+++ b/spec/foundation/06-collections.md
@@ -3852,17 +3852,15 @@ impl Virtualizer {
 
     /// Applies a collection update that may have changed flat item indices.
     ///
-    /// Because measured heights are keyed by flat index, adapters must call
-    /// this on inserts, removals, filtering, and reorders before reusing the
-    /// `Virtualizer` for the updated collection. The method updates
-    /// `total_count`, clears the measured-height cache, and drops an
-    /// out-of-bounds `focused_index`.
+    /// Because measured heights and focus are keyed by flat index, adapters
+    /// must call this on inserts, removals, filtering, and reorders before
+    /// reusing the `Virtualizer` for the updated collection. The method
+    /// updates `total_count`, clears the measured-height cache, and clears
+    /// `focused_index`.
     pub fn apply_collection_change_mut(&mut self, total_count: usize) {
         self.total_count = total_count;
         self.measured_heights.clear();
-        if self.focused_index.is_some_and(|i| i >= total_count) {
-            self.focused_index = None;
-        }
+        self.focused_index = None;
     }
 
     /// Immutable wrapper around `apply_collection_change_mut`.
@@ -4171,8 +4169,9 @@ TreeView, GridList) integrate the `Virtualizer` through these patterns:
 
 - Before reusing a `Virtualizer` after inserts, removals, filtering, or reorders,
   the adapter calls `virtualizer.apply_collection_change_mut(new_total_count)`.
-- This invalidates index-based measured heights so stale row measurements are
-  not applied to different items after flat indices shift.
+- This invalidates index-based measured heights and the stored focused index so
+  stale row measurements and stale focus targets are not applied to different
+  items after flat indices shift.
 
 **Scroll event handling:**
 

--- a/spec/foundation/06-collections.md
+++ b/spec/foundation/06-collections.md
@@ -3895,7 +3895,9 @@ impl Virtualizer {
         };
 
         let mut start = first_visible.saturating_sub(self.overscan);
-        let mut end   = (last_visible + self.overscan).min(self.total_count);
+        let mut end   = last_visible
+            .saturating_add(self.overscan)
+            .min(self.total_count);
 
         // Ensure the focused item is always included in the rendered range,
         // even when scrolled out of view (see §6.2 Focused Element Persistence).

--- a/spec/foundation/06-collections.md
+++ b/spec/foundation/06-collections.md
@@ -3850,6 +3850,28 @@ impl Virtualizer {
         new
     }
 
+    /// Applies a collection update that may have changed flat item indices.
+    ///
+    /// Because measured heights are keyed by flat index, adapters must call
+    /// this on inserts, removals, filtering, and reorders before reusing the
+    /// `Virtualizer` for the updated collection. The method updates
+    /// `total_count`, clears the measured-height cache, and drops an
+    /// out-of-bounds `focused_index`.
+    pub fn apply_collection_change_mut(&mut self, total_count: usize) {
+        self.total_count = total_count;
+        self.measured_heights.clear();
+        if self.focused_index.is_some_and(|i| i >= total_count) {
+            self.focused_index = None;
+        }
+    }
+
+    /// Immutable wrapper around `apply_collection_change_mut`.
+    pub fn apply_collection_change(&self, total_count: usize) -> Self {
+        let mut new = self.clone();
+        new.apply_collection_change_mut(total_count);
+        new
+    }
+
     /// The range of flat indices [start, end) that should be rendered,
     /// including overscan. Components iterate `start..end` and render
     /// `collection.get_by_index(i)` for each `i`.
@@ -4141,6 +4163,13 @@ TreeView, GridList) integrate the `Virtualizer` through these patterns:
 - The adapter iterates `range.start..range.end` and renders
   `collection.get_by_index(i)` for each `i`, positioned at
   `virtualizer.item_offset_px(i)`.
+
+**Collection updates:**
+
+- Before reusing a `Virtualizer` after inserts, removals, filtering, or reorders,
+  the adapter calls `virtualizer.apply_collection_change_mut(new_total_count)`.
+- This invalidates index-based measured heights so stale row measurements are
+  not applied to different items after flat indices shift.
 
 **Scroll event handling:**
 

--- a/spec/foundation/06-collections.md
+++ b/spec/foundation/06-collections.md
@@ -4020,16 +4020,17 @@ impl Virtualizer {
         };
         let viewport_extent = self.viewport_extent();
         let scroll_offset = self.scroll_offset();
+        let clamped_scroll_offset = self.clamped_scroll_offset(viewport_extent);
         let item_end = offset + extent;
 
         match align {
             ScrollAlign::Auto => {
-                if offset < scroll_offset {
+                if offset < clamped_scroll_offset {
                     offset
-                } else if item_end > scroll_offset + viewport_extent {
+                } else if item_end > clamped_scroll_offset + viewport_extent {
                     item_end - viewport_extent
                 } else {
-                    scroll_offset
+                    clamped_scroll_offset
                 }
             }
             ScrollAlign::Top    => offset,

--- a/spec/foundation/06-collections.md
+++ b/spec/foundation/06-collections.md
@@ -4019,11 +4019,11 @@ impl Virtualizer {
             _ => self.layout.estimated_item_extent(self.orientation),
         };
         let viewport_extent = self.viewport_extent();
-        let scroll_offset = self.scroll_offset();
+        let max_scroll = (self.total_main_axis_extent() - viewport_extent).max(0.0);
         let clamped_scroll_offset = self.clamped_scroll_offset(viewport_extent);
         let item_end = offset + extent;
 
-        match align {
+        let target_offset = match align {
             ScrollAlign::Auto => {
                 if offset < clamped_scroll_offset {
                     offset
@@ -4036,7 +4036,9 @@ impl Virtualizer {
             ScrollAlign::Top    => offset,
             ScrollAlign::Bottom => (item_end - viewport_extent).max(0.0),
             ScrollAlign::Center => (offset - (viewport_extent - extent) / 2.0).max(0.0),
-        }
+        };
+
+        target_offset.clamp(0.0, max_scroll)
     }
 
     /// Programmatically scroll to the item at `index` with the given alignment.

--- a/spec/foundation/06-collections.md
+++ b/spec/foundation/06-collections.md
@@ -3970,8 +3970,8 @@ impl Virtualizer {
         }
     }
 
-    /// Total scroll height of the list. Set as `height` on the inner scroll
-    /// container so the browser renders the correct scrollbar.
+    /// Total scroll extent of the list on the active axis. Adapters use this
+    /// to size the inner spacer so the browser renders the correct scrollbar.
     ///
     /// **Performance note:** For `VariableHeight`, this method iterates all items O(n).
     /// Callers in scroll handlers should cache the result rather than calling per-frame.
@@ -3994,9 +3994,9 @@ impl Virtualizer {
                 rows as f64 * item_height
             }
             // GridLayout, WaterfallLayout, TableLayout: estimate using
-            // uniform item height.
+            // the active-axis item size.
             _ => {
-                self.total_count as f64 * self.layout.estimated_item_height()
+                self.total_count as f64 * self.layout.estimated_item_extent(self.orientation)
             }
         }
     }

--- a/spec/foundation/06-collections.md
+++ b/spec/foundation/06-collections.md
@@ -3839,31 +3839,42 @@ impl Virtualizer {
     /// including overscan. Components iterate `start..end` and render
     /// `collection.get_by_index(i)` for each `i`.
     pub fn visible_range(&self) -> core::ops::Range<usize> {
-        if self.total_count == 0 || self.viewport_height == 0.0 {
+        let viewport_extent = match self.orientation {
+            Orientation::Vertical => self.viewport_height,
+            Orientation::Horizontal => self.viewport_width,
+        };
+
+        if self.total_count == 0 || viewport_extent == 0.0 {
             return 0..0;
         }
 
+        let max_scroll = (self.total_height_px() - viewport_extent).max(0.0);
+        let scroll_offset = match self.orientation {
+            Orientation::Vertical => self.scroll_top,
+            Orientation::Horizontal => self.scroll_left,
+        }.clamp(0.0, max_scroll);
+
         let (first_visible, last_visible) = match &self.layout {
             LayoutStrategy::FixedHeight { item_height } => {
-                let first = (self.scroll_top / item_height).floor() as usize;
-                let last  = ((self.scroll_top + self.viewport_height) / item_height).ceil() as usize;
+                let first = (scroll_offset / item_height).floor() as usize;
+                let last  = ((scroll_offset + viewport_extent) / item_height).ceil() as usize;
                 (first, last)
             }
             LayoutStrategy::VariableHeight { estimated_item_height } => {
-                self.variable_height_range(*estimated_item_height)
+                self.variable_height_range(*estimated_item_height, scroll_offset, viewport_extent)
             }
             LayoutStrategy::Grid { item_height, columns } => {
                 let cols = columns.get();
-                let row_start = (self.scroll_top / item_height).floor() as usize;
-                let row_end   = ((self.scroll_top + self.viewport_height) / item_height).ceil() as usize;
+                let row_start = (scroll_offset / item_height).floor() as usize;
+                let row_end   = ((scroll_offset + viewport_extent) / item_height).ceil() as usize;
                 (row_start * cols, (row_end * cols).min(self.total_count))
             }
             // GridLayout, WaterfallLayout, TableLayout: delegate to
             // estimated_item_height() for uniform range estimation.
             _ => {
                 let est = self.layout.estimated_item_height();
-                let first = (self.scroll_top / est).floor() as usize;
-                let last  = ((self.scroll_top + self.viewport_height) / est).ceil() as usize;
+                let first = (scroll_offset / est).floor() as usize;
+                let last  = ((scroll_offset + viewport_extent) / est).ceil() as usize;
                 (first, last)
             }
         };
@@ -4023,7 +4034,12 @@ impl Virtualizer {
         key_to_index(key).map(|index| self.scroll_to_index(index, align))
     }
 
-    fn variable_height_range(&self, estimated: f64) -> (usize, usize) {
+    fn variable_height_range(
+        &self,
+        estimated: f64,
+        scroll_offset: f64,
+        viewport_extent: f64,
+    ) -> (usize, usize) {
         let mut cumulative = 0.0_f64;
         let mut first = 0;
         let mut found_first = false;
@@ -4031,12 +4047,12 @@ impl Virtualizer {
 
         for i in 0..self.total_count {
             let h = self.measured_heights.get(&i).copied().unwrap_or(estimated);
-            if cumulative + h > self.scroll_top && !found_first {
+            if cumulative + h > scroll_offset && !found_first {
                 first = i;
                 found_first = true;
             }
             cumulative += h;
-            if cumulative >= self.scroll_top + self.viewport_height {
+            if cumulative >= scroll_offset + viewport_extent {
                 last = i + 1;
                 break;
             }


### PR DESCRIPTION
Closes #533

## Summary
- add the `Virtualizer`, `LayoutStrategy`, and `ScrollAlign` virtualization core in `ars-collections`
- split horizontal layout support into `HorizontalVirtualLayout` and update the spec to match
- expand virtualization and layout tests to improve branch coverage and lock in fallback behavior

## Verification
- cargo test -p ars-collections --lib
- cargo llvm-cov test -p ars-collections --lib --text -- virtualization:: virtual_layout::
- cargo xci