### PR TITLE
Implement collection announcements and callback-based OnAction

### DIFF
--- a/crates/ars-collections/src/announcements.rs
+++ b/crates/ars-collections/src/announcements.rs
@@ -1,0 +1,266 @@
+//! Localizable announcement message helpers for collection mutations.
+
+use alloc::{format, string::String, sync::Arc};
+use core::fmt::{self, Debug};
+
+use ars_core::{Locale, MessageFn};
+
+use crate::SortDirection;
+
+type CountLocaleMessage = dyn Fn(usize, &Locale) -> String + Send + Sync;
+type SortedLocaleMessage = dyn Fn(&str, SortDirection, &Locale) -> String + Send + Sync;
+type LocaleMessage = dyn Fn(&Locale) -> String + Send + Sync;
+
+/// Describes a change to a collection for screen reader announcement.
+#[derive(Clone, Debug, PartialEq)]
+pub enum CollectionChangeAnnouncement {
+    /// Items were added. Message via [`CollectionMessages::items_added`].
+    ItemsAdded {
+        /// The number of items added to the collection.
+        count: usize,
+    },
+
+    /// Items were removed. Message via [`CollectionMessages::items_removed`].
+    ItemsRemoved {
+        /// The number of items removed from the collection.
+        count: usize,
+    },
+
+    /// Collection was filtered. Message via [`CollectionMessages::filtered`].
+    Filtered {
+        /// The number of items matching the active filter.
+        matching_count: usize,
+    },
+
+    /// Collection was sorted. Message via [`CollectionMessages::sorted`].
+    Sorted {
+        /// The column used for sorting.
+        column: String,
+
+        /// The sort direction applied to `column`.
+        direction: SortDirection,
+    },
+
+    /// Collection is empty after the operation. Message via [`CollectionMessages::empty`].
+    Empty,
+
+    /// Async load completed. Message via [`CollectionMessages::loaded`].
+    Loaded {
+        /// The number of items loaded by the async operation.
+        count: usize,
+    },
+}
+
+/// Localizable message functions for collection change announcements.
+pub struct CollectionMessages {
+    /// Message for items added. Receives `(count, locale)`.
+    pub items_added: MessageFn<CountLocaleMessage>,
+
+    /// Message for items removed. Receives `(count, locale)`.
+    pub items_removed: MessageFn<CountLocaleMessage>,
+
+    /// Message for filtered results. Receives `(count, locale)`.
+    pub filtered: MessageFn<CountLocaleMessage>,
+
+    /// Message for sorted collection. Receives `(column, direction, locale)`.
+    pub sorted: MessageFn<SortedLocaleMessage>,
+
+    /// Message for an empty collection. Receives `locale`.
+    pub empty: MessageFn<LocaleMessage>,
+
+    /// Message for async load completion. Receives `(count, locale)`.
+    pub loaded: MessageFn<CountLocaleMessage>,
+}
+
+impl Default for CollectionMessages {
+    fn default() -> Self {
+        Self {
+            items_added: MessageFn::new(Arc::new(|count: usize, _locale: &Locale| {
+                if count == 1 {
+                    String::from("1 item added")
+                } else {
+                    format!("{count} items added")
+                }
+            }) as Arc<CountLocaleMessage>),
+
+            items_removed: MessageFn::new(Arc::new(|count: usize, _locale: &Locale| {
+                if count == 1 {
+                    String::from("1 item removed")
+                } else {
+                    format!("{count} items removed")
+                }
+            }) as Arc<CountLocaleMessage>),
+
+            filtered: MessageFn::new(Arc::new(|count: usize, _locale: &Locale| match count {
+                0 => String::from("No results found"),
+                1 => String::from("1 result available"),
+                n => format!("{n} results available"),
+            }) as Arc<CountLocaleMessage>),
+
+            sorted: MessageFn::new(Arc::new(
+                |column: &str, direction: SortDirection, _locale: &Locale| {
+                    format!("Sorted by {column}, {direction}")
+                },
+            ) as Arc<SortedLocaleMessage>),
+
+            empty: MessageFn::new(
+                Arc::new(|_locale: &Locale| String::from("No items")) as Arc<LocaleMessage>
+            ),
+
+            loaded: MessageFn::new(Arc::new(|count: usize, _locale: &Locale| {
+                if count == 1 {
+                    String::from("1 item loaded")
+                } else {
+                    format!("{count} items loaded")
+                }
+            }) as Arc<CountLocaleMessage>),
+        }
+    }
+}
+
+impl Debug for CollectionMessages {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("CollectionMessages { .. }")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::{format, string::String};
+
+    use ars_core::Locale;
+
+    use super::*;
+
+    fn locale() -> Locale {
+        Locale::parse("en-US").expect("en-US must parse")
+    }
+
+    #[test]
+    fn collection_change_announcement_variants_construct() {
+        let items_added = CollectionChangeAnnouncement::ItemsAdded { count: 1 };
+
+        let items_removed = CollectionChangeAnnouncement::ItemsRemoved { count: 2 };
+
+        let filtered = CollectionChangeAnnouncement::Filtered { matching_count: 3 };
+
+        let sorted = CollectionChangeAnnouncement::Sorted {
+            column: String::from("Name"),
+            direction: SortDirection::Ascending,
+        };
+
+        let empty = CollectionChangeAnnouncement::Empty;
+
+        let loaded = CollectionChangeAnnouncement::Loaded { count: 4 };
+
+        assert_eq!(
+            items_added,
+            CollectionChangeAnnouncement::ItemsAdded { count: 1 }
+        );
+        assert_eq!(
+            items_removed,
+            CollectionChangeAnnouncement::ItemsRemoved { count: 2 }
+        );
+        assert_eq!(
+            filtered,
+            CollectionChangeAnnouncement::Filtered { matching_count: 3 }
+        );
+        assert_eq!(
+            sorted,
+            CollectionChangeAnnouncement::Sorted {
+                column: String::from("Name"),
+                direction: SortDirection::Ascending,
+            }
+        );
+        assert_eq!(empty, CollectionChangeAnnouncement::Empty);
+        assert_eq!(loaded, CollectionChangeAnnouncement::Loaded { count: 4 });
+    }
+
+    #[test]
+    fn collection_change_announcement_derives_clone_debug_and_partial_eq() {
+        let announcement = CollectionChangeAnnouncement::Sorted {
+            column: String::from("Status"),
+            direction: SortDirection::Descending,
+        };
+
+        assert_eq!(announcement.clone(), announcement);
+        assert_eq!(
+            format!("{announcement:?}"),
+            "Sorted { column: \"Status\", direction: Descending }"
+        );
+    }
+
+    #[test]
+    fn default_items_added_messages_match_spec() {
+        let locale = locale();
+
+        let messages = CollectionMessages::default();
+
+        assert_eq!((messages.items_added)(1, &locale), "1 item added");
+        assert_eq!((messages.items_added)(5, &locale), "5 items added");
+    }
+
+    #[test]
+    fn default_items_removed_messages_match_spec() {
+        let locale = locale();
+
+        let messages = CollectionMessages::default();
+
+        assert_eq!((messages.items_removed)(1, &locale), "1 item removed");
+        assert_eq!((messages.items_removed)(5, &locale), "5 items removed");
+    }
+
+    #[test]
+    fn default_filtered_messages_match_spec() {
+        let locale = locale();
+
+        let messages = CollectionMessages::default();
+
+        assert_eq!((messages.filtered)(0, &locale), "No results found");
+        assert_eq!((messages.filtered)(1, &locale), "1 result available");
+        assert_eq!((messages.filtered)(5, &locale), "5 results available");
+    }
+
+    #[test]
+    fn default_sorted_messages_match_spec() {
+        let locale = locale();
+
+        let messages = CollectionMessages::default();
+
+        assert_eq!(
+            (messages.sorted)("Name", SortDirection::Ascending, &locale),
+            "Sorted by Name, ascending"
+        );
+        assert_eq!(
+            (messages.sorted)("Name", SortDirection::Descending, &locale),
+            "Sorted by Name, descending"
+        );
+    }
+
+    #[test]
+    fn default_empty_message_matches_spec() {
+        let locale = locale();
+
+        let messages = CollectionMessages::default();
+
+        assert_eq!((messages.empty)(&locale), "No items");
+    }
+
+    #[test]
+    fn default_loaded_messages_match_spec() {
+        let locale = locale();
+
+        let messages = CollectionMessages::default();
+
+        assert_eq!((messages.loaded)(1, &locale), "1 item loaded");
+        assert_eq!((messages.loaded)(5, &locale), "5 items loaded");
+    }
+
+    #[test]
+    fn collection_messages_debug_is_redacted() {
+        assert_eq!(
+            format!("{:?}", CollectionMessages::default()),
+            "CollectionMessages { .. }"
+        );
+    }
+}

