### PR TITLE
Implement keyboard testing helpers

### DIFF
--- a/crates/ars-a11y/src/aria/role.rs
+++ b/crates/ars-a11y/src/aria/role.rs
@@ -679,4 +679,28 @@ mod tests {
         );
         assert!(AriaRole::Button.required_owned_elements().is_empty());
     }
+
+    #[test]
+    fn required_owned_elements_cover_remaining_non_empty_contracts() {
+        assert_eq!(
+            AriaRole::Feed.required_owned_elements(),
+            &[&[AriaRole::Article]]
+        );
+        assert_eq!(
+            AriaRole::Radiogroup.required_owned_elements(),
+            &[&[AriaRole::Radio]]
+        );
+        assert_eq!(
+            AriaRole::Rowgroup.required_owned_elements(),
+            &[&[AriaRole::Row]]
+        );
+        assert_eq!(
+            AriaRole::Tablist.required_owned_elements(),
+            &[&[AriaRole::Tab]]
+        );
+        assert_eq!(
+            AriaRole::Treegrid.required_owned_elements(),
+            &[&[AriaRole::Row], &[AriaRole::Rowgroup]]
+        );
+    }
 }

--- a/crates/ars-a11y/src/focus/zone.rs
+++ b/crates/ars-a11y/src/focus/zone.rs
@@ -772,6 +772,36 @@ mod tests {
     }
 
     #[test]
