### PR TITLE
[codex] Implement ARIA validator infrastructure

### DIFF
--- a/crates/ars-a11y/Cargo.toml
+++ b/crates/ars-a11y/Cargo.toml
@@ -11,6 +11,7 @@ rust-version.workspace = true
 default               = ["aria-drag-drop-compat"]
 aria-drag-drop-compat = []
 axe                   = []
+testing               = []
 
 [dependencies]
 ars-core = { path = "../ars-core", default-features = false }

--- a/crates/ars-a11y/src/lib.rs
+++ b/crates/ars-a11y/src/lib.rs
@@ -45,8 +45,8 @@ pub use keyboard::{DomEvent, KeyModifiers, KeyboardShortcut, Platform};
 pub use label::{DescriptionConfig, FieldContext, LabelConfig};
 #[cfg(any(test, feature = "testing"))]
 pub use testing::{
-    AriaValidationError, AriaValidationWarning, AriaValidator, required_attributes_for_role,
-    validate_attr_map,
+    AriaValidationContext, AriaValidationError, AriaValidationWarning, AriaValidator,
+    required_attributes_for_role, validate_attr_map,
 };
 pub use touch::{
     InputMode, MIN_DRAG_TARGET_SIZE, MIN_TOUCH_TARGET_SIZE, should_use_roving_tabindex_for_mobile,

--- a/crates/ars-a11y/src/lib.rs
+++ b/crates/ars-a11y/src/lib.rs
@@ -17,6 +17,9 @@ pub mod focus;
 pub mod keyboard;
 /// Field labelling, descriptions, and error wiring helpers for form controls.
 pub mod label;
+/// Testing helpers for ARIA validation and keyboard-navigation assertions.
+#[cfg(any(test, feature = "testing"))]
+pub mod testing;
 /// Touch-target sizing and mobile accessibility helpers.
 pub mod touch;
 pub mod visually_hidden;
@@ -40,6 +43,11 @@ pub use focus::{
 };
 pub use keyboard::{DomEvent, KeyModifiers, KeyboardShortcut, Platform};
 pub use label::{DescriptionConfig, FieldContext, LabelConfig};
+#[cfg(any(test, feature = "testing"))]
+pub use testing::{
+    AriaValidationError, AriaValidationWarning, AriaValidator, required_attributes_for_role,
+    validate_attr_map,
+};
 pub use touch::{
     InputMode, MIN_DRAG_TARGET_SIZE, MIN_TOUCH_TARGET_SIZE, should_use_roving_tabindex_for_mobile,
     touch_target_attrs, touch_target_attrs_with_min,

--- a/crates/ars-a11y/src/testing/mod.rs
+++ b/crates/ars-a11y/src/testing/mod.rs
@@ -1,0 +1,8 @@
+//! Testing helpers for validating ARIA output from connect surfaces.
+
+mod validator;
+
+pub use validator::{
+    AriaValidationError, AriaValidationWarning, AriaValidator, required_attributes_for_role,
+    validate_attr_map,
+};

--- a/crates/ars-a11y/src/testing/mod.rs
+++ b/crates/ars-a11y/src/testing/mod.rs
@@ -3,6 +3,6 @@
 mod validator;
 
 pub use validator::{
-    AriaValidationError, AriaValidationWarning, AriaValidator, required_attributes_for_role,
-    validate_attr_map,
+    AriaValidationContext, AriaValidationError, AriaValidationWarning, AriaValidator,
+    required_attributes_for_role, validate_attr_map,
 };

--- a/crates/ars-a11y/src/testing/validator.rs
+++ b/crates/ars-a11y/src/testing/validator.rs
@@ -253,17 +253,6 @@ const fn idref_attr_name(attr: HtmlAttr) -> Option<&'static str> {
     }
 }
 
-const fn attr_value_contains_idrefs(attr: HtmlAttr) -> bool {
-    matches!(
-        attr,
-        HtmlAttr::Aria(AriaAttr::Controls)
-            | HtmlAttr::Aria(AriaAttr::DescribedBy)
-            | HtmlAttr::Aria(AriaAttr::FlowTo)
-            | HtmlAttr::Aria(AriaAttr::LabelledBy)
-            | HtmlAttr::Aria(AriaAttr::Owns)
-    )
-}
-
 /// Validate that an `AttrMap` produced by a connect surface is ARIA-conformant
 /// within the provided subtree context.
 #[must_use]
@@ -307,14 +296,7 @@ pub fn validate_attr_map(
             continue;
         };
 
-        let raw_ids = raw_value.split_whitespace();
-        let ids: Vec<&str> = if attr_value_contains_idrefs(*attr) {
-            raw_ids.collect()
-        } else {
-            raw_ids.take(1).collect()
-        };
-
-        for id in ids {
+        for id in raw_value.split_whitespace() {
             if !is_known_id(id, attr_map, context.known_ids) {
                 validator
                     .errors
@@ -791,6 +773,34 @@ mod tests {
                 .contains(&AriaValidationError::DanglingIdReference {
                     attribute: "aria-errormessage",
                     id: String::from("error-id"),
+                })
+        );
+    }
+
+    #[test]
+    fn validate_attr_map_checks_all_tokens_for_single_idref_attributes() {
+        let mut attr_map = AttrMap::new();
+
+        attr_map.set(
+            HtmlAttr::Aria(AriaAttr::ErrorMessage),
+            AttrValue::from("known-id missing-id"),
+        );
+
+        let validator = validate_attr_map(
+            None,
+            &attr_map,
+            AriaValidationContext {
+                known_ids: &["known-id"],
+                owned_roles: &[],
+            },
+        );
+
+        assert!(
+            validator
+                .errors()
+                .contains(&AriaValidationError::DanglingIdReference {
+                    attribute: "aria-errormessage",
+                    id: String::from("missing-id"),
                 })
         );
     }

--- a/crates/ars-a11y/src/testing/validator.rs
+++ b/crates/ars-a11y/src/testing/validator.rs
@@ -245,6 +245,7 @@ const fn idref_attr_name(attr: HtmlAttr) -> Option<&'static str> {
         HtmlAttr::Aria(AriaAttr::Controls) => Some("aria-controls"),
         HtmlAttr::Aria(AriaAttr::DescribedBy) => Some("aria-describedby"),
         HtmlAttr::Aria(AriaAttr::Details) => Some("aria-details"),
+        HtmlAttr::Aria(AriaAttr::ErrorMessage) => Some("aria-errormessage"),
         HtmlAttr::Aria(AriaAttr::FlowTo) => Some("aria-flowto"),
         HtmlAttr::Aria(AriaAttr::LabelledBy) => Some("aria-labelledby"),
         HtmlAttr::Aria(AriaAttr::Owns) => Some("aria-owns"),
@@ -771,6 +772,27 @@ mod tests {
                 ..
             }
         )));
+    }
+
+    #[test]
+    fn validate_attr_map_catches_dangling_aria_errormessage_reference() {
+        let mut attr_map = AttrMap::new();
+
+        attr_map.set(
+            HtmlAttr::Aria(AriaAttr::ErrorMessage),
+            AttrValue::from("error-id"),
+        );
+
+        let validator = validate_attr_map(None, &attr_map, AriaValidationContext::new());
+
+        assert!(
+            validator
+                .errors()
+                .contains(&AriaValidationError::DanglingIdReference {
+                    attribute: "aria-errormessage",
+                    id: String::from("error-id"),
+                })
+        );
     }
 
     #[test]

--- a/crates/ars-a11y/src/testing/validator.rs
+++ b/crates/ars-a11y/src/testing/validator.rs
@@ -92,10 +92,21 @@ impl AriaValidator {
             return;
         }
 
