### PR TITLE
Implement date and relative-time formatters in ars-i18n

### DIFF
--- a/crates/ars-i18n/src/calendar.rs
+++ b/crates/ars-i18n/src/calendar.rs
@@ -5,14 +5,7 @@ mod helpers;
 mod system;
 mod typed;
 
-#[cfg(feature = "icu4x")]
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "issue #128 lays the internal calendar foundation; production consumers arrive in follow-up issues #129 and #138"
-    )
-)]
+#[cfg(any(feature = "icu4x", feature = "web-intl"))]
 pub(crate) mod internal;
 
 #[cfg(test)]
@@ -21,13 +14,13 @@ mod tests;
 
 pub use date::CalendarDate;
 pub use helpers::DateRange;
-#[cfg(feature = "icu4x")]
+#[cfg(any(feature = "icu4x", feature = "web-intl"))]
 pub(crate) use helpers::platform_today_iso;
 pub(crate) use helpers::{
     bounded_days_in_month, bounded_months_in_year, coptic_like_days_in_month, default_era_for,
     gregorian_days_in_month, minimum_day_in_month, minimum_month_in_year, years_in_era,
 };
-#[cfg(any(test, feature = "icu4x"))]
+#[cfg(any(test, feature = "icu4x", feature = "web-intl"))]
 pub(crate) use helpers::{epoch_days_to_iso, iso_to_epoch_days};
 pub use system::{
     CalendarConversionError, CalendarError, CalendarMetadata, CalendarSystem, DateError, Era,

--- a/crates/ars-i18n/src/calendar/helpers.rs
+++ b/crates/ars-i18n/src/calendar/helpers.rs
@@ -10,7 +10,11 @@ use crate::IcuProvider;
 pub(super) const GREGORIAN_JDN_OFFSET: i64 = 1_721_426;
 
 /// Number of days between `0001-01-01` and the Unix epoch `1970-01-01`.
-#[cfg(all(feature = "icu4x", feature = "std", not(target_arch = "wasm32")))]
+#[cfg(all(
+    any(feature = "icu4x", feature = "web-intl"),
+    feature = "std",
+    not(target_arch = "wasm32")
+))]
 const UNIX_EPOCH_DAYS_FROM_CE: i64 = 719_162;
 
 /// Returns the number of days in a proleptic Gregorian month.
@@ -366,7 +370,11 @@ pub(crate) const fn epoch_days_to_iso(epoch_days: i64) -> (i32, u8, u8) {
     (year, month, day)
 }
 
-#[cfg(all(feature = "icu4x", feature = "std", not(target_arch = "wasm32")))]
+#[cfg(all(
+    any(feature = "icu4x", feature = "web-intl"),
+    feature = "std",
+    not(target_arch = "wasm32")
+))]
 pub(crate) fn platform_today_iso() -> Result<(i32, u8, u8), String> {
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -382,7 +390,26 @@ pub(crate) fn platform_today_iso() -> Result<(i32, u8, u8), String> {
     Ok(epoch_days_to_iso(days + UNIX_EPOCH_DAYS_FROM_CE))
 }
 
-#[cfg(all(feature = "icu4x", target_arch = "wasm32", feature = "web-intl"))]
+#[cfg(all(
+    any(feature = "icu4x", feature = "web-intl"),
+    feature = "std",
+    not(target_arch = "wasm32")
+))]
+// Keep the native `today()` plumbing reachable in library builds until the
+// full provider/default-provider tasks wire these helpers through normal
+// runtime call paths.
+const _: i64 = UNIX_EPOCH_DAYS_FROM_CE;
+
+#[cfg(all(
+    any(feature = "icu4x", feature = "web-intl"),
+    feature = "std",
+    not(target_arch = "wasm32")
+))]
+// This is the same reachability trick for the function item itself; remove it
+// once follow-up provider work gives `platform_today_iso()` a real caller.
+const _: fn() -> Result<(i32, u8, u8), String> = platform_today_iso;
+
+#[cfg(all(target_arch = "wasm32", feature = "web-intl"))]
 pub(crate) fn platform_today_iso() -> Result<(i32, u8, u8), String> {
     let date = js_sys::Date::new_0();
 
@@ -405,7 +432,11 @@ pub(crate) fn platform_today_iso() -> Result<(i32, u8, u8), String> {
     ))
 }
 
