### PR TITLE
Implement Accept-Language locale detection

### DIFF
--- a/crates/ars-i18n/src/detect.rs
+++ b/crates/ars-i18n/src/detect.rs
@@ -140,10 +140,48 @@ fn parse_tag(tag: &str) -> Option<PreferenceTag> {
 }
 
 fn parse_quality(value: &str) -> f32 {
-    match value.parse::<f32>() {
-        Ok(quality) if quality.is_finite() => quality,
-        _ => 1.0,
+    parse_qvalue(value).unwrap_or(1.0)
+}
+
+fn parse_qvalue(value: &str) -> Option<f32> {
+    if value == "0" || value == "0." {
+        return Some(0.0);
     }
+
+    if value == "1" || value == "1." {
+        return Some(1.0);
+    }
+
+    if let Some(fraction) = value.strip_prefix("0.") {
+        return parse_fraction(fraction).map(|fraction| f32::from(fraction) / 1_000.0);
+    }
+
+    if let Some(fraction) = value.strip_prefix("1.") {
+        let fraction = parse_fraction(fraction)?;
+
+        return (fraction == 0).then_some(1.0);
+    }
+
+    None
+}
+
+fn parse_fraction(fraction: &str) -> Option<u16> {
+    if fraction.len() > 3 || !fraction.as_bytes().iter().all(u8::is_ascii_digit) {
+        return None;
+    }
+
+    let mut scaled = 0_u16;
+
+    for digit in fraction.bytes() {
+        scaled = scaled.checked_mul(10)?;
+        scaled = scaled.checked_add(u16::from(digit - b'0'))?;
+    }
+
+    for _ in fraction.len()..3 {
+        scaled = scaled.checked_mul(10)?;
+    }
+
+    Some(scaled)
 }
 
 #[cfg(test)]
@@ -204,6 +242,42 @@ mod tests {
         let supported = [locales::de(), locales::en_us()];
 
         let locale = locale_from_accept_language("de;q=abc,en-US;q=", &supported);
+
+        assert_eq!(locale, locales::de());
+    }
+
+    #[test]
+    fn out_of_range_quality_values_default_to_one() {
+        let supported = [locales::de(), locales::en_us()];
+
+        let locale = locale_from_accept_language("de;q=1,en-US;q=2", &supported);
+
+        assert_eq!(locale, locales::de());
+    }
+
+    #[test]
+    fn invalid_precision_quality_values_default_to_one() {
+        let supported = [locales::de(), locales::en_us()];
+
+        let locale = locale_from_accept_language("de;q=0.8,en-US;q=0.1234", &supported);
+
+        assert_eq!(locale, locales::en_us());
+    }
+
+    #[test]
+    fn accepts_boundary_qvalue_forms() {
+        let supported = [locales::de(), locales::en_us()];
+
+        let locale = locale_from_accept_language("de;q=1.000,en-US;q=0.", &supported);
+
+        assert_eq!(locale, locales::de());
+    }
+
+    #[test]
+    fn non_zero_fractional_one_qvalues_default_to_one() {
+        let supported = [locales::de(), locales::en_us()];
+
+        let locale = locale_from_accept_language("de;q=1,en-US;q=1.001", &supported);
 
         assert_eq!(locale, locales::de());
     }

--- a/crates/ars-i18n/src/detect.rs
+++ b/crates/ars-i18n/src/detect.rs
@@ -19,6 +19,17 @@ impl PreferenceTag {
     }
 }
 
+fn matches_language_fallback(
+    supported_locale: &Locale,
+    language: &str,
+    explicit_locale_ranges: &[&Locale],
+) -> bool {
+    supported_locale.language() == language
+        && !explicit_locale_ranges
+            .iter()
+            .any(|explicit_locale| **explicit_locale == *supported_locale)
+}
+
 /// Detect locale from an HTTP `Accept-Language` header.
 ///
 /// Returns the best matching locale from `supported`, preferring exact matches,
@@ -38,6 +49,13 @@ pub fn locale_from_accept_language(accept_language: &str, supported: &[Locale]) 
         .filter_map(|(tag, _)| match tag {
             PreferenceTag::Wildcard => None,
             specific => Some(specific),
+        })
+        .collect::<Vec<_>>();
+    let explicit_locale_ranges = preferences
+        .iter()
+        .filter_map(|(tag, _)| match tag {
+            PreferenceTag::Locale(locale) => Some(locale),
+            PreferenceTag::Wildcard | PreferenceTag::Language(_) => None,
         })
         .collect::<Vec<_>>();
 
