### PR TITLE
[codex] Implement string collation backends

### DIFF
--- a/crates/ars-i18n/src/collation.rs
+++ b/crates/ars-i18n/src/collation.rs
@@ -15,7 +15,7 @@ use core::cmp::Ordering;
 #[cfg(feature = "icu4x")]
 use icu::collator::{
     Collator as OwnedCollator,
-    options::{CollatorOptions as IcuCollatorOptions, Strength},
+    options::{AlternateHandling, CollatorOptions as IcuCollatorOptions, MaxVariable, Strength},
     preferences::CollationNumericOrdering,
 };
 #[cfg(all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")))]
@@ -117,6 +117,8 @@ impl StringCollator {
     pub fn new(locale: &Locale, options: CollationOptions) -> Self {
         let mut icu_options = IcuCollatorOptions::default();
         icu_options.strength = Some(icu_strength(options));
+        icu_options.alternate_handling = Some(AlternateHandling::Shifted);
+        icu_options.max_variable = Some(MaxVariable::Punctuation);
 
         let mut preferences = icu::collator::CollatorPreferences::from(locale.as_icu());
         if options.numeric && preferences.numeric_ordering.is_none() {
@@ -158,7 +160,9 @@ impl StringCollator {
         let js_options = JsCollatorOptions::new();
         js_options.set_sensitivity(js_sensitivity(options));
         js_options.set_ignore_punctuation(js_ignore_punctuation(options));
-        js_options.set_numeric(options.numeric);
+        if locale.numeric_ordering_extension().is_none() {
+            js_options.set_numeric(options.numeric);
+        }
 
         let collator = JsCollator::new(&locales, js_options.as_ref());
 
@@ -337,6 +341,20 @@ mod tests {
 
     #[cfg(feature = "icu4x")]
     #[test]
+    fn tertiary_strength_ignores_punctuation_differences() {
+        let options = CollationOptions {
+            strength: CollationStrength::Tertiary,
+            numeric: false,
+            ..Default::default()
+        };
+
+        let collator = StringCollator::new(&locales::en(), options);
+
+        assert_eq!(collator.compare("ab", "a-b"), Ordering::Equal);
+    }
+
+    #[cfg(feature = "icu4x")]
+    #[test]
     fn quaternary_strength_keeps_case_and_accent_differences() {
         let options = CollationOptions {
             strength: CollationStrength::Quaternary,
@@ -348,6 +366,7 @@ mod tests {
 
         assert_ne!(collator.compare("Cafe", "café"), Ordering::Equal);
         assert_ne!(collator.compare("Cafe", "cafe"), Ordering::Equal);
+        assert_ne!(collator.compare("ab", "a-b"), Ordering::Equal);
     }
 
     #[cfg(feature = "icu4x")]
@@ -591,6 +610,18 @@ mod web_intl_tests {
         collator.sort(&mut items);
 
         assert_eq!(items, vec!["file2", "file9", "file10"]);
+    }
+
+    #[wasm_bindgen_test]
+    fn web_intl_locale_numeric_extension_is_not_overridden() {
+        let locale = Locale::parse("en-u-kn-false").expect("locale should parse");
+        let options = CollationOptions {
+            numeric: true,
+            ..Default::default()
+        };
+        let collator = StringCollator::new(&locale, options);
+
+        assert_eq!(collator.compare("file10", "file9"), Ordering::Less);
     }
 
     #[wasm_bindgen_test]

--- a/crates/ars-i18n/src/collation.rs
+++ b/crates/ars-i18n/src/collation.rs
@@ -1,0 +1,629 @@
+//! Locale-aware string sorting and comparison helpers.
+//!
+//! This module exposes the spec-defined collation API with backend selection
+//! hidden behind cargo features.
+//!
+//! - `icu4x` uses ICU4X collators with CLDR data compiled into the binary.
+//! - `web-intl` on `wasm32` uses the browser's `Intl.Collator` implementation.
+//! - Without either backend, or on non-wasm `web-intl` builds, comparison
+//!   falls back to Rust's byte-order `Ord` implementation so the public API
+//!   remains available in feature-matrix checks.
+
+use alloc::{string::String, vec::Vec};
+use core::cmp::Ordering;
+
+#[cfg(feature = "icu4x")]
+use icu::collator::{
+    Collator as OwnedCollator,
+    options::{CollatorOptions as IcuCollatorOptions, Strength},
+    preferences::CollationNumericOrdering,
+};
+#[cfg(all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")))]
+use {
+    js_sys::{
+        Array, Function,
+        Intl::{Collator as JsCollator, CollatorOptions as JsCollatorOptions},
+    },
+    wasm_bindgen::JsValue,
+};
+
+use crate::Locale;
+
+/// Comparison strength for locale-aware string collation.
+#[cfg(feature = "icu4x")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Default)]
+pub enum CollationStrength {
+    /// Compare base letters only, ignoring accents and case.
+    Primary,
+    /// Compare base letters and accents, ignoring case.
+    Secondary,
+    /// Compare base letters, accents, and case.
+    #[default]
+    Tertiary,
+    /// Compare punctuation and symbol differences in addition to tertiary data.
+    Quaternary,
+}
+
+/// Comparison strength for locale-aware string collation.
+///
+/// This fallback definition keeps downstream code compiling when ICU4X is not
+/// enabled. In that configuration, [`StringCollator`] degrades to Rust's
+/// default byte-order comparison regardless of the selected strength.
+#[cfg(not(feature = "icu4x"))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Default)]
+pub enum CollationStrength {
+    /// Compare base letters only, ignoring accents and case.
+    Primary,
+    /// Compare base letters and accents, ignoring case.
+    Secondary,
+    /// Compare base letters, accents, and case.
+    #[default]
+    Tertiary,
+    /// Compare punctuation and symbol differences in addition to tertiary data.
+    Quaternary,
+}
+
+/// Options controlling locale-aware string comparison.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CollationOptions {
+    /// The comparison sensitivity to use.
+    pub strength: CollationStrength,
+
+    /// Whether case differences should be ignored.
+    ///
+    /// When `true`, the effective sensitivity is forced to secondary-strength
+    /// behavior so case is ignored while accent differences remain observable.
+    pub case_insensitive: bool,
+
+    /// Whether numeric substrings should be ordered by numeric value.
+    ///
+    /// When enabled, strings such as `"file9"` and `"file10"` sort in natural
+    /// numeric order instead of pure lexicographic order.
+    pub numeric: bool,
+}
+
+impl Default for CollationOptions {
+    fn default() -> Self {
+        Self {
+            strength: CollationStrength::Tertiary,
+            case_insensitive: false,
+            numeric: true,
+        }
+    }
+}
+
+/// Common interface for collation backends.
+pub trait CollationFormat {
+    /// Compare two strings according to locale-aware collation rules.
+    fn compare(&self, a: &str, b: &str) -> Ordering;
+}
+
+/// A locale-aware string collator.
+///
+/// The concrete backend varies by feature set:
+/// - `icu4x`: ICU4X `Collator`
+/// - `web-intl` on `wasm32`: browser `Intl.Collator`
+/// - otherwise: Rust byte-order comparison
+#[cfg(feature = "icu4x")]
+#[derive(Debug)]
+pub struct StringCollator {
+    collator: OwnedCollator,
+}
+
+#[cfg(feature = "icu4x")]
+impl StringCollator {
+    /// Create a new locale-aware string collator.
+    #[must_use]
+    pub fn new(locale: &Locale, options: CollationOptions) -> Self {
+        let mut icu_options = IcuCollatorOptions::default();
+        icu_options.strength = Some(icu_strength(options));
+
+        let mut preferences = icu::collator::CollatorPreferences::from(locale.as_icu());
+        if options.numeric && preferences.numeric_ordering.is_none() {
+            preferences.numeric_ordering = Some(CollationNumericOrdering::True);
+        }
+
+        let collator = OwnedCollator::try_new(preferences, icu_options)
+            .expect("compiled_data guarantees collation data is available for all locales")
+            .static_to_owned();
+
+        Self { collator }
+    }
+
+    /// Compare two strings according to locale-aware collation rules.
+    #[must_use]
+    pub fn compare(&self, a: &str, b: &str) -> Ordering {
+        self.collator.as_borrowed().compare(a, b)
+    }
+}
+
+/// A locale-aware string collator.
+///
+/// The concrete backend varies by feature set:
+/// - `icu4x`: ICU4X `Collator`
+/// - `web-intl` on `wasm32`: browser `Intl.Collator`
+/// - otherwise: Rust byte-order comparison
+#[cfg(all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")))]
+#[derive(Debug)]
+pub struct StringCollator {
+    collator: JsCollator,
+}
+
+#[cfg(all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")))]
+impl StringCollator {
+    /// Create a new locale-aware string collator using `Intl.Collator`.
+    #[must_use]
+    pub fn new(locale: &Locale, options: CollationOptions) -> Self {
+        let locales = Array::of1(&JsValue::from_str(&locale.to_bcp47()));
+        let js_options = JsCollatorOptions::new();
+        js_options.set_sensitivity(js_sensitivity(options));
+        js_options.set_numeric(options.numeric);
+
+        let collator = JsCollator::new(&locales, js_options.as_ref());
+
+        Self { collator }
+    }
+
+    /// Compare two strings according to locale-aware collation rules.
+    #[must_use]
+    pub fn compare(&self, a: &str, b: &str) -> Ordering {
+        let compare: Function = self.collator.compare();
+        let value = compare
+            .call2(
+                &JsValue::UNDEFINED,
+                &JsValue::from_str(a),
+                &JsValue::from_str(b),
+            )
+            .expect("Intl.Collator.compare should not throw for string inputs");
+        let value = value
+            .as_f64()
+            .expect("Intl.Collator.compare should return a numeric ordering");
+
+        if value < 0.0 {
+            Ordering::Less
+        } else if value > 0.0 {
+            Ordering::Greater
+        } else {
+            Ordering::Equal
+        }
+    }
+}
+
+/// A locale-aware string collator.
+///
+/// In feature configurations without a runtime collation backend, this type
+/// preserves the shared API surface while falling back to byte-order
+/// comparison.
+#[cfg(any(
+    not(any(feature = "icu4x", feature = "web-intl")),
+    all(
+        feature = "web-intl",
+        not(target_arch = "wasm32"),
+        not(feature = "icu4x")
+    )
+))]
+#[derive(Debug)]
+pub struct StringCollator {}
+
+#[cfg(any(
+    not(any(feature = "icu4x", feature = "web-intl")),
+    all(
+        feature = "web-intl",
+        not(target_arch = "wasm32"),
+        not(feature = "icu4x")
+    )
+))]
+impl StringCollator {
+    /// Create a fallback collator using Rust's byte-order comparison.
+    #[must_use]
+    pub const fn new(_locale: &Locale, _options: CollationOptions) -> Self {
+        Self {}
+    }
+
+    /// Compare two strings using Rust's byte-order comparison.
+    #[must_use]
+    pub fn compare(&self, a: &str, b: &str) -> Ordering {
+        a.cmp(b)
+    }
+}
+
+// Valid for all backends
+impl StringCollator {
+    /// Sort a vector of strings in-place according to collation rules.
+    #[expect(clippy::ptr_arg, reason = "API matches the specification")]
+    pub fn sort(&self, items: &mut Vec<String>) {
+        items.sort_by(|a, b| self.compare(a, b));
+    }
+
+    /// Sort items by a string key according to collation rules.
+    #[expect(clippy::ptr_arg, reason = "API matches the specification")]
+    pub fn sort_by_key<T, F: Fn(&T) -> &str>(&self, items: &mut Vec<T>, key: F) {
+        items.sort_by(|a, b| self.compare(key(a), key(b)));
+    }
+}
+
+impl CollationFormat for StringCollator {
+    fn compare(&self, a: &str, b: &str) -> Ordering {
+        self.compare(a, b)
+    }
+}
+
+#[cfg(feature = "icu4x")]
+const fn icu_strength(options: CollationOptions) -> Strength {
+    if options.case_insensitive {
+        Strength::Secondary
+    } else {
+        match options.strength {
+            CollationStrength::Primary => Strength::Primary,
+            CollationStrength::Secondary => Strength::Secondary,
+            CollationStrength::Tertiary => Strength::Tertiary,
+            CollationStrength::Quaternary => Strength::Quaternary,
+        }
+    }
+}
+
+#[cfg(all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")))]
+const fn js_sensitivity(options: CollationOptions) -> js_sys::Intl::CollatorSensitivity {
+    if options.case_insensitive {
+        js_sys::Intl::CollatorSensitivity::Accent
+    } else {
+        match options.strength {
+            CollationStrength::Primary => js_sys::Intl::CollatorSensitivity::Base,
+            CollationStrength::Secondary => js_sys::Intl::CollatorSensitivity::Accent,
+            CollationStrength::Tertiary => js_sys::Intl::CollatorSensitivity::Case,
+            CollationStrength::Quaternary => js_sys::Intl::CollatorSensitivity::Variant,
+        }
+    }
+}
+
+#[cfg(all(
+    test,
+    not(all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")))
+))]
+mod tests {
+    use alloc::{string::ToString, vec};
+    use core::cmp::Ordering;
+
+    #[cfg(feature = "icu4x")]
+    use super::CollationStrength;
+    use super::{CollationFormat, CollationOptions, StringCollator};
+    #[cfg(feature = "icu4x")]
+    use crate::Locale;
+    use crate::locales;
+
+    fn compare_with_trait(collator: &dyn CollationFormat, a: &str, b: &str) -> Ordering {
+        collator.compare(a, b)
+    }
+
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn primary_strength_ignores_case_and_accents() {
+        let options = CollationOptions {
+            strength: CollationStrength::Primary,
+            ..Default::default()
+        };
+
+        let collator = StringCollator::new(&locales::en(), options);
+
+        assert_eq!(collator.compare("Cafe", "café"), Ordering::Equal);
+    }
+
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn tertiary_strength_distinguishes_case_and_accents() {
+        let options = CollationOptions {
+            strength: CollationStrength::Tertiary,
+            ..Default::default()
+        };
+
+        let collator = StringCollator::new(&locales::en(), options);
+
+        assert_ne!(collator.compare("Cafe", "café"), Ordering::Equal);
+        assert_ne!(collator.compare("Cafe", "cafe"), Ordering::Equal);
+    }
+
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn quaternary_strength_keeps_case_and_accent_differences() {
+        let options = CollationOptions {
+            strength: CollationStrength::Quaternary,
+            numeric: false,
+            ..Default::default()
+        };
+
+        let collator = StringCollator::new(&locales::en(), options);
+
+        assert_ne!(collator.compare("Cafe", "café"), Ordering::Equal);
+        assert_ne!(collator.compare("Cafe", "cafe"), Ordering::Equal);
+    }
+
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn case_insensitive_overrides_strength_to_secondary_behavior() {
+        let options = CollationOptions {
+            strength: CollationStrength::Tertiary,
+            case_insensitive: true,
+            numeric: false,
+        };
+
+        let collator = StringCollator::new(&locales::en(), options);
+
+        assert_eq!(collator.compare("Resume", "resume"), Ordering::Equal);
+        assert_ne!(collator.compare("resume", "résumé"), Ordering::Equal);
+    }
+
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn numeric_sort_orders_embedded_numbers_naturally() {
+        let collator = StringCollator::new(&locales::en(), CollationOptions::default());
+        let mut items = vec![
+            "file10".to_string(),
+            "file9".to_string(),
+            "file2".to_string(),
+        ];
+
+        collator.sort(&mut items);
+
+        assert_eq!(items, vec!["file2", "file9", "file10"]);
+    }
+
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn german_locale_sorts_umlauts_adjacent_to_base_letter() {
+        let locale = Locale::parse("de").expect("de should parse");
+        let collator = StringCollator::new(&locale, CollationOptions::default());
+        let mut items = vec!["z".to_string(), "ä".to_string(), "a".to_string()];
+
+        collator.sort(&mut items);
+
+        assert_eq!(items[2], "z");
+        assert!(items[..2].contains(&"a".to_string()));
+        assert!(items[..2].contains(&"ä".to_string()));
+    }
+
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn sort_by_key_uses_collation_rules() {
+        let collator = StringCollator::new(&locales::en(), CollationOptions::default());
+        let mut items = vec![("file10", 10_u8), ("file2", 2_u8), ("file9", 9_u8)];
+
+        collator.sort_by_key(&mut items, |item| item.0);
+
+        assert_eq!(items, vec![("file2", 2), ("file9", 9), ("file10", 10)]);
+    }
+
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn secondary_strength_ignores_case_but_respects_accents() {
+        let options = CollationOptions {
+            strength: CollationStrength::Secondary,
+            numeric: false,
+            ..Default::default()
+        };
+
+        let collator = StringCollator::new(&locales::en(), options);
+
+        assert_eq!(collator.compare("Resume", "resume"), Ordering::Equal);
+        assert_ne!(collator.compare("resume", "résumé"), Ordering::Equal);
+    }
+
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn locale_numeric_extension_is_not_overridden() {
+        let locale = Locale::parse("en-u-kn-false").expect("locale should parse");
+        let options = CollationOptions {
+            numeric: true,
+            ..Default::default()
+        };
+        let collator = StringCollator::new(&locale, options);
+
+        assert_eq!(collator.compare("file10", "file9"), Ordering::Less);
+    }
+
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn collator_implements_shared_trait() {
+        let collator = StringCollator::new(&locales::en(), CollationOptions::default());
+
+        assert_eq!(
+            compare_with_trait(&collator, "file9", "file10"),
+            Ordering::Less
+        );
+    }
+
+    #[cfg(not(any(
+        feature = "icu4x",
+        all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x"))
+    )))]
+    #[test]
+    fn fallback_compare_uses_byte_ordering() {
+        let collator = StringCollator::new(&locales::en(), CollationOptions::default());
+
+        assert_eq!(collator.compare("file10", "file9"), Ordering::Less);
+    }
+
+    #[cfg(not(any(
+        feature = "icu4x",
+        all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x"))
+    )))]
+    #[test]
+    fn fallback_sort_keeps_shared_api_available() {
+        let collator = StringCollator::new(&locales::en(), CollationOptions::default());
+        let mut items = vec!["file9".to_string(), "file10".to_string()];
+
+        collator.sort(&mut items);
+
+        assert_eq!(items, vec!["file10", "file9"]);
+    }
+
+    #[cfg(not(any(
+        feature = "icu4x",
+        all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x"))
+    )))]
+    #[test]
+    fn fallback_sort_by_key_keeps_shared_api_available() {
+        let collator = StringCollator::new(&locales::en(), CollationOptions::default());
+        let mut items = vec![("file9", 9_u8), ("file10", 10_u8)];
+
+        collator.sort_by_key(&mut items, |item| item.0);
+
+        assert_eq!(items, vec![("file10", 10), ("file9", 9)]);
+    }
+
+    #[cfg(not(any(
+        feature = "icu4x",
+        all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x"))
+    )))]
+    #[test]
+    fn fallback_collator_implements_shared_trait() {
+        let collator = StringCollator::new(&locales::en(), CollationOptions::default());
+
+        assert_eq!(
+            compare_with_trait(&collator, "file10", "file9"),
+            Ordering::Less
+        );
+    }
+}
+
+#[cfg(all(
+    test,
+    feature = "web-intl",
+    target_arch = "wasm32",
+    not(feature = "icu4x")
+))]
+mod web_intl_tests {
+    use alloc::{string::ToString, vec};
+    use core::cmp::Ordering;
+
+    use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+
+    use super::{CollationFormat, CollationOptions, CollationStrength, StringCollator};
+    use crate::{Locale, locales};
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    fn compare_with_trait(collator: &dyn CollationFormat, a: &str, b: &str) -> Ordering {
+        collator.compare(a, b)
+    }
+
+    #[wasm_bindgen_test]
+    fn web_intl_constructor_creates_collator() {
+        let collator = StringCollator::new(&locales::en(), CollationOptions::default());
+
+        assert_eq!(collator.compare("a", "a"), Ordering::Equal);
+    }
+
+    #[wasm_bindgen_test]
+    fn web_intl_primary_strength_ignores_case_and_accents() {
+        let options = CollationOptions {
+            strength: CollationStrength::Primary,
+            ..Default::default()
+        };
+
+        let collator = StringCollator::new(&locales::en(), options);
+
+        assert_eq!(collator.compare("Cafe", "café"), Ordering::Equal);
+    }
+
+    #[wasm_bindgen_test]
+    fn web_intl_tertiary_strength_respects_case_and_accents() {
+        let options = CollationOptions {
+            strength: CollationStrength::Tertiary,
+            ..Default::default()
+        };
+
+        let collator = StringCollator::new(&locales::en(), options);
+
+        assert_ne!(collator.compare("Cafe", "café"), Ordering::Equal);
+        assert_ne!(collator.compare("Cafe", "cafe"), Ordering::Equal);
+    }
+
+    #[wasm_bindgen_test]
+    fn web_intl_quaternary_strength_keeps_case_and_accent_differences() {
+        let options = CollationOptions {
+            strength: CollationStrength::Quaternary,
+            numeric: false,
+            ..Default::default()
+        };
+
+        let collator = StringCollator::new(&locales::en(), options);
+
+        assert_ne!(collator.compare("Cafe", "café"), Ordering::Equal);
+        assert_ne!(collator.compare("Cafe", "cafe"), Ordering::Equal);
+    }
+
+    #[wasm_bindgen_test]
+    fn web_intl_numeric_sort_orders_embedded_numbers_naturally() {
+        let collator = StringCollator::new(&locales::en(), CollationOptions::default());
+        let mut items = vec![
+            "file10".to_string(),
+            "file9".to_string(),
+            "file2".to_string(),
+        ];
+
+        collator.sort(&mut items);
+
+        assert_eq!(items, vec!["file2", "file9", "file10"]);
+    }
+
+    #[wasm_bindgen_test]
+    fn web_intl_case_insensitive_uses_accent_sensitivity() {
+        let options = CollationOptions {
+            strength: CollationStrength::Tertiary,
+            case_insensitive: true,
+            numeric: false,
+        };
+
+        let collator = StringCollator::new(&locales::en(), options);
+
+        assert_eq!(collator.compare("Resume", "resume"), Ordering::Equal);
+        assert_ne!(collator.compare("resume", "résumé"), Ordering::Equal);
+    }
+
+    #[wasm_bindgen_test]
+    fn web_intl_secondary_strength_ignores_case_but_respects_accents() {
+        let options = CollationOptions {
+            strength: CollationStrength::Secondary,
+            numeric: false,
+            ..Default::default()
+        };
+
+        let collator = StringCollator::new(&locales::en(), options);
+
+        assert_eq!(collator.compare("Resume", "resume"), Ordering::Equal);
+        assert_ne!(collator.compare("resume", "résumé"), Ordering::Equal);
+    }
+
+    #[wasm_bindgen_test]
+    fn web_intl_sort_by_key_uses_collation_rules() {
+        let collator = StringCollator::new(&locales::en(), CollationOptions::default());
+        let mut items = vec![("file10", 10_u8), ("file2", 2_u8), ("file9", 9_u8)];
+
+        collator.sort_by_key(&mut items, |item| item.0);
+
+        assert_eq!(items, vec![("file2", 2), ("file9", 9), ("file10", 10)]);
+    }
+
+    #[wasm_bindgen_test]
+    fn web_intl_collator_implements_shared_trait() {
+        let collator = StringCollator::new(&locales::en(), CollationOptions::default());
+
+        assert_eq!(
+            compare_with_trait(&collator, "file9", "file10"),
+            Ordering::Less
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn web_intl_german_locale_sorts_umlauts_adjacent_to_base_letter() {
+        let locale = Locale::parse("de").expect("de should parse");
+        let collator = StringCollator::new(&locale, CollationOptions::default());
+        let mut items = vec!["z".to_string(), "ä".to_string(), "a".to_string()];
+
+        collator.sort(&mut items);
+
+        assert_eq!(items[2], "z");
+        assert!(items[..2].contains(&"a".to_string()));
+        assert!(items[..2].contains(&"ä".to_string()));
+    }
+}

--- a/crates/ars-i18n/src/collation.rs
+++ b/crates/ars-i18n/src/collation.rs
@@ -157,6 +157,7 @@ impl StringCollator {
         let locales = Array::of1(&JsValue::from_str(&locale.to_bcp47()));
         let js_options = JsCollatorOptions::new();
         js_options.set_sensitivity(js_sensitivity(options));
+        js_options.set_ignore_punctuation(js_ignore_punctuation(options));
         js_options.set_numeric(options.numeric);
 
         let collator = JsCollator::new(&locales, js_options.as_ref());
@@ -270,9 +271,21 @@ const fn js_sensitivity(options: CollationOptions) -> js_sys::Intl::CollatorSens
         match options.strength {
             CollationStrength::Primary => js_sys::Intl::CollatorSensitivity::Base,
             CollationStrength::Secondary => js_sys::Intl::CollatorSensitivity::Accent,
-            CollationStrength::Tertiary => js_sys::Intl::CollatorSensitivity::Case,
-            CollationStrength::Quaternary => js_sys::Intl::CollatorSensitivity::Variant,
+            // `Intl.Collator` has no "accent + case, but not punctuation" mode.
+            // `Variant` + `ignorePunctuation = true` is the closest approximation.
+            CollationStrength::Tertiary | CollationStrength::Quaternary => {
+                js_sys::Intl::CollatorSensitivity::Variant
+            }
         }
+    }
+}
+
+#[cfg(all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")))]
+const fn js_ignore_punctuation(options: CollationOptions) -> bool {
+    if options.case_insensitive {
+        true
+    } else {
+        !matches!(options.strength, CollationStrength::Quaternary)
     }
 }
 
@@ -534,12 +547,12 @@ mod web_intl_tests {
 
         let collator = StringCollator::new(&locales::en(), options);
 
-        assert_ne!(collator.compare("Cafe", "café"), Ordering::Equal);
+        assert_ne!(collator.compare("cafe", "café"), Ordering::Equal);
         assert_ne!(collator.compare("Cafe", "cafe"), Ordering::Equal);
     }
 
     #[wasm_bindgen_test]
-    fn web_intl_quaternary_strength_keeps_case_and_accent_differences() {
+    fn web_intl_quaternary_strength_keeps_case_accent_and_punctuation_differences() {
         let options = CollationOptions {
             strength: CollationStrength::Quaternary,
             numeric: false,
@@ -550,6 +563,20 @@ mod web_intl_tests {
 
         assert_ne!(collator.compare("Cafe", "café"), Ordering::Equal);
         assert_ne!(collator.compare("Cafe", "cafe"), Ordering::Equal);
+        assert_ne!(collator.compare("ab", "a-b"), Ordering::Equal);
+    }
+
+    #[wasm_bindgen_test]
+    fn web_intl_tertiary_strength_ignores_punctuation_differences() {
+        let options = CollationOptions {
+            strength: CollationStrength::Tertiary,
+            numeric: false,
+            ..Default::default()
+        };
+
+        let collator = StringCollator::new(&locales::en(), options);
+
+        assert_eq!(collator.compare("ab", "a-b"), Ordering::Equal);
     }
 
     #[wasm_bindgen_test]

--- a/crates/ars-i18n/src/lib.rs
+++ b/crates/ars-i18n/src/lib.rs
@@ -1,15 +1,15 @@
-//! Internationalization types for locale, number formatting, text direction,
-//! layout orientation, plural rules, locale-aware case mapping, and
-//! logical-to-physical layout geometry.
+//! Internationalization types for locale, number formatting, locale-aware
+//! string sorting, text direction, layout orientation, plural rules,
+//! locale-aware case mapping, and logical-to-physical layout geometry.
 //!
 //! This crate provides the core i18n primitives shared across all ars-ui components:
 //! a BCP 47 [`Locale`] wrapper, a locale-aware [`NumberFormatter`], a
-//! [`Direction`] enum for LTR/RTL text flow, an [`Orientation`] enum for
-//! horizontal/vertical layout axes, RTL-aware layout geometry types
-//! ([`LogicalSide`], [`PhysicalSide`], [`LogicalRect`], [`PhysicalRect`]),
-//! plural and ordinal helpers, locale-aware [`to_uppercase`] and
-//! [`to_lowercase`] helpers, and the [`IcuProvider`] trait for calendar/locale
-//! data abstraction.
+//! [`Direction`] enum for LTR/RTL text flow, a [`StringCollator`] for
+//! locale-aware sorting, an [`Orientation`] enum for horizontal/vertical
+//! layout axes, RTL-aware layout geometry types ([`LogicalSide`],
+//! [`PhysicalSide`], [`LogicalRect`], [`PhysicalRect`]), plural and ordinal
+//! helpers, locale-aware [`to_uppercase`] and [`to_lowercase`] helpers, and
+//! the [`IcuProvider`] trait for calendar/locale data abstraction.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
@@ -23,6 +23,7 @@ use alloc::string::String;
 mod bidi;
 #[cfg(any(feature = "icu4x", feature = "web-intl"))]
 mod case;
+mod collation;
 #[cfg(feature = "std")]
 mod detect;
 mod layout;
@@ -36,6 +37,7 @@ mod weekday;
 pub use bidi::{IsolateDirection, isolate_text_safe};
 #[cfg(any(feature = "icu4x", feature = "web-intl"))]
 pub use case::{to_lowercase, to_uppercase};
+pub use collation::{CollationFormat, CollationOptions, CollationStrength, StringCollator};
 #[cfg(feature = "std")]
 pub use detect::locale_from_accept_language;
 pub use layout::{LogicalRect, LogicalSide, PhysicalRect, PhysicalSide};

--- a/crates/ars-i18n/src/locale.rs
+++ b/crates/ars-i18n/src/locale.rs
@@ -127,6 +127,25 @@ impl Locale {
         &self.0
     }
 
+    #[cfg(all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")))]
+    pub(crate) fn numeric_ordering_extension(&self) -> Option<bool> {
+        let value = self
+            .0
+            .extensions
+            .unicode
+            .keywords
+            .get(&icu::locale::extensions::unicode::key!("kn"))?;
+
+        Some(if value.is_empty() {
+            true
+        } else {
+            matches!(
+                value.as_single_subtag(),
+                Some(subtag) if subtag.as_str() == "true"
+            )
+        })
+    }
+
     fn script_or_default(&self) -> &str {
         self.script().unwrap_or_else(|| match self.language() {
             "ar" | "fa" | "ur" | "ps" | "ug" | "sd" | "ks" => "Arab",

--- a/spec/foundation/04-internationalization.md
+++ b/spec/foundation/04-internationalization.md
@@ -3112,11 +3112,15 @@ pub struct StringCollator {
 impl StringCollator {
     /// Create a new locale-aware string collator using `Intl.Collator`.
     ///
-    /// Maps `CollationStrength` to `Intl.Collator` `sensitivity` option:
-    /// - `Primary` → `"base"` (ignore accents and case)
-    /// - `Secondary` → `"accent"` (ignore case, respect accents)
-    /// - `Tertiary` → `"case"` (respect accents and case)
-    /// - `Quaternary` → `"variant"` (also respect punctuation)
+    /// Maps `CollationStrength` to `Intl.Collator` options:
+    /// - `Primary` → `sensitivity = "base"`, `ignorePunctuation = true`
+    /// - `Secondary` → `sensitivity = "accent"`, `ignorePunctuation = true`
+    /// - `Tertiary` → `sensitivity = "variant"`, `ignorePunctuation = true`
+    /// - `Quaternary` → `sensitivity = "variant"`, `ignorePunctuation = false`
+    ///
+    /// ECMAScript does not expose an exact "accent + case, but not punctuation"
+    /// sensitivity. The `Tertiary` mapping above is the closest available
+    /// browser approximation and preserves accent-sensitive comparison.
     pub fn new(locale: &Locale, options: CollationOptions) -> Self {
         use js_sys::{Array, Function, Intl::{Collator as JsCollator, CollatorOptions as JsCollatorOptions}};
         use wasm_bindgen::JsValue;
@@ -3129,9 +3133,14 @@ impl StringCollator {
             match options.strength {
                 CollationStrength::Primary => js_sys::Intl::CollatorSensitivity::Base,
                 CollationStrength::Secondary => js_sys::Intl::CollatorSensitivity::Accent,
-                CollationStrength::Tertiary => js_sys::Intl::CollatorSensitivity::Case,
+                CollationStrength::Tertiary => js_sys::Intl::CollatorSensitivity::Variant,
                 CollationStrength::Quaternary => js_sys::Intl::CollatorSensitivity::Variant,
             }
+        });
+        js_opts.set_ignore_punctuation(if options.case_insensitive {
+            true
+        } else {
+            !matches!(options.strength, CollationStrength::Quaternary)
         });
         js_opts.set_numeric(options.numeric);
 
@@ -3404,8 +3413,11 @@ impl NumberFormat for JsIntlNumberFormatter {
 // ── web-intl collation ──
 // StringCollator's web-intl backend is defined inline in §8 alongside the
 // ICU4X backend. Both use the same public API (new, compare, sort, sort_by_key).
-// The web-intl backend maps CollationStrength to Intl.Collator sensitivity:
-//   Primary → "base", Secondary → "accent", Tertiary → "case", Quaternary → "variant".
+// The web-intl backend maps CollationStrength to Intl.Collator options:
+//   Primary → "base" + ignorePunctuation, Secondary → "accent" + ignorePunctuation,
+//   Tertiary → "variant" + ignorePunctuation, Quaternary → "variant" without ignorePunctuation.
+// ECMAScript does not expose an exact tertiary mode that preserves accents and case
+// while still distinguishing punctuation, so Tertiary uses the closest browser approximation.
 // On stable `js-sys`, `Intl.Collator::compare` is exposed as a getter returning
 // a bound JS comparison function rather than a direct Rust method.
 

--- a/spec/foundation/04-internationalization.md
+++ b/spec/foundation/04-internationalization.md
@@ -3073,6 +3073,10 @@ impl StringCollator {
             CollationStrength::Tertiary => Strength::Tertiary,
             CollationStrength::Quaternary => Strength::Quaternary,
         });
+        // Shift punctuation to the quaternary level so punctuation differences
+        // are ignored below Quaternary and become observable at Quaternary.
+        icu_opts.alternate_handling = Some(icu::collator::options::AlternateHandling::Shifted);
+        icu_opts.max_variable = Some(icu::collator::options::MaxVariable::Punctuation);
         // case_insensitive = true forces strength to Secondary, overriding `strength`.
         // To set a specific strength, leave case_insensitive = false and set strength directly.
         if options.case_insensitive {
@@ -3121,6 +3125,10 @@ impl StringCollator {
     /// ECMAScript does not expose an exact "accent + case, but not punctuation"
     /// sensitivity. The `Tertiary` mapping above is the closest available
     /// browser approximation and preserves accent-sensitive comparison.
+    ///
+    /// Numeric ordering follows `CollationOptions::numeric` only when the locale
+    /// itself does not already specify a `u-kn-*` keyword. Explicit locale numeric
+    /// preferences are preserved across both backends.
     pub fn new(locale: &Locale, options: CollationOptions) -> Self {
         use js_sys::{Array, Function, Intl::{Collator as JsCollator, CollatorOptions as JsCollatorOptions}};
         use wasm_bindgen::JsValue;
@@ -3142,7 +3150,9 @@ impl StringCollator {
         } else {
             !matches!(options.strength, CollationStrength::Quaternary)
         });
-        js_opts.set_numeric(options.numeric);
+        if locale.numeric_ordering_extension().is_none() {
+            js_opts.set_numeric(options.numeric);
+        }
 
         let collator = JsCollator::new(&locales, js_opts.as_ref());
         Self { collator }
@@ -3413,11 +3423,14 @@ impl NumberFormat for JsIntlNumberFormatter {
 // ── web-intl collation ──
 // StringCollator's web-intl backend is defined inline in §8 alongside the
 // ICU4X backend. Both use the same public API (new, compare, sort, sort_by_key).
+// The ICU4X backend uses AlternateHandling::Shifted with MaxVariable::Punctuation
+// so punctuation differences are ignored below Quaternary and observable at Quaternary.
 // The web-intl backend maps CollationStrength to Intl.Collator options:
 //   Primary → "base" + ignorePunctuation, Secondary → "accent" + ignorePunctuation,
 //   Tertiary → "variant" + ignorePunctuation, Quaternary → "variant" without ignorePunctuation.
 // ECMAScript does not expose an exact tertiary mode that preserves accents and case
 // while still distinguishing punctuation, so Tertiary uses the closest browser approximation.
+// Both backends preserve explicit locale `u-kn-*` numeric-ordering preferences.
 // On stable `js-sys`, `Intl.Collator::compare` is exposed as a getter returning
 // a bound JS comparison function rather than a direct Rust method.
 

--- a/spec/foundation/04-internationalization.md
+++ b/spec/foundation/04-internationalization.md
@@ -2984,7 +2984,10 @@ in the adapter specs for the concrete signatures.
 ## 8. Collation (Locale-Aware String Sorting)
 
 ```rust
-use icu::collator::{Collator as OwnedCollator, CollatorOptions as IcuCollatorOptions, Strength};
+use icu::collator::{
+    Collator as OwnedCollator,
+    options::{CollatorOptions as IcuCollatorOptions, Strength},
+};
 
 /// Options for locale-aware string comparison.
 #[derive(Clone, Debug)]
@@ -3042,8 +3045,9 @@ impl Default for CollationOptions {
 ///
 /// The struct layout and `compare()` implementation are feature-gated:
 /// - `icu4x`: backed by ICU4X `Collator` with CLDR data.
-/// - `web-intl`: backed by browser `Intl.Collator` via `js_sys`.
-/// - Neither: falls back to Rust's default `Ord` (byte-order) comparison.
+/// - `web-intl` on `wasm32`: backed by browser `Intl.Collator` via `js_sys`.
+/// - Neither, or `web-intl` on non-wasm targets: falls back to Rust's default
+///   `Ord` (byte-order) comparison.
 ///
 /// The `sort()` and `sort_by_key()` methods are generic over `compare()`
 /// and work identically under all backends.
@@ -3052,7 +3056,6 @@ impl Default for CollationOptions {
 
 #[cfg(feature = "icu4x")]
 pub struct StringCollator {
-    locale: Locale,
     collator: OwnedCollator,
 }
 
@@ -3089,7 +3092,7 @@ impl StringCollator {
             .expect("compiled_data guarantees collation data is available for all locales")
             .static_to_owned();
 
-        Self { locale: locale.clone(), collator }
+        Self { collator }
     }
 
     /// Compare two strings according to locale rules.
@@ -3100,13 +3103,12 @@ impl StringCollator {
 
 // ── web-intl backend (WASM client builds) ──
 
-#[cfg(feature = "web-intl")]
+#[cfg(all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")))]
 pub struct StringCollator {
-    locale: Locale,
     collator: js_sys::Intl::Collator,
 }
 
-#[cfg(feature = "web-intl")]
+#[cfg(all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")))]
 impl StringCollator {
     /// Create a new locale-aware string collator using `Intl.Collator`.
     ///
@@ -3116,53 +3118,65 @@ impl StringCollator {
     /// - `Tertiary` → `"case"` (respect accents and case)
     /// - `Quaternary` → `"variant"` (also respect punctuation)
     pub fn new(locale: &Locale, options: CollationOptions) -> Self {
-        use js_sys::{Array, Object, Reflect, Intl};
+        use js_sys::{Array, Function, Intl::{Collator as JsCollator, CollatorOptions as JsCollatorOptions}};
         use wasm_bindgen::JsValue;
 
         let locales = Array::of1(&JsValue::from_str(&locale.to_bcp47()));
-        let js_opts = Object::new();
-
-        let sensitivity = if options.case_insensitive {
-            "accent" // case_insensitive overrides strength to Secondary
+        let js_opts = JsCollatorOptions::new();
+        js_opts.set_sensitivity(if options.case_insensitive {
+            js_sys::Intl::CollatorSensitivity::Accent
         } else {
             match options.strength {
-                CollationStrength::Primary => "base",
-                CollationStrength::Secondary => "accent",
-                CollationStrength::Tertiary => "case",
-                CollationStrength::Quaternary => "variant",
+                CollationStrength::Primary => js_sys::Intl::CollatorSensitivity::Base,
+                CollationStrength::Secondary => js_sys::Intl::CollatorSensitivity::Accent,
+                CollationStrength::Tertiary => js_sys::Intl::CollatorSensitivity::Case,
+                CollationStrength::Quaternary => js_sys::Intl::CollatorSensitivity::Variant,
             }
-        };
-        Reflect::set(&js_opts, &"sensitivity".into(), &JsValue::from_str(sensitivity))
-            .expect("Reflect::set on JS object");
-        Reflect::set(&js_opts, &"numeric".into(), &JsValue::from_bool(options.numeric))
-            .expect("Reflect::set on JS object");
+        });
+        js_opts.set_numeric(options.numeric);
 
-        let collator = Intl::Collator::new(&locales, &js_opts);
-        Self { locale: locale.clone(), collator }
+        let collator = JsCollator::new(&locales, js_opts.as_ref());
+        Self { collator }
     }
 
     /// Compare two strings according to locale rules.
     pub fn compare(&self, a: &str, b: &str) -> core::cmp::Ordering {
-        let result = self.collator.compare(a, b);
-        if result < 0 { core::cmp::Ordering::Less }
-        else if result > 0 { core::cmp::Ordering::Greater }
+        // On stable `js-sys`, `Intl.Collator::compare` is exposed as a getter
+        // returning the bound JS comparison function.
+        let compare: Function = self.collator.compare();
+        let result = compare
+            .call2(
+                &JsValue::UNDEFINED,
+                &JsValue::from_str(a),
+                &JsValue::from_str(b),
+            )
+            .expect("Intl.Collator.compare should not throw for string inputs")
+            .as_f64()
+            .expect("Intl.Collator.compare should return a numeric ordering");
+
+        if result < 0.0 { core::cmp::Ordering::Less }
+        else if result > 0.0 { core::cmp::Ordering::Greater }
         else { core::cmp::Ordering::Equal }
     }
 }
 
 // ── Fallback (no ICU4X, no web-intl) ──
 
-#[cfg(not(any(feature = "icu4x", feature = "web-intl")))]
-pub struct StringCollator {
-    locale: Locale,
-}
+#[cfg(any(
+    not(any(feature = "icu4x", feature = "web-intl")),
+    all(feature = "web-intl", not(target_arch = "wasm32"), not(feature = "icu4x"))
+))]
+pub struct StringCollator {}
 
-#[cfg(not(any(feature = "icu4x", feature = "web-intl")))]
+#[cfg(any(
+    not(any(feature = "icu4x", feature = "web-intl")),
+    all(feature = "web-intl", not(target_arch = "wasm32"), not(feature = "icu4x"))
+))]
 impl StringCollator {
     /// Fallback collator using Rust's default byte-order comparison.
-    /// Locale-aware sorting is not available without a backend.
-    pub fn new(locale: &Locale, _options: CollationOptions) -> Self {
-        Self { locale: locale.clone() }
+    /// Locale-aware sorting is not available without a runtime backend.
+    pub fn new(_locale: &Locale, _options: CollationOptions) -> Self {
+        Self {}
     }
 
     pub fn compare(&self, a: &str, b: &str) -> core::cmp::Ordering {
@@ -3392,6 +3406,8 @@ impl NumberFormat for JsIntlNumberFormatter {
 // ICU4X backend. Both use the same public API (new, compare, sort, sort_by_key).
 // The web-intl backend maps CollationStrength to Intl.Collator sensitivity:
 //   Primary → "base", Secondary → "accent", Tertiary → "case", Quaternary → "variant".
+// On stable `js-sys`, `Intl.Collator::compare` is exposed as a getter returning
+// a bound JS comparison function rather than a direct Rust method.
 
 #[cfg(feature = "web-intl")]
 impl CollationFormat for StringCollator {


### PR DESCRIPTION
## Summary
- add `StringCollator` to `ars-i18n` with ICU4X, browser `web-intl`, and byte-order fallback backends
- export the new collation API from the crate root and sync the internationalization spec with the final implementation details
- expand native, fallback, and wasm tests to cover sensitivity mapping, numeric ordering, locale behavior, trait dispatch, and sorting helpers

## Verification
- `cargo test -p ars-i18n collation::`
- `cargo test -p ars-i18n --no-default-features collation::`
- `cargo xtask spec validate`
- `cargo xtask coverage wasm --package ars-i18n --file /tmp/ars-i18n-web-intl-collation.lcov --feature web-intl --no-default-features`
- `cargo xci`

Closes #136
Closes #141