-#[cfg(all(feature = "icu4x", not(feature = "std"), not(target_arch = "wasm32")))]
+#[cfg(all(
+    any(feature = "icu4x", feature = "web-intl"),
+    not(feature = "std"),
+    not(target_arch = "wasm32")
+))]
 pub(crate) fn platform_today_iso() -> Result<(i32, u8, u8), String> {
     Err(String::from(
         "platform date unavailable without the `std` feature",

--- a/crates/ars-i18n/src/calendar/internal.rs
+++ b/crates/ars-i18n/src/calendar/internal.rs
@@ -1,7 +1,7 @@
 use alloc::string::{String, ToString};
 
 use icu::calendar::{
-    AnyCalendar, Date, Iso,
+    AnyCalendar, AnyCalendarKind, Date, Iso,
     cal::{
         Buddhist, ChineseTraditional, Coptic, Ethiopian, EthiopianEraStyle, Hebrew, Hijri, Indian,
         Japanese, KoreanTraditional, Persian, Roc,
@@ -76,10 +76,17 @@ impl CalendarDate {
         }
     }
 
-    /// Returns the display year for the date's calendar.
+    /// Returns the public year for the date's calendar.
+    ///
+    /// Gregorian public dates use astronomical year numbering even though ICU
+    /// exposes CE/BCE era years for Gregorian dates.
     #[must_use]
     pub(crate) fn year(&self) -> i32 {
-        self.inner.year().era_year_or_related_iso()
+        if self.inner.calendar().kind() == AnyCalendarKind::Gregorian {
+            self.inner.year().extended_year()
+        } else {
+            self.inner.year().era_year_or_related_iso()
+        }
     }
 
     /// Returns the 1-based month ordinal.

--- a/crates/ars-i18n/src/calendar/internal.rs
+++ b/crates/ars-i18n/src/calendar/internal.rs
@@ -2,6 +2,11 @@ use alloc::string::{String, ToString};
 
 use icu::calendar::{
     AnyCalendar, Date, Iso,
+    cal::{
+        Buddhist, ChineseTraditional, Coptic, Ethiopian, EthiopianEraStyle, Hebrew, Hijri, Indian,
+        Japanese, KoreanTraditional, Persian, Roc,
+        hijri::{self},
+    },
     error::DateFromFieldsError,
     types::{DateFields, YearInput},
 };
@@ -67,9 +72,7 @@ impl CalendarDate {
     #[must_use]
     pub(crate) fn to_calendar(&self, calendar: CalendarSystem) -> Self {
         Self {
-            inner: self
-                .inner
-                .to_calendar(AnyCalendar::new(calendar.to_icu_kind())),
+            inner: self.inner.to_calendar(any_calendar_for(calendar)),
         }
     }
 
@@ -161,10 +164,18 @@ impl CalendarDate {
             .map_err(|error| CalendarError::Arithmetic(error.to_string()))?;
 
         Ok(Self {
-            inner: iso.to_calendar(AnyCalendar::new(calendar.to_icu_kind())),
+            inner: iso.to_calendar(any_calendar_for(calendar)),
         })
     }
 }
+
+// Keep these internal helpers live in non-test library builds while they are
+// only exercised indirectly by formatter/provider follow-up work and tests.
+const _: fn(&CalendarDate) -> Weekday = CalendarDate::weekday;
+const _: fn(&CalendarDate, i32) -> Result<CalendarDate, CalendarError> = CalendarDate::add_days;
+const _: fn(&CalendarDate, &CalendarDate) -> Result<i32, CalendarError> = CalendarDate::days_until;
+const _: fn(&CalendarDate, &CalendarDate) -> Result<bool, CalendarError> = CalendarDate::is_before;
+const _: fn(CalendarSystem) -> Result<CalendarDate, CalendarError> = CalendarDate::today;
 
 pub(crate) fn months_in_year(year: i32, calendar: CalendarSystem, era: Option<&str>) -> Option<u8> {
     let date = date_from_ordinal_fields(year_input_from_parts(calendar, era, year), 1, 1, calendar)
@@ -230,14 +241,13 @@ fn date_from_ordinal_fields(
     day: u8,
     calendar: CalendarSystem,
 ) -> Result<Date<AnyCalendar>, DateFromFieldsError> {
-    let any_calendar = AnyCalendar::new(calendar.to_icu_kind());
     let mut fields = DateFields::default();
 
     assign_year_fields(&mut fields, year);
     fields.ordinal_month = Some(ordinal_month);
     fields.day = Some(day);
 
-    Date::try_from_fields(fields, Default::default(), any_calendar)
+    Date::try_from_fields(fields, Default::default(), any_calendar_for(calendar))
 }
 
 fn assign_year_fields<'a>(fields: &mut DateFields<'a>, year: YearInput<'a>) {
@@ -276,5 +286,50 @@ const fn default_era_code(calendar: CalendarSystem) -> Option<&'static str> {
     match calendar {
         CalendarSystem::Japanese => Some("reiwa"),
         _ => None,
+    }
+}
+
+#[expect(
+    deprecated,
+    reason = "CalendarSystem::Islamic maps to ICU4X's simulated Mecca Hijri constructor and enum variant"
+)]
+fn any_calendar_for(calendar: CalendarSystem) -> AnyCalendar {
+    match calendar {
+        CalendarSystem::Gregorian => AnyCalendar::Gregorian(icu::calendar::Gregorian),
+
+        CalendarSystem::Buddhist => AnyCalendar::Buddhist(Buddhist),
+
+        CalendarSystem::Japanese => AnyCalendar::Japanese(Japanese::default()),
+
+        CalendarSystem::Hebrew => AnyCalendar::Hebrew(Hebrew),
+
+        CalendarSystem::Islamic => AnyCalendar::HijriSimulated(Hijri::new_simulated_mecca()),
+
+        CalendarSystem::IslamicCivil => AnyCalendar::HijriTabular(Hijri::new_tabular(
+            hijri::TabularAlgorithmLeapYears::TypeII,
+            hijri::TabularAlgorithmEpoch::Friday,
+        )),
+
+        CalendarSystem::IslamicUmmAlQura => AnyCalendar::HijriUmmAlQura(Hijri::new_umm_al_qura()),
+
+        CalendarSystem::Persian => AnyCalendar::Persian(Persian),
+
+        CalendarSystem::Indian => AnyCalendar::Indian(Indian),
+
+        CalendarSystem::Chinese => AnyCalendar::Chinese(ChineseTraditional::new()),
+
+        CalendarSystem::Coptic => AnyCalendar::Coptic(Coptic),
+
+        CalendarSystem::Dangi => AnyCalendar::Dangi(KoreanTraditional::new()),
+
+        CalendarSystem::Ethiopic => AnyCalendar::Ethiopian(Ethiopian::new_with_era_style(
+            EthiopianEraStyle::AmeteMihret,
+        )),
+
+        CalendarSystem::EthiopicAmeteAlem => {
+            AnyCalendar::Ethiopian(Ethiopian::new_with_era_style(EthiopianEraStyle::AmeteAlem))
+        }
+
+        CalendarSystem::Roc => AnyCalendar::Roc(Roc),
     }
 }

--- a/crates/ars-i18n/src/date.rs
+++ b/crates/ars-i18n/src/date.rs
@@ -4,6 +4,7 @@
 //! builds. Backend selection is internal to this module.
 
 #[cfg(any(
+    all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")),
     not(any(feature = "icu4x", feature = "web-intl")),
     all(
         feature = "web-intl",
@@ -250,16 +251,20 @@ fn js_date_from_calendar(date: &CalendarDate) -> JsDate {
 
 #[cfg(all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")))]
 fn js_date_from_ymd(year: i32, month: u8, day: u8) -> JsDate {
-    let date = JsDate::new(&JsValue::from_f64(0.0));
+    let iso = format!("{}-{month:02}-{day:02}T12:00:00.000Z", js_iso_year(year),);
 
-    date.set_utc_full_year_with_month_date(
-        u32::try_from(year).expect("browser-backed date formatting requires Gregorian years >= 0"),
-        i32::from(month) - 1,
-        i32::from(day),
-    );
-    date.set_utc_hours(12);
+    JsDate::new(&JsValue::from_str(&iso))
+}
 
-    date
+#[cfg(all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")))]
+fn js_iso_year(year: i32) -> String {
+    if (0..=9_999).contains(&year) {
+        format!("{year:04}")
+    } else if year < 0 {
+        format!("-{:06}", year.unsigned_abs())
+    } else {
+        format!("+{year:06}")
+    }
 }
 
 #[cfg(any(
@@ -520,7 +525,9 @@ mod web_intl_tests {
 
     use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
 
-    use super::{DateFormatter, FormatLength, js_date_from_calendar, js_date_from_ymd};
+    use super::{
+        DateFormatter, FormatLength, js_date_from_calendar, js_date_from_ymd, js_iso_year,
+    };
     use crate::{CalendarDate, CalendarSystem, Locale, locales};
 
     wasm_bindgen_test_configure!(run_in_browser);
@@ -595,6 +602,17 @@ mod web_intl_tests {
         assert_eq!(converted.get_utc_full_year(), 44);
         assert_eq!(converted.get_utc_month(), 2);
         assert_eq!(converted.get_utc_date(), 15);
+    }
+
+    #[wasm_bindgen_test]
+    fn web_intl_date_helpers_support_pre_ce_gregorian_dates() {
+        let js_date = js_date_from_ymd(-1, 1, 1);
+
+        assert_eq!(js_date.to_iso_string(), "-000001-01-01T12:00:00.000Z");
+        assert_eq!(js_iso_year(-1), "-000001");
+        assert_eq!(js_iso_year(0), "0000");
+        assert_eq!(js_iso_year(44), "0044");
+        assert_eq!(js_iso_year(10_000), "+010000");
     }
 
     fn direct_browser_format(locale: &Locale, length: FormatLength, date: &CalendarDate) -> String {

--- a/crates/ars-i18n/src/date.rs
+++ b/crates/ars-i18n/src/date.rs
@@ -250,11 +250,16 @@ fn js_date_from_calendar(date: &CalendarDate) -> JsDate {
 
 #[cfg(all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")))]
 fn js_date_from_ymd(year: i32, month: u8, day: u8) -> JsDate {
-    let millis = JsDate::utc(f64::from(year), f64::from(month - 1))
-        + f64::from(day - 1) * 86_400_000.0
-        + 43_200_000.0;
+    let date = JsDate::new(&JsValue::from_f64(0.0));
 
-    JsDate::new(&JsValue::from_f64(millis))
+    date.set_utc_full_year_with_month_date(
+        u32::try_from(year).expect("browser-backed date formatting requires Gregorian years >= 0"),
+        i32::from(month) - 1,
+        i32::from(day),
+    );
+    date.set_utc_hours(12);
+
+    date
 }
 
 #[cfg(any(
@@ -515,7 +520,7 @@ mod web_intl_tests {
 
     use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
 
-    use super::{DateFormatter, FormatLength, js_date_from_calendar};
+    use super::{DateFormatter, FormatLength, js_date_from_calendar, js_date_from_ymd};
     use crate::{CalendarDate, CalendarSystem, Locale, locales};
 
     wasm_bindgen_test_configure!(run_in_browser);
@@ -571,6 +576,25 @@ mod web_intl_tests {
         assert_eq!(formatted, direct);
         assert!(formatted.contains("Reiwa"));
         assert_ne!(formatted, date.to_iso8601());
+    }
+
+    #[wasm_bindgen_test]
+    fn web_intl_date_helpers_preserve_low_gregorian_years() {
+        let date = CalendarDate::new_gregorian(
+            44,
+            NonZero::new(3).expect("nonzero"),
+            NonZero::new(15).expect("nonzero"),
+        );
+
+        let js_date = js_date_from_ymd(44, 3, 15);
+        let converted = js_date_from_calendar(&date);
+
+        assert_eq!(js_date.get_utc_full_year(), 44);
+        assert_eq!(js_date.get_utc_month(), 2);
+        assert_eq!(js_date.get_utc_date(), 15);
+        assert_eq!(converted.get_utc_full_year(), 44);
+        assert_eq!(converted.get_utc_month(), 2);
+        assert_eq!(converted.get_utc_date(), 15);
     }
 
     fn direct_browser_format(locale: &Locale, length: FormatLength, date: &CalendarDate) -> String {

--- a/crates/ars-i18n/src/date.rs
+++ b/crates/ars-i18n/src/date.rs
@@ -1,0 +1,600 @@
+//! Locale-aware date formatting helpers.
+//!
+//! The public API stays stable across ICU4X, browser `Intl`, and fallback
+//! builds. Backend selection is internal to this module.
+
+#[cfg(any(
+    not(any(feature = "icu4x", feature = "web-intl")),
+    all(
+        feature = "web-intl",
+        not(target_arch = "wasm32"),
+        not(feature = "icu4x")
+    )
+))]
+use alloc::format;
+use alloc::string::String;
+
+#[cfg(feature = "icu4x")]
+use icu::datetime::{
+    DateTimeFormatter as IcuDateTimeFormatter, DateTimeFormatterPreferences,
+    fieldsets::{T, YMD, YMDE},
+};
+#[cfg(all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")))]
+use {
+    js_sys::{
+        Array, Date as JsDate, Function,
+        Intl::{DateTimeFormat as JsDateTimeFormat, DateTimeFormatOptions, DateTimeStyle},
+    },
+    wasm_bindgen::JsValue,
+};
+
+#[cfg(any(
+    all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")),
+    not(any(feature = "icu4x", feature = "web-intl")),
+    all(
+        feature = "web-intl",
+        not(target_arch = "wasm32"),
+        not(feature = "icu4x")
+    )
+))]
+use crate::CalendarSystem;
+#[cfg(any(feature = "icu4x", all(feature = "web-intl", target_arch = "wasm32")))]
+use crate::calendar::internal::CalendarDate as InternalCalendarDate;
+use crate::{CalendarDate, Locale};
+
+/// Length of the formatted date/time string.
+#[derive(Clone, Copy, Debug, PartialEq, Default)]
+pub enum FormatLength {
+    /// Full date with weekday.
+    Full,
+    /// Long month name date.
+    Long,
+    /// Medium abbreviated date.
+    #[default]
+    Medium,
+    /// Short numeric date.
+    Short,
+}
+
+impl FormatLength {
+    /// Returns the ICU4X field set for date-only formatting.
+    #[cfg(feature = "icu4x")]
+    fn to_icu_date_field_set(self) -> YMD {
+        debug_assert!(
+            !self.is_full(),
+            "full format must use to_icu_full_date_field_set"
+        );
+
+        match self {
+            Self::Full | Self::Long => YMD::long(),
+            Self::Medium => YMD::medium(),
+            Self::Short => YMD::short(),
+        }
+    }
+
+    /// Returns the ICU4X field set for weekday-inclusive full dates.
+    #[cfg(feature = "icu4x")]
+    const fn to_icu_full_date_field_set(self) -> YMDE {
+        YMDE::long()
+    }
+
+    /// Returns `true` when this format length includes the weekday.
+    #[must_use]
+    pub const fn is_full(self) -> bool {
+        matches!(self, Self::Full)
+    }
+
+    /// Returns the ICU4X field set for time-only formatting.
+    #[cfg(feature = "icu4x")]
+    #[expect(
+        dead_code,
+        reason = "time field-set support is part of the public formatter contract even though date-only formatting is implemented in this task"
+    )]
+    fn to_icu_time_field_set(self) -> T {
+        match self {
+            Self::Full | Self::Long => T::hms(),
+            Self::Medium | Self::Short => T::hm(),
+        }
+    }
+
+    #[cfg(all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")))]
+    const fn to_js_date_style(self) -> DateTimeStyle {
+        match self {
+            Self::Full => DateTimeStyle::Full,
+            Self::Long => DateTimeStyle::Long,
+            Self::Medium => DateTimeStyle::Medium,
+            Self::Short => DateTimeStyle::Short,
+        }
+    }
+}
+
+/// Internal ICU4X formatter storage.
+#[cfg(feature = "icu4x")]
+#[derive(Debug)]
+enum DateFormatterInner {
+    Ymd(IcuDateTimeFormatter<YMD>),
+    Ymde(IcuDateTimeFormatter<YMDE>),
+}
+
+/// A locale-aware date formatter.
+pub struct DateFormatter {
+    locale: Locale,
+    length: FormatLength,
+    #[cfg(feature = "icu4x")]
+    inner: DateFormatterInner,
+    #[cfg(all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")))]
+    inner: JsDateTimeFormat,
+}
+
+impl core::fmt::Debug for DateFormatter {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DateFormatter")
+            .field("locale", &self.locale)
+            .field("length", &self.length)
+            .finish()
+    }
+}
+
+#[cfg(feature = "icu4x")]
+impl DateFormatter {
+    /// Creates a new locale-aware date formatter.
+    #[must_use]
+    pub fn new(locale: &Locale, length: FormatLength) -> Self {
+        let prefs = DateTimeFormatterPreferences::from(locale.as_icu());
+
+        let inner = if length.is_full() {
+            DateFormatterInner::Ymde(
+                IcuDateTimeFormatter::try_new(prefs, length.to_icu_full_date_field_set())
+                    .expect("compiled_data guarantees date formatter data for all locales"),
+            )
+        } else {
+            DateFormatterInner::Ymd(
+                IcuDateTimeFormatter::try_new(prefs, length.to_icu_date_field_set())
+                    .expect("compiled_data guarantees date formatter data for all locales"),
+            )
+        };
+
+        Self {
+            locale: locale.clone(),
+            length,
+            inner,
+        }
+    }
+
+    /// Formats a calendar date for the formatter locale.
+    #[must_use]
+    pub fn format(&self, date: &CalendarDate) -> String {
+        let internal = InternalCalendarDate::try_from(date)
+            .expect("CalendarDate should be valid for formatting");
+
+        match &self.inner {
+            DateFormatterInner::Ymd(formatter) => formatter.format(&internal.inner).to_string(),
+            DateFormatterInner::Ymde(formatter) => formatter.format(&internal.inner).to_string(),
+        }
+    }
+}
+
+#[cfg(all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")))]
+impl DateFormatter {
+    /// Creates a new browser-backed date formatter.
+    #[must_use]
+    pub fn new(locale: &Locale, length: FormatLength) -> Self {
+        let locales = Array::of1(&JsValue::from_str(&locale.to_bcp47()));
+
+        let options = DateTimeFormatOptions::new();
+        options.set_date_style(length.to_js_date_style());
+        options.set_time_zone("UTC");
+
+        let formatter = JsDateTimeFormat::new(&locales, options.as_ref());
+
+        Self {
+            locale: locale.clone(),
+            length,
+            inner: formatter,
+        }
+    }
+
+    /// Formats a calendar date through `Intl.DateTimeFormat`.
+    ///
+    /// Public `CalendarDate` values are first resolved to their absolute
+    /// Gregorian day and then formatted using the locale's active calendar,
+    /// including any `u-ca-*` Unicode extension carried by the locale.
+    #[must_use]
+    pub fn format(&self, date: &CalendarDate) -> String {
+        let js_date = js_date_from_calendar(date);
+
+        let format: Function = self.inner.format();
+
+        format
+            .call1(&JsValue::UNDEFINED, js_date.as_ref())
+            .expect("Intl.DateTimeFormat.format should not throw for a valid Date")
+            .as_string()
+            .unwrap_or_default()
+    }
+}
+
+#[cfg(any(
+    not(any(feature = "icu4x", feature = "web-intl")),
+    all(
+        feature = "web-intl",
+        not(target_arch = "wasm32"),
+        not(feature = "icu4x")
+    )
+))]
+impl DateFormatter {
+    /// Creates a compile-safe fallback date formatter.
+    #[must_use]
+    pub fn new(locale: &Locale, length: FormatLength) -> Self {
+        Self {
+            locale: locale.clone(),
+            length,
+        }
+    }
+
+    /// Formats dates using a deterministic English fallback.
+    #[must_use]
+    pub fn format(&self, date: &CalendarDate) -> String {
+        fallback_format_date(&self.locale, self.length, date)
+    }
+}
+
+#[cfg(all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")))]
+fn js_date_from_calendar(date: &CalendarDate) -> JsDate {
+    let internal = InternalCalendarDate::try_from(date)
+        .expect("CalendarDate should be valid for browser date formatting");
+
+    let gregorian = internal.to_calendar(CalendarSystem::Gregorian);
+
+    js_date_from_ymd(gregorian.year(), gregorian.month(), gregorian.day())
+}
+
+#[cfg(all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")))]
+fn js_date_from_ymd(year: i32, month: u8, day: u8) -> JsDate {
+    let millis = JsDate::utc(f64::from(year), f64::from(month - 1))
+        + f64::from(day - 1) * 86_400_000.0
+        + 43_200_000.0;
+
+    JsDate::new(&JsValue::from_f64(millis))
+}
+
+#[cfg(any(
+    not(any(feature = "icu4x", feature = "web-intl")),
+    all(
+        feature = "web-intl",
+        not(target_arch = "wasm32"),
+        not(feature = "icu4x")
+    )
+))]
+fn fallback_format_date(_locale: &Locale, length: FormatLength, date: &CalendarDate) -> String {
+    if date.calendar != CalendarSystem::Gregorian {
+        return date.to_iso8601();
+    }
+
+    let year = date.year;
+    let month = date.month.get();
+    let day = date.day.get();
+
+    match length {
+        FormatLength::Short => format!("{month}/{day}/{:02}", year.rem_euclid(100)),
+
+        FormatLength::Medium => {
+            format!("{} {day}, {year}", english_month_short(month))
+        }
+
+        FormatLength::Long => {
+            format!("{} {day}, {year}", english_month_long(month))
+        }
+
+        FormatLength::Full => {
+            format!(
+                "{}, {} {day}, {year}",
+                english_weekday_long(date.weekday()),
+                english_month_long(month)
+            )
+        }
+    }
+}
+
+#[cfg(any(
+    not(any(feature = "icu4x", feature = "web-intl")),
+    all(
+        feature = "web-intl",
+        not(target_arch = "wasm32"),
+        not(feature = "icu4x")
+    )
+))]
+const fn english_month_short(month: u8) -> &'static str {
+    match month {
+        1 => "Jan",
+        2 => "Feb",
+        3 => "Mar",
+        4 => "Apr",
+        5 => "May",
+        6 => "Jun",
+        7 => "Jul",
+        8 => "Aug",
+        9 => "Sep",
+        10 => "Oct",
+        11 => "Nov",
+        12 => "Dec",
+        _ => "???",
+    }
+}
+
+#[cfg(any(
+    not(any(feature = "icu4x", feature = "web-intl")),
+    all(
+        feature = "web-intl",
+        not(target_arch = "wasm32"),
+        not(feature = "icu4x")
+    )
+))]
+const fn english_month_long(month: u8) -> &'static str {
+    match month {
+        1 => "January",
+        2 => "February",
+        3 => "March",
+        4 => "April",
+        5 => "May",
+        6 => "June",
+        7 => "July",
+        8 => "August",
+        9 => "September",
+        10 => "October",
+        11 => "November",
+        12 => "December",
+        _ => "Unknown",
+    }
+}
+
+#[cfg(any(
+    not(any(feature = "icu4x", feature = "web-intl")),
+    all(
+        feature = "web-intl",
+        not(target_arch = "wasm32"),
+        not(feature = "icu4x")
+    )
+))]
+const fn english_weekday_long(weekday: crate::Weekday) -> &'static str {
+    match weekday {
+        crate::Weekday::Sunday => "Sunday",
+        crate::Weekday::Monday => "Monday",
+        crate::Weekday::Tuesday => "Tuesday",
+        crate::Weekday::Wednesday => "Wednesday",
+        crate::Weekday::Thursday => "Thursday",
+        crate::Weekday::Friday => "Friday",
+        crate::Weekday::Saturday => "Saturday",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(feature = "icu4x")]
+    use alloc::string::String;
+    #[cfg(feature = "icu4x")]
+    use core::num::NonZero;
+
+    #[cfg(feature = "icu4x")]
+    use super::{DateFormatter, FormatLength};
+    #[cfg(any(
+        not(any(feature = "icu4x", feature = "web-intl")),
+        all(
+            feature = "web-intl",
+            not(target_arch = "wasm32"),
+            not(feature = "icu4x")
+        )
+    ))]
+    use super::{DateFormatter, FormatLength};
+    #[cfg(any(
+        not(any(feature = "icu4x", feature = "web-intl")),
+        all(
+            feature = "web-intl",
+            not(target_arch = "wasm32"),
+            not(feature = "icu4x")
+        )
+    ))]
+    use crate::locales;
+    #[cfg(feature = "icu4x")]
+    use crate::{CalendarDate, CalendarSystem, Era, Locale, locales};
+
+    #[cfg(feature = "icu4x")]
+    fn march_2024() -> CalendarDate {
+        CalendarDate::new_gregorian(
+            2024,
+            NonZero::new(3).expect("nonzero"),
+            NonZero::new(15).expect("nonzero"),
+        )
+    }
+
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn short_date_formatter_formats_en_us_date() {
+        let formatter = DateFormatter::new(&locales::en_us(), FormatLength::Short);
+
+        assert_eq!(formatter.format(&march_2024()), "3/15/24");
+    }
+
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn full_date_formatter_includes_weekday_name() {
+        let formatter = DateFormatter::new(&locales::en_us(), FormatLength::Full);
+
+        let formatted = formatter.format(&march_2024());
+
+        assert!(formatted.contains("Friday"));
+        assert!(formatted.contains("March"));
+        assert!(formatted.contains("2024"));
+    }
+
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn date_formatter_supports_representative_locales() {
+        let english = DateFormatter::new(&locales::en_us(), FormatLength::Medium);
+
+        let german = DateFormatter::new(
+            &Locale::parse("de-DE").expect("locale should parse"),
+            FormatLength::Medium,
+        );
+
+        let arabic = DateFormatter::new(
+            &Locale::parse("ar-SA").expect("locale should parse"),
+            FormatLength::Medium,
+        );
+
+        let japanese = DateFormatter::new(
+            &Locale::parse("ja-JP").expect("locale should parse"),
+            FormatLength::Medium,
+        );
+
+        assert_ne!(english.format(&march_2024()), german.format(&march_2024()));
+        assert_ne!(english.format(&march_2024()), arabic.format(&march_2024()));
+        assert_ne!(
+            english.format(&march_2024()),
+            japanese.format(&march_2024())
+        );
+    }
+
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn non_gregorian_japanese_dates_format_with_era_year() {
+        let formatter = DateFormatter::new(
+            &Locale::parse("en-US-u-ca-japanese").expect("locale should parse"),
+            FormatLength::Long,
+        );
+
+        let date = CalendarDate {
+            calendar: CalendarSystem::Japanese,
+            era: Some(Era {
+                code: String::from("reiwa"),
+                display_name: String::from("Reiwa"),
+            }),
+            year: 1,
+            month: NonZero::new(5).expect("nonzero"),
+            day: NonZero::new(1).expect("nonzero"),
+        };
+
+        let formatted = formatter.format(&date);
+
+        assert!(formatted.contains("Reiwa"));
+        assert!(formatted.contains("May"));
+        assert_ne!(formatted, date.to_iso8601());
+    }
+
+    #[cfg(any(
+        not(any(feature = "icu4x", feature = "web-intl")),
+        all(
+            feature = "web-intl",
+            not(target_arch = "wasm32"),
+            not(feature = "icu4x")
+        )
+    ))]
+    #[test]
+    fn fallback_date_formatter_keeps_api_available() {
+        let formatter = DateFormatter::new(&locales::en_us(), FormatLength::Full);
+
+        let formatted = formatter.format(&crate::CalendarDate::new_gregorian(
+            2024,
+            core::num::NonZero::new(3).expect("nonzero"),
+            core::num::NonZero::new(15).expect("nonzero"),
+        ));
+
+        assert!(formatted.contains("Friday"));
+        assert!(formatted.contains("March"));
+    }
+}
+
+#[cfg(all(
+    test,
+    feature = "web-intl",
+    target_arch = "wasm32",
+    not(feature = "icu4x")
+))]
+mod web_intl_tests {
+    use alloc::string::String;
+    use core::num::NonZero;
+
+    use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+
+    use super::{DateFormatter, FormatLength, js_date_from_calendar};
+    use crate::{CalendarDate, CalendarSystem, Locale, locales};
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    fn march_2024() -> CalendarDate {
+        CalendarDate::new_gregorian(
+            2024,
+            NonZero::new(3).expect("nonzero"),
+            NonZero::new(15).expect("nonzero"),
+        )
+    }
+
+    #[wasm_bindgen_test]
+    fn web_intl_date_formatter_formats_gregorian_dates() {
+        let formatter = DateFormatter::new(&locales::en_us(), FormatLength::Short);
+
+        assert_eq!(formatter.format(&march_2024()), "3/15/24");
+    }
+
+    #[wasm_bindgen_test]
+    fn web_intl_date_formatter_tracks_locale_shape() {
+        let english = DateFormatter::new(&locales::en_us(), FormatLength::Medium);
+
+        let german = DateFormatter::new(
+            &Locale::parse("de-DE").expect("locale should parse"),
+            FormatLength::Medium,
+        );
+
+        assert_ne!(english.format(&march_2024()), german.format(&march_2024()));
+    }
+
+    #[wasm_bindgen_test]
+    fn web_intl_date_formatter_formats_non_gregorian_dates_via_browser_calendar() {
+        let locale = Locale::parse("en-US-u-ca-japanese").expect("locale should parse");
+
+        let formatter = DateFormatter::new(&locale, FormatLength::Long);
+
+        let date = CalendarDate {
+            calendar: CalendarSystem::Japanese,
+            era: Some(crate::Era {
+                code: String::from("reiwa"),
+                display_name: String::from("Reiwa"),
+            }),
+            year: 1,
+            month: NonZero::new(5).expect("nonzero"),
+            day: NonZero::new(1).expect("nonzero"),
+        };
+
+        let direct = direct_browser_format(&locale, FormatLength::Long, &date);
+
+        let formatted = formatter.format(&date);
+
+        assert_eq!(formatted, direct);
+        assert!(formatted.contains("Reiwa"));
+        assert_ne!(formatted, date.to_iso8601());
+    }
+
+    fn direct_browser_format(locale: &Locale, length: FormatLength, date: &CalendarDate) -> String {
+        use js_sys::{
+            Array, Function,
+            Intl::{DateTimeFormat as JsDateTimeFormat, DateTimeFormatOptions},
+        };
+        use wasm_bindgen::JsValue;
+
+        let locales = Array::of1(&JsValue::from_str(&locale.to_bcp47()));
+
+        let options = DateTimeFormatOptions::new();
+
+        options.set_date_style(length.to_js_date_style());
+        options.set_time_zone("UTC");
+
+        let formatter = JsDateTimeFormat::new(&locales, options.as_ref());
+
+        let format: Function = formatter.format();
+
+        format
+            .call1(&JsValue::UNDEFINED, js_date_from_calendar(date).as_ref())
+            .expect("Intl.DateTimeFormat.format should not throw for a valid Date")
+            .as_string()
+            .unwrap_or_default()
+    }
+}