-        if matches!(role, AriaRole::Separator) && !has_tabindex {
-            self.warnings.push(AriaValidationWarning::Hint {
-                message: "AriaRole::Separator requires tabindex for focusable separator. Use AriaRole::StructuralSeparator for non-focusable separators.",
-            });
+        if matches!(role, AriaRole::Separator | AriaRole::StructuralSeparator) {
+            let message = match role {
+                AriaRole::Separator if !has_tabindex => Some(
+                    "AriaRole::Separator requires tabindex for focusable separator. Use AriaRole::StructuralSeparator for non-focusable separators.",
+                ),
+                AriaRole::StructuralSeparator if has_tabindex => Some(
+                    "AriaRole::StructuralSeparator is the non-focusable separator role. Use AriaRole::Separator for focusable separators with tabindex.",
+                ),
+                _ => None,
+            };
+
+            if let Some(message) = message {
+                self.warnings
+                    .push(AriaValidationWarning::Hint { message });
+            }
         }
 
         self.check_required_attrs_for_role(role, attrs);
@@ -425,6 +436,21 @@ mod tests {
     }
 
     #[test]
+    fn structural_separator_with_tabindex_emits_hint_warning() {
+        let mut validator = AriaValidator::new();
+
+        validator.check_role(AriaRole::StructuralSeparator, &[], true);
+
+        assert_eq!(
+            validator.warnings(),
+            &[AriaValidationWarning::Hint {
+                message: "AriaRole::StructuralSeparator is the non-focusable separator role. Use AriaRole::Separator for focusable separators with tabindex.",
+            }]
+        );
+        assert!(validator.errors().is_empty());
+    }
+
+    #[test]
     fn option_has_no_globally_required_attributes() {
         assert!(required_attributes_for_role(AriaRole::Option).is_empty());
     }
@@ -494,6 +520,23 @@ mod tests {
 
         assert!(validator.errors().is_empty());
         assert!(validator.warnings().is_empty());
+    }
+
+    #[test]
+    fn validate_attr_map_structural_separator_with_tabindex_emits_hint_warning() {
+        let mut attr_map = AttrMap::new();
+
+        attr_map.set(HtmlAttr::TabIndex, AttrValue::from("0"));
+
+        let validator = validate_attr_map(Some(AriaRole::StructuralSeparator), &attr_map);
+
+        assert_eq!(
+            validator.warnings(),
+            &[AriaValidationWarning::Hint {
+                message: "AriaRole::StructuralSeparator is the non-focusable separator role. Use AriaRole::Separator for focusable separators with tabindex.",
+            }]
+        );
+        assert!(validator.errors().is_empty());
     }
 
     #[test]

--- a/crates/ars-a11y/src/testing/validator.rs
+++ b/crates/ars-a11y/src/testing/validator.rs
@@ -2,9 +2,29 @@
 
 use alloc::{string::String, vec::Vec};
 
-use ars_core::{AttrMap, HtmlAttr};
+use ars_core::{AriaAttr, AttrMap, HtmlAttr};
 
 use crate::{AriaAttribute, AriaRole};
+
+/// Additional subtree context used for ARIA validation beyond a single element's `AttrMap`.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct AriaValidationContext<'a> {
+    /// The DOM IDs currently present in the validated subtree.
+    pub known_ids: &'a [&'a str],
+    /// The direct owned child roles currently present under the validated role owner.
+    pub owned_roles: &'a [AriaRole],
+}
+
+impl<'a> AriaValidationContext<'a> {
+    /// Creates an empty validation context with no known IDs or owned roles.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            known_ids: &[],
+            owned_roles: &[],
+        }
+    }
+}
 
 /// A compile-time and runtime ARIA attribute validator.
 ///
@@ -83,8 +103,14 @@ impl AriaValidator {
         Self::default()
     }
 
-    /// Validate role usage against the provided ARIA attribute set.
-    pub fn check_role(&mut self, role: AriaRole, attrs: &[AriaAttribute], has_tabindex: bool) {
+    /// Validate role usage against the provided ARIA attribute set and subtree role context.
+    pub fn check_role(
+        &mut self,
+        role: AriaRole,
+        attrs: &[AriaAttribute],
+        has_tabindex: bool,
+        owned_roles: &[AriaRole],
+    ) {
         if role.is_abstract() {
             self.errors
                 .push(AriaValidationError::AbstractRoleUsed { role: role.name() });
@@ -104,12 +130,12 @@ impl AriaValidator {
             };
 
             if let Some(message) = message {
-                self.warnings
-                    .push(AriaValidationWarning::Hint { message });
+                self.warnings.push(AriaValidationWarning::Hint { message });
             }
         }
 
         self.check_required_attrs_for_role(role, attrs);
+        self.check_required_owned_elements_for_role(role, owned_roles);
     }
 
     fn check_required_attrs_for_role(&mut self, role: AriaRole, attrs: &[AriaAttribute]) {
@@ -124,6 +150,39 @@ impl AriaValidator {
                     });
             }
         }
+    }
+
+    fn check_required_owned_elements_for_role(&mut self, role: AriaRole, owned_roles: &[AriaRole]) {
+        let required_groups = role.required_owned_elements();
+        if required_groups.is_empty() {
+            return;
+        }
+
+        let satisfies_required_owned_elements = required_groups.iter().any(|group| {
+            group
+                .iter()
+                .all(|required_role| owned_roles.contains(required_role))
+        });
+
+        if satisfies_required_owned_elements {
+            return;
+        }
+
+        let mut required_one_of = Vec::new();
+        for group in required_groups {
+            for required_role in *group {
+                let role_name = required_role.name();
+                if !required_one_of.contains(&role_name) {
+                    required_one_of.push(role_name);
+                }
+            }
+        }
+
+        self.errors
+            .push(AriaValidationError::MissingRequiredOwnedElement {
+                role: role.name(),
+                required_one_of,
+            });
     }
 
     /// Returns `true` when validation has recorded any errors.
@@ -176,9 +235,42 @@ pub const fn required_attributes_for_role(role: AriaRole) -> &'static [&'static 
     }
 }
 
-/// Validate that an `AttrMap` produced by a connect surface is ARIA-conformant.
+fn is_known_id(id: &str, attr_map: &AttrMap, known_ids: &[&str]) -> bool {
+    attr_map.get(&HtmlAttr::Id) == Some(id) || known_ids.contains(&id)
+}
+
+const fn idref_attr_name(attr: HtmlAttr) -> Option<&'static str> {
+    match attr {
+        HtmlAttr::Aria(AriaAttr::ActiveDescendant) => Some("aria-activedescendant"),
+        HtmlAttr::Aria(AriaAttr::Controls) => Some("aria-controls"),
+        HtmlAttr::Aria(AriaAttr::DescribedBy) => Some("aria-describedby"),
+        HtmlAttr::Aria(AriaAttr::Details) => Some("aria-details"),
+        HtmlAttr::Aria(AriaAttr::FlowTo) => Some("aria-flowto"),
+        HtmlAttr::Aria(AriaAttr::LabelledBy) => Some("aria-labelledby"),
+        HtmlAttr::Aria(AriaAttr::Owns) => Some("aria-owns"),
+        _ => None,
+    }
+}
+
+const fn attr_value_contains_idrefs(attr: HtmlAttr) -> bool {
+    matches!(
+        attr,
+        HtmlAttr::Aria(AriaAttr::Controls)
+            | HtmlAttr::Aria(AriaAttr::DescribedBy)
+            | HtmlAttr::Aria(AriaAttr::FlowTo)
+            | HtmlAttr::Aria(AriaAttr::LabelledBy)
+            | HtmlAttr::Aria(AriaAttr::Owns)
+    )
+}
+
+/// Validate that an `AttrMap` produced by a connect surface is ARIA-conformant
+/// within the provided subtree context.
 #[must_use]
-pub fn validate_attr_map(role: Option<AriaRole>, attr_map: &AttrMap) -> AriaValidator {
+pub fn validate_attr_map(
+    role: Option<AriaRole>,
+    attr_map: &AttrMap,
+    context: AriaValidationContext<'_>,
+) -> AriaValidator {
     let mut validator = AriaValidator::new();
 
     let aria_attrs: Vec<AriaAttribute> = attr_map
@@ -189,7 +281,7 @@ pub fn validate_attr_map(role: Option<AriaRole>, attr_map: &AttrMap) -> AriaVali
     let has_tabindex = attr_map.contains(&HtmlAttr::TabIndex);
 
     if let Some(role) = role {
-        validator.check_role(role, &aria_attrs, has_tabindex);
+        validator.check_role(role, &aria_attrs, has_tabindex, context.owned_roles);
     }
 
     let has_active_descendant = aria_attrs
@@ -205,11 +297,41 @@ pub fn validate_attr_map(role: Option<AriaRole>, attr_map: &AttrMap) -> AriaVali
             .push(AriaValidationError::ActiveDescendantOnUnsupportedRole { role: role.name() });
     }
 
+    for (attr, value) in attr_map.iter() {
+        let Some(attribute) = idref_attr_name(*attr) else {
+            continue;
+        };
+
+        let Some(raw_value) = value.as_str() else {
+            continue;
+        };
+
+        let raw_ids = raw_value.split_whitespace();
+        let ids: Vec<&str> = if attr_value_contains_idrefs(*attr) {
+            raw_ids.collect()
+        } else {
+            raw_ids.take(1).collect()
+        };
+
+        for id in ids {
+            if !is_known_id(id, attr_map, context.known_ids) {
+                validator
+                    .errors
+                    .push(AriaValidationError::DanglingIdReference {
+                        attribute,
+                        id: String::from(id),
+                    });
+            }
+        }
+    }
+
     validator
 }
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec;
+
     use ars_core::{AriaAttr, AttrValue, HtmlAttr};
 
     use super::*;