--- a/crates/ars-collections/src/lib.rs
+++ b/crates/ars-collections/src/lib.rs
@@ -25,6 +25,8 @@
 //! - [`SortedCollection`] — comparator-based sorting view.
 //! - [`SortDirection`] — ascending or descending sort order.
 //! - [`SortDescriptor`] — column + direction for table sorting.
+//! - [`CollectionChangeAnnouncement`] — structured live-region event for collection mutations.
+//! - [`CollectionMessages`] — localizable message closures for collection mutation announcements.
 //! - [`CollectionError`] — error from an async page load.
 //! - [`typeahead`] — type-ahead / type-select state machine for keyboard search.
 //! - [`Virtualizer`] — visible-range and scroll math for virtualized rendering.
@@ -34,6 +36,7 @@
 //! - [`HorizontalVirtualLayout`] — optional extension trait for horizontal layout engines.
 //! - [`normalize_scroll_left_rtl`] — RTL scroll normalization for cross-browser consistency.
 //! - [`RtlScrollMode`] — browser convention for RTL `scrollLeft` values.
+//! - [`OnAction`] — platform-appropriate callback for item activation.
 //!
 //! # Locale-aware collation (`i18n` feature)
 //!
@@ -46,6 +49,8 @@
 
 extern crate alloc;
 