--- a/crates/ars-i18n/src/date.rs
+++ b/crates/ars-i18n/src/date.rs
@@ -4,6 +4,7 @@
 //! builds. Backend selection is internal to this module.
 
 #[cfg(any(
+    feature = "icu4x",
     all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")),
     not(any(feature = "icu4x", feature = "web-intl")),
     all(
@@ -29,19 +30,9 @@ use {
     wasm_bindgen::JsValue,
 };
 
-#[cfg(any(
-    all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")),
-    not(any(feature = "icu4x", feature = "web-intl")),
-    all(
-        feature = "web-intl",
-        not(target_arch = "wasm32"),
-        not(feature = "icu4x")
-    )
-))]
-use crate::CalendarSystem;
 #[cfg(any(feature = "icu4x", all(feature = "web-intl", target_arch = "wasm32")))]
 use crate::calendar::internal::CalendarDate as InternalCalendarDate;
-use crate::{CalendarDate, Locale};
+use crate::{CalendarDate, CalendarSystem, Locale};
 
 /// Length of the formatted date/time string.
 #[derive(Clone, Copy, Debug, PartialEq, Default)]
@@ -165,8 +156,9 @@ impl DateFormatter {
     /// Formats a calendar date for the formatter locale.
     #[must_use]
     pub fn format(&self, date: &CalendarDate) -> String {
-        let internal = InternalCalendarDate::try_from(date)
-            .expect("CalendarDate should be valid for formatting");
+        let Ok(internal) = InternalCalendarDate::try_from(date) else {
+            return fallback_format_date(&self.locale, self.length, date);
+        };
 
         match &self.inner {
             DateFormatterInner::Ymd(formatter) => formatter.format(&internal.inner).to_string(),
@@ -202,7 +194,9 @@ impl DateFormatter {
     /// including any `u-ca-*` Unicode extension carried by the locale.
     #[must_use]
     pub fn format(&self, date: &CalendarDate) -> String {
-        let js_date = js_date_from_calendar(date);
+        let Some(js_date) = js_date_from_calendar(date) else {
+            return fallback_format_date(&self.locale, self.length, date);
+        };
 
         let format: Function = self.inner.format();
 
@@ -240,13 +234,24 @@ impl DateFormatter {
 }
 
 #[cfg(all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")))]
-fn js_date_from_calendar(date: &CalendarDate) -> JsDate {
-    let internal = InternalCalendarDate::try_from(date)
-        .expect("CalendarDate should be valid for browser date formatting");
+fn js_date_from_calendar(date: &CalendarDate) -> Option<JsDate> {
+    if date.calendar == CalendarSystem::Gregorian {
+        return Some(js_date_from_ymd(
+            date.year,
+            date.month.get(),
+            date.day.get(),
+        ));
+    }
+
+    let internal = InternalCalendarDate::try_from(date).ok()?;
 
     let gregorian = internal.to_calendar(CalendarSystem::Gregorian);
 
-    js_date_from_ymd(gregorian.year(), gregorian.month(), gregorian.day())
+    Some(js_date_from_ymd(
+        gregorian.year(),
+        gregorian.month(),
+        gregorian.day(),
+    ))
 }
 
 #[cfg(all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")))]
@@ -267,14 +272,6 @@ fn js_iso_year(year: i32) -> String {
     }
 }
 
-#[cfg(any(
-    not(any(feature = "icu4x", feature = "web-intl")),
-    all(
-        feature = "web-intl",
-        not(target_arch = "wasm32"),
-        not(feature = "icu4x")
-    )
-))]
 fn fallback_format_date(_locale: &Locale, length: FormatLength, date: &CalendarDate) -> String {
     if date.calendar != CalendarSystem::Gregorian {
         return date.to_iso8601();
@@ -305,14 +302,6 @@ fn fallback_format_date(_locale: &Locale, length: FormatLength, date: &CalendarD
     }
 }
 
-#[cfg(any(
-    not(any(feature = "icu4x", feature = "web-intl")),
-    all(
-        feature = "web-intl",
-        not(target_arch = "wasm32"),
-        not(feature = "icu4x")
-    )
-))]
 const fn english_month_short(month: u8) -> &'static str {
     match month {
         1 => "Jan",
@@ -331,14 +320,6 @@ const fn english_month_short(month: u8) -> &'static str {
     }
 }
 