@@ -243,7 +365,7 @@ mod tests {
         for role in abstract_roles {
             let mut validator = AriaValidator::new();
 
-            validator.check_role(role, &[], false);
+            validator.check_role(role, &[], false, &[]);
 
             assert_eq!(
                 validator.errors(),
@@ -256,7 +378,7 @@ mod tests {
     fn checkbox_requires_aria_checked() {
         let mut validator = AriaValidator::new();
 
-        validator.check_role(AriaRole::Checkbox, &[], false);
+        validator.check_role(AriaRole::Checkbox, &[], false, &[]);
 
         assert_eq!(
             validator.errors(),
@@ -279,7 +401,7 @@ mod tests {
         for (role, role_name) in roles {
             let mut validator = AriaValidator::new();
 
-            validator.check_role(role, &[], false);
+            validator.check_role(role, &[], false, &[]);
 
             assert_eq!(
                 validator.errors(),
@@ -295,7 +417,7 @@ mod tests {
     fn slider_requires_value_attributes() {
         let mut validator = AriaValidator::new();
 
-        validator.check_role(AriaRole::Slider, &[], false);
+        validator.check_role(AriaRole::Slider, &[], false, &[]);
 
         assert_eq!(
             validator.errors(),
@@ -326,7 +448,7 @@ mod tests {
         for (role, role_name) in roles {
             let mut validator = AriaValidator::new();
 
-            validator.check_role(role, &[], false);
+            validator.check_role(role, &[], false, &[]);
 
             assert_eq!(
                 validator.errors(),
@@ -349,7 +471,7 @@ mod tests {
     fn scrollbar_requires_all_required_attributes() {
         let mut validator = AriaValidator::new();
 
-        validator.check_role(AriaRole::Scrollbar, &[], false);
+        validator.check_role(AriaRole::Scrollbar, &[], false, &[]);
 
         assert_eq!(
             validator.errors(),
@@ -378,7 +500,7 @@ mod tests {
     fn heading_requires_aria_level() {
         let mut validator = AriaValidator::new();
 
-        validator.check_role(AriaRole::Heading, &[], false);
+        validator.check_role(AriaRole::Heading, &[], false, &[]);
 
         assert_eq!(
             validator.errors(),
@@ -393,7 +515,7 @@ mod tests {
     fn button_has_no_required_attributes() {
         let mut validator = AriaValidator::new();
 
-        validator.check_role(AriaRole::Button, &[], false);
+        validator.check_role(AriaRole::Button, &[], false, &[]);
 
         assert!(!validator.has_errors());
         assert!(validator.warnings().is_empty());
@@ -409,7 +531,7 @@ mod tests {
             AriaAttribute::ValueMax(10.0),
         ];
 
-        validator.check_role(AriaRole::Separator, &attrs, false);
+        validator.check_role(AriaRole::Separator, &attrs, false, &[]);
 
         assert_eq!(
             validator.warnings(),
@@ -429,7 +551,7 @@ mod tests {
             AriaAttribute::ValueMax(10.0),
         ];
 
-        validator.check_role(AriaRole::Separator, &attrs, true);
+        validator.check_role(AriaRole::Separator, &attrs, true, &[]);
 
         assert!(validator.errors().is_empty());
         assert!(validator.warnings().is_empty());
@@ -439,7 +561,7 @@ mod tests {
     fn structural_separator_with_tabindex_emits_hint_warning() {
         let mut validator = AriaValidator::new();
 
-        validator.check_role(AriaRole::StructuralSeparator, &[], true);
+        validator.check_role(AriaRole::StructuralSeparator, &[], true, &[]);
 
         assert_eq!(
             validator.warnings(),
@@ -459,7 +581,11 @@ mod tests {
     fn validate_attr_map_catches_missing_combobox_expanded() {
         let attr_map = AttrMap::new();
 
-        let validator = validate_attr_map(Some(AriaRole::Combobox), &attr_map);
+        let validator = validate_attr_map(
+            Some(AriaRole::Combobox),
+            &attr_map,
+            AriaValidationContext::new(),
+        );
 
         assert_eq!(
             validator.errors(),
@@ -479,7 +605,14 @@ mod tests {
             AttrValue::from("item-1"),
         );
 
-        let validator = validate_attr_map(Some(AriaRole::Button), &attr_map);
+        let validator = validate_attr_map(
+            Some(AriaRole::Button),
+            &attr_map,
+            AriaValidationContext {
+                known_ids: &["item-1"],
+                owned_roles: &[],
+            },
+        );
 
         assert!(
             validator
@@ -500,7 +633,14 @@ mod tests {
         );
         attr_map.set(HtmlAttr::Aria(AriaAttr::Expanded), AttrValue::from("true"));
 
-        let validator = validate_attr_map(Some(AriaRole::Combobox), &attr_map);
+        let validator = validate_attr_map(
+            Some(AriaRole::Combobox),
+            &attr_map,
+            AriaValidationContext {
+                known_ids: &["item-1"],
+                owned_roles: &[],
+            },
+        );
 
         assert!(!validator.errors().contains(
             &AriaValidationError::ActiveDescendantOnUnsupportedRole { role: "combobox" }
@@ -516,7 +656,11 @@ mod tests {
         attr_map.set(HtmlAttr::Aria(AriaAttr::ValueMin), AttrValue::from("0"));
         attr_map.set(HtmlAttr::Aria(AriaAttr::ValueMax), AttrValue::from("10"));
 
-        let validator = validate_attr_map(Some(AriaRole::Separator), &attr_map);
+        let validator = validate_attr_map(
+            Some(AriaRole::Separator),
+            &attr_map,
+            AriaValidationContext::new(),
+        );
 
         assert!(validator.errors().is_empty());
         assert!(validator.warnings().is_empty());
@@ -528,7 +672,11 @@ mod tests {
 
         attr_map.set(HtmlAttr::TabIndex, AttrValue::from("0"));
 
-        let validator = validate_attr_map(Some(AriaRole::StructuralSeparator), &attr_map);
+        let validator = validate_attr_map(
+            Some(AriaRole::StructuralSeparator),
+            &attr_map,
+            AriaValidationContext::new(),
+        );
 
         assert_eq!(
             validator.warnings(),
@@ -540,6 +688,112 @@ mod tests {
     }
 
     #[test]
+    fn listbox_requires_owned_option_or_group_role() {
+        let mut validator = AriaValidator::new();
+
+        validator.check_role(AriaRole::Listbox, &[], false, &[]);
+
+        assert!(
+            validator
+                .errors()
+                .contains(&AriaValidationError::MissingRequiredOwnedElement {
+                    role: "listbox",
+                    required_one_of: vec!["option", "group"],
+                })
+        );
+    }
+
+    #[test]
+    fn listbox_owned_roles_satisfy_required_owned_element_contract() {
+        let mut validator = AriaValidator::new();
+
+        validator.check_role(AriaRole::Listbox, &[], false, &[AriaRole::Option]);
+
+        assert!(!validator.errors().iter().any(|error| matches!(
+            error,
+            AriaValidationError::MissingRequiredOwnedElement {
+                role: "listbox",
+                ..
+            }
+        )));
+    }
+
+    #[test]
+    fn validate_attr_map_catches_dangling_aria_labelledby_reference() {
+        let mut attr_map = AttrMap::new();
+
+        attr_map.set(
+            HtmlAttr::Aria(AriaAttr::LabelledBy),
+            AttrValue::from("missing-id"),
+        );
+
+        let validator = validate_attr_map(
+            None,
+            &attr_map,
+            AriaValidationContext {
+                known_ids: &[],
+                owned_roles: &[],
+            },
+        );
+
+        assert!(
+            validator
+                .errors()
+                .contains(&AriaValidationError::DanglingIdReference {
+                    attribute: "aria-labelledby",
+                    id: String::from("missing-id"),
+                })
+        );
+    }
+
+    #[test]
+    fn validate_attr_map_accepts_known_aria_describedby_references() {
+        let mut attr_map = AttrMap::new();
+
+        attr_map.set(
+            HtmlAttr::Aria(AriaAttr::DescribedBy),
+            AttrValue::from("description-id"),
+        );
+
+        let validator = validate_attr_map(
+            None,
+            &attr_map,
+            AriaValidationContext {
+                known_ids: &["description-id"],
+                owned_roles: &[],
+            },
+        );
+
+        assert!(!validator.errors().iter().any(|error| matches!(
+            error,
+            AriaValidationError::DanglingIdReference {
+                attribute: "aria-describedby",
+                ..
+            }
+        )));
+    }
+
+    #[test]
+    fn validate_attr_map_catches_missing_required_owned_roles_from_context() {
+        let attr_map = AttrMap::new();
+
+        let validator = validate_attr_map(
+            Some(AriaRole::Listbox),
+            &attr_map,
+            AriaValidationContext::new(),
+        );
+
+        assert!(
+            validator
+                .errors()
+                .contains(&AriaValidationError::MissingRequiredOwnedElement {
+                    role: "listbox",
+                    required_one_of: vec!["option", "group"],
+                })
+        );
+    }
+
+    #[test]
     fn validate_attr_map_without_role_skips_role_checks() {
         let mut attr_map = AttrMap::new();
 
@@ -548,9 +802,16 @@ mod tests {
             AttrValue::from("item-1"),
         );
 
-        let validator = validate_attr_map(None, &attr_map);
+        let validator = validate_attr_map(
+            None,
+            &attr_map,
+            AriaValidationContext {
+                known_ids: &["item-1"],
+                owned_roles: &[],
+            },
+        );
 
-        assert!(!validator.has_errors());
+        assert!(validator.errors().is_empty());
         assert!(validator.warnings().is_empty());
     }
 }

--- a/crates/ars-a11y/src/testing/validator.rs
+++ b/crates/ars-a11y/src/testing/validator.rs
@@ -239,6 +239,14 @@ fn is_known_id(id: &str, attr_map: &AttrMap, known_ids: &[&str]) -> bool {
     attr_map.get(&HtmlAttr::Id) == Some(id) || known_ids.contains(&id)
 }
 
+fn supported_aria_attribute(attr: AriaAttr) -> Option<AriaAttribute> {
+    match attr {
+        #[cfg(not(feature = "aria-drag-drop-compat"))]
+        AriaAttr::DropEffect | AriaAttr::Grabbed => None,
+        _ => Some(AriaAttribute::from(attr)),
+    }
+}
+
 const fn idref_attr_name(attr: HtmlAttr) -> Option<&'static str> {
     match attr {
         HtmlAttr::Aria(AriaAttr::ActiveDescendant) => Some("aria-activedescendant"),
@@ -265,7 +273,10 @@ pub fn validate_attr_map(
 
     let aria_attrs: Vec<AriaAttribute> = attr_map
         .iter_attrs()
-        .filter_map(|(key, _)| AriaAttribute::try_from(*key).ok())
+        .filter_map(|(key, _)| match key {
+            HtmlAttr::Aria(attr) => supported_aria_attribute(*attr),
+            _ => None,
+        })
         .collect();
 
     let has_tabindex = attr_map.contains(&HtmlAttr::TabIndex);
@@ -292,11 +303,7 @@ pub fn validate_attr_map(
             continue;
         };
 
-        let Some(raw_value) = value.as_str() else {
-            continue;
-        };
-
-        for id in raw_value.split_whitespace() {
+        for id in value.as_str().into_iter().flat_map(str::split_whitespace) {
             if !is_known_id(id, attr_map, context.known_ids) {
                 validator
                     .errors
@@ -692,13 +699,14 @@ mod tests {
 
         validator.check_role(AriaRole::Listbox, &[], false, &[AriaRole::Option]);
 
-        assert!(!validator.errors().iter().any(|error| matches!(
-            error,
-            AriaValidationError::MissingRequiredOwnedElement {
-                role: "listbox",
-                ..
-            }
-        )));
+        assert!(
+            !validator
+                .errors()
+                .contains(&AriaValidationError::MissingRequiredOwnedElement {
+                    role: "listbox",
+                    required_one_of: vec!["option", "group"],
+                })
+        );
     }
 
     #[test]
@@ -747,13 +755,14 @@ mod tests {
             },
         );
 
-        assert!(!validator.errors().iter().any(|error| matches!(
-            error,
-            AriaValidationError::DanglingIdReference {
-                attribute: "aria-describedby",
-                ..
-            }
-        )));
+        assert!(
+            !validator
+                .errors()
+                .contains(&AriaValidationError::DanglingIdReference {
+                    attribute: "aria-describedby",
+                    id: String::from("description-id"),
+                })
+        );
     }
 
     #[test]
@@ -801,6 +810,123 @@ mod tests {
                 .contains(&AriaValidationError::DanglingIdReference {
                     attribute: "aria-errormessage",
                     id: String::from("missing-id"),
+                })
+        );
+    }
+
+    #[test]
+    fn validate_attr_map_catches_dangling_ids_for_all_remaining_idref_attrs() {
+        let mut attr_map = AttrMap::new();
+
+        attr_map.set(
+            HtmlAttr::Aria(AriaAttr::Controls),
+            AttrValue::from("known-controls missing-controls"),
+        );
+        attr_map.set(
+            HtmlAttr::Aria(AriaAttr::Details),
+            AttrValue::from("missing-details"),
+        );
+        attr_map.set(
+            HtmlAttr::Aria(AriaAttr::FlowTo),
+            AttrValue::from("known-flow missing-flow"),
+        );
+        attr_map.set(
+            HtmlAttr::Aria(AriaAttr::Owns),
+            AttrValue::from("known-owns missing-owns"),
+        );
+
+        let validator = validate_attr_map(
+            None,
+            &attr_map,
+            AriaValidationContext {
+                known_ids: &["known-controls", "known-flow", "known-owns"],
+                owned_roles: &[],
+            },
+        );
+
+        assert!(
+            validator
+                .errors()
+                .contains(&AriaValidationError::DanglingIdReference {
+                    attribute: "aria-controls",
+                    id: String::from("missing-controls"),
+                })
+        );
+        assert!(
+            validator
+                .errors()
+                .contains(&AriaValidationError::DanglingIdReference {
+                    attribute: "aria-details",
+                    id: String::from("missing-details"),
+                })
+        );
+        assert!(
+            validator
+                .errors()
+                .contains(&AriaValidationError::DanglingIdReference {
+                    attribute: "aria-flowto",
+                    id: String::from("missing-flow"),
+                })
+        );
+        assert!(
+            validator
+                .errors()
+                .contains(&AriaValidationError::DanglingIdReference {
+                    attribute: "aria-owns",
+                    id: String::from("missing-owns"),
+                })
+        );
+    }
+
+    #[test]
+    fn validate_attr_map_ignores_non_string_idref_values() {
+        let mut attr_map = AttrMap::new();
+
+        attr_map.set(HtmlAttr::Aria(AriaAttr::Controls), AttrValue::None);
+
+        let validator = validate_attr_map(None, &attr_map, AriaValidationContext::new());
+
+        assert!(validator.errors().is_empty());
+        assert!(validator.warnings().is_empty());
+    }
+
+    #[test]
+    fn validate_attr_map_ignores_unsupported_drag_drop_compat_attrs() {
+        let mut attr_map = AttrMap::new();
+
+        attr_map.set(
+            HtmlAttr::Aria(AriaAttr::DropEffect),
+            AttrValue::from("copy"),
+        );
+        attr_map.set(HtmlAttr::Aria(AriaAttr::Grabbed), AttrValue::from("true"));
+
+        let validator = validate_attr_map(None, &attr_map, AriaValidationContext::new());
+
+        assert!(validator.errors().is_empty());
+        assert!(validator.warnings().is_empty());
+    }
+
+    #[test]
+    fn validate_attr_map_still_checks_role_requirements_with_unsupported_aria_keys() {
+        let mut attr_map = AttrMap::new();
+
+        attr_map.set(
+            HtmlAttr::Aria(AriaAttr::DropEffect),
+            AttrValue::from("move"),
+        );
+
+        let validator = validate_attr_map(
+            Some(AriaRole::Combobox),
+            &attr_map,
+            AriaValidationContext::new(),
+        );
+
+        assert!(
+            validator
+                .errors()
+                .contains(&AriaValidationError::MissingRequiredAttribute {
+                    role: "combobox",
+                    missing_attr: "aria-expanded",
                 })
         );
     }

--- a/crates/ars-a11y/src/testing/validator.rs
+++ b/crates/ars-a11y/src/testing/validator.rs
@@ -1,0 +1,513 @@
+//! Automated ARIA validation for tests and debug-only assertions.
+
+use alloc::{string::String, vec::Vec};
+
+use ars_core::{AttrMap, HtmlAttr};
+
+use crate::{AriaAttribute, AriaRole};
+
+/// A compile-time and runtime ARIA attribute validator.
+///
+/// Catches common ARIA mistakes:
+/// - Role set without required attributes
+/// - Required owned elements missing
+/// - Attributes used on incompatible roles
+/// - ID references pointing to non-existent elements
+#[derive(Debug, Default)]
+pub struct AriaValidator {
+    errors: Vec<AriaValidationError>,
+    warnings: Vec<AriaValidationWarning>,
+}
+
+/// Validation failures that should block the authored ARIA surface.
+#[derive(Clone, Debug, PartialEq)]
+pub enum AriaValidationError {
+    /// A required ARIA attribute is missing for the given role.
+    MissingRequiredAttribute {
+        /// The role being validated.
+        role: &'static str,
+        /// The missing required ARIA attribute.
+        missing_attr: &'static str,
+    },
+    /// An abstract role was used on a DOM element.
+    AbstractRoleUsed {
+        /// The abstract role name.
+        role: &'static str,
+    },
+    /// A required owned element is missing.
+    MissingRequiredOwnedElement {
+        /// The role whose ownership contract was violated.
+        role: &'static str,
+        /// One of the role groups that would satisfy the ownership rule.
+        required_one_of: Vec<&'static str>,
+    },
+    /// `aria-labelledby` or `aria-describedby` references a non-existent ID.
+    DanglingIdReference {
+        /// The ARIA relationship attribute containing the bad reference.
+        attribute: &'static str,
+        /// The missing DOM ID.
+        id: String,
+    },
+    /// `aria-activedescendant` used on a role that does not support it.
+    ActiveDescendantOnUnsupportedRole {
+        /// The unsupported role name.
+        role: &'static str,
+    },
+}
+
+/// Validation warnings that point to suspicious but not necessarily invalid ARIA.
+#[derive(Clone, Debug, PartialEq)]
+pub enum AriaValidationWarning {
+    /// Redundant ARIA role matches the implicit native role.
+    RedundantRole {
+        /// The native element type.
+        element: &'static str,
+        /// The redundant role.
+        role: &'static str,
+    },
+    /// `aria-label` used alongside visible text (prefer `aria-labelledby`).
+    AriaLabelWithVisibleText,
+    /// `aria-disabled` used on a native form element (prefer `disabled`).
+    AriaDisabledOnNativeFormElement,
+    /// General advisory hint from the validator.
+    Hint {
+        /// The advisory message.
+        message: &'static str,
+    },
+}
+
+impl AriaValidator {
+    /// Creates an empty validator with no accumulated errors or warnings.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Validate role usage against the provided ARIA attribute set.
+    pub fn check_role(&mut self, role: AriaRole, attrs: &[AriaAttribute], has_tabindex: bool) {
+        if role.is_abstract() {
+            self.errors
+                .push(AriaValidationError::AbstractRoleUsed { role: role.name() });
+
+            return;
+        }
+
+        if matches!(role, AriaRole::Separator) && !has_tabindex {
+            self.warnings.push(AriaValidationWarning::Hint {
+                message: "AriaRole::Separator requires tabindex for focusable separator. Use AriaRole::StructuralSeparator for non-focusable separators.",
+            });
+        }
+
+        self.check_required_attrs_for_role(role, attrs);
+    }
+
+    fn check_required_attrs_for_role(&mut self, role: AriaRole, attrs: &[AriaAttribute]) {
+        for required_attr in required_attributes_for_role(role) {
+            let present = attrs.iter().any(|attr| attr.attr_name() == *required_attr);
+
+            if !present {
+                self.errors
+                    .push(AriaValidationError::MissingRequiredAttribute {
+                        role: role.name(),
+                        missing_attr: required_attr,
+                    });
+            }
+        }
+    }
+
+    /// Returns `true` when validation has recorded any errors.
+    #[must_use]
+    pub fn has_errors(&self) -> bool {
+        !self.errors.is_empty()
+    }
+
+    /// Returns the accumulated validation errors.
+    #[must_use]
+    pub fn errors(&self) -> &[AriaValidationError] {
+        &self.errors
+    }
+
+    /// Returns the accumulated validation warnings.
+    #[must_use]
+    pub fn warnings(&self) -> &[AriaValidationWarning] {
+        &self.warnings
+    }
+}
+
+/// Returns required ARIA attributes for a role, as per the WAI-ARIA role contract.
+#[must_use]
+pub const fn required_attributes_for_role(role: AriaRole) -> &'static [&'static str] {
+    match role {
+        AriaRole::Checkbox
+        | AriaRole::Radio
+        | AriaRole::Switch
+        | AriaRole::Menuitemcheckbox
+        | AriaRole::Menuitemradio => &["aria-checked"],
+
+        AriaRole::Combobox => &["aria-expanded"],
+
+        AriaRole::Scrollbar => &[
+            "aria-controls",
+            "aria-valuenow",
+            "aria-valuemin",
+            "aria-valuemax",
+        ],
+
+        AriaRole::Slider | AriaRole::Separator => {
+            &["aria-valuenow", "aria-valuemin", "aria-valuemax"]
+        }
+
+        AriaRole::Spinbutton | AriaRole::Meter => &["aria-valuenow"],
+
+        AriaRole::Heading => &["aria-level"],
+
+        _ => &[],
+    }
+}
+
+/// Validate that an `AttrMap` produced by a connect surface is ARIA-conformant.
+#[must_use]
+pub fn validate_attr_map(role: Option<AriaRole>, attr_map: &AttrMap) -> AriaValidator {
+    let mut validator = AriaValidator::new();
+
+    let aria_attrs: Vec<AriaAttribute> = attr_map
+        .iter_attrs()
+        .filter_map(|(key, _)| AriaAttribute::try_from(*key).ok())
+        .collect();
+
+    let has_tabindex = attr_map.contains(&HtmlAttr::TabIndex);
+
+    if let Some(role) = role {
+        validator.check_role(role, &aria_attrs, has_tabindex);
+    }
+
+    let has_active_descendant = aria_attrs
+        .iter()
+        .any(|attr| matches!(attr, AriaAttribute::ActiveDescendant(_)));
+
+    if has_active_descendant
+        && let Some(role) = role
+        && !role.supports_active_descendant()
+    {
+        validator
+            .errors
+            .push(AriaValidationError::ActiveDescendantOnUnsupportedRole { role: role.name() });
+    }
+
+    validator
+}
+
+#[cfg(test)]
+mod tests {
+    use ars_core::{AriaAttr, AttrValue, HtmlAttr};
+
+    use super::*;
+
+    #[test]
+    fn validator_new_starts_empty() {
+        let validator = AriaValidator::new();
+
+        assert!(!validator.has_errors());
+        assert!(validator.errors().is_empty());
+        assert!(validator.warnings().is_empty());
+    }
+
+    #[test]
+    fn all_abstract_roles_produce_abstract_role_used() {
+        let abstract_roles = [
+            AriaRole::Command,
+            AriaRole::Composite,
+            AriaRole::Input,
+            AriaRole::Landmark,
+            AriaRole::Range,
+            AriaRole::RoleType,
+            AriaRole::Section,
+            AriaRole::SectionHead,
+            AriaRole::Select,
+            AriaRole::Structure,
+            AriaRole::Widget,
+            AriaRole::Window,
+        ];
+
+        for role in abstract_roles {
+            let mut validator = AriaValidator::new();
+
+            validator.check_role(role, &[], false);
+
+            assert_eq!(
+                validator.errors(),
+                &[AriaValidationError::AbstractRoleUsed { role: role.name() }]
+            );
+        }
+    }
+
+    #[test]
+    fn checkbox_requires_aria_checked() {
+        let mut validator = AriaValidator::new();
+
+        validator.check_role(AriaRole::Checkbox, &[], false);
+
+        assert_eq!(
+            validator.errors(),
+            &[AriaValidationError::MissingRequiredAttribute {
+                role: "checkbox",
+                missing_attr: "aria-checked",
+            }]
+        );
+    }
+
+    #[test]
+    fn aria_checked_roles_share_required_attribute_contract() {
+        let roles = [
+            (AriaRole::Radio, "radio"),
+            (AriaRole::Switch, "switch"),
+            (AriaRole::Menuitemcheckbox, "menuitemcheckbox"),
+            (AriaRole::Menuitemradio, "menuitemradio"),
+        ];
+
+        for (role, role_name) in roles {
+            let mut validator = AriaValidator::new();
+
+            validator.check_role(role, &[], false);
+
+            assert_eq!(
+                validator.errors(),
+                &[AriaValidationError::MissingRequiredAttribute {
+                    role: role_name,
+                    missing_attr: "aria-checked",
+                }]
+            );
+        }
+    }
+
+    #[test]
+    fn slider_requires_value_attributes() {
+        let mut validator = AriaValidator::new();
+
+        validator.check_role(AriaRole::Slider, &[], false);
+
+        assert_eq!(
+            validator.errors(),
+            &[
+                AriaValidationError::MissingRequiredAttribute {
+                    role: "slider",
+                    missing_attr: "aria-valuenow",
+                },
+                AriaValidationError::MissingRequiredAttribute {
+                    role: "slider",
+                    missing_attr: "aria-valuemin",
+                },
+                AriaValidationError::MissingRequiredAttribute {
+                    role: "slider",
+                    missing_attr: "aria-valuemax",
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn spinbutton_and_meter_require_only_value_now() {
+        let roles = [
+            (AriaRole::Spinbutton, "spinbutton"),
+            (AriaRole::Meter, "meter"),
+        ];
+
+        for (role, role_name) in roles {
+            let mut validator = AriaValidator::new();
+
+            validator.check_role(role, &[], false);
+
+            assert_eq!(
+                validator.errors(),
+                &[AriaValidationError::MissingRequiredAttribute {
+                    role: role_name,
+                    missing_attr: "aria-valuenow",
+                }]
+            );
+            assert!(!validator.errors().iter().any(|error| matches!(
+                error,
+                AriaValidationError::MissingRequiredAttribute {
+                    missing_attr: "aria-valuemin" | "aria-valuemax",
+                    ..
+                }
+            )));
+        }
+    }
+
+    #[test]
+    fn scrollbar_requires_all_required_attributes() {
+        let mut validator = AriaValidator::new();
+
+        validator.check_role(AriaRole::Scrollbar, &[], false);
+
+        assert_eq!(
+            validator.errors(),
+            &[
+                AriaValidationError::MissingRequiredAttribute {
+                    role: "scrollbar",
+                    missing_attr: "aria-controls",
+                },
+                AriaValidationError::MissingRequiredAttribute {
+                    role: "scrollbar",
+                    missing_attr: "aria-valuenow",
+                },
+                AriaValidationError::MissingRequiredAttribute {
+                    role: "scrollbar",
+                    missing_attr: "aria-valuemin",
+                },
+                AriaValidationError::MissingRequiredAttribute {
+                    role: "scrollbar",
+                    missing_attr: "aria-valuemax",
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn heading_requires_aria_level() {
+        let mut validator = AriaValidator::new();
+
+        validator.check_role(AriaRole::Heading, &[], false);
+
+        assert_eq!(
+            validator.errors(),
+            &[AriaValidationError::MissingRequiredAttribute {
+                role: "heading",
+                missing_attr: "aria-level",
+            }]
+        );
+    }
+
+    #[test]
+    fn button_has_no_required_attributes() {
+        let mut validator = AriaValidator::new();
+
+        validator.check_role(AriaRole::Button, &[], false);
+
+        assert!(!validator.has_errors());
+        assert!(validator.warnings().is_empty());
+    }
+
+    #[test]
+    fn separator_without_tabindex_emits_hint_warning() {
+        let mut validator = AriaValidator::new();
+
+        let attrs = [
+            AriaAttribute::ValueNow(5.0),
+            AriaAttribute::ValueMin(0.0),
+            AriaAttribute::ValueMax(10.0),
+        ];
+
+        validator.check_role(AriaRole::Separator, &attrs, false);
+
+        assert_eq!(
+            validator.warnings(),
+            &[AriaValidationWarning::Hint {
+                message: "AriaRole::Separator requires tabindex for focusable separator. Use AriaRole::StructuralSeparator for non-focusable separators.",
+            }]
+        );
+        assert!(validator.errors().is_empty());
+    }
+
+    #[test]
+    fn separator_with_tabindex_and_required_attrs_is_valid() {
+        let mut validator = AriaValidator::new();
+        let attrs = [
+            AriaAttribute::ValueNow(5.0),
+            AriaAttribute::ValueMin(0.0),
+            AriaAttribute::ValueMax(10.0),
+        ];
+
+        validator.check_role(AriaRole::Separator, &attrs, true);
+
+        assert!(validator.errors().is_empty());
+        assert!(validator.warnings().is_empty());
+    }
+
+    #[test]
+    fn option_has_no_globally_required_attributes() {
+        assert!(required_attributes_for_role(AriaRole::Option).is_empty());
+    }
+
+    #[test]
+    fn validate_attr_map_catches_missing_combobox_expanded() {
+        let attr_map = AttrMap::new();
+
+        let validator = validate_attr_map(Some(AriaRole::Combobox), &attr_map);
+
+        assert_eq!(
+            validator.errors(),
+            &[AriaValidationError::MissingRequiredAttribute {
+                role: "combobox",
+                missing_attr: "aria-expanded",
+            }]
+        );
+    }
+
+    #[test]
+    fn validate_attr_map_catches_unsupported_active_descendant() {
+        let mut attr_map = AttrMap::new();
+
+        attr_map.set(
+            HtmlAttr::Aria(AriaAttr::ActiveDescendant),
+            AttrValue::from("item-1"),
+        );
+
+        let validator = validate_attr_map(Some(AriaRole::Button), &attr_map);
+
+        assert!(
+            validator
+                .errors()
+                .contains(&AriaValidationError::ActiveDescendantOnUnsupportedRole {
+                    role: "button"
+                })
+        );
+    }
+
+    #[test]
+    fn validate_attr_map_allows_active_descendant_on_supported_roles() {
+        let mut attr_map = AttrMap::new();
+
+        attr_map.set(
+            HtmlAttr::Aria(AriaAttr::ActiveDescendant),
+            AttrValue::from("item-1"),
+        );
+        attr_map.set(HtmlAttr::Aria(AriaAttr::Expanded), AttrValue::from("true"));
+
+        let validator = validate_attr_map(Some(AriaRole::Combobox), &attr_map);
+
+        assert!(!validator.errors().contains(
+            &AriaValidationError::ActiveDescendantOnUnsupportedRole { role: "combobox" }
+        ));
+    }
+
+    #[test]
+    fn validate_attr_map_separator_with_tabindex_and_values_has_no_hint_warning() {
+        let mut attr_map = AttrMap::new();
+
+        attr_map.set(HtmlAttr::TabIndex, AttrValue::from("0"));
+        attr_map.set(HtmlAttr::Aria(AriaAttr::ValueNow), AttrValue::from("5"));
+        attr_map.set(HtmlAttr::Aria(AriaAttr::ValueMin), AttrValue::from("0"));
+        attr_map.set(HtmlAttr::Aria(AriaAttr::ValueMax), AttrValue::from("10"));
+
+        let validator = validate_attr_map(Some(AriaRole::Separator), &attr_map);
+
+        assert!(validator.errors().is_empty());
+        assert!(validator.warnings().is_empty());
+    }
+
+    #[test]
+    fn validate_attr_map_without_role_skips_role_checks() {
+        let mut attr_map = AttrMap::new();
+
+        attr_map.set(
+            HtmlAttr::Aria(AriaAttr::ActiveDescendant),
+            AttrValue::from("item-1"),
+        );
+
+        let validator = validate_attr_map(None, &attr_map);
+
+        assert!(!validator.has_errors());
+        assert!(validator.warnings().is_empty());
+    }
+}

--- a/spec/foundation/03-accessibility.md
+++ b/spec/foundation/03-accessibility.md
@@ -3903,6 +3903,14 @@ fn is_known_id(id: &str, attr_map: &AttrMap, known_ids: &[&str]) -> bool {
     attr_map.get(&HtmlAttr::Id) == Some(id) || known_ids.contains(&id)
 }
 
+fn supported_aria_attribute(attr: AriaAttr) -> Option<AriaAttribute> {
+    match attr {
+        #[cfg(not(feature = "aria-drag-drop-compat"))]
+        AriaAttr::DropEffect | AriaAttr::Grabbed => None,
+        _ => Some(AriaAttribute::from(attr)),
+    }
+}
+
 fn idref_attr_name(attr: HtmlAttr) -> Option<&'static str> {
     match attr {
         HtmlAttr::Aria(AriaAttr::ActiveDescendant) => Some("aria-activedescendant"),
@@ -3930,7 +3938,10 @@ pub fn validate_attr_map(
     // Extract ARIA attributes from the AttrMap for analysis.
     // AttrMap::iter_attrs() yields &(HtmlAttr, AttrValue) — filter ARIA variants via TryFrom.
     let aria_attrs: Vec<AriaAttribute> = attr_map.iter_attrs()
-        .filter_map(|(k, _)| AriaAttribute::try_from(*k).ok())
+        .filter_map(|(k, _)| match k {
+            HtmlAttr::Aria(attr) => supported_aria_attribute(*attr),
+            _ => None,
+        })
         .collect();
 
     // Check role with actual ARIA attributes from the AttrMap
@@ -3956,11 +3967,7 @@ pub fn validate_attr_map(
             continue;
         };
 
-        let Some(raw_value) = value.as_str() else {
-            continue;
-        };
-
-        for id in raw_value.split_whitespace() {
+        for id in value.as_str().into_iter().flat_map(str::split_whitespace) {
             if !is_known_id(id, attr_map, context.known_ids) {
                 validator.errors.push(AriaValidationError::DanglingIdReference {
                     attribute,

--- a/spec/foundation/03-accessibility.md
+++ b/spec/foundation/03-accessibility.md
@@ -3909,6 +3909,7 @@ fn idref_attr_name(attr: HtmlAttr) -> Option<&'static str> {
         HtmlAttr::Aria(AriaAttr::Controls) => Some("aria-controls"),
         HtmlAttr::Aria(AriaAttr::DescribedBy) => Some("aria-describedby"),
         HtmlAttr::Aria(AriaAttr::Details) => Some("aria-details"),
+        HtmlAttr::Aria(AriaAttr::ErrorMessage) => Some("aria-errormessage"),
         HtmlAttr::Aria(AriaAttr::FlowTo) => Some("aria-flowto"),
         HtmlAttr::Aria(AriaAttr::LabelledBy) => Some("aria-labelledby"),
         HtmlAttr::Aria(AriaAttr::Owns) => Some("aria-owns"),

--- a/spec/foundation/03-accessibility.md
+++ b/spec/foundation/03-accessibility.md
@@ -3917,17 +3917,6 @@ fn idref_attr_name(attr: HtmlAttr) -> Option<&'static str> {
     }
 }
 
-fn attr_value_contains_idrefs(attr: HtmlAttr) -> bool {
-    matches!(
-        attr,
-        HtmlAttr::Aria(AriaAttr::Controls)
-            | HtmlAttr::Aria(AriaAttr::DescribedBy)
-            | HtmlAttr::Aria(AriaAttr::FlowTo)
-            | HtmlAttr::Aria(AriaAttr::LabelledBy)
-            | HtmlAttr::Aria(AriaAttr::Owns)
-    )
-}
-
 /// Validate that an AttrMap produced by a connect() function is
 /// ARIA-conformant within the provided subtree context.
 #[must_use]
@@ -3971,13 +3960,7 @@ pub fn validate_attr_map(
             continue;
         };
 
-        let ids = if attr_value_contains_idrefs(*attr) {
-            raw_value.split_whitespace()
-        } else {
-            raw_value.split_whitespace().take(1)
-        };
-
-        for id in ids {
+        for id in raw_value.split_whitespace() {
             if !is_known_id(id, attr_map, context.known_ids) {
                 validator.errors.push(AriaValidationError::DanglingIdReference {
                     attribute,

--- a/spec/foundation/03-accessibility.md
+++ b/spec/foundation/03-accessibility.md
@@ -3772,14 +3772,22 @@ impl AriaValidator {
         }
 
         // Separator vs StructuralSeparator hint: AriaRole::Separator is the focusable
-        // widget variant and requires tabindex + value attributes. If the element is not
-        // focusable, the developer likely wants AriaRole::StructuralSeparator instead.
-        if matches!(role, AriaRole::Separator) {
-            if !has_tabindex {
-                self.warnings.push(AriaValidationWarning::Hint {
-                    message: "AriaRole::Separator requires tabindex for focusable separator. \
-                              Use AriaRole::StructuralSeparator for non-focusable separators.",
-                });
+        // widget variant and AriaRole::StructuralSeparator is the non-focusable variant.
+        if matches!(role, AriaRole::Separator | AriaRole::StructuralSeparator) {
+            let message = match role {
+                AriaRole::Separator if !has_tabindex => Some(
+                    "AriaRole::Separator requires tabindex for focusable separator. \
+                     Use AriaRole::StructuralSeparator for non-focusable separators.",
+                ),
+                AriaRole::StructuralSeparator if has_tabindex => Some(
+                    "AriaRole::StructuralSeparator is the non-focusable separator role. \
+                     Use AriaRole::Separator for focusable separators with tabindex.",
+                ),
+                _ => None,
+            };
+
+            if let Some(message) = message {
+                self.warnings.push(AriaValidationWarning::Hint { message });
             }
         }
 

--- a/spec/foundation/03-accessibility.md
+++ b/spec/foundation/03-accessibility.md
@@ -3714,6 +3714,22 @@ Consumers who need to override these defaults (e.g., to show a specific dialog i
 ///
 /// This surface is exported from `ars-a11y::testing` and is available when
 /// compiling tests or when the crate's `testing` feature is enabled.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct AriaValidationContext<'a> {
+    /// The DOM IDs currently present in the validated subtree.
+    pub known_ids: &'a [&'a str],
+    /// The direct owned child roles currently present under the validated role owner.
+    pub owned_roles: &'a [AriaRole],
+}
+
+impl<'a> AriaValidationContext<'a> {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self { known_ids: &[], owned_roles: &[] }
+    }
+}
+
+/// A compile-time and runtime ARIA attribute validator.
 #[derive(Debug, Default)]
 pub struct AriaValidator {
     errors: Vec<AriaValidationError>,
@@ -3762,7 +3778,13 @@ impl AriaValidator {
     }
 
     /// Validate role usage.
-    pub fn check_role(&mut self, role: AriaRole, attrs: &[AriaAttribute], has_tabindex: bool) {
+    pub fn check_role(
+        &mut self,
+        role: AriaRole,
+        attrs: &[AriaAttribute],
+        has_tabindex: bool,
+        owned_roles: &[AriaRole],
+    ) {
         // Check for abstract role usage
         if role.is_abstract() {
             self.errors.push(AriaValidationError::AbstractRoleUsed {
@@ -3793,6 +3815,7 @@ impl AriaValidator {
 
         // Check required attributes per role
         self.check_required_attrs_for_role(role, attrs);
+        self.check_required_owned_elements_for_role(role, owned_roles);
     }
 
     fn check_required_attrs_for_role(&mut self, role: AriaRole, attrs: &[AriaAttribute]) {
@@ -3806,6 +3829,40 @@ impl AriaValidator {
                 });
             }
         }
+    }
+
+    fn check_required_owned_elements_for_role(
+        &mut self,
+        role: AriaRole,
+        owned_roles: &[AriaRole],
+    ) {
+        let required_groups = role.required_owned_elements();
+        if required_groups.is_empty() {
+            return;
+        }
+
+        let satisfies_required_owned_elements = required_groups.iter().any(|group| {
+            group.iter().all(|required_role| owned_roles.contains(required_role))
+        });
+
+        if satisfies_required_owned_elements {
+            return;
+        }
+
+        let mut required_one_of = Vec::new();
+        for group in required_groups {
+            for required_role in *group {
+                let role_name = required_role.name();
+                if !required_one_of.contains(&role_name) {
+                    required_one_of.push(role_name);
+                }
+            }
+        }
+
+        self.errors.push(AriaValidationError::MissingRequiredOwnedElement {
+            role: role.name(),
+            required_one_of,
+        });
     }
 
     #[must_use]
@@ -3842,10 +3899,42 @@ pub const fn required_attributes_for_role(role: AriaRole) -> &'static [&'static 
     }
 }
 
+fn is_known_id(id: &str, attr_map: &AttrMap, known_ids: &[&str]) -> bool {
+    attr_map.get(&HtmlAttr::Id) == Some(id) || known_ids.contains(&id)
+}
+
+fn idref_attr_name(attr: HtmlAttr) -> Option<&'static str> {
+    match attr {
+        HtmlAttr::Aria(AriaAttr::ActiveDescendant) => Some("aria-activedescendant"),
+        HtmlAttr::Aria(AriaAttr::Controls) => Some("aria-controls"),
+        HtmlAttr::Aria(AriaAttr::DescribedBy) => Some("aria-describedby"),
+        HtmlAttr::Aria(AriaAttr::Details) => Some("aria-details"),
+        HtmlAttr::Aria(AriaAttr::FlowTo) => Some("aria-flowto"),
+        HtmlAttr::Aria(AriaAttr::LabelledBy) => Some("aria-labelledby"),
+        HtmlAttr::Aria(AriaAttr::Owns) => Some("aria-owns"),
+        _ => None,
+    }
+}
+
+fn attr_value_contains_idrefs(attr: HtmlAttr) -> bool {
+    matches!(
+        attr,
+        HtmlAttr::Aria(AriaAttr::Controls)
+            | HtmlAttr::Aria(AriaAttr::DescribedBy)
+            | HtmlAttr::Aria(AriaAttr::FlowTo)
+            | HtmlAttr::Aria(AriaAttr::LabelledBy)
+            | HtmlAttr::Aria(AriaAttr::Owns)
+    )
+}
+
 /// Validate that an AttrMap produced by a connect() function is
-/// ARIA-conformant. Called in debug builds and in test infrastructure.
+/// ARIA-conformant within the provided subtree context.
 #[must_use]
-pub fn validate_attr_map(role: Option<AriaRole>, attr_map: &AttrMap) -> AriaValidator {
+pub fn validate_attr_map(
+    role: Option<AriaRole>,
+    attr_map: &AttrMap,
+    context: AriaValidationContext<'_>,
+) -> AriaValidator {
     let mut validator = AriaValidator::new();
 
     // Extract ARIA attributes from the AttrMap for analysis.
@@ -3857,7 +3946,7 @@ pub fn validate_attr_map(role: Option<AriaRole>, attr_map: &AttrMap) -> AriaVali
     // Check role with actual ARIA attributes from the AttrMap
     let has_tabindex = attr_map.contains(&HtmlAttr::TabIndex);
     if let Some(role) = role {
-        validator.check_role(role, &aria_attrs, has_tabindex);
+        validator.check_role(role, &aria_attrs, has_tabindex, context.owned_roles);
     }
 
     // Check for aria-activedescendant on incompatible roles
@@ -3872,7 +3961,31 @@ pub fn validate_attr_map(role: Option<AriaRole>, attr_map: &AttrMap) -> AriaVali
         }
     }
 
-    let _ = aria_attrs;
+    for (attr, value) in attr_map.iter() {
+        let Some(attribute) = idref_attr_name(*attr) else {
+            continue;
+        };
+
+        let Some(raw_value) = value.as_str() else {
+            continue;
+        };
+
+        let ids = if attr_value_contains_idrefs(*attr) {
+            raw_value.split_whitespace()
+        } else {
+            raw_value.split_whitespace().take(1)
+        };
+
+        for id in ids {
+            if !is_known_id(id, attr_map, context.known_ids) {
+                validator.errors.push(AriaValidationError::DanglingIdReference {
+                    attribute,
+                    id: String::from(id),
+                });
+            }
+        }
+    }
+
     validator
 }
 ```

--- a/spec/foundation/03-accessibility.md
+++ b/spec/foundation/03-accessibility.md
@@ -3711,6 +3711,10 @@ Consumers who need to override these defaults (e.g., to show a specific dialog i
 /// - Required owned elements missing
 /// - Attributes used on incompatible roles
 /// - ID references pointing to non-existent elements
+///
+/// This surface is exported from `ars-a11y::testing` and is available when
+/// compiling tests or when the crate's `testing` feature is enabled.
+#[derive(Debug, Default)]
 pub struct AriaValidator {
     errors: Vec<AriaValidationError>,
     warnings: Vec<AriaValidationWarning>,
@@ -3752,8 +3756,9 @@ pub enum AriaValidationWarning {
 }
 
 impl AriaValidator {
+    #[must_use]
     pub fn new() -> Self {
-        Self { errors: Vec::new(), warnings: Vec::new() }
+        Self::default()
     }
 
     /// Validate role usage.
@@ -3795,14 +3800,18 @@ impl AriaValidator {
         }
     }
 
+    #[must_use]
     pub fn has_errors(&self) -> bool { !self.errors.is_empty() }
+    #[must_use]
     pub fn errors(&self) -> &[AriaValidationError] { &self.errors }
+    #[must_use]
     pub fn warnings(&self) -> &[AriaValidationWarning] { &self.warnings }
 }
 
 /// Returns required ARIA attributes for a role, as per WAI-ARIA 1.2 spec.
 /// These attributes MUST be present when using the role.
-pub fn required_attributes_for_role(role: AriaRole) -> &'static [&'static str] {
+#[must_use]
+pub const fn required_attributes_for_role(role: AriaRole) -> &'static [&'static str] {
     match role {
         AriaRole::Checkbox | AriaRole::Radio | AriaRole::Switch
         | AriaRole::Menuitemcheckbox | AriaRole::Menuitemradio
@@ -3811,32 +3820,23 @@ pub fn required_attributes_for_role(role: AriaRole) -> &'static [&'static str] {
             => &["aria-expanded"],
         AriaRole::Scrollbar
             => &["aria-controls", "aria-valuenow", "aria-valuemin", "aria-valuemax"],
-        AriaRole::Slider
+        AriaRole::Slider | AriaRole::Separator
             => &["aria-valuenow", "aria-valuemin", "aria-valuemax"],
         // WAI-ARIA 1.2 formally requires only aria-valuenow for Spinbutton.
         // aria-valuemin/max are strongly recommended but not required.
-        AriaRole::Spinbutton
+        AriaRole::Spinbutton | AriaRole::Meter
             => &["aria-valuenow"],
         // WAI-ARIA 1.2 formally requires only aria-valuenow for Meter.
         // aria-valuemin/max are strongly recommended (default 0 and 100 if absent).
-        AriaRole::Meter
-            => &["aria-valuenow"],
-        // Focusable separator (widget role) requires value attributes.
-        // Non-focusable separators should use AriaRole::StructuralSeparator instead,
-        // which falls through to the wildcard and requires no attributes.
-        AriaRole::Separator
-            => &["aria-valuenow", "aria-valuemin", "aria-valuemax"],
         AriaRole::Heading
             => &["aria-level"],
-        AriaRole::Option
-            => &[], // aria-selected is required in some contexts but not globally
-        // Note: StructuralSeparator has no required attributes (covered by wildcard)
         _ => &[],
     }
 }
 
 /// Validate that an AttrMap produced by a connect() function is
 /// ARIA-conformant. Called in debug builds and in test infrastructure.
+#[must_use]
 pub fn validate_attr_map(role: Option<AriaRole>, attr_map: &AttrMap) -> AriaValidator {
     let mut validator = AriaValidator::new();
 
@@ -4125,7 +4125,8 @@ mod tests {
 ```text
 crates/ars-a11y/
   src/
-    lib.rs                  // Re-exports; feature flags
+    lib.rs                  // Re-exports; feature flags (`testing` gated behind
+                            // #[cfg(any(test, feature = "testing"))])
     aria/
       mod.rs
       role.rs               // AriaRole enum (all roles)
@@ -4150,7 +4151,7 @@ crates/ars-a11y/
     media.rs                // Re-export facade behind #[cfg(feature = "dom")]; canonical
                             // implementations live in ars-dom
     touch.rs                // touch_target_attrs(), InputMode, should_use_roving_tabindex
-    testing/
+    testing/                // Exported when compiling tests or with feature = "testing"
       mod.rs
       validator.rs          // AriaValidator, AriaValidationError, validate_attr_map()
       keyboard.rs           // SimulatedKeyEvent, NavigationRecorder, FocusZoneTestHarness

--- a/spec/testing/13-policies.md
+++ b/spec/testing/13-policies.md
@@ -206,6 +206,16 @@ fn drag_drop_aria_attributes_present() {
 fn axe_core_integration_available() {
     // Verify axe-core runner is importable and functional
 }
+
+#[cfg(feature = "testing")]
+#[test]
+fn aria_testing_helpers_available() {
+    use ars_a11y::testing::{AriaValidator, required_attributes_for_role};
+
+    let validator = AriaValidator::new();
+    assert!(!validator.has_errors());
+    assert!(required_attributes_for_role(ars_a11y::AriaRole::Combobox).contains(&"aria-expanded"));
+}
 ```
 
 #### ars-collections Feature Flags

--- a/xtask/src/ci/feature_matrix.rs
+++ b/xtask/src/ci/feature_matrix.rs
@@ -13,8 +13,8 @@ pub(crate) enum Group {
     Core,
     /// `ars-i18n` feature combinations (11 combos + wasm32 cross-check).
     I18n,
-    /// `ars-interactions`, `ars-collections`, `ars-forms`, `ars-dom` combos
-    /// (12 combos + wasm32 cross-check).
+    /// `ars-a11y`, `ars-interactions`, `ars-collections`, `ars-forms`, `ars-dom`
+    /// combos (14 combos + wasm32 cross-check).
     Subsystems,
     /// `ars-leptos` render-mode combos (3 combos).
     Leptos,
@@ -154,6 +154,9 @@ static I18N_CROSS_CHECKS: &[CrossCheck] = &[CrossCheck {
 }];
 
 static SUBSYSTEMS_COMBOS: &[Combo] = &[
+    Combo {
+        args: &["-p", "ars-a11y", "--features", "testing"],
+    },
     Combo {
         args: &["-p", "ars-interactions", "--no-default-features"],
     },
@@ -357,8 +360,8 @@ mod tests {
     }
 
     #[test]
-    fn subsystems_has_13_combos_and_1_cross() {
-        assert_eq!(SUBSYSTEMS_COMBOS.len(), 13);
+    fn subsystems_has_14_combos_and_1_cross() {
+        assert_eq!(SUBSYSTEMS_COMBOS.len(), 14);
         assert_eq!(SUBSYSTEMS_CROSS_CHECKS.len(), 1);
     }
 
@@ -380,7 +383,7 @@ mod tests {
         let cases = &[
             (Group::Core, 15, 0),
             (Group::I18n, 11, 1),
-            (Group::Subsystems, 13, 1),
+            (Group::Subsystems, 14, 1),
             (Group::Leptos, 3, 0),
             (Group::Dioxus, 4, 1),
         ];


### PR DESCRIPTION
Closes #156

## Summary
- add the gated `ars-a11y::testing` surface with the ARIA validator API and spec-aligned error and warning types
- add validator coverage for required ARIA attributes, abstract roles, separator hints, and `aria-activedescendant` role support
- sync the accessibility and testing specs and extend the CI feature matrix to exercise `ars-a11y --features testing`

## Verification
- `cargo test -p ars-a11y --lib`
- `cargo check -p ars-a11y --features testing`
- `cargo nextest run -p ars-a11y --lib --features testing`
- `cargo xci`