+/// Localizable announcement message helpers for collection mutations.
+pub mod announcements;
 /// Async collection with pagination and loading state management.
 pub mod async_collection;
 /// Async data loading traits and result types.
@@ -77,6 +82,7 @@ pub mod virtual_layout;
 /// Virtualized rendering range and scroll math.
 pub mod virtualization;
 
+pub use announcements::{CollectionChangeAnnouncement, CollectionMessages};
 pub use async_collection::{AsyncCollection, AsyncLoadingState};
 pub use async_loader::{AsyncLoader, CollectionError, LoadResult};
 pub use builder::CollectionBuilder;
@@ -84,7 +90,7 @@ pub use collection::{Collection, CollectionItem};
 pub use filtered_collection::FilteredCollection;
 pub use key::Key;
 pub use node::{Node, NodeType};
-pub use selection::DisabledBehavior;
+pub use selection::{DisabledBehavior, OnAction};
 #[cfg(feature = "i18n")]
 pub use sorted_collection::{CollationSupport, CollationTarget, CollatorCache};
 pub use sorted_collection::{SortDescriptor, SortDirection, SortedCollection};

--- a/crates/ars-collections/src/selection.rs
+++ b/crates/ars-collections/src/selection.rs
@@ -1,5 +1,7 @@
 use alloc::{boxed::Box, collections::BTreeSet};
 
+use ars_core::Callback;
+
 use crate::{Collection, key::Key};
 
 /// Whether and how many items can be selected simultaneously.
@@ -126,6 +128,12 @@ pub enum DisabledBehavior {
     /// Disabled items are focusable but not selectable.
     FocusOnly,
 }