-#[cfg(any(
-    not(any(feature = "icu4x", feature = "web-intl")),
-    all(
-        feature = "web-intl",
-        not(target_arch = "wasm32"),
-        not(feature = "icu4x")
-    )
-))]
 const fn english_month_long(month: u8) -> &'static str {
     match month {
         1 => "January",
@@ -357,14 +338,6 @@ const fn english_month_long(month: u8) -> &'static str {
     }
 }
 
-#[cfg(any(
-    not(any(feature = "icu4x", feature = "web-intl")),
-    all(
-        feature = "web-intl",
-        not(target_arch = "wasm32"),
-        not(feature = "icu4x")
-    )
-))]
 const fn english_weekday_long(weekday: crate::Weekday) -> &'static str {
     match weekday {
         crate::Weekday::Sunday => "Sunday",
@@ -490,6 +463,19 @@ mod tests {
         assert_ne!(formatted, date.to_iso8601());
     }
 
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn formatter_gracefully_formats_large_gregorian_years() {
+        let formatter = DateFormatter::new(&locales::en_us(), FormatLength::Long);
+        let date = CalendarDate::new_gregorian(
+            10_000,
+            NonZero::new(1).expect("nonzero"),
+            NonZero::new(1).expect("nonzero"),
+        );
+
+        assert_eq!(formatter.format(&date), "January 1, 10000");
+    }
+
     #[cfg(any(
         not(any(feature = "icu4x", feature = "web-intl")),
         all(
@@ -594,7 +580,8 @@ mod web_intl_tests {
         );
 
         let js_date = js_date_from_ymd(44, 3, 15);
-        let converted = js_date_from_calendar(&date);
+        let converted =
+            js_date_from_calendar(&date).expect("Gregorian test fixture should map to a Date");
 
         assert_eq!(js_date.get_utc_full_year(), 44);
         assert_eq!(js_date.get_utc_month(), 2);
@@ -602,6 +589,20 @@ mod web_intl_tests {
         assert_eq!(converted.get_utc_full_year(), 44);
         assert_eq!(converted.get_utc_month(), 2);
         assert_eq!(converted.get_utc_date(), 15);
+    }
+
+    #[wasm_bindgen_test]
+    fn web_intl_date_formatter_gracefully_formats_large_gregorian_years() {
+        let formatter = DateFormatter::new(&locales::en_us(), FormatLength::Long);
+        let date = CalendarDate::new_gregorian(
+            10_000,
+            NonZero::new(1).expect("nonzero"),
+            NonZero::new(1).expect("nonzero"),
+        );
+
+        let formatted = formatter.format(&date);
+
+        assert_eq!(formatted, "January 1, 10000");
     }
 
     #[wasm_bindgen_test]
@@ -633,8 +634,11 @@ mod web_intl_tests {
 
         let format: Function = formatter.format();
 
+        let js_date =
+            js_date_from_calendar(date).expect("test fixtures should map to a browser Date");
+
         format
-            .call1(&JsValue::UNDEFINED, js_date_from_calendar(date).as_ref())
+            .call1(&JsValue::UNDEFINED, js_date.as_ref())
             .expect("Intl.DateTimeFormat.format should not throw for a valid Date")
             .as_string()
             .unwrap_or_default()

--- a/crates/ars-i18n/src/date.rs
+++ b/crates/ars-i18n/src/date.rs
@@ -236,22 +236,18 @@ impl DateFormatter {
 #[cfg(all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")))]
 fn js_date_from_calendar(date: &CalendarDate) -> Option<JsDate> {
     if date.calendar == CalendarSystem::Gregorian {
-        return Some(js_date_from_ymd(
-            date.year,
-            date.month.get(),
-            date.day.get(),
-        ));
+        let js_date = js_date_from_ymd(date.year, date.month.get(), date.day.get());
+
+        return js_date_is_valid(&js_date).then_some(js_date);
     }
 
     let internal = InternalCalendarDate::try_from(date).ok()?;
 
     let gregorian = internal.to_calendar(CalendarSystem::Gregorian);
 
-    Some(js_date_from_ymd(
-        gregorian.year(),
-        gregorian.month(),
-        gregorian.day(),
-    ))
+    let js_date = js_date_from_ymd(gregorian.year(), gregorian.month(), gregorian.day());
+
+    js_date_is_valid(&js_date).then_some(js_date)
 }
 
 #[cfg(all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")))]
@@ -259,6 +255,11 @@ fn js_date_from_ymd(year: i32, month: u8, day: u8) -> JsDate {
     let iso = format!("{}-{month:02}-{day:02}T12:00:00.000Z", js_iso_year(year),);
 
     JsDate::new(&JsValue::from_str(&iso))
+}
+
+#[cfg(all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")))]
+fn js_date_is_valid(date: &JsDate) -> bool {
+    !date.get_time().is_nan()
 }
 
 #[cfg(all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")))]
@@ -512,7 +513,8 @@ mod web_intl_tests {
     use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
 
     use super::{
-        DateFormatter, FormatLength, js_date_from_calendar, js_date_from_ymd, js_iso_year,
+        DateFormatter, FormatLength, js_date_from_calendar, js_date_from_ymd, js_date_is_valid,
+        js_iso_year,
     };
     use crate::{CalendarDate, CalendarSystem, Locale, locales};
 
@@ -614,6 +616,21 @@ mod web_intl_tests {
         assert_eq!(js_iso_year(0), "0000");
         assert_eq!(js_iso_year(44), "0044");
         assert_eq!(js_iso_year(10_000), "+010000");
+    }
+
+    #[wasm_bindgen_test]
+    fn web_intl_date_formatter_falls_back_for_js_out_of_range_gregorian_years() {
+        let formatter = DateFormatter::new(&locales::en_us(), FormatLength::Long);
+        let date = CalendarDate::new_gregorian(
+            1_000_000,
+            NonZero::new(1).expect("nonzero"),
+            NonZero::new(1).expect("nonzero"),
+        );
+
+        assert!(js_date_is_valid(&js_date_from_ymd(10_000, 1, 1)));
+        assert!(!js_date_is_valid(&js_date_from_ymd(1_000_000, 1, 1)));
+        assert!(js_date_from_calendar(&date).is_none());
+        assert_eq!(formatter.format(&date), "January 1, 1000000");
     }
 
     fn direct_browser_format(locale: &Locale, length: FormatLength, date: &CalendarDate) -> String {

--- a/crates/ars-i18n/src/date.rs
+++ b/crates/ars-i18n/src/date.rs
@@ -78,9 +78,12 @@ impl FormatLength {
 
     /// Returns the ICU4X field set for time-only formatting.
     #[cfg(feature = "icu4x")]
-    #[expect(
-        dead_code,
-        reason = "time field-set support is part of the public formatter contract even though date-only formatting is implemented in this task"
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "time field-set support is part of the public formatter contract even though date-only formatting is implemented in this task"
+        )
     )]
     fn to_icu_time_field_set(self) -> T {
         match self {
@@ -353,14 +356,8 @@ const fn english_weekday_long(weekday: crate::Weekday) -> &'static str {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "icu4x")]
-    use alloc::string::String;
-    #[cfg(feature = "icu4x")]
-    use core::num::NonZero;
-
-    #[cfg(feature = "icu4x")]
-    use super::{DateFormatter, FormatLength};
     #[cfg(any(
+        feature = "icu4x",
         not(any(feature = "icu4x", feature = "web-intl")),
         all(
             feature = "web-intl",
@@ -368,7 +365,44 @@ mod tests {
             not(feature = "icu4x")
         )
     ))]
-    use super::{DateFormatter, FormatLength};
+    use alloc::format;
+    #[cfg(any(
+        feature = "icu4x",
+        not(any(feature = "icu4x", feature = "web-intl")),
+        all(
+            feature = "web-intl",
+            not(target_arch = "wasm32"),
+            not(feature = "icu4x")
+        )
+    ))]
+    use alloc::string::String;
+    #[cfg(any(
+        feature = "icu4x",
+        not(any(feature = "icu4x", feature = "web-intl")),
+        all(
+            feature = "web-intl",
+            not(target_arch = "wasm32"),
+            not(feature = "icu4x")
+        )
+    ))]
+    use core::num::NonZero;
+
+    #[cfg(feature = "icu4x")]
+    use icu::datetime::fieldsets::{T, YMD, YMDE};
+
+    #[cfg(any(
+        feature = "icu4x",
+        not(any(feature = "icu4x", feature = "web-intl")),
+        all(
+            feature = "web-intl",
+            not(target_arch = "wasm32"),
+            not(feature = "icu4x")
+        )
+    ))]
+    use super::{
+        DateFormatter, FormatLength, english_month_long, english_month_short, english_weekday_long,
+        fallback_format_date,
+    };
     #[cfg(any(
         not(any(feature = "icu4x", feature = "web-intl")),
         all(
@@ -378,8 +412,18 @@ mod tests {
         )
     ))]
     use crate::locales;
+    #[cfg(any(
+        feature = "icu4x",
+        not(any(feature = "icu4x", feature = "web-intl")),
+        all(
+            feature = "web-intl",
+            not(target_arch = "wasm32"),
+            not(feature = "icu4x")
+        )
+    ))]
+    use crate::{CalendarDate, CalendarSystem, Era};
     #[cfg(feature = "icu4x")]
-    use crate::{CalendarDate, CalendarSystem, Era, Locale, locales};
+    use crate::{Locale, locales};
 
     #[cfg(feature = "icu4x")]
     fn march_2024() -> CalendarDate {
@@ -390,12 +434,50 @@ mod tests {
         )
     }
 
+    #[cfg(any(
+        feature = "icu4x",
+        not(any(feature = "icu4x", feature = "web-intl")),
+        all(
+            feature = "web-intl",
+            not(target_arch = "wasm32"),
+            not(feature = "icu4x")
+        )
+    ))]
+    fn japanese_reiwa_date() -> CalendarDate {
+        CalendarDate {
+            calendar: CalendarSystem::Japanese,
+            era: Some(Era {
+                code: String::from("reiwa"),
+                display_name: String::from("Reiwa"),
+            }),
+            year: 1,
+            month: NonZero::new(5).expect("nonzero"),
+            day: NonZero::new(1).expect("nonzero"),
+        }
+    }
+
     #[cfg(feature = "icu4x")]
     #[test]
     fn short_date_formatter_formats_en_us_date() {
         let formatter = DateFormatter::new(&locales::en_us(), FormatLength::Short);
 
         assert_eq!(formatter.format(&march_2024()), "3/15/24");
+    }
+
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn format_length_icu_field_sets_cover_time_and_full_variants() {
+        assert_eq!(
+            FormatLength::Full.to_icu_full_date_field_set(),
+            YMDE::long()
+        );
+        assert_eq!(FormatLength::Long.to_icu_date_field_set(), YMD::long());
+        assert_eq!(FormatLength::Medium.to_icu_date_field_set(), YMD::medium());
+        assert_eq!(FormatLength::Short.to_icu_date_field_set(), YMD::short());
+        assert_eq!(FormatLength::Full.to_icu_time_field_set(), T::hms());
+        assert_eq!(FormatLength::Long.to_icu_time_field_set(), T::hms());
+        assert_eq!(FormatLength::Medium.to_icu_time_field_set(), T::hm());
+        assert_eq!(FormatLength::Short.to_icu_time_field_set(), T::hm());
     }
 
     #[cfg(feature = "icu4x")]
