### PR TITLE
Implement MutableListData, MutableTreeData, and CollectionChange in ars-collections

### DIFF
--- a/crates/ars-collections/src/lib.rs
+++ b/crates/ars-collections/src/lib.rs
@@ -15,6 +15,9 @@
 //! - [`StaticCollection`] — in-memory `Collection` implementation.
 //! - [`TreeCollection`] — hierarchical `Collection` with expand/collapse.
 //! - [`TreeItemConfig`] — configuration for tree item construction.
+//! - [`CollectionChange`] — granular change event emitted by mutable collections.
+//! - [`MutableListData`] — mutable wrapper around [`StaticCollection`] with change tracking.
+//! - [`MutableTreeData`] — mutable wrapper around [`TreeCollection`] with change tracking.
 //! - [`selection`] — selection enums and state for collection-based components.
 //! - [`navigation`] — disabled-aware navigation helpers for collection widgets.
 //! - [`AsyncLoadingState`] — loading phase for async/paginated collections.
@@ -63,6 +66,8 @@ pub mod collection;
 pub mod filtered_collection;
 /// Stable node identifiers for collections.
 pub mod key;
+/// Mutable collection wrappers that track granular changes for adapters.
+pub mod mutable;
 /// Disabled-aware navigation helpers for collection widgets.
 pub mod navigation;
 /// Node types and structural metadata for collection items.
@@ -89,6 +94,7 @@ pub use builder::CollectionBuilder;
 pub use collection::{Collection, CollectionItem};
 pub use filtered_collection::FilteredCollection;
 pub use key::Key;
+pub use mutable::{CollectionChange, MutableListData, MutableTreeData};
 pub use node::{Node, NodeType};
 pub use selection::{DisabledBehavior, OnAction};
 #[cfg(feature = "i18n")]

--- a/crates/ars-collections/src/mutable.rs
+++ b/crates/ars-collections/src/mutable.rs
@@ -15,7 +15,10 @@
 //! Spec reference: `spec/foundation/06-collections.md` §1.8 "Mutable
 //! Collections".
 
