### PR TITLE
Add @media print CSS reset (a11y spec §8)

### DIFF
--- a/crates/ars-core/ars-base.css
+++ b/crates/ars-core/ars-base.css
@@ -47,3 +47,45 @@
 .ars-touch-none {
   touch-action: none !important;
 }
+
+/* Print media reset — spec/foundation/03-accessibility.md §8.
+ * Hide overlays, suppress focus rings, undo scroll-lock side-effects,
+ * and remove portal content that is detached from its logical context.
+ * Consumers who need to override these defaults (e.g., to show a
+ * specific dialog in print) can use a higher-specificity selector or
+ * additional @media print rules after this stylesheet. */
+@media print {
+  /* §8.1 — Hide overlays and backdrops (alertdialog remains visible). */
+  [data-ars-scope="dialog"]:not([role="alertdialog"]),
+  [data-ars-scope="drawer"],
+  [data-ars-scope="popover"],
+  [data-ars-scope="tooltip"],
+  [data-ars-scope="toast"],
+  [data-ars-backdrop] {
+    display: none !important;
+  }
+
+  /* §8.3 — Remove scroll-lock side-effects. */
+  html,
+  body {
+    overflow: visible !important;
+    padding-right: 0 !important;
+    height: auto !important;
+  }
+
+  /* §8.4 — Hide portal root (content should be inlined for print). */
+  #ars-portal-root {
+    display: none !important;
+  }
+
+  /* §8.2 — Suppress focus indicators. */
+  [data-ars-focus-visible] {
+    outline: none !important;
+    box-shadow: none !important;
+  }
+
+  /* Suppress loading spinners / skeleton screens. */
+  [data-ars-state="loading"] {
+    visibility: hidden;
+  }
+}


### PR DESCRIPTION
## Summary

- Add `@media print` block to `crates/ars-core/ars-base.css` implementing `spec/foundation/03-accessibility.md` §8
- Hides overlays (dialog, drawer, popover, tooltip, toast) and backdrops — except `alertdialog` which may contain critical info
- Removes scroll-lock side-effects on `html`/`body` (`overflow`, `padding-right`, `height`)
- Hides `#ars-portal-root` (portaled content should be inlined for print)
- Suppresses focus ring indicators (`[data-ars-focus-visible]`)
- Hides loading spinners/skeleton screens (`[data-ars-state="loading"]`)

This is the final task for **Epic #3 (A11y)** — all prior waves (1–5, 16 issues) are already closed.

Closes #559
Closes #3

## Test plan

- [x] `cargo xci` passes all stages (fmt, check, clippy, unit, release, integration, adapter, coverage)
- [x] CSS selectors match spec §8.5 exactly
- [x] No Rust code changes — pure CSS addition

🤖 Generated with [Claude Code](https://claude.com/claude-code)