+    fn grid_horizontal_wrap_uses_partial_last_row_bounds() {
+        let left_edge = FocusZone {
+            options: FocusZoneOptions {
+                direction: FocusZoneDirection::grid(NonZero::new(3).expect("hardcoded nonzero")),
+                ..FocusZoneOptions::default()
+            },
+            active_index: 3,
+            item_count: 5,
+        };
+
+        let right_edge = FocusZone {
+            options: FocusZoneOptions {
+                direction: FocusZoneDirection::grid(NonZero::new(3).expect("hardcoded nonzero")),
+                ..FocusZoneOptions::default()
+            },
+            active_index: 4,
+            item_count: 5,
+        };
+
+        assert_eq!(
+            left_edge.handle_key(KeyboardKey::ArrowLeft, false, disabled_items(&[])),
+            Some(4)
+        );
+        assert_eq!(
+            right_edge.handle_key(KeyboardKey::ArrowRight, false, disabled_items(&[])),
+            Some(3)
+        );
+    }
+
+    #[test]
     fn wrap_navigation_cycles_at_edges() {
         let zone = FocusZone {
             options: FocusZoneOptions::default(),
@@ -1011,6 +1041,68 @@ mod tests {
         assert_eq!(
             zone.handle_key(KeyboardKey::ArrowDown, false, disabled_items(&[1])),
             Some(4)
+        );
+    }
+
+    #[test]
+    fn grid_vertical_wrap_uses_last_existing_cell_in_partial_column() {
+        let upward_zone = FocusZone {
+            options: FocusZoneOptions {
+                direction: FocusZoneDirection::grid(NonZero::new(3).expect("hardcoded nonzero")),
+                ..FocusZoneOptions::default()
+            },
+            active_index: 1,
+            item_count: 5,
+        };
+
+        let downward_zone = FocusZone {
+            options: FocusZoneOptions {
+                direction: FocusZoneDirection::grid(NonZero::new(3).expect("hardcoded nonzero")),
+                ..FocusZoneOptions::default()
+            },
+            active_index: 4,
+            item_count: 5,
+        };
+
+        assert_eq!(
+            upward_zone.handle_key(KeyboardKey::ArrowUp, false, disabled_items(&[])),
+            Some(4)
+        );
+        assert_eq!(
+            downward_zone.handle_key(KeyboardKey::ArrowDown, false, disabled_items(&[])),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn page_navigation_scans_for_enabled_item_without_wrapping() {
+        let page_down_zone = FocusZone {
+            options: FocusZoneOptions {
+                page_navigation: true,
+                page_size: NonZero::new(2).expect("hardcoded nonzero"),
+                ..FocusZoneOptions::default()
+            },
+            active_index: 1,
+            item_count: 5,
+        };
+
+        let page_up_zone = FocusZone {
+            options: FocusZoneOptions {
+                page_navigation: true,
+                page_size: NonZero::new(2).expect("hardcoded nonzero"),
+                ..FocusZoneOptions::default()
+            },
+            active_index: 3,
+            item_count: 5,
+        };
+
+        assert_eq!(
+            page_down_zone.handle_key(KeyboardKey::PageDown, false, disabled_items(&[3])),
+            Some(4)
+        );
+        assert_eq!(
+            page_up_zone.handle_key(KeyboardKey::PageUp, false, disabled_items(&[1])),
+            Some(0)
         );
     }
 

--- a/crates/ars-a11y/src/testing/keyboard.rs
+++ b/crates/ars-a11y/src/testing/keyboard.rs
@@ -1,0 +1,602 @@
+//! Keyboard-navigation test helpers for focus-zone and keyboard event testing.
+
+use alloc::{collections::BTreeSet, vec::Vec};
+use core::sync::atomic::{AtomicBool, Ordering};
+
+use ars_core::KeyboardKey;
+
+use crate::{DomEvent, FocusZone, FocusZoneOptions};
+
+/// A simulated keyboard event for use in unit tests.
+#[derive(Debug)]
+pub struct SimulatedKeyEvent {
+    /// The DOM `key` value exposed by the event.
+    pub key: &'static str,
+
+    /// Whether the Shift modifier is pressed.
+    pub shift: bool,
+
+    /// Whether the Ctrl modifier is pressed.
+    pub ctrl: bool,
+
+    /// Whether the Meta/Cmd modifier is pressed.
+    pub meta: bool,
+
+    /// Whether the Alt/Option modifier is pressed.
+    pub alt: bool,
+
+    /// Whether `prevent_default()` has been called.
+    pub default_prevented: AtomicBool,
+
+    /// Whether `stop_propagation()` has been called.
+    pub propagation_stopped: AtomicBool,
+}
+
+impl SimulatedKeyEvent {
+    /// Creates a `keydown` event with the provided key and no modifiers.
+    #[must_use]
+    pub const fn key(key: &'static str) -> Self {
+        Self {
+            key,
+            shift: false,
+            ctrl: false,
+            meta: false,
+            alt: false,
+            default_prevented: AtomicBool::new(false),
+            propagation_stopped: AtomicBool::new(false),
+        }
+    }
+
+    /// Marks the event as having the Shift modifier pressed.
+    #[must_use]
+    pub const fn with_shift(mut self) -> Self {
+        self.shift = true;
+        self
+    }
+
+    /// Marks the event as having the Ctrl modifier pressed.
+    #[must_use]
+    pub const fn with_ctrl(mut self) -> Self {
+        self.ctrl = true;
+        self
+    }
+
+    /// Marks the event as having the Meta/Cmd modifier pressed.
+    #[must_use]
+    pub const fn with_meta(mut self) -> Self {
+        self.meta = true;
+        self
+    }
+
+    /// Marks the event as having the Alt/Option modifier pressed.
+    #[must_use]
+    pub const fn with_alt(mut self) -> Self {
+        self.alt = true;
+        self
+    }
+}
+
+// `AtomicBool` does not implement `Clone`, so the spec's derived `Clone`
+// example must be implemented manually to preserve the same public fields.
+impl Clone for SimulatedKeyEvent {
+    fn clone(&self) -> Self {
+        Self {
+            key: self.key,
+            shift: self.shift,
+            ctrl: self.ctrl,
+            meta: self.meta,
+            alt: self.alt,
+            default_prevented: AtomicBool::new(self.default_prevented.load(Ordering::Relaxed)),
+            propagation_stopped: AtomicBool::new(self.propagation_stopped.load(Ordering::Relaxed)),
+        }
+    }
+}
+
+impl DomEvent for SimulatedKeyEvent {
+    fn key(&self) -> Option<&str> {
+        Some(self.key)
+    }
+
+    fn shift_key(&self) -> bool {
+        self.shift
+    }
+
+    fn ctrl_key(&self) -> bool {
+        self.ctrl
+    }
+
+    fn meta_key(&self) -> bool {
+        self.meta
+    }
+
+    fn alt_key(&self) -> bool {
+        self.alt
+    }
+
+    fn event_type(&self) -> &str {
+        "keydown"
+    }
+
+    fn prevent_default(&self) {
+        self.default_prevented.store(true, Ordering::Relaxed);
+    }
+
+    fn stop_propagation(&self) {
+        self.propagation_stopped.store(true, Ordering::Relaxed);
+    }
+}
+
+/// A recorder that captures keyboard-navigation side effects in unit tests.
+#[derive(Debug)]
+pub struct NavigationRecorder {
+    /// The ordered list of recorded navigation events.
+    pub events: Vec<NavigationEvent>,
+}
+
+/// A keyboard-navigation side effect emitted by a test harness.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum NavigationEvent {
+    /// Focus moved from one item index to another.
+    FocusMoved {
+        /// The previously focused index.
+        from: usize,
+        /// The newly focused index.
+        to: usize,
+    },
+
+    /// Selection changed to the provided item index.
+    SelectionChanged {
+        /// The selected index.
+        index: usize,
+    },
+
+    /// The currently focused item was activated.
+    Activated {
+        /// The activated index.
+        index: usize,
+    },
+
+    /// Navigation escaped the current composite widget.
+    Escaped,
+}
+
+impl NavigationRecorder {
+    /// Creates an empty navigation recorder.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self { events: Vec::new() }
+    }
+
+    /// Records a focus transition between two item indices.
+    pub fn record_focus_move(&mut self, from: usize, to: usize) {
+        self.events.push(NavigationEvent::FocusMoved { from, to });
+    }
+
+    /// Asserts that the recorded focus transitions match `expected` exactly.
+    pub fn assert_focus_sequence(&self, expected: &[(usize, usize)]) {
+        let actual: Vec<(usize, usize)> = self
+            .events
+            .iter()
+            .filter_map(|event| match event {
+                NavigationEvent::FocusMoved { from, to } => Some((*from, *to)),
+                NavigationEvent::SelectionChanged { .. }
+                | NavigationEvent::Activated { .. }
+                | NavigationEvent::Escaped => None,
+            })
+            .collect();
+
+        assert_eq!(actual, expected, "Focus navigation sequence mismatch");
+    }
+}
+
+impl Default for NavigationRecorder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// A `FocusZone` test harness that records focus movement after each key press.
+///
+/// This helper defaults `is_rtl` to `false`; callers that need explicit RTL
+/// behavior should test `FocusZone::handle_key()` directly.
+#[derive(Debug)]
+pub struct FocusZoneTestHarness {
+    /// The focus zone under test.
+    pub zone: FocusZone,
+
+    /// The current focused item index tracked by the harness.
+    pub current_index: usize,
+
+    /// The recorder storing navigation side effects.
+    pub recorder: NavigationRecorder,
+
+    /// Disabled item indices skipped by keyboard navigation when configured.
+    pub disabled_indices: BTreeSet<usize>,
+}
+
+impl FocusZoneTestHarness {
+    /// Creates a new focus-zone harness starting at item index `0`.
+    #[must_use]
+    pub const fn new(options: FocusZoneOptions, item_count: usize) -> Self {
+        Self {
+            zone: FocusZone::new(options, item_count),
+            current_index: 0,
+            recorder: NavigationRecorder::new(),
+            disabled_indices: BTreeSet::new(),
+        }
+    }
+
+    /// Marks an item index as disabled for subsequent navigation.
+    pub fn disable(&mut self, index: usize) {
+        self.disabled_indices.insert(index);
+    }
+
+    /// Sends a key to the underlying `FocusZone`.
+    ///
+    /// Returns `true` when the key changed focus and `false` when the key was
+    /// not handled.
+    pub fn send_key(&mut self, key: KeyboardKey) -> bool {
+        let is_disabled = |index: usize| self.disabled_indices.contains(&index);
+
+        if let Some(next) = self.zone.handle_key(key, false, is_disabled) {
+            self.recorder.record_focus_move(self.current_index, next);
+            self.current_index = next;
+            self.zone.active_index = next;
+
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Asserts that the harness focus is currently at `expected_index`.
+    pub fn assert_at(&self, expected_index: usize) {
+        assert_eq!(
+            self.current_index, expected_index,
+            "Expected focus at index {}, but was at {}",
+            expected_index, self.current_index
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use alloc::{boxed::Box, string::String, vec};
+    use core::{any::Any, panic::AssertUnwindSafe, sync::atomic::Ordering};
+    use std::{
+        panic::{catch_unwind, set_hook, take_hook},
+        sync::{Mutex, OnceLock},
+    };
+
+    use super::*;
+    use crate::{
+        AriaAttribute, AriaRole, AriaValidationError, AriaValidator, FocusZoneDirection,
+        LiveAnnouncer,
+    };
+
+    fn panic_message(payload: Box<dyn Any + Send>) -> String {
+        match payload.downcast::<String>() {
+            Ok(message) => *message,
+            Err(payload) => match payload.downcast::<&'static str>() {
+                Ok(message) => String::from(*message),
+                Err(_) => String::from("non-string panic payload"),
+            },
+        }
+    }
+
+    fn catch_panic_silently(
+        f: impl FnOnce() + core::panic::UnwindSafe,
+    ) -> Result<(), Box<dyn Any + Send>> {
+        static PANIC_HOOK_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+        let lock = PANIC_HOOK_LOCK.get_or_init(|| Mutex::new(()));
+        let _guard = lock.lock().expect("panic hook lock poisoned");
+        let previous_hook = take_hook();
+
+        set_hook(Box::new(|_| {}));
+        let result = catch_unwind(f);
+        set_hook(previous_hook);
+
+        result
+    }
+
+    #[test]
+    fn simulated_key_event_key_constructor_sets_defaults() {
+        let event = SimulatedKeyEvent::key("Tab");
+
+        assert_eq!(event.key, "Tab");
+        assert!(!event.shift);
+        assert!(!event.ctrl);
+        assert!(!event.meta);
+        assert!(!event.alt);
+        assert!(!event.default_prevented.load(Ordering::Relaxed));
+        assert!(!event.propagation_stopped.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn simulated_key_event_builder_sets_modifiers() {
+        let event = SimulatedKeyEvent::key("a").with_shift().with_ctrl();
+
+        assert!(event.shift);
+        assert!(event.ctrl);
+        assert!(!event.meta);
+        assert!(!event.alt);
+    }
+
+    #[test]
+    fn simulated_key_event_builder_can_enable_all_modifiers() {
+        let event = SimulatedKeyEvent::key("a")
+            .with_shift()
+            .with_ctrl()
+            .with_meta()
+            .with_alt();
+
+        assert!(event.shift);
+        assert!(event.ctrl);
+        assert!(event.meta);
+        assert!(event.alt);
+    }
+
+    #[test]
+    fn simulated_key_event_implements_dom_event() {
+        let event = SimulatedKeyEvent::key("Tab");
+
+        assert_eq!(event.key(), Some("Tab"));
+        assert_eq!(event.event_type(), "keydown");
+        assert!(!event.shift_key());
+        assert!(!event.ctrl_key());
+        assert!(!event.meta_key());
+        assert!(!event.alt_key());
+    }
+
+    #[test]
+    fn simulated_key_event_prevent_default_and_stop_propagation_set_flags() {
+        let event = SimulatedKeyEvent::key("Enter");
+
+        event.prevent_default();
+        event.stop_propagation();
+
+        assert!(event.default_prevented.load(Ordering::Relaxed));
+        assert!(event.propagation_stopped.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn navigation_recorder_new_starts_empty() {
+        let recorder = NavigationRecorder::new();
+
+        assert!(recorder.events.is_empty());
+    }
+
+    #[test]
+    fn navigation_recorder_default_starts_empty() {
+        let recorder = NavigationRecorder::default();
+
+        assert!(recorder.events.is_empty());
+    }
+
+    #[test]
+    fn record_focus_move_adds_focus_moved_event() {
+        let mut recorder = NavigationRecorder::new();
+
+        recorder.record_focus_move(0, 1);
+
+        assert_eq!(
+            recorder.events,
+            vec![NavigationEvent::FocusMoved { from: 0, to: 1 }]
+        );
+    }
+
+    #[test]
+    fn assert_focus_sequence_matches_exact_sequence() {
+        let recorder = NavigationRecorder {
+            events: vec![
+                NavigationEvent::SelectionChanged { index: 0 },
+                NavigationEvent::FocusMoved { from: 0, to: 1 },
+                NavigationEvent::Activated { index: 1 },
+                NavigationEvent::FocusMoved { from: 1, to: 2 },
+            ],
+        };
+
+        recorder.assert_focus_sequence(&[(0, 1), (1, 2)]);
+    }
+
+    #[test]
+    fn assert_focus_sequence_panics_on_mismatch() {
+        let recorder = NavigationRecorder {
+            events: vec![NavigationEvent::FocusMoved { from: 0, to: 1 }],
+        };
+
+        let panic = catch_panic_silently(AssertUnwindSafe(|| {
+            recorder.assert_focus_sequence(&[(0, 2)]);
+        }))
+        .expect_err("mismatched focus sequence should panic");
+
+        assert!(panic_message(panic).contains("Focus navigation sequence mismatch"));
+    }
+
+    #[test]
+    fn focus_zone_test_harness_new_starts_at_zero() {
+        let harness = FocusZoneTestHarness::new(FocusZoneOptions::default(), 5);
+
+        assert_eq!(harness.current_index, 0);
+        assert_eq!(harness.zone.active_index, 0);
+        assert!(harness.recorder.events.is_empty());
+        assert!(harness.disabled_indices.is_empty());
+    }
+
+    #[test]
+    fn send_key_moves_vertical_focus_zone_and_returns_true() {
+        let mut harness = FocusZoneTestHarness::new(FocusZoneOptions::default(), 5);
+
+        assert!(harness.send_key(KeyboardKey::ArrowDown));
+        harness.assert_at(1);
+        harness.recorder.assert_focus_sequence(&[(0, 1)]);
+    }
+
+    #[test]
+    fn send_key_returns_false_for_unhandled_key() {
+        let mut harness = FocusZoneTestHarness::new(FocusZoneOptions::default(), 5);
+
+        assert!(!harness.send_key(KeyboardKey::Tab));
+        harness.assert_at(0);
+        assert!(harness.recorder.events.is_empty());
+    }
+
+    #[test]
+    fn send_key_skips_disabled_items() {
+        let mut harness = FocusZoneTestHarness::new(FocusZoneOptions::default(), 5);
+        harness.disable(1);
+        harness.disable(2);
+
+        assert!(harness.send_key(KeyboardKey::ArrowDown));
+        harness.assert_at(3);
+        harness.recorder.assert_focus_sequence(&[(0, 3)]);
+    }
+
+    #[test]
+    fn send_key_returns_false_when_no_enabled_target_exists() {
+        let mut harness = FocusZoneTestHarness::new(FocusZoneOptions::default(), 3);
+        harness.disable(1);
+        harness.disable(2);
+
+        assert!(!harness.send_key(KeyboardKey::ArrowDown));
+        harness.assert_at(0);
+        assert!(harness.recorder.events.is_empty());
+    }
+
+    #[test]
+    fn assert_at_panics_with_descriptive_message() {
+        let harness = FocusZoneTestHarness::new(FocusZoneOptions::default(), 5);
+
+        let panic = catch_panic_silently(AssertUnwindSafe(|| {
+            harness.assert_at(1);
+        }))
+        .expect_err("assert_at should panic on mismatch");
+
+        let message = panic_message(panic);
+
+        assert!(message.contains("Expected focus at index 1, but was at 0"));
+    }
+
+    #[test]
+    fn vertical_zone_wraps() {
+        let options = FocusZoneOptions {
+            direction: FocusZoneDirection::Vertical,
+            wrap: true,
+            ..FocusZoneOptions::default()
+        };
+        let mut harness = FocusZoneTestHarness::new(options, 3);
+
+        harness.send_key(KeyboardKey::ArrowDown);
+        harness.send_key(KeyboardKey::ArrowDown);
+        harness.send_key(KeyboardKey::ArrowDown);
+
+        harness.assert_at(0);
+        harness
+            .recorder
+            .assert_focus_sequence(&[(0, 1), (1, 2), (2, 0)]);
+    }
+
+    #[test]
+    fn zone_skips_disabled_items() {
+        let mut harness = FocusZoneTestHarness::new(FocusZoneOptions::default(), 5);
+        harness.disable(1);
+        harness.disable(2);
+
+        harness.send_key(KeyboardKey::ArrowDown);
+
+        harness.assert_at(3);
+    }
+
+    #[test]
+    fn home_end_navigation() {
+        let mut harness = FocusZoneTestHarness::new(FocusZoneOptions::default(), 5);
+
+        harness.send_key(KeyboardKey::End);
+        harness.assert_at(4);
+
+        harness.send_key(KeyboardKey::Home);
+        harness.assert_at(0);
+    }
+
+    #[test]
+    fn aria_validator_catches_abstract_role() {
+        let mut validator = AriaValidator::new();
+
+        validator.check_role(AriaRole::Widget, &[], false, &[]);
+
+        assert!(validator.has_errors());
+        assert!(matches!(
+            validator.errors()[0],
+            AriaValidationError::AbstractRoleUsed { .. }
+        ));
+    }
+
+    #[test]
+    fn aria_validator_catches_missing_required_attr() {
+        let mut validator = AriaValidator::new();
+
+        validator.check_role(AriaRole::Slider, &[], false, &[]);
+
+        assert!(validator.errors().iter().any(|error| matches!(
+            error,
+            AriaValidationError::MissingRequiredAttribute {
+                missing_attr: "aria-valuenow",
+                ..
+            }
+        )));
+    }
+
+    #[test]
+    fn live_announcer_deduplicates_voiceover() {
+        let mut announcer = LiveAnnouncer::new();
+
+        announcer.announce("Test message");
+        announcer.notify_announced();
+        announcer.announce("Test message");
+        announcer.notify_announced();
+        announcer.announce("Test message");
+    }
+
+    #[test]
+    fn simulated_key_event_clone_preserves_flags() {
+        let event = SimulatedKeyEvent::key("Escape")
+            .with_shift()
+            .with_meta()
+            .with_alt();
+
+        event.prevent_default();
+        event.stop_propagation();
+
+        let cloned = event.clone();
+
+        assert_eq!(cloned.key, "Escape");
+        assert!(cloned.shift);
+        assert!(cloned.meta);
+        assert!(cloned.alt);
+        assert!(cloned.default_prevented.load(Ordering::Relaxed));
+        assert!(cloned.propagation_stopped.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn aria_validator_example_uses_real_attribute_shape() {
+        let mut validator = AriaValidator::new();
+
+        validator.check_role(
+            AriaRole::Slider,
+            &[AriaAttribute::ValueNow(42.0)],
+            false,
+            &[],
+        );
+
+        assert!(validator.errors().iter().any(|error| matches!(
+            error,
+            AriaValidationError::MissingRequiredAttribute {
+                missing_attr: "aria-valuemin",
+                ..
+            }
+        )));
+    }
+}

--- a/crates/ars-a11y/src/testing/keyboard.rs
+++ b/crates/ars-a11y/src/testing/keyboard.rs
@@ -237,9 +237,12 @@ impl FocusZoneTestHarness {
     /// not handled.
     pub fn send_key(&mut self, key: KeyboardKey) -> bool {
         let is_disabled = |index: usize| self.disabled_indices.contains(&index);
+        let from = self.zone.active_index;
+
+        self.current_index = from;
 
         if let Some(next) = self.zone.handle_key(key, false, is_disabled) {
-            self.recorder.record_focus_move(self.current_index, next);
+            self.recorder.record_focus_move(from, next);
             self.current_index = next;
             self.zone.active_index = next;
 
@@ -433,6 +436,17 @@ mod tests {
         assert!(harness.send_key(KeyboardKey::ArrowDown));
         harness.assert_at(1);
         harness.recorder.assert_focus_sequence(&[(0, 1)]);
+    }
+
+    #[test]
+    fn send_key_records_from_seeded_zone_active_index() {
+        let mut harness = FocusZoneTestHarness::new(FocusZoneOptions::default(), 5);
+
+        harness.zone.active_index = 2;
+
+        assert!(harness.send_key(KeyboardKey::ArrowDown));
+        harness.assert_at(3);
+        harness.recorder.assert_focus_sequence(&[(2, 3)]);
     }
 
     #[test]

--- a/crates/ars-a11y/src/testing/mod.rs
+++ b/crates/ars-a11y/src/testing/mod.rs
@@ -1,7 +1,9 @@
 //! Testing helpers for validating ARIA output from connect surfaces.
 
+mod keyboard;
 mod validator;
 
+pub use keyboard::{FocusZoneTestHarness, NavigationEvent, NavigationRecorder, SimulatedKeyEvent};
 pub use validator::{
     AriaValidationContext, AriaValidationError, AriaValidationWarning, AriaValidator,
     required_attributes_for_role, validate_attr_map,

--- a/crates/ars-collections/Cargo.toml
+++ b/crates/ars-collections/Cargo.toml
@@ -18,6 +18,7 @@ serde   = []
 ars-a11y = { path = "../ars-a11y", default-features = false }
 ars-core = { path = "../ars-core", default-features = false }
 ars-i18n = { path = "../ars-i18n", optional = true }
+hashbrown = { version = "0.17", default-features = false, features = ["default-hasher"] }
 icu      = { version = "2.2", default-features = false, features = ["compiled_data"], optional = true }
 indexmap = { version = "2", default-features = false }
 uuid     = { version = "1", default-features = false, optional = true }

--- a/crates/ars-collections/src/builder.rs
+++ b/crates/ars-collections/src/builder.rs
@@ -1,7 +1,9 @@
 // ars-collections/src/builder.rs
 
 use alloc::{format, string::String, vec::Vec};
+use core::fmt::{self, Debug};
 
+use hashbrown::DefaultHashBuilder;
 use indexmap::IndexMap;
 
 use crate::{
@@ -25,8 +27,10 @@ use crate::{
 pub struct CollectionBuilder<T> {
     /// Nodes accumulated so far in flat iteration order.
     nodes: Vec<Node<T>>,
+
     /// Maps each key to its flat index for O(1) duplicate detection.
-    key_to_index: IndexMap<Key, usize>,
+    key_to_index: IndexMap<Key, usize, DefaultHashBuilder>,
+
     /// The key of the currently open section, if any.
     current_section: Option<Key>,
 }
@@ -39,7 +43,7 @@ impl<T> CollectionBuilder<T> {
     pub fn new() -> Self {
         Self {
             nodes: Vec::new(),
-            key_to_index: IndexMap::new(),
+            key_to_index: IndexMap::default(),
             current_section: None,
         }
     }
@@ -50,7 +54,9 @@ impl<T> CollectionBuilder<T> {
     #[must_use]
     pub fn item(mut self, key: impl Into<Key>, text_value: impl Into<String>, value: T) -> Self {
         let key = key.into();
+
         let index = self.nodes.len();
+
         let node = Node {
             key: key.clone(),
             node_type: NodeType::Item,
@@ -62,12 +68,15 @@ impl<T> CollectionBuilder<T> {
             parent_key: self.current_section.clone(),
             index,
         };
+
         debug_assert!(
             !self.key_to_index.contains_key(&key),
             "CollectionBuilder: duplicate key {key:?}"
         );
+
         self.key_to_index.insert(key, index);
         self.nodes.push(node);
+
         self
     }
 
@@ -80,7 +89,9 @@ impl<T> CollectionBuilder<T> {
 
         // Push the Section node itself.
         let section_index = self.nodes.len();
+
         self.key_to_index.insert(key.clone(), section_index);
+
         self.nodes.push(Node {
             key: key.clone(),
             node_type: NodeType::Section,
@@ -95,7 +106,9 @@ impl<T> CollectionBuilder<T> {
 
         // Push a Header node for the visible label.
         let header_index = self.nodes.len();
+
         self.key_to_index.insert(header_key.clone(), header_index);
+
         self.nodes.push(Node {
             key: header_key,
             node_type: NodeType::Header,
@@ -109,6 +122,7 @@ impl<T> CollectionBuilder<T> {
         });
 
         self.current_section = Some(key);
+
         self
     }
 
@@ -116,6 +130,7 @@ impl<T> CollectionBuilder<T> {
     #[must_use]
     pub fn end_section(mut self) -> Self {
         self.current_section = None;
+
         self
     }
 
@@ -123,8 +138,11 @@ impl<T> CollectionBuilder<T> {
     #[must_use]
     pub fn separator(mut self) -> Self {
         let index = self.nodes.len();
+
         let key = Key::str(format!("separator-{index}"));
+
         self.key_to_index.insert(key.clone(), index);
+
         self.nodes.push(Node {
             key,
             node_type: NodeType::Separator,
@@ -136,6 +154,7 @@ impl<T> CollectionBuilder<T> {
             parent_key: self.current_section.clone(),
             index,
         });
+
         self
     }
 }
@@ -158,8 +177,8 @@ impl<T> Default for CollectionBuilder<T> {
 }
 
 /// Manual `Debug` avoids requiring `T: Debug`. Prints item count only.
-impl<T> core::fmt::Debug for CollectionBuilder<T> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+impl<T> Debug for CollectionBuilder<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("CollectionBuilder")
             .field("items", &self.nodes.len())
             .finish()
@@ -168,12 +187,15 @@ impl<T> core::fmt::Debug for CollectionBuilder<T> {
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec;
+
     use super::*;
     use crate::Collection;
 
     #[test]
     fn builder_empty() {
         let c = CollectionBuilder::<String>::new().build();
+
         assert_eq!(c.size(), 0);
         assert!(c.is_empty());
     }
@@ -185,7 +207,9 @@ mod tests {
             .build();
 
         assert_eq!(c.size(), 1);
+
         let node = c.get(&Key::int(1)).expect("should find key 1");
+
         assert_eq!(node.node_type, NodeType::Item);
         assert_eq!(node.text_value, "Apple");
         assert_eq!(node.value, Some("apple_data"));
@@ -203,7 +227,9 @@ mod tests {
             .build();
 
         assert_eq!(c.size(), 3);
+
         let keys = c.keys().collect::<Vec<_>>();
+
         assert_eq!(keys, vec![&Key::int(1), &Key::int(2), &Key::int(3)]);
 
         // Verify indices
@@ -226,18 +252,21 @@ mod tests {
 
         // Section node
         let section = c.get(&Key::str("fruits")).expect("section");
+
         assert_eq!(section.node_type, NodeType::Section);
         assert_eq!(section.text_value, "Fruits");
         assert!(section.has_children);
 
         // Header node
         let header = c.get(&Key::str("fruits-header")).expect("header");
+
         assert_eq!(header.node_type, NodeType::Header);
         assert_eq!(header.text_value, "Fruits");
         assert_eq!(header.parent_key, Some(Key::str("fruits")));
 
         // Items have level 1 and parent_key
         let apple = c.get(&Key::int(1)).expect("apple");
+
         assert_eq!(apple.level, 1);
         assert_eq!(apple.parent_key, Some(Key::str("fruits")));
     }
@@ -252,10 +281,12 @@ mod tests {
             .build();
 
         let inside = c.get(&Key::int(1)).expect("inside");
+
         assert_eq!(inside.level, 1);
         assert_eq!(inside.parent_key, Some(Key::str("sec")));
 
         let outside = c.get(&Key::int(2)).expect("outside");
+
         assert_eq!(outside.level, 0);
         assert_eq!(outside.parent_key, None);
     }
@@ -272,6 +303,7 @@ mod tests {
 
         // The separator is at index 1, so its key is "separator-1"
         let sep = c.get(&Key::str("separator-1")).expect("separator");
+
         assert_eq!(sep.node_type, NodeType::Separator);
         assert!(sep.text_value.is_empty());
         assert!(!sep.is_focusable());
@@ -280,7 +312,9 @@ mod tests {
     #[test]
     fn builder_default_equals_new() {
         let a = CollectionBuilder::<String>::new();
+
         let b = CollectionBuilder::<String>::default();
+
         assert_eq!(a.build().size(), b.build().size());
     }
 
@@ -290,7 +324,9 @@ mod tests {
             CollectionBuilder::new()
                 .item(Key::int(1), "A", "a")
                 .item(Key::int(2), "B", "b");
+
         let debug = alloc::format!("{builder:?}");
+
         assert!(debug.contains("CollectionBuilder"));
         assert!(debug.contains("2"));
     }

--- a/crates/ars-collections/src/collection.rs
+++ b/crates/ars-collections/src/collection.rs
@@ -183,7 +183,10 @@ pub trait Collection<T> {
 
 #[cfg(test)]
 mod tests {
+    use alloc::{vec, vec::Vec};
+
     use super::*;
+    use crate::CollectionBuilder;
 
     /// Test struct implementing `CollectionItem` with custom text.
     struct LabeledItem {
@@ -234,5 +237,35 @@ mod tests {
     fn collection_item_text_value_default() {
         let item = BareItem { id: Key::int(1) };
         assert_eq!(item.text_value(), "");
+    }
+
+    #[test]
+    fn collection_default_helpers_delegate_to_required_methods() {
+        let collection = CollectionBuilder::new()
+            .item(Key::int(1), "Apple", "apple")
+            .item(Key::int(2), "Banana", "banana")
+            .build();
+
+        assert!(!collection.is_empty());
+        assert!(collection.contains_key(&Key::int(1)));
+        assert!(!collection.contains_key(&Key::int(99)));
+        assert_eq!(collection.text_value_of(&Key::int(2)), Some("Banana"));
+        assert_eq!(collection.text_value_of(&Key::int(99)), None);
+    }
+
+    #[test]
+    fn item_keys_default_iterator_skips_structural_nodes() {
+        let collection = CollectionBuilder::new()
+            .section(Key::str("fruits"), "Fruits")
+            .item(Key::int(1), "Apple", "apple")
+            .separator()
+            .item(Key::int(2), "Banana", "banana")
+            .end_section()
+            .item(Key::int(3), "Cherry", "cherry")
+            .build();
+
+        let item_keys = collection.item_keys().cloned().collect::<Vec<_>>();
+
+        assert_eq!(item_keys, vec![Key::int(1), Key::int(2), Key::int(3)]);
     }
 }

--- a/crates/ars-collections/src/filtered_collection.rs
+++ b/crates/ars-collections/src/filtered_collection.rs
@@ -99,6 +99,7 @@ impl<'a, T: Clone, C: Collection<T>> FilteredCollection<'a, T, C> {
                 if n.is_focusable() {
                     return passing.contains(&n.index);
                 }
+
                 match (&n.parent_key, n.node_type) {
                     (_, NodeType::Section) => inner
                         .children_of(&n.key)
@@ -269,6 +270,8 @@ impl<T, C: Collection<T>> Debug for FilteredCollection<'_, T, C> {
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec;
+
     use super::*;
     use crate::{builder::CollectionBuilder, key::Key, node::NodeType};
 

--- a/crates/ars-collections/src/sorted_collection/mod.rs
+++ b/crates/ars-collections/src/sorted_collection/mod.rs
@@ -369,6 +369,8 @@ impl<T, C: Collection<T>> Debug for SortedCollection<'_, T, C> {
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec;
+
     use super::*;
     use crate::{builder::CollectionBuilder, key::Key};
 

--- a/crates/ars-collections/src/static_collection.rs
+++ b/crates/ars-collections/src/static_collection.rs
@@ -2,6 +2,7 @@
 
 use alloc::{string::String, vec::Vec};
 
+use hashbrown::DefaultHashBuilder;
 use indexmap::IndexMap;
 
 use crate::{
@@ -18,7 +19,7 @@ pub struct StaticCollection<T> {
     nodes: Vec<Node<T>>,
 
     /// Maps Key → flat index for O(1) `get`.
-    key_to_index: IndexMap<Key, usize>,
+    key_to_index: IndexMap<Key, usize, DefaultHashBuilder>,
 
     /// Cached index of the first focusable item.
     first_focusable: Option<usize>,
@@ -29,9 +30,14 @@ pub struct StaticCollection<T> {
 
 impl<T: Clone> StaticCollection<T> {
     /// Construct from pre-built parts (used by `CollectionBuilder`).
-    pub(crate) fn from_parts(nodes: Vec<Node<T>>, key_to_index: IndexMap<Key, usize>) -> Self {
+    pub(crate) fn from_parts(
+        nodes: Vec<Node<T>>,
+        key_to_index: IndexMap<Key, usize, DefaultHashBuilder>,
+    ) -> Self {
         let first_focusable = nodes.iter().position(Node::is_focusable);
+
         let last_focusable = nodes.iter().rposition(Node::is_focusable);
+
         Self {
             nodes,
             key_to_index,
@@ -66,9 +72,11 @@ impl<T: Clone> From<Vec<(Key, String, T)>> for StaticCollection<T> {
 impl<T: Clone> FromIterator<(Key, String, T)> for StaticCollection<T> {
     fn from_iter<I: IntoIterator<Item = (Key, String, T)>>(iter: I) -> Self {
         let mut builder = CollectionBuilder::new();
+
         for (key, text, value) in iter {
             builder = builder.item(key, text, value);
         }
+
         builder.build()
     }
 }
@@ -110,7 +118,7 @@ impl<T: Clone> Collection<T> for StaticCollection<T> {
         let start = *self.key_to_index.get(key)? + 1;
         self.nodes[start..]
             .iter()
-            .find(|n| n.is_focusable())
+            .find(|node| node.is_focusable())
             .map(|n| &n.key)
     }
 
@@ -118,7 +126,7 @@ impl<T: Clone> Collection<T> for StaticCollection<T> {
         let end = *self.key_to_index.get(key)?;
         self.nodes[..end]
             .iter()
-            .rfind(|n| n.is_focusable())
+            .rfind(|node| node.is_focusable())
             .map(|n| &n.key)
     }
 
@@ -200,30 +208,38 @@ impl<T: CollectionItem> StaticCollection<T> {
     /// Insert an item at the given index, shifting subsequent items.
     pub fn insert(&mut self, index: usize, item: T) {
         let key = item.key().clone();
+
         let node = Node::item(key.clone(), index, item);
+
         self.nodes.insert(index, node);
         self.key_to_index.insert(key, index);
+
         self.reindex_from(index + 1);
     }
 
     /// Remove items by key. Returns the removed item values.
     pub fn remove_by_keys(&mut self, keys: &[Key]) -> Vec<T> {
         let mut removed = Vec::with_capacity(keys.len());
+
         for key in keys {
             if let Some(idx) = self.key_to_index.shift_remove(key) {
                 let node = self.nodes.remove(idx);
+
                 if let Some(val) = node.value {
                     removed.push(val);
                 }
+
                 self.reindex_from(idx);
             }
         }
+
         removed
     }
 
     /// Replace an item's data (matched by key).
     pub fn replace(&mut self, item: T) {
         let key = item.key().clone();
+
         if let Some(&idx) = self.key_to_index.get(&key) {
             self.nodes[idx].value = Some(item);
         }
@@ -238,8 +254,11 @@ impl<T: CollectionItem> StaticCollection<T> {
     /// Move an item from one index to another.
     pub fn move_item(&mut self, from: usize, to: usize) {
         let node = self.nodes.remove(from);
+
         self.nodes.insert(to, node);
+
         let start = from.min(to);
+
         self.reindex_from(start);
     }
 
@@ -253,7 +272,9 @@ impl<T: CollectionItem> StaticCollection<T> {
     fn reindex_from(&mut self, start: usize) {
         for i in start..self.nodes.len() {
             self.nodes[i].index = i;
+
             let key = &self.nodes[i].key;
+
             self.key_to_index.insert(key.clone(), i);
         }
     }
@@ -314,6 +335,7 @@ mod tests {
     #[test]
     fn from_vec_basic() {
         let c = three_items();
+
         assert_eq!(c.size(), 3);
         assert!(!c.is_empty());
     }
@@ -321,6 +343,7 @@ mod tests {
     #[test]
     fn from_vec_empty() {
         let c = StaticCollection::<String>::default();
+
         assert_eq!(c.size(), 0);
         assert!(c.is_empty());
     }
@@ -331,10 +354,12 @@ mod tests {
             (Key::int(1), "X".to_string(), 10),
             (Key::int(2), "Y".to_string(), 20),
         ]);
+
         let b = StaticCollection::new([
             (Key::int(1), "X".to_string(), 10),
             (Key::int(2), "Y".to_string(), 20),
         ]);
+
         assert_eq!(a, b);
     }
 
@@ -344,7 +369,9 @@ mod tests {
             (Key::int(1), "A".to_string(), "a"),
             (Key::int(2), "B".to_string(), "b"),
         ];
+
         let c = items.into_iter().collect::<StaticCollection<_>>();
+
         assert_eq!(c.size(), 2);
     }
 
@@ -361,6 +388,7 @@ mod tests {
             .separator()
             .item(Key::int(2), "B", "b")
             .build();
+
         // Section + Header + item + separator + item = 5
         assert_eq!(c.size(), 5);
     }
@@ -372,7 +400,9 @@ mod tests {
     #[test]
     fn get_existing() {
         let c = three_items();
+
         let node = c.get(&Key::int(2)).expect("key 2 should exist");
+
         assert_eq!(node.text_value, "Banana");
         assert_eq!(node.value, Some("b"));
     }
@@ -380,31 +410,37 @@ mod tests {
     #[test]
     fn get_missing() {
         let c = three_items();
+
         assert!(c.get(&Key::int(99)).is_none());
     }
 
     #[test]
     fn contains_key_true() {
         let c = three_items();
+
         assert!(c.contains_key(&Key::int(1)));
     }
 
     #[test]
     fn contains_key_false() {
         let c = three_items();
+
         assert!(!c.contains_key(&Key::int(99)));
     }
 
     #[test]
     fn get_by_index_valid() {
         let c = three_items();
+
         let node = c.get_by_index(1).expect("index 1");
+
         assert_eq!(node.key, Key::int(2));
     }
 
     #[test]
     fn get_by_index_out_of_range() {
         let c = three_items();
+
         assert!(c.get_by_index(100).is_none());
     }
 
@@ -415,12 +451,14 @@ mod tests {
     #[test]
     fn first_key_with_items() {
         let c = three_items();
+
         assert_eq!(c.first_key(), Some(&Key::int(1)));
     }
 
     #[test]
     fn first_key_empty() {
         let c = StaticCollection::<String>::default();
+
         assert_eq!(c.first_key(), None);
     }
 
@@ -431,6 +469,7 @@ mod tests {
             .item(Key::int(1), "Apple", "a")
             .end_section()
             .build();
+
         // Section and Header are structural; first focusable is the item
         assert_eq!(c.first_key(), Some(&Key::int(1)));
     }
@@ -438,6 +477,7 @@ mod tests {
     #[test]
     fn last_key_with_items() {
         let c = three_items();
+
         assert_eq!(c.last_key(), Some(&Key::int(3)));
     }
 
@@ -447,6 +487,7 @@ mod tests {
             .item(Key::int(1), "A", "a")
             .separator()
             .build();
+
         // Separator is structural; last focusable is item 1
         assert_eq!(c.last_key(), Some(&Key::int(1)));
     }
@@ -454,6 +495,7 @@ mod tests {
     #[test]
     fn first_and_last_key_only_structural() {
         let c = CollectionBuilder::<String>::new().separator().build();
+
         assert_eq!(c.first_key(), None);
         assert_eq!(c.last_key(), None);
     }
@@ -465,12 +507,14 @@ mod tests {
     #[test]
     fn key_after_middle() {
         let c = three_items();
+
         assert_eq!(c.key_after(&Key::int(1)), Some(&Key::int(2)));
     }
 
     #[test]
     fn key_after_wraps_at_end() {
         let c = three_items();
+
         // key_after the last item wraps to first
         assert_eq!(c.key_after(&Key::int(3)), Some(&Key::int(1)));
     }
@@ -478,12 +522,14 @@ mod tests {
     #[test]
     fn key_before_middle() {
         let c = three_items();
+
         assert_eq!(c.key_before(&Key::int(3)), Some(&Key::int(2)));
     }
 
     #[test]
     fn key_before_wraps_at_start() {
         let c = three_items();
+
         // key_before the first item wraps to last
         assert_eq!(c.key_before(&Key::int(1)), Some(&Key::int(3)));
     }
@@ -491,6 +537,7 @@ mod tests {
     #[test]
     fn key_after_unknown_key() {
         let c = three_items();
+
         // Unknown key → key_after_no_wrap returns None → or_else(first_key)
         // But wait — key_to_index.get returns None, so key_after_no_wrap returns None,
         // then or_else calls first_key which returns Some(1).
@@ -502,6 +549,7 @@ mod tests {
     #[test]
     fn key_before_unknown_key() {
         let c = three_items();
+
         assert_eq!(c.key_before(&Key::int(99)), Some(&Key::int(3)));
     }
 
@@ -512,36 +560,42 @@ mod tests {
     #[test]
     fn key_after_no_wrap_middle() {
         let c = three_items();
+
         assert_eq!(c.key_after_no_wrap(&Key::int(1)), Some(&Key::int(2)));
     }
 
     #[test]
     fn key_after_no_wrap_at_end() {
         let c = three_items();
+
         assert_eq!(c.key_after_no_wrap(&Key::int(3)), None);
     }
 
     #[test]
     fn key_before_no_wrap_middle() {
         let c = three_items();
+
         assert_eq!(c.key_before_no_wrap(&Key::int(3)), Some(&Key::int(2)));
     }
 
     #[test]
     fn key_before_no_wrap_at_start() {
         let c = three_items();
+
         assert_eq!(c.key_before_no_wrap(&Key::int(1)), None);
     }
 
     #[test]
     fn key_after_no_wrap_unknown_key() {
         let c = three_items();
+
         assert_eq!(c.key_after_no_wrap(&Key::int(99)), None);
     }
 
     #[test]
     fn key_before_no_wrap_unknown_key() {
         let c = three_items();
+
         assert_eq!(c.key_before_no_wrap(&Key::int(99)), None);
     }
 
@@ -556,6 +610,7 @@ mod tests {
             .separator()
             .item(Key::int(2), "B", "b")
             .build();
+
         // key_after(1) should skip separator and land on 2
         assert_eq!(c.key_after(&Key::int(1)), Some(&Key::int(2)));
     }
@@ -567,6 +622,7 @@ mod tests {
             .separator()
             .item(Key::int(2), "B", "b")
             .build();
+
         // key_before(2) should skip separator and land on 1
         assert_eq!(c.key_before(&Key::int(2)), Some(&Key::int(1)));
     }
@@ -596,14 +652,18 @@ mod tests {
     #[test]
     fn keys_iterator() {
         let c = three_items();
+
         let keys = c.keys().collect::<Vec<_>>();
+
         assert_eq!(keys, vec![&Key::int(1), &Key::int(2), &Key::int(3)]);
     }
 
     #[test]
     fn nodes_iterator() {
         let c = three_items();
+
         let text_values = c.nodes().map(|n| n.text_value.as_str()).collect::<Vec<_>>();
+
         assert_eq!(text_values, vec!["Apple", "Banana", "Cherry"]);
     }
 
@@ -616,8 +676,10 @@ mod tests {
             .separator()
             .item(Key::int(2), "B", "b")
             .build();
+
         // item_keys should only return focusable items
         let item_keys = c.item_keys().collect::<Vec<_>>();
+
         assert_eq!(item_keys, vec![&Key::int(1), &Key::int(2)]);
     }
 
@@ -636,6 +698,7 @@ mod tests {
             .build();
 
         let children = c.children_of(&Key::str("fruits")).collect::<Vec<_>>();
+
         // Header + 2 items are children of the section
         assert_eq!(children.len(), 3);
         assert_eq!(children[0].node_type, NodeType::Header);
@@ -646,7 +709,9 @@ mod tests {
     #[test]
     fn children_of_no_match() {
         let c = three_items();
+
         let children = c.children_of(&Key::str("nonexistent")).collect::<Vec<_>>();
+
         assert!(children.is_empty());
     }
 
@@ -657,12 +722,14 @@ mod tests {
     #[test]
     fn text_value_of_existing() {
         let c = three_items();
+
         assert_eq!(c.text_value_of(&Key::int(2)), Some("Banana"));
     }
 
     #[test]
     fn text_value_of_missing() {
         let c = three_items();
+
         assert_eq!(c.text_value_of(&Key::int(99)), None);
     }
 
@@ -673,14 +740,18 @@ mod tests {
     #[test]
     fn clone_produces_equal_collection() {
         let c = three_items();
+
         let cloned = c.clone();
+
         assert_eq!(c, cloned);
     }
 
     #[test]
     fn debug_contains_size() {
         let c = three_items();
+
         let debug = format!("{c:?}");
+
         assert!(debug.contains("StaticCollection"));
         assert!(debug.contains("3"));
     }
@@ -688,21 +759,27 @@ mod tests {
     #[test]
     fn partial_eq_equal() {
         let a = three_items();
+
         let b = three_items();
+
         assert_eq!(a, b);
     }
 
     #[test]
     fn partial_eq_different_size() {
         let a = three_items();
+
         let b = StaticCollection::new([(Key::int(1), "Apple".to_string(), "a")]);
+
         assert_ne!(a, b);
     }
 
     #[test]
     fn partial_eq_different_values() {
         let a = StaticCollection::new([(Key::int(1), "Apple".to_string(), "a")]);
+
         let b = StaticCollection::new([(Key::int(1), "Apple".to_string(), "z")]);
+
         assert_ne!(a, b);
     }
 
@@ -712,26 +789,33 @@ mod tests {
 
     fn fruit_collection() -> StaticCollection<Fruit> {
         let mut c = CollectionBuilder::new().build();
+
         c.insert(0, Fruit::new(1, "Apple"));
         c.insert(1, Fruit::new(2, "Banana"));
         c.insert(2, Fruit::new(3, "Cherry"));
+
         c
     }
 
     #[test]
     fn mutation_len() {
         let c = fruit_collection();
+
         assert_eq!(c.len(), 3);
     }
 
     #[test]
     fn mutation_insert_at_beginning() {
         let mut c = fruit_collection();
+
         c.insert(0, Fruit::new(0, "Avocado"));
+
         assert_eq!(c.len(), 4);
         assert_eq!(c.get_by_index(0).expect("index 0").key, Key::int(0));
+
         // Original items shifted
         assert_eq!(c.get_by_index(1).expect("index 1").key, Key::int(1));
+
         // Indices recomputed
         assert_eq!(c.index_of(&Key::int(0)), Some(0));
         assert_eq!(c.index_of(&Key::int(1)), Some(1));
@@ -740,7 +824,9 @@ mod tests {
     #[test]
     fn mutation_insert_at_end() {
         let mut c = fruit_collection();
+
         c.insert(3, Fruit::new(4, "Dragonfruit"));
+
         assert_eq!(c.len(), 4);
         assert_eq!(c.get_by_index(3).expect("index 3").key, Key::int(4));
     }
@@ -748,7 +834,9 @@ mod tests {
     #[test]
     fn mutation_remove_by_keys() {
         let mut c = fruit_collection();
+
         let removed = c.remove_by_keys(&[Key::int(2)]);
+
         assert_eq!(removed.len(), 1);
         assert_eq!(removed[0].name, "Banana");
         assert_eq!(c.len(), 2);
@@ -758,7 +846,9 @@ mod tests {
     #[test]
     fn mutation_remove_missing_key() {
         let mut c = fruit_collection();
+
         let removed = c.remove_by_keys(&[Key::int(99)]);
+
         assert!(removed.is_empty());
         assert_eq!(c.len(), 3);
     }
@@ -766,15 +856,20 @@ mod tests {
     #[test]
     fn mutation_replace_existing() {
         let mut c = fruit_collection();
+
         c.replace(Fruit::new(2, "Blueberry"));
+
         let node = c.get(&Key::int(2)).expect("key 2");
+
         assert_eq!(node.value.as_ref().expect("value").name, "Blueberry");
     }
 
     #[test]
     fn mutation_replace_missing() {
         let mut c = fruit_collection();
+
         c.replace(Fruit::new(99, "Unknown"));
+
         // No change — key 99 doesn't exist
         assert_eq!(c.len(), 3);
         assert!(!c.contains_key(&Key::int(99)));
@@ -783,7 +878,9 @@ mod tests {
     #[test]
     fn mutation_clear() {
         let mut c = fruit_collection();
+
         c.clear();
+
         assert_eq!(c.len(), 0);
         assert!(c.is_empty());
     }
@@ -791,11 +888,14 @@ mod tests {
     #[test]
     fn mutation_move_item() {
         let mut c = fruit_collection();
+
         // Move Cherry (index 2) to index 0
         c.move_item(2, 0);
+
         assert_eq!(c.get_by_index(0).expect("index 0").key, Key::int(3));
         assert_eq!(c.get_by_index(1).expect("index 1").key, Key::int(1));
         assert_eq!(c.get_by_index(2).expect("index 2").key, Key::int(2));
+
         // Indices updated
         assert_eq!(c.index_of(&Key::int(3)), Some(0));
         assert_eq!(c.index_of(&Key::int(1)), Some(1));
@@ -805,6 +905,7 @@ mod tests {
     #[test]
     fn mutation_index_of() {
         let c = fruit_collection();
+
         assert_eq!(c.index_of(&Key::int(1)), Some(0));
         assert_eq!(c.index_of(&Key::int(2)), Some(1));
         assert_eq!(c.index_of(&Key::int(3)), Some(2));
@@ -818,10 +919,13 @@ mod tests {
     #[test]
     fn single_item_wrapping_navigation() {
         let c = StaticCollection::new([(Key::int(1), "Only".to_string(), "x")]);
+
         // key_after wraps to itself
         assert_eq!(c.key_after(&Key::int(1)), Some(&Key::int(1)));
+
         // key_before wraps to itself
         assert_eq!(c.key_before(&Key::int(1)), Some(&Key::int(1)));
+
         // no_wrap returns None (no other focusable item)
         assert_eq!(c.key_after_no_wrap(&Key::int(1)), None);
         assert_eq!(c.key_before_no_wrap(&Key::int(1)), None);
@@ -834,6 +938,7 @@ mod tests {
     #[test]
     fn empty_collection_navigation() {
         let c = StaticCollection::<String>::default();
+
         assert_eq!(c.first_key(), None);
         assert_eq!(c.last_key(), None);
         assert_eq!(c.key_after(&Key::int(1)), None);

--- a/crates/ars-collections/src/tree_collection.rs
+++ b/crates/ars-collections/src/tree_collection.rs
@@ -1,8 +1,13 @@
 // ars-collections/src/tree_collection.rs
 
-use alloc::{collections::BTreeSet, string::String, vec::Vec};
+use alloc::{
+    collections::BTreeSet,
+    string::{String, ToString},
+    vec::Vec,
+};
 use core::fmt::{self, Debug};
 
+use hashbrown::DefaultHashBuilder;
 use indexmap::IndexMap;
 
 use crate::{
@@ -15,12 +20,16 @@ use crate::{
 pub struct TreeItemConfig<T> {
     /// Stable identity of the tree item.
     pub key: Key,
+
     /// Plain-text representation for type-ahead and ARIA fallback.
     pub text_value: String,
+
     /// The user's data value.
     pub value: T,
+
     /// Child items nested under this item.
     pub children: Vec<TreeItemConfig<T>>,
+
     /// Whether the item starts expanded. Default `false`.
     pub default_expanded: bool,
 }
@@ -65,7 +74,7 @@ pub struct TreeCollection<T> {
     visible_indices: Vec<usize>,
 
     /// Map from Key to flat index in `all_nodes`.
-    key_to_index: IndexMap<Key, usize>,
+    key_to_index: IndexMap<Key, usize, DefaultHashBuilder>,
 
     /// Set of keys whose subtrees are currently expanded.
     expanded_keys: BTreeSet<Key>,
@@ -170,7 +179,7 @@ impl<T: Clone> TreeCollection<T> {
     /// Build a `TreeCollection` from a list of root-level items.
     pub fn new(roots: impl IntoIterator<Item = TreeItemConfig<T>>) -> Self {
         let mut all_nodes = Vec::new();
-        let mut key_to_index = IndexMap::new();
+        let mut key_to_index = IndexMap::default();
         let mut expanded_keys = BTreeSet::new();
 
         // Recursive DFS insertion.
@@ -179,7 +188,7 @@ impl<T: Clone> TreeCollection<T> {
             level: usize,
             parent_key: Option<Key>,
             all_nodes: &mut Vec<Node<T>>,
-            key_to_index: &mut IndexMap<Key, usize>,
+            key_to_index: &mut IndexMap<Key, usize, DefaultHashBuilder>,
             expanded_keys: &mut BTreeSet<Key>,
         ) {
             assert!(
@@ -187,12 +196,17 @@ impl<T: Clone> TreeCollection<T> {
                 "TreeCollection: nesting depth {level} exceeds MAX_TREE_DEPTH ({MAX_TREE_DEPTH}). \
                  Deep nesting risks stack overflow in WASM targets.",
             );
+
             let has_children = !item.children.is_empty();
+
             let index = all_nodes.len();
+
             if item.default_expanded && has_children {
                 expanded_keys.insert(item.key.clone());
             }
+
             key_to_index.insert(item.key.clone(), index);
+
             all_nodes.push(Node {
                 key: item.key.clone(),
                 node_type: NodeType::Item,
@@ -208,6 +222,7 @@ impl<T: Clone> TreeCollection<T> {
                 parent_key,
                 index,
             });
+
             for child in item.children {
                 insert_item(
                     child,
@@ -233,6 +248,7 @@ impl<T: Clone> TreeCollection<T> {
 
         let (visible_indices, first_focusable_visible, last_focusable_visible) =
             Self::compute_visible(&all_nodes);
+
         Self {
             all_nodes,
             visible_indices,
@@ -255,6 +271,7 @@ impl<T: Clone> TreeCollection<T> {
             .is_some_and(|&i| self.all_nodes[i].has_children);
 
         let mut new_expanded = self.expanded_keys.clone();
+
         if is_expandable {
             if expanded {
                 new_expanded.insert(key.clone());
@@ -265,6 +282,7 @@ impl<T: Clone> TreeCollection<T> {
 
         // Update the is_expanded field on the node.
         let mut new_nodes = self.all_nodes.clone();
+
         if is_expandable {
             if let Some(&idx) = self.key_to_index.get(key) {
                 new_nodes[idx].is_expanded = Some(expanded);
@@ -273,6 +291,7 @@ impl<T: Clone> TreeCollection<T> {
 
         let (visible_indices, first_focusable_visible, last_focusable_visible) =
             Self::compute_visible(&new_nodes);
+
         Self {
             all_nodes: new_nodes,
             visible_indices,
@@ -301,6 +320,7 @@ impl<T: Clone> TreeCollection<T> {
                 if node.level > level {
                     continue;
                 }
+
                 skip_until_level = None;
             }
 
@@ -311,6 +331,7 @@ impl<T: Clone> TreeCollection<T> {
                 skip_until_level = Some(node.level);
             }
         }
+
         visible
     }
 
@@ -320,6 +341,7 @@ impl<T: Clone> TreeCollection<T> {
         let Some(&node_index) = self.key_to_index.get(key) else {
             return false;
         };
+
         let node = &self.all_nodes[node_index];
 
         // Root-level nodes are always visible.
@@ -329,6 +351,7 @@ impl<T: Clone> TreeCollection<T> {
 
         // Walk backwards to find ancestors and check each is in the expanded set.
         let mut current_level = node.level;
+
         for i in (0..node_index).rev() {
             let ancestor = &self.all_nodes[i];
             if ancestor.level < current_level {
@@ -336,12 +359,15 @@ impl<T: Clone> TreeCollection<T> {
                 if !expanded.contains(&ancestor.key) {
                     return false;
                 }
+
                 current_level = ancestor.level;
+
                 if current_level == 0 {
                     break;
                 }
             }
         }
+
         true
     }
 }
@@ -377,8 +403,10 @@ impl<T: Clone> Collection<T> for TreeCollection<T> {
 
     fn key_after_no_wrap(&self, key: &Key) -> Option<&Key> {
         let current = *self.key_to_index.get(key)?;
+
         // Find position of `current` in visible_indices, then search forward.
         let pos = self.visible_indices.iter().position(|&i| i == current)?;
+
         self.visible_indices[pos + 1..]
             .iter()
             .find(|&&i| self.all_nodes[i].is_focusable())
@@ -387,7 +415,9 @@ impl<T: Clone> Collection<T> for TreeCollection<T> {
 
     fn key_before_no_wrap(&self, key: &Key) -> Option<&Key> {
         let current = *self.key_to_index.get(key)?;
+
         let pos = self.visible_indices.iter().position(|&i| i == current)?;
+
         self.visible_indices[..pos]
             .iter()
             .rfind(|&&i| self.all_nodes[i].is_focusable())
@@ -442,14 +472,16 @@ impl<T: CollectionItem> TreeCollection<T> {
         }
 
         let key = item.key().clone();
-        let (level, parent_key_owned) = match parent {
-            Some(pk) => {
-                let parent_level = self.all_nodes[self.key_to_index[pk]].level;
-                (parent_level + 1, Some(pk.clone()))
-            }
-            None => (0, None),
+
+        let (level, parent_key_owned) = if let Some(pk) = parent {
+            let parent_level = self.all_nodes[self.key_to_index[pk]].level;
+            (parent_level + 1, Some(pk.clone()))
+        } else {
+            (0, None)
         };
+
         let text_value = item.text_value().to_string();
+
         let node = Node {
             key: key.clone(),
             node_type: NodeType::Item,
@@ -472,7 +504,9 @@ impl<T: CollectionItem> TreeCollection<T> {
             if let Some(&pi) = self.key_to_index.get(pk) {
                 // pi may have shifted if flat_pos <= pi, adjust
                 let adj = if flat_pos <= pi { pi + 1 } else { pi };
+
                 self.all_nodes[adj].has_children = true;
+
                 if self.all_nodes[adj].is_expanded.is_none() {
                     self.all_nodes[adj].is_expanded = Some(false);
                 }
@@ -485,20 +519,27 @@ impl<T: CollectionItem> TreeCollection<T> {
     /// Remove items by key (and their entire subtrees).
     pub fn remove_by_keys(&mut self, keys: &[Key]) -> Vec<T> {
         let mut removed = Vec::new();
+
         for key in keys {
             // Collect the subtree rooted at `key` (DFS order in all_nodes).
             if let Some(&start) = self.key_to_index.get(key) {
                 let parent_key = self.all_nodes[start].parent_key.clone();
+
                 let root_level = self.all_nodes[start].level;
+
                 let mut end = start + 1;
+
                 while end < self.all_nodes.len() && self.all_nodes[end].level > root_level {
                     end += 1;
                 }
+
                 // Drain the range [start..end] from all_nodes.
                 let drained = self.all_nodes.drain(start..end).collect::<Vec<_>>();
+
                 for node in &drained {
                     self.expanded_keys.remove(&node.key);
                 }
+
                 for node in drained {
                     if let Some(val) = node.value {
                         removed.push(val);
@@ -513,6 +554,7 @@ impl<T: CollectionItem> TreeCollection<T> {
                             .all_nodes
                             .iter()
                             .any(|n| n.parent_key.as_ref() == Some(pk));
+
                         if !still_has_children {
                             self.all_nodes[pi].has_children = false;
                             self.all_nodes[pi].is_expanded = None;
@@ -526,6 +568,7 @@ impl<T: CollectionItem> TreeCollection<T> {
                 self.rebuild_indices();
             }
         }
+
         removed
     }
 
@@ -554,6 +597,7 @@ impl<T: CollectionItem> TreeCollection<T> {
 
         // Extract the subtree.
         let subtree = self.extract_subtree(key);
+
         if subtree.is_empty() {
             return;
         }
@@ -565,10 +609,13 @@ impl<T: CollectionItem> TreeCollection<T> {
                 // Descendant was part of the extracted subtree — re-insert
                 // at the original flat position to preserve tree integrity.
                 let insert_pos = self.all_nodes.len().min(subtree[0].index);
+
                 for (offset, node) in subtree.into_iter().enumerate() {
                     self.all_nodes.insert(insert_pos + offset, node);
                 }
+
                 self.rebuild_indices();
+
                 return;
             }
         }
@@ -580,6 +627,7 @@ impl<T: CollectionItem> TreeCollection<T> {
                     .all_nodes
                     .iter()
                     .any(|n| n.parent_key.as_ref() == Some(pk));
+
                 if !still_has_children {
                     self.all_nodes[pi].has_children = false;
                     self.all_nodes[pi].is_expanded = None;
@@ -593,20 +641,21 @@ impl<T: CollectionItem> TreeCollection<T> {
         self.rebuild_indices();
 
         // Recompute levels relative to new parent.
-        let new_level = match new_parent {
-            Some(pk) => self
-                .key_to_index
+        let new_level = new_parent.map_or(0, |pk| {
+            self.key_to_index
                 .get(pk)
-                .map_or(0, |&i| self.all_nodes[i].level + 1),
-            None => 0,
-        };
+                .map_or(0, |&i| self.all_nodes[i].level + 1)
+        });
+
         let old_level = subtree[0].level;
+
         let level_delta = new_level as isize - old_level as isize;
 
         // Mark the new parent as having children (if it was a leaf).
         if let Some(pk) = new_parent {
             if let Some(&pi) = self.key_to_index.get(pk) {
                 self.all_nodes[pi].has_children = true;
+
                 if self.all_nodes[pi].is_expanded.is_none() {
                     self.all_nodes[pi].is_expanded = Some(false);
                 }
@@ -614,20 +663,26 @@ impl<T: CollectionItem> TreeCollection<T> {
         }
 
         let flat_pos = self.flat_insert_position(new_parent, sibling_index);
+
         for (offset, mut node) in subtree.into_iter().enumerate() {
             node.level = (node.level as isize + level_delta) as usize;
+
             if offset == 0 {
                 node.parent_key = new_parent.cloned();
             }
+
             self.all_nodes.insert(flat_pos + offset, node);
         }
+
         self.rebuild_indices();
     }
 
     /// Reorder a node among its siblings to the given sibling index.
     pub fn reorder_sibling(&mut self, key: &Key, to_sibling_index: usize) {
         let parent_key = self.parent_of(key).cloned();
+
         let subtree = self.extract_subtree(key);
+
         if subtree.is_empty() {
             return;
         }
@@ -636,15 +691,18 @@ impl<T: CollectionItem> TreeCollection<T> {
         self.rebuild_indices();
 
         let flat_pos = self.flat_insert_position(parent_key.as_ref(), to_sibling_index);
+
         for (offset, node) in subtree.into_iter().enumerate() {
             self.all_nodes.insert(flat_pos + offset, node);
         }
+
         self.rebuild_indices();
     }
 
     /// Replace an item's data (matched by key).
     pub fn replace(&mut self, item: T) {
         let key = item.key().clone();
+
         if let Some(&idx) = self.key_to_index.get(&key) {
             self.all_nodes[idx].value = Some(item);
         }
@@ -661,16 +719,17 @@ impl<T: CollectionItem> TreeCollection<T> {
     /// removed nodes. After extraction, indices are stale until
     /// `rebuild_indices()` is called.
     fn extract_subtree(&mut self, key: &Key) -> Vec<Node<T>> {
-        if let Some(&start) = self.key_to_index.get(key) {
+        self.key_to_index.get(key).map_or_else(Vec::new, |&start| {
             let root_level = self.all_nodes[start].level;
+
             let mut end = start + 1;
+
             while end < self.all_nodes.len() && self.all_nodes[end].level > root_level {
                 end += 1;
             }
+
             self.all_nodes.drain(start..end).collect()
-        } else {
-            Vec::new()
-        }
+        })
     }
 
     /// Compute the flat insertion position for a new child at `sibling_index`
@@ -696,14 +755,18 @@ impl<T: CollectionItem> TreeCollection<T> {
                 .map(|(i, _)| i)
                 .collect::<Vec<_>>()
         };
+
         if sibling_index >= children.len() {
             // Append after the last sibling's subtree.
             if let Some(&last_child_idx) = children.last() {
                 let root_level = self.all_nodes[last_child_idx].level;
+
                 let mut end = last_child_idx + 1;
+
                 while end < self.all_nodes.len() && self.all_nodes[end].level > root_level {
                     end += 1;
                 }
+
                 end
             } else {
                 // No existing children — insert right after the parent.
@@ -724,8 +787,10 @@ impl<T: CollectionItem> TreeCollection<T> {
     /// after a structural mutation.
     fn rebuild_indices(&mut self) {
         self.key_to_index.clear();
+
         for (i, node) in self.all_nodes.iter_mut().enumerate() {
             node.index = i;
+
             self.key_to_index.insert(node.key.clone(), i);
         }
 
@@ -832,6 +897,7 @@ mod tests {
     #[test]
     fn new_empty() {
         let tree = TreeCollection::<&str>::new(Vec::new());
+
         assert_eq!(tree.size(), 0);
         assert!(tree.is_empty());
     }
@@ -839,8 +905,11 @@ mod tests {
     #[test]
     fn new_single_root() {
         let tree = TreeCollection::new(vec![leaf(1, "Root")]);
+
         assert_eq!(tree.size(), 1);
+
         let node = tree.get(&Key::int(1)).expect("root node");
+
         assert_eq!(node.level, 0);
         assert!(!node.has_children);
         assert_eq!(node.is_expanded, None);
@@ -850,15 +919,19 @@ mod tests {
     #[test]
     fn new_flat_roots() {
         let tree = TreeCollection::new(vec![leaf(1, "A"), leaf(2, "B"), leaf(3, "C")]);
+
         assert_eq!(tree.size(), 3);
+
         // DFS order: 1, 2, 3
         let keys = tree.keys().collect::<Vec<_>>();
+
         assert_eq!(keys, vec![&Key::int(1), &Key::int(2), &Key::int(3)]);
     }
 
     #[test]
     fn new_nested_dfs_order() {
         let tree = sample_tree();
+
         // All nodes in DFS pre-order: 1, 2, 3, 4, 5, 6, 7
         assert_eq!(tree.all_nodes.len(), 7);
         assert_eq!(tree.all_nodes[0].key, Key::int(1));
@@ -873,6 +946,7 @@ mod tests {
     #[test]
     fn new_nested_levels() {
         let tree = sample_tree();
+
         assert_eq!(tree.all_nodes[0].level, 0); // Fruits
         assert_eq!(tree.all_nodes[1].level, 1); // Apple
         assert_eq!(tree.all_nodes[2].level, 1); // Banana
@@ -885,6 +959,7 @@ mod tests {
     #[test]
     fn new_nested_parent_keys() {
         let tree = sample_tree();
+
         assert_eq!(tree.all_nodes[0].parent_key, None); // Fruits
         assert_eq!(tree.all_nodes[1].parent_key, Some(Key::int(1))); // Apple → Fruits
         assert_eq!(tree.all_nodes[2].parent_key, Some(Key::int(1))); // Banana → Fruits
@@ -897,6 +972,7 @@ mod tests {
     #[test]
     fn new_has_children() {
         let tree = sample_tree();
+
         assert!(tree.all_nodes[0].has_children); // Fruits
         assert!(!tree.all_nodes[1].has_children); // Apple
         assert!(!tree.all_nodes[2].has_children); // Banana
@@ -907,12 +983,15 @@ mod tests {
     #[test]
     fn new_default_expanded() {
         let tree = sample_tree();
+
         // Fruits is default_expanded=true
         assert!(tree.is_expanded(&Key::int(1)));
         assert_eq!(tree.all_nodes[0].is_expanded, Some(true));
+
         // Vegetables is default_expanded=false
         assert!(!tree.is_expanded(&Key::int(4)));
         assert_eq!(tree.all_nodes[3].is_expanded, Some(false));
+
         // Grains is a leaf — is_expanded is None
         assert_eq!(tree.all_nodes[6].is_expanded, None);
     }
@@ -940,8 +1019,10 @@ mod tests {
                 }
             }
         }
+
         // Levels 0..=32 = 33 nodes, all within MAX_TREE_DEPTH
         let tree = TreeCollection::new(vec![chain(0)]);
+
         assert_eq!(tree.all_nodes.len(), MAX_TREE_DEPTH + 1);
     }
 
@@ -968,6 +1049,7 @@ mod tests {
                 }
             }
         }
+
         // This should panic — depth 33 exceeds MAX_TREE_DEPTH (32)
         TreeCollection::new(vec![chain(0)]);
     }
@@ -979,14 +1061,17 @@ mod tests {
     #[test]
     fn set_expanded_collapse() {
         let tree = sample_tree();
+
         // Fruits is expanded — Apple and Banana are visible
         assert!(tree.keys().any(|k| k == &Key::int(2))); // Apple visible
 
         // Collapse Fruits
         let collapsed = tree.set_expanded(&Key::int(1), false);
+
         // Apple and Banana should be hidden
         assert!(!collapsed.keys().any(|k| k == &Key::int(2)));
         assert!(!collapsed.keys().any(|k| k == &Key::int(3)));
+
         // Fruits itself is still visible
         assert!(collapsed.keys().any(|k| k == &Key::int(1)));
     }
@@ -994,11 +1079,13 @@ mod tests {
     #[test]
     fn set_expanded_expand() {
         let tree = sample_tree();
+
         // Vegetables is collapsed — Carrot not visible
         assert!(!tree.keys().any(|k| k == &Key::int(5)));
 
         // Expand Vegetables
         let expanded = tree.set_expanded(&Key::int(4), true);
+
         assert!(expanded.keys().any(|k| k == &Key::int(5))); // Carrot visible
         assert!(expanded.keys().any(|k| k == &Key::int(6))); // Daikon visible
     }
@@ -1006,10 +1093,12 @@ mod tests {
     #[test]
     fn set_expanded_returns_new_instance() {
         let tree = sample_tree();
+
         let original_size = tree.size();
 
         // Collapse Fruits — original should be unchanged
         let collapsed = tree.set_expanded(&Key::int(1), false);
+
         assert_eq!(tree.size(), original_size);
         assert_ne!(tree.size(), collapsed.size());
     }
@@ -1017,6 +1106,7 @@ mod tests {
     #[test]
     fn is_expanded_true_false() {
         let tree = sample_tree();
+
         assert!(tree.is_expanded(&Key::int(1))); // Fruits expanded
         assert!(!tree.is_expanded(&Key::int(4))); // Vegetables collapsed
         assert!(!tree.is_expanded(&Key::int(7))); // Grains is a leaf
@@ -1026,7 +1116,9 @@ mod tests {
     #[test]
     fn set_expanded_nonexistent_key() {
         let tree = sample_tree();
+
         let result = tree.set_expanded(&Key::int(99), true);
+
         // Should not panic; tree should be functionally equivalent
         assert_eq!(result.all_nodes.len(), tree.all_nodes.len());
     }
@@ -1034,22 +1126,31 @@ mod tests {
     #[test]
     fn collapse_already_collapsed() {
         let tree = sample_tree();
+
         // Vegetables is already collapsed
         let result = tree.set_expanded(&Key::int(4), false);
+
         assert!(!result.is_expanded(&Key::int(4)));
+
         // Visible set should be the same
         let orig_keys = tree.keys().collect::<Vec<_>>();
+
         let result_keys = result.keys().collect::<Vec<_>>();
+
         assert_eq!(orig_keys, result_keys);
     }
 
     #[test]
     fn expand_leaf_node() {
         let tree = sample_tree();
+
         // Grains is a leaf — expanding it is a no-op
         let result = tree.set_expanded(&Key::int(7), true);
+
         let orig_keys = tree.keys().collect::<Vec<_>>();
+
         let result_keys = result.keys().collect::<Vec<_>>();
+
         assert_eq!(orig_keys, result_keys);
     }
 
@@ -1060,10 +1161,14 @@ mod tests {
     #[test]
     fn visibility_with_mixed_expansion() {
         let tree = sample_tree();
+
         // Fruits expanded, Vegetables collapsed
         // Visible: 1(Fruits), 2(Apple), 3(Banana), 4(Vegetables), 7(Grains)
+
         assert_eq!(tree.size(), 5);
+
         let visible_keys = tree.keys().collect::<Vec<_>>();
+
         assert_eq!(
             visible_keys,
             vec![
@@ -1079,7 +1184,9 @@ mod tests {
     #[test]
     fn visibility_all_expanded() {
         let tree = sample_tree();
+
         let fully_expanded = tree.set_expanded(&Key::int(4), true);
+
         // All 7 nodes visible
         assert_eq!(fully_expanded.size(), 7);
     }
@@ -1087,7 +1194,9 @@ mod tests {
     #[test]
     fn visibility_all_collapsed() {
         let tree = sample_tree();
+
         let collapsed = tree.set_expanded(&Key::int(1), false);
+
         // Only roots visible: 1(Fruits), 4(Vegetables), 7(Grains)
         assert_eq!(collapsed.size(), 3);
     }
@@ -1095,11 +1204,14 @@ mod tests {
     #[test]
     fn visible_keys_with_expanded_external_set() {
         let tree = sample_tree();
+
         // External expanded set: only Vegetables expanded
+
         let mut expanded = BTreeSet::new();
         expanded.insert(Key::int(4));
 
         let visible = tree.visible_keys_with_expanded(&expanded);
+
         // Fruits collapsed (children hidden), Vegetables expanded (children shown)
         assert_eq!(
             visible,
@@ -1116,7 +1228,9 @@ mod tests {
     #[test]
     fn is_visible_with_expanded_root() {
         let tree = sample_tree();
+
         let expanded = BTreeSet::new(); // nothing expanded
+
         // Root nodes are always visible
         assert!(tree.is_visible_with_expanded(&Key::int(1), &expanded));
         assert!(tree.is_visible_with_expanded(&Key::int(4), &expanded));
@@ -1126,7 +1240,9 @@ mod tests {
     #[test]
     fn is_visible_with_expanded_child_of_collapsed() {
         let tree = sample_tree();
+
         let expanded = BTreeSet::new(); // nothing expanded
+
         // Apple is child of Fruits which is not expanded
         assert!(!tree.is_visible_with_expanded(&Key::int(2), &expanded));
     }
@@ -1134,15 +1250,20 @@ mod tests {
     #[test]
     fn is_visible_with_expanded_child_of_expanded() {
         let tree = sample_tree();
+
         let mut expanded = BTreeSet::new();
+
         expanded.insert(Key::int(1)); // Fruits expanded
+
         assert!(tree.is_visible_with_expanded(&Key::int(2), &expanded)); // Apple visible
     }
 
     #[test]
     fn is_visible_with_expanded_nonexistent_key() {
         let tree = sample_tree();
+
         let expanded = BTreeSet::new();
+
         assert!(!tree.is_visible_with_expanded(&Key::int(99), &expanded));
     }
 
@@ -1158,17 +1279,22 @@ mod tests {
 
         // All expanded — leaf is visible
         let mut all_expanded = BTreeSet::new();
+
         all_expanded.insert(Key::int(1));
         all_expanded.insert(Key::int(2));
+
         assert!(tree.is_visible_with_expanded(&Key::int(3), &all_expanded));
 
         // Only root expanded, mid collapsed — leaf is NOT visible
         let mut root_only = BTreeSet::new();
+
         root_only.insert(Key::int(1));
+
         assert!(!tree.is_visible_with_expanded(&Key::int(3), &root_only));
 
         // Nothing expanded — mid is NOT visible
         let none_expanded = BTreeSet::new();
+
         assert!(!tree.is_visible_with_expanded(&Key::int(2), &none_expanded));
     }
 
@@ -1179,6 +1305,7 @@ mod tests {
     #[test]
     fn size_equals_visible_count() {
         let tree = sample_tree();
+
         // 5 visible nodes (Fruits expanded, Vegetables collapsed)
         assert_eq!(tree.size(), 5);
     }
@@ -1190,32 +1317,42 @@ mod tests {
     #[test]
     fn get_returns_any_node() {
         let tree = sample_tree();
+
         // Carrot (key 5) is inside collapsed Vegetables — still accessible via get
         let node = tree.get(&Key::int(5)).expect("Carrot should exist");
+
         assert_eq!(node.text_value, "Carrot");
     }
 
     #[test]
     fn get_missing_key() {
         let tree = sample_tree();
+
         assert!(tree.get(&Key::int(99)).is_none());
     }
 
     #[test]
     fn get_by_index_uses_visible() {
         let tree = sample_tree();
+
         // Visible order: 1(Fruits), 2(Apple), 3(Banana), 4(Vegetables), 7(Grains)
         let node = tree.get_by_index(0).expect("index 0");
+
         assert_eq!(node.key, Key::int(1)); // Fruits
+
         let node = tree.get_by_index(3).expect("index 3");
+
         assert_eq!(node.key, Key::int(4)); // Vegetables
+
         let node = tree.get_by_index(4).expect("index 4");
+
         assert_eq!(node.key, Key::int(7)); // Grains
     }
 
     #[test]
     fn get_by_index_out_of_range() {
         let tree = sample_tree();
+
         assert!(tree.get_by_index(100).is_none());
     }
 
@@ -1226,6 +1363,7 @@ mod tests {
     #[test]
     fn first_key_and_last_key() {
         let tree = sample_tree();
+
         assert_eq!(tree.first_key(), Some(&Key::int(1)));
         assert_eq!(tree.last_key(), Some(&Key::int(7)));
     }
@@ -1233,6 +1371,7 @@ mod tests {
     #[test]
     fn first_key_empty() {
         let tree = TreeCollection::<&str>::new(Vec::new());
+
         assert_eq!(tree.first_key(), None);
         assert_eq!(tree.last_key(), None);
     }
@@ -1244,6 +1383,7 @@ mod tests {
     #[test]
     fn key_after_middle() {
         let tree = sample_tree();
+
         // After Apple(2) → Banana(3)
         assert_eq!(tree.key_after(&Key::int(2)), Some(&Key::int(3)));
     }
@@ -1251,6 +1391,7 @@ mod tests {
     #[test]
     fn key_after_wraps_at_end() {
         let tree = sample_tree();
+
         // After Grains(7) wraps to Fruits(1)
         assert_eq!(tree.key_after(&Key::int(7)), Some(&Key::int(1)));
     }
@@ -1258,6 +1399,7 @@ mod tests {
     #[test]
     fn key_before_middle() {
         let tree = sample_tree();
+
         // Before Banana(3) → Apple(2)
         assert_eq!(tree.key_before(&Key::int(3)), Some(&Key::int(2)));
     }
@@ -1265,6 +1407,7 @@ mod tests {
     #[test]
     fn key_before_wraps_at_start() {
         let tree = sample_tree();
+
         // Before Fruits(1) wraps to Grains(7)
         assert_eq!(tree.key_before(&Key::int(1)), Some(&Key::int(7)));
     }
@@ -1276,26 +1419,31 @@ mod tests {
     #[test]
     fn key_after_no_wrap_middle() {
         let tree = sample_tree();
+
         assert_eq!(tree.key_after_no_wrap(&Key::int(2)), Some(&Key::int(3)));
     }
 
     #[test]
     fn key_after_no_wrap_at_end() {
         let tree = sample_tree();
+
         assert_eq!(tree.key_after_no_wrap(&Key::int(7)), None);
     }
 
     #[test]
     fn key_before_no_wrap_at_start() {
         let tree = sample_tree();
+
         assert_eq!(tree.key_before_no_wrap(&Key::int(1)), None);
     }
 
     #[test]
     fn key_after_no_wrap_skips_collapsed() {
         let tree = sample_tree();
+
         // After Banana(3) → Vegetables(4), skipping collapsed children 5,6
         assert_eq!(tree.key_after_no_wrap(&Key::int(3)), Some(&Key::int(4)));
+
         // After Vegetables(4) → Grains(7), because 5,6 are not visible
         assert_eq!(tree.key_after_no_wrap(&Key::int(4)), Some(&Key::int(7)));
     }
@@ -1303,6 +1451,7 @@ mod tests {
     #[test]
     fn key_after_no_wrap_unknown_key() {
         let tree = sample_tree();
+
         assert_eq!(tree.key_after_no_wrap(&Key::int(99)), None);
     }
 
@@ -1313,7 +1462,9 @@ mod tests {
     #[test]
     fn keys_iterator_only_visible() {
         let tree = sample_tree();
+
         let keys = tree.keys().collect::<Vec<_>>();
+
         assert_eq!(
             keys,
             vec![
@@ -1329,10 +1480,12 @@ mod tests {
     #[test]
     fn nodes_iterator_only_visible() {
         let tree = sample_tree();
+
         let text_values = tree
             .nodes()
             .map(|n| n.text_value.as_str())
             .collect::<Vec<_>>();
+
         assert_eq!(
             text_values,
             vec!["Fruits", "Apple", "Banana", "Vegetables", "Grains"]
@@ -1342,8 +1495,10 @@ mod tests {
     #[test]
     fn item_keys_filters_visible_focusable() {
         let tree = sample_tree();
+
         // All visible nodes are Item type, so item_keys == keys for this tree
         let item_keys = tree.item_keys().collect::<Vec<_>>();
+
         assert_eq!(
             item_keys,
             vec![
@@ -1363,8 +1518,11 @@ mod tests {
     #[test]
     fn children_of_returns_all_including_collapsed() {
         let tree = sample_tree();
+
         // Vegetables(4) is collapsed but children_of should still return its children
+
         let children = tree.children_of(&Key::int(4)).collect::<Vec<_>>();
+
         assert_eq!(children.len(), 2);
         assert_eq!(children[0].key, Key::int(5)); // Carrot
         assert_eq!(children[1].key, Key::int(6)); // Daikon
@@ -1373,14 +1531,18 @@ mod tests {
     #[test]
     fn children_of_leaf() {
         let tree = sample_tree();
+
         let children = tree.children_of(&Key::int(7)).collect::<Vec<_>>();
+
         assert!(children.is_empty());
     }
 
     #[test]
     fn children_of_nonexistent() {
         let tree = sample_tree();
+
         let children = tree.children_of(&Key::int(99)).collect::<Vec<_>>();
+
         assert!(children.is_empty());
     }
 
@@ -1391,12 +1553,14 @@ mod tests {
     #[test]
     fn text_value_of_existing() {
         let tree = sample_tree();
+
         assert_eq!(tree.text_value_of(&Key::int(2)), Some("Apple"));
     }
 
     #[test]
     fn text_value_of_missing() {
         let tree = sample_tree();
+
         assert_eq!(tree.text_value_of(&Key::int(99)), None);
     }
 
@@ -1441,9 +1605,13 @@ mod tests {
     #[test]
     fn insert_child_at_root() {
         let mut tree = fruit_tree();
+
         let original_size = tree.all_nodes.len();
+
         tree.insert_child(None, 0, TreeFruit::new(10, "Root Item"));
+
         assert_eq!(tree.all_nodes.len(), original_size + 1);
+
         // Inserted at root level, sibling_index 0 — should be first node
         assert_eq!(tree.all_nodes[0].key, Key::int(10));
         assert_eq!(tree.all_nodes[0].level, 0);
@@ -1453,10 +1621,14 @@ mod tests {
     #[test]
     fn insert_child_under_parent() {
         let mut tree = fruit_tree();
+
         // Insert Cherry under Fruits at sibling_index 2 (after Banana)
         tree.insert_child(Some(&Key::int(1)), 2, TreeFruit::new(5, "Cherry"));
+
         // Cherry should be a child of Fruits at level 1
+
         let cherry = tree.get(&Key::int(5)).expect("Cherry");
+
         assert_eq!(cherry.level, 1);
         assert_eq!(cherry.parent_key, Some(Key::int(1)));
     }
@@ -1464,23 +1636,28 @@ mod tests {
     #[test]
     fn insert_child_updates_parent_has_children() {
         let mut tree = fruit_tree();
+
         // Other(4) is a leaf
         assert!(!tree.get(&Key::int(4)).expect("Other").has_children);
 
         // Insert a child under Other
         tree.insert_child(Some(&Key::int(4)), 0, TreeFruit::new(10, "Sub"));
+
         assert!(tree.get(&Key::int(4)).expect("Other").has_children);
     }
 
     #[test]
     fn remove_by_keys_removes_subtree() {
         let mut tree = fruit_tree();
+
         // Remove Fruits(1) — should also remove Apple(2) and Banana(3)
         let removed = tree.remove_by_keys(&[Key::int(1)]);
+
         assert_eq!(removed.len(), 3); // Fruits + Apple + Banana
         assert!(!tree.contains_key(&Key::int(1)));
         assert!(!tree.contains_key(&Key::int(2)));
         assert!(!tree.contains_key(&Key::int(3)));
+
         // Other(4) should still be there
         assert!(tree.contains_key(&Key::int(4)));
     }
@@ -1488,7 +1665,9 @@ mod tests {
     #[test]
     fn remove_by_keys_missing() {
         let mut tree = fruit_tree();
+
         let removed = tree.remove_by_keys(&[Key::int(99)]);
+
         assert!(removed.is_empty());
         assert_eq!(tree.all_nodes.len(), 4);
     }
@@ -1496,6 +1675,7 @@ mod tests {
     #[test]
     fn flat_index_of_returns_correct_index() {
         let tree = fruit_tree();
+
         assert_eq!(tree.flat_index_of(&Key::int(1)), Some(0));
         assert_eq!(tree.flat_index_of(&Key::int(2)), Some(1));
         assert_eq!(tree.flat_index_of(&Key::int(3)), Some(2));
@@ -1506,9 +1686,12 @@ mod tests {
     #[test]
     fn reparent_to_root() {
         let mut tree = fruit_tree();
+
         // Move Apple(2) from under Fruits(1) to root level
         tree.reparent(&Key::int(2), None, 0);
+
         let apple = tree.get(&Key::int(2)).expect("Apple");
+
         assert_eq!(apple.level, 0);
         assert_eq!(apple.parent_key, None);
     }
@@ -1516,10 +1699,14 @@ mod tests {
     #[test]
     fn reparent_to_different_parent() {
         let mut tree = fruit_tree();
+
         // Move Apple(2) from under Fruits(1) to under Other(4)
         tree.reparent(&Key::int(2), Some(&Key::int(4)), 0);
+
         let apple = tree.get(&Key::int(2)).expect("Apple");
+
         assert_eq!(apple.parent_key, Some(Key::int(4)));
+
         // Level should adjust: Other is level 0, so Apple is level 1
         assert_eq!(apple.level, 1);
     }
@@ -1527,10 +1714,14 @@ mod tests {
     #[test]
     fn reorder_sibling() {
         let mut tree = fruit_tree();
+
         // Banana(3) is sibling index 1 under Fruits. Move to index 0.
         tree.reorder_sibling(&Key::int(3), 0);
+
         // Now Banana should come before Apple in DFS
+
         let children = tree.children_of(&Key::int(1)).collect::<Vec<_>>();
+
         assert_eq!(children[0].key, Key::int(3)); // Banana first
         assert_eq!(children[1].key, Key::int(2)); // Apple second
     }
@@ -1538,15 +1729,20 @@ mod tests {
     #[test]
     fn replace_value() {
         let mut tree = fruit_tree();
+
         tree.replace(TreeFruit::new(2, "Green Apple"));
+
         let node = tree.get(&Key::int(2)).expect("Apple");
+
         assert_eq!(node.value.as_ref().expect("value").name, "Green Apple");
     }
 
     #[test]
     fn replace_missing_key() {
         let mut tree = fruit_tree();
+
         tree.replace(TreeFruit::new(99, "Unknown"));
+
         // No change — key 99 doesn't exist
         assert!(!tree.contains_key(&Key::int(99)));
     }
@@ -1558,14 +1754,18 @@ mod tests {
     #[test]
     fn clone_produces_equal_collection() {
         let tree = sample_tree();
+
         let cloned = tree.clone();
+
         assert_eq!(tree, cloned);
     }
 
     #[test]
     fn debug_contains_name_and_counts() {
         let tree = sample_tree();
+
         let debug = format!("{tree:?}");
+
         assert!(debug.contains("TreeCollection"));
         assert!(debug.contains("7")); // total_nodes
         assert!(debug.contains("5")); // visible_nodes
@@ -1574,14 +1774,18 @@ mod tests {
     #[test]
     fn partial_eq_equal() {
         let a = sample_tree();
+
         let b = sample_tree();
+
         assert_eq!(a, b);
     }
 
     #[test]
     fn partial_eq_different_expansion() {
         let a = sample_tree();
+
         let b = a.set_expanded(&Key::int(4), true);
+
         assert_ne!(a, b);
     }
 
@@ -1592,6 +1796,7 @@ mod tests {
     #[test]
     fn single_item_wrapping_navigation() {
         let tree = TreeCollection::new(vec![leaf(1, "Only")]);
+
         assert_eq!(tree.key_after(&Key::int(1)), Some(&Key::int(1)));
         assert_eq!(tree.key_before(&Key::int(1)), Some(&Key::int(1)));
         assert_eq!(tree.key_after_no_wrap(&Key::int(1)), None);
@@ -1601,6 +1806,7 @@ mod tests {
     #[test]
     fn empty_tree_navigation() {
         let tree = TreeCollection::<&str>::new(Vec::new());
+
         assert_eq!(tree.first_key(), None);
         assert_eq!(tree.last_key(), None);
         assert_eq!(tree.key_after(&Key::int(1)), None);
@@ -1610,6 +1816,7 @@ mod tests {
     #[test]
     fn contains_key_in_collapsed_subtree() {
         let tree = sample_tree();
+
         // Carrot(5) is inside collapsed Vegetables — contains_key should still find it
         assert!(tree.contains_key(&Key::int(5)));
     }
@@ -1627,8 +1834,10 @@ mod tests {
             true,
             vec![branch(2, "B", false, vec![leaf(3, "C")]), leaf(4, "D")],
         )]);
+
         // Visible: A, B, D (C is inside collapsed B)
         assert_eq!(tree.size(), 3);
+
         let visible_keys = tree.keys().collect::<Vec<_>>();
         assert_eq!(visible_keys, vec![&Key::int(1), &Key::int(2), &Key::int(4)]);
     }
@@ -1636,6 +1845,7 @@ mod tests {
     #[test]
     fn node_index_fields_correct() {
         let tree = sample_tree();
+
         for (i, node) in tree.all_nodes.iter().enumerate() {
             assert_eq!(node.index, i, "Node at position {i} has wrong index field");
         }
@@ -1648,6 +1858,7 @@ mod tests {
     #[test]
     fn key_after_no_wrap_from_collapsed_node() {
         let tree = sample_tree();
+
         // Carrot(5) is inside collapsed Vegetables — it exists in key_to_index
         // but its flat index is NOT in visible_indices. The position() call
         // returns None, so key_after_no_wrap returns None.
@@ -1657,6 +1868,7 @@ mod tests {
     #[test]
     fn key_before_no_wrap_from_collapsed_node() {
         let tree = sample_tree();
+
         // Same for key_before_no_wrap on a non-visible key
         assert_eq!(tree.key_before_no_wrap(&Key::int(5)), None);
     }
@@ -1664,10 +1876,12 @@ mod tests {
     #[test]
     fn insert_child_at_index_zero_before_parent() {
         let mut tree = fruit_tree();
+
         // Insert as first child of Fruits(1). Fruits is at flat index 0.
         // The first child slot (sibling_index=0) is at flat index 1 (after parent).
         // This exercises the case where flat_pos > pi (insertion after parent).
         tree.insert_child(Some(&Key::int(1)), 0, TreeFruit::new(10, "Mango"));
+
         let mango = tree.get(&Key::int(10)).expect("Mango");
         assert_eq!(mango.parent_key, Some(Key::int(1)));
         assert_eq!(mango.level, 1);
@@ -1698,9 +1912,11 @@ mod tests {
 
         // Reparent Mid(2) + Leaf(3) to root level
         tree.reparent(&Key::int(2), None, 1);
+
         let mid = tree.get(&Key::int(2)).expect("Mid");
         assert_eq!(mid.level, 0);
         assert_eq!(mid.parent_key, None);
+
         // Leaf should also adjust: was level 2, now level 1
         let leaf_node = tree.get(&Key::int(3)).expect("Leaf");
         assert_eq!(leaf_node.level, 1);
@@ -1709,22 +1925,28 @@ mod tests {
     #[test]
     fn reorder_sibling_nonexistent_key() {
         let mut tree = fruit_tree();
+
         // Reorder a nonexistent key — should be a no-op
         tree.reorder_sibling(&Key::int(99), 0);
+
         assert_eq!(tree.all_nodes.len(), 4);
     }
 
     #[test]
     fn reparent_nonexistent_key() {
         let mut tree = fruit_tree();
+
         tree.reparent(&Key::int(99), None, 0);
+
         assert_eq!(tree.all_nodes.len(), 4);
     }
 
     #[test]
     fn tree_item_config_debug() {
         let config = leaf(1, "Apple");
+
         let debug = format!("{config:?}");
+
         assert!(debug.contains("TreeItemConfig"));
         assert!(debug.contains("Apple"));
     }
@@ -1733,7 +1955,9 @@ mod tests {
     fn insert_child_into_empty_tree() {
         // Covers flat_insert_position: parent=None, no existing root children
         let mut tree = TreeCollection::default();
+
         tree.insert_child(None, 0, TreeFruit::new(1, "First"));
+
         assert_eq!(tree.all_nodes.len(), 1);
         assert_eq!(tree.all_nodes[0].key, Key::int(1));
     }
@@ -1743,21 +1967,28 @@ mod tests {
         // Covers flat_insert_position: append after last sibling whose subtree
         // must be skipped (the while end += 1 loop body).
         let mut tree = fruit_tree();
+
         // Fruits(1) has children Apple(2), Banana(3).
         // Insert at sibling_index=999 (past end) → appends after Banana's subtree.
         // But Banana has no children so the while loop doesn't execute.
         // Instead, give Banana a child first, then insert after it.
         tree.insert_child(Some(&Key::int(3)), 0, TreeFruit::new(30, "Baby Banana"));
+
         // Now Banana(3) has child Baby Banana(30). Insert new sibling after Banana
         // under Fruits at sibling_index=999 (past end of 2 children).
         tree.insert_child(Some(&Key::int(1)), 999, TreeFruit::new(5, "Cherry"));
+
         // Cherry should appear after Banana's subtree (after Baby Banana)
         let cherry = tree.get(&Key::int(5)).expect("Cherry");
+
         assert_eq!(cherry.parent_key, Some(Key::int(1)));
         assert_eq!(cherry.level, 1);
+
         // Verify DFS order: Cherry comes after Baby Banana
         let cherry_idx = tree.flat_index_of(&Key::int(5)).expect("cherry index");
+
         let baby_idx = tree.flat_index_of(&Key::int(30)).expect("baby index");
+
         assert!(cherry_idx > baby_idx);
     }
 
@@ -1769,11 +2000,13 @@ mod tests {
     fn first_last_key_update_on_expand_collapse() {
         // All collapsed: visible = [Fruits(1), Vegetables(4), Grains(7)]
         let all_collapsed = sample_tree().set_expanded(&Key::int(1), false);
+
         assert_eq!(all_collapsed.first_key(), Some(&Key::int(1)));
         assert_eq!(all_collapsed.last_key(), Some(&Key::int(7)));
 
         // Expand Vegetables: visible adds Carrot(5), Daikon(6)
         let veg_expanded = all_collapsed.set_expanded(&Key::int(4), true);
+
         assert_eq!(veg_expanded.first_key(), Some(&Key::int(1)));
         assert_eq!(veg_expanded.last_key(), Some(&Key::int(7)));
 
@@ -1786,10 +2019,12 @@ mod tests {
             true,
             vec![leaf(2, "A"), leaf(3, "B")],
         )]);
+
         assert_eq!(single.first_key(), Some(&Key::int(1)));
         assert_eq!(single.last_key(), Some(&Key::int(3)));
 
         let collapsed = single.set_expanded(&Key::int(1), false);
+
         assert_eq!(collapsed.first_key(), Some(&Key::int(1)));
         assert_eq!(collapsed.last_key(), Some(&Key::int(1))); // only root visible
     }
@@ -1797,10 +2032,14 @@ mod tests {
     #[test]
     fn first_last_key_update_after_insert() {
         let mut tree = fruit_tree();
+
         let orig_first = tree.first_key().cloned();
+
         // Insert at root position 0 — new node becomes first
         tree.insert_child(None, 0, TreeFruit::new(0, "Zzz First"));
+
         assert_eq!(tree.first_key(), Some(&Key::int(0)));
+
         // Original first is now second
         assert_ne!(tree.first_key().cloned(), orig_first);
     }
@@ -1808,8 +2047,11 @@ mod tests {
     #[test]
     fn first_last_key_update_after_remove() {
         let mut tree = fruit_tree();
+
         assert_eq!(tree.last_key(), Some(&Key::int(4))); // Other
+
         tree.remove_by_keys(&[Key::int(4)]);
+
         // After removing Other(4), last focusable is Banana(3)
         assert_eq!(tree.last_key(), Some(&Key::int(3)));
     }
@@ -1817,8 +2059,10 @@ mod tests {
     #[test]
     fn first_last_key_empty_after_clear() {
         let mut tree = fruit_tree();
+
         // Multi-key removal is safe — rebuild_indices runs after each drain.
         tree.remove_by_keys(&[Key::int(1), Key::int(4)]);
+
         assert_eq!(tree.first_key(), None);
         assert_eq!(tree.last_key(), None);
     }
@@ -1831,9 +2075,11 @@ mod tests {
     fn remove_by_keys_multi_key_safe() {
         // Previously panicked due to stale key_to_index after first drain.
         let mut tree = fruit_tree();
+
         // Fruits(1) has children Apple(2), Banana(3); Other(4) is a root.
         // Remove both roots in a single call.
         let removed = tree.remove_by_keys(&[Key::int(1), Key::int(4)]);
+
         assert_eq!(removed.len(), 4); // Fruits + Apple + Banana + Other
         assert!(tree.is_empty());
     }
@@ -1841,15 +2087,18 @@ mod tests {
     #[test]
     fn remove_by_keys_cleans_expanded_keys() {
         let tree = sample_tree();
+
         // Fruits(1) is expanded
         assert!(tree.is_expanded(&Key::int(1)));
 
         // Convert to mutable tree via CollectionItem
         let mut tree = fruit_tree();
+
         // Expand Fruits in fruit_tree (it's already default_expanded=true)
         assert!(tree.is_expanded(&Key::int(1)));
 
         tree.remove_by_keys(&[Key::int(1)]);
+
         // Stale expanded key should be cleaned up
         assert!(!tree.is_expanded(&Key::int(1)));
     }
@@ -1857,12 +2106,15 @@ mod tests {
     #[test]
     fn reparent_marks_new_parent_has_children() {
         let mut tree = fruit_tree();
+
         // Other(4) is a leaf — has_children == false
         assert!(!tree.get(&Key::int(4)).expect("Other").has_children);
 
         // Reparent Apple(2) under Other(4)
         tree.reparent(&Key::int(2), Some(&Key::int(4)), 0);
+
         let other = tree.get(&Key::int(4)).expect("Other after reparent");
+
         assert!(other.has_children);
         assert_eq!(other.is_expanded, Some(false));
     }
@@ -1870,27 +2122,34 @@ mod tests {
     #[test]
     fn reparent_collapse_new_parent_hides_children() {
         let mut tree = fruit_tree();
+
         // Reparent Apple(2) under Other(4)
         tree.reparent(&Key::int(2), Some(&Key::int(4)), 0);
+
         // Other is now a parent with is_expanded=Some(false), so Apple is hidden
         assert!(!tree.keys().any(|k| k == &Key::int(2)));
 
         // Expand Other — Apple becomes visible
         let expanded = tree.set_expanded(&Key::int(4), true);
+
         assert!(expanded.keys().any(|k| k == &Key::int(2)));
     }
 
     #[test]
     fn set_expanded_on_leaf_is_noop() {
         let tree = sample_tree();
+
         // Grains(7) is a leaf
         let node = tree.get(&Key::int(7)).expect("Grains");
+
         assert_eq!(node.is_expanded, None);
         assert!(!node.has_children);
 
         // Attempting to expand a leaf should not change anything
         let after = tree.set_expanded(&Key::int(7), true);
+
         let node = after.get(&Key::int(7)).expect("Grains after");
+
         assert_eq!(node.is_expanded, None); // still None, not Some(true)
         assert!(!after.is_expanded(&Key::int(7))); // not in expanded_keys
     }
@@ -1898,7 +2157,9 @@ mod tests {
     #[test]
     fn set_expanded_on_missing_key_is_noop() {
         let tree = sample_tree();
+
         let after = tree.set_expanded(&Key::int(99), true);
+
         // Should not insert phantom key into expanded_keys
         assert!(!after.is_expanded(&Key::int(99)));
     }
@@ -1906,23 +2167,32 @@ mod tests {
     #[test]
     fn partial_eq_detects_hierarchy_change() {
         let tree_a = fruit_tree();
+
         let mut tree_b = fruit_tree();
+
         // Reparent Apple(2) to root level — same nodes, different hierarchy
         tree_b.reparent(&Key::int(2), None, 0);
+
         assert_ne!(tree_a, tree_b);
     }
 
     #[test]
     fn reparent_to_nonexistent_parent_is_noop() {
         let mut tree = fruit_tree();
+
         let before_keys: Vec<_> = tree.keys().cloned().collect();
+
         // Reparent Apple(2) under nonexistent key 99 — should be a no-op
         tree.reparent(&Key::int(2), Some(&Key::int(99)), 0);
+
         let after_keys: Vec<_> = tree.keys().cloned().collect();
+
         // Tree should be unchanged
         assert_eq!(before_keys, after_keys);
+
         // Apple should still exist with original parent
         let apple = tree.get(&Key::int(2)).expect("Apple");
+
         assert_eq!(apple.parent_key, Some(Key::int(1)));
     }
 
@@ -1938,6 +2208,7 @@ mod tests {
 
         // Fruits should now be a leaf
         let fruits = tree.get(&Key::int(1)).expect("Fruits after");
+
         assert!(!fruits.has_children);
         assert_eq!(fruits.is_expanded, None);
         assert!(!tree.is_expanded(&Key::int(1)));
@@ -1946,18 +2217,24 @@ mod tests {
     #[test]
     fn remove_one_child_keeps_parent_as_branch() {
         let mut tree = fruit_tree();
+
         // Remove only Apple(2), Banana(3) still under Fruits
         tree.remove_by_keys(&[Key::int(2)]);
+
         let fruits = tree.get(&Key::int(1)).expect("Fruits");
+
         assert!(fruits.has_children); // still has Banana
     }
 
     #[test]
     fn insert_child_under_missing_parent_is_noop() {
         let mut tree = fruit_tree();
+
         let before_len = tree.all_nodes.len();
+
         // Attempt to insert under nonexistent key 99
         tree.insert_child(Some(&Key::int(99)), 0, TreeFruit::new(10, "Orphan"));
+
         assert_eq!(tree.all_nodes.len(), before_len);
         assert!(!tree.contains_key(&Key::int(10)));
     }
@@ -1965,17 +2242,21 @@ mod tests {
     #[test]
     fn reparent_resets_old_parent_to_leaf() {
         let mut tree = fruit_tree();
+
         // Fruits(1) has Apple(2) and Banana(3)
         assert!(tree.get(&Key::int(1)).expect("Fruits").has_children);
 
         // Move Apple to root
         tree.reparent(&Key::int(2), None, 0);
+
         // Fruits still has Banana
         assert!(tree.get(&Key::int(1)).expect("Fruits").has_children);
 
         // Move Banana to root too — Fruits has no children left
         tree.reparent(&Key::int(3), None, 0);
+
         let fruits = tree.get(&Key::int(1)).expect("Fruits after");
+
         assert!(!fruits.has_children);
         assert_eq!(fruits.is_expanded, None);
     }

--- a/crates/ars-collections/src/typeahead.rs
+++ b/crates/ars-collections/src/typeahead.rs
@@ -543,6 +543,41 @@ mod tests {
         assert_eq!(found, Some(Key::int(2))); // Still Banana — "ba" matches
     }
 
+    #[test]
+    fn typeahead_finds_matching_item() {
+        let collection = CollectionBuilder::new()
+            .item(Key::int(1), "Apple", "apple")
+            .item(Key::int(2), "Banana", "banana")
+            .item(Key::int(3), "Cherry", "cherry")
+            .item(Key::int(4), "Apricot", "apricot")
+            .item(Key::int(5), "Blueberry", "blueberry")
+            .build();
+
+        let state = State::default();
+
+        let (state, found) = state.process_char(
+            'a',
+            0,
+            Some(&Key::int(1)),
+            &collection,
+            &no_disabled(),
+            DisabledBehavior::Skip,
+        );
+
+        assert_eq!(found, Some(Key::int(4)));
+
+        let (_, found) = state.process_char(
+            'p',
+            10,
+            Some(&Key::int(4)),
+            &collection,
+            &no_disabled(),
+            DisabledBehavior::Skip,
+        );
+
+        assert_eq!(found, Some(Key::int(4)));
+    }
+
     // ------------------------------------------------------------------ //
     // Match cycling (repeated same character)                             //
     // ------------------------------------------------------------------ //

--- a/spec/foundation/03-accessibility.md
+++ b/spec/foundation/03-accessibility.md
@@ -2343,108 +2343,52 @@ Focus is contained within the dialog. Tab at the last element wraps to the first
 
 ### 4.3 Type-Ahead / Type-Select Implementation
 
+Type-ahead state is shared across collection-based widgets and lives in
+`ars-collections::typeahead`, not in `ars-a11y`. `ars-a11y` consumes that
+shared state from component tests and higher-level keyboard helpers rather than
+shipping a duplicate implementation.
+
 ```rust
-// ars-a11y/src/keyboard/typeahead.rs
+// ars-collections/src/typeahead.rs
 
-use unicode_normalization::UnicodeNormalization;
+use alloc::{collections::BTreeSet, string::String};
+use core::time::Duration;
 
-/// Type-ahead (type-select) state for list widgets.
-///
-/// All string comparisons use NFC-normalized forms to ensure consistent
-/// matching regardless of how users or data sources compose characters.
-///
-/// When the user types printable characters quickly, moves focus to the
-/// next item whose label starts with the typed string. After a timeout,
-/// the search string is cleared and restarts.
+use crate::{Collection, DisabledBehavior, Key};
+
+/// Default time window for accumulating multi-character type-ahead queries.
+pub const TYPEAHEAD_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// The accumulated type-ahead search state.
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct State {
-    /// The accumulated search string (cleared after `timeout_ms`).
-    buffer: String,
-    /// Timestamp (milliseconds) of the last key press.
-    last_key_time: f64,
-    /// How long (ms) to wait before clearing the buffer. Default: 500ms.
-    pub timeout_ms: f64,
+    /// The accumulated search string, e.g. `"ban"` after typing B, A, N.
+    pub search: String,
+    /// Timestamp (in milliseconds since epoch) of the last contributing keypress.
+    pub last_key_time_ms: u64,
+    /// The key that was focused when the current search started.
+    pub search_start_key: Option<Key>,
 }
 
 impl State {
-    pub fn new() -> Self {
-        Self { buffer: String::new(), last_key_time: 0.0, timeout_ms: 500.0 }
-    }
-
-    /// Process a printable key character and return the search string.
-    ///
-    /// `now_ms` is the current time in milliseconds (e.g., `performance.now()`).
-    /// If `now_ms - last_key_time > timeout_ms`, the buffer is reset before
-    /// appending the new character.
-    ///
-    /// Returns the current search string to match against item labels.
-    pub fn process_key(&mut self, key: char, now_ms: f64) -> &str {
-        if now_ms - self.last_key_time > self.timeout_ms {
-            self.buffer.clear();
-        }
-        self.last_key_time = now_ms;
-        // Unicode-aware lowercase — supports CJK, Arabic, Cyrillic, etc.
-        // (to_ascii_lowercase would break non-Latin scripts)
-        for c in key.to_lowercase() {
-            self.buffer.push(c);
-        }
-        // Normalize buffer to NFC before comparison so that equivalent
-        // compositions (e.g., 'é' as U+00E9 vs U+0065 U+0301) always match.
-        self.buffer = self.buffer.nfc().collect::<String>();
-        &self.buffer
-    }
-
-    /// Find the next matching item index, starting search AFTER `from_index`.
-    ///
-    /// Search wraps around. Matching is case-insensitive prefix match.
-    /// If `buffer` contains a single repeated character (e.g., "aaa"), cycles
-    /// through all items starting with that character.
-    pub fn find_next_match(
+    /// Process a new character and return the next immutable state plus any match.
+    pub fn process_char<T, C: Collection<T>>(
         &self,
-        from_index: usize,
-        item_count: usize,
-        label_for: impl Fn(usize) -> String,
-        is_disabled: impl Fn(usize) -> bool,
-    ) -> Option<usize> {
-        if self.buffer.is_empty() || item_count == 0 { return None; }
-
-        let search = &self.buffer;
-
-        // Detect repeated-char scenario: "aaa" → search for "a"
-        let first_char = search.chars().next();
-        let effective_search: &str = if first_char.is_some() && search.chars().all(|c| Some(c) == first_char) {
-            &search[..search.char_indices().nth(1).map(|(i, _)| i).unwrap_or(search.len())]
-        } else {
-            search
-        };
-
-        for offset in 1..=item_count {
-            let idx = (from_index + offset) % item_count;
-            if is_disabled(idx) { continue; }
-            // Normalize label to NFC before case-folding for consistent matching.
-            let label = label_for(idx).nfc().collect::<String>().to_lowercase();
-            if label.starts_with(effective_search) {
-                return Some(idx);
-            }
-        }
-        None
+        ch: char,
+        now_ms: u64,
+        current_focus: Option<&Key>,
+        collection: &C,
+        disabled_keys: &BTreeSet<Key>,
+        disabled_behavior: DisabledBehavior,
+    ) -> (Self, Option<Key>) {
+        /* see spec/foundation/06-collections.md §Typeahead for full algorithm */
     }
-
-    pub fn clear(&mut self) {
-        self.buffer.clear();
-    }
-}
-
-/// Returns true if a `KeyboardEventData` represents a printable character suitable
-/// for type-ahead. With the `KeyboardKey` enum, printable characters are indicated
-/// by `data.character.is_some()` — this helper exists for readability.
-pub fn is_printable_key(data: &KeyboardEventData) -> bool {
-    data.character.is_some()
 }
 ```
 
 > **Dead-key handling.** Dead keys (used for diacritics in many European keyboard layouts)
-> fire `key="Dead"`, which is a multi-character string correctly rejected by
-> `is_printable_key()`. Dead-key compositions arrive via `compositionend`. Type-ahead
+> fire `key="Dead"`, which is a multi-character string and should not be fed
+> into `process_char()`. Dead-key compositions arrive via `compositionend`. Type-ahead
 > SHOULD listen for `input` events as fallback for composed characters.
 >
 > **Locale-specific case folding.** `to_lowercase()` handles most scripts correctly but
@@ -3987,19 +3931,27 @@ pub fn validate_attr_map(
 // ars-a11y/src/testing/keyboard.rs
 
 /// A simulated keyboard event for use in unit tests.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct SimulatedKeyEvent {
+    /// The DOM `key` value exposed by the event.
     pub key: &'static str,
+    /// Whether the Shift modifier is pressed.
     pub shift: bool,
+    /// Whether the Ctrl modifier is pressed.
     pub ctrl: bool,
+    /// Whether the Meta/Cmd modifier is pressed.
     pub meta: bool,
+    /// Whether the Alt/Option modifier is pressed.
     pub alt: bool,
+    /// Whether `prevent_default()` has been called.
     pub default_prevented: AtomicBool,
+    /// Whether `stop_propagation()` has been called.
     pub propagation_stopped: AtomicBool,
 }
 
 impl SimulatedKeyEvent {
-    pub fn key(key: &'static str) -> Self {
+    /// Creates a `keydown` event with the provided key and no modifiers.
+    pub const fn key(key: &'static str) -> Self {
         Self {
             key,
             shift: false, ctrl: false, meta: false, alt: false,
@@ -4008,10 +3960,30 @@ impl SimulatedKeyEvent {
         }
     }
 
-    pub fn with_shift(mut self) -> Self { self.shift = true; self }
-    pub fn with_ctrl(mut self) -> Self { self.ctrl = true; self }
-    pub fn with_meta(mut self) -> Self { self.meta = true; self }
-    pub fn with_alt(mut self) -> Self { self.alt = true; self }
+    /// Marks the event as having the Shift modifier pressed.
+    pub const fn with_shift(mut self) -> Self { self.shift = true; self }
+    /// Marks the event as having the Ctrl modifier pressed.
+    pub const fn with_ctrl(mut self) -> Self { self.ctrl = true; self }
+    /// Marks the event as having the Meta/Cmd modifier pressed.
+    pub const fn with_meta(mut self) -> Self { self.meta = true; self }
+    /// Marks the event as having the Alt/Option modifier pressed.
+    pub const fn with_alt(mut self) -> Self { self.alt = true; self }
+}
+
+// `AtomicBool` does not implement `Clone`, so the spec's field layout
+// requires a manual `Clone` impl instead of `#[derive(Clone)]`.
+impl Clone for SimulatedKeyEvent {
+    fn clone(&self) -> Self {
+        Self {
+            key: self.key,
+            shift: self.shift,
+            ctrl: self.ctrl,
+            meta: self.meta,
+            alt: self.alt,
+            default_prevented: AtomicBool::new(self.default_prevented.load(Ordering::Relaxed)),
+            propagation_stopped: AtomicBool::new(self.propagation_stopped.load(Ordering::Relaxed)),
+        }
+    }
 }
 
 impl crate::DomEvent for SimulatedKeyEvent {
@@ -4028,10 +4000,12 @@ impl crate::DomEvent for SimulatedKeyEvent {
 /// A recorder that captures the sequence of focus index changes
 /// during keyboard navigation testing.
 pub struct NavigationRecorder {
+    /// The ordered list of recorded navigation events.
     pub events: Vec<NavigationEvent>,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+/// A keyboard-navigation side effect emitted by a test harness.
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum NavigationEvent {
     FocusMoved { from: usize, to: usize },
     SelectionChanged { index: usize },
@@ -4040,7 +4014,8 @@ pub enum NavigationEvent {
 }
 
 impl NavigationRecorder {
-    pub fn new() -> Self { Self { events: Vec::new() } }
+    /// Creates an empty navigation recorder.
+    pub const fn new() -> Self { Self { events: Vec::new() } }
 
     pub fn record_focus_move(&mut self, from: usize, to: usize) {
         self.events.push(NavigationEvent::FocusMoved { from, to });
@@ -4055,6 +4030,10 @@ impl NavigationRecorder {
             .collect();
         assert_eq!(actual, expected, "Focus navigation sequence mismatch");
     }
+}
+
+impl Default for NavigationRecorder {
+    fn default() -> Self { Self::new() }
 }
 
 /// Test helper: simulate keyboard navigation through a FocusZone and
@@ -4080,14 +4059,19 @@ impl NavigationRecorder {
 /// recorder.assert_focus_sequence(&[(0, 1), (1, 2), (2, 4), (4, 3)]);
 /// ```
 pub struct FocusZoneTestHarness {
+    /// The focus zone under test.
     pub zone: FocusZone,
+    /// The current focused item index tracked by the harness.
     pub current_index: usize,
+    /// The recorder storing navigation side effects.
     pub recorder: NavigationRecorder,
+    /// Disabled item indices skipped by keyboard navigation when configured.
     pub disabled_indices: std::collections::BTreeSet<usize>,
 }
 
 impl FocusZoneTestHarness {
-    pub fn new(options: FocusZoneOptions, item_count: usize) -> Self {
+    /// Creates a new focus-zone harness starting at item index `0`.
+    pub const fn new(options: FocusZoneOptions, item_count: usize) -> Self {
         Self {
             zone: FocusZone::new(options, item_count),
             current_index: 0,
@@ -4096,6 +4080,7 @@ impl FocusZoneTestHarness {
         }
     }
 
+    /// Marks an item index as disabled for subsequent navigation.
     pub fn disable(&mut self, index: usize) {
         self.disabled_indices.insert(index);
     }
@@ -4114,6 +4099,7 @@ impl FocusZoneTestHarness {
         }
     }
 
+    /// Asserts that the harness focus is currently at `expected_index`.
     pub fn assert_at(&self, expected_index: usize) {
         assert_eq!(
             self.current_index, expected_index,
@@ -4127,8 +4113,9 @@ impl FocusZoneTestHarness {
 
 #[cfg(test)]
 mod tests {
+    use ars_collections::{CollectionBuilder, DisabledBehavior, Key, typeahead};
     use super::*;
-    use crate::focus::zone::{FocusZone, FocusZoneOptions, FocusZoneDirection};
+    use crate::{AriaRole, AriaValidationError, AriaValidator, FocusZoneOptions, FocusZoneDirection, LiveAnnouncer};
 
     #[test]
     fn vertical_zone_wraps() {
@@ -4172,33 +4159,41 @@ mod tests {
 
     #[test]
     fn typeahead_finds_matching_item() {
-        let mut ta = typeahead::State::new();
-        let labels = vec!["Apple", "Banana", "Cherry", "Apricot", "Blueberry"];
+        let collection = CollectionBuilder::new()
+            .item(Key::int(1), "Apple", "apple")
+            .item(Key::int(2), "Banana", "banana")
+            .item(Key::int(3), "Cherry", "cherry")
+            .item(Key::int(4), "Apricot", "apricot")
+            .item(Key::int(5), "Blueberry", "blueberry")
+            .build();
+        let disabled = Default::default();
 
-        let search = ta.process_key('a', 0.0);
-        let result = ta.find_next_match(
+        let state = typeahead::State::default();
+        let (state, result) = state.process_char(
+            'a',
             0,
-            labels.len(),
-            |i| labels[i].to_string(),
-            |_| false,
+            Some(&Key::int(1)),
+            &collection,
+            &disabled,
+            DisabledBehavior::Skip,
         );
-        assert_eq!(result, Some(3)); // "Apricot" comes after "Apple" (from_index=0)
+        assert_eq!(result, Some(Key::int(4))); // "Apricot" comes after "Apple"
 
-        let search2 = ta.process_key('p', 10.0); // 10ms later, still in window
-        let result2 = ta.find_next_match(
-            0,
-            labels.len(),
-            |i| labels[i].to_string(),
-            |_| false,
+        let (_, result2) = state.process_char(
+            'p',
+            10, // 10ms later, still in window
+            Some(&Key::int(4)),
+            &collection,
+            &disabled,
+            DisabledBehavior::Skip,
         );
-        assert_eq!(result2, Some(3)); // "Apricot" starts with "ap"
-        let _ = (search, search2);
+        assert_eq!(result2, Some(Key::int(4))); // "Apricot" starts with "ap"
     }
 
     #[test]
     fn aria_validator_catches_abstract_role() {
         let mut validator = AriaValidator::new();
-        validator.check_role(AriaRole::Widget, &[], false);
+        validator.check_role(AriaRole::Widget, &[], false, &[]);
         assert!(validator.has_errors());
         assert!(matches!(
             validator.errors()[0],
@@ -4210,7 +4205,7 @@ mod tests {
     fn aria_validator_catches_missing_required_attr() {
         let mut validator = AriaValidator::new();
         // Slider requires aria-valuenow
-        validator.check_role(AriaRole::Slider, &[], false);
+        validator.check_role(AriaRole::Slider, &[], false, &[]);
         assert!(validator.errors().iter().any(|e| matches!(
             e,
             AriaValidationError::MissingRequiredAttribute { missing_attr: "aria-valuenow", .. }
@@ -4221,11 +4216,11 @@ mod tests {
     fn live_announcer_deduplicates_voiceover() {
         let mut announcer = LiveAnnouncer::new();
         announcer.announce("Test message");
-        // VoiceOver toggle alternates on each call.
-        // A second identical message should have a different DOM content.
+        announcer.notify_announced();
         announcer.announce("Test message");
-        // The voiceover_toggle alternated → content differs → VoiceOver re-announces.
-        // This is the intended behavior; no assertion here, it's a behavioral guarantee.
+        announcer.notify_announced();
+        announcer.announce("Test message");
+        // The repeated message path alternates rendered content so VoiceOver re-announces.
     }
 }
 ````
@@ -4252,9 +4247,8 @@ crates/ars-a11y/
       zone.rs               // FocusZone, FocusZoneOptions, FocusZoneDirection
     keyboard/
       mod.rs
-      typeahead.rs          // typeahead::State, is_printable_key()
-                            // Depends on `unicode-normalization` crate (no_std + alloc compatible)
       shortcuts.rs          // KeyboardShortcut, KeyModifiers, Platform
+                            // Shared type-ahead state lives in `ars-collections::typeahead`
     announcer.rs            // LiveAnnouncer, AnnouncementPriority, Announcement
     announcements.rs        // Pre-built announcement string helpers
     visually_hidden.rs      // visually_hidden_attrs(), visually_hidden_focusable_attrs()


### PR DESCRIPTION
Closes #157

## Summary
- add the new keyboard testing helpers in `ars-a11y` and re-export them from the testing module
- sync the accessibility spec with the shipped helper API and improve targeted coverage around keyboard, focus zone, ARIA role, and collection helpers
- fix `ars-collections` no-std `indexmap` usage and move the typeahead integration test there to break the `ars-a11y` test-only dependency cycle

## Verification
- `cargo test -p ars-a11y`
- `cargo test -p ars-collections typeahead_finds_matching_item`
- `cargo check -p ars-a11y --tests`
- `cargo test -p ars-a11y keyboard -- --nocapture`
- `cargo xci`