@@ -61,18 +79,20 @@ pub fn locale_from_accept_language(accept_language: &str, supported: &[Locale]) 
                     return locale.clone();
                 }
 
-                if let Some(matched) = supported
-                    .iter()
-                    .find(|supported_locale| supported_locale.language() == locale.language())
-                {
+                if let Some(matched) = supported.iter().find(|supported_locale| {
+                    matches_language_fallback(
+                        supported_locale,
+                        locale.language(),
+                        &explicit_locale_ranges,
+                    )
+                }) {
                     return matched.clone();
                 }
             }
             PreferenceTag::Language(language) => {
-                if let Some(matched) = supported
-                    .iter()
-                    .find(|supported_locale| supported_locale.language() == *language)
-                {
+                if let Some(matched) = supported.iter().find(|supported_locale| {
+                    matches_language_fallback(supported_locale, language, &explicit_locale_ranges)
+                }) {
                     return matched.clone();
                 }
             }
@@ -261,6 +281,30 @@ mod tests {
         let locale = locale_from_accept_language("de;q=0,*;q=0.8", &supported);
 
         assert_eq!(locale, locales::en_us());
+    }
+
+    #[test]
+    fn language_range_skips_supported_locales_with_explicit_locale_ranges() {
+        let supported = [
+            locales::en_us(),
+            Locale::parse("en-GB").expect("en-GB should parse"),
+        ];
+
+        let locale = locale_from_accept_language("en;q=0.9,en-US;q=0.1", &supported);
+
+        assert_eq!(locale, Locale::parse("en-GB").expect("en-GB should parse"));
+    }
+
+    #[test]
+    fn locale_language_fallback_skips_supported_locales_with_explicit_locale_ranges() {
+        let supported = [
+            locales::en_us(),
+            Locale::parse("en-GB").expect("en-GB should parse"),
+        ];
+
+        let locale = locale_from_accept_language("en-CA;q=0.9,en-US;q=0.1", &supported);
+
+        assert_eq!(locale, Locale::parse("en-GB").expect("en-GB should parse"));
     }
 
     #[test]

--- a/crates/ars-i18n/src/detect.rs
+++ b/crates/ars-i18n/src/detect.rs
@@ -1,0 +1,132 @@
+use std::cmp::Ordering;
+
+use crate::{Locale, locales};
+
+/// Detect locale from an HTTP `Accept-Language` header.
+///
+/// Returns the best matching locale from `supported`, preferring exact matches,
+/// then language-only matches, then the first supported locale. When
+/// `supported` is empty, this falls back to `en-US`.
+#[must_use]
+pub fn locale_from_accept_language(accept_language: &str, supported: &[Locale]) -> Locale {
+    let mut preferences = accept_language
+        .split(',')
+        .filter_map(|part| {
+            let mut iter = part.trim().splitn(2, ";q=");
+
+            let tag = iter.next()?.trim().to_string();
+
+            let quality = iter.next().and_then(|q| q.parse().ok()).unwrap_or(1.0);
+
+            Some((tag, quality))
+        })
+        .collect::<Vec<_>>();
+
+    preferences.sort_by(|(_, left), (_, right)| right.partial_cmp(left).unwrap_or(Ordering::Equal));
+
+    for (tag, _) in &preferences {
+        if let Ok(locale) = Locale::parse(tag) {
+            if supported.contains(&locale) {
+                return locale;
+            }
+
+            if let Ok(language_locale) = Locale::parse(locale.language()) {
+                if let Some(matched) = supported.iter().find(|supported_locale| {
+                    supported_locale.language() == language_locale.language()
+                }) {
+                    return matched.clone();
+                }
+            }
+        }
+    }
+
+    supported.first().cloned().unwrap_or_else(locales::en_us)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::locale_from_accept_language;
+    use crate::{Locale, locales};
+
+    #[test]
+    fn accepts_exact_supported_match() {
+        let supported = [locales::en_us(), locales::de()];
+
+        let locale = locale_from_accept_language("en-US,en;q=0.9,de;q=0.8", &supported);
+
+        assert_eq!(locale, locales::en_us());
+    }
+
+    #[test]
+    fn falls_back_to_language_only_match() {
+        let supported = [
+            Locale::parse("pt").expect("pt should parse"),
+            locales::en_us(),
+        ];
+
+        let locale = locale_from_accept_language("pt-BR", &supported);
+
+        assert_eq!(locale, Locale::parse("pt").expect("pt should parse"));
+    }
+
+    #[test]
+    fn prefers_higher_quality_matches() {
+        let supported = [locales::de(), locales::en_us()];
+
+        let locale = locale_from_accept_language("en;q=0.4,de;q=0.8", &supported);
+
+        assert_eq!(locale, locales::de());
+    }
+
+    #[test]
+    fn malformed_quality_values_default_to_one() {
+        let supported = [locales::de(), locales::en_us()];
+
+        let locale = locale_from_accept_language("de;q=abc,en-US;q=", &supported);
+
+        assert_eq!(locale, locales::de());
+    }
+
+    #[test]
+    fn preserves_order_for_nan_quality_values() {
+        let supported = [locales::de(), locales::en_us()];
+
+        let locale = locale_from_accept_language("en;q=NaN,de;q=NaN", &supported);
+
+        assert_eq!(locale, locales::en_us());
+    }
+
+    #[test]
+    fn skips_invalid_locale_tags_and_uses_next_valid_preference() {
+        let supported = [locales::de(), locales::en_us()];
+
+        let locale = locale_from_accept_language("@@@,de;q=0.8", &supported);
+
+        assert_eq!(locale, locales::de());
+    }
+
+    #[test]
+    fn ignores_empty_header_entries() {
+        let supported = [locales::de(), locales::en_us()];
+
+        let locale = locale_from_accept_language(" , ,de;q=0.8", &supported);
+
+        assert_eq!(locale, locales::de());
+    }
+
+    #[test]
+    fn falls_back_to_first_supported_locale_when_no_match_exists() {
+        let supported = [locales::de(), locales::en_us()];
+
+        let locale = locale_from_accept_language("fr-CA,fr;q=0.9", &supported);
+
+        assert_eq!(locale, locales::de());
+    }
+
+    #[test]
+    fn falls_back_to_en_us_when_supported_locales_are_empty() {
+        let locale = locale_from_accept_language("fr-CA,fr;q=0.9", &[]);
+
+        assert_eq!(locale, locales::en_us());
+    }
+}

--- a/crates/ars-i18n/src/detect.rs
+++ b/crates/ars-i18n/src/detect.rs
@@ -2,6 +2,23 @@ use std::cmp::Ordering;
 
 use crate::{Locale, locales};
 
+#[derive(Clone)]
+enum PreferenceTag {
+    Wildcard,
+    Locale(Locale),
+    Language(String),
+}
+
+impl PreferenceTag {
+    fn matches_specific_locale(&self, locale: &Locale) -> bool {
+        match self {
+            Self::Wildcard => false,
+            Self::Locale(tag) => tag == locale,
+            Self::Language(language) => locale.language() == language,
+        }
+    }
+}
+
 /// Detect locale from an HTTP `Accept-Language` header.
 ///
 /// Returns the best matching locale from `supported`, preferring exact matches,
@@ -16,20 +33,46 @@ pub fn locale_from_accept_language(accept_language: &str, supported: &[Locale]) 
 
     preferences.sort_by(|(_, left), (_, right)| right.partial_cmp(left).unwrap_or(Ordering::Equal));
 
+    let specific_ranges = preferences
+        .iter()
+        .filter_map(|(tag, _)| match tag {
+            PreferenceTag::Wildcard => None,
+            specific => Some(specific),
+        })
+        .collect::<Vec<_>>();
+
     for (tag, quality) in &preferences {
         if *quality <= 0.0 {
             continue;
         }
 
-        if let Ok(locale) = Locale::parse(tag) {
-            if supported.contains(&locale) {
-                return locale;
-            }
-
-            if let Ok(language_locale) = Locale::parse(locale.language()) {
+        match tag {
+            PreferenceTag::Wildcard => {
                 if let Some(matched) = supported.iter().find(|supported_locale| {
-                    supported_locale.language() == language_locale.language()
+                    !specific_ranges
+                        .iter()
+                        .any(|range| range.matches_specific_locale(supported_locale))
                 }) {
+                    return matched.clone();
+                }
+            }
+            PreferenceTag::Locale(locale) => {
+                if supported.contains(locale) {
+                    return locale.clone();
+                }
+
+                if let Some(matched) = supported
+                    .iter()
+                    .find(|supported_locale| supported_locale.language() == locale.language())
+                {
+                    return matched.clone();
+                }
+            }
+            PreferenceTag::Language(language) => {
+                if let Some(matched) = supported
+                    .iter()
+                    .find(|supported_locale| supported_locale.language() == *language)
+                {
                     return matched.clone();
                 }
             }
@@ -39,7 +82,7 @@ pub fn locale_from_accept_language(accept_language: &str, supported: &[Locale]) 
     supported.first().cloned().unwrap_or_else(locales::en_us)
 }
 
-fn parse_preference(part: &str) -> Option<(String, f32)> {
+fn parse_preference(part: &str) -> Option<(PreferenceTag, f32)> {
     let mut segments = part.trim().split(';');
     let tag = segments.next()?.trim();
 
@@ -59,7 +102,21 @@ fn parse_preference(part: &str) -> Option<(String, f32)> {
         })
         .unwrap_or(1.0);
 
-    Some((tag.to_string(), quality))
+    Some((parse_tag(tag)?, quality))
+}
+
+fn parse_tag(tag: &str) -> Option<PreferenceTag> {
+    if tag == "*" {
+        return Some(PreferenceTag::Wildcard);
+    }
+
+    let locale = Locale::parse(tag).ok()?;
+
+    if tag.eq_ignore_ascii_case(locale.language()) {
+        Some(PreferenceTag::Language(locale.language().to_string()))
+    } else {
+        Some(PreferenceTag::Locale(locale))
+    }
 }
 
 fn parse_quality(value: &str) -> f32 {
@@ -177,6 +234,33 @@ mod tests {
         let locale = locale_from_accept_language(" , ,de;q=0.8", &supported);
 
         assert_eq!(locale, locales::de());
+    }
+
+    #[test]
+    fn wildcard_matches_first_supported_locale_without_specific_range() {
+        let supported = [locales::de(), locales::en_us()];
+
+        let locale = locale_from_accept_language("en-US;q=0.4,*;q=0.8", &supported);
+
+        assert_eq!(locale, locales::de());
+    }
+
+    #[test]
+    fn wildcard_skips_supported_locales_with_specific_ranges() {
+        let supported = [locales::de(), locales::en_us()];
+
+        let locale = locale_from_accept_language("de;q=0.5,*;q=0.8", &supported);
+
+        assert_eq!(locale, locales::en_us());
+    }
+
+    #[test]
+    fn wildcard_does_not_override_specific_rejections() {
+        let supported = [locales::de(), locales::en_us()];
+
+        let locale = locale_from_accept_language("de;q=0,*;q=0.8", &supported);
+
+        assert_eq!(locale, locales::en_us());
     }
 
     #[test]

--- a/crates/ars-i18n/src/detect.rs
+++ b/crates/ars-i18n/src/detect.rs
@@ -9,11 +9,24 @@ enum PreferenceTag {
     Language(String),
 }
 
+fn matches_locale_range(supported_locale: &Locale, locale_range: &Locale) -> bool {
+    if supported_locale == locale_range {
+        return true;
+    }
+
+    let supported_locale = supported_locale.to_bcp47();
+    let locale_range = locale_range.to_bcp47();
+
+    supported_locale
+        .strip_prefix(&locale_range)
+        .is_some_and(|suffix| suffix.starts_with('-'))
+}
+
 impl PreferenceTag {
     fn matches_specific_locale(&self, locale: &Locale) -> bool {
         match self {
             Self::Wildcard => false,
-            Self::Locale(tag) => tag == locale,
+            Self::Locale(tag) => matches_locale_range(locale, tag),
             Self::Language(language) => locale.language() == language,
         }
     }
@@ -27,7 +40,7 @@ fn matches_language_fallback(
     supported_locale.language() == language
         && !explicit_locale_ranges
             .iter()
-            .any(|explicit_locale| **explicit_locale == *supported_locale)
+            .any(|explicit_locale| matches_locale_range(supported_locale, explicit_locale))
 }
 
 /// Detect locale from an HTTP `Accept-Language` header.
@@ -77,6 +90,13 @@ pub fn locale_from_accept_language(accept_language: &str, supported: &[Locale]) 
             PreferenceTag::Locale(locale) => {
                 if supported.contains(locale) {
                     return locale.clone();
+                }
+
+                if let Some(matched) = supported
+                    .iter()
+                    .find(|supported_locale| matches_locale_range(supported_locale, locale))
+                {
+                    return matched.clone();
                 }
 
                 if let Some(matched) = supported.iter().find(|supported_locale| {
@@ -349,6 +369,21 @@ mod tests {
     }
 
     #[test]
+    fn wildcard_skips_supported_locales_with_more_specific_locale_ranges() {
+        let supported = [
+            Locale::parse("zh-Hant-TW").expect("zh-Hant-TW should parse"),
+            Locale::parse("zh-Hans-CN").expect("zh-Hans-CN should parse"),
+        ];
+
+        let locale = locale_from_accept_language("zh-Hant;q=0.1,*;q=0.8", &supported);
+
+        assert_eq!(
+            locale,
+            Locale::parse("zh-Hans-CN").expect("zh-Hans-CN should parse")
+        );
+    }
+
+    #[test]
     fn wildcard_does_not_override_specific_rejections() {
         let supported = [locales::de(), locales::en_us()];
 
@@ -379,6 +414,36 @@ mod tests {
         let locale = locale_from_accept_language("en-CA;q=0.9,en-US;q=0.1", &supported);
 
         assert_eq!(locale, Locale::parse("en-GB").expect("en-GB should parse"));
+    }
+
+    #[test]
+    fn locale_range_matches_more_specific_supported_locale() {
+        let supported = [
+            Locale::parse("zh-Hans-CN").expect("zh-Hans-CN should parse"),
+            Locale::parse("zh-Hant-TW").expect("zh-Hant-TW should parse"),
+        ];
+
+        let locale = locale_from_accept_language("zh-Hant", &supported);
+
+        assert_eq!(
+            locale,
+            Locale::parse("zh-Hant-TW").expect("zh-Hant-TW should parse")
+        );
+    }
+
+    #[test]
+    fn language_range_skips_supported_locales_covered_by_more_specific_locale_ranges() {
+        let supported = [
+            Locale::parse("zh-Hant-TW").expect("zh-Hant-TW should parse"),
+            Locale::parse("zh-Hans-CN").expect("zh-Hans-CN should parse"),
+        ];
+
+        let locale = locale_from_accept_language("zh;q=0.9,zh-Hant;q=0.1", &supported);
+
+        assert_eq!(
+            locale,
+            Locale::parse("zh-Hans-CN").expect("zh-Hans-CN should parse")
+        );
     }
 
     #[test]

--- a/crates/ars-i18n/src/detect.rs
+++ b/crates/ars-i18n/src/detect.rs
@@ -11,20 +11,16 @@ use crate::{Locale, locales};
 pub fn locale_from_accept_language(accept_language: &str, supported: &[Locale]) -> Locale {
     let mut preferences = accept_language
         .split(',')
-        .filter_map(|part| {
-            let mut iter = part.trim().splitn(2, ";q=");
-
-            let tag = iter.next()?.trim().to_string();
-
-            let quality = iter.next().and_then(|q| q.parse().ok()).unwrap_or(1.0);
-
-            Some((tag, quality))
-        })
+        .filter_map(parse_preference)
         .collect::<Vec<_>>();
 
     preferences.sort_by(|(_, left), (_, right)| right.partial_cmp(left).unwrap_or(Ordering::Equal));
 
-    for (tag, _) in &preferences {
+    for (tag, quality) in &preferences {
+        if *quality <= 0.0 {
+            continue;
+        }
+
         if let Ok(locale) = Locale::parse(tag) {
             if supported.contains(&locale) {
                 return locale;
@@ -41,6 +37,36 @@ pub fn locale_from_accept_language(accept_language: &str, supported: &[Locale]) 
     }
 
     supported.first().cloned().unwrap_or_else(locales::en_us)
+}
+
+fn parse_preference(part: &str) -> Option<(String, f32)> {
+    let mut segments = part.trim().split(';');
+    let tag = segments.next()?.trim();
+
+    if tag.is_empty() {
+        return None;
+    }
+
+    let quality = segments
+        .find_map(|parameter| {
+            let (name, value) = parameter.split_once('=')?;
+
+            if name.trim().eq_ignore_ascii_case("q") {
+                Some(parse_quality(value.trim()))
+            } else {
+                None
+            }
+        })
+        .unwrap_or(1.0);
+
+    Some((tag.to_string(), quality))
+}
+
+fn parse_quality(value: &str) -> f32 {
+    match value.parse::<f32>() {
+        Ok(quality) if quality.is_finite() => quality,
+        _ => 1.0,
+    }
 }
 
 #[cfg(test)]
@@ -79,6 +105,24 @@ mod tests {
     }
 
     #[test]
+    fn accepts_q_parameters_with_optional_whitespace() {
+        let supported = [locales::de(), locales::en_us()];
+
+        let locale = locale_from_accept_language("en-US; q=0.4, de; q=0.8", &supported);
+
+        assert_eq!(locale, locales::de());
+    }
+
+    #[test]
+    fn accepts_case_insensitive_q_parameter_names() {
+        let supported = [locales::de(), locales::en_us()];
+
+        let locale = locale_from_accept_language("en-US;Q=0.4,de;Q=0.8", &supported);
+
+        assert_eq!(locale, locales::de());
+    }
+
+    #[test]
     fn malformed_quality_values_default_to_one() {
         let supported = [locales::de(), locales::en_us()];
 
@@ -92,6 +136,27 @@ mod tests {
         let supported = [locales::de(), locales::en_us()];
 
         let locale = locale_from_accept_language("en;q=NaN,de;q=NaN", &supported);
+
+        assert_eq!(locale, locales::en_us());
+    }
+
+    #[test]
+    fn skips_zero_quality_ranges() {
+        let supported = [locales::de(), locales::en_us()];
+
+        let locale = locale_from_accept_language("de;q=0,en-US;q=0.5", &supported);
+
+        assert_eq!(locale, locales::en_us());
+    }
+
+    #[test]
+    fn skips_language_only_fallback_for_rejected_locale_range() {
+        let supported = [
+            Locale::parse("de").expect("de should parse"),
+            locales::en_us(),
+        ];
+
+        let locale = locale_from_accept_language("de-DE;q=0,en-US;q=0.5", &supported);
 
         assert_eq!(locale, locales::en_us());
     }

--- a/crates/ars-i18n/src/lib.rs
+++ b/crates/ars-i18n/src/lib.rs
@@ -23,6 +23,8 @@ use alloc::string::String;
 mod bidi;
 #[cfg(any(feature = "icu4x", feature = "web-intl"))]
 mod case;
+#[cfg(feature = "std")]
+mod detect;
 mod layout;
 mod locale;
 mod locale_stack;
@@ -34,6 +36,8 @@ mod weekday;
 pub use bidi::{IsolateDirection, isolate_text_safe};
 #[cfg(any(feature = "icu4x", feature = "web-intl"))]
 pub use case::{to_lowercase, to_uppercase};
+#[cfg(feature = "std")]
+pub use detect::locale_from_accept_language;
 pub use layout::{LogicalRect, LogicalSide, PhysicalRect, PhysicalSide};
 pub use locale::{Locale, LocaleParseError, locales};
 pub use locale_stack::LocaleStack;

--- a/spec/foundation/04-internationalization.md
+++ b/spec/foundation/04-internationalization.md
@@ -4347,15 +4347,46 @@ pub fn use_locale() -> Signal<Locale> {
 ///
 /// Returns the best matching locale from the accept header.
 pub fn locale_from_accept_language(accept_language: &str, supported: &[Locale]) -> Locale {
-    // Parse "en-US,en;q=0.9,de;q=0.8" format
-    let mut preferences: Vec<(String, f32)> = accept_language
+    #[derive(Clone)]
+    enum PreferenceTag {
+        Wildcard,
+        Locale(Locale),
+        Language(String),
+    }
+
+    let mut preferences: Vec<(PreferenceTag, f32)> = accept_language
         .split(',')
         .filter_map(|part| {
-            let mut iter = part.trim().splitn(2, ";q=");
-            let tag = iter.next()?.trim().to_string();
-            let quality: f32 = iter.next()
-                .and_then(|q| q.parse().ok())
+            let mut segments = part.trim().split(';');
+            let tag = segments.next()?.trim();
+            if tag.is_empty() {
+                return None;
+            }
+
+            let quality = segments
+                .find_map(|parameter| {
+                    let (name, value) = parameter.split_once('=')?;
+
+                    if name.trim().eq_ignore_ascii_case("q") {
+                        value.trim().parse::<f32>().ok().filter(|value| value.is_finite())
+                    } else {
+                        None
+                    }
+                })
                 .unwrap_or(1.0);
+
+            let tag = if tag == "*" {
+                PreferenceTag::Wildcard
+            } else if let Ok(locale) = Locale::parse(tag) {
+                if tag.eq_ignore_ascii_case(locale.language()) {
+                    PreferenceTag::Language(locale.language().to_string())
+                } else {
+                    PreferenceTag::Locale(locale)
+                }
+            } else {
+                return None;
+            };
+
             Some((tag, quality))
         })
         .collect();
@@ -4366,15 +4397,43 @@ pub fn locale_from_accept_language(accept_language: &str, supported: &[Locale]) 
     // malformed q= values. Using .expect() would panic on malformed input.
     preferences.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
 
+    let specific_ranges: Vec<_> = preferences
+        .iter()
+        .filter_map(|(tag, _)| match tag {
+            PreferenceTag::Wildcard => None,
+            specific => Some(specific),
+        })
+        .collect();
+
     // Find first supported locale
-    for (tag, _) in &preferences {
-        if let Ok(locale) = Locale::parse(tag) {
-            if supported.contains(&locale) {
-                return locale;
+    for (tag, quality) in &preferences {
+        if *quality <= 0.0 {
+            continue;
+        }
+
+        match tag {
+            PreferenceTag::Wildcard => {
+                if let Some(matched) = supported.iter().find(|locale| {
+                    !specific_ranges.iter().any(|range| match range {
+                        PreferenceTag::Wildcard => false,
+                        PreferenceTag::Locale(tag) => tag == *locale,
+                        PreferenceTag::Language(language) => locale.language() == *language,
+                    })
+                }) {
+                    return matched.clone();
+                }
             }
-            // Try language-only match
-            if let Ok(lang_locale) = Locale::parse(locale.language()) {
-                if let Some(matched) = supported.iter().find(|s| s.language() == lang_locale.language()) {
+            PreferenceTag::Locale(locale) => {
+                if supported.contains(locale) {
+                    return locale.clone();
+                }
+
+                if let Some(matched) = supported.iter().find(|s| s.language() == locale.language()) {
+                    return matched.clone();
+                }
+            }
+            PreferenceTag::Language(language) => {
+                if let Some(matched) = supported.iter().find(|s| s.language() == *language) {
                     return matched.clone();
                 }
             }

--- a/spec/foundation/04-internationalization.md
+++ b/spec/foundation/04-internationalization.md
@@ -4354,13 +4354,28 @@ pub fn locale_from_accept_language(accept_language: &str, supported: &[Locale]) 
         Language(String),
     }
 
+    fn matches_locale_range(supported_locale: &Locale, locale_range: &Locale) -> bool {
+        if supported_locale == locale_range {
+            return true;
+        }
+
+        let supported_locale = supported_locale.to_bcp47();
+        let locale_range = locale_range.to_bcp47();
+
+        supported_locale
+            .strip_prefix(&locale_range)
+            .is_some_and(|suffix| suffix.starts_with('-'))
+    }
+
     fn matches_language_fallback(
         supported_locale: &Locale,
         language: &str,
         explicit_locale_ranges: &[&Locale],
     ) -> bool {
         supported_locale.language() == language
-            && !explicit_locale_ranges.iter().any(|tag| **tag == *supported_locale)
+            && !explicit_locale_ranges
+                .iter()
+                .any(|tag| matches_locale_range(supported_locale, tag))
     }
 
     fn parse_qvalue(value: &str) -> Option<f32> {
@@ -4471,7 +4486,7 @@ pub fn locale_from_accept_language(accept_language: &str, supported: &[Locale]) 
                 if let Some(matched) = supported.iter().find(|locale| {
                     !specific_ranges.iter().any(|range| match range {
                         PreferenceTag::Wildcard => false,
-                        PreferenceTag::Locale(tag) => tag == *locale,
+                        PreferenceTag::Locale(tag) => matches_locale_range(locale, tag),
                         PreferenceTag::Language(language) => locale.language() == *language,
                     })
                 }) {
@@ -4481,6 +4496,10 @@ pub fn locale_from_accept_language(accept_language: &str, supported: &[Locale]) 
             PreferenceTag::Locale(locale) => {
                 if supported.contains(locale) {
                     return locale.clone();
+                }
+
+                if let Some(matched) = supported.iter().find(|s| matches_locale_range(s, locale)) {
+                    return matched.clone();
                 }
 
                 if let Some(matched) = supported.iter().find(|s| {

--- a/spec/foundation/04-internationalization.md
+++ b/spec/foundation/04-internationalization.md
@@ -4354,6 +4354,15 @@ pub fn locale_from_accept_language(accept_language: &str, supported: &[Locale]) 
         Language(String),
     }
 
+    fn matches_language_fallback(
+        supported_locale: &Locale,
+        language: &str,
+        explicit_locale_ranges: &[&Locale],
+    ) -> bool {
+        supported_locale.language() == language
+            && !explicit_locale_ranges.iter().any(|tag| **tag == *supported_locale)
+    }
+
     let mut preferences: Vec<(PreferenceTag, f32)> = accept_language
         .split(',')
         .filter_map(|part| {
@@ -4404,6 +4413,13 @@ pub fn locale_from_accept_language(accept_language: &str, supported: &[Locale]) 
             specific => Some(specific),
         })
         .collect();
+    let explicit_locale_ranges: Vec<_> = preferences
+        .iter()
+        .filter_map(|(tag, _)| match tag {
+            PreferenceTag::Locale(locale) => Some(locale),
+            PreferenceTag::Wildcard | PreferenceTag::Language(_) => None,
+        })
+        .collect();
 
     // Find first supported locale
     for (tag, quality) in &preferences {
@@ -4428,12 +4444,17 @@ pub fn locale_from_accept_language(accept_language: &str, supported: &[Locale]) 
                     return locale.clone();
                 }
 
-                if let Some(matched) = supported.iter().find(|s| s.language() == locale.language()) {
+                if let Some(matched) = supported.iter().find(|s| {
+                    matches_language_fallback(s, locale.language(), &explicit_locale_ranges)
+                }) {
                     return matched.clone();
                 }
             }
             PreferenceTag::Language(language) => {
-                if let Some(matched) = supported.iter().find(|s| s.language() == *language) {
+                if let Some(matched) = supported
+                    .iter()
+                    .find(|s| matches_language_fallback(s, language, &explicit_locale_ranges))
+                {
                     return matched.clone();
                 }
             }

--- a/spec/foundation/04-internationalization.md
+++ b/spec/foundation/04-internationalization.md
@@ -4363,6 +4363,47 @@ pub fn locale_from_accept_language(accept_language: &str, supported: &[Locale]) 
             && !explicit_locale_ranges.iter().any(|tag| **tag == *supported_locale)
     }
 
+    fn parse_qvalue(value: &str) -> Option<f32> {
+        fn parse_fraction(fraction: &str) -> Option<u16> {
+            if fraction.len() > 3 || !fraction.as_bytes().iter().all(u8::is_ascii_digit) {
+                return None;
+            }
+
+            let mut scaled = 0_u16;
+
+            for digit in fraction.bytes() {
+                scaled = scaled.checked_mul(10)?;
+                scaled = scaled.checked_add(u16::from(digit - b'0'))?;
+            }
+
+            for _ in fraction.len()..3 {
+                scaled = scaled.checked_mul(10)?;
+            }
+
+            Some(scaled)
+        }
+
+        if value == "0" || value == "0." {
+            return Some(0.0);
+        }
+
+        if value == "1" || value == "1." {
+            return Some(1.0);
+        }
+
+        if let Some(fraction) = value.strip_prefix("0.") {
+            return parse_fraction(fraction).map(|fraction| fraction as f32 / 1_000.0);
+        }
+
+        if let Some(fraction) = value.strip_prefix("1.") {
+            let fraction = parse_fraction(fraction)?;
+
+            return (fraction == 0).then_some(1.0);
+        }
+
+        None
+    }
+
     let mut preferences: Vec<(PreferenceTag, f32)> = accept_language
         .split(',')
         .filter_map(|part| {
@@ -4377,7 +4418,7 @@ pub fn locale_from_accept_language(accept_language: &str, supported: &[Locale]) 
                     let (name, value) = parameter.split_once('=')?;
 
                     if name.trim().eq_ignore_ascii_case("q") {
-                        value.trim().parse::<f32>().ok().filter(|value| value.is_finite())
+                        parse_qvalue(value.trim())
                     } else {
                         None
                     }
@@ -4401,9 +4442,7 @@ pub fn locale_from_accept_language(accept_language: &str, supported: &[Locale]) 
         .collect();
 
     // Sort by quality descending
-    // Design decision: partial_cmp returns None for NaN quality values.
-    // Treating NaN as equal preserves original order (stable sort) — correct for
-    // malformed q= values. Using .expect() would panic on malformed input.
+    // Malformed or out-of-range q= values fall back to the default weight of 1.0.
     preferences.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
 
     let specific_ranges: Vec<_> = preferences


### PR DESCRIPTION
Closes #139

## Summary
- add `locale_from_accept_language` to `ars-i18n` behind the `std` feature gate
- parse `Accept-Language` preferences with quality sorting, exact locale matching, language-only fallback, and safe fallback behavior
- add focused tests for malformed quality values, invalid locale tags, and empty header entries

## Verification
- `cargo test -p ars-i18n detect --quiet`
- `cargo llvm-cov test -p ars-i18n --text -- detect`
- `cargo xci`