@@ -478,6 +560,97 @@ mod tests {
     }
 
     #[cfg(any(
+        feature = "icu4x",
+        not(any(feature = "icu4x", feature = "web-intl")),
+        all(
+            feature = "web-intl",
+            not(target_arch = "wasm32"),
+            not(feature = "icu4x")
+        )
+    ))]
+    #[test]
+    fn date_formatter_debug_includes_locale_and_length() {
+        let formatter = DateFormatter::new(&locales::en_us(), FormatLength::Long);
+        let debug = format!("{formatter:?}");
+
+        assert!(debug.contains("DateFormatter"));
+        assert!(debug.contains("en-US"));
+        assert!(debug.contains("Long"));
+    }
+
+    #[cfg(any(
+        feature = "icu4x",
+        not(any(feature = "icu4x", feature = "web-intl")),
+        all(
+            feature = "web-intl",
+            not(target_arch = "wasm32"),
+            not(feature = "icu4x")
+        )
+    ))]
+    #[test]
+    fn fallback_format_date_covers_all_lengths_and_non_gregorian_passthrough() {
+        let locale = locales::en_us();
+        let gregorian = CalendarDate::new_gregorian(
+            2024,
+            NonZero::new(3).expect("nonzero"),
+            NonZero::new(15).expect("nonzero"),
+        );
+
+        assert_eq!(
+            fallback_format_date(&locale, FormatLength::Short, &gregorian),
+            "3/15/24"
+        );
+        assert_eq!(
+            fallback_format_date(&locale, FormatLength::Medium, &gregorian),
+            "Mar 15, 2024"
+        );
+        assert_eq!(
+            fallback_format_date(&locale, FormatLength::Long, &gregorian),
+            "March 15, 2024"
+        );
+        assert_eq!(
+            fallback_format_date(&locale, FormatLength::Full, &gregorian),
+            "Friday, March 15, 2024"
+        );
+
+        let japanese = japanese_reiwa_date();
+        assert_eq!(
+            fallback_format_date(&locale, FormatLength::Long, &japanese),
+            japanese.to_iso8601()
+        );
+    }
+
+    #[cfg(any(
+        feature = "icu4x",
+        not(any(feature = "icu4x", feature = "web-intl")),
+        all(
+            feature = "web-intl",
+            not(target_arch = "wasm32"),
+            not(feature = "icu4x")
+        )
+    ))]
+    #[test]
+    fn english_fallback_helpers_cover_valid_and_invalid_inputs() {
+        assert_eq!(english_month_short(1), "Jan");
+        assert_eq!(english_month_short(12), "Dec");
+        assert_eq!(english_month_short(0), "???");
+        assert_eq!(english_month_short(13), "???");
+
+        assert_eq!(english_month_long(1), "January");
+        assert_eq!(english_month_long(12), "December");
+        assert_eq!(english_month_long(0), "Unknown");
+        assert_eq!(english_month_long(13), "Unknown");
+
+        assert_eq!(english_weekday_long(crate::Weekday::Sunday), "Sunday");
+        assert_eq!(english_weekday_long(crate::Weekday::Monday), "Monday");
+        assert_eq!(english_weekday_long(crate::Weekday::Tuesday), "Tuesday");
+        assert_eq!(english_weekday_long(crate::Weekday::Wednesday), "Wednesday");
+        assert_eq!(english_weekday_long(crate::Weekday::Thursday), "Thursday");
+        assert_eq!(english_weekday_long(crate::Weekday::Friday), "Friday");
+        assert_eq!(english_weekday_long(crate::Weekday::Saturday), "Saturday");
+    }
+
+    #[cfg(any(
         not(any(feature = "icu4x", feature = "web-intl")),
         all(
             feature = "web-intl",
@@ -489,10 +662,10 @@ mod tests {
     fn fallback_date_formatter_keeps_api_available() {
         let formatter = DateFormatter::new(&locales::en_us(), FormatLength::Full);
 
-        let formatted = formatter.format(&crate::CalendarDate::new_gregorian(
+        let formatted = formatter.format(&CalendarDate::new_gregorian(
             2024,
-            core::num::NonZero::new(3).expect("nonzero"),
-            core::num::NonZero::new(15).expect("nonzero"),
+            NonZero::new(3).expect("nonzero"),
+            NonZero::new(15).expect("nonzero"),
         ));
 
         assert!(formatted.contains("Friday"));
@@ -516,7 +689,7 @@ mod web_intl_tests {
         DateFormatter, FormatLength, js_date_from_calendar, js_date_from_ymd, js_date_is_valid,
         js_iso_year,
     };
-    use crate::{CalendarDate, CalendarSystem, Locale, locales};
+    use crate::{CalendarDate, CalendarSystem, Locale, StubIcuProvider, locales};
 
     wasm_bindgen_test_configure!(run_in_browser);
 
@@ -616,6 +789,18 @@ mod web_intl_tests {
         assert_eq!(js_iso_year(0), "0000");
         assert_eq!(js_iso_year(44), "0044");
         assert_eq!(js_iso_year(10_000), "+010000");
+    }
+
+    #[wasm_bindgen_test]
+    fn web_intl_date_helpers_preserve_astronomical_gregorian_years_from_non_gregorian_input() {
+        let provider = StubIcuProvider;
+        let buddhist = CalendarDate::new(&provider, CalendarSystem::Buddhist, None, 1, 1, 1)
+            .expect("Buddhist date should validate");
+
+        let converted = js_date_from_calendar(&buddhist)
+            .expect("Buddhist fixture should map to a browser Date");
+
+        assert_eq!(converted.to_iso_string(), "-000542-01-01T12:00:00.000Z");
     }
 
     #[wasm_bindgen_test]

--- a/crates/ars-i18n/src/lib.rs
+++ b/crates/ars-i18n/src/lib.rs
@@ -26,6 +26,7 @@ mod calendar;
 #[cfg(any(feature = "icu4x", feature = "web-intl"))]
 mod case;
 mod collation;
+mod date;
 #[cfg(feature = "std")]
 mod detect;
 mod layout;
@@ -33,6 +34,7 @@ mod locale;
 mod locale_stack;
 mod number;
 mod plural;
+mod relative_time;
 mod translate;
 mod weekday;
 
@@ -47,6 +49,7 @@ pub use calendar::{
 #[cfg(any(feature = "icu4x", feature = "web-intl"))]
 pub use case::{to_lowercase, to_uppercase};
 pub use collation::{CollationFormat, CollationOptions, CollationStrength, StringCollator};
+pub use date::{DateFormatter, FormatLength};
 #[cfg(feature = "std")]
 pub use detect::locale_from_accept_language;
 pub use layout::{LogicalRect, LogicalSide, PhysicalRect, PhysicalSide};
@@ -66,6 +69,7 @@ pub use plural::{
     Plural, PluralCategory, PluralRuleType, PluralRulesFormat, format_plural, plural_category,
     select_plural,
 };
+pub use relative_time::{NumericOption, RelativeTimeFormatter};
 pub use translate::Translate;
 pub use weekday::Weekday;
 
@@ -280,16 +284,9 @@ pub trait IcuProvider: Send + Sync + 'static {
             return months;
         }
 
-        #[cfg(feature = "icu4x")]
+        #[cfg(any(feature = "icu4x", feature = "web-intl"))]
         if let Some(months) = calendar::internal::months_in_year(year, *calendar, _era) {
             return months;
-        }
-
-        if matches!(calendar, CalendarSystem::Chinese | CalendarSystem::Dangi) {
-            // East Asian leap months require calendar data. Without ICU4X, use
-            // the non-leap baseline so we reject impossible month 13 values
-            // instead of accepting them in every year.
-            return 12;
         }
 
         match calendar {
@@ -320,7 +317,7 @@ pub trait IcuProvider: Send + Sync + 'static {
             return days;
         }
 
-        #[cfg(feature = "icu4x")]
+        #[cfg(any(feature = "icu4x", feature = "web-intl"))]
         if let Some(days) = calendar::internal::days_in_month(year, month, *_calendar, _era) {
             return days;
         }
@@ -378,6 +375,30 @@ pub trait IcuProvider: Send + Sync + 'static {
             return date.clone();
         }
 
+        #[cfg(any(feature = "icu4x", feature = "web-intl"))]
+        {
+            let internal = calendar::internal::CalendarDate::try_from(date)
+                .expect("CalendarDate should be valid for calendar conversion");
+            let converted = internal.to_calendar(target);
+
+            CalendarDate {
+                calendar: target,
+                era: converted
+                    .era()
+                    .filter(|_| target.has_custom_eras())
+                    .map(|code| Era {
+                        code: code.clone(),
+                        display_name: code,
+                    }),
+                year: converted.year(),
+                month: NonZero::new(converted.month())
+                    .expect("internal calendar conversion yields a 1-based month"),
+                day: NonZero::new(converted.day())
+                    .expect("internal calendar conversion yields a 1-based day"),
+            }
+        }
+
+        #[cfg(not(any(feature = "icu4x", feature = "web-intl")))]
         panic!(
             "StubIcuProvider does not support non-Gregorian calendar conversion; use Icu4xProvider"
         );
@@ -397,7 +418,7 @@ impl IcuProvider for StubIcuProvider {}
 mod tests {
     use alloc::{string::ToString, vec, vec::Vec};
     use core::num::NonZero;
-    #[cfg(feature = "std")]
+    #[cfg(all(feature = "std", not(any(feature = "icu4x", feature = "web-intl"))))]
     use std::panic::catch_unwind;
 
     use super::*;
@@ -730,13 +751,13 @@ mod tests {
             provider.max_months_in_year(&CalendarSystem::Hebrew, 5785, None),
             12
         );
-        #[cfg(feature = "icu4x")]
+        #[cfg(any(feature = "icu4x", feature = "web-intl"))]
         assert_eq!(
             provider.max_months_in_year(&CalendarSystem::Dangi, 2024, None),
             calendar::internal::months_in_year(2024, CalendarSystem::Dangi, None)
                 .expect("ICU4X should resolve Dangi month counts")
         );
-        #[cfg(not(feature = "icu4x"))]
+        #[cfg(not(any(feature = "icu4x", feature = "web-intl")))]
         assert_eq!(
             provider.max_months_in_year(&CalendarSystem::Dangi, 2024, None),
             12
@@ -801,9 +822,38 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(all(feature = "std", any(feature = "icu4x", feature = "web-intl")))]
     #[test]
-    fn stub_icu_provider_convert_date_panics_for_non_identity_conversions() {
+    fn stub_icu_provider_convert_date_supports_non_identity_conversions_when_internal_calendar_is_available()
+     {
+        let provider = StubIcuProvider;
+        let gregorian = CalendarDate::new(&provider, CalendarSystem::Gregorian, None, 2024, 3, 15)
+            .expect("Gregorian date should validate");
+        let japanese = provider.convert_date(&gregorian, CalendarSystem::Japanese);
+        let round_trip = provider.convert_date(&japanese, CalendarSystem::Gregorian);
+
+        assert_eq!(
+            japanese,
+            CalendarDate::new(
+                &provider,
+                CalendarSystem::Japanese,
+                Some(Era {
+                    code: String::from("reiwa"),
+                    display_name: String::from("reiwa"),
+                }),
+                6,
+                3,
+                15,
+            )
+            .expect("converted Japanese date should validate")
+        );
+        assert_eq!(round_trip, gregorian);
+    }
+
+    #[cfg(all(feature = "std", not(any(feature = "icu4x", feature = "web-intl"))))]
+    #[test]
+    fn stub_icu_provider_convert_date_panics_for_non_identity_conversions_without_calendar_backend()
+    {
         let provider = StubIcuProvider;
         let gregorian = CalendarDate::new(&provider, CalendarSystem::Gregorian, None, 2024, 3, 15)
             .expect("Gregorian date should validate");

--- a/crates/ars-i18n/src/lib.rs
+++ b/crates/ars-i18n/src/lib.rs
@@ -853,6 +853,35 @@ mod tests {
 
     #[cfg(all(feature = "std", any(feature = "icu4x", feature = "web-intl")))]
     #[test]
+    fn stub_icu_provider_convert_date_preserves_bce_gregorian_years() {
+        let provider = StubIcuProvider;
+        let buddhist = CalendarDate::new(&provider, CalendarSystem::Buddhist, None, 1, 1, 1)
+            .expect("Buddhist date should validate");
+
+        let gregorian = provider.convert_date(&buddhist, CalendarSystem::Gregorian);
+
+        assert_eq!(
+            gregorian,
+            CalendarDate {
+                calendar: CalendarSystem::Gregorian,
+                era: None,
+                year: -542,
+                month: NonZero::new(1).expect("one is non-zero"),
+                day: NonZero::new(1).expect("one is non-zero"),
+            }
+        );
+        assert_eq!(
+            buddhist.to_calendar(&provider, CalendarSystem::Gregorian),
+            gregorian
+        );
+        assert_eq!(
+            provider.convert_date(&gregorian, CalendarSystem::Buddhist),
+            buddhist
+        );
+    }
+
+    #[cfg(all(feature = "std", any(feature = "icu4x", feature = "web-intl")))]
+    #[test]
     fn stub_icu_provider_convert_date_falls_back_for_inputs_outside_internal_bridge_range() {
         let provider = StubIcuProvider;
         let gregorian = CalendarDate::new_gregorian(

--- a/crates/ars-i18n/src/lib.rs
+++ b/crates/ars-i18n/src/lib.rs
@@ -377,8 +377,9 @@ pub trait IcuProvider: Send + Sync + 'static {
 
         #[cfg(any(feature = "icu4x", feature = "web-intl"))]
         {
-            let internal = calendar::internal::CalendarDate::try_from(date)
-                .expect("CalendarDate should be valid for calendar conversion");
+            let Ok(internal) = calendar::internal::CalendarDate::try_from(date) else {
+                return date.clone();
+            };
             let converted = internal.to_calendar(target);
 
             CalendarDate {
@@ -848,6 +849,26 @@ mod tests {
             .expect("converted Japanese date should validate")
         );
         assert_eq!(round_trip, gregorian);
+    }
+
+    #[cfg(all(feature = "std", any(feature = "icu4x", feature = "web-intl")))]
+    #[test]
+    fn stub_icu_provider_convert_date_falls_back_for_inputs_outside_internal_bridge_range() {
+        let provider = StubIcuProvider;
+        let gregorian = CalendarDate::new_gregorian(
+            10_000,
+            NonZero::new(1).expect("one is non-zero"),
+            NonZero::new(1).expect("one is non-zero"),
+        );
+
+        assert_eq!(
+            provider.convert_date(&gregorian, CalendarSystem::Japanese),
+            gregorian
+        );
+        assert_eq!(
+            gregorian.to_calendar(&provider, CalendarSystem::Japanese),
+            gregorian
+        );
     }
 
     #[cfg(all(feature = "std", not(any(feature = "icu4x", feature = "web-intl"))))]

--- a/crates/ars-i18n/src/relative_time.rs
+++ b/crates/ars-i18n/src/relative_time.rs
@@ -1,0 +1,399 @@
+//! Locale-aware relative time formatting helpers.
+
+#[cfg(any(
+    not(any(feature = "icu4x", feature = "web-intl")),
+    all(
+        feature = "web-intl",
+        not(target_arch = "wasm32"),
+        not(feature = "icu4x")
+    )
+))]
+use alloc::format;
+use alloc::string::String;
+
+#[cfg(feature = "icu4x")]
+use {
+    fixed_decimal::Decimal,
+    icu_experimental::relativetime::{
+        RelativeTimeFormatter as IcuRelativeTimeFormatter, RelativeTimeFormatterOptions,
+        RelativeTimeFormatterPreferences, options::Numeric,
+    },
+};
+#[cfg(all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")))]
+use {
+    js_sys::{
+        Array,
+        Intl::{
+            RelativeTimeFormat as JsRelativeTimeFormat, RelativeTimeFormatNumeric,
+            RelativeTimeFormatOptions, RelativeTimeFormatStyle,
+        },
+    },
+    wasm_bindgen::JsValue,
+};
+
+use crate::Locale;
+
+/// Controls whether relative time uses numeric or natural-language phrasing.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub enum NumericOption {
+    /// Always use numeric output such as `1 day ago`.
+    #[default]
+    Always,
+    /// Use natural-language output where the backend supports it.
+    Auto,
+}
+
+impl NumericOption {
+    #[cfg(feature = "icu4x")]
+    fn to_icu(self) -> RelativeTimeFormatterOptions {
+        let mut options = RelativeTimeFormatterOptions::default();
+
+        options.numeric = match self {
+            Self::Always => Numeric::Always,
+            Self::Auto => Numeric::Auto,
+        };
+
+        options
+    }
+
+    #[cfg(all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")))]
+    const fn to_js(self) -> RelativeTimeFormatNumeric {
+        match self {
+            Self::Always => RelativeTimeFormatNumeric::Always,
+            Self::Auto => RelativeTimeFormatNumeric::Auto,
+        }
+    }
+}
+
+/// A locale-aware relative-time formatter.
+pub struct RelativeTimeFormatter {
+    locale: Locale,
+
+    numeric: NumericOption,
+
+    #[cfg(feature = "icu4x")]
+    second_formatter: IcuRelativeTimeFormatter,
+
+    #[cfg(feature = "icu4x")]
+    minute_formatter: IcuRelativeTimeFormatter,
+
+    #[cfg(feature = "icu4x")]
+    hour_formatter: IcuRelativeTimeFormatter,
+
+    #[cfg(feature = "icu4x")]
+    day_formatter: IcuRelativeTimeFormatter,
+
+    #[cfg(all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")))]
+    formatter: JsRelativeTimeFormat,
+}
+
+impl core::fmt::Debug for RelativeTimeFormatter {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("RelativeTimeFormatter")
+            .field("locale", &self.locale)
+            .field("numeric", &self.numeric)
+            .finish()
+    }
+}
+
+#[cfg(feature = "icu4x")]
+impl RelativeTimeFormatter {
+    /// Creates a formatter using numeric phrasing by default.
+    #[must_use]
+    pub fn new(locale: &Locale) -> Self {
+        Self::with_numeric(locale, NumericOption::default())
+    }
+
+    /// Creates a formatter with an explicit numeric strategy.
+    #[must_use]
+    pub fn with_numeric(locale: &Locale, numeric: NumericOption) -> Self {
+        let options = numeric.to_icu();
+        let prefs = RelativeTimeFormatterPreferences::from(locale.as_icu());
+
+        Self {
+            locale: locale.clone(),
+            numeric,
+            second_formatter: IcuRelativeTimeFormatter::try_new_long_second(prefs, options)
+                .expect("compiled_data guarantees second relative-time data"),
+            minute_formatter: IcuRelativeTimeFormatter::try_new_long_minute(prefs, options)
+                .expect("compiled_data guarantees minute relative-time data"),
+            hour_formatter: IcuRelativeTimeFormatter::try_new_long_hour(prefs, options)
+                .expect("compiled_data guarantees hour relative-time data"),
+            day_formatter: IcuRelativeTimeFormatter::try_new_long_day(prefs, options)
+                .expect("compiled_data guarantees day relative-time data"),
+        }
+    }
+
+    /// Formats a duration in seconds relative to now.
+    #[must_use]
+    pub fn format_seconds(&self, seconds: i64) -> String {
+        if seconds.abs() < 60 {
+            return self
+                .second_formatter
+                .format(Decimal::from(seconds))
+                .to_string();
+        }
+
+        if seconds.abs() < 3_600 {
+            return self
+                .minute_formatter
+                .format(Decimal::from(seconds / 60))
+                .to_string();
+        }
+
+        if seconds.abs() < 86_400 {
+            return self
+                .hour_formatter
+                .format(Decimal::from(seconds / 3_600))
+                .to_string();
+        }
+
+        self.day_formatter
+            .format(Decimal::from(seconds / 86_400))
+            .to_string()
+    }
+}
+
+#[cfg(all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")))]
+impl RelativeTimeFormatter {
+    /// Creates a formatter using numeric phrasing by default.
+    #[must_use]
+    pub fn new(locale: &Locale) -> Self {
+        Self::with_numeric(locale, NumericOption::default())
+    }
+
+    /// Creates a formatter with an explicit numeric strategy.
+    #[must_use]
+    pub fn with_numeric(locale: &Locale, numeric: NumericOption) -> Self {
+        let locales = Array::of1(&JsValue::from_str(&locale.to_bcp47()));
+
+        let options = RelativeTimeFormatOptions::new();
+        options.set_numeric(numeric.to_js());
+        options.set_style(RelativeTimeFormatStyle::Long);
+
+        Self {
+            locale: locale.clone(),
+            numeric,
+            formatter: JsRelativeTimeFormat::new(&locales, options.as_ref()),
+        }
+    }
+
+    /// Formats a duration in seconds relative to now using browser `Intl`.
+    #[must_use]
+    pub fn format_seconds(&self, seconds: i64) -> String {
+        let (value, unit) = bucket_relative_time(seconds);
+
+        String::from(self.formatter.format(value as f64, unit))
+    }
+}
+
+#[cfg(any(
+    not(any(feature = "icu4x", feature = "web-intl")),
+    all(
+        feature = "web-intl",
+        not(target_arch = "wasm32"),
+        not(feature = "icu4x")
+    )
+))]
+impl RelativeTimeFormatter {
+    /// Creates a formatter using numeric phrasing by default.
+    #[must_use]
+    pub fn new(locale: &Locale) -> Self {
+        Self::with_numeric(locale, NumericOption::default())
+    }
+
+    /// Creates a formatter with an explicit numeric strategy.
+    #[must_use]
+    pub fn with_numeric(locale: &Locale, numeric: NumericOption) -> Self {
+        Self {
+            locale: locale.clone(),
+            numeric,
+        }
+    }
+
+    /// Formats a duration in seconds relative to now using the English fallback.
+    #[must_use]
+    pub fn format_seconds(&self, seconds: i64) -> String {
+        fallback_format_relative_time(self.numeric, seconds)
+    }
+}
+
+#[cfg(any(
+    all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")),
+    not(any(feature = "icu4x", feature = "web-intl")),
+    all(
+        feature = "web-intl",
+        not(target_arch = "wasm32"),
+        not(feature = "icu4x")
+    )
+))]
+const fn bucket_relative_time(seconds: i64) -> (i64, &'static str) {
+    if seconds.abs() < 60 {
+        (seconds, "second")
+    } else if seconds.abs() < 3_600 {
+        (seconds / 60, "minute")
+    } else if seconds.abs() < 86_400 {
+        (seconds / 3_600, "hour")
+    } else {
+        (seconds / 86_400, "day")
+    }
+}
+
+#[cfg(any(
+    not(any(feature = "icu4x", feature = "web-intl")),
+    all(
+        feature = "web-intl",
+        not(target_arch = "wasm32"),
+        not(feature = "icu4x")
+    )
+))]
+fn fallback_format_relative_time(numeric: NumericOption, seconds: i64) -> String {
+    let (value, unit) = bucket_relative_time(seconds);
+
+    if numeric == NumericOption::Auto {
+        match (unit, value) {
+            ("second", 0) => return String::from("now"),
+            ("minute", 0) => return String::from("this minute"),
+            ("hour", 0) => return String::from("this hour"),
+            ("day", -1) => return String::from("yesterday"),
+            ("day", 0) => return String::from("today"),
+            ("day", 1) => return String::from("tomorrow"),
+            _ => {}
+        }
+    }
+
+    let magnitude = value.unsigned_abs();
+
+    let suffix = if magnitude == 1 { "" } else { "s" };
+
+    if value < 0 {
+        format!("{magnitude} {unit}{suffix} ago")
+    } else {
+        format!("in {magnitude} {unit}{suffix}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(feature = "icu4x")]
+    use super::{NumericOption, RelativeTimeFormatter};
+    #[cfg(any(
+        not(any(feature = "icu4x", feature = "web-intl")),
+        all(
+            feature = "web-intl",
+            not(target_arch = "wasm32"),
+            not(feature = "icu4x")
+        )
+    ))]
+    use super::{NumericOption, RelativeTimeFormatter};
+    #[cfg(any(
+        not(any(feature = "icu4x", feature = "web-intl")),
+        all(
+            feature = "web-intl",
+            not(target_arch = "wasm32"),
+            not(feature = "icu4x")
+        )
+    ))]
+    use crate::locales;
+    #[cfg(feature = "icu4x")]
+    use crate::{Locale, locales};
+
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn format_seconds_formats_past_minute_in_english() {
+        let formatter = RelativeTimeFormatter::new(&locales::en_us());
+
+        assert_eq!(formatter.format_seconds(-60), "1 minute ago");
+    }
+
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn format_seconds_formats_future_hour_in_english() {
+        let formatter = RelativeTimeFormatter::new(&locales::en_us());
+
+        assert_eq!(formatter.format_seconds(3_600), "in 1 hour");
+    }
+
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn numeric_auto_uses_yesterday_for_negative_day() {
+        let formatter = RelativeTimeFormatter::with_numeric(&locales::en_us(), NumericOption::Auto);
+
+        assert_eq!(formatter.format_seconds(-86_400), "yesterday");
+    }
+
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn arabic_relative_time_uses_arabic_output() {
+        let formatter = RelativeTimeFormatter::new(&Locale::parse("ar-EG").expect("locale"));
+
+        let formatted = formatter.format_seconds(-60);
+
+        assert!(formatted.contains("قبل"));
+    }
+
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn relative_time_covers_seconds_minutes_hours_and_days() {
+        let formatter = RelativeTimeFormatter::new(&locales::en_us());
+
+        assert_eq!(formatter.format_seconds(59), "in 59 seconds");
+        assert_eq!(formatter.format_seconds(60), "in 1 minute");
+        assert_eq!(formatter.format_seconds(3_599), "in 59 minutes");
+        assert_eq!(formatter.format_seconds(3_600), "in 1 hour");
+        assert_eq!(formatter.format_seconds(86_399), "in 23 hours");
+        assert_eq!(formatter.format_seconds(86_400), "in 1 day");
+    }
+
+    #[cfg(any(
+        not(any(feature = "icu4x", feature = "web-intl")),
+        all(
+            feature = "web-intl",
+            not(target_arch = "wasm32"),
+            not(feature = "icu4x")
+        )
+    ))]
+    #[test]
+    fn fallback_relative_time_keeps_api_available() {
+        let formatter = RelativeTimeFormatter::with_numeric(&locales::en_us(), NumericOption::Auto);
+
+        assert_eq!(formatter.format_seconds(-86_400), "yesterday");
+        assert_eq!(formatter.format_seconds(3_600), "in 1 hour");
+    }
+}
+
+#[cfg(all(
+    test,
+    feature = "web-intl",
+    target_arch = "wasm32",
+    not(feature = "icu4x")
+))]
+mod web_intl_tests {
+    use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+
+    use super::{NumericOption, RelativeTimeFormatter};
+    use crate::{Locale, locales};
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    #[wasm_bindgen_test]
+    fn web_intl_relative_time_formats_future_hour() {
+        let formatter = RelativeTimeFormatter::new(&locales::en_us());
+
+        assert_eq!(formatter.format_seconds(3_600), "in 1 hour");
+    }
+
+    #[wasm_bindgen_test]
+    fn web_intl_relative_time_formats_yesterday_in_auto_mode() {
+        let formatter = RelativeTimeFormatter::with_numeric(&locales::en_us(), NumericOption::Auto);
+
+        assert_eq!(formatter.format_seconds(-86_400), "yesterday");
+    }
+
+    #[wasm_bindgen_test]
+    fn web_intl_relative_time_uses_representative_arabic_output() {
+        let formatter = RelativeTimeFormatter::new(&Locale::parse("ar-EG").expect("locale"));
+
+        assert!(formatter.format_seconds(-60).contains("قبل"));
+    }
+}