+
+/// Callback for item action (Enter, double-click, tap in replace mode).
+///
+/// Distinct from selection change: action activates the item associated with
+/// the provided [`Key`].
+pub type OnAction = Option<Callback<dyn Fn(Key)>>;
 
 /// The full selection state for a collection-based component.
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -385,7 +393,8 @@ impl State {
 
 #[cfg(test)]
 mod tests {
-    use alloc::{collections::BTreeSet, vec, vec::Vec};
+    use alloc::{collections::BTreeSet, sync::Arc, vec, vec::Vec};
+    use core::sync::atomic::{AtomicBool, Ordering};
 
     use super::*;
     use crate::CollectionBuilder;
@@ -830,5 +839,23 @@ mod tests {
         let state = multiple_toggle_state().set_focus(Key::int(4));
         assert_eq!(state.focused_key, Some(Key::int(4)));
         assert_eq!(state.selected_keys, Set::Empty);
+    }
+
+    #[test]
+    fn on_action_uses_callback_abstraction() {
+        let called = Arc::new(AtomicBool::new(false));
+        let callback: Option<Callback<dyn Fn(Key)>> = {
+            let called = Arc::clone(&called);
+            Some(Callback::new(move |key| {
+                if key == Key::int(7) {
+                    called.store(true, Ordering::Relaxed);
+                }
+            }))
+        };
+        let on_action: OnAction = callback.clone();
+
+        assert!(on_action.is_some());
+        on_action.expect("OnAction should exist")(Key::int(7));
+        assert!(called.load(Ordering::Relaxed));
     }
 }

--- a/spec/foundation/06-collections.md
+++ b/spec/foundation/06-collections.md
@@ -634,12 +634,12 @@ pub enum CollectionChangeAnnouncement {
 /// for count-dependent messages.
 ///
 /// Default English messages are provided. Override via Props to localize.
-// Uses `MessageFn` and `Locale` from ars-i18n (04-internationalization.md §7.1).
-use ars_i18n::{Locale, MessageFn};
+// Uses `MessageFn` and `Locale` from ars-core, which re-exports locale support.
+use alloc::sync::Arc;
+use ars_core::{Locale, MessageFn};
 
-/// All closure fields use `MessageFn::new()` which delegates to the cfg-gated `From` impls
-/// defined in `04-internationalization.md` §7.1 — `Rc` on WASM, `Arc` on native.
-/// Trait objects include `+ Send + Sync` on all targets (see design note in §7.1).
+/// `ars_core::MessageFn` wraps closures in `Arc` on all targets.
+/// Trait objects include `+ Send + Sync` on all targets.
 
 pub struct CollectionMessages {
     /// Message for items added. Receives (count, locale) for plural-aware formatting.
@@ -680,9 +680,11 @@ impl Default for CollectionMessages {
                 n => format!("{n} results available"),
             }),
             // Note: `SortDirection` is defined in §7.2 and imported at the crate level.
-            sorted: MessageFn::new(|col: &str, dir: SortDirection, _locale: &Locale| {
-                format!("Sorted by {col}, {dir}")
-            }),
+            sorted: MessageFn::new(Arc::new(
+                |col: &str, dir: SortDirection, _locale: &Locale| {
+                    format!("Sorted by {col}, {dir}")
+                },
+            ) as Arc<dyn Fn(&str, SortDirection, &Locale) -> String + Send + Sync>),
             empty: MessageFn::new(|_locale: &Locale| "No items".into()),
             loaded: MessageFn::new(|count: usize, _locale: &Locale| {
                 if count == 1 { "1 item loaded".into() }
@@ -2164,13 +2166,9 @@ pub enum Mode {
 
 /// Callback for item action (Enter, double-click, tap in Replace mode).
 /// Distinct from selection change — action activates the item.
-/// Uses the same cfg-gated pattern as `Callback<T>`: `Rc` on WASM, `Arc` on native,
-/// ensuring cross-platform safety for multi-threaded native runtimes.
-#[cfg(target_arch = "wasm32")]
-pub type OnAction = Option<Rc<dyn Fn(Key)>>;
-
-#[cfg(not(target_arch = "wasm32"))]
-pub type OnAction = Option<Arc<dyn Fn(Key) + Send + Sync>>;
+/// Uses the shared `Callback` abstraction so ownership and equality semantics
+/// stay consistent with other event handlers across all targets.
+pub type OnAction = Option<Callback<dyn Fn(Key)>>;
 ```
 
 > **Capture semantics**: OnAction callbacks are invoked synchronously during event processing.


### PR DESCRIPTION
Closes #548

## Summary
- add `CollectionChangeAnnouncement` and `CollectionMessages` to `ars-collections`
- switch `OnAction` to the shared `Callback` abstraction and re-export the new APIs
- update the collections spec to match the implementation details and callback-based action alias

## Verification
- `cargo test -p ars-collections --lib`
- `cargo test -p ars-collections --lib --target wasm32-unknown-unknown --no-run`
- `cargo xci`