-use alloc::{collections::BTreeSet, vec::Vec};
+use alloc::{
+    collections::{BTreeMap, BTreeSet},
+    vec::Vec,
+};
 use core::{
     fmt::{self, Debug},
     mem,
@@ -447,27 +450,47 @@ impl<T: CollectionItem> MutableTreeData<T> {
     /// Remove the listed nodes (and their descendants), returning their
     /// owned item values.
     ///
-    /// Emits [`CollectionChange::Remove`] carrying every key that
-    /// disappeared from the **visible iteration** as a result of the
-    /// call — that includes:
+    /// Emits up to two kinds of event, in DFS order:
     ///
-    /// * the input keys that actually matched a node,
-    /// * cascade-removed descendants that were rendered, and
-    /// * structural nodes ([`Section`], [`Header`], [`Separator`]) which
-    ///   carry no payload and would never appear in the returned
-    ///   `Vec<T>`.
+    /// * [`CollectionChange::Remove`] — carrying every key that
+    ///   disappeared from the **visible iteration** as a result of the
+    ///   call. That includes:
+    ///     - the input keys that actually matched a node,
+    ///     - cascade-removed descendants that were rendered, and
+    ///     - structural nodes ([`Section`], [`Header`], [`Separator`]),
+    ///       which carry no payload and would never appear in the
+    ///       returned `Vec<T>`.
     ///
-    /// Hidden nodes (those inside a collapsed ancestor) were never
-    /// rendered, so they stay out of the change event — emitting them
-    /// would force the adapter to no-op and pollute the truthful change
-    /// log. When every removed item was hidden the call returns the
-    /// values without emitting any event.
+    ///   Hidden nodes (those inside a collapsed ancestor) were never
+    ///   rendered, so they stay out of the change event — emitting them
+    ///   would force the adapter to no-op and pollute the truthful
+    ///   change log.
     ///
-    /// The diff is computed against `visible_keys()` before and after
-    /// the inner mutation rather than from the returned `Vec<T>`, both
-    /// to capture cascaded descendants and to surface structural
-    /// removals that have no payload to enumerate.
+    /// * [`CollectionChange::Replace`] — one event per still-visible
+    ///   parent whose [`has_children`] flipped from `true` to `false`
+    ///   as a side effect of the removal. A parent transitions from a
+    ///   branch to a leaf when the removal drains its last remaining
+    ///   child (visible *or* hidden); the inner tree flips
+    ///   `has_children: true → false` and `is_expanded: Some(_) → None`
+    ///   on that node. Adapters key expander chevrons and
+    ///   `aria-expanded` off those flags, so the parent row must be
+    ///   re-rendered even when none of its visible children appeared in
+    ///   the `Remove` event. Parents that are themselves hidden (inside
+    ///   a collapsed ancestor) are skipped: their row isn't rendered,
+    ///   so the metadata change is invisible until an ancestor expands
+    ///   and the adapter re-reads them.
     ///
+    /// Remove events precede Replace events in the drained buffer, and
+    /// Replace events are emitted in pre-mutation DFS order so the
+    /// event trace is stable for keyed reconcilers.
+    ///
+    /// The Remove diff is computed against `visible_keys()` before and
+    /// after the inner mutation rather than from the returned `Vec<T>`,
+    /// both to capture cascaded descendants and to surface structural
+    /// removals that have no payload to enumerate. The branch→leaf
+    /// detection reuses the same pre-mutation snapshot.
+    ///
+    /// [`has_children`]: crate::node::Node::has_children
     /// [`Section`]: crate::node::NodeType::Section
     /// [`Header`]: crate::node::NodeType::Header
     /// [`Separator`]: crate::node::NodeType::Separator
@@ -476,22 +499,50 @@ impl<T: CollectionItem> MutableTreeData<T> {
         // `Collection::keys`, available because `MutableTreeData::remove`
         // only requires `T: CollectionItem`. Capturing the iteration
         // order in a `Vec` (not a `BTreeSet`) lets us preserve DFS
-        // order in the change event.
+        // order in the change event. The parallel `BTreeMap` snapshot
+        // records branch/leaf state for each visible key so the
+        // post-mutation loop can detect parents whose last child was
+        // drained by this call.
         let visible_before = self.inner.visible_keys().cloned().collect::<Vec<_>>();
+
+        let visible_before_has_children = visible_before
+            .iter()
+            .map(|k| (k.clone(), self.inner.has_children(k)))
+            .collect::<BTreeMap<_, _>>();
 
         let removed = self.inner.remove_by_keys(keys);
 
         let visible_after = self.inner.visible_keys().cloned().collect::<BTreeSet<_>>();
 
         let visible_removed_keys = visible_before
-            .into_iter()
-            .filter(|k| !visible_after.contains(k))
+            .iter()
+            .filter(|k| !visible_after.contains(*k))
+            .cloned()
             .collect::<Vec<_>>();
 
         if !visible_removed_keys.is_empty() {
             self.pending_changes.push(CollectionChange::Remove {
                 keys: visible_removed_keys,
             });
+        }
+
+        // Emit Replace for any still-visible parent whose `has_children`
+        // flipped from true to false. Removal can only lose children,
+        // never gain them, so the leaf→branch direction is not
+        // considered here. Iterating `visible_before` keeps the
+        // emission order DFS-stable and matches how the Remove event
+        // itself is ordered.
+        for k in &visible_before {
+            if !visible_after.contains(k) {
+                continue;
+            }
+
+            let was_branch = visible_before_has_children.get(k).copied().unwrap_or(false);
+
+            if was_branch && !self.inner.has_children(k) {
+                self.pending_changes
+                    .push(CollectionChange::Replace { key: k.clone() });
+            }
         }
 
         removed
@@ -514,42 +565,79 @@ impl<T: CollectionItem> MutableTreeData<T> {
     /// expanded subtree into a visible location surfaces all of it at
     /// once). A single `Move` event is therefore not always sufficient
     /// to describe the DOM impact. The wrapper picks the event shape
-    /// that matches the visibility transition:
+    /// that matches the subtree-visibility transition:
     ///
     /// | From visible | To visible | Event emitted                                                                    |
     /// | ------------ | ---------- | -------------------------------------------------------------------------------- |
     /// | yes          | yes        | `Move { key, from: vis_from, to: vis_to }`                                       |
     /// | yes          | no         | `Remove { keys: <previously-visible subtree keys, DFS order> }`                  |
     /// | no           | yes        | `Insert { index: vis_to, count: <number of newly-visible subtree nodes> }`       |
-    /// | no           | no         | *(no event — neither location is rendered)*                                      |
+    /// | no           | no         | *(no subtree event — neither location is rendered)*                              |
     ///
     /// In all cases the indices are **visible iteration indices**, not
     /// flat DFS indices, so the adapter can apply them directly against
     /// [`Collection::get_by_index`]. The `Insert` always spans
     /// `count` consecutive positions starting at `to_index`.
+    ///
+    /// # Parent metadata transitions
+    ///
+    /// Reparenting can also flip [`has_children`] on the old and new
+    /// parents independently of the moved subtree's own visibility:
+    ///
+    /// * the **old parent** transitions branch → leaf when the moved
+    ///   node was its only remaining child (`has_children: true →
+    ///   false`, `is_expanded: Some(_) → None`);
+    /// * the **new parent** transitions leaf → collapsed branch when it
+    ///   had no children before (`has_children: false → true`,
+    ///   `is_expanded: None → Some(false)`).
+    ///
+    /// These transitions change the parent row's rendered state
+    /// (expander chevron, `aria-expanded`) without changing its
+    /// iteration position, so they are surfaced as
+    /// [`CollectionChange::Replace`] events keyed by the affected
+    /// parent — one per still-visible parent that flipped. The
+    /// transition is silent when the affected parent is itself hidden
+    /// inside a collapsed ancestor, since its row is not rendered.
+    ///
+    /// The subtree event (if any) is emitted first, followed by the
+    /// parent `Replace` events in pre-mutation DFS order. The moved
+    /// key itself cannot flip `has_children` through a reparent — the
+    /// subtree moves as a unit — so it never triggers a `Replace` of
+    /// its own even when it appears in both the pre- and post-mutation
+    /// visible set.
+    ///
+    /// [`has_children`]: crate::node::Node::has_children
     pub fn reparent(
         &mut self,
         key: &Key,
         new_parent: Option<&Key>,
         index: usize,
     ) -> Option<(usize, usize)> {
-        // Snapshot the pre-mutation visible-key set in DFS order. The
-        // visible→hidden and hidden→visible branches both need to
-        // compare visibility before/after to capture every subtree
-        // descendant whose visibility flipped — only the moved
-        // subtree's visibility can change here, so a set difference
-        // against the full visible iteration is exactly the subtree
-        // delta. Capturing eagerly is simpler than re-deriving the
-        // pre-mutation state by walking the moved subtree post-move,
-        // and the visible iteration is bounded by what the adapter
-        // would render anyway.
+        // Snapshot the pre-mutation visible-key set in DFS order and
+        // the branch/leaf flag for each visible key.
+        //
+        // Both visibility-crossing subtree branches need to compare
+        // pre/post visibility to capture every subtree descendant that
+        // flipped — only the moved subtree's visibility can change, so
+        // a set difference against the full visible iteration is
+        // exactly the subtree delta. The same snapshot doubles as a
+        // membership set for the hidden→visible count and as the
+        // source of pre-mutation `has_children` state for the parent
+        // metadata-transition detection.
         let visible_before = self.inner.visible_keys().cloned().collect::<Vec<_>>();
+
+        let visible_before_has_children = visible_before
+            .iter()
+            .map(|k| (k.clone(), self.inner.has_children(k)))
+            .collect::<BTreeMap<_, _>>();
 
         let from_visible = self.inner.visible_index_of(key);
 
         let (from_flat, to_flat) = self.inner.reparent(key, new_parent, index)?;
 
         let to_visible = self.inner.visible_index_of(key);
+
+        let visible_after = self.inner.visible_keys().cloned().collect::<BTreeSet<_>>();
 
         match (from_visible, to_visible) {
             (Some(from_index), Some(to_index)) => {
@@ -567,11 +655,10 @@ impl<T: CollectionItem> MutableTreeData<T> {
                 // order so a keyed reconciler can drop the matching
                 // DOM rows in one pass — emitting only `key` would
                 // leave orphan descendants in the DOM/state.
-                let visible_after = self.inner.visible_keys().cloned().collect::<BTreeSet<_>>();
-
                 let removed_keys = visible_before
-                    .into_iter()
-                    .filter(|k| !visible_after.contains(k))
+                    .iter()
+                    .filter(|k| !visible_after.contains(*k))
+                    .cloned()
                     .collect::<Vec<_>>();
 
                 self.pending_changes
@@ -584,13 +671,14 @@ impl<T: CollectionItem> MutableTreeData<T> {
                 // in `count` consecutive visible positions starting at
                 // `to_index`. Emitting `count: 1` would leave adapters
                 // that honour `count` under-applying the change and
-                // drifting subsequent indices.
-                let visible_before_set = visible_before.into_iter().collect::<BTreeSet<_>>();
-
+                // drifting subsequent indices. Reuse
+                // `visible_before_has_children` as a membership set —
+                // `contains_key` is O(log n) and avoids a second
+                // allocation.
                 let count = self
                     .inner
                     .visible_keys()
-                    .filter(|k| !visible_before_set.contains(*k))
+                    .filter(|k| !visible_before_has_children.contains_key(*k))
                     .count();
 
                 self.pending_changes.push(CollectionChange::Insert {
@@ -600,7 +688,38 @@ impl<T: CollectionItem> MutableTreeData<T> {
             }
 
             (None, None) => {
-                // Both endpoints hidden — no DOM change to report.
+                // Both subtree endpoints hidden — no subtree event.
+                // Parent-metadata transitions may still fire below.
+            }
+        }
+
+        // Emit Replace for any still-visible key whose `has_children`
+        // flipped in either direction. Iteration follows pre-mutation
+        // DFS order so the event trace is stable and matches the
+        // ordering used elsewhere.
+        //
+        // This loop is what surfaces `old_parent` losing its last
+        // child (branch → leaf) and `new_parent` gaining its first
+        // child (leaf → branch). The moved `key` itself cannot flip
+        // here — its subtree moves as a unit, so its own
+        // `has_children` is invariant under reparent — which means
+        // even if it appears in both visible sets the branch-state
+        // comparison short-circuits.
+        for k in visible_before {
+            if !visible_after.contains(&k) {
+                continue;
+            }
+
+            let was_branch = visible_before_has_children
+                .get(&k)
+                .copied()
+                .unwrap_or(false);
+
+            let is_branch = self.inner.has_children(&k);
+
+            if was_branch != is_branch {
+                self.pending_changes
+                    .push(CollectionChange::Replace { key: k });
             }
         }
 
@@ -1510,10 +1629,14 @@ mod tests {
         let mut tree = mixed_visibility_tree();
 
         // Root C (id 3) is a visible leaf in the fixture.
-        assert!(
-            tree.get(&Key::int(3))
-                .is_some_and(|n| !n.has_children && n.is_expanded.is_none()),
-            "fixture: Root C must be a leaf before the insert",
+        let root_c_before = tree
+            .get(&Key::int(3))
+            .expect("fixture: Root C must be present before the insert");
+
+        assert!(!root_c_before.has_children, "Root C starts as a leaf");
+        assert_eq!(
+            root_c_before.is_expanded, None,
+            "a leaf has no expansion state",
         );
 
         let flat = tree.insert_child(Some(&Key::int(3)), 0, Item::new(99, "New Child"));
@@ -1555,10 +1678,12 @@ mod tests {
         let mut tree = mixed_visibility_tree();
 
         // Child A1 is a hidden leaf (under collapsed Root A).
-        assert!(
-            tree.get(&Key::int(11))
-                .is_some_and(|n| !n.has_children && n.is_expanded.is_none()),
-            "fixture: Child A1 is a hidden leaf",
+        let child_a1_before = tree.get(&Key::int(11)).expect("fixture: Child A1 present");
+
+        assert!(!child_a1_before.has_children, "Child A1 starts as a leaf");
+        assert_eq!(
+            child_a1_before.is_expanded, None,
+            "Child A1 is a leaf, not an expanded branch",
         );
 
         let flat = tree.insert_child(Some(&Key::int(11)), 0, Item::new(111, "Hidden Grand"));
@@ -1567,10 +1692,18 @@ mod tests {
 
         // Inner state changed (Child A1 is now a collapsed branch),
         // but neither it nor the new grandchild is rendered.
+        let child_a1_after = tree
+            .get(&Key::int(11))
+            .expect("Child A1 still present after insert");
+
         assert!(
-            tree.get(&Key::int(11))
-                .is_some_and(|n| n.has_children && n.is_expanded == Some(false)),
-            "Child A1 transitioned to a collapsed branch internally",
+            child_a1_after.has_children,
+            "Child A1 flipped leaf→branch internally",
+        );
+        assert_eq!(
+            child_a1_after.is_expanded,
+            Some(false),
+            "Child A1 is now a collapsed branch",
         );
 
         let drained = tree.drain_changes();
@@ -1621,20 +1754,36 @@ mod tests {
     }
 
     #[test]
-    fn tree_remove_hidden_only_emits_no_event() {
-        // Remove the children of collapsed Root A. They were never
-        // visible, so the adapter has no DOM to clean up — no event.
+    fn tree_remove_hidden_non_last_child_emits_no_event() {
+        // Remove one hidden child of collapsed Root A. Root A still has
+        // its other hidden child afterwards, so `has_children` stays
+        // `true` (no branch→leaf flip), *and* no visible keys are
+        // removed. With nothing to render differently, the adapter gets
+        // an empty drain. (Removing *both* children would drain Root A's
+        // child list and emit `Replace { Root A }` — see
+        // `tree_remove_hidden_last_children_emits_replace_for_visible_parent`.)
         let mut tree = mixed_visibility_tree();
 
-        let removed = tree.remove(&[Key::int(11), Key::int(12)]);
+        let removed = tree.remove(&[Key::int(11)]);
 
-        assert_eq!(removed.len(), 2, "inner removal still returns the values");
+        assert_eq!(removed.len(), 1, "inner removal returned Child A1");
+
+        // Root A is still a collapsed branch (Child A2 remains).
+        let root_a = tree.get(&Key::int(1)).expect("Root A still in tree");
+
+        assert!(root_a.has_children, "Root A still has Child A2");
+        assert_eq!(
+            root_a.is_expanded,
+            Some(false),
+            "Root A is still a collapsed branch",
+        );
 
         let drained = tree.drain_changes();
 
         assert!(
             drained.is_empty(),
-            "no event when removed items were all hidden; got {drained:?}"
+            "no event when removed node was hidden and parent stayed a branch; \
+             got {drained:?}"
         );
     }
 
@@ -1661,6 +1810,104 @@ mod tests {
         assert_eq!(
             drained, expected,
             "Remove event must include only previously-visible keys"
+        );
+    }
+
+    #[test]
+    fn tree_remove_hidden_last_children_emits_replace_for_visible_parent() {
+        // Remove *both* hidden children of collapsed Root A. None of the
+        // removed keys were visible, so `visible_removed_keys` is empty —
+        // but `TreeCollection::remove_by_keys` still flips Root A's
+        // metadata from a collapsed branch to a leaf:
+        //   has_children: true  → false
+        //   is_expanded:  Some(false) → None
+        // Root A is *visible*, and adapters key expander chevron /
+        // `aria-expanded` off those flags. A reconciler consuming only
+        // `CollectionChange` would leave Root A rendered as a collapsed
+        // branch forever unless the wrapper emits `Replace`.
+        let mut tree = mixed_visibility_tree();
+
+        // Sanity: Root A starts as a collapsed branch.
+        let root_a_before = tree
+            .get(&Key::int(1))
+            .expect("fixture: Root A present before remove");
+
+        assert!(root_a_before.has_children, "Root A starts with children");
+        assert_eq!(
+            root_a_before.is_expanded,
+            Some(false),
+            "Root A starts collapsed",
+        );
+
+        let removed = tree.remove(&[Key::int(11), Key::int(12)]);
+
+        assert_eq!(
+            removed.len(),
+            2,
+            "inner removal still returns both payloads"
+        );
+
+        // Confirm the branch→leaf transition actually landed, since
+        // that is the precondition for the Replace event.
+        let root_a = tree.get(&Key::int(1)).expect("Root A still present");
+
+        assert!(!root_a.has_children, "Root A lost its last child");
+        assert_eq!(root_a.is_expanded, None, "a leaf has no expansion state",);
+
+        let drained = tree.drain_changes();
+
+        assert_eq!(
+            drained,
+            vec![CollectionChange::Replace { key: Key::int(1) }],
+            "branch→leaf transition on a visible parent must emit Replace, \
+             even though no visible descendants were removed",
+        );
+    }
+
+    #[test]
+    fn tree_remove_visible_last_child_emits_replace_alongside_remove() {
+        // Remove Child B1, the only visible child of Root B. The visible
+        // iteration loses Child B1 (→ Remove event) *and* Root B flips
+        // from an expanded branch to a leaf:
+        //   has_children: true → false
+        //   is_expanded:  Some(true) → None
+        // Root B is still visible at the same row, so its chevron /
+        // `aria-expanded` must be refreshed in the same update cycle.
+        // The Replace for Root B fires alongside the Remove for Child B1.
+        let mut tree = mixed_visibility_tree();
+
+        let root_b_before = tree
+            .get(&Key::int(2))
+            .expect("fixture: Root B present before remove");
+
+        assert!(root_b_before.has_children, "Root B starts with children");
+        assert_eq!(
+            root_b_before.is_expanded,
+            Some(true),
+            "Root B starts expanded",
+        );
+
+        let removed = tree.remove(&[Key::int(21)]);
+
+        assert_eq!(removed.len(), 1, "Child B1 payload returned");
+
+        let root_b = tree.get(&Key::int(2)).expect("Root B still present");
+
+        assert!(!root_b.has_children, "Root B lost its last child");
+        assert_eq!(root_b.is_expanded, None, "Root B is now a leaf");
+
+        let drained = tree.drain_changes();
+
+        assert_eq!(
+            drained,
+            vec![
+                CollectionChange::Remove {
+                    keys: vec![Key::int(21)],
+                },
+                CollectionChange::Replace { key: Key::int(2) },
+            ],
+            "visible child removal that flips the visible parent must emit \
+             Remove for the child and Replace for the parent in that order",
         );
     }
 
@@ -1767,6 +2014,12 @@ mod tests {
         // becomes visible at once — `count` must reflect the full
         // subtree size, not 1, otherwise adapters that honour `count`
         // will under-apply the change and drift indices.
+        //
+        // Child A1 is Root A's *only* child in this fixture, so the
+        // move also drains Root A: it flips branch → leaf while
+        // staying visible at row 0. The wrapper emits the subtree
+        // `Insert` first, then a `Replace` for Root A's metadata flip,
+        // in that order.
         let mut tree = MutableTreeData::new(TreeCollection::new([
             TreeItemConfig {
                 key: Key::int(1),
@@ -1823,15 +2076,28 @@ mod tests {
 
         assert_eq!(
             drained,
-            vec![CollectionChange::Insert { index: 1, count: 2 }],
-            "Insert count must reflect every newly-visible subtree node, not just the root"
+            vec![
+                CollectionChange::Insert { index: 1, count: 2 },
+                CollectionChange::Replace { key: Key::int(1) },
+            ],
+            "Insert count must reflect every newly-visible subtree node, not \
+             just the root; Replace must fire for Root A's branch→leaf flip",
         );
     }
 
     #[test]
-    fn tree_reparent_hidden_to_hidden_emits_no_event() {
-        // Build a tree with two collapsed parents so we can shuffle a
-        // child between them without ever entering the visible region.
+    fn tree_reparent_hidden_to_hidden_flips_both_visible_roots_emits_replace_for_each() {
+        // Two collapsed visible roots (Box 1, Box 2) with a single
+        // hidden item under Box 1. Moving the item between them keeps
+        // both subtree endpoints hidden (a `(None, None)` case — no
+        // `Move` / `Insert` / `Remove` for the subtree itself), but
+        // both roots *are* visible and both flip their branch/leaf
+        // state:
+        //   Box 1: has_children true → false, is_expanded Some(false) → None
+        //   Box 2: has_children false → true, is_expanded None → Some(false)
+        // The wrapper must emit one `Replace` per affected visible
+        // parent in pre-mutation DFS order, otherwise adapters leave
+        // both chevrons stale.
         let mut tree = MutableTreeData::new(TreeCollection::new([
             TreeItemConfig {
                 key: Key::int(1),
@@ -1855,12 +2121,279 @@ mod tests {
             },
         ]));
 
+        // Sanity: both roots are visible; the item is hidden.
+        assert_eq!(
+            tree.keys().cloned().collect::<Vec<_>>(),
+            vec![Key::int(1), Key::int(2)],
+            "fixture: only the two roots are visible",
+        );
+
         let indices = tree.reparent(&Key::int(11), Some(&Key::int(2)), 0);
 
         assert!(indices.is_some(), "reparent succeeded");
+
+        // Confirm both transitions landed.
+        let box_1 = tree.get(&Key::int(1)).expect("Box 1 still present");
+
+        assert!(!box_1.has_children, "Box 1 lost its only child");
+        assert_eq!(box_1.is_expanded, None, "Box 1 is now a leaf");
+
+        let box_2 = tree.get(&Key::int(2)).expect("Box 2 still present");
+
+        assert!(box_2.has_children, "Box 2 gained the item");
+        assert_eq!(
+            box_2.is_expanded,
+            Some(false),
+            "Box 2 is now a collapsed branch",
+        );
+
+        // The visible iteration is unchanged — the item is hidden
+        // under the newly-collapsed Box 2.
+        assert_eq!(
+            tree.keys().cloned().collect::<Vec<_>>(),
+            vec![Key::int(1), Key::int(2)],
+        );
+
+        let drained = tree.drain_changes();
+
+        assert_eq!(
+            drained,
+            vec![
+                CollectionChange::Replace { key: Key::int(1) },
+                CollectionChange::Replace { key: Key::int(2) },
+            ],
+            "both visible parents flipped metadata; one Replace per parent, \
+             pre-mutation DFS order",
+        );
+    }
+
+    #[test]
+    fn tree_reparent_hidden_to_hidden_emits_replace_for_visible_leaf_destination() {
+        // Move Child A1 (hidden under collapsed Root A) to be the first
+        // child of Root C (a visible leaf). The moved subtree is hidden
+        // before *and* after (Root C flips into a collapsed branch the
+        // moment it gains a child, so Child A1 lands inside a collapsed
+        // ancestor). That makes this a `(None, None)` subtree-visibility
+        // case — no `Move` / `Insert` / `Remove` fires for the subtree —
+        // yet Root C's *visible row* transitioned:
+        //   has_children: false → true
+        //   is_expanded:  None  → Some(false)
+        // Adapters key expander chevron / `aria-expanded` off those
+        // flags, so a reconciler consuming only `CollectionChange`
+        // would leave Root C rendered as a leaf unless the wrapper
+        // emits `Replace` for it. Root A still has Child A2, so its
+        // `has_children` flag is unchanged — no Replace for Root A.
+        let mut tree = mixed_visibility_tree();
+
+        // Sanity: Root C starts as a visible leaf.
+        let root_c_before = tree
+            .get(&Key::int(3))
+            .expect("fixture: Root C present before reparent");
+
+        assert!(!root_c_before.has_children, "Root C starts as a leaf");
+        assert_eq!(
+            root_c_before.is_expanded, None,
+            "a leaf has no expansion state",
+        );
+
+        let indices = tree.reparent(&Key::int(11), Some(&Key::int(3)), 0);
+
+        assert!(indices.is_some(), "reparent succeeded");
+
+        // Confirm the leaf→branch transition landed on Root C.
+        let root_c = tree.get(&Key::int(3)).expect("Root C still present");
+
+        assert!(root_c.has_children, "Root C gained a child");
+        assert_eq!(
+            root_c.is_expanded,
+            Some(false),
+            "Root C is now a collapsed branch",
+        );
+
+        // Child A1 is hidden under newly-collapsed Root C; the visible
+        // iteration length is unchanged (still [Root A, Root B, Child
+        // B1, Root C]).
+        assert_eq!(
+            tree.keys().cloned().collect::<Vec<_>>(),
+            vec![Key::int(1), Key::int(2), Key::int(21), Key::int(3)],
+            "Child A1 is hidden under the newly-collapsed Root C",
+        );
+
+        // Root A still has Child A2 and remains a branch.
+        let root_a_after = tree
+            .get(&Key::int(1))
+            .expect("Root A present after reparent");
+
+        assert!(root_a_after.has_children, "Root A kept Child A2");
+        assert_eq!(
+            root_a_after.is_expanded,
+            Some(false),
+            "Root A is still a collapsed branch",
+        );
+
+        let drained = tree.drain_changes();
+
+        assert_eq!(
+            drained,
+            vec![CollectionChange::Replace { key: Key::int(3) }],
+            "leaf→branch transition on a visible destination must emit \
+             Replace even when neither subtree endpoint is visible",
+        );
+    }
+
+    #[test]
+    fn tree_reparent_visible_move_flips_src_parent_emits_move_and_replace() {
+        // Both endpoints visible (Move case). Root A has only Child A1,
+        // so moving Child A1 away drains Root A's child list:
+        //   has_children: true → false
+        //   is_expanded:  Some(true) → None
+        // Root A stays visible at row 0, so the wrapper must emit both
+        // the subtree `Move` *and* a `Replace` for Root A's branch→leaf
+        // flip in the same drain cycle.
+        let mut tree = MutableTreeData::new(TreeCollection::new([
+            TreeItemConfig {
+                key: Key::int(1),
+                text_value: "Root A".to_string(),
+                value: Item::new(1, "Root A"),
+                children: vec![TreeItemConfig {
+                    key: Key::int(11),
+                    text_value: "Child A1".to_string(),
+                    value: Item::new(11, "Child A1"),
+                    children: vec![],
+                    default_expanded: true,
+                }],
+                default_expanded: true,
+            },
+            TreeItemConfig {
+                key: Key::int(2),
+                text_value: "Root B".to_string(),
+                value: Item::new(2, "Root B"),
+                children: vec![TreeItemConfig {
+                    key: Key::int(21),
+                    text_value: "Child B1".to_string(),
+                    value: Item::new(21, "Child B1"),
+                    children: vec![],
+                    default_expanded: true,
+                }],
+                default_expanded: true,
+            },
+        ]));
+
+        // Sanity: everything is visible, Root A is an expanded branch.
+        assert_eq!(
+            tree.keys().cloned().collect::<Vec<_>>(),
+            vec![Key::int(1), Key::int(11), Key::int(2), Key::int(21),],
+        );
+
+        // Move Child A1 under Root B at sibling-index 0.
+        let indices = tree.reparent(&Key::int(11), Some(&Key::int(2)), 0);
+
+        assert!(indices.is_some(), "reparent succeeded");
+
+        // Root A now has no children (branch→leaf) while Root B still
+        // has two (Root B's branch state is unchanged).
+        let root_a = tree.get(&Key::int(1)).expect("Root A still present");
+
+        assert!(!root_a.has_children, "Root A lost its only child");
+        assert_eq!(root_a.is_expanded, None, "Root A is now a leaf");
+
+        let root_b = tree.get(&Key::int(2)).expect("Root B still present");
+
+        assert!(root_b.has_children, "Root B still a branch");
+        assert_eq!(root_b.is_expanded, Some(true), "Root B still expanded",);
+
+        // Post-move visible order: Root A (leaf), Root B, Child A1, Child B1.
+        assert_eq!(
+            tree.keys().cloned().collect::<Vec<_>>(),
+            vec![Key::int(1), Key::int(2), Key::int(11), Key::int(21),],
+        );
+
+        let drained = tree.drain_changes();
+
+        assert_eq!(
+            drained,
+            vec![
+                CollectionChange::Move {
+                    key: Key::int(11),
+                    from_index: 1,
+                    to_index: 2,
+                },
+                CollectionChange::Replace { key: Key::int(1) },
+            ],
+            "visible move that drains src_parent's last child must emit \
+             Move then Replace for the src_parent's branch→leaf flip",
+        );
+    }
+
+    #[test]
+    fn tree_reparent_hidden_to_hidden_with_hidden_parents_emits_no_event() {
+        // Deeply nested fixture: a single visible collapsed root that
+        // hides two sub-parents (a collapsed branch and a leaf) with
+        // their own hidden item. Moving the hidden item between the
+        // two hidden sub-parents flips `has_children` on both — but
+        // since neither sub-parent is itself rendered (both are hidden
+        // under the outer collapsed root), the metadata change is
+        // invisible and no event should fire. This is the negative
+        // guard for the leaf→branch / branch→leaf Replace emissions in
+        // `reparent`: the transitions only matter when the affected
+        // parent is actually part of the visible iteration.
+        let mut tree = MutableTreeData::new(TreeCollection::new([TreeItemConfig {
+            key: Key::int(1),
+            text_value: "Outer".to_string(),
+            value: Item::new(1, "Outer"),
+            children: vec![
+                TreeItemConfig {
+                    key: Key::int(11),
+                    text_value: "Box 1".to_string(),
+                    value: Item::new(11, "Box 1"),
+                    children: vec![TreeItemConfig {
+                        key: Key::int(111),
+                        text_value: "Item".to_string(),
+                        value: Item::new(111, "Item"),
+                        children: vec![],
+                        default_expanded: true,
+                    }],
+                    default_expanded: false,
+                },
+                TreeItemConfig {
+                    key: Key::int(12),
+                    text_value: "Box 2".to_string(),
+                    value: Item::new(12, "Box 2"),
+                    children: vec![],
+                    default_expanded: false,
+                },
+            ],
+            default_expanded: false,
+        }]));
+
+        // Sanity: only Outer is visible. Everything below is hidden.
+        assert_eq!(tree.keys().cloned().collect::<Vec<_>>(), vec![Key::int(1)],);
+
+        let indices = tree.reparent(&Key::int(111), Some(&Key::int(12)), 0);
+
+        assert!(indices.is_some(), "reparent succeeded");
+
+        // Box 1 (hidden) transitioned branch→leaf; Box 2 (hidden)
+        // transitioned leaf→branch. Both are invisible under the
+        // collapsed Outer, so no Replace is emitted.
+        let box_1 = tree.get(&Key::int(11)).expect("Box 1 present");
+
+        assert!(!box_1.has_children, "Box 1 flipped branch→leaf internally");
+        assert_eq!(box_1.is_expanded, None, "Box 1 has no expansion state");
+
+        let box_2 = tree.get(&Key::int(12)).expect("Box 2 present");
+
+        assert!(box_2.has_children, "Box 2 flipped leaf→branch internally");
+        assert_eq!(
+            box_2.is_expanded,
+            Some(false),
+            "Box 2 is now a collapsed branch",
+        );
+
         assert!(
             tree.drain_changes().is_empty(),
-            "no event when both endpoints are hidden"
+            "no event when every affected parent is hidden; got {:?}",
+            tree.drain_changes(),
         );
     }
 

--- a/crates/ars-collections/src/mutable.rs
+++ b/crates/ars-collections/src/mutable.rs
@@ -202,11 +202,27 @@ impl<T: CollectionItem> MutableListData<T> {
         old
     }
 
-    /// Remove every item and emit [`CollectionChange::Reset`]. Adapters
-    /// treat this as a hint to re-render the full list.
+    /// Remove every item and emit a single [`CollectionChange::Reset`].
+    ///
+    /// Any earlier pending events (`Insert`, `Remove`, `Move`, `Replace`)
+    /// are discarded before pushing `Reset` so the buffer is always
+    /// `[Reset]` after a clear. Coalescing matters because:
+    ///
+    /// * `Insert { index, count }` does not carry the inserted payload —
+    ///   replaying a stale `Insert` against the now-empty inner collection
+    ///   would let the adapter reference an item that no longer exists.
+    /// * `Reset` is by definition a full-rebuild signal, so any change
+    ///   that preceded it within the same update cycle is invisible to the
+    ///   adapter anyway.
+    ///
+    /// Adapters treat the resulting `Reset` as a hint to re-render the
+    /// full list from scratch.
     pub fn clear(&mut self) {
         self.inner.clear();
 
+        // Drop stale events queued earlier in this cycle: they describe
+        // intermediate states the adapter never observes.
+        self.pending_changes.clear();
         self.pending_changes.push(CollectionChange::Reset);
     }
 
@@ -732,6 +748,105 @@ mod tests {
 
         assert_eq!(list.size(), 0);
         assert_eq!(list.drain_changes(), vec![CollectionChange::Reset]);
+    }
+
+    #[test]
+    fn clear_discards_pending_events_and_emits_only_reset() {
+        // Regression test: prior behaviour was to append `Reset` to the
+        // existing buffer, leaving entries like `[Insert, Reset]` for the
+        // adapter to drain. `Insert { index, count }` carries no payload,
+        // so an adapter cannot replay a stale insert against the cleared
+        // collection. After `clear`, the buffer must be exactly `[Reset]`
+        // regardless of what was queued earlier in the cycle.
+        let mut list = list_of_three();
+
+        // Queue every other variant before clearing.
+        list.push(Item::new(4, "Date")); // Insert
+        list.remove(&[Key::int(2)]); // Remove
+        list.move_item(&Key::int(1), 1); // Move
+        list.replace(Item::new(3, "Cherry-2")); // Replace
+
+        // Sanity check: four events queued before clear.
+        assert_eq!(
+            list.drain_changes().len(),
+            4,
+            "precondition: four events queued before clear"
+        );
+
+        // Re-queue more events, then clear.
+        list.push(Item::new(5, "Elderberry"));
+        list.push(Item::new(6, "Fig"));
+
+        list.clear();
+
+        // After clear, the buffer must contain exactly one Reset event —
+        // the prior Insert events would reference indices the adapter
+        // can no longer replay.
+        let drained = list.drain_changes();
+
+        assert_eq!(
+            drained,
+            vec![CollectionChange::Reset],
+            "clear must coalesce all pending events into a single Reset; got {drained:?}"
+        );
+
+        // Inner state is also empty.
+        assert_eq!(list.size(), 0);
+    }
+
+    #[test]
+    fn clear_on_empty_buffer_still_emits_single_reset() {
+        // No prior events queued — clear must still emit exactly `[Reset]`.
+        let mut list = list_of_three();
+
+        list.clear();
+
+        assert_eq!(list.drain_changes(), vec![CollectionChange::Reset]);
+    }
+
+    #[test]
+    fn replace_on_structural_node_returns_none_and_emits_no_event() {
+        // Regression test: a Section node shares the key namespace with
+        // items, so a caller could supply an item whose key collides with
+        // a Section. `MutableListData::replace` must return `None` (the
+        // inner `StaticCollection::replace` refuses to mutate structural
+        // nodes) AND must NOT emit a `Replace` event for the structural
+        // key — otherwise the adapter would try to re-render a Section
+        // as if it were an item.
+        let inner = CollectionBuilder::new()
+            .section(Key::str("fruits"), "Fruits")
+            .item(Key::int(1), "Apple", Item::new(1, "Apple"))
+            .end_section()
+            .build();
+
+        let mut list = MutableListData::new(inner);
+
+        // Drain the empty initial buffer to make assertions unambiguous.
+        drop(list.drain_changes());
+
+        // Build an Item whose key collides with the Section's key.
+        let intruder = Item {
+            id: Key::str("fruits"),
+            label: "Pineapple".to_string(),
+        };
+
+        let old = list.replace(intruder);
+
+        assert!(old.is_none(), "replace must report failure on Section key");
+
+        let drained = list.drain_changes();
+
+        assert!(
+            drained.is_empty(),
+            "no Replace event should be emitted for structural-node keys; got {drained:?}"
+        );
+
+        // The Section is still a Section — no silent promotion to an Item.
+        let section = list
+            .get(&Key::str("fruits"))
+            .expect("section still present");
+
+        assert!(section.value.is_none(), "Section value must remain None");
     }
 
     #[test]

--- a/crates/ars-collections/src/mutable.rs
+++ b/crates/ars-collections/src/mutable.rs
@@ -15,7 +15,7 @@
 //! Spec reference: `spec/foundation/06-collections.md` §1.8 "Mutable
 //! Collections".
 
-use alloc::vec::Vec;
+use alloc::{collections::BTreeSet, vec::Vec};
 use core::{
     fmt::{self, Debug},
     mem,
@@ -341,30 +341,71 @@ impl<T: CollectionItem> MutableTreeData<T> {
     ///
     /// Returns the flat DFS index of the inserted node on success, or
     /// `None` if the inner [`TreeCollection::insert_child`] rejected the
-    /// insert (unknown parent key). `CollectionChange::Insert` is emitted
-    /// only on success, so the change log never references a phantom node.
+    /// insert (unknown parent key).
+    ///
+    /// # Visibility-aware change events
+    ///
+    /// The emitted `CollectionChange::Insert` carries the **visible
+    /// iteration index**, matching the position the adapter would use
+    /// against [`Collection::get_by_index`]. When the new child lands
+    /// inside a collapsed ancestor it is not part of the visible
+    /// iteration, so **no event is emitted** — the adapter's DOM is
+    /// already consistent (the node simply isn't rendered yet) and
+    /// emitting an `Insert { index, count }` carrying a flat DFS index
+    /// that has no corresponding visible position would mis-place the
+    /// DOM update. The hidden node will surface naturally when its
+    /// ancestor is later expanded and the adapter re-fetches the
+    /// expanded subtree.
     pub fn insert_child(&mut self, parent: Option<&Key>, index: usize, item: T) -> Option<usize> {
+        let key = item.key().clone();
         let flat_index = self.inner.insert_child(parent, index, item)?;
 
-        self.pending_changes.push(CollectionChange::Insert {
-            index: flat_index,
-            count: 1,
-        });
+        // Only emit an event when the new child is part of the visible
+        // iteration. A hidden insert produces no DOM change for the
+        // adapter to apply.
+        if let Some(visible_index) = self.inner.visible_index_of(&key) {
+            self.pending_changes.push(CollectionChange::Insert {
+                index: visible_index,
+                count: 1,
+            });
+        }
 
         Some(flat_index)
     }
 
     /// Remove the listed nodes (and their descendants), returning their
-    /// owned values. Emits [`CollectionChange::Remove`] carrying only the
-    /// keys that actually matched an item — unknown keys are silently
-    /// skipped by the inner collection and excluded from the change event.
+    /// owned values.
+    ///
+    /// Emits [`CollectionChange::Remove`] carrying only the keys that
+    /// were both **(a)** actually matched by the inner collection and
+    /// **(b)** part of the visible iteration immediately before the
+    /// removal. Hidden nodes (those inside a collapsed ancestor) were
+    /// never rendered, so signalling their removal would force the
+    /// adapter to no-op anyway and pollutes the truthful change log.
+    /// When every removed item was hidden the call returns the values
+    /// without emitting any event.
     pub fn remove(&mut self, keys: &[Key]) -> Vec<T> {
+        // Snapshot the visible-key set BEFORE mutation so we can later
+        // tell which removed items the adapter had actually rendered.
+        // `visible_keys` is the inherent (Clone-free) twin of
+        // `Collection::keys`, available because `MutableTreeData::remove`
+        // only requires `T: CollectionItem`.
+        let visible_before = self.inner.visible_keys().cloned().collect::<BTreeSet<_>>();
+
         let removed = self.inner.remove_by_keys(keys);
 
         if !removed.is_empty() {
-            self.pending_changes.push(CollectionChange::Remove {
-                keys: removed.iter().map(|t| t.key().clone()).collect(),
-            });
+            let visible_removed_keys = removed
+                .iter()
+                .map(|t| t.key().clone())
+                .filter(|k| visible_before.contains(k))
+                .collect::<Vec<_>>();
+
+            if !visible_removed_keys.is_empty() {
+                self.pending_changes.push(CollectionChange::Remove {
+                    keys: visible_removed_keys,
+                });
+            }
         }
 
         removed
@@ -376,40 +417,97 @@ impl<T: CollectionItem> MutableTreeData<T> {
     /// Returns `Some((from_flat_index, to_flat_index))` on success, or
     /// `None` when the inner [`TreeCollection::reparent`] rejected the
     /// move (unknown key, unknown `new_parent`, or `new_parent` is a
-    /// descendant of `key`). `CollectionChange::Move` is emitted only on
-    /// success.
+    /// descendant of `key`).
+    ///
+    /// # Visibility-aware change events
+    ///
+    /// The visibility of the moved node may differ between the old and
+    /// new locations (e.g. moving from an expanded parent into a
+    /// collapsed one), so a single `Move` event is not always sufficient
+    /// to describe the DOM impact. The wrapper handles each case
+    /// precisely:
+    ///
+    /// | From visible | To visible | Event emitted                                               |
+    /// | ------------ | ---------- | ----------------------------------------------------------- |
+    /// | yes          | yes        | `Move { key, from: vis_from, to: vis_to }`                  |
+    /// | yes          | no         | `Remove { keys: [key] }` (subtree disappears from the DOM)  |
+    /// | no           | yes        | `Insert { index: vis_to, count: 1 }` (subtree appears)      |
+    /// | no           | no         | *(no event — neither location is rendered)*                 |
+    ///
+    /// In all cases the indices are **visible iteration indices**, not
+    /// flat DFS indices, so the adapter can apply them directly against
+    /// [`Collection::get_by_index`].
     pub fn reparent(
         &mut self,
         key: &Key,
         new_parent: Option<&Key>,
         index: usize,
     ) -> Option<(usize, usize)> {
-        let (from_index, to_index) = self.inner.reparent(key, new_parent, index)?;
+        // Capture pre-mutation visibility so we can pick the right event
+        // shape after the inner collection settles.
+        let from_visible = self.inner.visible_index_of(key);
 
-        self.pending_changes.push(CollectionChange::Move {
-            key: key.clone(),
-            from_index,
-            to_index,
-        });
+        let (from_flat, to_flat) = self.inner.reparent(key, new_parent, index)?;
 
-        Some((from_index, to_index))
+        let to_visible = self.inner.visible_index_of(key);
+
+        match (from_visible, to_visible) {
+            (Some(from_index), Some(to_index)) => {
+                self.pending_changes.push(CollectionChange::Move {
+                    key: key.clone(),
+                    from_index,
+                    to_index,
+                });
+            }
+
+            (Some(_), None) => {
+                self.pending_changes.push(CollectionChange::Remove {
+                    keys: alloc::vec![key.clone()],
+                });
+            }
+
+            (None, Some(to_index)) => {
+                self.pending_changes.push(CollectionChange::Insert {
+                    index: to_index,
+                    count: 1,
+                });
+            }
+
+            (None, None) => {
+                // Both endpoints hidden — no DOM change to report.
+            }
+        }
+
+        Some((from_flat, to_flat))
     }
 
     /// Reorder a node among its existing siblings (same parent).
     ///
     /// Returns `Some((from_flat_index, to_flat_index))` on success, or
-    /// `None` when `key` does not exist in the tree. `CollectionChange::Move`
-    /// is emitted only on success.
+    /// `None` when `key` does not exist in the tree.
+    ///
+    /// # Visibility-aware change events
+    ///
+    /// Reordering preserves the parent and therefore preserves
+    /// visibility — either both endpoints are visible (the parent is
+    /// expanded) or both are hidden (the parent is collapsed). In the
+    /// visible case `CollectionChange::Move` is emitted using **visible
+    /// iteration indices**; in the hidden case no event is emitted.
     pub fn reorder(&mut self, key: &Key, to_sibling_index: usize) -> Option<(usize, usize)> {
-        let (from_index, to_index) = self.inner.reorder_sibling(key, to_sibling_index)?;
+        let from_visible = self.inner.visible_index_of(key);
 
-        self.pending_changes.push(CollectionChange::Move {
-            key: key.clone(),
-            from_index,
-            to_index,
-        });
+        let (from_flat, to_flat) = self.inner.reorder_sibling(key, to_sibling_index)?;
 
-        Some((from_index, to_index))
+        if let (Some(from_index), Some(to_index)) = (from_visible, self.inner.visible_index_of(key))
+        {
+            self.pending_changes.push(CollectionChange::Move {
+                key: key.clone(),
+                from_index,
+                to_index,
+            });
+        }
+
+        Some((from_flat, to_flat))
     }
 
     /// Replace a node's data in place. Children are preserved.
@@ -1106,6 +1204,359 @@ mod tests {
         let second = tree.drain_changes();
 
         assert!(second.is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // MutableTreeData — visibility-aware change events
+    //
+    // The events `MutableTreeData` emits must describe *visible* iteration
+    // changes, not raw `all_nodes` mutations. Hidden subtrees never appear
+    // in `Collection::nodes`, so adapters relying on `get_by_index` would
+    // mis-place DOM updates if the events carried flat DFS indices that
+    // pointed inside a collapsed ancestor.
+    // -----------------------------------------------------------------------
+
+    /// Helper: build a tree with one collapsed root parent and one expanded
+    /// root parent, plus a leaf root at the end. After construction:
+    ///
+    /// ```text
+    /// 1 Root A   (collapsed)         flat 0, visible 0
+    /// ├── 11 Child A1                flat 1, visible — (hidden)
+    /// └── 12 Child A2                flat 2, visible — (hidden)
+    /// 2 Root B   (expanded)          flat 3, visible 1
+    /// └── 21 Child B1                flat 4, visible 2
+    /// 3 Root C   (leaf)              flat 5, visible 3
+    /// ```
+    fn mixed_visibility_tree() -> MutableTreeData<Item> {
+        MutableTreeData::new(TreeCollection::new([
+            TreeItemConfig {
+                key: Key::int(1),
+                text_value: "Root A".to_string(),
+                value: Item::new(1, "Root A"),
+                children: vec![
+                    TreeItemConfig {
+                        key: Key::int(11),
+                        text_value: "Child A1".to_string(),
+                        value: Item::new(11, "Child A1"),
+                        children: vec![],
+                        default_expanded: true,
+                    },
+                    TreeItemConfig {
+                        key: Key::int(12),
+                        text_value: "Child A2".to_string(),
+                        value: Item::new(12, "Child A2"),
+                        children: vec![],
+                        default_expanded: true,
+                    },
+                ],
+                default_expanded: false, // <-- A is collapsed
+            },
+            TreeItemConfig {
+                key: Key::int(2),
+                text_value: "Root B".to_string(),
+                value: Item::new(2, "Root B"),
+                children: vec![TreeItemConfig {
+                    key: Key::int(21),
+                    text_value: "Child B1".to_string(),
+                    value: Item::new(21, "Child B1"),
+                    children: vec![],
+                    default_expanded: true,
+                }],
+                default_expanded: true,
+            },
+            TreeItemConfig {
+                key: Key::int(3),
+                text_value: "Root C".to_string(),
+                value: Item::new(3, "Root C"),
+                children: vec![],
+                default_expanded: true,
+            },
+        ]))
+    }
+
+    #[test]
+    fn tree_visibility_fixture_has_expected_visible_iteration() {
+        // Sanity check: confirm that `mixed_visibility_tree` actually
+        // hides the children of Root A, so the visibility-aware tests
+        // below exercise the real "hidden" branches.
+        let tree = mixed_visibility_tree();
+
+        let visible = tree.keys().cloned().collect::<Vec<_>>();
+
+        assert_eq!(
+            visible,
+            vec![Key::int(1), Key::int(2), Key::int(21), Key::int(3)],
+            "Children of collapsed Root A must be hidden from visible iteration"
+        );
+    }
+
+    #[test]
+    fn tree_insert_child_under_collapsed_parent_emits_no_event() {
+        // Insert a new child under the collapsed Root A. The child sits
+        // inside a hidden subtree, so adapters have nothing to render.
+        // Per the visibility-aware contract no event is emitted.
+        let mut tree = mixed_visibility_tree();
+
+        let flat = tree.insert_child(Some(&Key::int(1)), 0, Item::new(99, "Hidden Child"));
+
+        assert!(
+            flat.is_some(),
+            "insert succeeded — Some(_) returned even though no event is emitted"
+        );
+
+        // The node IS in the inner tree (just not in the visible iteration).
+        assert!(
+            tree.get(&Key::int(99)).is_some(),
+            "hidden node is still reachable by key"
+        );
+
+        let drained = tree.drain_changes();
+
+        assert!(
+            drained.is_empty(),
+            "no event for insert under collapsed parent; got {drained:?}"
+        );
+    }
+
+    #[test]
+    fn tree_insert_child_emits_visible_index_when_visibility_skews_flat() {
+        // Insert a new root after Root B. Because Root A's subtree is
+        // collapsed, the new root's flat DFS index differs from its
+        // visible iteration index — the event must use the visible one.
+        //
+        // Before insert (flat / visible):
+        //   1 Root A    flat 0 / visible 0
+        //   11/12       flat 1,2 / hidden
+        //   2 Root B    flat 3 / visible 1
+        //   21          flat 4 / visible 2
+        //   3 Root C    flat 5 / visible 3
+        //
+        // After inserting a new root at sibling_index 2 (between B and C):
+        //   New root    flat 5 / visible 3
+        let mut tree = mixed_visibility_tree();
+
+        let flat = tree.insert_child(None, 2, Item::new(50, "New Root"));
+
+        assert_eq!(flat, Some(5), "flat DFS index after the existing nodes");
+
+        let drained = tree.drain_changes();
+
+        assert_eq!(
+            drained,
+            vec![CollectionChange::Insert {
+                index: 3, // visible position, not flat position
+                count: 1,
+            }],
+            "Insert event must carry visible iteration index, not flat DFS"
+        );
+
+        // Sanity check: the visible iteration now includes the new root
+        // at position 3.
+        let visible_at_3 = tree.get_by_index(3).expect("visible index 3");
+
+        assert_eq!(visible_at_3.key, Key::int(50));
+    }
+
+    #[test]
+    fn tree_remove_hidden_only_emits_no_event() {
+        // Remove the children of collapsed Root A. They were never
+        // visible, so the adapter has no DOM to clean up — no event.
+        let mut tree = mixed_visibility_tree();
+
+        let removed = tree.remove(&[Key::int(11), Key::int(12)]);
+
+        assert_eq!(removed.len(), 2, "inner removal still returns the values");
+
+        let drained = tree.drain_changes();
+
+        assert!(
+            drained.is_empty(),
+            "no event when removed items were all hidden; got {drained:?}"
+        );
+    }
+
+    #[test]
+    fn tree_remove_filters_event_to_visible_keys() {
+        // Remove a mix: Root B (visible, plus its visible child 21) and
+        // Child A1 (hidden inside collapsed Root A).
+        // The Remove event must list ONLY the previously-visible keys.
+        let mut tree = mixed_visibility_tree();
+
+        let removed = tree.remove(&[Key::int(2), Key::int(11)]);
+
+        // Root B + Child B1 + Child A1 = 3 inner removals.
+        assert_eq!(removed.len(), 3);
+
+        let drained = tree.drain_changes();
+
+        // Order of keys in the event mirrors the order returned by the
+        // inner `remove_by_keys` (subtree-by-subtree).
+        let expected = vec![CollectionChange::Remove {
+            keys: vec![Key::int(2), Key::int(21)],
+        }];
+
+        assert_eq!(
+            drained, expected,
+            "Remove event must include only previously-visible keys"
+        );
+    }
+
+    #[test]
+    fn tree_reparent_visible_to_hidden_emits_remove() {
+        // Move Root C (visible leaf) under collapsed Root A.
+        // From the adapter's DOM perspective, Root C disappears.
+        let mut tree = mixed_visibility_tree();
+
+        let indices = tree.reparent(&Key::int(3), Some(&Key::int(1)), 0);
+
+        assert!(indices.is_some(), "reparent succeeded");
+
+        let visible_keys = tree.keys().cloned().collect::<Vec<_>>();
+
+        assert!(
+            !visible_keys.contains(&Key::int(3)),
+            "Root C is no longer visible after moving under collapsed parent; \
+             visible: {visible_keys:?}"
+        );
+
+        let drained = tree.drain_changes();
+
+        assert_eq!(
+            drained,
+            vec![CollectionChange::Remove {
+                keys: vec![Key::int(3)],
+            }],
+            "visible→hidden reparent must emit Remove, not Move"
+        );
+    }
+
+    #[test]
+    fn tree_reparent_hidden_to_visible_emits_insert() {
+        // Move Child A1 (hidden inside collapsed Root A) out to be a
+        // root sibling. From the adapter's DOM perspective, Child A1
+        // appears for the first time.
+        let mut tree = mixed_visibility_tree();
+
+        // Reparent Child A1 to root, between Root B and Root C.
+        let indices = tree.reparent(&Key::int(11), None, 2);
+
+        assert!(indices.is_some(), "reparent succeeded");
+
+        let drained = tree.drain_changes();
+
+        // Visible iteration after reparent:
+        //   1 Root A    visible 0 (still collapsed; only Child A2 hidden)
+        //   2 Root B    visible 1
+        //   21 Child B1 visible 2
+        //   11 Child A1 visible 3 (newly inserted)
+        //   3 Root C    visible 4
+        assert_eq!(
+            drained,
+            vec![CollectionChange::Insert { index: 3, count: 1 }],
+            "hidden→visible reparent must emit Insert at the visible position"
+        );
+    }
+
+    #[test]
+    fn tree_reparent_hidden_to_hidden_emits_no_event() {
+        // Build a tree with two collapsed parents so we can shuffle a
+        // child between them without ever entering the visible region.
+        let mut tree = MutableTreeData::new(TreeCollection::new([
+            TreeItemConfig {
+                key: Key::int(1),
+                text_value: "Box 1".to_string(),
+                value: Item::new(1, "Box 1"),
+                children: vec![TreeItemConfig {
+                    key: Key::int(11),
+                    text_value: "Item".to_string(),
+                    value: Item::new(11, "Item"),
+                    children: vec![],
+                    default_expanded: true,
+                }],
+                default_expanded: false,
+            },
+            TreeItemConfig {
+                key: Key::int(2),
+                text_value: "Box 2".to_string(),
+                value: Item::new(2, "Box 2"),
+                children: vec![],
+                default_expanded: false,
+            },
+        ]));
+
+        let indices = tree.reparent(&Key::int(11), Some(&Key::int(2)), 0);
+
+        assert!(indices.is_some(), "reparent succeeded");
+        assert!(
+            tree.drain_changes().is_empty(),
+            "no event when both endpoints are hidden"
+        );
+    }
+
+    #[test]
+    fn tree_reorder_under_collapsed_parent_emits_no_event() {
+        // Reorder hidden siblings under the collapsed Root A.
+        // Visibility is preserved (still hidden) so no event.
+        let mut tree = mixed_visibility_tree();
+
+        let indices = tree.reorder(&Key::int(11), 1);
+
+        assert!(indices.is_some(), "reorder succeeded internally");
+
+        let drained = tree.drain_changes();
+
+        assert!(
+            drained.is_empty(),
+            "no event when reordering hidden siblings; got {drained:?}"
+        );
+    }
+
+    #[test]
+    fn tree_reorder_visible_emits_visible_index_move() {
+        // In the mixed-visibility fixture, the only expanded subtree
+        // with multiple siblings would be a manufactured one. Build a
+        // small tree where Root B has two visible children we can swap.
+        let mut tree = MutableTreeData::new(TreeCollection::new([TreeItemConfig {
+            key: Key::int(2),
+            text_value: "Root B".to_string(),
+            value: Item::new(2, "Root B"),
+            children: vec![
+                TreeItemConfig {
+                    key: Key::int(21),
+                    text_value: "Child B1".to_string(),
+                    value: Item::new(21, "Child B1"),
+                    children: vec![],
+                    default_expanded: true,
+                },
+                TreeItemConfig {
+                    key: Key::int(22),
+                    text_value: "Child B2".to_string(),
+                    value: Item::new(22, "Child B2"),
+                    children: vec![],
+                    default_expanded: true,
+                },
+            ],
+            default_expanded: true,
+        }]));
+
+        // Visible: [Root B (0), Child B1 (1), Child B2 (2)].
+        // Move Child B1 to sibling_index 1 → it becomes the second
+        // visible child (visible index 2).
+        let indices = tree.reorder(&Key::int(21), 1);
+
+        assert_eq!(indices, Some((1, 2)), "flat indices match visible here");
+
+        let drained = tree.drain_changes();
+
+        assert_eq!(
+            drained,
+            vec![CollectionChange::Move {
+                key: Key::int(21),
+                from_index: 1,
+                to_index: 2,
+            }],
+            "visible reorder uses visible iteration indices"
+        );
     }
 
     #[test]

--- a/crates/ars-collections/src/mutable.rs
+++ b/crates/ars-collections/src/mutable.rs
@@ -421,30 +421,44 @@ impl<T: CollectionItem> MutableTreeData<T> {
     ///
     /// # Visibility-aware change events
     ///
-    /// The visibility of the moved node may differ between the old and
-    /// new locations (e.g. moving from an expanded parent into a
-    /// collapsed one), so a single `Move` event is not always sufficient
-    /// to describe the DOM impact. The wrapper handles each case
-    /// precisely:
+    /// The visibility of the moved node — and of every descendant in
+    /// its subtree — may differ between the old and new locations
+    /// (e.g. moving an expanded subtree under a collapsed parent hides
+    /// every node it contained, while moving a hidden but internally
+    /// expanded subtree into a visible location surfaces all of it at
+    /// once). A single `Move` event is therefore not always sufficient
+    /// to describe the DOM impact. The wrapper picks the event shape
+    /// that matches the visibility transition:
     ///
-    /// | From visible | To visible | Event emitted                                               |
-    /// | ------------ | ---------- | ----------------------------------------------------------- |
-    /// | yes          | yes        | `Move { key, from: vis_from, to: vis_to }`                  |
-    /// | yes          | no         | `Remove { keys: [key] }` (subtree disappears from the DOM)  |
-    /// | no           | yes        | `Insert { index: vis_to, count: 1 }` (subtree appears)      |
-    /// | no           | no         | *(no event — neither location is rendered)*                 |
+    /// | From visible | To visible | Event emitted                                                                    |
+    /// | ------------ | ---------- | -------------------------------------------------------------------------------- |
+    /// | yes          | yes        | `Move { key, from: vis_from, to: vis_to }`                                       |
+    /// | yes          | no         | `Remove { keys: <previously-visible subtree keys, DFS order> }`                  |
+    /// | no           | yes        | `Insert { index: vis_to, count: <number of newly-visible subtree nodes> }`       |
+    /// | no           | no         | *(no event — neither location is rendered)*                                      |
     ///
     /// In all cases the indices are **visible iteration indices**, not
     /// flat DFS indices, so the adapter can apply them directly against
-    /// [`Collection::get_by_index`].
+    /// [`Collection::get_by_index`]. The `Insert` always spans
+    /// `count` consecutive positions starting at `to_index`.
     pub fn reparent(
         &mut self,
         key: &Key,
         new_parent: Option<&Key>,
         index: usize,
     ) -> Option<(usize, usize)> {
-        // Capture pre-mutation visibility so we can pick the right event
-        // shape after the inner collection settles.
+        // Snapshot the pre-mutation visible-key set in DFS order. The
+        // visible→hidden and hidden→visible branches both need to
+        // compare visibility before/after to capture every subtree
+        // descendant whose visibility flipped — only the moved
+        // subtree's visibility can change here, so a set difference
+        // against the full visible iteration is exactly the subtree
+        // delta. Capturing eagerly is simpler than re-deriving the
+        // pre-mutation state by walking the moved subtree post-move,
+        // and the visible iteration is bounded by what the adapter
+        // would render anyway.
+        let visible_before = self.inner.visible_keys().cloned().collect::<Vec<_>>();
+
         let from_visible = self.inner.visible_index_of(key);
 
         let (from_flat, to_flat) = self.inner.reparent(key, new_parent, index)?;
@@ -461,15 +475,41 @@ impl<T: CollectionItem> MutableTreeData<T> {
             }
 
             (Some(_), None) => {
-                self.pending_changes.push(CollectionChange::Remove {
-                    keys: alloc::vec![key.clone()],
-                });
+                // The moved subtree's root and every visible descendant
+                // disappear together under the collapsed new parent.
+                // Emit Remove with all of them in pre-mutation DFS
+                // order so a keyed reconciler can drop the matching
+                // DOM rows in one pass — emitting only `key` would
+                // leave orphan descendants in the DOM/state.
+                let visible_after = self.inner.visible_keys().cloned().collect::<BTreeSet<_>>();
+
+                let removed_keys = visible_before
+                    .into_iter()
+                    .filter(|k| !visible_after.contains(k))
+                    .collect::<Vec<_>>();
+
+                self.pending_changes
+                    .push(CollectionChange::Remove { keys: removed_keys });
             }
 
             (None, Some(to_index)) => {
+                // The root and any descendants whose own expansion
+                // state keeps them visible under the new parent appear
+                // in `count` consecutive visible positions starting at
+                // `to_index`. Emitting `count: 1` would leave adapters
+                // that honour `count` under-applying the change and
+                // drifting subsequent indices.
+                let visible_before_set = visible_before.into_iter().collect::<BTreeSet<_>>();
+
+                let count = self
+                    .inner
+                    .visible_keys()
+                    .filter(|k| !visible_before_set.contains(*k))
+                    .count();
+
                 self.pending_changes.push(CollectionChange::Insert {
                     index: to_index,
-                    count: 1,
+                    count,
                 });
             }
 
@@ -1431,6 +1471,45 @@ mod tests {
     }
 
     #[test]
+    fn tree_reparent_visible_to_hidden_emits_full_subtree_remove() {
+        // Move Root B (expanded, with visible Child B1) under collapsed
+        // Root A. Both Root B AND its visible descendant disappear from
+        // the iteration — the Remove event must list every previously
+        // visible key in the moved subtree, not just the moved root,
+        // otherwise keyed reconcilers leave orphan rows in the DOM.
+        let mut tree = mixed_visibility_tree();
+
+        // Sanity-check the pre-mutation visible iteration so the regression
+        // is obvious if the fixture changes.
+        assert_eq!(
+            tree.keys().cloned().collect::<Vec<_>>(),
+            vec![Key::int(1), Key::int(2), Key::int(21), Key::int(3)],
+            "fixture: Root A collapsed, Root B expanded with Child B1 visible",
+        );
+
+        let indices = tree.reparent(&Key::int(2), Some(&Key::int(1)), 0);
+
+        assert!(indices.is_some(), "reparent succeeded");
+
+        let visible_after = tree.keys().cloned().collect::<Vec<_>>();
+        assert_eq!(
+            visible_after,
+            vec![Key::int(1), Key::int(3)],
+            "Root B and Child B1 must both be hidden under collapsed Root A",
+        );
+
+        let drained = tree.drain_changes();
+
+        assert_eq!(
+            drained,
+            vec![CollectionChange::Remove {
+                keys: vec![Key::int(2), Key::int(21)],
+            }],
+            "Remove must include every previously-visible subtree key in DFS order"
+        );
+    }
+
+    #[test]
     fn tree_reparent_hidden_to_visible_emits_insert() {
         // Move Child A1 (hidden inside collapsed Root A) out to be a
         // root sibling. From the adapter's DOM perspective, Child A1
@@ -1454,6 +1533,75 @@ mod tests {
             drained,
             vec![CollectionChange::Insert { index: 3, count: 1 }],
             "hidden→visible reparent must emit Insert at the visible position"
+        );
+    }
+
+    #[test]
+    fn tree_reparent_hidden_to_visible_emits_subtree_insert_count() {
+        // Move Child A1 (hidden inside collapsed Root A, but itself
+        // expanded with an expanded grandchild) out to root level.
+        // The whole previously-hidden subtree (Child A1 + Grand A11)
+        // becomes visible at once — `count` must reflect the full
+        // subtree size, not 1, otherwise adapters that honour `count`
+        // will under-apply the change and drift indices.
+        let mut tree = MutableTreeData::new(TreeCollection::new([
+            TreeItemConfig {
+                key: Key::int(1),
+                text_value: "Root A".to_string(),
+                value: Item::new(1, "Root A"),
+                children: vec![TreeItemConfig {
+                    key: Key::int(11),
+                    text_value: "Child A1".to_string(),
+                    value: Item::new(11, "Child A1"),
+                    children: vec![TreeItemConfig {
+                        key: Key::int(111),
+                        text_value: "Grand A11".to_string(),
+                        value: Item::new(111, "Grand A11"),
+                        children: vec![],
+                        default_expanded: true,
+                    }],
+                    default_expanded: true,
+                }],
+                default_expanded: false, // Root A collapsed → subtree hidden
+            },
+            TreeItemConfig {
+                key: Key::int(2),
+                text_value: "Root B".to_string(),
+                value: Item::new(2, "Root B"),
+                children: vec![],
+                default_expanded: true,
+            },
+        ]));
+
+        // Sanity: only the two roots are visible to start.
+        assert_eq!(
+            tree.keys().cloned().collect::<Vec<_>>(),
+            vec![Key::int(1), Key::int(2)],
+            "fixture: Child A1 / Grand A11 hidden under collapsed Root A",
+        );
+
+        // Move Child A1 to root sibling-index 1 (between Root A and Root B).
+        let indices = tree.reparent(&Key::int(11), None, 1);
+
+        assert!(indices.is_some(), "reparent succeeded");
+
+        // Visible iteration after reparent:
+        //   1   Root A    visible 0 (now leaf)
+        //   11  Child A1  visible 1 (newly visible, expanded)
+        //   111 Grand A11 visible 2 (newly visible alongside its parent)
+        //   2   Root B    visible 3
+        assert_eq!(
+            tree.keys().cloned().collect::<Vec<_>>(),
+            vec![Key::int(1), Key::int(11), Key::int(111), Key::int(2)],
+            "Grand A11 must surface alongside Child A1 because the subtree was already expanded",
+        );
+
+        let drained = tree.drain_changes();
+
+        assert_eq!(
+            drained,
+            vec![CollectionChange::Insert { index: 1, count: 2 }],
+            "Insert count must reflect every newly-visible subtree node, not just the root"
         );
     }
 

--- a/crates/ars-collections/src/mutable.rs
+++ b/crates/ars-collections/src/mutable.rs
@@ -73,9 +73,24 @@ pub enum CollectionChange<K: Clone> {
         to_index: usize,
     },
 
-    /// An item's data was replaced in-place (key unchanged).
+    /// The node at this key needs to be re-rendered in place — its
+    /// position in the iteration is unchanged.
+    ///
+    /// Emitted in two situations:
+    ///
+    /// * `replace()` swapped the item's payload `T`, leaving the key
+    ///   and surrounding structure untouched.
+    /// * A non-payload mutation flipped the node's rendered state
+    ///   while leaving the iteration order intact — for example,
+    ///   inserting a child under a previously-leaf tree node turns
+    ///   that parent into a collapsed branch (`has_children: false →
+    ///   true`, `is_expanded: None → Some(false)`), which adapters
+    ///   key DOM off (expander chevron, `aria-expanded`).
+    ///
+    /// Adapters handle both cases identically: re-fetch the node by
+    /// key and re-render it in place.
     Replace {
-        /// Key of the replaced item.
+        /// Key of the node whose rendered state changed.
         key: K,
     },
 
@@ -370,28 +385,59 @@ impl<T: CollectionItem> MutableTreeData<T> {
     ///
     /// # Visibility-aware change events
     ///
-    /// The emitted `CollectionChange::Insert` carries the **visible
-    /// iteration index**, matching the position the adapter would use
-    /// against [`Collection::get_by_index`]. When the new child lands
-    /// inside a collapsed ancestor it is not part of the visible
-    /// iteration, so **no event is emitted** — the adapter's DOM is
-    /// already consistent (the node simply isn't rendered yet) and
-    /// emitting an `Insert { index, count }` carrying a flat DFS index
-    /// that has no corresponding visible position would mis-place the
-    /// DOM update. The hidden node will surface naturally when its
-    /// ancestor is later expanded and the adapter re-fetches the
-    /// expanded subtree.
+    /// The wrapper emits at most one of:
+    ///
+    /// * `Insert { index: visible_index, count: 1 }` — when the new
+    ///   child lands in the visible iteration. A hidden insert (one
+    ///   under a collapsed ancestor) emits no `Insert`; the hidden
+    ///   node surfaces naturally when an ancestor later expands and
+    ///   the adapter re-fetches the expanded subtree.
+    /// * `Replace { key: parent_key }` — when the parent flipped from
+    ///   leaf to collapsed branch. [`TreeCollection::insert_child`]
+    ///   sets `has_children = true` and `is_expanded = Some(false)` on
+    ///   a previously-leaf parent, which adapters key DOM off
+    ///   (expander chevron, `aria-expanded`). The transition only
+    ///   needs surfacing when the parent is itself visible — a hidden
+    ///   parent's row is not rendered, so the metadata change is
+    ///   invisible until an ancestor expands and the adapter re-reads
+    ///   the parent.
+    ///
+    /// The two events are mutually exclusive: a leaf parent always
+    /// becomes collapsed, so its new child is hidden and never
+    /// produces an `Insert`. A parent that was already an expanded
+    /// branch keeps its visible state and surfaces the new child via
+    /// `Insert` alone.
     pub fn insert_child(&mut self, parent: Option<&Key>, index: usize, item: T) -> Option<usize> {
         let key = item.key().clone();
+
+        // Snapshot whether the parent (if any) is currently a visible
+        // leaf, before the inner call flips its `has_children` /
+        // `is_expanded` metadata. We only care about visible leaves —
+        // hidden leaves transition the same way internally, but their
+        // row isn't rendered so the metadata change has no DOM impact
+        // until an ancestor expands.
+        let visible_leaf_parent = parent
+            .filter(|p| self.inner.visible_index_of(p).is_some() && !self.inner.has_children(p));
+
         let flat_index = self.inner.insert_child(parent, index, item)?;
 
-        // Only emit an event when the new child is part of the visible
-        // iteration. A hidden insert produces no DOM change for the
-        // adapter to apply.
         if let Some(visible_index) = self.inner.visible_index_of(&key) {
+            // The new child is part of the visible iteration. The
+            // parent therefore couldn't have been a leaf (a leaf
+            // parent would have collapsed the new child), so no
+            // Replace fires alongside.
             self.pending_changes.push(CollectionChange::Insert {
                 index: visible_index,
                 count: 1,
+            });
+        } else if let Some(parent_key) = visible_leaf_parent {
+            // Hidden child + previously-visible-leaf parent → the
+            // parent is now a collapsed branch and needs its rendered
+            // chevron / `aria-expanded` updated. Emit Replace so a
+            // reconciler that consumes only `CollectionChange` picks
+            // up the new metadata.
+            self.pending_changes.push(CollectionChange::Replace {
+                key: parent_key.clone(),
             });
         }
 
@@ -1444,6 +1490,94 @@ mod tests {
         assert!(
             drained.is_empty(),
             "no event for insert under collapsed parent; got {drained:?}"
+        );
+    }
+
+    #[test]
+    fn tree_insert_child_under_visible_leaf_parent_emits_replace_for_parent() {
+        // Adding a child under a visible *leaf* flips that parent from
+        // leaf to collapsed branch:
+        //   has_children: false → true
+        //   is_expanded:  None  → Some(false)
+        //
+        // The new child lands inside the now-collapsed parent and is
+        // therefore hidden from the visible iteration, so no Insert
+        // event fires for the child. But the parent's rendered state
+        // genuinely changed — adapters key DOM off `has_children` and
+        // `is_expanded` (expander chevron, `aria-expanded`), so a
+        // reconciler that consumes only `CollectionChange` would leave
+        // the parent row stale unless we emit `Replace` for it.
+        let mut tree = mixed_visibility_tree();
+
+        // Root C (id 3) is a visible leaf in the fixture.
+        assert!(
+            tree.get(&Key::int(3))
+                .is_some_and(|n| !n.has_children && n.is_expanded.is_none()),
+            "fixture: Root C must be a leaf before the insert",
+        );
+
+        let flat = tree.insert_child(Some(&Key::int(3)), 0, Item::new(99, "New Child"));
+
+        assert!(flat.is_some(), "insert succeeded");
+
+        // The child is in the inner tree but hidden under newly-
+        // collapsed Root C.
+        assert!(
+            tree.get(&Key::int(99)).is_some(),
+            "child is reachable by key",
+        );
+        assert!(
+            !tree.keys().any(|k| *k == Key::int(99)),
+            "child must NOT be in the visible iteration",
+        );
+
+        // Confirm the leaf→branch transition actually happened on Root
+        // C, since that is the precondition for the Replace event.
+        let root_c = tree.get(&Key::int(3)).expect("Root C still in tree");
+        assert!(root_c.has_children, "Root C now has children");
+        assert_eq!(root_c.is_expanded, Some(false), "Root C is collapsed");
+
+        let drained = tree.drain_changes();
+
+        assert_eq!(
+            drained,
+            vec![CollectionChange::Replace { key: Key::int(3) }],
+            "leaf→branch transition on a visible parent must emit Replace so adapters re-render",
+        );
+    }
+
+    #[test]
+    fn tree_insert_child_under_hidden_leaf_parent_emits_no_event() {
+        // Same leaf→branch transition mechanics as the previous test,
+        // but the parent itself is hidden inside a collapsed ancestor.
+        // Its rendered state can't be stale because the row isn't
+        // rendered at all, so no event must fire.
+        let mut tree = mixed_visibility_tree();
+
+        // Child A1 is a hidden leaf (under collapsed Root A).
+        assert!(
+            tree.get(&Key::int(11))
+                .is_some_and(|n| !n.has_children && n.is_expanded.is_none()),
+            "fixture: Child A1 is a hidden leaf",
+        );
+
+        let flat = tree.insert_child(Some(&Key::int(11)), 0, Item::new(111, "Hidden Grand"));
+
+        assert!(flat.is_some(), "insert succeeded");
+
+        // Inner state changed (Child A1 is now a collapsed branch),
+        // but neither it nor the new grandchild is rendered.
+        assert!(
+            tree.get(&Key::int(11))
+                .is_some_and(|n| n.has_children && n.is_expanded == Some(false)),
+            "Child A1 transitioned to a collapsed branch internally",
+        );
+
+        let drained = tree.drain_changes();
+
+        assert!(
+            drained.is_empty(),
+            "no event for leaf→branch on a hidden parent; got {drained:?}",
         );
     }
 

--- a/crates/ars-collections/src/mutable.rs
+++ b/crates/ars-collections/src/mutable.rs
@@ -1,0 +1,1154 @@
+//! Mutable collection wrappers with change tracking for DOM reconciliation.
+//!
+//! Adapters (Leptos, Dioxus, …) need to perform targeted DOM updates when a
+//! collection mutates, rather than re-rendering every item. The wrappers in
+//! this module — [`MutableListData`] and [`MutableTreeData`] — delegate all
+//! read-only [`Collection`] access to an inner [`StaticCollection`] or
+//! [`TreeCollection`] while recording each mutation as a [`CollectionChange`]
+//! in an internal buffer.
+//!
+//! After an update cycle, the adapter calls [`MutableListData::drain_changes`]
+//! / [`MutableTreeData::drain_changes`] to retrieve and clear the buffered
+//! events, and then applies them as granular DOM mutations (insert / remove /
+//! move / replace / reset).
+//!
+//! Spec reference: `spec/foundation/06-collections.md` §1.8 "Mutable
+//! Collections".
+
+use alloc::vec::Vec;
+use core::{
+    fmt::{self, Debug},
+    mem,
+};
+
+use crate::{
+    collection::{Collection, CollectionItem},
+    key::Key,
+    node::Node,
+    static_collection::StaticCollection,
+    tree_collection::TreeCollection,
+};
+
+// ---------------------------------------------------------------------------
+// CollectionChange
+// ---------------------------------------------------------------------------
+
+/// A granular change event emitted when a mutable collection is modified.
+///
+/// Adapters consume a sequence of these events to perform targeted DOM
+/// updates instead of re-rendering the entire list. The generic key type `K`
+/// is parameterised so tests and alternative collection implementations can
+/// use keys other than [`Key`]; production wrappers always use
+/// `CollectionChange<Key>`.
+#[derive(Clone, Debug, PartialEq)]
+pub enum CollectionChange<K: Clone> {
+    /// New items inserted at the given flat index.
+    ///
+    /// `count` is always `1` for single-item mutations but is kept as a field
+    /// so future bulk inserts can share the variant without a breaking API
+    /// change.
+    Insert {
+        /// Flat insertion index in the collection's iteration order.
+        index: usize,
+
+        /// Number of items inserted starting at `index`.
+        count: usize,
+    },
+
+    /// Items with the given keys were removed.
+    Remove {
+        /// Keys of the removed items, in the order the caller supplied them.
+        keys: Vec<K>,
+    },
+
+    /// An item moved from one flat index to another.
+    Move {
+        /// Key of the moved item.
+        key: K,
+
+        /// Flat index the item occupied before the move.
+        from_index: usize,
+
+        /// Flat index the item occupies after the move.
+        to_index: usize,
+    },
+
+    /// An item's data was replaced in-place (key unchanged).
+    Replace {
+        /// Key of the replaced item.
+        key: K,
+    },
+
+    /// The entire collection was reset (e.g. bulk replacement or clear).
+    ///
+    /// Adapters should re-render all items instead of trying to reconcile
+    /// individual changes.
+    Reset,
+}
+
+// ---------------------------------------------------------------------------
+// MutableListData
+// ---------------------------------------------------------------------------
+
+/// A mutable flat-list collection that tracks granular changes.
+///
+/// Wraps a [`StaticCollection`] and records every mutation as a
+/// [`CollectionChange`] in `pending_changes`. The adapter drains this buffer
+/// each update cycle via [`MutableListData::drain_changes`].
+pub struct MutableListData<T: CollectionItem> {
+    /// The inner collection holding the canonical item data.
+    inner: StaticCollection<T>,
+
+    /// Pending change events to be drained by the adapter layer.
+    pending_changes: Vec<CollectionChange<Key>>,
+}
+
+/// Manual `Debug` avoids requiring `T: Debug`, matching [`StaticCollection`]'s
+/// approach. Prints the inner collection and pending-change count only.
+impl<T: CollectionItem> Debug for MutableListData<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MutableListData")
+            .field("inner", &self.inner)
+            .field("pending_changes", &self.pending_changes.len())
+            .finish()
+    }
+}
+
+impl<T: CollectionItem> MutableListData<T> {
+    /// Wrap an existing [`StaticCollection`] so subsequent mutations emit
+    /// change events. The change buffer starts empty — construction itself
+    /// is not reported as a change.
+    #[must_use]
+    pub const fn new(collection: StaticCollection<T>) -> Self {
+        Self {
+            inner: collection,
+            pending_changes: Vec::new(),
+        }
+    }
+
+    /// Append an item to the end of the collection. Emits
+    /// [`CollectionChange::Insert`] with `count: 1` at the appended index.
+    pub fn push(&mut self, item: T) {
+        let index = self.inner.len();
+
+        self.inner.insert(index, item);
+
+        self.pending_changes
+            .push(CollectionChange::Insert { index, count: 1 });
+    }
+
+    /// Insert an item at the given flat index, shifting subsequent items.
+    /// Emits [`CollectionChange::Insert`] with `count: 1`.
+    pub fn insert(&mut self, index: usize, item: T) {
+        self.inner.insert(index, item);
+
+        self.pending_changes
+            .push(CollectionChange::Insert { index, count: 1 });
+    }
+
+    /// Remove items with the given keys, returning their owned values in
+    /// iteration order. Emits [`CollectionChange::Remove`] carrying the keys
+    /// that actually matched an item — unknown keys are silently skipped by
+    /// the inner collection, so they are excluded from the change event to
+    /// keep the change log truthful. Returns an empty `Vec` (and emits no
+    /// event) when no key in `keys` matches.
+    pub fn remove(&mut self, keys: &[Key]) -> Vec<T> {
+        let removed = self.inner.remove_by_keys(keys);
+
+        if !removed.is_empty() {
+            self.pending_changes.push(CollectionChange::Remove {
+                keys: removed.iter().map(|t| t.key().clone()).collect(),
+            });
+        }
+
+        removed
+    }
+
+    /// Move an item identified by `key` to the given flat index.
+    ///
+    /// Returns `Some((from_flat_index, to_flat_index))` on success, or
+    /// `None` if `key` is not present in the collection.
+    /// [`CollectionChange::Move`] is emitted only on success, so the change
+    /// log never references a key the collection does not contain.
+    pub fn move_item(&mut self, key: &Key, to_index: usize) -> Option<(usize, usize)> {
+        let from_index = self.inner.index_of(key)?;
+
+        self.inner.move_item(from_index, to_index);
+
+        self.pending_changes.push(CollectionChange::Move {
+            key: key.clone(),
+            from_index,
+            to_index,
+        });
+
+        Some((from_index, to_index))
+    }
+
+    /// Replace an item's data in place.
+    ///
+    /// Returns the previous value at `item.key()` on success, or `None` if
+    /// the key is not present. The `Replace` change event is emitted only
+    /// on success, so the change log never references a key the collection
+    /// does not contain.
+    pub fn replace(&mut self, item: T) -> Option<T> {
+        let key = item.key().clone();
+
+        let old = self.inner.replace(item);
+
+        if old.is_some() {
+            self.pending_changes.push(CollectionChange::Replace { key });
+        }
+
+        old
+    }
+
+    /// Remove every item and emit [`CollectionChange::Reset`]. Adapters
+    /// treat this as a hint to re-render the full list.
+    pub fn clear(&mut self) {
+        self.inner.clear();
+
+        self.pending_changes.push(CollectionChange::Reset);
+    }
+
+    /// Take the pending change log, leaving the buffer empty. Called by the
+    /// adapter once per update cycle.
+    pub fn drain_changes(&mut self) -> Vec<CollectionChange<Key>> {
+        mem::take(&mut self.pending_changes)
+    }
+}
+
+// The `Collection<T>` delegation requires `T: Clone` because the inner
+// `StaticCollection<T>` only implements `Collection<T>` when `T: Clone`
+// (see `static_collection.rs`). Mutation methods above are available for
+// any `T: CollectionItem`.
+impl<T: CollectionItem + Clone> Collection<T> for MutableListData<T> {
+    fn size(&self) -> usize {
+        self.inner.size()
+    }
+
+    fn get(&self, key: &Key) -> Option<&Node<T>> {
+        self.inner.get(key)
+    }
+
+    fn get_by_index(&self, index: usize) -> Option<&Node<T>> {
+        self.inner.get_by_index(index)
+    }
+
+    fn first_key(&self) -> Option<&Key> {
+        self.inner.first_key()
+    }
+
+    fn last_key(&self) -> Option<&Key> {
+        self.inner.last_key()
+    }
+
+    fn key_after(&self, key: &Key) -> Option<&Key> {
+        self.inner.key_after(key)
+    }
+
+    fn key_before(&self, key: &Key) -> Option<&Key> {
+        self.inner.key_before(key)
+    }
+
+    fn key_after_no_wrap(&self, key: &Key) -> Option<&Key> {
+        self.inner.key_after_no_wrap(key)
+    }
+
+    fn key_before_no_wrap(&self, key: &Key) -> Option<&Key> {
+        self.inner.key_before_no_wrap(key)
+    }
+
+    fn keys<'a>(&'a self) -> impl Iterator<Item = &'a Key>
+    where
+        T: 'a,
+    {
+        self.inner.keys()
+    }
+
+    fn nodes<'a>(&'a self) -> impl Iterator<Item = &'a Node<T>>
+    where
+        T: 'a,
+    {
+        self.inner.nodes()
+    }
+
+    fn children_of<'a>(&'a self, parent_key: &Key) -> impl Iterator<Item = &'a Node<T>>
+    where
+        T: 'a,
+    {
+        self.inner.children_of(parent_key)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MutableTreeData
+// ---------------------------------------------------------------------------
+
+/// A mutable tree collection that tracks granular changes.
+///
+/// Wraps a [`TreeCollection`] and records every mutation — including
+/// reparenting and sibling reordering — as a [`CollectionChange`] using
+/// flat DFS indices. The adapter drains this buffer each update cycle via
+/// [`MutableTreeData::drain_changes`].
+pub struct MutableTreeData<T: CollectionItem> {
+    /// The inner tree holding the canonical hierarchy.
+    inner: TreeCollection<T>,
+
+    /// Pending change events to be drained by the adapter layer.
+    pending_changes: Vec<CollectionChange<Key>>,
+}
+
+/// Manual `Debug` avoids requiring `T: Debug`, matching [`TreeCollection`]'s
+/// approach. Prints the inner tree and pending-change count only.
+impl<T: CollectionItem> Debug for MutableTreeData<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MutableTreeData")
+            .field("inner", &self.inner)
+            .field("pending_changes", &self.pending_changes.len())
+            .finish()
+    }
+}
+
+impl<T: CollectionItem> MutableTreeData<T> {
+    /// Wrap an existing [`TreeCollection`] so subsequent mutations emit
+    /// change events. The change buffer starts empty.
+    #[must_use]
+    pub const fn new(collection: TreeCollection<T>) -> Self {
+        Self {
+            inner: collection,
+            pending_changes: Vec::new(),
+        }
+    }
+
+    /// Insert a child under `parent` at the given sibling index (or at the
+    /// root when `parent` is `None`).
+    ///
+    /// Returns the flat DFS index of the inserted node on success, or
+    /// `None` if the inner [`TreeCollection::insert_child`] rejected the
+    /// insert (unknown parent key). `CollectionChange::Insert` is emitted
+    /// only on success, so the change log never references a phantom node.
+    pub fn insert_child(&mut self, parent: Option<&Key>, index: usize, item: T) -> Option<usize> {
+        let flat_index = self.inner.insert_child(parent, index, item)?;
+
+        self.pending_changes.push(CollectionChange::Insert {
+            index: flat_index,
+            count: 1,
+        });
+
+        Some(flat_index)
+    }
+
+    /// Remove the listed nodes (and their descendants), returning their
+    /// owned values. Emits [`CollectionChange::Remove`] carrying only the
+    /// keys that actually matched an item — unknown keys are silently
+    /// skipped by the inner collection and excluded from the change event.
+    pub fn remove(&mut self, keys: &[Key]) -> Vec<T> {
+        let removed = self.inner.remove_by_keys(keys);
+
+        if !removed.is_empty() {
+            self.pending_changes.push(CollectionChange::Remove {
+                keys: removed.iter().map(|t| t.key().clone()).collect(),
+            });
+        }
+
+        removed
+    }
+
+    /// Move a node (with its subtree) under a new parent at the given
+    /// sibling index.
+    ///
+    /// Returns `Some((from_flat_index, to_flat_index))` on success, or
+    /// `None` when the inner [`TreeCollection::reparent`] rejected the
+    /// move (unknown key, unknown `new_parent`, or `new_parent` is a
+    /// descendant of `key`). `CollectionChange::Move` is emitted only on
+    /// success.
+    pub fn reparent(
+        &mut self,
+        key: &Key,
+        new_parent: Option<&Key>,
+        index: usize,
+    ) -> Option<(usize, usize)> {
+        let (from_index, to_index) = self.inner.reparent(key, new_parent, index)?;
+
+        self.pending_changes.push(CollectionChange::Move {
+            key: key.clone(),
+            from_index,
+            to_index,
+        });
+
+        Some((from_index, to_index))
+    }
+
+    /// Reorder a node among its existing siblings (same parent).
+    ///
+    /// Returns `Some((from_flat_index, to_flat_index))` on success, or
+    /// `None` when `key` does not exist in the tree. `CollectionChange::Move`
+    /// is emitted only on success.
+    pub fn reorder(&mut self, key: &Key, to_sibling_index: usize) -> Option<(usize, usize)> {
+        let (from_index, to_index) = self.inner.reorder_sibling(key, to_sibling_index)?;
+
+        self.pending_changes.push(CollectionChange::Move {
+            key: key.clone(),
+            from_index,
+            to_index,
+        });
+
+        Some((from_index, to_index))
+    }
+
+    /// Replace a node's data in place. Children are preserved.
+    ///
+    /// Returns the previous value at `item.key()` on success, or `None` if
+    /// the key is not present. The `Replace` change event is emitted only
+    /// on success, so the change log never references a key the tree does
+    /// not contain.
+    pub fn replace(&mut self, item: T) -> Option<T> {
+        let key = item.key().clone();
+
+        let old = self.inner.replace(item);
+
+        if old.is_some() {
+            self.pending_changes.push(CollectionChange::Replace { key });
+        }
+
+        old
+    }
+
+    /// Take the pending change log, leaving the buffer empty.
+    pub fn drain_changes(&mut self) -> Vec<CollectionChange<Key>> {
+        mem::take(&mut self.pending_changes)
+    }
+}
+
+// The `Collection<T>` delegation requires `T: Clone` for the same reason as
+// `MutableListData` — see that impl's note.
+impl<T: CollectionItem + Clone> Collection<T> for MutableTreeData<T> {
+    fn size(&self) -> usize {
+        self.inner.size()
+    }
+
+    fn get(&self, key: &Key) -> Option<&Node<T>> {
+        self.inner.get(key)
+    }
+
+    fn get_by_index(&self, index: usize) -> Option<&Node<T>> {
+        self.inner.get_by_index(index)
+    }
+
+    fn first_key(&self) -> Option<&Key> {
+        self.inner.first_key()
+    }
+
+    fn last_key(&self) -> Option<&Key> {
+        self.inner.last_key()
+    }
+
+    fn key_after(&self, key: &Key) -> Option<&Key> {
+        self.inner.key_after(key)
+    }
+
+    fn key_before(&self, key: &Key) -> Option<&Key> {
+        self.inner.key_before(key)
+    }
+
+    fn key_after_no_wrap(&self, key: &Key) -> Option<&Key> {
+        self.inner.key_after_no_wrap(key)
+    }
+
+    fn key_before_no_wrap(&self, key: &Key) -> Option<&Key> {
+        self.inner.key_before_no_wrap(key)
+    }
+
+    fn keys<'a>(&'a self) -> impl Iterator<Item = &'a Key>
+    where
+        T: 'a,
+    {
+        self.inner.keys()
+    }
+
+    fn nodes<'a>(&'a self) -> impl Iterator<Item = &'a Node<T>>
+    where
+        T: 'a,
+    {
+        self.inner.nodes()
+    }
+
+    fn children_of<'a>(&'a self, parent_key: &Key) -> impl Iterator<Item = &'a Node<T>>
+    where
+        T: 'a,
+    {
+        self.inner.children_of(parent_key)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use alloc::{
+        format,
+        string::{String, ToString},
+        vec,
+        vec::Vec,
+    };
+
+    use super::*;
+    use crate::{builder::CollectionBuilder, tree_collection::TreeItemConfig};
+
+    // -----------------------------------------------------------------------
+    // Fixtures
+    // -----------------------------------------------------------------------
+
+    #[derive(Clone, Debug, PartialEq)]
+    struct Item {
+        id: Key,
+        label: String,
+    }
+
+    impl Item {
+        fn new(id: u64, label: &str) -> Self {
+            Self {
+                id: Key::int(id),
+                label: label.to_string(),
+            }
+        }
+    }
+
+    impl CollectionItem for Item {
+        fn key(&self) -> &Key {
+            &self.id
+        }
+
+        fn text_value(&self) -> &str {
+            &self.label
+        }
+    }
+
+    fn list_of_three() -> MutableListData<Item> {
+        MutableListData::new(
+            CollectionBuilder::new()
+                .item(Key::int(1), "Apple", Item::new(1, "Apple"))
+                .item(Key::int(2), "Banana", Item::new(2, "Banana"))
+                .item(Key::int(3), "Cherry", Item::new(3, "Cherry"))
+                .build(),
+        )
+    }
+
+    fn tree_config(
+        id: u64,
+        label: &str,
+        children: Vec<TreeItemConfig<Item>>,
+    ) -> TreeItemConfig<Item> {
+        TreeItemConfig {
+            key: Key::int(id),
+            text_value: label.to_string(),
+            value: Item::new(id, label),
+            children,
+            default_expanded: true,
+        }
+    }
+
+    /// Build a small tree:
+    ///
+    /// ```text
+    /// 1 Root A
+    /// ├── 11 Child A1
+    /// └── 12 Child A2
+    /// 2 Root B
+    /// └── 21 Child B1
+    /// ```
+    ///
+    /// Flat DFS order: [1, 11, 12, 2, 21] → indices 0, 1, 2, 3, 4.
+    fn sample_tree() -> MutableTreeData<Item> {
+        MutableTreeData::new(TreeCollection::new([
+            tree_config(
+                1,
+                "Root A",
+                vec![
+                    tree_config(11, "Child A1", vec![]),
+                    tree_config(12, "Child A2", vec![]),
+                ],
+            ),
+            tree_config(2, "Root B", vec![tree_config(21, "Child B1", vec![])]),
+        ]))
+    }
+
+    // -----------------------------------------------------------------------
+    // MutableListData — single mutations
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn push_appends_and_emits_insert_change() {
+        let mut list = list_of_three();
+
+        list.push(Item::new(4, "Date"));
+
+        assert_eq!(list.size(), 4);
+        assert_eq!(
+            list.drain_changes(),
+            vec![CollectionChange::Insert { index: 3, count: 1 }]
+        );
+
+        // The appended item is retrievable under its key.
+        let node = list.get(&Key::int(4)).expect("pushed item is present");
+
+        assert_eq!(node.key, Key::int(4));
+    }
+
+    #[test]
+    fn insert_at_index_emits_insert_change() {
+        let mut list = list_of_three();
+
+        list.insert(1, Item::new(42, "Mango"));
+
+        assert_eq!(list.size(), 4);
+        assert_eq!(
+            list.drain_changes(),
+            vec![CollectionChange::Insert { index: 1, count: 1 }]
+        );
+
+        // The inserted item lands at flat index 1.
+        let node = list.get_by_index(1).expect("index 1");
+
+        assert_eq!(node.key, Key::int(42));
+    }
+
+    #[test]
+    fn remove_emits_remove_change_with_keys() {
+        let mut list = list_of_three();
+
+        let keys = [Key::int(1), Key::int(3)];
+
+        let removed = list.remove(&keys);
+
+        assert_eq!(removed.len(), 2);
+        assert_eq!(list.size(), 1);
+        assert_eq!(
+            list.drain_changes(),
+            vec![CollectionChange::Remove {
+                keys: keys.to_vec(),
+            }]
+        );
+    }
+
+    #[test]
+    fn remove_change_contains_only_matched_keys() {
+        let mut list = list_of_three();
+
+        // Mix of valid (1) and unknown (999) keys.
+        let removed = list.remove(&[Key::int(1), Key::int(999)]);
+
+        assert_eq!(removed.len(), 1);
+        assert_eq!(list.size(), 2);
+
+        // The change event reflects only the key that actually matched.
+        assert_eq!(
+            list.drain_changes(),
+            vec![CollectionChange::Remove {
+                keys: vec![Key::int(1)],
+            }]
+        );
+    }
+
+    #[test]
+    fn remove_all_unknown_keys_emits_no_event() {
+        let mut list = list_of_three();
+
+        let removed = list.remove(&[Key::int(998), Key::int(999)]);
+
+        assert!(removed.is_empty());
+        assert_eq!(list.size(), 3);
+        assert!(list.drain_changes().is_empty());
+    }
+
+    #[test]
+    fn move_item_emits_move_change_and_returns_indices() {
+        let mut list = list_of_three();
+
+        let indices = list.move_item(&Key::int(1), 2);
+
+        assert_eq!(indices, Some((0, 2)));
+        assert_eq!(
+            list.drain_changes(),
+            vec![CollectionChange::Move {
+                key: Key::int(1),
+                from_index: 0,
+                to_index: 2,
+            }]
+        );
+
+        // After the move, the item previously at flat 0 is at flat 2.
+        let node = list.get_by_index(2).expect("index 2");
+
+        assert_eq!(node.key, Key::int(1));
+    }
+
+    #[test]
+    fn move_item_unknown_key_returns_none_and_emits_no_event() {
+        let mut list = list_of_three();
+
+        let indices = list.move_item(&Key::int(999), 0);
+
+        assert_eq!(indices, None);
+        assert!(list.drain_changes().is_empty());
+    }
+
+    #[test]
+    fn replace_emits_replace_change_and_returns_old_value() {
+        let mut list = list_of_three();
+
+        let old = list.replace(Item::new(2, "Blueberry"));
+
+        assert_eq!(old.expect("old value").label, "Banana");
+        assert_eq!(
+            list.drain_changes(),
+            vec![CollectionChange::Replace { key: Key::int(2) }]
+        );
+
+        // Value is replaced in place; key is unchanged.
+        let node = list.get(&Key::int(2)).expect("key 2");
+
+        assert_eq!(node.value.as_ref().expect("value").label, "Blueberry");
+    }
+
+    #[test]
+    fn replace_unknown_key_returns_none_and_emits_no_event() {
+        let mut list = list_of_three();
+
+        let old = list.replace(Item::new(999, "Phantom"));
+
+        assert!(old.is_none());
+        assert_eq!(list.size(), 3);
+        assert!(list.drain_changes().is_empty());
+    }
+
+    #[test]
+    fn clear_emits_reset_change() {
+        let mut list = list_of_three();
+
+        list.clear();
+
+        assert_eq!(list.size(), 0);
+        assert_eq!(list.drain_changes(), vec![CollectionChange::Reset]);
+    }
+
+    #[test]
+    fn drain_changes_returns_and_clears_buffer() {
+        let mut list = list_of_three();
+
+        list.push(Item::new(4, "Date"));
+        list.push(Item::new(5, "Elderberry"));
+
+        let first = list.drain_changes();
+
+        assert_eq!(first.len(), 2);
+
+        // Buffer is now empty.
+        let second = list.drain_changes();
+
+        assert!(second.is_empty());
+    }
+
+    #[test]
+    fn list_delegates_collection_methods() {
+        let mut list = list_of_three();
+
+        assert_eq!(list.size(), 3);
+        assert!(!list.is_empty());
+        assert!(list.get(&Key::int(2)).is_some());
+        assert!(list.get(&Key::int(99)).is_none());
+        assert_eq!(list.get_by_index(1).expect("idx 1").key, Key::int(2));
+        assert_eq!(list.first_key(), Some(&Key::int(1)));
+        assert_eq!(list.last_key(), Some(&Key::int(3)));
+        assert_eq!(list.key_after(&Key::int(1)), Some(&Key::int(2)));
+        assert_eq!(list.key_before(&Key::int(2)), Some(&Key::int(1)));
+        assert_eq!(
+            list.key_after_no_wrap(&Key::int(3)),
+            None,
+            "no wrap past last"
+        );
+        assert_eq!(
+            list.key_before_no_wrap(&Key::int(1)),
+            None,
+            "no wrap past first"
+        );
+
+        let keys = list.keys().cloned().collect::<Vec<_>>();
+
+        assert_eq!(keys, vec![Key::int(1), Key::int(2), Key::int(3)]);
+
+        let node_count = list.nodes().count();
+
+        assert_eq!(node_count, 3);
+
+        // children_of on a flat list yields nothing.
+        assert_eq!(list.children_of(&Key::int(1)).count(), 0);
+
+        // Drain sanity — no reads should have mutated the change buffer.
+        assert!(list.drain_changes().is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // MutableTreeData — single mutations
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn tree_insert_child_emits_insert_with_flat_index() {
+        let mut tree = sample_tree();
+
+        // Insert a new root as the third root sibling (sibling_index 2).
+        // Expected flat index after insert: 5 (after the original 5 nodes).
+        let root_flat = tree.insert_child(None, 2, Item::new(3, "Root C"));
+
+        assert_eq!(root_flat, Some(5));
+        assert_eq!(
+            tree.drain_changes(),
+            vec![CollectionChange::Insert { index: 5, count: 1 }]
+        );
+
+        // Insert a new child under Root A (key 1) at sibling_index 0.
+        // Expected flat index: 1 (just after Root A).
+        let child_flat = tree.insert_child(Some(&Key::int(1)), 0, Item::new(10, "Child A0"));
+
+        assert_eq!(child_flat, Some(1));
+        assert_eq!(
+            tree.drain_changes(),
+            vec![CollectionChange::Insert { index: 1, count: 1 }]
+        );
+    }
+
+    #[test]
+    fn tree_insert_child_with_invalid_parent_returns_none_and_emits_no_event() {
+        let mut tree = sample_tree();
+
+        let flat = tree.insert_child(Some(&Key::int(999)), 0, Item::new(77, "Orphan"));
+
+        assert_eq!(flat, None, "wrapper returns None on rejected insert");
+        assert_eq!(tree.size(), 5, "tree size is unchanged");
+        assert!(
+            tree.drain_changes().is_empty(),
+            "no change event for rejected insert"
+        );
+    }
+
+    #[test]
+    fn tree_remove_emits_remove_change() {
+        let mut tree = sample_tree();
+
+        let keys = [Key::int(11)];
+
+        let removed = tree.remove(&keys);
+
+        assert_eq!(removed.len(), 1);
+        assert_eq!(
+            tree.drain_changes(),
+            vec![CollectionChange::Remove {
+                keys: keys.to_vec(),
+            }]
+        );
+    }
+
+    #[test]
+    fn tree_remove_change_contains_only_matched_keys() {
+        let mut tree = sample_tree();
+
+        // Mix of valid (11) and unknown (999) keys.
+        let removed = tree.remove(&[Key::int(11), Key::int(999)]);
+
+        assert_eq!(removed.len(), 1);
+        assert_eq!(
+            tree.drain_changes(),
+            vec![CollectionChange::Remove {
+                keys: vec![Key::int(11)],
+            }]
+        );
+    }
+
+    #[test]
+    fn tree_remove_all_unknown_keys_emits_no_event() {
+        let mut tree = sample_tree();
+
+        let removed = tree.remove(&[Key::int(998), Key::int(999)]);
+
+        assert!(removed.is_empty());
+        assert_eq!(tree.size(), 5);
+        assert!(tree.drain_changes().is_empty());
+    }
+
+    #[test]
+    fn tree_reparent_emits_move_with_correct_flat_indices() {
+        let mut tree = sample_tree();
+
+        // Move Child A1 (flat index 1) to be the first child of Root B.
+        // Before: [1, 11, 12, 2, 21] — Child A1 at index 1.
+        // After reparent under key 2 at sibling_index 0:
+        //   [1, 12, 2, 11, 21] — Child A1 now at flat index 3.
+        let indices = tree.reparent(&Key::int(11), Some(&Key::int(2)), 0);
+
+        assert_eq!(indices, Some((1, 3)));
+        assert_eq!(
+            tree.drain_changes(),
+            vec![CollectionChange::Move {
+                key: Key::int(11),
+                from_index: 1,
+                to_index: 3,
+            }]
+        );
+    }
+
+    #[test]
+    fn tree_reparent_unknown_key_returns_none_and_emits_no_event() {
+        let mut tree = sample_tree();
+
+        let indices = tree.reparent(&Key::int(999), None, 0);
+
+        assert_eq!(indices, None);
+        assert!(tree.drain_changes().is_empty());
+    }
+
+    #[test]
+    fn tree_reparent_unknown_new_parent_returns_none_and_emits_no_event() {
+        let mut tree = sample_tree();
+
+        let indices = tree.reparent(&Key::int(11), Some(&Key::int(999)), 0);
+
+        assert_eq!(indices, None);
+        assert!(tree.drain_changes().is_empty());
+    }
+
+    #[test]
+    fn tree_reorder_emits_move_with_correct_flat_indices() {
+        let mut tree = sample_tree();
+
+        // Move Child A1 (flat index 1) after Child A2 among its siblings.
+        // Before: [1, 11, 12, 2, 21] — Child A1 at 1, Child A2 at 2.
+        // After reorder_sibling(11, 1):
+        //   [1, 12, 11, 2, 21] — Child A1 now at flat index 2.
+        let indices = tree.reorder(&Key::int(11), 1);
+
+        assert_eq!(indices, Some((1, 2)));
+        assert_eq!(
+            tree.drain_changes(),
+            vec![CollectionChange::Move {
+                key: Key::int(11),
+                from_index: 1,
+                to_index: 2,
+            }]
+        );
+    }
+
+    #[test]
+    fn tree_reorder_unknown_key_returns_none_and_emits_no_event() {
+        let mut tree = sample_tree();
+
+        let indices = tree.reorder(&Key::int(999), 0);
+
+        assert_eq!(indices, None);
+        assert!(tree.drain_changes().is_empty());
+    }
+
+    #[test]
+    fn tree_replace_emits_replace_change_and_returns_old_value() {
+        let mut tree = sample_tree();
+
+        let old = tree.replace(Item::new(11, "Renamed A1"));
+
+        assert_eq!(old.expect("old value").label, "Child A1");
+        assert_eq!(
+            tree.drain_changes(),
+            vec![CollectionChange::Replace { key: Key::int(11) }]
+        );
+
+        let node = tree.get(&Key::int(11)).expect("key 11");
+
+        assert_eq!(node.value.as_ref().expect("value").label, "Renamed A1");
+    }
+
+    #[test]
+    fn tree_replace_unknown_key_returns_none_and_emits_no_event() {
+        let mut tree = sample_tree();
+
+        let old = tree.replace(Item::new(999, "Phantom"));
+
+        assert!(old.is_none());
+        assert_eq!(tree.size(), 5);
+        assert!(tree.drain_changes().is_empty());
+    }
+
+    #[test]
+    fn tree_drain_changes_returns_and_clears_buffer() {
+        let mut tree = sample_tree();
+
+        tree.replace(Item::new(11, "X"));
+        tree.replace(Item::new(12, "Y"));
+
+        let first = tree.drain_changes();
+
+        assert_eq!(first.len(), 2);
+
+        let second = tree.drain_changes();
+
+        assert!(second.is_empty());
+    }
+
+    #[test]
+    fn tree_delegates_collection_methods() {
+        let mut tree = sample_tree();
+
+        assert_eq!(tree.size(), 5);
+        assert!(!tree.is_empty());
+        assert!(tree.get(&Key::int(11)).is_some());
+        assert!(tree.get(&Key::int(999)).is_none());
+        assert_eq!(tree.get_by_index(0).expect("idx 0").key, Key::int(1));
+        assert_eq!(tree.first_key(), Some(&Key::int(1)));
+        assert_eq!(tree.last_key(), Some(&Key::int(21)));
+        assert_eq!(tree.key_after(&Key::int(1)), Some(&Key::int(11)));
+        assert_eq!(tree.key_before(&Key::int(11)), Some(&Key::int(1)));
+
+        // No-wrap variants: past-the-end / before-the-start return None.
+        assert_eq!(tree.key_after_no_wrap(&Key::int(21)), None);
+        assert_eq!(tree.key_before_no_wrap(&Key::int(1)), None);
+        // And behave like their wrapping counterparts mid-collection.
+        assert_eq!(tree.key_after_no_wrap(&Key::int(1)), Some(&Key::int(11)),);
+        assert_eq!(tree.key_before_no_wrap(&Key::int(21)), Some(&Key::int(2)),);
+
+        let keys = tree.keys().cloned().collect::<Vec<_>>();
+
+        assert_eq!(
+            keys,
+            vec![
+                Key::int(1),
+                Key::int(11),
+                Key::int(12),
+                Key::int(2),
+                Key::int(21),
+            ],
+        );
+        assert_eq!(tree.nodes().count(), 5);
+
+        // Direct children of Root A (key 1).
+        let child_keys = tree
+            .children_of(&Key::int(1))
+            .map(|n| n.key.clone())
+            .collect::<Vec<_>>();
+
+        assert_eq!(child_keys, vec![Key::int(11), Key::int(12)]);
+
+        // Reads do not populate the change buffer.
+        assert!(tree.drain_changes().is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // Debug impls (coverage + smoke test for non-Debug payload types)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn list_debug_includes_type_name_and_pending_count() {
+        let mut list = list_of_three();
+
+        // Queue one pending change so the debug count isn't 0.
+        list.push(Item::new(4, "Date"));
+
+        let debug = format!("{list:?}");
+
+        assert!(debug.contains("MutableListData"), "got: {debug}");
+        assert!(
+            debug.contains("pending_changes"),
+            "debug should show pending_changes field: {debug}"
+        );
+        assert!(debug.contains("StaticCollection"), "got: {debug}");
+    }
+
+    #[test]
+    fn tree_debug_includes_type_name_and_pending_count() {
+        let mut tree = sample_tree();
+
+        tree.replace(Item::new(11, "X"));
+
+        let debug = format!("{tree:?}");
+
+        assert!(debug.contains("MutableTreeData"), "got: {debug}");
+        assert!(
+            debug.contains("pending_changes"),
+            "debug should show pending_changes field: {debug}"
+        );
+        assert!(debug.contains("TreeCollection"), "got: {debug}");
+    }
+
+    // -----------------------------------------------------------------------
+    // reparent cycle rejection — the inner's descendant-of-moved check
+    // runs after extraction and triggers a subtree restore, which must not
+    // emit a change event from the wrapper.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn tree_reparent_to_descendant_returns_none_and_restores_tree() {
+        // Build a tree with a 3-level chain so we can try to reparent a node
+        // under its own descendant:
+        //   1 Root
+        //   └── 2 Mid
+        //       └── 3 Leaf
+        let inner = TreeCollection::new([tree_config(
+            1,
+            "Root",
+            vec![tree_config(2, "Mid", vec![tree_config(3, "Leaf", vec![])])],
+        )]);
+
+        let mut tree = MutableTreeData::new(inner);
+
+        // Try to reparent Mid(2) under Leaf(3) — a descendant of Mid —
+        // which would create a cycle. The inner detects this after
+        // extraction and restores the subtree.
+        let indices = tree.reparent(&Key::int(2), Some(&Key::int(3)), 0);
+
+        assert_eq!(indices, None, "cycle-creating reparent must return None");
+        assert_eq!(tree.size(), 3, "tree size unchanged after restore");
+        assert!(
+            tree.drain_changes().is_empty(),
+            "no change event for rejected reparent"
+        );
+
+        // The tree structure is intact: Root -> Mid -> Leaf still in place.
+        let keys = tree.keys().cloned().collect::<Vec<_>>();
+
+        assert_eq!(keys, vec![Key::int(1), Key::int(2), Key::int(3)]);
+    }
+
+    // -----------------------------------------------------------------------
+    // CollectionChange — derives
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn collection_change_derives_clone_debug_partial_eq() {
+        // Exercise Clone + PartialEq + Debug for every variant so the
+        // derives are actually instantiated for each shape.
+        let variants = [
+            CollectionChange::Insert { index: 2, count: 1 },
+            CollectionChange::Remove {
+                keys: vec![Key::int(1)],
+            },
+            CollectionChange::Move {
+                key: Key::int(1),
+                from_index: 0,
+                to_index: 1,
+            },
+            CollectionChange::Replace { key: Key::int(1) },
+            CollectionChange::Reset,
+        ];
+
+        let expected_debug = ["Insert", "Remove", "Move", "Replace", "Reset"];
+
+        for (variant, tag) in variants.iter().zip(expected_debug.iter()) {
+            assert_eq!(variant.clone(), *variant, "PartialEq + Clone roundtrip");
+
+            let debug = format!("{variant:?}");
+
+            assert!(
+                debug.contains(tag),
+                "Debug for {tag} includes variant name; got {debug}"
+            );
+        }
+    }
+}

--- a/crates/ars-collections/src/mutable.rs
+++ b/crates/ars-collections/src/mutable.rs
@@ -146,19 +146,44 @@ impl<T: CollectionItem> MutableListData<T> {
             .push(CollectionChange::Insert { index, count: 1 });
     }
 
-    /// Remove items with the given keys, returning their owned values in
-    /// iteration order. Emits [`CollectionChange::Remove`] carrying the keys
-    /// that actually matched an item — unknown keys are silently skipped by
-    /// the inner collection, so they are excluded from the change event to
-    /// keep the change log truthful. Returns an empty `Vec` (and emits no
-    /// event) when no key in `keys` matches.
+    /// Remove items with the given keys, returning their owned item values
+    /// in iteration order. Emits [`CollectionChange::Remove`] carrying every
+    /// **input key that actually existed** in the collection (deduped, in
+    /// input order) — unknown keys are silently skipped by the inner
+    /// collection, so they are excluded from the change event to keep the
+    /// change log truthful. Returns an empty `Vec` of payloads (and emits
+    /// no event) when no key in `keys` matches.
+    ///
+    /// The change event must be derived from existence-before-mutation, not
+    /// from the returned `Vec<T>`: [`StaticCollection::remove_by_keys`]
+    /// drops structural nodes ([`Section`], [`Header`], [`Separator`])
+    /// silently from its return because they carry no payload, even though
+    /// removing one mutates the collection and reindexes every later
+    /// position. Without the snapshot, an adapter reconciling from
+    /// `CollectionChange` would leave a phantom row in the DOM.
+    ///
+    /// [`Section`]: crate::node::NodeType::Section
+    /// [`Header`]: crate::node::NodeType::Header
+    /// [`Separator`]: crate::node::NodeType::Separator
     pub fn remove(&mut self, keys: &[Key]) -> Vec<T> {
+        // Snapshot which input keys are genuinely going to mutate the
+        // collection. We dedup as we go so a duplicated input key only
+        // appears once in the change event — that mirrors the inner
+        // method's behaviour (the second `remove_by_keys` pass over an
+        // already-removed key is a no-op).
+        let mut seen = BTreeSet::<Key>::new();
+
+        let matched_keys = keys
+            .iter()
+            .filter(|k| seen.insert((*k).clone()) && self.inner.index_of(k).is_some())
+            .cloned()
+            .collect::<Vec<_>>();
+
         let removed = self.inner.remove_by_keys(keys);
 
-        if !removed.is_empty() {
-            self.pending_changes.push(CollectionChange::Remove {
-                keys: removed.iter().map(|t| t.key().clone()).collect(),
-            });
+        if !matched_keys.is_empty() {
+            self.pending_changes
+                .push(CollectionChange::Remove { keys: matched_keys });
         }
 
         removed
@@ -374,38 +399,53 @@ impl<T: CollectionItem> MutableTreeData<T> {
     }
 
     /// Remove the listed nodes (and their descendants), returning their
-    /// owned values.
+    /// owned item values.
     ///
-    /// Emits [`CollectionChange::Remove`] carrying only the keys that
-    /// were both **(a)** actually matched by the inner collection and
-    /// **(b)** part of the visible iteration immediately before the
-    /// removal. Hidden nodes (those inside a collapsed ancestor) were
-    /// never rendered, so signalling their removal would force the
-    /// adapter to no-op anyway and pollutes the truthful change log.
-    /// When every removed item was hidden the call returns the values
-    /// without emitting any event.
+    /// Emits [`CollectionChange::Remove`] carrying every key that
+    /// disappeared from the **visible iteration** as a result of the
+    /// call — that includes:
+    ///
+    /// * the input keys that actually matched a node,
+    /// * cascade-removed descendants that were rendered, and
+    /// * structural nodes ([`Section`], [`Header`], [`Separator`]) which
+    ///   carry no payload and would never appear in the returned
+    ///   `Vec<T>`.
+    ///
+    /// Hidden nodes (those inside a collapsed ancestor) were never
+    /// rendered, so they stay out of the change event — emitting them
+    /// would force the adapter to no-op and pollute the truthful change
+    /// log. When every removed item was hidden the call returns the
+    /// values without emitting any event.
+    ///
+    /// The diff is computed against `visible_keys()` before and after
+    /// the inner mutation rather than from the returned `Vec<T>`, both
+    /// to capture cascaded descendants and to surface structural
+    /// removals that have no payload to enumerate.
+    ///
+    /// [`Section`]: crate::node::NodeType::Section
+    /// [`Header`]: crate::node::NodeType::Header
+    /// [`Separator`]: crate::node::NodeType::Separator
     pub fn remove(&mut self, keys: &[Key]) -> Vec<T> {
-        // Snapshot the visible-key set BEFORE mutation so we can later
-        // tell which removed items the adapter had actually rendered.
         // `visible_keys` is the inherent (Clone-free) twin of
         // `Collection::keys`, available because `MutableTreeData::remove`
-        // only requires `T: CollectionItem`.
-        let visible_before = self.inner.visible_keys().cloned().collect::<BTreeSet<_>>();
+        // only requires `T: CollectionItem`. Capturing the iteration
+        // order in a `Vec` (not a `BTreeSet`) lets us preserve DFS
+        // order in the change event.
+        let visible_before = self.inner.visible_keys().cloned().collect::<Vec<_>>();
 
         let removed = self.inner.remove_by_keys(keys);
 
-        if !removed.is_empty() {
-            let visible_removed_keys = removed
-                .iter()
-                .map(|t| t.key().clone())
-                .filter(|k| visible_before.contains(k))
-                .collect::<Vec<_>>();
+        let visible_after = self.inner.visible_keys().cloned().collect::<BTreeSet<_>>();
 
-            if !visible_removed_keys.is_empty() {
-                self.pending_changes.push(CollectionChange::Remove {
-                    keys: visible_removed_keys,
-                });
-            }
+        let visible_removed_keys = visible_before
+            .into_iter()
+            .filter(|k| !visible_after.contains(k))
+            .collect::<Vec<_>>();
+
+        if !visible_removed_keys.is_empty() {
+            self.pending_changes.push(CollectionChange::Remove {
+                keys: visible_removed_keys,
+            });
         }
 
         removed
@@ -815,6 +855,55 @@ mod tests {
         assert!(removed.is_empty());
         assert_eq!(list.size(), 3);
         assert!(list.drain_changes().is_empty());
+    }
+
+    #[test]
+    fn remove_separator_emits_remove_event_despite_empty_payload() {
+        // A separator (and Section/Header) is a structural node — it
+        // appears in `Collection::keys` and adapters render a row for
+        // it, but it carries no `T` payload. `StaticCollection::
+        // remove_by_keys` drops structural nodes silently from its
+        // returned `Vec<T>` even though it does mutate the collection
+        // (the node is gone, every later index has shifted). The
+        // wrapper must still emit `Remove` for that key, otherwise the
+        // change log lies and a reconciler keyed off `CollectionChange`
+        // leaves a phantom row in the DOM.
+        let mut list = MutableListData::new(
+            CollectionBuilder::<Item>::new()
+                .item(Key::int(1), "Apple", Item::new(1, "Apple"))
+                .separator()
+                .item(Key::int(2), "Banana", Item::new(2, "Banana"))
+                .build(),
+        );
+
+        // `separator()` derives its key from the insertion index (1
+        // here, between the two items) — see `CollectionBuilder`.
+        let separator_key = Key::str("separator-1");
+
+        assert_eq!(list.size(), 3, "two items + one separator");
+        assert!(
+            list.contains_key(&separator_key),
+            "separator must be part of the iteration",
+        );
+
+        let removed = list.remove(core::slice::from_ref(&separator_key));
+
+        // The separator carries no payload; the inner method returns
+        // an empty `Vec<T>` even though the node was removed.
+        assert!(removed.is_empty(), "structural nodes never carry a payload",);
+        assert_eq!(
+            list.size(),
+            2,
+            "separator was removed even though no payload was returned",
+        );
+
+        assert_eq!(
+            list.drain_changes(),
+            vec![CollectionChange::Remove {
+                keys: vec![separator_key],
+            }],
+            "structural-key removal must still emit Remove so adapters reconcile",
+        );
     }
 
     #[test]

--- a/crates/ars-collections/src/static_collection.rs
+++ b/crates/ars-collections/src/static_collection.rs
@@ -239,13 +239,30 @@ impl<T: CollectionItem> StaticCollection<T> {
     /// Replace an item's data (matched by key).
     ///
     /// Returns the previous value at `item.key()` on success, or `None` if
-    /// the key is not present in the collection. When `None` is returned,
-    /// `item` is dropped because the collection is unchanged — if the caller
-    /// needs to recover the item on failure, check `contains_key` first.
+    /// the key is not present in the collection **or** the existing node is
+    /// a structural node ([`Section`], [`Header`], or [`Separator`]) that
+    /// carries no item payload. When `None` is returned, `item` is dropped
+    /// and the collection is left unchanged — structural nodes are never
+    /// silently promoted to items. Callers that need to recover the item
+    /// on failure should check `contains_key` and the node's
+    /// [`is_structural`](Node::is_structural) flag first.
+    ///
+    /// [`Section`]: crate::node::NodeType::Section
+    /// [`Header`]: crate::node::NodeType::Header
+    /// [`Separator`]: crate::node::NodeType::Separator
     pub fn replace(&mut self, item: T) -> Option<T> {
-        self.nodes[*self.key_to_index.get(item.key())?]
-            .value
-            .replace(item)
+        let idx = *self.key_to_index.get(item.key())?;
+        let value_slot = &mut self.nodes[idx].value;
+
+        // Refuse to overwrite structural nodes (Section/Header/Separator),
+        // which always have `value: None`. Silently promoting them to items
+        // would corrupt the collection's structural metadata and confuse
+        // adapters that key off `NodeType`.
+        if value_slot.is_none() {
+            return None;
+        }
+
+        value_slot.replace(item)
     }
 
     /// Remove all items.
@@ -879,6 +896,67 @@ mod tests {
         assert!(old.is_none(), "replace returns None on unknown key");
         assert_eq!(c.len(), 3);
         assert!(!c.contains_key(&Key::int(99)));
+    }
+
+    #[test]
+    fn replace_does_not_mutate_section_node() {
+        // Build a collection where the key "fruits" belongs to a Section
+        // (a structural node with `value: None`). Calling `replace` with
+        // an item whose key collides with that Section must NOT silently
+        // promote the structural node to an Item — it must return `None`
+        // and leave the node untouched.
+        let mut c: StaticCollection<Fruit> = CollectionBuilder::new()
+            .section(Key::str("fruits"), "Fruits")
+            .item(Key::int(1), "Apple", Fruit::new(1, "Apple"))
+            .end_section()
+            .build();
+
+        // Hand-craft a Fruit with the Section's key.
+        let intruder = Fruit {
+            id: Key::str("fruits"),
+            name: "Pineapple".to_string(),
+        };
+
+        let old = c.replace(intruder);
+
+        // 1. `replace` must report failure.
+        assert!(old.is_none(), "replace must refuse to overwrite Section");
+
+        // 2. The structural node must remain a Section with `value: None`.
+        let section = c.get(&Key::str("fruits")).expect("section still present");
+
+        assert_eq!(section.node_type, NodeType::Section);
+        assert!(
+            section.value.is_none(),
+            "Section value must remain None — silent promotion would corrupt the collection"
+        );
+        assert_eq!(section.text_value, "Fruits");
+    }
+
+    #[test]
+    fn replace_does_not_mutate_separator_node() {
+        let mut c: StaticCollection<Fruit> = CollectionBuilder::new()
+            .item(Key::int(1), "Apple", Fruit::new(1, "Apple"))
+            .separator()
+            .item(Key::int(2), "Banana", Fruit::new(2, "Banana"))
+            .build();
+
+        // The builder names the separator "separator-1" (its flat index).
+        let separator_key = Key::str("separator-1");
+
+        let intruder = Fruit {
+            id: separator_key.clone(),
+            name: "Imposter".to_string(),
+        };
+
+        let old = c.replace(intruder);
+
+        assert!(old.is_none(), "replace must refuse to overwrite Separator");
+
+        let sep = c.get(&separator_key).expect("separator still present");
+
+        assert_eq!(sep.node_type, NodeType::Separator);
+        assert!(sep.value.is_none(), "Separator value must remain None");
     }
 
     #[test]

--- a/crates/ars-collections/src/static_collection.rs
+++ b/crates/ars-collections/src/static_collection.rs
@@ -237,12 +237,15 @@ impl<T: CollectionItem> StaticCollection<T> {
     }
 
     /// Replace an item's data (matched by key).
-    pub fn replace(&mut self, item: T) {
-        let key = item.key().clone();
-
-        if let Some(&idx) = self.key_to_index.get(&key) {
-            self.nodes[idx].value = Some(item);
-        }
+    ///
+    /// Returns the previous value at `item.key()` on success, or `None` if
+    /// the key is not present in the collection. When `None` is returned,
+    /// `item` is dropped because the collection is unchanged — if the caller
+    /// needs to recover the item on failure, check `contains_key` first.
+    pub fn replace(&mut self, item: T) -> Option<T> {
+        self.nodes[*self.key_to_index.get(item.key())?]
+            .value
+            .replace(item)
     }
 
     /// Remove all items.
@@ -270,12 +273,12 @@ impl<T: CollectionItem> StaticCollection<T> {
 
     /// Recompute `key_to_index` and `Node::index` from a starting position.
     fn reindex_from(&mut self, start: usize) {
-        for i in start..self.nodes.len() {
-            self.nodes[i].index = i;
+        for idx in start..self.nodes.len() {
+            self.nodes[idx].index = idx;
 
-            let key = &self.nodes[i].key;
+            let key = &self.nodes[idx].key;
 
-            self.key_to_index.insert(key.clone(), i);
+            self.key_to_index.insert(key.clone(), idx);
         }
     }
 }
@@ -857,7 +860,9 @@ mod tests {
     fn mutation_replace_existing() {
         let mut c = fruit_collection();
 
-        c.replace(Fruit::new(2, "Blueberry"));
+        let old = c.replace(Fruit::new(2, "Blueberry"));
+
+        assert_eq!(old.expect("old value returned").name, "Banana");
 
         let node = c.get(&Key::int(2)).expect("key 2");
 
@@ -868,9 +873,10 @@ mod tests {
     fn mutation_replace_missing() {
         let mut c = fruit_collection();
 
-        c.replace(Fruit::new(99, "Unknown"));
+        let old = c.replace(Fruit::new(99, "Unknown"));
 
         // No change — key 99 doesn't exist
+        assert!(old.is_none(), "replace returns None on unknown key");
         assert_eq!(c.len(), 3);
         assert!(!c.contains_key(&Key::int(99)));
     }

--- a/crates/ars-collections/src/tree_collection.rs
+++ b/crates/ars-collections/src/tree_collection.rs
@@ -591,6 +591,25 @@ impl<T: CollectionItem> TreeCollection<T> {
         self.key_to_index.get(key).copied()
     }
 
+    /// Returns `true` when the node at `key` currently has at least one
+    /// child (i.e. it is a branch, not a leaf), or `false` when the
+    /// node is a leaf **or** the key is unknown.
+    ///
+    /// Mirrors the [`Node::has_children`] field. Available without the
+    /// `T: Clone` bound that `Collection::get(&node).has_children` would
+    /// require, so callers operating on a generic `T: CollectionItem`
+    /// (such as [`MutableTreeData`]'s mutation methods) can detect
+    /// leaf↔branch transitions without paying for `Clone`.
+    ///
+    /// [`Node::has_children`]: crate::node::Node::has_children
+    /// [`MutableTreeData`]: crate::mutable::MutableTreeData
+    #[must_use]
+    pub fn has_children(&self, key: &Key) -> bool {
+        self.key_to_index
+            .get(key)
+            .is_some_and(|&i| self.all_nodes[i].has_children)
+    }
+
     /// Get the **visible** iteration index of a node by key, or `None`
     /// when the key is unknown **or** the node sits inside a collapsed
     /// ancestor (and is therefore hidden from `Collection::nodes` /

--- a/crates/ars-collections/src/tree_collection.rs
+++ b/crates/ars-collections/src/tree_collection.rs
@@ -461,13 +461,19 @@ impl<T: CollectionItem> TreeCollection<T> {
     /// (or among root nodes when `parent` is `None`). The node is inserted
     /// into `all_nodes` at the correct DFS position and indices are rebuilt.
     ///
-    /// If `parent` is `Some` but the key does not exist in the tree, the
-    /// operation is a no-op to avoid creating dangling parent references.
-    pub fn insert_child(&mut self, parent: Option<&Key>, sibling_index: usize, item: T) {
+    /// Returns the flat DFS index of the inserted node on success, or
+    /// `None` if `parent` is `Some(k)` and `k` is not present in the tree
+    /// (rejected to avoid creating dangling parent references).
+    pub fn insert_child(
+        &mut self,
+        parent: Option<&Key>,
+        sibling_index: usize,
+        item: T,
+    ) -> Option<usize> {
         // Reject inserts under a nonexistent parent.
         if let Some(pk) = parent {
             if !self.key_to_index.contains_key(pk) {
-                return;
+                return None;
             }
         }
 
@@ -514,6 +520,9 @@ impl<T: CollectionItem> TreeCollection<T> {
         }
 
         self.rebuild_indices();
+
+        // After rebuild, `key_to_index` points at the freshly inserted node.
+        self.key_to_index.get(&key).copied()
     }
 
     /// Remove items by key (and their entire subtrees).
@@ -579,18 +588,34 @@ impl<T: CollectionItem> TreeCollection<T> {
 
     /// Move a node (and its subtree) to a new parent at the given child index.
     ///
-    /// If `new_parent` is `Some` but the key does not exist in the tree
-    /// (or is a descendant of the node being moved), the operation is a
-    /// no-op to avoid creating dangling parent references.
-    pub fn reparent(&mut self, key: &Key, new_parent: Option<&Key>, sibling_index: usize) {
+    /// Returns `Some((from_flat_index, to_flat_index))` on success, or
+    /// `None` if the move was rejected. Rejection happens when:
+    ///
+    /// - `key` does not exist in the tree;
+    /// - `new_parent` is `Some(k)` and `k` is not present in the tree; or
+    /// - `new_parent` is a descendant of the node being moved (would create
+    ///   a cycle; detected after extraction).
+    ///
+    /// In the third case the subtree is restored to its original position
+    /// so the tree remains well-formed.
+    pub fn reparent(
+        &mut self,
+        key: &Key,
+        new_parent: Option<&Key>,
+        sibling_index: usize,
+    ) -> Option<(usize, usize)> {
         // Validate new_parent exists before extraction. Checking after
         // extraction is insufficient because the target might be a descendant
         // of the moved node (and thus removed by extract_subtree).
         if let Some(pk) = new_parent {
             if !self.key_to_index.contains_key(pk) {
-                return;
+                return None;
             }
         }
+
+        // Capture the node's current flat index before extraction; used in
+        // both the success return and the descendant-rejection restore path.
+        let from_index = *self.key_to_index.get(key)?;
 
         // Save old parent key before extraction for metadata cleanup.
         let old_parent_key = self.parent_of(key).cloned();
@@ -599,7 +624,7 @@ impl<T: CollectionItem> TreeCollection<T> {
         let subtree = self.extract_subtree(key);
 
         if subtree.is_empty() {
-            return;
+            return None;
         }
 
         // Reject reparenting under a descendant of the moved node.
@@ -616,7 +641,7 @@ impl<T: CollectionItem> TreeCollection<T> {
 
                 self.rebuild_indices();
 
-                return;
+                return None;
             }
         }
 
@@ -675,16 +700,29 @@ impl<T: CollectionItem> TreeCollection<T> {
         }
 
         self.rebuild_indices();
+
+        // After rebuild, `key_to_index` points at the moved node's new position.
+        let to_index = *self.key_to_index.get(key)?;
+        Some((from_index, to_index))
     }
 
     /// Reorder a node among its siblings to the given sibling index.
-    pub fn reorder_sibling(&mut self, key: &Key, to_sibling_index: usize) {
+    ///
+    /// Returns `Some((from_flat_index, to_flat_index))` on success, or
+    /// `None` if `key` does not exist in the tree.
+    pub fn reorder_sibling(
+        &mut self,
+        key: &Key,
+        to_sibling_index: usize,
+    ) -> Option<(usize, usize)> {
+        let from_index = *self.key_to_index.get(key)?;
+
         let parent_key = self.parent_of(key).cloned();
 
         let subtree = self.extract_subtree(key);
 
         if subtree.is_empty() {
-            return;
+            return None;
         }
 
         // Rebuild indices after extraction so flat_insert_position uses valid state.
@@ -697,15 +735,21 @@ impl<T: CollectionItem> TreeCollection<T> {
         }
 
         self.rebuild_indices();
+
+        let to_index = *self.key_to_index.get(key)?;
+
+        Some((from_index, to_index))
     }
 
     /// Replace an item's data (matched by key).
-    pub fn replace(&mut self, item: T) {
-        let key = item.key().clone();
-
-        if let Some(&idx) = self.key_to_index.get(&key) {
-            self.all_nodes[idx].value = Some(item);
-        }
+    ///
+    /// Returns the previous value at `item.key()` on success, or `None` if
+    /// the key is not present in the tree. Children are preserved — only
+    /// the node's payload is swapped.
+    pub fn replace(&mut self, item: T) -> Option<T> {
+        self.all_nodes[*self.key_to_index.get(item.key())?]
+            .value
+            .replace(item)
     }
 
     /// Return the parent key of a node, if any.
@@ -716,20 +760,39 @@ impl<T: CollectionItem> TreeCollection<T> {
     }
 
     /// Extract a node and its subtree from `all_nodes`, returning the
-    /// removed nodes. After extraction, indices are stale until
-    /// `rebuild_indices()` is called.
+    /// removed nodes.
+    ///
+    /// Also removes the extracted nodes' keys from `key_to_index` so that
+    /// callers can distinguish "still in tree" from "was extracted" (used
+    /// by `reparent` to detect reparenting under a descendant of the moved
+    /// node). The positional indices stored in `key_to_index` for the
+    /// *surviving* nodes may still be stale until `rebuild_indices()` is
+    /// called, so callers must not use those values between extraction and
+    /// rebuild — only membership (`contains_key`) is reliable.
     fn extract_subtree(&mut self, key: &Key) -> Vec<Node<T>> {
-        self.key_to_index.get(key).map_or_else(Vec::new, |&start| {
-            let root_level = self.all_nodes[start].level;
+        self.key_to_index
+            .get(key)
+            .copied()
+            .map_or_else(Vec::new, |start| {
+                let root_level = self.all_nodes[start].level;
 
-            let mut end = start + 1;
+                let mut end = start + 1;
 
-            while end < self.all_nodes.len() && self.all_nodes[end].level > root_level {
-                end += 1;
-            }
+                while end < self.all_nodes.len() && self.all_nodes[end].level > root_level {
+                    end += 1;
+                }
 
-            self.all_nodes.drain(start..end).collect()
-        })
+                let drained = self.all_nodes.drain(start..end).collect::<Vec<_>>();
+
+                // Remove the extracted keys from `key_to_index` so subsequent
+                // `contains_key` checks (e.g. in `reparent`'s cycle guard)
+                // correctly report that these nodes are no longer in the tree.
+                for node in &drained {
+                    self.key_to_index.shift_remove(&node.key);
+                }
+
+                drained
+            })
     }
 
     /// Compute the flat insertion position for a new child at `sibling_index`
@@ -788,10 +851,10 @@ impl<T: CollectionItem> TreeCollection<T> {
     fn rebuild_indices(&mut self) {
         self.key_to_index.clear();
 
-        for (i, node) in self.all_nodes.iter_mut().enumerate() {
-            node.index = i;
+        for (idx, node) in self.all_nodes.iter_mut().enumerate() {
+            node.index = idx;
 
-            self.key_to_index.insert(node.key.clone(), i);
+            self.key_to_index.insert(node.key.clone(), idx);
         }
 
         let (visible_indices, first_focusable_visible, last_focusable_visible) =
@@ -2180,12 +2243,12 @@ mod tests {
     fn reparent_to_nonexistent_parent_is_noop() {
         let mut tree = fruit_tree();
 
-        let before_keys: Vec<_> = tree.keys().cloned().collect();
+        let before_keys = tree.keys().cloned().collect::<Vec<_>>();
 
         // Reparent Apple(2) under nonexistent key 99 — should be a no-op
         tree.reparent(&Key::int(2), Some(&Key::int(99)), 0);
 
-        let after_keys: Vec<_> = tree.keys().cloned().collect();
+        let after_keys = tree.keys().cloned().collect::<Vec<_>>();
 
         // Tree should be unchanged
         assert_eq!(before_keys, after_keys);
@@ -2259,5 +2322,164 @@ mod tests {
 
         assert!(!fruits.has_children);
         assert_eq!(fruits.is_expanded, None);
+    }
+
+    // ---------------------------------------------------------------
+    // Return-value contracts on mutation methods
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn insert_child_returns_flat_index_on_success() {
+        let mut tree = fruit_tree();
+
+        // fruit_tree has 4 nodes: [Fruits(1), Apple(2), Banana(3), Other(4)].
+        // Insert a root sibling at the end (sibling_index 2) — flat index 4.
+        let flat = tree.insert_child(None, 2, TreeFruit::new(100, "New Root"));
+
+        assert_eq!(flat, Some(4));
+        assert_eq!(tree.flat_index_of(&Key::int(100)), Some(4));
+    }
+
+    #[test]
+    fn insert_child_returns_none_on_unknown_parent() {
+        let mut tree = fruit_tree();
+
+        let flat = tree.insert_child(Some(&Key::int(999)), 0, TreeFruit::new(10, "Orphan"));
+
+        assert_eq!(flat, None);
+        assert!(!tree.contains_key(&Key::int(10)));
+    }
+
+    #[test]
+    fn reparent_returns_flat_indices_on_success() {
+        let mut tree = fruit_tree();
+
+        // Apple(2) is at flat index 1. Moving to root at sibling_index 0
+        // places it at flat index 0.
+        let indices = tree.reparent(&Key::int(2), None, 0);
+
+        assert_eq!(indices, Some((1, 0)));
+    }
+
+    #[test]
+    fn reparent_returns_none_on_unknown_key() {
+        let mut tree = fruit_tree();
+
+        let indices = tree.reparent(&Key::int(999), None, 0);
+
+        assert_eq!(indices, None);
+    }
+
+    #[test]
+    fn reparent_returns_none_on_unknown_new_parent() {
+        let mut tree = fruit_tree();
+
+        let indices = tree.reparent(&Key::int(2), Some(&Key::int(999)), 0);
+
+        assert_eq!(indices, None);
+    }
+
+    #[test]
+    fn reparent_to_own_descendant_returns_none_and_restores_subtree() {
+        // Build a 3-level chain so we can try to reparent a node under its
+        // own descendant:
+        //   1 Root
+        //   └── 2 Mid
+        //       └── 3 Leaf
+        let mut tree = TreeCollection::new(vec![TreeItemConfig {
+            key: Key::int(1),
+            text_value: "Root".to_string(),
+            value: TreeFruit::new(1, "Root"),
+            children: vec![TreeItemConfig {
+                key: Key::int(2),
+                text_value: "Mid".to_string(),
+                value: TreeFruit::new(2, "Mid"),
+                children: vec![TreeItemConfig {
+                    key: Key::int(3),
+                    text_value: "Leaf".to_string(),
+                    value: TreeFruit::new(3, "Leaf"),
+                    children: Vec::new(),
+                    default_expanded: false,
+                }],
+                default_expanded: true,
+            }],
+            default_expanded: true,
+        }]);
+
+        // Try to move Mid(2) under Leaf(3) — a descendant of Mid. That
+        // would create a cycle. The inner detects this after extracting
+        // Mid's subtree and restores it.
+        let indices = tree.reparent(&Key::int(2), Some(&Key::int(3)), 0);
+
+        assert_eq!(indices, None, "cycle-creating reparent must return None");
+
+        // Tree structure is intact.
+        assert_eq!(tree.all_nodes.len(), 3);
+        assert!(tree.contains_key(&Key::int(1)));
+        assert!(tree.contains_key(&Key::int(2)));
+        assert!(tree.contains_key(&Key::int(3)));
+
+        // Flat order is preserved: Root, Mid, Leaf.
+        assert_eq!(tree.flat_index_of(&Key::int(1)), Some(0));
+        assert_eq!(tree.flat_index_of(&Key::int(2)), Some(1));
+        assert_eq!(tree.flat_index_of(&Key::int(3)), Some(2));
+
+        // Parent/level metadata intact.
+        assert_eq!(
+            tree.get(&Key::int(2)).expect("Mid").parent_key,
+            Some(Key::int(1))
+        );
+        assert_eq!(
+            tree.get(&Key::int(3)).expect("Leaf").parent_key,
+            Some(Key::int(2))
+        );
+    }
+
+    #[test]
+    fn reorder_sibling_returns_flat_indices_on_success() {
+        let mut tree = fruit_tree();
+
+        // Apple(2) at flat 1, moving to sibling_index 1 among Fruits's
+        // children places it at flat 2 (after Banana).
+        let indices = tree.reorder_sibling(&Key::int(2), 1);
+
+        assert_eq!(indices, Some((1, 2)));
+    }
+
+    #[test]
+    fn reorder_sibling_returns_none_on_unknown_key() {
+        let mut tree = fruit_tree();
+
+        let indices = tree.reorder_sibling(&Key::int(999), 0);
+
+        assert_eq!(indices, None);
+    }
+
+    #[test]
+    fn replace_returns_old_value_on_success() {
+        let mut tree = fruit_tree();
+
+        let old = tree.replace(TreeFruit::new(2, "Green Apple"));
+
+        assert_eq!(old.expect("old value").name, "Apple");
+        assert_eq!(
+            tree.get(&Key::int(2))
+                .expect("key 2")
+                .value
+                .as_ref()
+                .expect("value")
+                .name,
+            "Green Apple"
+        );
+    }
+
+    #[test]
+    fn replace_returns_none_on_unknown_key() {
+        let mut tree = fruit_tree();
+
+        let old = tree.replace(TreeFruit::new(999, "Phantom"));
+
+        assert!(old.is_none());
+        assert!(!tree.contains_key(&Key::int(999)));
     }
 }

--- a/crates/ars-collections/src/tree_collection.rs
+++ b/crates/ars-collections/src/tree_collection.rs
@@ -581,9 +581,40 @@ impl<T: CollectionItem> TreeCollection<T> {
         removed
     }
 
-    /// Get the flat index of a node by key.
+    /// Get the flat (DFS) index of a node by key. The flat index includes
+    /// nodes hidden inside collapsed subtrees and is suitable for
+    /// stable-storage operations on `all_nodes`. For DOM reconciliation
+    /// or any code that drives the visible iteration exposed via
+    /// [`Collection::nodes`] / [`Collection::get_by_index`], use
+    /// [`visible_index_of`](Self::visible_index_of) instead.
     pub fn flat_index_of(&self, key: &Key) -> Option<usize> {
         self.key_to_index.get(key).copied()
+    }
+
+    /// Get the **visible** iteration index of a node by key, or `None`
+    /// when the key is unknown **or** the node sits inside a collapsed
+    /// ancestor (and is therefore hidden from `Collection::nodes` /
+    /// `Collection::get_by_index`).
+    ///
+    /// Adapters driving DOM reconciliation should consume visible indices
+    /// — the flat DFS index returned by [`flat_index_of`](Self::flat_index_of)
+    /// does not correspond to any DOM position when a node is hidden.
+    pub fn visible_index_of(&self, key: &Key) -> Option<usize> {
+        let flat = self.flat_index_of(key)?;
+        // `visible_indices` is sorted ascending (it preserves DFS order),
+        // so binary search is correct and faster than a linear scan for
+        // large trees.
+        self.visible_indices.binary_search(&flat).ok()
+    }
+
+    /// Iterate the **visible** keys of the tree in DFS order.
+    ///
+    /// Mirrors the iteration of [`Collection::keys`] but is available
+    /// without the `T: Clone` bound the trait impl requires, so it can be
+    /// called from generic contexts (such as `MutableTreeData`'s mutation
+    /// methods, which only require `T: CollectionItem`).
+    pub fn visible_keys(&self) -> impl Iterator<Item = &Key> {
+        self.visible_indices.iter().map(|&i| &self.all_nodes[i].key)
     }
 
     /// Move a node (and its subtree) to a new parent at the given child index.
@@ -1756,6 +1787,61 @@ mod tests {
         assert_eq!(tree.flat_index_of(&Key::int(3)), Some(2));
         assert_eq!(tree.flat_index_of(&Key::int(4)), Some(3));
         assert_eq!(tree.flat_index_of(&Key::int(99)), None);
+    }
+
+    #[test]
+    fn visible_index_of_matches_flat_when_fully_expanded() {
+        // The fruit_tree fixture is fully expanded by default, so visible
+        // and flat indices must agree for every key.
+        let tree = fruit_tree();
+
+        assert_eq!(tree.visible_index_of(&Key::int(1)), Some(0));
+        assert_eq!(tree.visible_index_of(&Key::int(2)), Some(1));
+        assert_eq!(tree.visible_index_of(&Key::int(3)), Some(2));
+        assert_eq!(tree.visible_index_of(&Key::int(4)), Some(3));
+        assert_eq!(tree.visible_index_of(&Key::int(99)), None);
+    }
+
+    #[test]
+    fn visible_index_of_returns_none_for_collapsed_descendants() {
+        // Collapse the Fruits group so its children become hidden. The
+        // root itself stays visible and its children disappear from the
+        // visible iteration.
+        let collapsed = fruit_tree().set_expanded(&Key::int(1), false);
+
+        assert_eq!(
+            collapsed.visible_index_of(&Key::int(1)),
+            Some(0),
+            "the collapsed parent itself is still visible"
+        );
+        assert_eq!(
+            collapsed.visible_index_of(&Key::int(2)),
+            None,
+            "Apple is hidden inside collapsed Fruits"
+        );
+        assert_eq!(
+            collapsed.visible_index_of(&Key::int(3)),
+            None,
+            "Banana is hidden inside collapsed Fruits"
+        );
+        assert_eq!(
+            collapsed.visible_index_of(&Key::int(4)),
+            Some(1),
+            "Other shifts up to visible index 1 once Fruits' children are hidden"
+        );
+    }
+
+    #[test]
+    fn visible_keys_iterates_only_visible_nodes() {
+        let collapsed = fruit_tree().set_expanded(&Key::int(1), false);
+
+        let visible_keys = collapsed.visible_keys().cloned().collect::<Vec<_>>();
+
+        assert_eq!(
+            visible_keys,
+            vec![Key::int(1), Key::int(4)],
+            "visible_keys must skip nodes inside collapsed ancestors"
+        );
     }
 
     #[test]

--- a/crates/ars-collections/src/tree_collection.rs
+++ b/crates/ars-collections/src/tree_collection.rs
@@ -744,12 +744,24 @@ impl<T: CollectionItem> TreeCollection<T> {
     /// Replace an item's data (matched by key).
     ///
     /// Returns the previous value at `item.key()` on success, or `None` if
-    /// the key is not present in the tree. Children are preserved — only
-    /// the node's payload is swapped.
+    /// the key is not present in the tree **or** the existing node carries
+    /// no item payload (a structural node). Children are preserved — only
+    /// the node's payload is swapped. Structural nodes are never silently
+    /// promoted to items.
     pub fn replace(&mut self, item: T) -> Option<T> {
-        self.all_nodes[*self.key_to_index.get(item.key())?]
-            .value
-            .replace(item)
+        let idx = *self.key_to_index.get(item.key())?;
+        let value_slot = &mut self.all_nodes[idx].value;
+
+        // Refuse to overwrite structural nodes, mirroring
+        // `StaticCollection::replace`. Tree builders today only emit Item
+        // nodes, but defending the invariant here keeps the contract
+        // consistent across both collection types and prevents future
+        // structural-node support from introducing a silent corruption.
+        if value_slot.is_none() {
+            return None;
+        }
+
+        value_slot.replace(item)
     }
 
     /// Return the parent key of a node, if any.

--- a/spec/foundation/06-collections.md
+++ b/spec/foundation/06-collections.md
@@ -981,7 +981,7 @@ This mirrors `HashMap::insert` in idiom: the return value tells the caller wheth
 
 - All indices in `Insert { index, .. }` and `Move { from_index, to_index, .. }` are **visible iteration indices** (the position the adapter would obtain from `Collection::get_by_index`), never flat DFS indices into `all_nodes`.
 - Mutations confined to a hidden subtree (e.g. `insert_child` under a collapsed parent, or `reorder` of two hidden siblings) emit **no event** — the adapter has nothing to render and the inner state will surface naturally when the ancestor is later expanded.
-- Mutations that cross visibility (`reparent` from a visible parent into a hidden one, or vice versa) are translated into the matching DOM-shaped event (`Remove` or `Insert`) instead of `Move`. See `reparent` below for the full table.
+- Mutations that cross visibility (`reparent` from a visible parent into a hidden one, or vice versa) are translated into the matching DOM-shaped event (`Remove` or `Insert`) instead of `Move`, and the event covers the **entire subtree** that crossed the boundary — `Remove` carries every previously-visible key in DFS order, and `Insert` reports `count` equal to the number of newly-visible nodes — because every visible descendant disappears or appears alongside the moved root. See `reparent` below for the full table.
 
 This contract keeps the change log "truthful" in the sense already required for failure modes: every event corresponds to a DOM operation the adapter must perform. Hidden-only churn does not generate phantom events that an adapter would have to filter or no-op.
 
@@ -1074,23 +1074,35 @@ impl<T: CollectionItem> MutableTreeData<T> {
     /// `Some((from_flat_index, to_flat_index))` on success; `None` when
     /// the move is rejected (see §2.3 and the table above).
     ///
-    /// Visibility may differ between the old and new locations, so the
-    /// emitted event is chosen to describe the DOM impact precisely:
+    /// Visibility may differ between the old and new locations — and a
+    /// single move can flip visibility for every descendant in the
+    /// subtree, not just the moved root — so the emitted event is
+    /// chosen to describe the DOM impact precisely:
     ///
-    /// | From visible | To visible | Event emitted                               |
-    /// | ------------ | ---------- | ------------------------------------------- |
-    /// | yes          | yes        | `Move { key, from: vis_from, to: vis_to }`  |
-    /// | yes          | no         | `Remove { keys: [key] }`                    |
-    /// | no           | yes        | `Insert { index: vis_to, count: 1 }`        |
-    /// | no           | no         | *(no event)*                                |
+    /// | From visible | To visible | Event emitted                                                                |
+    /// | ------------ | ---------- | ---------------------------------------------------------------------------- |
+    /// | yes          | yes        | `Move { key, from: vis_from, to: vis_to }`                                   |
+    /// | yes          | no         | `Remove { keys: <previously-visible subtree keys, DFS order> }`              |
+    /// | no           | yes        | `Insert { index: vis_to, count: <number of newly-visible subtree nodes> }`   |
+    /// | no           | no         | *(no event)*                                                                 |
     ///
-    /// Indices are visible iteration indices, not flat DFS indices.
+    /// Indices are visible iteration indices, not flat DFS indices. The
+    /// `Insert` always spans `count` consecutive positions starting at
+    /// `to_index`. Emitting only `[key]` for visible→hidden, or
+    /// `count: 1` for hidden→visible, would leave keyed reconcilers
+    /// with orphan descendant rows or miscounted indices.
     pub fn reparent(
         &mut self,
         key: &Key,
         new_parent: Option<&Key>,
         index: usize,
     ) -> Option<(usize, usize)> {
+        // Snapshot the pre-mutation visible iteration. Both visibility-
+        // crossing branches need to compare visible-before vs
+        // visible-after to capture every subtree descendant whose
+        // visibility flipped — only the moved subtree's visibility can
+        // change, so the set difference is exactly the subtree delta.
+        let visible_before: Vec<Key> = self.inner.visible_keys().cloned().collect();
         let from_visible = self.inner.visible_index_of(key);
         let (from_flat, to_flat) = self.inner.reparent(key, new_parent, index)?;
         let to_visible = self.inner.visible_index_of(key);
@@ -1101,13 +1113,32 @@ impl<T: CollectionItem> MutableTreeData<T> {
                 });
             }
             (Some(_), None) => {
+                // Root + every visible descendant disappears together
+                // under the collapsed new parent. Remove must list all
+                // of them in pre-mutation DFS order.
+                let visible_after: BTreeSet<Key> =
+                    self.inner.visible_keys().cloned().collect();
+                let removed_keys: Vec<Key> = visible_before
+                    .into_iter()
+                    .filter(|k| !visible_after.contains(k))
+                    .collect();
                 self.pending_changes.push(CollectionChange::Remove {
-                    keys: vec![key.clone()],
+                    keys: removed_keys,
                 });
             }
             (None, Some(to_index)) => {
+                // Root + descendants whose internal expansion keeps
+                // them visible at the new location appear in `count`
+                // consecutive positions starting at `to_index`.
+                let visible_before_set: BTreeSet<Key> =
+                    visible_before.into_iter().collect();
+                let count = self
+                    .inner
+                    .visible_keys()
+                    .filter(|k| !visible_before_set.contains(*k))
+                    .count();
                 self.pending_changes.push(CollectionChange::Insert {
-                    index: to_index, count: 1,
+                    index: to_index, count,
                 });
             }
             (None, None) => {} // both endpoints hidden, nothing to report

--- a/spec/foundation/06-collections.md
+++ b/spec/foundation/06-collections.md
@@ -960,9 +960,9 @@ impl<T: CollectionItem + Clone> Collection<T> for MutableListData<T> {
 
 Every mutation method in `MutableTreeData` — `insert_child`, `reparent`, `reorder`, `replace`, `remove` — follows the same pattern:
 
-- The inner `TreeCollection` mutation method (see §2.3) returns an `Option` communicating whether the mutation took effect, and carrying the flat DFS index(es) the caller needs to emit a precise change event.
+- The inner `TreeCollection` mutation method (see §2.3) returns an `Option` communicating whether the mutation took effect, and carrying the flat DFS index(es) the caller needs to make further bookkeeping decisions.
 - The wrapper forwards that `Option` unchanged as its own return value.
-- The wrapper pushes a `CollectionChange` into `pending_changes` **only** when the inner call returned `Some(_)`.
+- The wrapper pushes a `CollectionChange` into `pending_changes` **only** when the inner call returned `Some(_)` **and** the change has a visible-iteration footprint (see "Visibility-aware change events" below).
 
 Failure modes the `Option` captures:
 
@@ -974,6 +974,16 @@ Failure modes the `Option` captures:
 | `replace`      | `item.key()` unknown                                                                               |
 
 This mirrors `HashMap::insert` in idiom: the return value tells the caller whether the operation happened and, when applicable, what changed. Callers that know the precondition holds can ignore the return; callers that need to react to failure can match on `Option::None` without a separate `contains_key` probe.
+
+##### Visibility-aware change events
+
+`Collection::nodes` and `Collection::get_by_index` iterate the **visible** subset of a tree — items inside a collapsed ancestor are excluded. Adapters drive DOM reconciliation against that visible iteration, so `CollectionChange` events emitted by `MutableTreeData` describe **visible-iteration changes**, not raw `all_nodes` mutations. Specifically:
+
+- All indices in `Insert { index, .. }` and `Move { from_index, to_index, .. }` are **visible iteration indices** (the position the adapter would obtain from `Collection::get_by_index`), never flat DFS indices into `all_nodes`.
+- Mutations confined to a hidden subtree (e.g. `insert_child` under a collapsed parent, or `reorder` of two hidden siblings) emit **no event** — the adapter has nothing to render and the inner state will surface naturally when the ancestor is later expanded.
+- Mutations that cross visibility (`reparent` from a visible parent into a hidden one, or vice versa) are translated into the matching DOM-shaped event (`Remove` or `Insert`) instead of `Move`. See `reparent` below for the full table.
+
+This contract keeps the change log "truthful" in the sense already required for failure modes: every event corresponds to a DOM operation the adapter must perform. Hidden-only churn does not generate phantom events that an adapter would have to filter or no-op.
 
 ```rust
 /// A mutable tree collection that tracks granular changes.
@@ -1009,68 +1019,126 @@ impl<T: CollectionItem> MutableTreeData<T> {
     }
 
     /// Insert a child under the given parent at the specified sibling
-    /// index (or at the root when `parent` is `None`). Returns the flat DFS
-    /// index of the inserted node on success, or `None` when the inner
-    /// call rejected the insert (unknown parent). Emits `Insert` only on
-    /// success.
+    /// index (or at the root when `parent` is `None`). Returns the flat
+    /// DFS index of the inserted node on success, or `None` when the
+    /// inner call rejected the insert (unknown parent).
+    ///
+    /// Emits `Insert { index, count: 1 }` using the **visible iteration
+    /// index** of the new child, matching `Collection::get_by_index`.
+    /// When the child lands inside a collapsed ancestor it is hidden
+    /// from the visible iteration and **no event is emitted** — emitting
+    /// a flat DFS index would mis-place the DOM update.
     pub fn insert_child(
         &mut self,
         parent: Option<&Key>,
         index: usize,
         item: T,
     ) -> Option<usize> {
+        let key = item.key().clone();
         let flat_index = self.inner.insert_child(parent, index, item)?;
-        self.pending_changes
-            .push(CollectionChange::Insert { index: flat_index, count: 1 });
+        if let Some(visible_index) = self.inner.visible_index_of(&key) {
+            self.pending_changes
+                .push(CollectionChange::Insert { index: visible_index, count: 1 });
+        }
         Some(flat_index)
     }
 
-    /// Remove the listed nodes (and their descendants). Emits `Remove`
-    /// containing only the keys that actually matched; returns the removed
-    /// values. Emits no event and returns an empty `Vec` when no key matches.
+    /// Remove the listed nodes (and their descendants); returns the
+    /// removed values.
+    ///
+    /// Emits `Remove` carrying only the keys that were both **(a)**
+    /// matched by the inner collection and **(b)** part of the visible
+    /// iteration immediately before the removal. Hidden nodes were never
+    /// rendered, so signalling their removal would force the adapter to
+    /// no-op and pollutes the truthful change log. When every removed
+    /// item was hidden, no event is emitted.
     pub fn remove(&mut self, keys: &[Key]) -> Vec<T> {
+        // Snapshot visible keys before mutation.
+        let visible_before: BTreeSet<Key> = self.inner.visible_keys().cloned().collect();
         let removed = self.inner.remove_by_keys(keys);
         if !removed.is_empty() {
-            let removed_keys: Vec<Key> = removed.iter().map(|t| t.key().clone()).collect();
-            self.pending_changes.push(CollectionChange::Remove { keys: removed_keys });
+            let visible_removed_keys: Vec<Key> = removed
+                .iter()
+                .map(|t| t.key().clone())
+                .filter(|k| visible_before.contains(k))
+                .collect();
+            if !visible_removed_keys.is_empty() {
+                self.pending_changes
+                    .push(CollectionChange::Remove { keys: visible_removed_keys });
+            }
         }
         removed
     }
 
     /// Move a node (with its subtree) to a new parent. Returns
-    /// `Some((from_flat_index, to_flat_index))` on success; `None` when the
-    /// move is rejected (see §2.3 and the table above). Emits `Move` only
-    /// on success.
+    /// `Some((from_flat_index, to_flat_index))` on success; `None` when
+    /// the move is rejected (see §2.3 and the table above).
+    ///
+    /// Visibility may differ between the old and new locations, so the
+    /// emitted event is chosen to describe the DOM impact precisely:
+    ///
+    /// | From visible | To visible | Event emitted                               |
+    /// | ------------ | ---------- | ------------------------------------------- |
+    /// | yes          | yes        | `Move { key, from: vis_from, to: vis_to }`  |
+    /// | yes          | no         | `Remove { keys: [key] }`                    |
+    /// | no           | yes        | `Insert { index: vis_to, count: 1 }`        |
+    /// | no           | no         | *(no event)*                                |
+    ///
+    /// Indices are visible iteration indices, not flat DFS indices.
     pub fn reparent(
         &mut self,
         key: &Key,
         new_parent: Option<&Key>,
         index: usize,
     ) -> Option<(usize, usize)> {
-        let (from_index, to_index) = self.inner.reparent(key, new_parent, index)?;
-        self.pending_changes.push(CollectionChange::Move {
-            key: key.clone(),
-            from_index,
-            to_index,
-        });
-        Some((from_index, to_index))
+        let from_visible = self.inner.visible_index_of(key);
+        let (from_flat, to_flat) = self.inner.reparent(key, new_parent, index)?;
+        let to_visible = self.inner.visible_index_of(key);
+        match (from_visible, to_visible) {
+            (Some(from_index), Some(to_index)) => {
+                self.pending_changes.push(CollectionChange::Move {
+                    key: key.clone(), from_index, to_index,
+                });
+            }
+            (Some(_), None) => {
+                self.pending_changes.push(CollectionChange::Remove {
+                    keys: vec![key.clone()],
+                });
+            }
+            (None, Some(to_index)) => {
+                self.pending_changes.push(CollectionChange::Insert {
+                    index: to_index, count: 1,
+                });
+            }
+            (None, None) => {} // both endpoints hidden, nothing to report
+        }
+        Some((from_flat, to_flat))
     }
 
     /// Reorder a node among its existing siblings. Returns
     /// `Some((from_flat_index, to_flat_index))` on success; `None` when
-    /// `key` is unknown. Emits `Move` only on success.
+    /// `key` is unknown.
+    ///
+    /// Reordering preserves the parent and therefore preserves
+    /// visibility — either both endpoints are visible (parent expanded)
+    /// or both are hidden (parent collapsed). When visible, emits
+    /// `Move` using **visible iteration indices**; when hidden, emits
+    /// no event.
     pub fn reorder(
         &mut self,
         key: &Key,
         to_sibling_index: usize,
     ) -> Option<(usize, usize)> {
-        let (from_index, to_index) = self.inner.reorder_sibling(key, to_sibling_index)?;
-        self.pending_changes.push(CollectionChange::Move {
-            key: key.clone(),
-            from_index,
-            to_index,
-        });
-        Some((from_index, to_index))
+        let from_visible = self.inner.visible_index_of(key);
+        let (from_flat, to_flat) = self.inner.reorder_sibling(key, to_sibling_index)?;
+        if let (Some(from_index), Some(to_index)) =
+            (from_visible, self.inner.visible_index_of(key))
+        {
+            self.pending_changes.push(CollectionChange::Move {
+                key: key.clone(), from_index, to_index,
+            });
+        }
+        Some((from_flat, to_flat))
     }
 
     /// Replace a node's data in place (children preserved). Returns the
@@ -2095,9 +2163,31 @@ impl<T: CollectionItem> TreeCollection<T> {
         removed
     }
 
-    /// Get the flat index of a node by key.
+    /// Get the flat (DFS) index of a node by key. Includes nodes hidden
+    /// inside collapsed subtrees. For DOM reconciliation, use
+    /// `visible_index_of` instead.
     pub fn flat_index_of(&self, key: &Key) -> Option<usize> {
         self.key_to_index.get(key).copied()
+    }
+
+    /// Get the visible iteration index of a node by key, or `None` when
+    /// the key is unknown or the node sits inside a collapsed ancestor
+    /// (and is therefore hidden from `Collection::nodes` /
+    /// `Collection::get_by_index`). `MutableTreeData` uses this to emit
+    /// visibility-correct change events.
+    pub fn visible_index_of(&self, key: &Key) -> Option<usize> {
+        let flat = self.flat_index_of(key)?;
+        // `visible_indices` is sorted ascending, so binary search is
+        // correct and faster than a linear scan for large trees.
+        self.visible_indices.binary_search(&flat).ok()
+    }
+
+    /// Iterate the visible keys of the tree in DFS order. Inherent twin
+    /// of `Collection::keys` that drops the `T: Clone` bound, so it can
+    /// be called from `MutableTreeData`'s mutation methods (which only
+    /// require `T: CollectionItem`).
+    pub fn visible_keys(&self) -> impl Iterator<Item = &Key> {
+        self.visible_indices.iter().map(|&i| &self.all_nodes[i].key)
     }
 
     /// Move a node (and its subtree) to a new parent at the given child index.

--- a/spec/foundation/06-collections.md
+++ b/spec/foundation/06-collections.md
@@ -864,15 +864,37 @@ impl<T: CollectionItem> MutableListData<T> {
         self.pending_changes.push(CollectionChange::Insert { index, count: 1 });
     }
 
-    /// Remove items by key. Returns the removed values; emits a `Remove`
-    /// change containing only the keys that actually matched (unknown keys
-    /// are silently skipped by the inner collection and excluded from the
-    /// event). Returns an empty `Vec` and emits no event when no key matches.
+    /// Remove items by key. Returns the removed item values; emits
+    /// `Remove` carrying every input key that actually existed in the
+    /// collection (deduped, in input order). Unknown keys are silently
+    /// skipped by the inner collection and excluded from the event.
+    /// Returns an empty `Vec` of payloads and emits no event when no
+    /// key matches.
+    ///
+    /// The change-event keys must come from an existence snapshot, not
+    /// from the returned `Vec<T>`: `StaticCollection::remove_by_keys`
+    /// drops structural nodes (`Section` / `Header` / `Separator`)
+    /// silently from its return because they carry no payload, even
+    /// though removing one mutates the collection and reindexes every
+    /// later position. Without the snapshot, an adapter reconciling
+    /// from `CollectionChange` would leave a phantom row in the DOM.
     pub fn remove(&mut self, keys: &[Key]) -> Vec<T> {
+        // Snapshot which input keys are genuinely going to mutate the
+        // collection. Dedup as we go so a duplicated input key only
+        // appears once in the change event — that mirrors the inner
+        // method's behaviour on an already-removed key.
+        let mut seen = BTreeSet::<Key>::new();
+        let matched_keys: Vec<Key> = keys
+            .iter()
+            .filter(|k| seen.insert((*k).clone()) && self.inner.index_of(k).is_some())
+            .cloned()
+            .collect();
+
         let removed = self.inner.remove_by_keys(keys);
-        if !removed.is_empty() {
-            let removed_keys: Vec<Key> = removed.iter().map(|t| t.key().clone()).collect();
-            self.pending_changes.push(CollectionChange::Remove { keys: removed_keys });
+
+        if !matched_keys.is_empty() {
+            self.pending_changes
+                .push(CollectionChange::Remove { keys: matched_keys });
         }
         removed
     }
@@ -1044,28 +1066,36 @@ impl<T: CollectionItem> MutableTreeData<T> {
     }
 
     /// Remove the listed nodes (and their descendants); returns the
-    /// removed values.
+    /// removed item values.
     ///
-    /// Emits `Remove` carrying only the keys that were both **(a)**
-    /// matched by the inner collection and **(b)** part of the visible
-    /// iteration immediately before the removal. Hidden nodes were never
-    /// rendered, so signalling their removal would force the adapter to
-    /// no-op and pollutes the truthful change log. When every removed
-    /// item was hidden, no event is emitted.
+    /// Emits `Remove` carrying every key that disappeared from the
+    /// **visible iteration** as a result of the call — input keys that
+    /// matched, cascade-removed visible descendants, and any structural
+    /// node (`Section` / `Header` / `Separator`) that carries no
+    /// payload. Hidden nodes (inside a collapsed ancestor) were never
+    /// rendered, so they stay out of the change event — emitting them
+    /// would force the adapter to no-op and pollute the truthful
+    /// change log. When every removed node was hidden, no event is
+    /// emitted.
+    ///
+    /// The diff is computed against `visible_keys()` before and after
+    /// the inner mutation rather than from the returned `Vec<T>`, both
+    /// to capture cascaded descendants and to surface structural
+    /// removals that have no payload to enumerate.
     pub fn remove(&mut self, keys: &[Key]) -> Vec<T> {
-        // Snapshot visible keys before mutation.
-        let visible_before: BTreeSet<Key> = self.inner.visible_keys().cloned().collect();
+        // Capture visible iteration order in a `Vec` (not a
+        // `BTreeSet`) so the change event preserves DFS order.
+        let visible_before: Vec<Key> = self.inner.visible_keys().cloned().collect();
         let removed = self.inner.remove_by_keys(keys);
-        if !removed.is_empty() {
-            let visible_removed_keys: Vec<Key> = removed
-                .iter()
-                .map(|t| t.key().clone())
-                .filter(|k| visible_before.contains(k))
-                .collect();
-            if !visible_removed_keys.is_empty() {
-                self.pending_changes
-                    .push(CollectionChange::Remove { keys: visible_removed_keys });
-            }
+        let visible_after: BTreeSet<Key> =
+            self.inner.visible_keys().cloned().collect();
+        let visible_removed_keys: Vec<Key> = visible_before
+            .into_iter()
+            .filter(|k| !visible_after.contains(k))
+            .collect();
+        if !visible_removed_keys.is_empty() {
+            self.pending_changes
+                .push(CollectionChange::Remove { keys: visible_removed_keys });
         }
         removed
     }

--- a/spec/foundation/06-collections.md
+++ b/spec/foundation/06-collections.md
@@ -892,8 +892,10 @@ impl<T: CollectionItem> MutableListData<T> {
     }
 
     /// Replace an item's data in-place. Returns the previous value at
-    /// `item.key()` on success, or `None` if the key is not present.
-    /// Emits `Replace` only on success.
+    /// `item.key()` on success, or `None` if the key is not present **or**
+    /// the existing node is structural (Section/Header/Separator) and
+    /// carries no item payload. Emits `Replace` only on success — never
+    /// silently promotes a structural node to an item.
     pub fn replace(&mut self, item: T) -> Option<T> {
         let key = item.key().clone();
         let old = self.inner.replace(item);
@@ -903,9 +905,15 @@ impl<T: CollectionItem> MutableListData<T> {
         old
     }
 
-    /// Remove all items.
+    /// Remove all items and emit a single `Reset`. Any earlier pending
+    /// events queued in this update cycle are discarded before the reset
+    /// is pushed: `Insert { index, count }` carries no payload, so adapters
+    /// cannot meaningfully replay it against the now-empty collection, and
+    /// `Reset` already implies a full re-render anyway. The buffer is
+    /// therefore guaranteed to be exactly `[Reset]` after `clear()`.
     pub fn clear(&mut self) {
         self.inner.clear();
+        self.pending_changes.clear();
         self.pending_changes.push(CollectionChange::Reset);
     }
 
@@ -1067,7 +1075,9 @@ impl<T: CollectionItem> MutableTreeData<T> {
 
     /// Replace a node's data in place (children preserved). Returns the
     /// previous value at `item.key()` on success, or `None` when the key
-    /// is unknown. Emits `Replace` only on success.
+    /// is unknown **or** the existing node carries no item payload.
+    /// Emits `Replace` only on success — never silently promotes a
+    /// structural node to an item.
     pub fn replace(&mut self, item: T) -> Option<T> {
         let key = item.key().clone();
         let old = self.inner.replace(item);
@@ -1509,12 +1519,18 @@ impl<T: CollectionItem> StaticCollection<T> {
     }
 
     /// Replace an item's data (matched by key). Returns the previous
-    /// value on success, or `None` if the key is unknown (in which case
-    /// `item` is dropped and the collection is unchanged).
+    /// value on success, or `None` if the key is unknown **or** the
+    /// existing node is structural (Section/Header/Separator) and carries
+    /// no item payload — in either failure case `item` is dropped and the
+    /// collection is unchanged. Structural nodes are never silently
+    /// promoted to items.
     pub fn replace(&mut self, item: T) -> Option<T> {
-        let key = item.key().clone();
-        let idx = *self.key_to_index.get(&key)?;
-        self.nodes[idx].value.replace(item)
+        let idx = *self.key_to_index.get(item.key())?;
+        let value_slot = &mut self.nodes[idx].value;
+        if value_slot.is_none() {
+            return None;
+        }
+        value_slot.replace(item)
     }
 
     /// Remove all items.
@@ -2210,12 +2226,17 @@ impl<T: CollectionItem> TreeCollection<T> {
     }
 
     /// Replace an item's data (matched by key). Returns the previous
-    /// value on success, or `None` if the key is unknown. Children are
-    /// preserved — only the node's payload is swapped.
+    /// value on success, or `None` if the key is unknown **or** the
+    /// existing node carries no item payload (a structural node).
+    /// Children are preserved — only the node's payload is swapped.
+    /// Structural nodes are never silently promoted to items.
     pub fn replace(&mut self, item: T) -> Option<T> {
-        let key = item.key().clone();
-        let idx = *self.key_to_index.get(&key)?;
-        self.all_nodes[idx].value.replace(item)
+        let idx = *self.key_to_index.get(item.key())?;
+        let value_slot = &mut self.all_nodes[idx].value;
+        if value_slot.is_none() {
+            return None;
+        }
+        value_slot.replace(item)
     }
 
     /// Return the parent key of a node, if any.

--- a/spec/foundation/06-collections.md
+++ b/spec/foundation/06-collections.md
@@ -1017,6 +1017,7 @@ This mirrors `HashMap::insert` in idiom: the return value tells the caller wheth
 - All indices in `Insert { index, .. }` and `Move { from_index, to_index, .. }` are **visible iteration indices** (the position the adapter would obtain from `Collection::get_by_index`), never flat DFS indices into `all_nodes`.
 - Mutations confined to a hidden subtree (e.g. `insert_child` under a collapsed parent, or `reorder` of two hidden siblings) emit **no event** — the adapter has nothing to render and the inner state will surface naturally when the ancestor is later expanded.
 - Mutations that cross visibility (`reparent` from a visible parent into a hidden one, or vice versa) are translated into the matching DOM-shaped event (`Remove` or `Insert`) instead of `Move`, and the event covers the **entire subtree** that crossed the boundary — `Remove` carries every previously-visible key in DFS order, and `Insert` reports `count` equal to the number of newly-visible nodes — because every visible descendant disappears or appears alongside the moved root. See `reparent` below for the full table.
+- Mutations that flip a still-visible parent's `has_children` flag (and therefore its `is_expanded` state) emit a `Replace { key: parent_key }` alongside the subtree event (if any). This covers `insert_child` turning a visible leaf into a collapsed branch, `remove` draining a visible branch's last remaining child, and `reparent` doing either transition on the old and new parents in any combination. Parents that are themselves hidden are skipped — their rendered state cannot be stale because their row isn't drawn — so the change log stays truthful. `Replace` events are emitted **after** the subtree event (if any) in pre-mutation DFS order.
 
 This contract keeps the change log "truthful" in the sense already required for failure modes: every event corresponds to a DOM operation the adapter must perform. Hidden-only churn does not generate phantom events that an adapter would have to filter or no-op.
 
@@ -1111,34 +1112,71 @@ impl<T: CollectionItem> MutableTreeData<T> {
     /// Remove the listed nodes (and their descendants); returns the
     /// removed item values.
     ///
-    /// Emits `Remove` carrying every key that disappeared from the
-    /// **visible iteration** as a result of the call — input keys that
-    /// matched, cascade-removed visible descendants, and any structural
-    /// node (`Section` / `Header` / `Separator`) that carries no
-    /// payload. Hidden nodes (inside a collapsed ancestor) were never
-    /// rendered, so they stay out of the change event — emitting them
-    /// would force the adapter to no-op and pollute the truthful
-    /// change log. When every removed node was hidden, no event is
-    /// emitted.
+    /// Emits up to two kinds of event, in this order:
     ///
-    /// The diff is computed against `visible_keys()` before and after
-    /// the inner mutation rather than from the returned `Vec<T>`, both
-    /// to capture cascaded descendants and to surface structural
-    /// removals that have no payload to enumerate.
+    /// * `Remove` — carrying every key that disappeared from the
+    ///   **visible iteration** as a result of the call: input keys
+    ///   that matched, cascade-removed visible descendants, and any
+    ///   structural node (`Section` / `Header` / `Separator`) that
+    ///   carries no payload. Hidden nodes (inside a collapsed
+    ///   ancestor) were never rendered, so they stay out of the
+    ///   change event — emitting them would force the adapter to
+    ///   no-op and pollute the truthful change log.
+    /// * `Replace { key: parent_key }` — one event per still-visible
+    ///   parent whose `has_children` flipped from `true` to `false`
+    ///   as a side effect of the removal. The inner tree flips
+    ///   `has_children: true → false` and `is_expanded: Some(_) → None`
+    ///   on a node the moment its last remaining child (visible *or*
+    ///   hidden) is removed; adapters key expander chevrons and
+    ///   `aria-expanded` off those flags, so the parent row must be
+    ///   re-rendered even when none of its visible children appeared
+    ///   in the `Remove` event. Parents that are themselves hidden
+    ///   are skipped — their row isn't drawn. `Replace` events are
+    ///   emitted in pre-mutation DFS order.
+    ///
+    /// The `Remove` diff is computed against `visible_keys()` before
+    /// and after the inner mutation rather than from the returned
+    /// `Vec<T>`, both to capture cascaded descendants and to surface
+    /// structural removals that have no payload to enumerate. The
+    /// branch→leaf detection reuses the same pre-mutation snapshot.
     pub fn remove(&mut self, keys: &[Key]) -> Vec<T> {
         // Capture visible iteration order in a `Vec` (not a
-        // `BTreeSet`) so the change event preserves DFS order.
+        // `BTreeSet`) so the change event preserves DFS order, and
+        // snapshot branch/leaf state alongside so the post-mutation
+        // loop can detect parents that lost their last child.
         let visible_before: Vec<Key> = self.inner.visible_keys().cloned().collect();
+        let visible_before_has_children: BTreeMap<Key, bool> = visible_before
+            .iter()
+            .map(|k| (k.clone(), self.inner.has_children(k)))
+            .collect();
         let removed = self.inner.remove_by_keys(keys);
         let visible_after: BTreeSet<Key> =
             self.inner.visible_keys().cloned().collect();
         let visible_removed_keys: Vec<Key> = visible_before
-            .into_iter()
-            .filter(|k| !visible_after.contains(k))
+            .iter()
+            .filter(|k| !visible_after.contains(*k))
+            .cloned()
             .collect();
         if !visible_removed_keys.is_empty() {
             self.pending_changes
                 .push(CollectionChange::Remove { keys: visible_removed_keys });
+        }
+        // Emit Replace for any still-visible parent whose
+        // `has_children` flipped true → false. Removal can only lose
+        // children, never gain them, so the leaf → branch direction
+        // is not considered here. Iterating `visible_before` keeps
+        // emission order DFS-stable and matches how the Remove event
+        // itself is ordered.
+        for k in &visible_before {
+            if !visible_after.contains(k) {
+                continue;
+            }
+            let was_branch = visible_before_has_children
+                .get(k).copied().unwrap_or(false);
+            if was_branch && !self.inner.has_children(k) {
+                self.pending_changes
+                    .push(CollectionChange::Replace { key: k.clone() });
+            }
         }
         removed
     }
@@ -1147,38 +1185,70 @@ impl<T: CollectionItem> MutableTreeData<T> {
     /// `Some((from_flat_index, to_flat_index))` on success; `None` when
     /// the move is rejected (see §2.3 and the table above).
     ///
+    /// ## Subtree visibility
+    ///
     /// Visibility may differ between the old and new locations — and a
     /// single move can flip visibility for every descendant in the
-    /// subtree, not just the moved root — so the emitted event is
+    /// subtree, not just the moved root — so the subtree event is
     /// chosen to describe the DOM impact precisely:
     ///
-    /// | From visible | To visible | Event emitted                                                                |
+    /// | From visible | To visible | Subtree event emitted                                                        |
     /// | ------------ | ---------- | ---------------------------------------------------------------------------- |
     /// | yes          | yes        | `Move { key, from: vis_from, to: vis_to }`                                   |
     /// | yes          | no         | `Remove { keys: <previously-visible subtree keys, DFS order> }`              |
     /// | no           | yes        | `Insert { index: vis_to, count: <number of newly-visible subtree nodes> }`   |
-    /// | no           | no         | *(no event)*                                                                 |
+    /// | no           | no         | *(no subtree event)*                                                         |
     ///
     /// Indices are visible iteration indices, not flat DFS indices. The
     /// `Insert` always spans `count` consecutive positions starting at
     /// `to_index`. Emitting only `[key]` for visible→hidden, or
     /// `count: 1` for hidden→visible, would leave keyed reconcilers
     /// with orphan descendant rows or miscounted indices.
+    ///
+    /// ## Parent metadata transitions
+    ///
+    /// Reparenting can also flip `has_children` on the old and new
+    /// parents independently of the moved subtree's visibility:
+    ///
+    /// * the old parent transitions branch → leaf when the moved node
+    ///   was its only remaining child (`has_children: true → false`,
+    ///   `is_expanded: Some(_) → None`);
+    /// * the new parent transitions leaf → collapsed branch when it
+    ///   had no children before (`has_children: false → true`,
+    ///   `is_expanded: None → Some(false)`).
+    ///
+    /// These transitions change the parent row's rendered state
+    /// (expander chevron, `aria-expanded`) without moving the row, so
+    /// each still-visible parent that flipped receives a
+    /// `Replace { key: parent }` event emitted **after** the subtree
+    /// event in pre-mutation DFS order. Parents that are themselves
+    /// hidden are skipped. The moved key itself cannot flip
+    /// `has_children` through a reparent — the subtree moves as a
+    /// unit — so no `Replace` for the moved key is ever emitted.
     pub fn reparent(
         &mut self,
         key: &Key,
         new_parent: Option<&Key>,
         index: usize,
     ) -> Option<(usize, usize)> {
-        // Snapshot the pre-mutation visible iteration. Both visibility-
-        // crossing branches need to compare visible-before vs
-        // visible-after to capture every subtree descendant whose
-        // visibility flipped — only the moved subtree's visibility can
-        // change, so the set difference is exactly the subtree delta.
+        // Snapshot the pre-mutation visible iteration and branch/leaf
+        // state. The visibility-crossing branches compare visible-
+        // before vs visible-after to capture subtree descendants that
+        // flipped — only the moved subtree's visibility can change,
+        // so the set difference is exactly the subtree delta. The
+        // same snapshot doubles as a membership set for the
+        // hidden→visible count and as the source of pre-mutation
+        // `has_children` state for the parent-transition detection.
         let visible_before: Vec<Key> = self.inner.visible_keys().cloned().collect();
+        let visible_before_has_children: BTreeMap<Key, bool> = visible_before
+            .iter()
+            .map(|k| (k.clone(), self.inner.has_children(k)))
+            .collect();
         let from_visible = self.inner.visible_index_of(key);
         let (from_flat, to_flat) = self.inner.reparent(key, new_parent, index)?;
         let to_visible = self.inner.visible_index_of(key);
+        let visible_after: BTreeSet<Key> =
+            self.inner.visible_keys().cloned().collect();
         match (from_visible, to_visible) {
             (Some(from_index), Some(to_index)) => {
                 self.pending_changes.push(CollectionChange::Move {
@@ -1189,11 +1259,10 @@ impl<T: CollectionItem> MutableTreeData<T> {
                 // Root + every visible descendant disappears together
                 // under the collapsed new parent. Remove must list all
                 // of them in pre-mutation DFS order.
-                let visible_after: BTreeSet<Key> =
-                    self.inner.visible_keys().cloned().collect();
                 let removed_keys: Vec<Key> = visible_before
-                    .into_iter()
-                    .filter(|k| !visible_after.contains(k))
+                    .iter()
+                    .filter(|k| !visible_after.contains(*k))
+                    .cloned()
                     .collect();
                 self.pending_changes.push(CollectionChange::Remove {
                     keys: removed_keys,
@@ -1203,18 +1272,38 @@ impl<T: CollectionItem> MutableTreeData<T> {
                 // Root + descendants whose internal expansion keeps
                 // them visible at the new location appear in `count`
                 // consecutive positions starting at `to_index`.
-                let visible_before_set: BTreeSet<Key> =
-                    visible_before.into_iter().collect();
+                // Reuse `visible_before_has_children` as a membership
+                // set — `contains_key` is O(log n) and avoids a
+                // second allocation.
                 let count = self
                     .inner
                     .visible_keys()
-                    .filter(|k| !visible_before_set.contains(*k))
+                    .filter(|k| !visible_before_has_children.contains_key(*k))
                     .count();
                 self.pending_changes.push(CollectionChange::Insert {
                     index: to_index, count,
                 });
             }
-            (None, None) => {} // both endpoints hidden, nothing to report
+            (None, None) => {} // both endpoints hidden, no subtree event
+        }
+        // Emit Replace for any still-visible key whose `has_children`
+        // flipped in either direction. This loop surfaces the old
+        // parent losing its last child (branch → leaf) and the new
+        // parent gaining its first child (leaf → branch). The moved
+        // key's own `has_children` is invariant under reparent, so
+        // even if it appears in both visible sets the branch-state
+        // comparison short-circuits.
+        for k in &visible_before {
+            if !visible_after.contains(k) {
+                continue;
+            }
+            let was_branch = visible_before_has_children
+                .get(k).copied().unwrap_or(false);
+            let is_branch = self.inner.has_children(k);
+            if was_branch != is_branch {
+                self.pending_changes
+                    .push(CollectionChange::Replace { key: k.clone() });
+            }
         }
         Some((from_flat, to_flat))
     }

--- a/spec/foundation/06-collections.md
+++ b/spec/foundation/06-collections.md
@@ -758,23 +758,49 @@ Mutable collection wrappers support dynamic add, remove, reorder, and move opera
 
 #### 1.8.1 Change Events
 
+`CollectionChange` is the adapter-facing event type. The generic `K` lets tests and alternative collection backends use keys other than the default `Key`; production wrappers (§1.8.2, §1.8.3) always use `CollectionChange<Key>`. The derived `Clone + Debug + PartialEq` bounds are part of the contract — adapters diff and log these events.
+
+The `count` field on `Insert` is always `1` for single-item mutations today but is kept as a field so future bulk inserts can share the variant without a breaking API change.
+
 ```rust
 // ars-collections/src/mutable.rs
 
 /// A granular change event emitted when a mutable collection is modified.
-/// Adapters use these to perform targeted DOM updates instead of full re-renders.
+///
+/// Adapters consume a sequence of these events to perform targeted DOM
+/// updates instead of re-rendering the entire list.
 #[derive(Clone, Debug, PartialEq)]
 pub enum CollectionChange<K: Clone> {
-    /// New items inserted at the given index.
-    Insert { index: usize, count: usize },
+    /// New items inserted at the given flat index.
+    Insert {
+        /// Flat insertion index in the collection's iteration order.
+        index: usize,
+        /// Number of items inserted starting at `index`. Always `1` today;
+        /// reserved for future bulk inserts.
+        count: usize,
+    },
     /// Items with the given keys were removed.
-    Remove { keys: Vec<K> },
-    /// An item moved from one index to another.
-    Move { key: K, from_index: usize, to_index: usize },
+    Remove {
+        /// Keys of the removed items, in iteration order.
+        keys: Vec<K>,
+    },
+    /// An item moved from one flat index to another.
+    Move {
+        /// Key of the moved item.
+        key: K,
+        /// Flat index the item occupied before the move.
+        from_index: usize,
+        /// Flat index the item occupies after the move.
+        to_index: usize,
+    },
     /// An item's data was replaced in-place (key unchanged).
-    Replace { key: K },
-    /// The entire collection was reset (e.g., bulk replacement).
-    /// Adapters should re-render all items.
+    Replace {
+        /// Key of the replaced item.
+        key: K,
+    },
+    /// The entire collection was reset (e.g. bulk replacement or clear).
+    /// Adapters should re-render all items instead of trying to reconcile
+    /// individual changes.
     Reset,
 }
 ```
@@ -783,16 +809,45 @@ pub enum CollectionChange<K: Clone> {
 
 `MutableListData<T>` wraps a `StaticCollection<T>` with mutation methods. It maintains an internal change log that the adapter drains after each update cycle.
 
+Design constraints reflected in the code below:
+
+- **Inherent mutation methods are bounded only by `T: CollectionItem`**, matching the inner `StaticCollection`'s own mutation impl — no `Clone` is required to call `push` / `insert` / `remove` / `move_item` / `replace` / `clear`.
+- **The `Collection<T>` delegation requires `T: CollectionItem + Clone`.** `StaticCollection<T>` only implements `Collection<T>` when `T: Clone` (see §2.2 and `static_collection.rs`), so every delegated call transitively requires `Clone`. Omitting the bound would make the delegation body fail to type-check.
+- **Iterator-returning trait methods (`keys`, `nodes`, `children_of`) carry explicit lifetime parameters** with `T: 'a` bounds, matching the `Collection` trait definition in §1.6 (required by Rust 2024's RPITIT lifetime-capture rules). These bounds are load-bearing, not decorative.
+- **`new` is `const fn` and `#[must_use]`** so callers can construct a wrapper in a `const` context and the compiler flags accidentally discarded constructor calls.
+- **A manual `Debug` impl is provided** so the wrapper can be debug-printed without forcing a `T: Debug` bound on every consumer — mirroring `StaticCollection`'s own manual `Debug` impl.
+
+**Truthful change-log contract.** Each mutation method emits a `CollectionChange` event **only** when the underlying mutation actually happened. `remove` emits with the keys that actually matched (skipping unknown keys), and `replace` emits only when the key exists. This keeps the change log in sync with the collection state — adapters never receive a phantom event referencing a key the collection does not contain.
+
 ```rust
 /// A mutable flat-list collection that tracks granular changes.
+///
+/// Wraps a `StaticCollection` and records every mutation as a
+/// `CollectionChange`. The adapter drains the buffer via
+/// `drain_changes()` each update cycle.
 pub struct MutableListData<T: CollectionItem> {
+    /// The inner collection holding the canonical item data.
     inner: StaticCollection<T>,
+    /// Pending change events to be drained by the adapter layer.
     pending_changes: Vec<CollectionChange<Key>>,
 }
 
+/// Manual `Debug` avoids requiring `T: Debug`, matching `StaticCollection`'s
+/// approach. Prints the inner collection and pending-change count only.
+impl<T: CollectionItem> core::fmt::Debug for MutableListData<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("MutableListData")
+            .field("inner", &self.inner)
+            .field("pending_changes", &self.pending_changes.len())
+            .finish()
+    }
+}
+
 impl<T: CollectionItem> MutableListData<T> {
-    /// Create from an existing static collection.
-    pub fn new(collection: StaticCollection<T>) -> Self {
+    /// Create from an existing static collection. The change buffer starts
+    /// empty — construction is not itself reported as a change.
+    #[must_use]
+    pub const fn new(collection: StaticCollection<T>) -> Self {
         Self { inner: collection, pending_changes: Vec::new() }
     }
 
@@ -809,30 +864,43 @@ impl<T: CollectionItem> MutableListData<T> {
         self.pending_changes.push(CollectionChange::Insert { index, count: 1 });
     }
 
-    /// Remove items by key. Returns the removed items.
+    /// Remove items by key. Returns the removed values; emits a `Remove`
+    /// change containing only the keys that actually matched (unknown keys
+    /// are silently skipped by the inner collection and excluded from the
+    /// event). Returns an empty `Vec` and emits no event when no key matches.
     pub fn remove(&mut self, keys: &[Key]) -> Vec<T> {
         let removed = self.inner.remove_by_keys(keys);
-        self.pending_changes.push(CollectionChange::Remove { keys: keys.to_vec() });
+        if !removed.is_empty() {
+            let removed_keys: Vec<Key> = removed.iter().map(|t| t.key().clone()).collect();
+            self.pending_changes.push(CollectionChange::Remove { keys: removed_keys });
+        }
         removed
     }
 
-    /// Move an item from one index to another.
-    pub fn move_item(&mut self, key: &Key, to_index: usize) {
-        if let Some(from_index) = self.inner.index_of(key) {
-            self.inner.move_item(from_index, to_index);
-            self.pending_changes.push(CollectionChange::Move {
-                key: key.clone(),
-                from_index,
-                to_index,
-            });
-        }
+    /// Move an item from one index to another. Returns
+    /// `Some((from_flat_index, to_flat_index))` on success, or `None` if
+    /// `key` is not present. Emits `Move` only on success.
+    pub fn move_item(&mut self, key: &Key, to_index: usize) -> Option<(usize, usize)> {
+        let from_index = self.inner.index_of(key)?;
+        self.inner.move_item(from_index, to_index);
+        self.pending_changes.push(CollectionChange::Move {
+            key: key.clone(),
+            from_index,
+            to_index,
+        });
+        Some((from_index, to_index))
     }
 
-    /// Replace an item's data in-place (key must match).
-    pub fn replace(&mut self, item: T) {
+    /// Replace an item's data in-place. Returns the previous value at
+    /// `item.key()` on success, or `None` if the key is not present.
+    /// Emits `Replace` only on success.
+    pub fn replace(&mut self, item: T) -> Option<T> {
         let key = item.key().clone();
-        self.inner.replace(item);
-        self.pending_changes.push(CollectionChange::Replace { key });
+        let old = self.inner.replace(item);
+        if old.is_some() {
+            self.pending_changes.push(CollectionChange::Replace { key });
+        }
+        old
     }
 
     /// Remove all items.
@@ -847,8 +915,9 @@ impl<T: CollectionItem> MutableListData<T> {
     }
 }
 
-impl<T: CollectionItem> Collection<T> for MutableListData<T> {
-    // Delegates all Collection trait methods to self.inner (StaticCollection<T>).
+// The `+ Clone` bound is required: `StaticCollection<T>: Collection<T>` is
+// itself gated on `T: Clone`, so delegation cannot compile without it.
+impl<T: CollectionItem + Clone> Collection<T> for MutableListData<T> {
     fn size(&self) -> usize { self.inner.size() }
     fn get(&self, key: &Key) -> Option<&Node<T>> { self.inner.get(key) }
     fn get_by_index(&self, index: usize) -> Option<&Node<T>> { self.inner.get_by_index(index) }
@@ -858,9 +927,18 @@ impl<T: CollectionItem> Collection<T> for MutableListData<T> {
     fn key_before(&self, key: &Key) -> Option<&Key> { self.inner.key_before(key) }
     fn key_after_no_wrap(&self, key: &Key) -> Option<&Key> { self.inner.key_after_no_wrap(key) }
     fn key_before_no_wrap(&self, key: &Key) -> Option<&Key> { self.inner.key_before_no_wrap(key) }
-    fn keys(&self) -> impl Iterator<Item = &Key> { self.inner.keys() }
-    fn nodes(&self) -> impl Iterator<Item = &Node<T>> { self.inner.nodes() }
-    fn children_of(&self, parent_key: &Key) -> impl Iterator<Item = &Node<T>> { self.inner.children_of(parent_key) }
+
+    fn keys<'a>(&'a self) -> impl Iterator<Item = &'a Key>
+    where T: 'a,
+    { self.inner.keys() }
+
+    fn nodes<'a>(&'a self) -> impl Iterator<Item = &'a Node<T>>
+    where T: 'a,
+    { self.inner.nodes() }
+
+    fn children_of<'a>(&'a self, parent_key: &Key) -> impl Iterator<Item = &'a Node<T>>
+    where T: 'a,
+    { self.inner.children_of(parent_key) }
 }
 ```
 
@@ -868,62 +946,135 @@ impl<T: CollectionItem> Collection<T> for MutableListData<T> {
 
 `MutableTreeData<T>` wraps a `TreeCollection<T>` with tree-specific mutations including reparenting.
 
+`MutableTreeData` inherits all four design constraints from §1.8.2 (inherent methods only require `CollectionItem`; `Collection<T>` delegation requires `CollectionItem + Clone`; iterator methods carry `<'a>` lifetime parameters; a manual `Debug` impl avoids forcing `T: Debug`). The truthful-change-log contract from §1.8.2 applies identically.
+
+##### Return-value contract for tree mutations
+
+Every mutation method in `MutableTreeData` — `insert_child`, `reparent`, `reorder`, `replace`, `remove` — follows the same pattern:
+
+- The inner `TreeCollection` mutation method (see §2.3) returns an `Option` communicating whether the mutation took effect, and carrying the flat DFS index(es) the caller needs to emit a precise change event.
+- The wrapper forwards that `Option` unchanged as its own return value.
+- The wrapper pushes a `CollectionChange` into `pending_changes` **only** when the inner call returned `Some(_)`.
+
+Failure modes the `Option` captures:
+
+| Method         | `None` when                                                                                        |
+| -------------- | -------------------------------------------------------------------------------------------------- |
+| `insert_child` | `parent` is `Some(k)` and `k` is unknown                                                           |
+| `reparent`     | `key` unknown, `new_parent` is `Some(k)` and `k` unknown, or `new_parent` is a descendant of `key` |
+| `reorder`      | `key` unknown                                                                                      |
+| `replace`      | `item.key()` unknown                                                                               |
+
+This mirrors `HashMap::insert` in idiom: the return value tells the caller whether the operation happened and, when applicable, what changed. Callers that know the precondition holds can ignore the return; callers that need to react to failure can match on `Option::None` without a separate `contains_key` probe.
+
 ```rust
 /// A mutable tree collection that tracks granular changes.
+///
+/// Wraps a `TreeCollection` and records every mutation — including
+/// reparenting and sibling reordering — as a `CollectionChange` using flat
+/// DFS indices. The adapter drains the buffer via `drain_changes()` each
+/// update cycle.
 pub struct MutableTreeData<T: CollectionItem> {
+    /// The inner tree holding the canonical hierarchy.
     inner: TreeCollection<T>,
+    /// Pending change events to be drained by the adapter layer.
     pending_changes: Vec<CollectionChange<Key>>,
 }
 
+/// Manual `Debug` avoids requiring `T: Debug`, matching `TreeCollection`'s
+/// approach. Prints the inner tree and pending-change count only.
+impl<T: CollectionItem> core::fmt::Debug for MutableTreeData<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("MutableTreeData")
+            .field("inner", &self.inner)
+            .field("pending_changes", &self.pending_changes.len())
+            .finish()
+    }
+}
+
 impl<T: CollectionItem> MutableTreeData<T> {
-    /// Create from an existing tree collection.
-    pub fn new(collection: TreeCollection<T>) -> Self {
+    /// Create from an existing tree collection. The change buffer starts
+    /// empty — construction is not itself reported as a change.
+    #[must_use]
+    pub const fn new(collection: TreeCollection<T>) -> Self {
         Self { inner: collection, pending_changes: Vec::new() }
     }
 
-    /// Insert a child under the given parent at the specified index.
-    /// Use `parent: None` for root-level insertion.
-    pub fn insert_child(&mut self, parent: Option<&Key>, index: usize, item: T) {
-        let flat_index = self.inner.insert_child(parent, index, item);
-        self.pending_changes.push(CollectionChange::Insert { index: flat_index, count: 1 });
+    /// Insert a child under the given parent at the specified sibling
+    /// index (or at the root when `parent` is `None`). Returns the flat DFS
+    /// index of the inserted node on success, or `None` when the inner
+    /// call rejected the insert (unknown parent). Emits `Insert` only on
+    /// success.
+    pub fn insert_child(
+        &mut self,
+        parent: Option<&Key>,
+        index: usize,
+        item: T,
+    ) -> Option<usize> {
+        let flat_index = self.inner.insert_child(parent, index, item)?;
+        self.pending_changes
+            .push(CollectionChange::Insert { index: flat_index, count: 1 });
+        Some(flat_index)
     }
 
-    /// Remove a node and all its descendants.
+    /// Remove the listed nodes (and their descendants). Emits `Remove`
+    /// containing only the keys that actually matched; returns the removed
+    /// values. Emits no event and returns an empty `Vec` when no key matches.
     pub fn remove(&mut self, keys: &[Key]) -> Vec<T> {
         let removed = self.inner.remove_by_keys(keys);
-        self.pending_changes.push(CollectionChange::Remove { keys: keys.to_vec() });
+        if !removed.is_empty() {
+            let removed_keys: Vec<Key> = removed.iter().map(|t| t.key().clone()).collect();
+            self.pending_changes.push(CollectionChange::Remove { keys: removed_keys });
+        }
         removed
     }
 
-    /// Move a node to a new parent (reparent). The node keeps its subtree.
-    pub fn reparent(&mut self, key: &Key, new_parent: Option<&Key>, index: usize) {
-        let from_index = self.inner.flat_index_of(key).expect("key must exist");
-        self.inner.reparent(key, new_parent, index);
-        let to_index = self.inner.flat_index_of(key).expect("key must exist after reparent");
+    /// Move a node (with its subtree) to a new parent. Returns
+    /// `Some((from_flat_index, to_flat_index))` on success; `None` when the
+    /// move is rejected (see §2.3 and the table above). Emits `Move` only
+    /// on success.
+    pub fn reparent(
+        &mut self,
+        key: &Key,
+        new_parent: Option<&Key>,
+        index: usize,
+    ) -> Option<(usize, usize)> {
+        let (from_index, to_index) = self.inner.reparent(key, new_parent, index)?;
         self.pending_changes.push(CollectionChange::Move {
             key: key.clone(),
             from_index,
             to_index,
         });
+        Some((from_index, to_index))
     }
 
-    /// Reorder a node among its siblings (same parent).
-    pub fn reorder(&mut self, key: &Key, to_sibling_index: usize) {
-        let from_index = self.inner.flat_index_of(key).expect("key must exist");
-        self.inner.reorder_sibling(key, to_sibling_index);
-        let to_index = self.inner.flat_index_of(key).expect("key must exist after reorder");
+    /// Reorder a node among its existing siblings. Returns
+    /// `Some((from_flat_index, to_flat_index))` on success; `None` when
+    /// `key` is unknown. Emits `Move` only on success.
+    pub fn reorder(
+        &mut self,
+        key: &Key,
+        to_sibling_index: usize,
+    ) -> Option<(usize, usize)> {
+        let (from_index, to_index) = self.inner.reorder_sibling(key, to_sibling_index)?;
         self.pending_changes.push(CollectionChange::Move {
             key: key.clone(),
             from_index,
             to_index,
         });
+        Some((from_index, to_index))
     }
 
-    /// Replace a node's data in-place (key must match, children preserved).
-    pub fn replace(&mut self, item: T) {
+    /// Replace a node's data in place (children preserved). Returns the
+    /// previous value at `item.key()` on success, or `None` when the key
+    /// is unknown. Emits `Replace` only on success.
+    pub fn replace(&mut self, item: T) -> Option<T> {
         let key = item.key().clone();
-        self.inner.replace(item);
-        self.pending_changes.push(CollectionChange::Replace { key });
+        let old = self.inner.replace(item);
+        if old.is_some() {
+            self.pending_changes.push(CollectionChange::Replace { key });
+        }
+        old
     }
 
     /// Drain pending changes.
@@ -932,8 +1083,9 @@ impl<T: CollectionItem> MutableTreeData<T> {
     }
 }
 
-impl<T: CollectionItem> Collection<T> for MutableTreeData<T> {
-    // Delegates all Collection trait methods to self.inner (TreeCollection<T>).
+// The `+ Clone` bound is required: `TreeCollection<T>: Collection<T>` is
+// itself gated on `T: Clone`, so delegation cannot compile without it.
+impl<T: CollectionItem + Clone> Collection<T> for MutableTreeData<T> {
     fn size(&self) -> usize { self.inner.size() }
     fn get(&self, key: &Key) -> Option<&Node<T>> { self.inner.get(key) }
     fn get_by_index(&self, index: usize) -> Option<&Node<T>> { self.inner.get_by_index(index) }
@@ -943,9 +1095,18 @@ impl<T: CollectionItem> Collection<T> for MutableTreeData<T> {
     fn key_before(&self, key: &Key) -> Option<&Key> { self.inner.key_before(key) }
     fn key_after_no_wrap(&self, key: &Key) -> Option<&Key> { self.inner.key_after_no_wrap(key) }
     fn key_before_no_wrap(&self, key: &Key) -> Option<&Key> { self.inner.key_before_no_wrap(key) }
-    fn keys(&self) -> impl Iterator<Item = &Key> { self.inner.keys() }
-    fn nodes(&self) -> impl Iterator<Item = &Node<T>> { self.inner.nodes() }
-    fn children_of(&self, parent_key: &Key) -> impl Iterator<Item = &Node<T>> { self.inner.children_of(parent_key) }
+
+    fn keys<'a>(&'a self) -> impl Iterator<Item = &'a Key>
+    where T: 'a,
+    { self.inner.keys() }
+
+    fn nodes<'a>(&'a self) -> impl Iterator<Item = &'a Node<T>>
+    where T: 'a,
+    { self.inner.nodes() }
+
+    fn children_of<'a>(&'a self, parent_key: &Key) -> impl Iterator<Item = &'a Node<T>>
+    where T: 'a,
+    { self.inner.children_of(parent_key) }
 }
 ```
 
@@ -1347,12 +1508,13 @@ impl<T: CollectionItem> StaticCollection<T> {
         removed
     }
 
-    /// Replace an item's data (matched by key).
-    pub fn replace(&mut self, item: T) {
+    /// Replace an item's data (matched by key). Returns the previous
+    /// value on success, or `None` if the key is unknown (in which case
+    /// `item` is dropped and the collection is unchanged).
+    pub fn replace(&mut self, item: T) -> Option<T> {
         let key = item.key().clone();
-        if let Some(&idx) = self.key_to_index.get(&key) {
-            self.nodes[idx].value = Some(item);
-        }
+        let idx = *self.key_to_index.get(&key)?;
+        self.nodes[idx].value.replace(item)
     }
 
     /// Remove all items.
@@ -1812,13 +1974,19 @@ impl<T: CollectionItem> TreeCollection<T> {
     /// (or among root nodes when `parent` is `None`). The node is inserted
     /// into `all_nodes` at the correct DFS position and indices are rebuilt.
     ///
-    /// If `parent` is `Some` but the key does not exist in the tree, the
-    /// operation is a no-op to avoid creating dangling parent references.
-    pub fn insert_child(&mut self, parent: Option<&Key>, sibling_index: usize, item: T) {
+    /// Returns the flat DFS index of the inserted node on success, or
+    /// `None` if `parent` is `Some(k)` and `k` is not present in the tree
+    /// (rejected to avoid creating dangling parent references).
+    pub fn insert_child(
+        &mut self,
+        parent: Option<&Key>,
+        sibling_index: usize,
+        item: T,
+    ) -> Option<usize> {
         // Reject inserts under a nonexistent parent.
         if let Some(pk) = parent {
             if !self.key_to_index.contains_key(pk) {
-                return;
+                return None;
             }
         }
 
@@ -1861,6 +2029,9 @@ impl<T: CollectionItem> TreeCollection<T> {
         }
 
         self.rebuild_indices();
+
+        // After rebuild, key_to_index points at the freshly inserted node.
+        self.key_to_index.get(&key).copied()
     }
 
     /// Remove items by key (and their entire subtrees).
@@ -1915,23 +2086,35 @@ impl<T: CollectionItem> TreeCollection<T> {
 
     /// Move a node (and its subtree) to a new parent at the given child index.
     ///
-    /// If `new_parent` is `Some` but the key does not exist in the tree
-    /// (or is a descendant of the node being moved), the operation is a
-    /// no-op to avoid creating dangling parent references.
-    pub fn reparent(&mut self, key: &Key, new_parent: Option<&Key>, sibling_index: usize) {
+    /// Returns `Some((from_flat_index, to_flat_index))` on success, or
+    /// `None` if the move was rejected. Rejection happens when `key` is
+    /// unknown, `new_parent` is `Some(k)` and `k` is unknown, or
+    /// `new_parent` is a descendant of the node being moved (would create
+    /// a cycle; detected after extraction — the subtree is restored to its
+    /// original position so the tree stays well-formed).
+    pub fn reparent(
+        &mut self,
+        key: &Key,
+        new_parent: Option<&Key>,
+        sibling_index: usize,
+    ) -> Option<(usize, usize)> {
         // Validate new_parent exists before extraction.
         if let Some(pk) = new_parent {
             if !self.key_to_index.contains_key(pk) {
-                return;
+                return None;
             }
         }
+
+        // Capture the node's current flat index before extraction; used in
+        // both the success return and the descendant-rejection restore path.
+        let from_index = *self.key_to_index.get(key)?;
 
         // Save old parent key before extraction for metadata cleanup.
         let old_parent_key = self.parent_of(key).cloned();
 
         // Extract the subtree.
         let subtree = self.extract_subtree(key);
-        if subtree.is_empty() { return; }
+        if subtree.is_empty() { return None; }
 
         // Reject reparenting under a descendant of the moved node.
         // After extraction the descendant is no longer in the tree.
@@ -1942,7 +2125,7 @@ impl<T: CollectionItem> TreeCollection<T> {
                     self.all_nodes.insert(insert_pos + offset, node);
                 }
                 self.rebuild_indices();
-                return;
+                return None;
             }
         }
 
@@ -1993,13 +2176,25 @@ impl<T: CollectionItem> TreeCollection<T> {
             self.all_nodes.insert(flat_pos + offset, node);
         }
         self.rebuild_indices();
+
+        let to_index = *self.key_to_index.get(key)?;
+        Some((from_index, to_index))
     }
 
     /// Reorder a node among its siblings to the given sibling index.
-    pub fn reorder_sibling(&mut self, key: &Key, to_sibling_index: usize) {
+    ///
+    /// Returns `Some((from_flat_index, to_flat_index))` on success, or
+    /// `None` if `key` does not exist in the tree.
+    pub fn reorder_sibling(
+        &mut self,
+        key: &Key,
+        to_sibling_index: usize,
+    ) -> Option<(usize, usize)> {
+        let from_index = *self.key_to_index.get(key)?;
+
         let parent_key = self.parent_of(key).cloned();
         let subtree = self.extract_subtree(key);
-        if subtree.is_empty() { return; }
+        if subtree.is_empty() { return None; }
 
         // Rebuild indices after extraction so flat_insert_position uses valid state.
         self.rebuild_indices();
@@ -2009,14 +2204,18 @@ impl<T: CollectionItem> TreeCollection<T> {
             self.all_nodes.insert(flat_pos + offset, node);
         }
         self.rebuild_indices();
+
+        let to_index = *self.key_to_index.get(key)?;
+        Some((from_index, to_index))
     }
 
-    /// Replace an item's data (matched by key).
-    pub fn replace(&mut self, item: T) {
+    /// Replace an item's data (matched by key). Returns the previous
+    /// value on success, or `None` if the key is unknown. Children are
+    /// preserved — only the node's payload is swapped.
+    pub fn replace(&mut self, item: T) -> Option<T> {
         let key = item.key().clone();
-        if let Some(&idx) = self.key_to_index.get(&key) {
-            self.all_nodes[idx].value = Some(item);
-        }
+        let idx = *self.key_to_index.get(&key)?;
+        self.all_nodes[idx].value.replace(item)
     }
 
     /// Return the parent key of a node, if any.

--- a/spec/foundation/06-collections.md
+++ b/spec/foundation/06-collections.md
@@ -793,9 +793,22 @@ pub enum CollectionChange<K: Clone> {
         /// Flat index the item occupies after the move.
         to_index: usize,
     },
-    /// An item's data was replaced in-place (key unchanged).
+    /// The node at this key needs to be re-rendered in place — its
+    /// position in the iteration is unchanged. Emitted in two cases:
+    ///
+    /// * `replace()` swapped the item's payload `T`, leaving key and
+    ///   structure intact.
+    /// * A non-payload mutation flipped the node's rendered state
+    ///   while leaving the iteration order intact — for example,
+    ///   inserting a child under a previously-leaf tree node turns
+    ///   that parent into a collapsed branch (`has_children: false →
+    ///   true`, `is_expanded: None → Some(false)`), which adapters
+    ///   key DOM off (expander chevron, `aria-expanded`).
+    ///
+    /// Adapters handle both cases identically: re-fetch the node by
+    /// key and re-render it in place.
     Replace {
-        /// Key of the replaced item.
+        /// Key of the node whose rendered state changed.
         key: K,
     },
     /// The entire collection was reset (e.g. bulk replacement or clear).
@@ -1045,11 +1058,27 @@ impl<T: CollectionItem> MutableTreeData<T> {
     /// DFS index of the inserted node on success, or `None` when the
     /// inner call rejected the insert (unknown parent).
     ///
-    /// Emits `Insert { index, count: 1 }` using the **visible iteration
-    /// index** of the new child, matching `Collection::get_by_index`.
-    /// When the child lands inside a collapsed ancestor it is hidden
-    /// from the visible iteration and **no event is emitted** — emitting
-    /// a flat DFS index would mis-place the DOM update.
+    /// Emits at most one of:
+    ///
+    /// * `Insert { index: visible_index, count: 1 }` — when the new
+    ///   child lands in the visible iteration. A hidden insert (one
+    ///   under a collapsed ancestor) emits no `Insert`; the hidden
+    ///   node surfaces naturally when an ancestor later expands and
+    ///   the adapter re-fetches the expanded subtree.
+    /// * `Replace { key: parent_key }` — when the parent flipped from
+    ///   leaf to collapsed branch. `TreeCollection::insert_child` sets
+    ///   `has_children = true` and `is_expanded = Some(false)` on a
+    ///   previously-leaf parent, which adapters key DOM off (expander
+    ///   chevron, `aria-expanded`). The transition only needs
+    ///   surfacing when the parent is itself visible — a hidden
+    ///   parent's row is not rendered, so the metadata change is
+    ///   invisible until an ancestor expands.
+    ///
+    /// The two events are mutually exclusive: a leaf parent always
+    /// becomes collapsed, so its new child is hidden and never
+    /// produces an `Insert`; an already-expanded branch parent keeps
+    /// its visible state and surfaces the new child via `Insert`
+    /// alone.
     pub fn insert_child(
         &mut self,
         parent: Option<&Key>,
@@ -1057,10 +1086,24 @@ impl<T: CollectionItem> MutableTreeData<T> {
         item: T,
     ) -> Option<usize> {
         let key = item.key().clone();
+        // Snapshot whether the parent (if any) is currently a visible
+        // leaf, before the inner call flips its `has_children` /
+        // `is_expanded` metadata.
+        let visible_leaf_parent = parent.filter(|p| {
+            self.inner.visible_index_of(p).is_some() && !self.inner.has_children(p)
+        });
         let flat_index = self.inner.insert_child(parent, index, item)?;
         if let Some(visible_index) = self.inner.visible_index_of(&key) {
             self.pending_changes
                 .push(CollectionChange::Insert { index: visible_index, count: 1 });
+        } else if let Some(parent_key) = visible_leaf_parent {
+            // Hidden child + previously-visible-leaf parent → the
+            // parent is now a collapsed branch and needs its rendered
+            // chevron / `aria-expanded` updated. Emit Replace so a
+            // reconciler that consumes only `CollectionChange` picks
+            // up the new metadata.
+            self.pending_changes
+                .push(CollectionChange::Replace { key: parent_key.clone() });
         }
         Some(flat_index)
     }
@@ -2229,6 +2272,19 @@ impl<T: CollectionItem> TreeCollection<T> {
     /// `visible_index_of` instead.
     pub fn flat_index_of(&self, key: &Key) -> Option<usize> {
         self.key_to_index.get(key).copied()
+    }
+
+    /// Returns `true` when the node at `key` currently has at least one
+    /// child (i.e. it is a branch, not a leaf), or `false` when the
+    /// node is a leaf or the key is unknown. Inherent twin of
+    /// `Collection::get(&node).has_children` that drops the `T: Clone`
+    /// bound, so `MutableTreeData::insert_child` can detect a leaf →
+    /// branch transition before calling the inner mutation.
+    #[must_use]
+    pub fn has_children(&self, key: &Key) -> bool {
+        self.key_to_index
+            .get(key)
+            .is_some_and(|&i| self.all_nodes[i].has_children)
     }
 
     /// Get the visible iteration index of a node by key, or `None` when


### PR DESCRIPTION
## Summary

- Adds `CollectionChange<K>` enum with `Insert`, `Remove`, `Move`, `Replace`, and `Reset` variants for granular DOM reconciliation signals
- Implements `MutableListData<T>` wrapping `StaticCollection<T>` with full mutation API (`push`, `insert`, `remove`, `move_item`, `replace`, `clear`, `drain_changes`) and `Collection<T>` delegation
- Implements `MutableTreeData<T>` wrapping `TreeCollection<T>` with tree-aware mutation API (`insert_child`, `remove`, `reparent`, `reorder`, `replace`, `drain_changes`) and `Collection<T>` delegation
- Updates spec `06-collections.md` §1.8 to match the implemented API
- All types re-exported from `ars-collections` crate root; crate remains `no_std` compatible

Closes #547

## Test plan

- [x] `cargo test -p ars-collections` — all unit tests for `MutableListData` and `MutableTreeData` pass
- [x] `cargo xci` — full CI suite passes with zero warnings
- [x] `CollectionChange` derives `Clone`, `Debug`, `PartialEq` — verified by tests
- [x] `drain_changes` clears buffer (verified by drain-twice tests)
- [x] Both wrappers delegate all `Collection<T>` reads to `self.inner`

🤖 Generated with [Claude Code](https://claude.com/claude-code)