--- a/crates/ars-i18n/src/relative_time.rs
+++ b/crates/ars-i18n/src/relative_time.rs
@@ -259,6 +259,17 @@ fn fallback_format_relative_time(numeric: NumericOption, seconds: i64) -> String
 
 #[cfg(test)]
 mod tests {
+    #[cfg(any(
+        feature = "icu4x",
+        not(any(feature = "icu4x", feature = "web-intl")),
+        all(
+            feature = "web-intl",
+            not(target_arch = "wasm32"),
+            not(feature = "icu4x")
+        )
+    ))]
+    use alloc::format;
+
     #[cfg(feature = "icu4x")]
     use super::{NumericOption, RelativeTimeFormatter, bucket_relative_time};
     #[cfg(any(
@@ -335,6 +346,17 @@ mod tests {
         assert_eq!(bucket_relative_time(i64::MIN), (i64::MIN / 86_400, "day"));
     }
 
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn relative_time_formatter_debug_includes_locale_and_numeric_mode() {
+        let formatter = RelativeTimeFormatter::with_numeric(&locales::en_us(), NumericOption::Auto);
+        let debug = format!("{formatter:?}");
+
+        assert!(debug.contains("RelativeTimeFormatter"));
+        assert!(debug.contains("en-US"));
+        assert!(debug.contains("Auto"));
+    }
+
     #[cfg(any(
         not(any(feature = "icu4x", feature = "web-intl")),
         all(
@@ -360,8 +382,44 @@ mod tests {
         )
     ))]
     #[test]
+    fn fallback_relative_time_auto_covers_additional_natural_language_branches() {
+        let formatter = RelativeTimeFormatter::with_numeric(&locales::en_us(), NumericOption::Auto);
+
+        assert_eq!(formatter.format_seconds(0), "now");
+        assert_eq!(formatter.format_seconds(30), "in 30 seconds");
+        assert_eq!(formatter.format_seconds(3_599), "in 59 minutes");
+        assert_eq!(formatter.format_seconds(86_400), "tomorrow");
+    }
+
+    #[cfg(any(
+        not(any(feature = "icu4x", feature = "web-intl")),
+        all(
+            feature = "web-intl",
+            not(target_arch = "wasm32"),
+            not(feature = "icu4x")
+        )
+    ))]
+    #[test]
     fn fallback_bucketing_handles_i64_min_without_overflow() {
         assert_eq!(bucket_relative_time(i64::MIN), (i64::MIN / 86_400, "day"));
+    }
+
+    #[cfg(any(
+        not(any(feature = "icu4x", feature = "web-intl")),
+        all(
+            feature = "web-intl",
+            not(target_arch = "wasm32"),
+            not(feature = "icu4x")
+        )
+    ))]
+    #[test]
+    fn fallback_relative_time_formatter_debug_includes_locale_and_numeric_mode() {
+        let formatter = RelativeTimeFormatter::with_numeric(&locales::en_us(), NumericOption::Auto);
+        let debug = format!("{formatter:?}");
+
+        assert!(debug.contains("RelativeTimeFormatter"));
+        assert!(debug.contains("en-US"));
+        assert!(debug.contains("Auto"));
     }
 }
 

--- a/crates/ars-i18n/src/relative_time.rs
+++ b/crates/ars-i18n/src/relative_time.rs
@@ -96,6 +96,20 @@ impl core::fmt::Debug for RelativeTimeFormatter {
     }
 }
 
+const fn bucket_relative_time(seconds: i64) -> (i64, &'static str) {
+    let magnitude = seconds.unsigned_abs();
+
+    if magnitude < 60 {
+        (seconds, "second")
+    } else if magnitude < 3_600 {
+        (seconds / 60, "minute")
+    } else if magnitude < 86_400 {
+        (seconds / 3_600, "hour")
+    } else {
+        (seconds / 86_400, "day")
+    }
+}
+
 #[cfg(feature = "icu4x")]
 impl RelativeTimeFormatter {
     /// Creates a formatter using numeric phrasing by default.
@@ -127,30 +141,21 @@ impl RelativeTimeFormatter {
     /// Formats a duration in seconds relative to now.
     #[must_use]
     pub fn format_seconds(&self, seconds: i64) -> String {
-        if seconds.abs() < 60 {
-            return self
+        let (value, unit) = bucket_relative_time(seconds);
+
+        match unit {
+            "second" => self
                 .second_formatter
-                .format(Decimal::from(seconds))
-                .to_string();
-        }
-
-        if seconds.abs() < 3_600 {
-            return self
+                .format(Decimal::from(value))
+                .to_string(),
+            "minute" => self
                 .minute_formatter
-                .format(Decimal::from(seconds / 60))
-                .to_string();
+                .format(Decimal::from(value))
+                .to_string(),
+            "hour" => self.hour_formatter.format(Decimal::from(value)).to_string(),
+            "day" => self.day_formatter.format(Decimal::from(value)).to_string(),
+            _ => unreachable!("bucket_relative_time only returns supported units"),
         }
-
-        if seconds.abs() < 86_400 {
-            return self
-                .hour_formatter
-                .format(Decimal::from(seconds / 3_600))
-                .to_string();
-        }
-
-        self.day_formatter
-            .format(Decimal::from(seconds / 86_400))
-            .to_string()
     }
 }
 
@@ -219,27 +224,6 @@ impl RelativeTimeFormatter {
 }
 
 #[cfg(any(
-    all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")),
-    not(any(feature = "icu4x", feature = "web-intl")),
-    all(
-        feature = "web-intl",
-        not(target_arch = "wasm32"),
-        not(feature = "icu4x")
-    )
-))]
-const fn bucket_relative_time(seconds: i64) -> (i64, &'static str) {
-    if seconds.abs() < 60 {
-        (seconds, "second")
-    } else if seconds.abs() < 3_600 {
-        (seconds / 60, "minute")
-    } else if seconds.abs() < 86_400 {
-        (seconds / 3_600, "hour")
-    } else {
-        (seconds / 86_400, "day")
-    }
-}
-
-#[cfg(any(
     not(any(feature = "icu4x", feature = "web-intl")),
     all(
         feature = "web-intl",
@@ -276,7 +260,7 @@ fn fallback_format_relative_time(numeric: NumericOption, seconds: i64) -> String
 #[cfg(test)]
 mod tests {
     #[cfg(feature = "icu4x")]
-    use super::{NumericOption, RelativeTimeFormatter};
+    use super::{NumericOption, RelativeTimeFormatter, bucket_relative_time};
     #[cfg(any(
         not(any(feature = "icu4x", feature = "web-intl")),
         all(
@@ -285,7 +269,7 @@ mod tests {
             not(feature = "icu4x")
         )
     ))]
-    use super::{NumericOption, RelativeTimeFormatter};
+    use super::{NumericOption, RelativeTimeFormatter, bucket_relative_time};
     #[cfg(any(
         not(any(feature = "icu4x", feature = "web-intl")),
         all(
@@ -345,6 +329,12 @@ mod tests {
         assert_eq!(formatter.format_seconds(86_400), "in 1 day");
     }
 
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn bucketing_handles_i64_min_without_overflow() {
+        assert_eq!(bucket_relative_time(i64::MIN), (i64::MIN / 86_400, "day"));
+    }
+
     #[cfg(any(
         not(any(feature = "icu4x", feature = "web-intl")),
         all(
@@ -360,6 +350,19 @@ mod tests {
         assert_eq!(formatter.format_seconds(-86_400), "yesterday");
         assert_eq!(formatter.format_seconds(3_600), "in 1 hour");
     }
+
+    #[cfg(any(
+        not(any(feature = "icu4x", feature = "web-intl")),
+        all(
+            feature = "web-intl",
+            not(target_arch = "wasm32"),
+            not(feature = "icu4x")
+        )
+    ))]
+    #[test]
+    fn fallback_bucketing_handles_i64_min_without_overflow() {
+        assert_eq!(bucket_relative_time(i64::MIN), (i64::MIN / 86_400, "day"));
+    }
 }
 
 #[cfg(all(
@@ -371,7 +374,7 @@ mod tests {
 mod web_intl_tests {
     use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
 
-    use super::{NumericOption, RelativeTimeFormatter};
+    use super::{NumericOption, RelativeTimeFormatter, bucket_relative_time};
     use crate::{Locale, locales};
 
     wasm_bindgen_test_configure!(run_in_browser);
@@ -395,5 +398,10 @@ mod web_intl_tests {
         let formatter = RelativeTimeFormatter::new(&Locale::parse("ar-EG").expect("locale"));
 
         assert!(formatter.format_seconds(-60).contains("قبل"));
+    }
+
+    #[wasm_bindgen_test]
+    fn web_intl_bucketing_handles_i64_min_without_overflow() {
+        assert_eq!(bucket_relative_time(i64::MIN), (i64::MIN / 86_400, "day"));
     }
 }

--- a/crates/ars-i18n/tests/unit/calendar.rs
+++ b/crates/ars-i18n/tests/unit/calendar.rs
@@ -1,9 +1,9 @@
 use alloc::string::{String, ToString};
 use core::{cmp::Ordering, num::NonZero};
 
-#[cfg(feature = "icu4x")]
+#[cfg(any(feature = "icu4x", feature = "web-intl"))]
 use super::internal::CalendarDate as InternalCalendarDate;
-#[cfg(feature = "icu4x")]
+#[cfg(any(feature = "icu4x", feature = "web-intl"))]
 use super::internal::{
     days_in_month as internal_days_in_month, months_in_year as internal_months_in_year,
 };
@@ -16,7 +16,7 @@ use super::{
 };
 use crate::{IcuProvider, Locale, StubIcuProvider, Weekday};
 
-#[cfg(feature = "icu4x")]
+#[cfg(any(feature = "icu4x", feature = "web-intl"))]
 #[test]
 fn internal_calendar_date_from_iso_exposes_components() {
     let date = InternalCalendarDate::from_iso(2024, 3, 15).expect("date should be valid");
@@ -27,7 +27,7 @@ fn internal_calendar_date_from_iso_exposes_components() {
     assert_eq!(date.weekday(), Weekday::Friday);
 }
 
-#[cfg(feature = "icu4x")]
+#[cfg(any(feature = "icu4x", feature = "web-intl"))]
 #[test]
 fn internal_calendar_date_from_calendar_accepts_gregorian_fields() {
     let date = InternalCalendarDate::from_calendar(2024, 3, 15, CalendarSystem::Gregorian)
@@ -38,7 +38,7 @@ fn internal_calendar_date_from_calendar_accepts_gregorian_fields() {
     assert_eq!(date.day(), 15);
 }
 
-#[cfg(feature = "icu4x")]
+#[cfg(any(feature = "icu4x", feature = "web-intl"))]
 #[test]
 fn internal_calendar_date_from_calendar_uses_ordinal_months_for_chinese() {
     let date = InternalCalendarDate::from_calendar(2023, 3, 1, CalendarSystem::Chinese)
@@ -47,7 +47,7 @@ fn internal_calendar_date_from_calendar_uses_ordinal_months_for_chinese() {
     assert_eq!(date.month(), 3);
 }
 
-#[cfg(feature = "icu4x")]
+#[cfg(any(feature = "icu4x", feature = "web-intl"))]
 #[test]
 fn internal_calendar_date_from_calendar_defaults_japanese_to_current_era() {
     let date = InternalCalendarDate::from_calendar(6, 3, 15, CalendarSystem::Japanese)
@@ -60,7 +60,7 @@ fn internal_calendar_date_from_calendar_defaults_japanese_to_current_era() {
     assert_eq!(gregorian.day(), 15);
 }
 
-#[cfg(feature = "icu4x")]
+#[cfg(any(feature = "icu4x", feature = "web-intl"))]
 #[test]
 fn stub_provider_uses_year_dependent_chinese_month_counts() {
     let provider = StubIcuProvider;
@@ -122,7 +122,7 @@ fn stub_provider_rejects_invalid_coptic_and_ethiopic_epagomenal_days() {
     );
 }
 
-#[cfg(feature = "icu4x")]
+#[cfg(any(feature = "icu4x", feature = "web-intl"))]
 #[test]
 fn internal_calendar_date_from_calendar_with_era_preserves_japanese_era() {
     let date =
@@ -136,7 +136,7 @@ fn internal_calendar_date_from_calendar_with_era_preserves_japanese_era() {
     assert_eq!(gregorian.day(), 30);
 }
 
-#[cfg(feature = "icu4x")]
+#[cfg(any(feature = "icu4x", feature = "web-intl"))]
 #[test]
 fn internal_calendar_date_add_days_and_ordering_work() {
     let start = InternalCalendarDate::from_iso(2024, 3, 15).expect("date should be valid");
@@ -147,7 +147,7 @@ fn internal_calendar_date_add_days_and_ordering_work() {
     assert_eq!(end.day(), 18);
 }
 
-#[cfg(feature = "icu4x")]
+#[cfg(any(feature = "icu4x", feature = "web-intl"))]
 #[test]
 fn internal_calendar_date_conversion_and_era_helpers_are_callable() {
     let gregorian = InternalCalendarDate::from_iso(2024, 3, 15).expect("date should be valid");
@@ -157,7 +157,7 @@ fn internal_calendar_date_conversion_and_era_helpers_are_callable() {
     assert_eq!(converted.era(), Some(String::from("ce")));
 }
 
-#[cfg(all(feature = "icu4x", feature = "std"))]
+#[cfg(all(any(feature = "icu4x", feature = "web-intl"), feature = "std"))]
 #[test]
 fn internal_calendar_date_today_returns_a_valid_date() {
     let today =
@@ -1097,7 +1097,7 @@ fn public_calendar_date_non_gregorian_provider_paths_delegate() {
     );
 }
 
-#[cfg(feature = "icu4x")]
+#[cfg(any(feature = "icu4x", feature = "web-intl"))]
 #[test]
 fn public_calendar_date_to_internal_preserves_explicit_japanese_era() {
     let heisei = CalendarDate {
@@ -1340,12 +1340,12 @@ fn stub_provider_fallback_helpers_cover_remaining_calendar_defaults() {
         provider.days_in_month(&CalendarSystem::EthiopicAmeteAlem, 2015, 13, None),
         6
     );
-    #[cfg(feature = "icu4x")]
+    #[cfg(any(feature = "icu4x", feature = "web-intl"))]
     assert_eq!(
         provider.days_in_month(&CalendarSystem::Roc, 113, 2, None),
         29
     );
-    #[cfg(not(feature = "icu4x"))]
+    #[cfg(not(any(feature = "icu4x", feature = "web-intl")))]
     assert_eq!(
         provider.days_in_month(&CalendarSystem::Roc, 113, 2, None),
         28
@@ -1359,7 +1359,7 @@ fn stub_provider_fallback_helpers_cover_remaining_calendar_defaults() {
     assert_eq!(provider.first_day_of_week(&locale), Weekday::Sunday);
 }
 
-#[cfg(feature = "icu4x")]
+#[cfg(any(feature = "icu4x", feature = "web-intl"))]
 #[test]
 fn internal_calendar_shape_helpers_cover_remaining_icu_backed_paths() {
     let leap_month_year = (2020..=2030)
@@ -1391,7 +1391,7 @@ fn internal_calendar_shape_helpers_cover_remaining_icu_backed_paths() {
     );
 }
 
-#[cfg(feature = "icu4x")]
+#[cfg(any(feature = "icu4x", feature = "web-intl"))]
 #[test]
 fn internal_calendar_date_invalid_construction_paths_return_errors() {
     assert_eq!(
@@ -1417,7 +1417,7 @@ fn internal_calendar_date_invalid_construction_paths_return_errors() {
     );
 }
 
-#[cfg(all(feature = "icu4x", feature = "std"))]
+#[cfg(all(any(feature = "icu4x", feature = "web-intl"), feature = "std"))]
 #[test]
 fn internal_calendar_date_additional_paths_cover_identity_and_ordering() {
     let start = InternalCalendarDate::from_iso(2024, 3, 15).expect("date should be valid");

--- a/spec/foundation/04-internationalization.md
+++ b/spec/foundation/04-internationalization.md
@@ -19,7 +19,7 @@ The `ars-i18n` crate provides complete internationalization support for ars-ui c
 `ars-i18n` supports two formatting backends via feature flags:
 
 - **`icu4x`** (default): Rust-native ICU4X implementation. Required for SSR, desktop, and non-browser environments. Adds ~100-500KB to WASM binary.
-- **`web-intl`**: Delegates to the browser's `Intl` API via `js-sys`. Zero binary size overhead. WASM client only.
+- **`web-intl`**: Delegates localized formatting to the browser's `Intl` API via `js-sys`. No compiled CLDR data is linked into the WASM bundle, but non-Gregorian `CalendarDate` support still relies on a small Rust-side calendar conversion layer. WASM client only.
 
 `Locale` parsing, BCP 47 metadata access (`language()`, `script()`, `region()`,
 Unicode extensions), and `DataLocale` conversion are foundational and may rely on
@@ -2042,7 +2042,8 @@ impl DateFormatter {
     }
 
     pub fn format(&self, date: &shared::CalendarDate) -> String {
-        let internal: CalendarDate = date.into();
+        let internal = CalendarDate::try_from(date)
+            .expect("CalendarDate should be valid for formatting");
         match &self.inner {
             DateFormatterInner::Ymd(fmt) => fmt.format(&internal.inner).to_string(),
             DateFormatterInner::Ymde(fmt) => fmt.format(&internal.inner).to_string(),
@@ -2077,7 +2078,7 @@ impl TryFrom<&shared::CalendarDate> for CalendarDate {
 ### 5.5 RelativeTimeFormatter
 
 ```rust
-use icu::experimental::relativetime::{
+use icu_experimental::relativetime::{
     RelativeTimeFormatter as IcuRelativeTimeFormatter,
     RelativeTimeFormatterPreferences,
     options::{RelativeTimeFormatterOptions, Numeric},
@@ -3367,7 +3368,7 @@ pub fn get_number_formatter(locale: &Locale, options: &NumberFormatOptions) -> N
 ### 9.4 Browser Intl API Feature Flag (`web-intl`)
 
 For WASM client builds, the browser's `Intl` API provides the same formatting
-capabilities as ICU4X with zero bundle size overhead. The `web-intl` feature
+capabilities as ICU4X without shipping compiled CLDR data. The `web-intl` feature
 flag enables this backend on `wasm32`; non-wasm builds that enable the feature
 continue to use the documented English fallback behavior for APIs that depend
 on browser `Intl`.
@@ -4061,7 +4062,20 @@ pub fn default_provider() -> Box<dyn IcuProvider> {
 
 The `web-intl` backend implements `IcuProvider` using browser `Intl` APIs for WASM client
 builds. This mirrors `Icu4xProvider` (§9.5.2) but delegates to browser-native ICU data,
-eliminating compiled CLDR data from the WASM bundle.
+keeping browser-native formatting as the source of localized output. For
+non-Gregorian public `CalendarDate` values, the formatter and provider layers
+use a Rust-side calendar conversion bridge to resolve an absolute day before
+handing that day to `Intl.DateTimeFormat`. This bridge does not require
+`icu/compiled_data`.
+
+For the public formatter surface, `DateFormatter` and `RelativeTimeFormatter` remain the
+backend-neutral APIs. The implementation chooses ICU4X or browser `Intl` internally rather
+than exposing public `JsIntl*` wrapper types.
+
+`RelativeTimeFormatter` maps cleanly to `Intl.RelativeTimeFormat`. `DateFormatter` maps
+cleanly to `Intl.DateTimeFormat` by converting public `CalendarDate` values to their
+absolute Gregorian day first, then formatting that day under the locale's active
+calendar, including `u-ca-*` Unicode extension preferences.
 
 **Browser API mapping:**
 

--- a/spec/shared/date-time-types.md
+++ b/spec/shared/date-time-types.md
@@ -598,7 +598,7 @@ When validating dates against a specific calendar system, `CalendarDate` MUST en
 **Leap Month Handling**:
 
 - **Hebrew**: In a leap year (years 3, 6, 8, 11, 14, 17, 19 of the 19-year Metonic cycle), a 13th month (Adar II / אדר ב׳) is inserted. Setting `month = 13` in a non-leap Hebrew year MUST return `Err(CalendarValidationError::InvalidLeapMonth)`.
-- **Chinese (if supported)**: Intercalary (leap) months can occur after any month. The leap month is identified by a boolean flag, not a month number. Validation requires consulting the Chinese calendar data for the specific year.
+- **Chinese / Dangi**: Intercalary (leap) months can occur after any month. The public `CalendarDate` type keeps `month: NonZero<u8>` and represents these calendars using the ordinal month position within the year (`1..=13`), not a separate public leap-month boolean. Validation therefore requires consulting calendar data or calendar arithmetic for the specific year to determine whether ordinal month `13` exists and how ordinal months map onto named display months.
 
 **Era Validation** (Japanese Calendar):
 


### PR DESCRIPTION
## Summary
- add backend-neutral `DateFormatter` and `RelativeTimeFormatter` to `ars-i18n`
- implement ICU4X and `web-intl` formatter backends, including browser-backed relative time and date formatting
- refactor web date conversion to avoid `icu/compiled_data`, keep calendar parity through the internal calendar bridge, and sync the i18n/date-time specs

## Verification
- `cargo test -p ars-i18n`
- `cargo test -p ars-i18n --no-default-features --features web-intl --target wasm32-unknown-unknown --no-run`
- `CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=wasm-bindgen-test-runner cargo test -p ars-i18n --no-default-features --features web-intl --target wasm32-unknown-unknown`
- `cargo xci` (run from `/private/tmp/ars-ui-07d0` to avoid the macOS wasm coverage linker path-length issue in the worktree path)

Closes #125
Closes #129
Closes #130