### PR TITLE
Implement form messages and submit refinements

### DIFF
--- a/crates/ars-core/src/lib.rs
+++ b/crates/ars-core/src/lib.rs
@@ -127,9 +127,11 @@ type EffectSetupFn<M> = Box<
 pub struct PendingEffect<M: Machine> {
     /// The identifier for this effect, used by adapters to match and execute it.
     pub name: &'static str,
+
     /// The state after the transition that produced this effect.
     /// Set by [`Service::drain_queue`] before returning to the adapter.
     pub target_state: Option<M::State>,
+
     /// Setup closure — receives a snapshot of context, props, and the
     /// strong send handle. Returns a cleanup function.
     pub(crate) setup: EffectSetupFn<M>,
@@ -192,6 +194,8 @@ impl<M: Machine> Debug for PendingEffect<M> {
 // TransitionPlan
 // ────────────────────────────────────────────────────────────────────
 
+type ApplyFn<M> = dyn FnOnce(&mut <M as Machine>::Context);
+
 /// The result of a state machine transition, describing what should change.
 ///
 /// Built using a fluent builder pattern. Returning `None` from
@@ -200,15 +204,19 @@ impl<M: Machine> Debug for PendingEffect<M> {
 pub struct TransitionPlan<M: Machine> {
     /// The new state to transition to, or `None` to remain in the current state.
     pub target: Option<M::State>,
+
     /// Mutation to apply to the context after state change.
-    #[expect(clippy::type_complexity, reason = "closure type is inherently complex")]
-    pub(crate) apply: Option<Box<dyn FnOnce(&mut M::Context)>>,
+    pub(crate) apply: Option<Box<ApplyFn<M>>>,
+
     /// Human-readable description of the apply closure's purpose.
     pub(crate) apply_description: Option<&'static str>,
+
     /// Events to enqueue after this transition completes.
     pub then_send: Vec<M::Event>,
+
     /// Side effects for the adapter to set up.
     pub effects: Vec<PendingEffect<M>>,
+
     /// Named effects to cancel (cleanup runs immediately, no replacement).
     pub cancel_effects: Vec<&'static str>,
 }
@@ -372,6 +380,7 @@ impl<T: Clone + PartialEq + Debug> BindableValue for T {}
 pub struct Bindable<T: BindableValue> {
     /// The externally controlled value, or `None` if uncontrolled.
     controlled: Option<T>,
+
     /// The internal value managed by the component.
     internal: T,
 }
@@ -521,6 +530,7 @@ pub trait ConnectApi {
 pub struct Env {
     /// The resolved locale from `ArsProvider`.
     pub locale: Locale,
+
     /// Calendar/locale data provider for date-time formatting.
     /// Defaults to [`StubIcuProvider`] (English-only, zero dependencies).
     pub icu_provider: Arc<dyn IcuProvider>,
@@ -556,14 +566,19 @@ impl Default for Env {
 pub trait Machine: Sized + 'static {
     /// The state type representing the machine's current configuration.
     type State: Clone + Debug + PartialEq;
+
     /// The event type that triggers state transitions.
     type Event: Clone + Debug;
+
     /// Internal context accumulated across transitions (e.g. focused index, scroll offset).
     type Context: Clone + Debug;
+
     /// External configuration passed in by the parent component.
     type Props: Clone + PartialEq + HasId;
+
     /// Per-component i18n messages type.
     type Messages: ComponentMessages + Clone + Default + 'static;
+
     /// The connect API type that produces attributes from current state.
     type Api<'a>: ConnectApi
     where
@@ -619,13 +634,16 @@ const MAX_DRAIN_ITERATIONS: usize = 100;
 #[cfg(feature = "debug")]
 fn format_effect_names<M: Machine>(effects: &[PendingEffect<M>]) -> String {
     let mut formatted = String::from("[");
+
     for (index, effect) in effects.iter().enumerate() {
         if index > 0 {
             formatted.push_str(", ");
         }
         formatted.push_str(effect.name);
     }
+
     formatted.push(']');
+
     formatted
 }
 
@@ -656,17 +674,22 @@ fn format_apply_description(description: Option<&'static str>) -> String {
 pub struct SendResult<M: Machine> {
     /// Whether any state change occurred during this send cycle.
     pub state_changed: bool,
+
     /// Whether any context mutation occurred (via `plan.apply`).
     ///
     /// Adapters should trigger re-render when `state_changed || context_changed`.
     pub context_changed: bool,
+
     /// Effects that the adapter must set up.
     pub pending_effects: Vec<PendingEffect<M>>,
+
     /// Named effects to cancel. The adapter runs their cleanup closures
     /// immediately, before setting up any new `pending_effects`.
     pub cancel_effects: Vec<&'static str>,
+
     /// Whether the event queue was truncated due to hitting `MAX_DRAIN_ITERATIONS`.
     pub truncated: bool,
+
     /// Number of consecutive context-only iterations at the end of drain.
     ///
     /// Useful for diagnostics — a high trailing value may indicate a
@@ -726,7 +749,9 @@ impl<M: Machine> Service<M> {
     #[must_use]
     pub fn new(props: M::Props, env: &Env, messages: &M::Messages) -> Self {
         debug_assert!(!props.id().is_empty(), "Props::id must not be empty");
+
         let (state, context) = M::init(&props, env, messages);
+
         Self {
             state,
             context,
@@ -753,7 +778,9 @@ impl<M: Machine> Service<M> {
         messages: &M::Messages,
     ) -> Self {
         debug_assert!(!props.id().is_empty(), "Props::id must not be empty");
+
         let (_init_state, context) = M::init(&props, env, messages);
+
         Self {
             state,
             context,
@@ -798,6 +825,7 @@ impl<M: Machine> Service<M> {
     #[must_use]
     pub fn send(&mut self, event: M::Event) -> SendResult<M> {
         debug_assert!(!self.unmounted, "send() called after unmount()");
+
         if self.unmounted {
             #[cfg(feature = "debug")]
             log::debug!(
@@ -805,6 +833,7 @@ impl<M: Machine> Service<M> {
                 self.props.id(),
                 event
             );
+
             return SendResult {
                 state_changed: false,
                 context_changed: false,
@@ -814,16 +843,22 @@ impl<M: Machine> Service<M> {
                 context_change_count: 0,
             };
         }
+
         self.event_queue.push_back(event);
+
         self.drain_queue()
     }
 
     /// Processes all queued events iteratively with loop safety.
     fn drain_queue(&mut self) -> SendResult<M> {
         let mut pending_effects = Vec::new();
+
         let mut cancel_effects = Vec::new();
+
         let mut state_changed = false;
+
         let mut context_changed = false;
+
         #[cfg_attr(
             debug_assertions,
             expect(
@@ -832,21 +867,27 @@ impl<M: Machine> Service<M> {
             )
         )]
         let mut truncated = false;
+
         let mut iterations = 0;
+
         let mut context_change_count = 0;
 
         while let Some(event) = self.event_queue.pop_front() {
             iterations += 1;
+
             #[cfg(feature = "debug")]
             let state_before = format!("{:?}", self.state);
+
             #[cfg(feature = "debug")]
             let event_repr = format!("{event:?}");
+
             if iterations > MAX_DRAIN_ITERATIONS {
                 #[cfg(debug_assertions)]
                 panic!(
                     "Event queue exceeded {MAX_DRAIN_ITERATIONS} iterations — \
                      likely an infinite loop in transitions"
                 );
+
                 #[cfg(not(debug_assertions))]
                 {
                     #[cfg(feature = "debug")]
@@ -855,7 +896,9 @@ impl<M: Machine> Service<M> {
                          truncating. This likely indicates an infinite loop in state machine \
                          transitions."
                     );
+
                     truncated = true;
+
                     break;
                 }
             }
@@ -863,22 +906,27 @@ impl<M: Machine> Service<M> {
             if let Some(plan) = M::transition(&self.state, &event, &self.context, &self.props) {
                 #[cfg(feature = "debug")]
                 let target_state = format_target_state(plan.target.as_ref());
+
                 #[cfg(feature = "debug")]
                 let effect_names = format_effect_names(&plan.effects);
+
                 #[cfg(feature = "debug")]
                 let apply_description = format_apply_description(plan.apply_description);
+
                 #[cfg(feature = "debug")]
                 let follow_up_events = format_follow_up_events(&plan.then_send);
 
                 // Apply context mutation.
                 if let Some(apply) = plan.apply {
                     apply(&mut self.context);
+
                     context_changed = true;
                 }
 
                 // Track context-only iterations for diagnostics.
                 if plan.target.is_none() {
                     context_change_count += 1;
+
                     if context_change_count >= MAX_DRAIN_ITERATIONS {
                         #[cfg(debug_assertions)]
                         panic!(
@@ -886,6 +934,7 @@ impl<M: Machine> Service<M> {
                              iterations without a state change — likely an infinite \
                              context_only + then_send loop"
                         );
+
                         #[cfg(not(debug_assertions))]
                         {
                             #[cfg(feature = "debug")]
@@ -893,7 +942,9 @@ impl<M: Machine> Service<M> {
                                 "drain_queue: {context_change_count} context_only iterations \
                                  without state change — possible infinite loop, truncating."
                             );
+
                             truncated = true;
+
                             break;
                         }
                     }
@@ -903,12 +954,14 @@ impl<M: Machine> Service<M> {
 
                 // Enqueue follow-up events.
                 self.event_queue.extend(plan.then_send);
+
                 #[cfg(feature = "debug")]
                 let queue_depth = self.event_queue.len();
 
                 // Apply state change.
                 if let Some(next) = plan.target {
                     self.state = next;
+
                     state_changed = true;
                 }
 
@@ -925,10 +978,12 @@ impl<M: Machine> Service<M> {
                 #[cfg(feature = "debug")]
                 {
                     let component_id = self.props.id();
+
                     log::trace!(
                         "[ars:{component_id}] {state_before} + {event_repr} → {target_state} \
                          (guard: pass, effects: {effect_names})"
                     );
+
                     log::trace!(
                         "[ars:{component_id}]   apply: {apply_description}, then_send: \
                          {follow_up_events}, iteration: {iterations}, queue_depth: {queue_depth}"
@@ -961,10 +1016,13 @@ impl<M: Machine> Service<M> {
     /// enqueues any returned events, and drains the queue.
     pub fn set_props(&mut self, props: M::Props) -> SendResult<M> {
         let old_props = core::mem::replace(&mut self.props, props);
+
         let events = M::on_props_changed(&old_props, &self.props);
+
         for event in events {
             self.event_queue.push_back(event);
         }
+
         self.drain_queue()
     }
 
@@ -974,10 +1032,13 @@ impl<M: Machine> Service<M> {
     /// In debug builds, subsequent sends will panic; in release builds,
     /// they return an inert [`SendResult`].
     pub fn unmount(&mut self, active_cleanups: Vec<CleanupFn>) {
-        for cleanup in active_cleanups.into_iter().rev() {
-            cleanup();
-        }
+        active_cleanups
+            .into_iter()
+            .rev()
+            .for_each(|cleanup| cleanup());
+
         self.event_queue.clear();
+
         self.unmounted = true;
     }
 
@@ -1003,7 +1064,9 @@ impl<M: Machine> Service<M> {
     #[cfg(test)]
     pub fn set_state_for_test(&mut self, state: M::State) {
         let (_init_state, context) = M::init(&self.props, &Env::default(), &M::Messages::default());
+
         self.state = state;
+
         self.context = context;
     }
 }
@@ -1081,23 +1144,29 @@ mod tests {
     #[cfg(feature = "debug")]
     fn capture_logs(run: impl FnOnce()) -> Vec<CapturedLog> {
         init_test_logger();
+
         let _capture_guard = CAPTURE_LOCK.lock().expect("capture mutex poisoned");
+
         TEST_LOGGER
             .records
             .lock()
             .expect("test logger mutex poisoned")
             .clear();
+
         run();
+
         let records = TEST_LOGGER
             .records
             .lock()
             .expect("test logger mutex poisoned")
             .clone();
+
         TEST_LOGGER
             .records
             .lock()
             .expect("test logger mutex poisoned")
             .clear();
+
         records
     }
 
@@ -1185,6 +1254,7 @@ mod tests {
                 (ToggleState::Off, ToggleEvent::Toggle) => {
                     Some(TransitionPlan::to(ToggleState::On))
                 }
+
                 (ToggleState::On, ToggleEvent::Toggle) => {
                     Some(TransitionPlan::to(ToggleState::Off))
                 }
@@ -1210,9 +1280,11 @@ mod tests {
             &Env::default(),
             &(),
         );
+
         assert_eq!(service.state(), &ToggleState::Off);
 
         let result = service.send(ToggleEvent::Toggle);
+
         assert!(result.state_changed);
         assert!(result.pending_effects.is_empty());
         assert_eq!(service.state(), &ToggleState::On);
@@ -1227,10 +1299,14 @@ mod tests {
             &Env::default(),
             &(),
         );
+
         // Toggle is exhaustive so nothing is ignored — toggle twice and check.
         let result = service.send(ToggleEvent::Toggle);
+
         assert!(result.state_changed);
+
         let result = service.send(ToggleEvent::Toggle);
+
         assert!(result.state_changed);
         assert_eq!(service.state(), &ToggleState::Off);
     }
@@ -1287,7 +1363,9 @@ mod tests {
             &Env::default(),
             &(),
         );
+
         let result = service.send(ToggleEvent::Toggle);
+
         assert!(!result.state_changed);
         assert!(result.context_changed);
         assert_eq!(service.context().count, 1);
@@ -1343,7 +1421,9 @@ mod tests {
             &Env::default(),
             &(),
         );
+
         let result = service.send(ToggleEvent::Toggle);
+
         assert_eq!(result.cancel_effects, vec!["timer", "polling"]);
     }
 
@@ -1393,7 +1473,9 @@ mod tests {
             &Env::default(),
             &(),
         );
+
         let result = service.send(ToggleEvent::Toggle);
+
         assert_eq!(result.pending_effects.len(), 1);
         assert_eq!(result.pending_effects[0].name, "focus");
         assert_eq!(
@@ -1441,6 +1523,7 @@ mod tests {
                 match event {
                     PropsEvent::SetMode(m) => {
                         let m = *m;
+
                         Some(TransitionPlan::context_only(move |ctx: &mut PropsCtx| {
                             ctx.mode = m;
                         }))
@@ -1478,6 +1561,7 @@ mod tests {
         let result = service.set_props(ToggleProps {
             id: String::from("b"),
         });
+
         assert!(result.context_changed);
         assert_eq!(service.context().mode, 1);
     }
@@ -1491,9 +1575,11 @@ mod tests {
             &Env::default(),
             &(),
         );
+
         assert_eq!(service.state(), &ToggleState::Off);
 
         service.set_state_for_test(ToggleState::On);
+
         assert_eq!(service.state(), &ToggleState::On);
     }
 
@@ -1508,6 +1594,7 @@ mod tests {
     #[test]
     fn env_default_has_en_us_locale() {
         let env = Env::default();
+
         assert_eq!(env.locale.to_bcp47(), "en-US");
     }
 
@@ -1619,6 +1706,7 @@ mod tests {
             .iter()
             .find(|record| record.message.contains("[ars:menu#item-1]"))
             .expect("expected transition log");
+
         assert!(
             transition.message.contains("effects: [focus, announce]"),
             "expected comma-joined effect names: {transition:?}"
@@ -1669,10 +1757,14 @@ mod tests {
                             .apply(|ctx: &mut DebugContext| ctx.pressed = true)
                             .then(DebugEvent::Notify)
                             .with_effect(PendingEffect::named("notify_change"));
+
                         plan.apply_description = Some("set pressed = true");
+
                         Some(plan)
                     }
+
                     (ToggleState::On, DebugEvent::Notify) => Some(TransitionPlan::new()),
+
                     _ => None,
                 }
             }
@@ -1707,6 +1799,7 @@ mod tests {
                     .contains("[ars:toggle#btn-1] Off + Toggle → On")
             })
             .expect("expected transition log");
+
         assert_eq!(transition.level, log::Level::Trace);
         assert!(
             transition.message.contains("guard: pass"),
@@ -1800,6 +1893,7 @@ mod tests {
             .iter()
             .find(|record| record.message.contains("[ars:combobox#cb-1]"))
             .expect("expected rejected transition log");
+
         assert!(
             rejected.message.contains("guard: reject"),
             "missing guard reject marker: {rejected:?}"
@@ -1847,9 +1941,11 @@ mod tests {
                     (ToggleState::Off, ChainEvent::Start) => {
                         Some(TransitionPlan::to(ToggleState::On).then(ChainEvent::Continue))
                     }
+
                     (ToggleState::On, ChainEvent::Continue) => {
                         Some(TransitionPlan::to(ToggleState::Off))
                     }
+
                     _ => None,
                 }
             }
@@ -1885,6 +1981,7 @@ mod tests {
                     && record.message.contains("iteration: 1")
             })
             .expect("expected first detail log");
+
         assert!(
             iteration_one.message.contains("queue_depth: 1"),
             "expected queued follow-up event after first iteration: {iteration_one:?}"
@@ -1899,6 +1996,7 @@ mod tests {
                     && record.message.contains("iteration: 2")
             })
             .expect("expected second detail log");
+
         assert!(
             iteration_two.message.contains("queue_depth: 0"),
             "expected queue to be drained after second iteration: {iteration_two:?}"
@@ -2046,10 +2144,12 @@ mod tests {
             &Env::default(),
             &(),
         );
+
         service.unmount(Vec::new());
 
         let logs = capture_logs(|| {
             let result = service.send(ToggleEvent::Toggle);
+
             assert!(!result.state_changed);
             assert!(!result.context_changed);
             assert!(result.pending_effects.is_empty());
@@ -2062,6 +2162,7 @@ mod tests {
             .iter()
             .find(|record| record.level == log::Level::Debug)
             .expect("expected dropped-event debug log");
+
         assert!(
             dropped
                 .message
@@ -2106,6 +2207,7 @@ mod tests {
                     (ToggleState::Off, LoopEvent::Continue) => {
                         Some(TransitionPlan::to(ToggleState::On).then(LoopEvent::Continue))
                     }
+
                     (ToggleState::On, LoopEvent::Continue) => {
                         Some(TransitionPlan::to(ToggleState::Off).then(LoopEvent::Continue))
                     }
@@ -2132,6 +2234,7 @@ mod tests {
 
         let logs = capture_logs(|| {
             let result = service.send(LoopEvent::Continue);
+
             assert!(result.truncated);
             assert!(result.state_changed);
             assert!(!result.context_changed);
@@ -2142,6 +2245,7 @@ mod tests {
             .iter()
             .find(|record| record.level == log::Level::Warn)
             .expect("expected truncation warning log");
+
         assert!(
             warning
                 .message
@@ -2225,6 +2329,7 @@ mod tests {
             .iter()
             .find(|record| record.level == log::Level::Warn)
             .expect("expected context_only truncation warning");
+
         assert!(
             warning
                 .message
@@ -2236,27 +2341,35 @@ mod tests {
     #[test]
     fn bindable_set_updates_internal_value_in_both_modes() {
         let mut uncontrolled = Bindable::uncontrolled(1_u8);
+
         uncontrolled.set(2);
+
         assert_eq!(uncontrolled.get(), &2);
 
         let mut controlled = Bindable::controlled(1_u8);
+
         controlled.set(2);
+
         assert_eq!(controlled.get(), &1);
 
         controlled.sync_controlled(None);
+
         assert_eq!(controlled.get(), &2);
     }
 
     #[test]
     fn bindable_sync_controlled_updates_only_the_controlled_value() {
         let mut b = Bindable::uncontrolled(10_u8);
+
         assert!(!b.is_controlled());
 
         b.sync_controlled(Some(20));
+
         assert!(b.is_controlled());
         assert_eq!(b.get(), &20);
 
         b.sync_controlled(None);
+
         assert!(!b.is_controlled());
         assert_eq!(b.get(), &10);
     }
@@ -2275,9 +2388,11 @@ mod tests {
         let mut b = Bindable::controlled(vec![String::from("controlled")]);
 
         b.get_mut_owned().push(String::from("pending"));
+
         assert_eq!(b.get(), &vec![String::from("controlled")]);
 
         b.sync_controlled(None);
+
         assert_eq!(
             b.get(),
             &vec![String::from("controlled"), String::from("pending")]
@@ -2289,12 +2404,17 @@ mod tests {
         use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
         let observed = Arc::new(AtomicBool::new(false));
+
         let cleanup_calls = Arc::new(AtomicUsize::new(0));
+
         let effect = PendingEffect::<ToggleMachine>::new("notify", {
             let cleanup_calls = Arc::clone(&cleanup_calls);
+
             move |_ctx, _props, send| {
                 send.call_if_alive(ToggleEvent::Toggle);
+
                 let cleanup_calls = Arc::clone(&cleanup_calls);
+
                 Box::new(move || {
                     cleanup_calls.fetch_add(1, Ordering::SeqCst);
                 })
@@ -2303,6 +2423,7 @@ mod tests {
 
         let send: StrongSend<ToggleEvent> = {
             let observed = Arc::clone(&observed);
+
             Arc::new(move |_event| {
                 observed.store(true, Ordering::SeqCst);
             })
@@ -2313,9 +2434,11 @@ mod tests {
         let (_state, context) = ToggleMachine::init(&props, &Env::default(), &());
 
         let cleanup = effect.run(&context, &props, send);
+
         assert!(observed.load(Ordering::SeqCst));
 
         cleanup();
+
         assert_eq!(cleanup_calls.load(Ordering::SeqCst), 1);
     }
 
@@ -2324,6 +2447,7 @@ mod tests {
         use alloc::format;
 
         let effect = PendingEffect::<ToggleMachine>::named("focus");
+
         assert_eq!(
             format!("{effect:?}"),
             "PendingEffect { name: \"focus\", target_state: None, setup: \"<closure>\" }"
@@ -2332,9 +2456,13 @@ mod tests {
         let props = ToggleProps {
             id: String::from("toggle"),
         };
+
         let (_state, context) = ToggleMachine::init(&props, &Env::default(), &());
+
         let send: StrongSend<ToggleEvent> = Arc::new(|_| {});
+
         let cleanup = effect.run(&context, &props, send);
+
         cleanup();
     }
 
@@ -2395,6 +2523,7 @@ mod tests {
     #[test]
     fn no_cleanup_is_callable() {
         let cleanup = no_cleanup();
+
         cleanup();
     }
 }

--- a/crates/ars-forms/src/form/context.rs
+++ b/crates/ars-forms/src/form/context.rs
@@ -7,7 +7,11 @@
 //! composition. [`Data`] is the collected field data passed to submit
 //! handlers.
 
-use std::{collections::BTreeMap, fmt};
+use std::{
+    collections::BTreeMap,
+    fmt::{self, Debug},
+    sync::Arc,
+};
 
 use indexmap::IndexMap;
 
@@ -66,7 +70,7 @@ pub struct Context {
     cross_field_registry: BTreeMap<String, Vec<CrossFieldValidator>>,
 }
 
-impl fmt::Debug for Context {
+impl Debug for Context {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Context")
             .field("fields", &self.fields)
@@ -103,10 +107,13 @@ impl fmt::Debug for Context {
 pub struct Mode {
     /// Validate on input change.
     pub on_change: bool,
+
     /// Validate on field blur.
     pub on_blur: bool,
+
     /// Validate on every keystroke (before debounce).
     pub on_input: bool,
+
     /// If already invalid, re-validate on change (React Hook Form pattern).
     pub revalidate_on_change: bool,
 }
@@ -144,7 +151,7 @@ pub struct AnyValidator {
     pub validators: Vec<BoxedValidator>,
 }
 
-impl fmt::Debug for AnyValidator {
+impl Debug for AnyValidator {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("AnyValidator")
             .field(
@@ -192,13 +199,8 @@ impl Validator for AnyValidator {
 /// registered on.
 /// A type-erased cross-field validation function.
 ///
-/// On native targets, requires `Send + Sync`. On WASM, uses `Rc`.
-#[cfg(not(target_arch = "wasm32"))]
-type CrossFieldValidateFn = std::sync::Arc<dyn Fn(&Value, &ValContext) -> Result + Send + Sync>;
-
-/// A type-erased cross-field validation function (WASM variant).
-#[cfg(target_arch = "wasm32")]
-type CrossFieldValidateFn = std::rc::Rc<dyn Fn(&Value, &ValContext) -> Result>;
+/// Uses [`Arc`](std::sync::Arc) on all targets for shared ownership.
+type CrossFieldValidateFn = Arc<dyn Fn(&Value, &ValContext) -> Result + Send + Sync>;
 
 /// Validates a field using values from other fields in the form.
 ///
@@ -210,11 +212,12 @@ pub struct CrossFieldValidator {
     /// Names of fields this validator reads from. When any field in this
     /// list changes, `Context` re-validates the owning field.
     pub depends_on: Vec<String>,
+
     /// The validation function.
     pub validate_fn: CrossFieldValidateFn,
 }
 
-impl fmt::Debug for CrossFieldValidator {
+impl Debug for CrossFieldValidator {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("CrossFieldValidator")
             .field("depends_on", &self.depends_on)
@@ -258,15 +261,21 @@ impl Context {
         async_validator: Option<BoxedAsyncValidator>,
     ) {
         let name = name.into();
+
         self.fields.insert(name.clone(), State::new(initial));
+
         // Remove stale validators before inserting new ones, so re-registration
         // with validator=None properly clears a previously registered validator.
         self.validators.remove(&name);
+
         self.async_validators.remove(&name);
+
         self.cross_field_registry.remove(&name);
+
         if let Some(v) = validator {
             self.validators.insert(name.clone(), v);
         }
+
         if let Some(v) = async_validator {
             self.async_validators.insert(name, v);
         }
@@ -343,8 +352,10 @@ impl Context {
         } else {
             return;
         }
+
         // Clear server errors when user modifies a field.
         self.server_errors.remove(name);
+
         if self.validation_mode.on_input {
             self.run_field_validation(name);
         } else if let Some(field) = self.fields.get_mut(name) {
@@ -360,6 +371,7 @@ impl Context {
     /// Returns `Err(Errors)` when the field fails validation.
     pub fn validate_field(&mut self, name: &str) -> Result {
         self.run_field_validation(name);
+
         self.fields
             .get(name)
             .map_or(Ok(()), |f| f.validation.clone())
@@ -368,9 +380,12 @@ impl Context {
     /// Validate all fields. Returns `true` if the form is valid.
     pub fn validate_all(&mut self) -> bool {
         let names = self.fields.keys().cloned().collect::<Vec<_>>();
+
         let mut valid = true;
+
         for name in names {
             self.run_field_validation(&name);
+
             if self
                 .fields
                 .get(&name)
@@ -379,6 +394,7 @@ impl Context {
                 valid = false;
             }
         }
+
         valid
     }
 
@@ -388,16 +404,22 @@ impl Context {
     /// Preserves client-side errors from `validate_all()`.
     pub fn set_server_errors(&mut self, errors: impl Into<BTreeMap<String, Vec<String>>>) {
         let errors = errors.into();
+
         for (name, messages) in &errors {
             if let Some(field) = self.fields.get_mut(name) {
                 field.touched = true; // Show errors immediately
+
                 let server_errs = messages.iter().map(Error::server).collect::<Vec<_>>();
+
                 // Merge: keep existing client-side errors, replace server errors
-                let mut client_errs = match &field.validation {
-                    Err(Errors(errs)) => errs.iter().filter(|e| !e.is_server()).cloned().collect(),
-                    _ => vec![],
+                let mut client_errs = if let Err(Errors(errs)) = &field.validation {
+                    errs.iter().filter(|e| !e.is_server()).cloned().collect()
+                } else {
+                    vec![]
                 };
+
                 client_errs.extend(server_errs);
+
                 field.validation = Err(Errors(client_errs));
             }
         }
@@ -415,8 +437,10 @@ impl Context {
             field.validating = false;
             field.validation_generation += 1;
         }
+
         self.is_submitting = false;
         self.is_submitted = false;
+
         self.server_errors.clear();
     }
 
@@ -431,9 +455,8 @@ impl Context {
     /// `field.validation`. Does not return the result — callers that need
     /// the outcome read it from `self.fields` afterward.
     fn run_field_validation(&mut self, name: &str) {
-        let value = match self.fields.get(name) {
-            Some(f) => f.value.clone(),
-            None => return,
+        let Some(value) = self.fields.get(name).map(|f| f.value.clone()) else {
+            return;
         };
 
         let all_values = self
@@ -461,16 +484,21 @@ impl Context {
                     .iter()
                     .any(|cv| cv.depends_on.contains(&name.to_string()))
             {
-                let target_value = match self.fields.get(target_name.as_str()) {
-                    Some(f) => f.value.clone(),
-                    None => continue,
+                let Some(target_value) = self
+                    .fields
+                    .get(target_name.as_str())
+                    .map(|f| f.value.clone())
+                else {
+                    continue;
                 };
+
                 let target_result = validators
                     .iter()
                     .filter(|cv| cv.depends_on.contains(&name.to_string()))
                     .map(|cv| cv.validate(&target_value, &ctx))
                     .reduce(ResultExt::merge)
                     .unwrap_or(Ok(()));
+
                 if let Some(field) = self.fields.get_mut(target_name.as_str()) {
                     field.validation = target_result;
                 }
@@ -502,15 +530,20 @@ impl Context {
         F: FnOnce(Data),
     {
         self.is_submitted = true;
+
         self.touch_all();
 
         let is_valid = self.validate_all();
 
         if is_valid {
             self.is_submitting = true;
+
             let data = self.collect_form_data();
+
             handler(data);
+
             self.is_submitting = false;
+
             Ok(())
         } else {
             // Adapter: call first_invalid_field_id() and focus the result (see §9)
@@ -570,10 +603,12 @@ impl Context {
         validator: BoxedAsyncValidator,
     ) {
         let name = name.into();
+
         debug_assert!(
             self.fields.contains_key(&name),
             "register_async_validator: field '{name}' not registered — validator will never run"
         );
+
         self.async_validators.insert(name, validator);
     }
 
@@ -589,11 +624,13 @@ impl Context {
 
     fn collect_all_errors(&self) -> Errors {
         let mut all = Errors::new();
+
         for field in self.fields.values() {
             if let Some(errors) = field.validation.errors() {
                 all.0.extend(errors.0.clone());
             }
         }
+
         all
     }
 }
@@ -643,19 +680,22 @@ mod tests {
 
     fn required_validator() -> BoxedValidator {
         struct RequiredV;
+
         impl Validator for RequiredV {
             fn validate(&self, value: &Value, _ctx: &ValContext) -> Result {
-                if let Some(t) = value.as_text() {
-                    if t.trim().is_empty() {
-                        return Err(Errors(vec![Error {
-                            code: ErrorCode::Required,
-                            message: "required".to_string(),
-                        }]));
-                    }
+                if let Some(t) = value.as_text()
+                    && t.trim().is_empty()
+                {
+                    return Err(Errors(vec![Error {
+                        code: ErrorCode::Required,
+                        message: "required".to_string(),
+                    }]));
                 }
+
                 Ok(())
             }
         }
+
         crate::validation::boxed_validator(RequiredV)
     }
 
@@ -664,31 +704,38 @@ mod tests {
     #[test]
     fn register_preserves_insertion_order() {
         let mut ctx = Context::new(Mode::on_submit());
+
         ctx.register("name", text(""), None, None);
         ctx.register("email", text(""), None, None);
         ctx.register("age", Value::Number(None), None, None);
 
         let keys = ctx.fields.keys().collect::<Vec<_>>();
+
         assert_eq!(keys, vec!["name", "email", "age"]);
     }
 
     #[test]
     fn deregister_removes_field_and_validators() {
         let mut ctx = Context::new(Mode::on_submit());
+
         ctx.register("email", text(""), Some(required_validator()), None);
+
         assert!(ctx.field("email").is_some());
 
         ctx.deregister("email");
+
         assert!(ctx.field("email").is_none());
     }
 
     #[test]
     fn register_replaces_existing() {
         let mut ctx = Context::new(Mode::on_submit());
+
         ctx.register("name", text("old"), None, None);
         ctx.register("name", text("new"), None, None);
 
         let field = ctx.field("name").expect("field exists");
+
         assert_eq!(field.value, text("new"));
         assert_eq!(field.initial_value, text("new"));
     }
@@ -696,13 +743,16 @@ mod tests {
     #[test]
     fn field_returns_registered_state() {
         let mut ctx = Context::new(Mode::on_submit());
+
         ctx.register("email", text("test@test.com"), None, None);
+
         assert!(ctx.field("email").is_some());
     }
 
     #[test]
     fn field_returns_none_for_unknown() {
         let ctx = Context::new(Mode::on_submit());
+
         assert!(ctx.field("missing").is_none());
     }
 
@@ -711,21 +761,26 @@ mod tests {
     #[test]
     fn set_server_errors_marks_touched() {
         let mut ctx = Context::new(Mode::on_submit());
+
         ctx.register("email", text(""), None, None);
+
         assert!(!ctx.field("email").expect("exists").touched);
 
         ctx.set_server_errors([("email".to_string(), vec!["Already exists".to_string()])]);
+
         assert!(ctx.field("email").expect("exists").touched);
     }
 
     #[test]
     fn set_server_errors_shows_error() {
         let mut ctx = Context::new(Mode::on_submit());
+
         ctx.register("email", text(""), None, None);
 
         ctx.set_server_errors([("email".to_string(), vec!["Already exists".to_string()])]);
 
         let field = ctx.field("email").expect("exists");
+
         assert!(field.show_error());
         assert_eq!(field.error_message(), Some("Already exists"));
     }
@@ -733,31 +788,39 @@ mod tests {
     #[test]
     fn server_error_cleared_on_change() {
         let mut ctx = Context::new(Mode::on_submit());
+
         ctx.register("email", text(""), None, None);
 
         ctx.set_server_errors([("email".to_string(), vec!["Taken".to_string()])]);
+
         assert!(ctx.field("email").expect("exists").validation.is_err());
 
         // Change clears server error
         ctx.on_change("email", text("new@test.com"));
+
         let field = ctx.field("email").expect("exists");
+
         assert!(field.validation.is_ok());
     }
 
     #[test]
     fn set_server_errors_preserves_client_errors() {
         let mut ctx = Context::new(Mode::on_submit());
+
         ctx.register("email", text(""), Some(required_validator()), None);
 
         // First trigger client-side validation
         let _result = ctx.validate_field("email");
+
         assert!(ctx.field("email").expect("exists").validation.is_err());
 
         // Now inject server errors — client errors should be preserved
         ctx.set_server_errors([("email".to_string(), vec!["Already exists".to_string()])]);
 
         let field = ctx.field("email").expect("exists");
+
         let all_errors = field.validation.errors().expect("has errors");
+
         // Should have both client and server errors
         assert!(all_errors.len() >= 2);
         assert!(all_errors.0.iter().any(|e| !e.is_server()));
@@ -769,6 +832,7 @@ mod tests {
     #[test]
     fn on_blur_validates_when_mode_set() {
         let mut ctx = Context::new(Mode::on_blur_revalidate());
+
         ctx.register("name", text(""), Some(required_validator()), None);
 
         ctx.on_blur("name");
@@ -779,29 +843,35 @@ mod tests {
     #[test]
     fn on_change_validates_when_mode_set() {
         let mut ctx = Context::new(Mode::on_change());
+
         ctx.register("name", text("hello"), Some(required_validator()), None);
 
         ctx.on_change("name", text(""));
+
         assert!(ctx.field("name").expect("exists").validation.is_err());
     }
 
     #[test]
     fn on_change_revalidates_when_invalid() {
         let mut ctx = Context::new(Mode::on_blur_revalidate());
+
         ctx.register("name", text(""), Some(required_validator()), None);
 
         // Make it invalid first via validate_field
         let _result = ctx.validate_field("name");
+
         assert!(ctx.field("name").expect("exists").validation.is_err());
 
         // on_change should revalidate because revalidate_on_change is true
         ctx.on_change("name", text("fixed"));
+
         assert!(ctx.field("name").expect("exists").validation.is_ok());
     }
 
     #[test]
     fn validate_all_returns_false_when_invalid() {
         let mut ctx = Context::new(Mode::on_submit());
+
         ctx.register("name", text(""), Some(required_validator()), None);
         ctx.register("email", text("test@test.com"), None, None);
 
@@ -811,13 +881,16 @@ mod tests {
     #[test]
     fn submit_calls_handler_when_valid() {
         let mut ctx = Context::new(Mode::on_submit());
+
         ctx.register("name", text("Alice"), None, None);
 
         let mut called = false;
+
         let result = ctx.submit(|data| {
             called = true;
             assert_eq!(data.get_text("name"), Some("Alice"));
         });
+
         assert!(called);
         assert!(result.is_ok());
         assert!(ctx.is_submitted);
@@ -826,12 +899,15 @@ mod tests {
     #[test]
     fn submit_does_not_call_handler_when_invalid() {
         let mut ctx = Context::new(Mode::on_submit());
+
         ctx.register("name", text(""), Some(required_validator()), None);
 
         let mut called = false;
+
         let result = ctx.submit(|_| {
             called = true;
         });
+
         assert!(!called);
         assert!(result.is_err());
         assert!(ctx.is_submitted);
@@ -840,6 +916,7 @@ mod tests {
     #[test]
     fn submit_touches_all_fields() {
         let mut ctx = Context::new(Mode::on_submit());
+
         ctx.register("a", text(""), None, None);
         ctx.register("b", text(""), None, None);
 
@@ -855,17 +932,20 @@ mod tests {
     #[test]
     fn reset_restores_initial_values() {
         let mut ctx = Context::new(Mode::on_submit());
+
         ctx.register("name", text("initial"), Some(required_validator()), None);
 
         // Modify the field
         ctx.on_change("name", text("modified"));
         ctx.on_blur("name");
+
         ctx.is_submitted = true;
         ctx.is_submitting = true;
 
         ctx.reset();
 
         let field = ctx.field("name").expect("exists");
+
         assert_eq!(field.value, text("initial"));
         assert!(!field.dirty);
         assert!(!field.touched);
@@ -877,29 +957,34 @@ mod tests {
     #[test]
     fn is_valid_and_is_dirty() {
         let mut ctx = Context::new(Mode::on_submit());
+
         ctx.register("name", text(""), None, None);
 
         assert!(ctx.is_valid());
         assert!(!ctx.is_dirty());
 
         ctx.on_change("name", text("Alice"));
+
         assert!(ctx.is_dirty());
     }
 
     #[test]
     fn cross_field_validator_triggers_on_dependency_change() {
         let mut ctx = Context::new(Mode::on_change());
+
         ctx.register("password", text("secret"), None, None);
         ctx.register("confirm", text("secret"), None, None);
 
         let cv = CrossFieldValidator {
             depends_on: vec!["password".to_string()],
-            validate_fn: std::sync::Arc::new(|value, ctx_inner| {
+            validate_fn: Arc::new(|value, ctx_inner| {
                 let password = ctx_inner
                     .form_values
                     .get("password")
                     .and_then(Value::as_text);
+
                 let confirm = value.as_text().unwrap_or_default();
+
                 if password.is_some_and(|p| p == confirm) {
                     Ok(())
                 } else {
@@ -910,12 +995,14 @@ mod tests {
                 }
             }),
         };
+
         ctx.register_cross_field_validator("confirm", cv);
 
         // Changing password triggers re-validation of confirm
         ctx.on_change("password", text("changed"));
 
         let confirm = ctx.field("confirm").expect("exists");
+
         assert!(confirm.validation.is_err());
     }
 
@@ -924,12 +1011,15 @@ mod tests {
     #[test]
     fn any_validator_passes_if_one_passes() {
         struct AlwaysFail;
+
         impl Validator for AlwaysFail {
             fn validate(&self, _v: &Value, _c: &ValContext) -> Result {
                 Err(Errors(vec![Error::custom("fail", "always fails")]))
             }
         }
+
         struct AlwaysPass;
+
         impl Validator for AlwaysPass {
             fn validate(&self, _v: &Value, _c: &ValContext) -> Result {
                 Ok(())
@@ -940,19 +1030,24 @@ mod tests {
             crate::validation::boxed_validator(AlwaysFail),
             crate::validation::boxed_validator(AlwaysPass),
         ]);
+
         let ctx = ValContext::standalone("test");
+
         assert!(any.validate(&text("x"), &ctx).is_ok());
     }
 
     #[test]
     fn any_validator_fails_if_all_fail() {
         struct Fail1;
+
         impl Validator for Fail1 {
             fn validate(&self, _v: &Value, _c: &ValContext) -> Result {
                 Err(Errors(vec![Error::custom("f1", "fail 1")]))
             }
         }
+
         struct Fail2;
+
         impl Validator for Fail2 {
             fn validate(&self, _v: &Value, _c: &ValContext) -> Result {
                 Err(Errors(vec![Error::custom("f2", "fail 2")]))
@@ -963,8 +1058,11 @@ mod tests {
             crate::validation::boxed_validator(Fail1),
             crate::validation::boxed_validator(Fail2),
         ]);
+
         let ctx = ValContext::standalone("test");
+
         let result = any.validate(&text("x"), &ctx);
+
         assert!(result.is_err());
         assert_eq!(result.errors().expect("has errors").len(), 2);
     }
@@ -974,7 +1072,9 @@ mod tests {
     #[test]
     fn form_data_get_text() {
         let mut data = Data::default();
+
         data.fields.insert("name".to_string(), text("Alice"));
+
         assert_eq!(data.get_text("name"), Some("Alice"));
         assert_eq!(data.get_text("missing"), None);
     }
@@ -982,8 +1082,10 @@ mod tests {
     #[test]
     fn form_data_get_number() {
         let mut data = Data::default();
+
         data.fields
             .insert("age".to_string(), Value::Number(Some(30.0)));
+
         assert_eq!(data.get_number("age"), Some(30.0));
         assert_eq!(data.get_number("missing"), None);
     }
@@ -991,6 +1093,7 @@ mod tests {
     #[test]
     fn form_data_default_is_empty() {
         let data = Data::default();
+
         assert!(data.fields.is_empty());
     }
 
@@ -999,6 +1102,7 @@ mod tests {
     #[test]
     fn validation_mode_on_submit_all_false() {
         let mode = Mode::on_submit();
+
         assert!(!mode.on_change);
         assert!(!mode.on_blur);
         assert!(!mode.on_input);
@@ -1008,6 +1112,7 @@ mod tests {
     #[test]
     fn validation_mode_on_blur_revalidate() {
         let mode = Mode::on_blur_revalidate();
+
         assert!(mode.on_blur);
         assert!(mode.revalidate_on_change);
         assert!(!mode.on_change);
@@ -1017,6 +1122,7 @@ mod tests {
     #[test]
     fn validation_mode_on_change() {
         let mode = Mode::on_change();
+
         assert!(mode.on_change);
         assert!(!mode.on_blur);
     }
@@ -1026,10 +1132,13 @@ mod tests {
     #[test]
     fn on_input_updates_value_without_marking_dirty() {
         let mut ctx = Context::new(Mode::on_submit());
+
         ctx.register("name", text(""), None, None);
 
         ctx.on_input("name", text("typing"));
+
         let field = ctx.field("name").expect("exists");
+
         assert_eq!(field.value, text("typing"));
         assert!(!field.dirty); // on_input does NOT set dirty
     }
@@ -1037,12 +1146,15 @@ mod tests {
     #[test]
     fn on_input_clears_server_errors() {
         let mut ctx = Context::new(Mode::on_submit());
+
         ctx.register("email", text(""), None, None);
 
         ctx.set_server_errors([("email".to_string(), vec!["Taken".to_string()])]);
+
         assert!(ctx.field("email").expect("exists").validation.is_err());
 
         ctx.on_input("email", text("new"));
+
         assert!(ctx.field("email").expect("exists").validation.is_ok());
     }
 
@@ -1052,30 +1164,39 @@ mod tests {
             on_input: true,
             ..Default::default()
         };
+
         let mut ctx = Context::new(mode);
+
         ctx.register("name", text(""), Some(required_validator()), None);
 
         ctx.on_input("name", text(""));
+
         assert!(ctx.field("name").expect("exists").validation.is_err());
 
         ctx.on_input("name", text("valid"));
+
         assert!(ctx.field("name").expect("exists").validation.is_ok());
     }
 
     #[test]
     fn on_input_increments_validation_generation() {
         let mut ctx = Context::new(Mode::on_submit());
+
         ctx.register("name", text(""), None, None);
+
         let gen_before = ctx.field("name").expect("exists").validation_generation;
 
         ctx.on_input("name", text("a"));
+
         let gen_after = ctx.field("name").expect("exists").validation_generation;
+
         assert_eq!(gen_after, gen_before + 1);
     }
 
     #[test]
     fn on_input_on_unregistered_field_is_noop() {
         let mut ctx = Context::new(Mode::on_submit());
+
         ctx.on_input("ghost", text("x")); // should not panic
     }
 
@@ -1084,18 +1205,21 @@ mod tests {
     #[test]
     fn on_change_on_unregistered_field_is_noop() {
         let mut ctx = Context::new(Mode::on_change());
+
         ctx.on_change("ghost", text("x")); // should not panic
     }
 
     #[test]
     fn on_blur_on_unregistered_field_is_noop() {
         let mut ctx = Context::new(Mode::on_blur_revalidate());
+
         ctx.on_blur("ghost"); // should not panic
     }
 
     #[test]
     fn set_server_errors_ignores_unknown_fields() {
         let mut ctx = Context::new(Mode::on_submit());
+
         ctx.register("name", text(""), None, None);
 
         ctx.set_server_errors([("nonexistent".to_string(), vec!["err".to_string()])]);
@@ -1109,9 +1233,11 @@ mod tests {
     #[test]
     fn field_mut_allows_mutation() {
         let mut ctx = Context::new(Mode::on_submit());
+
         ctx.register("name", text("old"), None, None);
 
         ctx.field_mut("name").expect("exists").value = text("new");
+
         assert_eq!(ctx.field("name").expect("exists").value, text("new"));
     }
 
@@ -1120,6 +1246,7 @@ mod tests {
     #[test]
     fn has_async_validators_false_by_default() {
         let ctx = Context::new(Mode::on_submit());
+
         assert!(!ctx.has_async_validators());
     }
 
@@ -1130,6 +1257,7 @@ mod tests {
         use crate::validation::{AsyncValidator, BoxedAsyncValidator};
 
         struct StubAsync;
+
         impl AsyncValidator for StubAsync {
             fn validate_async<'a>(
                 &'a self,
@@ -1141,14 +1269,19 @@ mod tests {
         }
 
         let mut ctx = Context::new(Mode::on_submit());
+
         ctx.register("email", text(""), None, None);
+
         assert!(!ctx.has_async_validators());
 
-        let boxed: BoxedAsyncValidator = std::sync::Arc::new(StubAsync);
+        let boxed: BoxedAsyncValidator = Arc::new(StubAsync);
+
         ctx.register_async_validator("email", boxed);
+
         assert!(ctx.has_async_validators());
 
         let collected = ctx.collect_async_validators();
+
         assert_eq!(collected.len(), 1);
         assert_eq!(collected[0].0, "email");
     }
@@ -1158,8 +1291,10 @@ mod tests {
     #[test]
     fn validate_all_returns_true_when_all_valid() {
         let mut ctx = Context::new(Mode::on_submit());
+
         ctx.register("name", text("Alice"), None, None);
         ctx.register("email", text("a@b.com"), None, None);
+
         assert!(ctx.validate_all());
     }
 
@@ -1168,12 +1303,15 @@ mod tests {
     #[test]
     fn reset_clears_server_errors() {
         let mut ctx = Context::new(Mode::on_submit());
+
         ctx.register("email", text(""), None, None);
 
         ctx.set_server_errors([("email".to_string(), vec!["Taken".to_string()])]);
+
         assert!(!ctx.server_errors.is_empty());
 
         ctx.reset();
+
         assert!(ctx.server_errors.is_empty());
         assert!(ctx.field("email").expect("exists").validation.is_ok());
     }
@@ -1183,7 +1321,9 @@ mod tests {
     #[test]
     fn form_data_get_bool() {
         let mut data = Data::default();
+
         data.fields.insert("agree".to_string(), Value::Bool(true));
+
         assert_eq!(data.get_bool("agree"), Some(true));
         assert_eq!(data.get_bool("missing"), None);
     }
@@ -1193,6 +1333,7 @@ mod tests {
     #[test]
     fn any_validator_boxed_wraps_correctly() {
         struct AlwaysPass;
+
         impl Validator for AlwaysPass {
             fn validate(&self, _v: &Value, _c: &ValContext) -> Result {
                 Ok(())
@@ -1200,8 +1341,11 @@ mod tests {
         }
 
         let any = AnyValidator::new(vec![crate::validation::boxed_validator(AlwaysPass)]);
+
         let boxed = any.boxed();
+
         let ctx = ValContext::standalone("test");
+
         assert!(boxed.validate(&text("x"), &ctx).is_ok());
     }
 
@@ -1210,7 +1354,9 @@ mod tests {
     #[test]
     fn debug_impl_does_not_panic() {
         let ctx = Context::new(Mode::on_submit());
+
         let debug = format!("{ctx:?}");
+
         assert!(debug.contains("Context"));
         assert!(debug.contains("<0 validators>"));
     }

--- a/crates/ars-forms/src/form/context.rs
+++ b/crates/ars-forms/src/form/context.rs
@@ -200,6 +200,13 @@ impl Validator for AnyValidator {
 /// A type-erased cross-field validation function.
 ///
 /// Uses [`Arc`](std::sync::Arc) on all targets for shared ownership.
+#[cfg(target_arch = "wasm32")]
+type CrossFieldValidateFn = Arc<dyn Fn(&Value, &ValContext) -> Result>;
+
+/// A type-erased cross-field validation function.
+///
+/// Uses [`Arc`](std::sync::Arc) on all targets for shared ownership.
+#[cfg(not(target_arch = "wasm32"))]
 type CrossFieldValidateFn = Arc<dyn Fn(&Value, &ValContext) -> Result + Send + Sync>;
 
 /// Validates a field using values from other fields in the form.
@@ -1259,6 +1266,16 @@ mod tests {
         struct StubAsync;
 
         impl AsyncValidator for StubAsync {
+            #[cfg(target_arch = "wasm32")]
+            fn validate_async<'a>(
+                &'a self,
+                _value: &'a Value,
+                _ctx: &'a ValContext<'a>,
+            ) -> Pin<Box<dyn Future<Output = Result> + 'a>> {
+                Box::pin(async { Ok(()) })
+            }
+
+            #[cfg(not(target_arch = "wasm32"))]
             fn validate_async<'a>(
                 &'a self,
                 _value: &'a Value,
@@ -1284,6 +1301,38 @@ mod tests {
 
         assert_eq!(collected.len(), 1);
         assert_eq!(collected[0].0, "email");
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    #[test]
+    #[expect(
+        clippy::arc_with_non_send_sync,
+        reason = "CrossFieldValidateFn intentionally preserves single-threaded wasm closures"
+    )]
+    fn cross_field_validator_allows_non_send_captures_on_wasm() {
+        use std::{cell::RefCell, rc::Rc};
+
+        let hits = Rc::new(RefCell::new(0_u8));
+        let validator = CrossFieldValidator {
+            depends_on: vec![String::from("password")],
+            validate_fn: Arc::new({
+                let hits = Rc::clone(&hits);
+                move |_value, _ctx| {
+                    *hits.borrow_mut() += 1;
+                    Ok(())
+                }
+            }),
+        };
+
+        assert!(
+            validator
+                .validate(
+                    &Value::Text(String::new()),
+                    &ValContext::standalone("confirm")
+                )
+                .is_ok()
+        );
+        assert_eq!(*hits.borrow(), 1);
     }
 
     // ── validate_all true path ──────────────────────────────────────────

--- a/crates/ars-forms/src/form_messages.rs
+++ b/crates/ars-forms/src/form_messages.rs
@@ -1,0 +1,217 @@
+//! Localizable messages for form submission and validation errors.
+
+use ars_core::{ComponentMessages, MessageFn};
+use ars_i18n::Locale;
+
+type LocaleMessage = dyn Fn(&Locale) -> String + Send + Sync;
+type CountLocaleMessage = dyn Fn(usize, &Locale) -> String + Send + Sync;
+type FloatLocaleMessage = dyn Fn(f64, &Locale) -> String + Send + Sync;
+
+/// Localizable messages for form component announcements and validator errors.
+///
+/// This struct follows the shared `ComponentMessages` pattern so adapters can
+/// provide a single locale-aware message bundle to all form components in a
+/// subtree while keeping English defaults available for zero-config usage.
+#[derive(Clone, Debug)]
+pub struct FormMessages {
+    /// Message announced via a status region on successful submission.
+    pub submit_success: MessageFn<LocaleMessage>,
+
+    /// Message announced via a status region when validation fails.
+    ///
+    /// Receives the number of errors found. Production adapters should use
+    /// locale-aware plural rules for this message; the built-in default is an
+    /// English-only fallback.
+    pub submit_error_count: MessageFn<CountLocaleMessage>,
+
+    /// Message used for required-field validation failures.
+    pub required_error: MessageFn<LocaleMessage>,
+
+    /// Message used when a value is shorter than the minimum length.
+    pub min_length_error: MessageFn<CountLocaleMessage>,
+
+    /// Message used when a value exceeds the maximum length.
+    pub max_length_error: MessageFn<CountLocaleMessage>,
+
+    /// Message used when a value does not match the expected pattern.
+    pub pattern_error: MessageFn<LocaleMessage>,
+
+    /// Message used when a numeric value is below the minimum.
+    pub min_error: MessageFn<FloatLocaleMessage>,
+
+    /// Message used when a numeric value exceeds the maximum.
+    pub max_error: MessageFn<FloatLocaleMessage>,
+
+    /// Message used when a value is not a valid email address.
+    pub email_error: MessageFn<LocaleMessage>,
+
+    /// Message used when a numeric value does not match the required step.
+    pub step_error: MessageFn<FloatLocaleMessage>,
+
+    /// Message used when a value is not a valid URL.
+    pub url_error: MessageFn<LocaleMessage>,
+}
+
+impl Default for FormMessages {
+    fn default() -> Self {
+        Self {
+            submit_success: MessageFn::new(|_locale: &Locale| {
+                "Form submitted successfully.".into()
+            }),
+
+            submit_error_count: MessageFn::new(|count: usize, _locale: &Locale| {
+                if count == 1 {
+                    "1 error found. Please correct the highlighted field.".into()
+                } else {
+                    format!("{count} errors found. Please correct the highlighted fields.")
+                }
+            }),
+
+            required_error: MessageFn::new(|_locale: &Locale| "This field is required".into()),
+
+            min_length_error: MessageFn::new(|min: usize, _locale: &Locale| {
+                format!("Must be at least {min} characters")
+            }),
+
+            max_length_error: MessageFn::new(|max: usize, _locale: &Locale| {
+                format!("Must be at most {max} characters")
+            }),
+
+            pattern_error: MessageFn::new(|_locale: &Locale| "Invalid format".into()),
+
+            min_error: MessageFn::new(|min: f64, _locale: &Locale| {
+                format!("Must be at least {min}")
+            }),
+
+            max_error: MessageFn::new(|max: f64, _locale: &Locale| {
+                format!("Must be at most {max}")
+            }),
+
+            email_error: MessageFn::new(|_locale: &Locale| "Must be a valid email address".into()),
+
+            step_error: MessageFn::new(|step: f64, _locale: &Locale| {
+                format!(
+                    "Please enter a valid value. The nearest allowed value is a multiple of {step}."
+                )
+            }),
+
+            url_error: MessageFn::new(|_locale: &Locale| "Please enter a valid URL.".into()),
+        }
+    }
+}
+
+impl ComponentMessages for FormMessages {}
+
+#[cfg(test)]
+mod tests {
+    use ars_i18n::locales;
+
+    use super::FormMessages;
+
+    #[test]
+    fn form_messages_default_required() {
+        let messages = FormMessages::default();
+
+        assert_eq!(
+            (messages.required_error)(&locales::en()),
+            "This field is required"
+        );
+    }
+
+    #[test]
+    fn form_messages_default_submit_error_count_singular() {
+        let messages = FormMessages::default();
+
+        assert_eq!(
+            (messages.submit_error_count)(1, &locales::en()),
+            "1 error found. Please correct the highlighted field."
+        );
+    }
+
+    #[test]
+    fn form_messages_default_submit_error_count_plural() {
+        let messages = FormMessages::default();
+
+        assert_eq!(
+            (messages.submit_error_count)(3, &locales::en()),
+            "3 errors found. Please correct the highlighted fields."
+        );
+    }
+
+    #[test]
+    fn form_messages_default_submit_success() {
+        let messages = FormMessages::default();
+
+        assert_eq!(
+            (messages.submit_success)(&locales::en()),
+            "Form submitted successfully."
+        );
+    }
+
+    #[test]
+    fn form_messages_default_max_length() {
+        let messages = FormMessages::default();
+
+        assert_eq!(
+            (messages.max_length_error)(8, &locales::en()),
+            "Must be at most 8 characters"
+        );
+    }
+
+    #[test]
+    fn form_messages_default_pattern() {
+        let messages = FormMessages::default();
+
+        assert_eq!((messages.pattern_error)(&locales::en()), "Invalid format");
+    }
+
+    #[test]
+    fn form_messages_default_min() {
+        let messages = FormMessages::default();
+
+        assert_eq!(
+            (messages.min_error)(2.5, &locales::en()),
+            "Must be at least 2.5"
+        );
+    }
+
+    #[test]
+    fn form_messages_default_max() {
+        let messages = FormMessages::default();
+
+        assert_eq!(
+            (messages.max_error)(9.5, &locales::en()),
+            "Must be at most 9.5"
+        );
+    }
+
+    #[test]
+    fn form_messages_default_email() {
+        let messages = FormMessages::default();
+
+        assert_eq!(
+            (messages.email_error)(&locales::en()),
+            "Must be a valid email address"
+        );
+    }
+
+    #[test]
+    fn form_messages_default_step() {
+        let messages = FormMessages::default();
+
+        assert_eq!(
+            (messages.step_error)(0.25, &locales::en()),
+            "Please enter a valid value. The nearest allowed value is a multiple of 0.25."
+        );
+    }
+
+    #[test]
+    fn form_messages_default_url() {
+        let messages = FormMessages::default();
+
+        assert_eq!(
+            (messages.url_error)(&locales::en()),
+            "Please enter a valid URL."
+        );
+    }
+}

--- a/crates/ars-forms/src/form_submit.rs
+++ b/crates/ars-forms/src/form_submit.rs
@@ -481,6 +481,16 @@ mod tests {
     struct DummyAsyncValidator;
 
     impl AsyncValidator for DummyAsyncValidator {
+        #[cfg(target_arch = "wasm32")]
+        fn validate_async<'a>(
+            &'a self,
+            _value: &'a Value,
+            _ctx: &'a ValidationContext<'a>,
+        ) -> Pin<Box<dyn Future<Output = ValidationResult> + 'a>> {
+            Box::pin(async { Ok(()) })
+        }
+
+        #[cfg(not(target_arch = "wasm32"))]
         fn validate_async<'a>(
             &'a self,
             _value: &'a Value,

--- a/crates/ars-forms/src/form_submit.rs
+++ b/crates/ars-forms/src/form_submit.rs
@@ -7,7 +7,14 @@
 //!
 //! [`Machine`]: ars_core::Machine
 
-use std::{collections::BTreeMap, fmt};
+use std::{
+    collections::BTreeMap,
+    fmt::{self, Debug, Display},
+    sync::{
+        Arc,
+        atomic::{self, AtomicBool},
+    },
+};
 
 use ars_core::{
     AriaAttr, AttrMap, Callback, ComponentIds, ComponentPart, ConnectApi, Env, HtmlAttr,
@@ -28,27 +35,32 @@ use crate::{
 pub enum State {
     /// Form is ready for user input.
     Idle,
+
     /// Client-side validation is running.
     Validating,
+
     /// Validation failed — errors are shown.
     ValidationFailed,
+
     /// Submission is in progress (async).
     Submitting,
+
     /// Submission succeeded.
     Succeeded,
+
     /// Submission failed (server/network error).
     Failed,
 }
 
-impl fmt::Display for State {
+impl Display for State {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            State::Idle => write!(f, "idle"),
-            State::Validating => write!(f, "validating"),
-            State::ValidationFailed => write!(f, "validation-failed"),
-            State::Submitting => write!(f, "submitting"),
-            State::Succeeded => write!(f, "succeeded"),
-            State::Failed => write!(f, "failed"),
+            Self::Idle => write!(f, "idle"),
+            Self::Validating => write!(f, "validating"),
+            Self::ValidationFailed => write!(f, "validation-failed"),
+            Self::Submitting => write!(f, "submitting"),
+            Self::Succeeded => write!(f, "succeeded"),
+            Self::Failed => write!(f, "failed"),
         }
     }
 }
@@ -62,18 +74,25 @@ impl fmt::Display for State {
 pub enum Event {
     /// User initiated submit (e.g., clicked submit button).
     Submit,
+
     /// All validators (sync + async) passed.
     ValidationPassed,
+
     /// One or more validators failed.
     ValidationFailed,
+
     /// Server submission succeeded.
     SubmitComplete,
+
     /// Server submission failed with an error message.
     SubmitError(String),
+
     /// Reset the form to initial state.
     Reset,
+
     /// Inject server-side validation errors into field state.
     SetServerErrors(BTreeMap<String, Vec<String>>),
+
     /// Update the validation mode without resetting form state.
     SetMode(Mode),
 }
@@ -87,14 +106,21 @@ pub enum Event {
 pub struct Context {
     /// The embedded form context tracking all field state.
     pub form: FormContext,
+
     /// Component IDs for accessibility attributes.
     pub ids: ComponentIds,
+
     /// Error message from a failed submission (server/network error).
     pub submit_error: Option<String>,
+
     /// Whether synchronous validation passed (used by the async-validation effect).
     pub sync_valid: bool,
     // Server errors stored in `form.server_errors` (single source of truth).
 }
+
+type SpawnAsyncValidationInput = (Vec<(String, BoxedAsyncValidator)>, WeakSend<Event>);
+type SpawnAsyncValidationFn = dyn Fn(SpawnAsyncValidationInput) -> Box<dyn FnOnce()>;
+type ScheduleMicrotaskFn = dyn Fn(Box<dyn FnOnce()>);
 
 // ────────────────────────────────────────────────────────────────────
 // Props
@@ -108,21 +134,20 @@ pub struct Context {
 pub struct Props {
     /// DOM ID for the form element.
     pub id: String,
+
     /// Validation trigger mode.
     pub validation_mode: Mode,
+
     /// Adapter-provided async spawn for running async validators concurrently.
     ///
     /// Signature: `(validators, send) -> CleanupFn`.
     /// Leptos: wraps `spawn_local`; Dioxus: wraps `spawn`.
-    #[expect(clippy::type_complexity, reason = "spec-defined callback signature")]
-    pub spawn_async_validation: Callback<
-        dyn Fn((Vec<(String, BoxedAsyncValidator)>, WeakSend<Event>)) -> Box<dyn FnOnce()>,
-    >,
+    pub spawn_async_validation: Callback<SpawnAsyncValidationFn>,
+
     /// Adapter-provided microtask scheduler for deferred event dispatch.
     ///
     /// WASM: wraps `queueMicrotask`; native: wraps `tokio::spawn` or equivalent.
-    #[expect(clippy::type_complexity, reason = "spec-defined callback signature")]
-    pub schedule_microtask: Callback<dyn Fn(Box<dyn FnOnce()>)>,
+    pub schedule_microtask: Callback<ScheduleMicrotaskFn>,
 }
 
 impl PartialEq for Props {
@@ -132,7 +157,7 @@ impl PartialEq for Props {
     }
 }
 
-impl fmt::Debug for Props {
+impl Debug for Props {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("form_submit::Props")
             .field("id", &self.id)
@@ -199,6 +224,7 @@ impl ars_core::Machine for Machine {
                         |ctx: &Context, props: &Props, send: WeakSend<Event>| {
                             if ctx.form.has_async_validators() {
                                 let validators = ctx.form.collect_async_validators();
+
                                 (props.spawn_async_validation)((validators, send))
                             } else {
                                 let event = if ctx.sync_valid {
@@ -206,30 +232,21 @@ impl ars_core::Machine for Machine {
                                 } else {
                                     Event::ValidationFailed
                                 };
-                                #[cfg(not(target_arch = "wasm32"))]
-                                let cancelled =
-                                    std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
-                                #[cfg(target_arch = "wasm32")]
-                                let cancelled = std::rc::Rc::new(std::cell::Cell::new(false));
-                                #[cfg(not(target_arch = "wasm32"))]
-                                let cancelled_clone = std::sync::Arc::clone(&cancelled);
-                                #[cfg(target_arch = "wasm32")]
-                                let cancelled_clone = std::rc::Rc::clone(&cancelled);
+
+                                let cancelled = Arc::new(AtomicBool::new(false));
+
+                                let cancelled_clone = Arc::clone(&cancelled);
+
                                 (props.schedule_microtask)(Box::new(move || {
-                                    #[cfg(not(target_arch = "wasm32"))]
                                     let is_cancelled =
-                                        cancelled_clone.load(std::sync::atomic::Ordering::Relaxed);
-                                    #[cfg(target_arch = "wasm32")]
-                                    let is_cancelled = cancelled_clone.get();
+                                        cancelled_clone.load(atomic::Ordering::Relaxed);
                                     if !is_cancelled {
                                         send.call_if_alive(event);
                                     }
                                 }));
+
                                 Box::new(move || {
-                                    #[cfg(not(target_arch = "wasm32"))]
-                                    cancelled.store(true, std::sync::atomic::Ordering::Relaxed);
-                                    #[cfg(target_arch = "wasm32")]
-                                    cancelled.set(true);
+                                    cancelled.store(true, atomic::Ordering::Relaxed);
                                 })
                             }
                         },
@@ -279,6 +296,7 @@ impl ars_core::Machine for Machine {
                     TransitionPlan::to(State::ValidationFailed).apply(move |ctx: &mut Context| {
                         ctx.form.is_submitting = false;
                         ctx.submit_error = None;
+
                         ctx.form.set_server_errors(errors);
                     }),
                 )
@@ -292,6 +310,7 @@ impl ars_core::Machine for Machine {
                         .cancel_effect("submit")
                         .apply(move |ctx: &mut Context| {
                             ctx.form.reset();
+
                             ctx.form.validation_mode = mode;
                             ctx.submit_error = None;
                         }),
@@ -343,6 +362,7 @@ impl ars_core::Machine for Machine {
 pub enum Part {
     /// The root `<form>` element.
     Root,
+
     /// The submit button element.
     SubmitButton,
 }
@@ -358,7 +378,7 @@ pub struct Api<'a> {
     send: &'a dyn Fn(Event),
 }
 
-impl fmt::Debug for Api<'_> {
+impl Debug for Api<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("form_submit::Api")
             .field("state", &self.state)
@@ -400,11 +420,15 @@ impl<'a> Api<'a> {
     #[must_use]
     pub fn root_attrs(&self) -> AttrMap {
         let mut attrs = AttrMap::new();
+
         attrs.set(HtmlAttr::Id, self.ctx.ids.id());
+
         let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Root.data_attrs();
+
         attrs.set(scope_attr, scope_val);
         attrs.set(part_attr, part_val);
         attrs.set(HtmlAttr::Data("ars-state"), self.state.to_string());
+
         attrs
     }
 
@@ -417,14 +441,18 @@ impl<'a> Api<'a> {
     #[must_use]
     pub fn submit_button_attrs(&self) -> AttrMap {
         let mut attrs = AttrMap::new();
+
         let [(scope_attr, scope_val), (part_attr, part_val)] = Part::SubmitButton.data_attrs();
+
         attrs.set(scope_attr, scope_val);
         attrs.set(part_attr, part_val);
+
         if self.is_submitting() {
             attrs.set(HtmlAttr::Aria(AriaAttr::Busy), "true");
             attrs.set(HtmlAttr::Aria(AriaAttr::Disabled), "true");
             attrs.set_bool(HtmlAttr::Disabled, true);
         }
+
         attrs
     }
 }
@@ -435,10 +463,49 @@ impl<'a> Api<'a> {
 
 #[cfg(test)]
 mod tests {
+    use core::pin::Pin;
+    use std::sync::{Arc, Mutex};
+
     // Import Machine trait for on_props_changed.
-    use ars_core::{Machine as _, Service, callback};
+    use ars_core::{Machine as _, Service, StrongSend, callback};
 
     use super::*;
+    use crate::{
+        field::Value,
+        validation::{
+            AsyncValidator, Context as ValidationContext, Error, ErrorCode, Errors,
+            Result as ValidationResult, Validator, boxed_validator,
+        },
+    };
+
+    struct DummyAsyncValidator;
+
+    impl AsyncValidator for DummyAsyncValidator {
+        fn validate_async<'a>(
+            &'a self,
+            _value: &'a Value,
+            _ctx: &'a ValidationContext<'a>,
+        ) -> Pin<Box<dyn Future<Output = ValidationResult> + Send + 'a>> {
+            Box::pin(async { Ok(()) })
+        }
+    }
+
+    struct RequiredValidator;
+
+    impl Validator for RequiredValidator {
+        fn validate(&self, value: &Value, _ctx: &ValidationContext) -> ValidationResult {
+            if let Some(text) = value.as_text()
+                && text.trim().is_empty()
+            {
+                Err(Errors(vec![Error {
+                    code: ErrorCode::Required,
+                    message: "required".to_string(),
+                }]))
+            } else {
+                Ok(())
+            }
+        }
+    }
 
     /// Helper to construct Props with no-op callbacks for testing.
     fn test_props() -> Props {
@@ -459,17 +526,48 @@ mod tests {
     #[test]
     fn init_state_is_idle() {
         let service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
         assert_eq!(service.state(), &State::Idle);
         assert!(service.context().submit_error.is_none());
         assert!(!service.context().sync_valid);
     }
 
     #[test]
+    fn props_partial_eq_ignores_callback_identity() {
+        let props_a = test_props();
+
+        let props_b = Props {
+            id: props_a.id.clone(),
+            validation_mode: props_a.validation_mode,
+            spawn_async_validation: callback(
+                |_: (Vec<(String, BoxedAsyncValidator)>, WeakSend<Event>)| -> Box<dyn FnOnce()> {
+                    Box::new(|| {})
+                },
+            ),
+            schedule_microtask: callback(|_: Box<dyn FnOnce()>| {}),
+        };
+
+        assert_eq!(props_a, props_b);
+    }
+
+    #[test]
+    fn props_debug_includes_public_configuration() {
+        let debug = format!("{:?}", test_props());
+
+        assert!(debug.contains("form_submit::Props"));
+        assert!(debug.contains("test-form"));
+        assert!(debug.contains("validation_mode"));
+    }
+
+    #[test]
     fn submit_from_idle_transitions_to_validating() {
         let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
         let result = service.send(Event::Submit);
+
         assert!(result.state_changed);
         assert_eq!(service.state(), &State::Validating);
+
         // Should have "async-validation" effect
         assert_eq!(result.pending_effects.len(), 1);
         assert_eq!(result.pending_effects[0].name, "async-validation");
@@ -478,11 +576,14 @@ mod tests {
     #[test]
     fn submit_from_validation_failed_transitions_to_validating() {
         let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
         drop(service.send(Event::Submit));
         drop(service.send(Event::ValidationFailed));
+
         assert_eq!(service.state(), &State::ValidationFailed);
 
         let result = service.send(Event::Submit);
+
         assert!(result.state_changed);
         assert_eq!(service.state(), &State::Validating);
     }
@@ -490,12 +591,15 @@ mod tests {
     #[test]
     fn submit_from_failed_transitions_to_validating() {
         let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
         drop(service.send(Event::Submit));
         drop(service.send(Event::ValidationPassed));
         drop(service.send(Event::SubmitError("server error".into())));
+
         assert_eq!(service.state(), &State::Failed);
 
         let result = service.send(Event::Submit);
+
         assert!(result.state_changed);
         assert_eq!(service.state(), &State::Validating);
     }
@@ -503,12 +607,15 @@ mod tests {
     #[test]
     fn submit_from_succeeded_transitions_to_validating() {
         let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
         drop(service.send(Event::Submit));
         drop(service.send(Event::ValidationPassed));
         drop(service.send(Event::SubmitComplete));
+
         assert_eq!(service.state(), &State::Succeeded);
 
         let result = service.send(Event::Submit);
+
         assert!(result.state_changed);
         assert_eq!(service.state(), &State::Validating);
     }
@@ -516,10 +623,13 @@ mod tests {
     #[test]
     fn submit_from_validating_is_ignored() {
         let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
         drop(service.send(Event::Submit));
+
         assert_eq!(service.state(), &State::Validating);
 
         let result = service.send(Event::Submit);
+
         assert!(!result.state_changed);
         assert_eq!(service.state(), &State::Validating);
     }
@@ -527,11 +637,14 @@ mod tests {
     #[test]
     fn submit_from_submitting_is_ignored() {
         let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
         drop(service.send(Event::Submit));
         drop(service.send(Event::ValidationPassed));
+
         assert_eq!(service.state(), &State::Submitting);
 
         let result = service.send(Event::Submit);
+
         assert!(!result.state_changed);
         assert_eq!(service.state(), &State::Submitting);
     }
@@ -539,9 +652,11 @@ mod tests {
     #[test]
     fn validation_passed_transitions_to_submitting() {
         let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
         drop(service.send(Event::Submit));
 
         let result = service.send(Event::ValidationPassed);
+
         assert!(result.state_changed);
         assert_eq!(service.state(), &State::Submitting);
         assert!(service.context().form.is_submitting);
@@ -552,9 +667,11 @@ mod tests {
     #[test]
     fn validation_failed_transitions_to_validation_failed() {
         let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
         drop(service.send(Event::Submit));
 
         let result = service.send(Event::ValidationFailed);
+
         assert!(result.state_changed);
         assert_eq!(service.state(), &State::ValidationFailed);
         assert!(!service.context().sync_valid);
@@ -563,10 +680,12 @@ mod tests {
     #[test]
     fn submit_complete_transitions_to_succeeded() {
         let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
         drop(service.send(Event::Submit));
         drop(service.send(Event::ValidationPassed));
 
         let result = service.send(Event::SubmitComplete);
+
         assert!(result.state_changed);
         assert_eq!(service.state(), &State::Succeeded);
         assert!(!service.context().form.is_submitting);
@@ -576,10 +695,12 @@ mod tests {
     #[test]
     fn submit_error_transitions_to_failed() {
         let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
         drop(service.send(Event::Submit));
         drop(service.send(Event::ValidationPassed));
 
         let result = service.send(Event::SubmitError("server down".into()));
+
         assert!(result.state_changed);
         assert_eq!(service.state(), &State::Failed);
         assert!(!service.context().form.is_submitting);
@@ -594,15 +715,15 @@ mod tests {
     #[test]
     fn set_server_errors_from_idle_transitions_to_validation_failed() {
         let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
         // Register a field so set_server_errors has something to inject into.
-        service.context_mut().form.register(
-            "email",
-            crate::field::Value::Text(String::new()),
-            None,
-            None,
-        );
+        service
+            .context_mut()
+            .form
+            .register("email", Value::Text(String::new()), None, None);
 
         let errors = BTreeMap::from([("email".into(), vec!["Already registered".into()])]);
+
         let result = service.send(Event::SetServerErrors(errors));
 
         assert!(result.state_changed);
@@ -613,11 +734,14 @@ mod tests {
     #[test]
     fn set_server_errors_from_submitting_clears_is_submitting() {
         let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
         drop(service.send(Event::Submit));
         drop(service.send(Event::ValidationPassed));
+
         assert!(service.context().form.is_submitting);
 
         let errors = BTreeMap::from([("email".into(), vec!["Taken".into()])]);
+
         drop(service.send(Event::SetServerErrors(errors)));
 
         assert_eq!(service.state(), &State::ValidationFailed);
@@ -629,13 +753,16 @@ mod tests {
     #[test]
     fn reset_transitions_to_idle_and_cancels_effects() {
         let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
         drop(service.send(Event::Submit));
         drop(service.send(Event::ValidationPassed));
         drop(service.send(Event::SubmitError("err".into())));
+
         assert_eq!(service.state(), &State::Failed);
         assert!(service.context().submit_error.is_some());
 
         let result = service.send(Event::Reset);
+
         assert!(result.state_changed);
         assert_eq!(service.state(), &State::Idle);
         assert!(service.context().submit_error.is_none());
@@ -647,7 +774,9 @@ mod tests {
     #[test]
     fn set_mode_updates_context_only() {
         let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
         let result = service.send(Event::SetMode(Mode::on_change()));
+
         assert!(!result.state_changed);
         assert!(result.context_changed);
         assert_eq!(service.context().form.validation_mode, Mode::on_change());
@@ -664,6 +793,7 @@ mod tests {
                 ..test_props()
             },
         );
+
         assert_eq!(events.len(), 1);
         assert!(matches!(events[0], Event::SetMode(_)));
     }
@@ -671,32 +801,68 @@ mod tests {
     #[test]
     fn on_props_changed_emits_nothing_when_mode_same() {
         let events = Machine::on_props_changed(&test_props(), &test_props());
+
         assert!(events.is_empty());
     }
 
     // --- Connect API tests ---
 
     #[test]
+    fn api_debug_is_stable() {
+        let service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        let noop = |_: Event| {};
+
+        let debug = format!("{:?}", service.connect(&noop));
+
+        assert!(debug.contains("form_submit::Api"));
+        assert!(debug.contains("Idle"));
+    }
+
+    #[test]
     fn api_is_submitting_reflects_state() {
         let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
         let noop = |_: Event| {};
 
         let api = service.connect(&noop);
+
         assert!(!api.is_submitting());
 
         drop(service.send(Event::Submit));
         drop(service.send(Event::ValidationPassed));
 
         let api = service.connect(&noop);
+
         assert!(api.is_submitting());
+    }
+
+    #[test]
+    fn api_is_valid_reflects_form_context() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        service.context_mut().form.register(
+            "email",
+            Value::Text(String::new()),
+            Some(boxed_validator(RequiredValidator)),
+            None,
+        );
+
+        let _ = service.context_mut().form.validate_all();
+
+        let noop = |_: Event| {};
+
+        assert!(!service.connect(&noop).is_valid());
     }
 
     #[test]
     fn api_submit_error_reflects_context() {
         let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
         let noop = |_: Event| {};
 
         let api = service.connect(&noop);
+
         assert!(api.submit_error().is_none());
 
         drop(service.send(Event::Submit));
@@ -704,14 +870,18 @@ mod tests {
         drop(service.send(Event::SubmitError("oops".into())));
 
         let api = service.connect(&noop);
+
         assert_eq!(api.submit_error(), Some("oops"));
     }
 
     #[test]
     fn api_root_attrs_contain_required_fields() {
         let service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
         let noop = |_: Event| {};
+
         let api = service.connect(&noop);
+
         let attrs = api.root_attrs();
 
         assert_eq!(attrs.get(&HtmlAttr::Id).unwrap(), "test-form");
@@ -726,11 +896,14 @@ mod tests {
     #[test]
     fn api_submit_button_attrs_disabled_when_submitting() {
         let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
         drop(service.send(Event::Submit));
         drop(service.send(Event::ValidationPassed));
 
         let noop = |_: Event| {};
+
         let api = service.connect(&noop);
+
         let attrs = api.submit_button_attrs();
 
         assert_eq!(attrs.get(&HtmlAttr::Aria(AriaAttr::Busy)).unwrap(), "true");
@@ -744,12 +917,30 @@ mod tests {
     #[test]
     fn api_submit_button_attrs_not_disabled_when_idle() {
         let service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
         let noop = |_: Event| {};
+
         let api = service.connect(&noop);
+
         let attrs = api.submit_button_attrs();
 
         assert!(attrs.get(&HtmlAttr::Aria(AriaAttr::Busy)).is_none());
         assert!(attrs.get(&HtmlAttr::Disabled).is_none());
+    }
+
+    #[test]
+    fn api_part_attrs_delegate_to_part_specific_helpers() {
+        let service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        let noop = |_: Event| {};
+
+        let api = service.connect(&noop);
+
+        assert_eq!(api.part_attrs(Part::Root), api.root_attrs());
+        assert_eq!(
+            api.part_attrs(Part::SubmitButton),
+            api.submit_button_attrs()
+        );
     }
 
     // --- Context mutation verification ---
@@ -757,20 +948,20 @@ mod tests {
     #[test]
     fn submit_touches_all_fields_and_runs_validation() {
         let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
         // Register two fields — neither is touched initially.
-        service.context_mut().form.register(
-            "email",
-            crate::field::Value::Text(String::new()),
-            None,
-            None,
-        );
-        service.context_mut().form.register(
-            "name",
-            crate::field::Value::Text(String::new()),
-            None,
-            None,
-        );
+        service
+            .context_mut()
+            .form
+            .register("email", Value::Text(String::new()), None, None);
+
+        service
+            .context_mut()
+            .form
+            .register("name", Value::Text(String::new()), None, None);
+
         assert!(!service.context().form.fields.get("email").unwrap().touched);
+
         assert!(!service.context().form.fields.get("name").unwrap().touched);
 
         drop(service.send(Event::Submit));
@@ -778,6 +969,7 @@ mod tests {
         // Both fields should be touched after submit.
         assert!(service.context().form.fields.get("email").unwrap().touched);
         assert!(service.context().form.fields.get("name").unwrap().touched);
+
         // sync_valid should be true (no validators registered → all pass).
         assert!(service.context().sync_valid);
     }
@@ -787,10 +979,11 @@ mod tests {
         use crate::validation::{Error, ErrorCode, Errors, Validator, boxed_validator};
 
         struct AlwaysFail;
+
         impl Validator for AlwaysFail {
             fn validate(
                 &self,
-                _value: &crate::field::Value,
+                _value: &Value,
                 _ctx: &crate::validation::Context<'_>,
             ) -> crate::validation::Result {
                 Err(Errors(vec![Error {
@@ -801,9 +994,10 @@ mod tests {
         }
 
         let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
         service.context_mut().form.register(
             "email",
-            crate::field::Value::Text(String::new()),
+            Value::Text(String::new()),
             Some(boxed_validator(AlwaysFail)),
             None,
         );
@@ -816,26 +1010,33 @@ mod tests {
     #[test]
     fn submit_from_failed_clears_stale_error() {
         let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
         drop(service.send(Event::Submit));
         drop(service.send(Event::ValidationPassed));
         drop(service.send(Event::SubmitError("old error".into())));
+
         assert_eq!(service.context().submit_error.as_deref(), Some("old error"));
 
         // Re-submit should clear the stale error.
         drop(service.send(Event::Submit));
+
         assert!(service.context().submit_error.is_none());
     }
 
     #[test]
     fn set_server_errors_clears_submit_error() {
         let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
         drop(service.send(Event::Submit));
         drop(service.send(Event::ValidationPassed));
         drop(service.send(Event::SubmitError("network failure".into())));
+
         assert!(service.context().submit_error.is_some());
 
         let errors = BTreeMap::from([("email".into(), vec!["Taken".into()])]);
+
         drop(service.send(Event::SetServerErrors(errors)));
+
         assert!(service.context().submit_error.is_none());
     }
 
@@ -844,8 +1045,10 @@ mod tests {
     #[test]
     fn validation_passed_ignored_outside_validating() {
         let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
         // From Idle — should be ignored.
         let result = service.send(Event::ValidationPassed);
+
         assert!(!result.state_changed);
         assert_eq!(service.state(), &State::Idle);
     }
@@ -853,7 +1056,9 @@ mod tests {
     #[test]
     fn submit_complete_ignored_outside_submitting() {
         let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
         let result = service.send(Event::SubmitComplete);
+
         assert!(!result.state_changed);
         assert_eq!(service.state(), &State::Idle);
     }
@@ -861,7 +1066,9 @@ mod tests {
     #[test]
     fn submit_error_ignored_outside_submitting() {
         let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
         let result = service.send(Event::SubmitError("err".into()));
+
         assert!(!result.state_changed);
         assert_eq!(service.state(), &State::Idle);
     }
@@ -881,17 +1088,22 @@ mod tests {
     #[test]
     fn root_attrs_state_reflects_current_state() {
         let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
         let noop = |_: Event| {};
 
         drop(service.send(Event::Submit));
+
         let attrs = service.connect(&noop).root_attrs();
+
         assert_eq!(
             attrs.get(&HtmlAttr::Data("ars-state")).unwrap(),
             "validating"
         );
 
         drop(service.send(Event::ValidationPassed));
+
         let attrs = service.connect(&noop).root_attrs();
+
         assert_eq!(
             attrs.get(&HtmlAttr::Data("ars-state")).unwrap(),
             "submitting"
@@ -901,7 +1113,9 @@ mod tests {
     #[test]
     fn submit_button_attrs_contain_scope_and_part() {
         let service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
         let noop = |_: Event| {};
+
         let attrs = service.connect(&noop).submit_button_attrs();
 
         assert_eq!(
@@ -914,21 +1128,182 @@ mod tests {
         );
     }
 
+    #[test]
+    fn submit_effect_runs_with_noop_cleanup() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        drop(service.send(Event::Submit));
+
+        let result = service.send(Event::ValidationPassed);
+
+        let effect = result.pending_effects.into_iter().next().unwrap();
+
+        let send: StrongSend<Event> = Arc::new(|_| {});
+
+        let cleanup = effect.run(service.context(), service.props(), send);
+
+        cleanup();
+    }
+
+    #[test]
+    fn async_validation_effect_with_async_validators_uses_spawn_callback() {
+        let observed = Arc::new(Mutex::new(0usize));
+
+        let props = Props {
+            id: "test-form".into(),
+            validation_mode: Mode::on_submit(),
+            spawn_async_validation: callback({
+                let observed = Arc::clone(&observed);
+                move |(validators, _send): (Vec<(String, BoxedAsyncValidator)>, WeakSend<Event>)| -> Box<dyn FnOnce()> {
+                    *observed.lock().unwrap() = validators.len();
+                    Box::new(|| {})
+                }
+            }),
+            schedule_microtask: callback(|_: Box<dyn FnOnce()>| {}),
+        };
+
+        let mut service = Service::<Machine>::new(props, &Env::default(), &());
+
+        service
+            .context_mut()
+            .form
+            .register("email", Value::Text("ok".into()), None, None);
+
+        service
+            .context_mut()
+            .form
+            .register_async_validator("email", Arc::new(DummyAsyncValidator));
+
+        let result = service.send(Event::Submit);
+
+        let effect = result.pending_effects.into_iter().next().unwrap();
+
+        let send: StrongSend<Event> = Arc::new(|_| {});
+
+        let cleanup = effect.run(service.context(), service.props(), send);
+
+        assert_eq!(*observed.lock().unwrap(), 1);
+
+        cleanup();
+    }
+
+    #[test]
+    fn async_validation_effect_with_async_validators_runs_default_spawn_helper() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        service
+            .context_mut()
+            .form
+            .register("email", Value::Text("ok".into()), None, None);
+
+        service
+            .context_mut()
+            .form
+            .register_async_validator("email", Arc::new(DummyAsyncValidator));
+
+        let result = service.send(Event::Submit);
+
+        let effect = result.pending_effects.into_iter().next().unwrap();
+
+        let send: StrongSend<Event> = Arc::new(|_| {});
+
+        let cleanup = effect.run(service.context(), service.props(), send);
+
+        cleanup();
+    }
+
+    #[test]
+    fn async_validation_effect_without_async_validators_schedules_validation_passed() {
+        let observed = Arc::new(Mutex::new(Vec::new()));
+
+        let props = Props {
+            id: "test-form".into(),
+            validation_mode: Mode::on_submit(),
+            spawn_async_validation: test_props().spawn_async_validation,
+            schedule_microtask: callback(|task: Box<dyn FnOnce()>| task()),
+        };
+
+        let mut service = Service::<Machine>::new(props, &Env::default(), &());
+
+        let result = service.send(Event::Submit);
+
+        let effect = result.pending_effects.into_iter().next().unwrap();
+
+        let send: StrongSend<Event> = Arc::new({
+            let observed = Arc::clone(&observed);
+
+            move |event| observed.lock().unwrap().push(event)
+        });
+
+        let cleanup = effect.run(service.context(), service.props(), send);
+
+        assert!(matches!(
+            observed.lock().unwrap().as_slice(),
+            [Event::ValidationPassed]
+        ));
+
+        cleanup();
+    }
+
+    #[test]
+    fn async_validation_effect_without_async_validators_schedules_validation_failed() {
+        let observed = Arc::new(Mutex::new(Vec::new()));
+
+        let props = Props {
+            id: "test-form".into(),
+            validation_mode: Mode::on_submit(),
+            spawn_async_validation: test_props().spawn_async_validation,
+            schedule_microtask: callback(|task: Box<dyn FnOnce()>| task()),
+        };
+
+        let mut service = Service::<Machine>::new(props, &Env::default(), &());
+
+        service.context_mut().form.register(
+            "email",
+            Value::Text(String::new()),
+            Some(boxed_validator(RequiredValidator)),
+            None,
+        );
+
+        let result = service.send(Event::Submit);
+
+        let effect = result.pending_effects.into_iter().next().unwrap();
+
+        let send: StrongSend<Event> = Arc::new({
+            let observed = Arc::clone(&observed);
+
+            move |event| observed.lock().unwrap().push(event)
+        });
+
+        let cleanup = effect.run(service.context(), service.props(), send);
+
+        assert!(matches!(
+            observed.lock().unwrap().as_slice(),
+            [Event::ValidationFailed]
+        ));
+
+        cleanup();
+    }
+
     // --- Lifecycle integration ---
 
     #[test]
     fn full_happy_path_lifecycle() {
         let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
         assert_eq!(service.state(), &State::Idle);
 
         drop(service.send(Event::Submit));
+
         assert_eq!(service.state(), &State::Validating);
 
         drop(service.send(Event::ValidationPassed));
+
         assert_eq!(service.state(), &State::Submitting);
         assert!(service.context().form.is_submitting);
 
         drop(service.send(Event::SubmitComplete));
+
         assert_eq!(service.state(), &State::Succeeded);
         assert!(!service.context().form.is_submitting);
     }
@@ -941,26 +1316,32 @@ mod tests {
         drop(service.send(Event::Submit));
         drop(service.send(Event::ValidationPassed));
         drop(service.send(Event::SubmitError("timeout".into())));
+
         assert_eq!(service.state(), &State::Failed);
         assert_eq!(service.context().submit_error.as_deref(), Some("timeout"));
 
         // Retry succeeds.
         drop(service.send(Event::Submit));
+
         assert!(service.context().submit_error.is_none()); // cleared on re-submit
+
         drop(service.send(Event::ValidationPassed));
         drop(service.send(Event::SubmitComplete));
+
         assert_eq!(service.state(), &State::Succeeded);
     }
 
     #[test]
     fn set_props_updates_mode_through_service() {
         let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
         assert_eq!(service.context().form.validation_mode, Mode::on_submit());
 
         let result = service.set_props(Props {
             validation_mode: Mode::on_change(),
             ..test_props()
         });
+
         assert!(result.context_changed);
         assert_eq!(service.context().form.validation_mode, Mode::on_change());
     }
@@ -970,10 +1351,13 @@ mod tests {
     #[test]
     fn reset_from_validating_cancels_async_validation() {
         let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
         drop(service.send(Event::Submit));
+
         assert_eq!(service.state(), &State::Validating);
 
         let result = service.send(Event::Reset);
+
         assert_eq!(service.state(), &State::Idle);
         assert!(result.cancel_effects.contains(&"async-validation"));
     }
@@ -981,11 +1365,14 @@ mod tests {
     #[test]
     fn reset_from_submitting_cancels_submit() {
         let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
         drop(service.send(Event::Submit));
         drop(service.send(Event::ValidationPassed));
+
         assert_eq!(service.state(), &State::Submitting);
 
         let result = service.send(Event::Reset);
+
         assert_eq!(service.state(), &State::Idle);
         assert!(result.cancel_effects.contains(&"submit"));
         assert!(!service.context().form.is_submitting);
@@ -994,19 +1381,25 @@ mod tests {
     #[test]
     fn on_form_submit_dispatches_submit_event() {
         let service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
         let called = std::cell::Cell::new(false);
+
         let send_fn = |e: Event| {
             assert!(matches!(e, Event::Submit));
             called.set(true);
         };
+
         let api = service.connect(&send_fn);
+
         api.on_form_submit();
+
         assert!(called.get());
     }
 
     #[test]
     fn init_context_has_correct_component_ids() {
         let service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
         assert_eq!(service.context().ids.id(), "test-form");
     }
 }

--- a/crates/ars-forms/src/lib.rs
+++ b/crates/ars-forms/src/lib.rs
@@ -14,11 +14,13 @@
 //!   [`validation::AsyncValidator`]
 //! - **[`form`]** — [`form::Context`], [`form::Data`], [`form::Mode`],
 //!   [`form::CrossFieldValidator`], [`form::AnyValidator`]
+//! - **[`form_messages`]** — [`form_messages::FormMessages`]
 //! - **[`hidden_input`]** — [`hidden_input::Config`], [`hidden_input::Value`],
 //!   [`hidden_input::attrs()`], [`hidden_input::multi_attrs()`]
 
 pub mod field;
 pub mod form;
+pub mod form_messages;
 pub mod form_submit;
 pub mod hidden_input;
 pub mod validation;

--- a/crates/ars-forms/src/validation/async_validator.rs
+++ b/crates/ars-forms/src/validation/async_validator.rs
@@ -10,23 +10,44 @@ use std::{pin::Pin, sync::Arc};
 use super::{result::Result, validator::Context};
 use crate::field::Value;
 
+#[cfg(target_arch = "wasm32")]
+type AsyncValidationFuture<'a> = dyn Future<Output = Result> + 'a;
+
+#[cfg(not(target_arch = "wasm32"))]
+type AsyncValidationFuture<'a> = dyn Future<Output = Result> + Send + 'a;
+
 /// Async validation trait.
 ///
-/// Async validators are always `Send + Sync`, and returned futures are always
-/// `Send`, so the same trait object shape works on every target.
+/// Native targets require async validators and their returned futures to be
+/// `Send + Sync`; `wasm32` preserves single-threaded browser futures.
+#[cfg(target_arch = "wasm32")]
+pub trait AsyncValidator {
+    /// Validates the given value asynchronously.
+    fn validate_async<'a>(
+        &'a self,
+        value: &'a Value,
+        ctx: &'a Context<'a>,
+    ) -> Pin<Box<AsyncValidationFuture<'a>>>;
+}
+
+/// Async validation trait.
+///
+/// Native targets require async validators and their returned futures to be
+/// `Send + Sync`; `wasm32` preserves single-threaded browser futures.
+#[cfg(not(target_arch = "wasm32"))]
 pub trait AsyncValidator: Send + Sync {
     /// Validates the given value asynchronously.
     fn validate_async<'a>(
         &'a self,
         value: &'a Value,
         ctx: &'a Context<'a>,
-    ) -> Pin<Box<dyn Future<Output = Result> + Send + 'a>>;
+    ) -> Pin<Box<AsyncValidationFuture<'a>>>;
 }
 
 /// A type-erased async validator.
 ///
 /// Uses [`Arc`](std::sync::Arc) on all targets for cheap shared ownership.
-pub type BoxedAsyncValidator = Arc<dyn AsyncValidator + Send + Sync>;
+pub type BoxedAsyncValidator = Arc<dyn AsyncValidator>;
 
 #[cfg(test)]
 mod tests {
@@ -69,7 +90,7 @@ mod tests {
             &'a self,
             _value: &'a Value,
             _ctx: &'a Context<'a>,
-        ) -> Pin<Box<dyn Future<Output = Result> + Send + 'a>> {
+        ) -> Pin<Box<AsyncValidationFuture<'a>>> {
             Box::pin(async { Ok(()) })
         }
     }
@@ -90,5 +111,47 @@ mod tests {
         let result = block_on_ready(validator.validate_async(&value, &ctx));
 
         assert_eq!(result, Ok(()));
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    #[test]
+    #[expect(
+        clippy::arc_with_non_send_sync,
+        reason = "BoxedAsyncValidator intentionally preserves single-threaded wasm validators"
+    )]
+    fn boxed_async_validator_allows_non_send_futures_on_wasm() {
+        use std::{cell::RefCell, rc::Rc};
+
+        struct RcAsyncValidator {
+            hits: Rc<RefCell<u8>>,
+        }
+
+        impl AsyncValidator for RcAsyncValidator {
+            fn validate_async<'a>(
+                &'a self,
+                _value: &'a Value,
+                _ctx: &'a Context<'a>,
+            ) -> Pin<Box<AsyncValidationFuture<'a>>> {
+                let hits = Rc::clone(&self.hits);
+                Box::pin(async move {
+                    *hits.borrow_mut() += 1;
+                    Ok(())
+                })
+            }
+        }
+
+        let hits = Rc::new(RefCell::new(0));
+        let validator: BoxedAsyncValidator = Arc::new(RcAsyncValidator {
+            hits: Rc::clone(&hits),
+        });
+
+        let value = Value::Text(String::from("hello"));
+        let ctx = Context::standalone("email");
+
+        assert_eq!(
+            block_on_ready(validator.validate_async(&value, &ctx)),
+            Ok(())
+        );
+        assert_eq!(*hits.borrow(), 1);
     }
 }

--- a/crates/ars-forms/src/validation/async_validator.rs
+++ b/crates/ars-forms/src/validation/async_validator.rs
@@ -5,14 +5,15 @@
 //! [`FormContext`](crate::FormContext) to support async validation (e.g.,
 //! server-side uniqueness checks).
 
-use core::pin::Pin;
+use std::{pin::Pin, sync::Arc};
 
 use super::{result::Result, validator::Context};
 use crate::field::Value;
 
-/// Async validation trait. On non-WASM targets, returned futures must be `Send`.
-/// On WASM (single-threaded), the `Send` bound is relaxed.
-#[cfg(not(target_arch = "wasm32"))]
+/// Async validation trait.
+///
+/// Async validators are always `Send + Sync`, and returned futures are always
+/// `Send`, so the same trait object shape works on every target.
 pub trait AsyncValidator: Send + Sync {
     /// Validates the given value asynchronously.
     fn validate_async<'a>(
@@ -22,30 +23,43 @@ pub trait AsyncValidator: Send + Sync {
     ) -> Pin<Box<dyn Future<Output = Result> + Send + 'a>>;
 }
 
-/// Async validation trait (WASM variant without `Send` bounds).
-#[cfg(target_arch = "wasm32")]
-pub trait AsyncValidator {
-    /// Validates the given value asynchronously.
-    fn validate_async<'a>(
-        &'a self,
-        value: &'a Value,
-        ctx: &'a Context<'a>,
-    ) -> Pin<Box<dyn Future<Output = Result> + 'a>>;
-}
-
 /// A type-erased async validator.
 ///
-/// Uses `Arc` on native targets for thread-safe sharing, `Rc` on WASM.
-#[cfg(not(target_arch = "wasm32"))]
-pub type BoxedAsyncValidator = std::sync::Arc<dyn AsyncValidator + Send + Sync>;
-
-/// A type-erased async validator (WASM variant using `Rc`).
-#[cfg(target_arch = "wasm32")]
-pub type BoxedAsyncValidator = std::rc::Rc<dyn AsyncValidator>;
+/// Uses [`Arc`](std::sync::Arc) on all targets for cheap shared ownership.
+pub type BoxedAsyncValidator = Arc<dyn AsyncValidator + Send + Sync>;
 
 #[cfg(test)]
 mod tests {
+    use core::{
+        pin::Pin,
+        task::{Context as TaskContext, Poll, Waker},
+    };
+    use std::{sync::Arc, task::Wake};
+
     use super::*;
+    use crate::field::Value;
+
+    struct NoopWake;
+
+    impl Wake for NoopWake {
+        fn wake(self: Arc<Self>) {}
+    }
+
+    fn block_on_ready<F>(future: F) -> F::Output
+    where
+        F: Future,
+    {
+        let waker = Waker::from(Arc::new(NoopWake));
+
+        let mut context = TaskContext::from_waker(&waker);
+
+        let mut future = Pin::from(Box::new(future));
+
+        match Future::poll(future.as_mut(), &mut context) {
+            Poll::Ready(output) => output,
+            Poll::Pending => panic!("test future unexpectedly pending"),
+        }
+    }
 
     /// Verifies that `BoxedAsyncValidator` can hold a trait object.
     struct AlwaysValidAsync;
@@ -62,6 +76,19 @@ mod tests {
 
     #[test]
     fn async_validator_trait_object_compiles() {
-        let _boxed: BoxedAsyncValidator = std::sync::Arc::new(AlwaysValidAsync);
+        let _boxed: BoxedAsyncValidator = Arc::new(AlwaysValidAsync);
+    }
+
+    #[test]
+    fn async_validator_validate_async_returns_ok() {
+        let validator = AlwaysValidAsync;
+
+        let value = Value::Text("hello".to_string());
+
+        let ctx = Context::standalone("email");
+
+        let result = block_on_ready(validator.validate_async(&value, &ctx));
+
+        assert_eq!(result, Ok(()));
     }
 }

--- a/crates/ars-forms/src/validation/error.rs
+++ b/crates/ars-forms/src/validation/error.rs
@@ -43,10 +43,10 @@ impl Error {
     }
 
     /// Creates a pattern validation error with a localized message.
-    pub fn pattern(messages: &FormMessages, locale: &Locale) -> Self {
+    pub fn pattern(pattern: impl Into<String>, messages: &FormMessages, locale: &Locale) -> Self {
         Self {
             message: (messages.pattern_error)(locale),
-            code: ErrorCode::Pattern(String::new()),
+            code: ErrorCode::Pattern(pattern.into()),
         }
     }
 
@@ -322,10 +322,22 @@ mod tests {
 
     #[test]
     fn error_pattern_factory() {
-        let err = Error::pattern(&FormMessages::default(), &locales::en());
+        let err = Error::pattern(r"^[a-z]+$", &FormMessages::default(), &locales::en());
 
         assert_eq!(err.message, "Invalid format");
-        assert_eq!(err.code, ErrorCode::Pattern(String::new()));
+        assert_eq!(err.code, ErrorCode::Pattern(String::from(r"^[a-z]+$")));
+    }
+
+    #[test]
+    fn validation_errors_has_code_matches_pattern_payload() {
+        let pattern = String::from(r"^[a-z]+$");
+        let errors = Errors(vec![Error::pattern(
+            pattern.clone(),
+            &FormMessages::default(),
+            &locales::en(),
+        )]);
+
+        assert!(errors.has_code(&ErrorCode::Pattern(pattern)));
     }
 
     #[test]

--- a/crates/ars-forms/src/validation/error.rs
+++ b/crates/ars-forms/src/validation/error.rs
@@ -3,16 +3,93 @@
 //! Defines [`Error`], [`ErrorCode`], and [`Errors`] —
 //! the building blocks for reporting field-level validation failures.
 
+use ars_i18n::Locale;
+
+use crate::form_messages::FormMessages;
+
 /// A single validation failure.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Error {
     /// Human-readable error message.
     pub message: String,
+
     /// Machine-readable code for programmatic handling.
     pub code: ErrorCode,
 }
 
 impl Error {
+    /// Creates a required-field validation error with a localized message.
+    pub fn required(messages: &FormMessages, locale: &Locale) -> Self {
+        Self {
+            message: (messages.required_error)(locale),
+            code: ErrorCode::Required,
+        }
+    }
+
+    /// Creates a minimum-length validation error with a localized message.
+    pub fn min_length(min: usize, messages: &FormMessages, locale: &Locale) -> Self {
+        Self {
+            message: (messages.min_length_error)(min, locale),
+            code: ErrorCode::MinLength(min),
+        }
+    }
+
+    /// Creates a maximum-length validation error with a localized message.
+    pub fn max_length(max: usize, messages: &FormMessages, locale: &Locale) -> Self {
+        Self {
+            message: (messages.max_length_error)(max, locale),
+            code: ErrorCode::MaxLength(max),
+        }
+    }
+
+    /// Creates a pattern validation error with a localized message.
+    pub fn pattern(messages: &FormMessages, locale: &Locale) -> Self {
+        Self {
+            message: (messages.pattern_error)(locale),
+            code: ErrorCode::Pattern(String::new()),
+        }
+    }
+
+    /// Creates a minimum-value validation error with a localized message.
+    pub fn min(min: f64, messages: &FormMessages, locale: &Locale) -> Self {
+        Self {
+            message: (messages.min_error)(min, locale),
+            code: ErrorCode::Min(min),
+        }
+    }
+
+    /// Creates a maximum-value validation error with a localized message.
+    pub fn max(max: f64, messages: &FormMessages, locale: &Locale) -> Self {
+        Self {
+            message: (messages.max_error)(max, locale),
+            code: ErrorCode::Max(max),
+        }
+    }
+
+    /// Creates an email validation error with a localized message.
+    pub fn email(messages: &FormMessages, locale: &Locale) -> Self {
+        Self {
+            message: (messages.email_error)(locale),
+            code: ErrorCode::Email,
+        }
+    }
+
+    /// Creates a step validation error with a localized message.
+    pub fn step(step: f64, messages: &FormMessages, locale: &Locale) -> Self {
+        Self {
+            message: (messages.step_error)(step, locale),
+            code: ErrorCode::Step(step),
+        }
+    }
+
+    /// Creates a URL validation error with a localized message.
+    pub fn url(messages: &FormMessages, locale: &Locale) -> Self {
+        Self {
+            message: (messages.url_error)(locale),
+            code: ErrorCode::Url,
+        }
+    }
+
     /// Creates a custom validation error with a named code and message.
     pub fn custom(code: impl Into<String>, message: impl Into<String>) -> Self {
         Self {
@@ -27,6 +104,7 @@ impl Error {
     /// so that `is_server()` can identify it.
     pub fn server(message: impl Into<String>) -> Self {
         let message = message.into();
+
         Self {
             code: ErrorCode::Server(message.clone()),
             message,
@@ -48,26 +126,37 @@ impl Error {
 pub enum ErrorCode {
     /// The field value is required but empty.
     Required,
+
     /// The value is shorter than the minimum length.
     MinLength(usize),
+
     /// The value exceeds the maximum length.
     MaxLength(usize),
+
     /// The numeric value is below the minimum.
     Min(f64),
+
     /// The numeric value exceeds the maximum.
     Max(f64),
+
     /// The numeric value does not match the step increment.
     Step(f64),
+
     /// The value does not match the expected pattern.
     Pattern(String),
+
     /// The value is not a valid email address.
     Email,
+
     /// The value is not a valid URL.
     Url,
+
     /// A custom validation rule identified by name.
     Custom(String),
+
     /// An error returned from the server.
     Server(String),
+
     /// An error from an async validator.
     Async(String),
 }
@@ -115,8 +204,10 @@ impl Errors {
 
 #[cfg(test)]
 mod tests {
+    use ars_i18n::locales;
 
     use super::*;
+    use crate::form_messages::FormMessages;
 
     #[test]
     fn valid_result_is_server() {
@@ -124,12 +215,14 @@ mod tests {
             code: ErrorCode::Server("duplicate".to_string()),
             message: "Already exists".to_string(),
         };
+
         assert!(server.is_server());
 
         let client = Error {
             code: ErrorCode::Required,
             message: "Required".to_string(),
         };
+
         assert!(!client.is_server());
     }
 
@@ -139,6 +232,7 @@ mod tests {
             code: ErrorCode::Required,
             message: "Required".to_string(),
         }]);
+
         assert_eq!(errors.first_message(), Some("Required"));
     }
 
@@ -148,6 +242,7 @@ mod tests {
             code: ErrorCode::MinLength(3),
             message: "Too short".to_string(),
         }]);
+
         assert!(errors.has_code(&ErrorCode::MinLength(3)));
         assert!(!errors.has_code(&ErrorCode::Required));
     }
@@ -155,6 +250,7 @@ mod tests {
     #[test]
     fn validation_error_custom_factory() {
         let err = Error::custom("my_code", "My message");
+
         assert_eq!(err.message, "My message");
         assert_eq!(err.code, ErrorCode::Custom("my_code".to_string()));
         assert!(!err.is_server());
@@ -163,6 +259,7 @@ mod tests {
     #[test]
     fn validation_error_server_factory() {
         let err = Error::server("Already exists");
+
         assert_eq!(err.message, "Already exists");
         assert_eq!(err.code, ErrorCode::Server("Already exists".to_string()));
         assert!(err.is_server());
@@ -174,17 +271,20 @@ mod tests {
             code: ErrorCode::Async("check_unique".to_string()),
             message: "Not unique".to_string(),
         };
+
         assert!(err.is_server());
     }
 
     #[test]
     fn errors_new_and_push() {
         let mut errors = Errors::new();
+
         assert!(errors.is_empty());
         assert_eq!(errors.len(), 0);
 
         errors.push(Error::custom("a", "first"));
         errors.push(Error::custom("b", "second"));
+
         assert!(!errors.is_empty());
         assert_eq!(errors.len(), 2);
     }
@@ -192,6 +292,82 @@ mod tests {
     #[test]
     fn errors_first_message_on_empty() {
         let errors = Errors::new();
+
         assert_eq!(errors.first_message(), None);
+    }
+
+    #[test]
+    fn error_required_factory() {
+        let err = Error::required(&FormMessages::default(), &locales::en());
+
+        assert_eq!(err.message, "This field is required");
+        assert_eq!(err.code, ErrorCode::Required);
+    }
+
+    #[test]
+    fn error_min_length_factory() {
+        let err = Error::min_length(3, &FormMessages::default(), &locales::en());
+
+        assert_eq!(err.message, "Must be at least 3 characters");
+        assert_eq!(err.code, ErrorCode::MinLength(3));
+    }
+
+    #[test]
+    fn error_max_length_factory() {
+        let err = Error::max_length(8, &FormMessages::default(), &locales::en());
+
+        assert_eq!(err.message, "Must be at most 8 characters");
+        assert_eq!(err.code, ErrorCode::MaxLength(8));
+    }
+
+    #[test]
+    fn error_pattern_factory() {
+        let err = Error::pattern(&FormMessages::default(), &locales::en());
+
+        assert_eq!(err.message, "Invalid format");
+        assert_eq!(err.code, ErrorCode::Pattern(String::new()));
+    }
+
+    #[test]
+    fn error_min_factory() {
+        let err = Error::min(2.5, &FormMessages::default(), &locales::en());
+
+        assert_eq!(err.message, "Must be at least 2.5");
+        assert_eq!(err.code, ErrorCode::Min(2.5));
+    }
+
+    #[test]
+    fn error_max_factory() {
+        let err = Error::max(9.5, &FormMessages::default(), &locales::en());
+
+        assert_eq!(err.message, "Must be at most 9.5");
+        assert_eq!(err.code, ErrorCode::Max(9.5));
+    }
+
+    #[test]
+    fn error_email_factory() {
+        let err = Error::email(&FormMessages::default(), &locales::en());
+
+        assert_eq!(err.message, "Must be a valid email address");
+        assert_eq!(err.code, ErrorCode::Email);
+    }
+
+    #[test]
+    fn error_step_factory() {
+        let err = Error::step(0.25, &FormMessages::default(), &locales::en());
+
+        assert_eq!(
+            err.message,
+            "Please enter a valid value. The nearest allowed value is a multiple of 0.25."
+        );
+        assert_eq!(err.code, ErrorCode::Step(0.25));
+    }
+
+    #[test]
+    fn error_url_factory() {
+        let err = Error::url(&FormMessages::default(), &locales::en());
+
+        assert_eq!(err.message, "Please enter a valid URL.");
+        assert_eq!(err.code, ErrorCode::Url);
     }
 }

--- a/crates/ars-forms/src/validation/validator.rs
+++ b/crates/ars-forms/src/validation/validator.rs
@@ -106,8 +106,23 @@ impl<'a> Context<'a> {
 
 /// A synchronous field validator.
 ///
-/// Validators are always `Send + Sync`, so the same trait object shape works
-/// on every target without cfg-gated API differences.
+/// Native targets require validators to be `Send + Sync`, while `wasm32`
+/// preserves single-threaded validators that capture browser-only state.
+#[cfg(target_arch = "wasm32")]
+pub trait Validator {
+    /// Validates the given value and returns a result with any errors found.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(Errors)` when the value fails validation.
+    fn validate(&self, value: &Value, ctx: &Context) -> Result;
+}
+
+/// A synchronous field validator.
+///
+/// Native targets require validators to be `Send + Sync`, while `wasm32`
+/// preserves single-threaded validators that capture browser-only state.
+#[cfg(not(target_arch = "wasm32"))]
 pub trait Validator: Send + Sync {
     /// Validates the given value and returns a result with any errors found.
     ///
@@ -120,7 +135,7 @@ pub trait Validator: Send + Sync {
 /// A type-erased synchronous validator.
 ///
 /// Uses [`Arc`](std::sync::Arc) on all targets for cheap shared ownership.
-pub type BoxedValidator = Arc<dyn Validator + Send + Sync>;
+pub type BoxedValidator = Arc<dyn Validator>;
 
 /// Helper to wrap a [`Validator`] into the standard shared pointer type.
 pub fn boxed_validator(v: impl Validator + 'static) -> BoxedValidator {
@@ -226,6 +241,39 @@ mod tests {
 
         assert!(boxed.validate(&Value::Text(String::new()), &ctx).is_err());
         assert!(boxed.validate(&Value::Text("ok".to_string()), &ctx).is_ok());
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    #[test]
+    #[expect(
+        clippy::arc_with_non_send_sync,
+        reason = "BoxedValidator intentionally preserves single-threaded wasm validators"
+    )]
+    fn boxed_validator_allows_non_send_captures_on_wasm() {
+        use std::{cell::RefCell, rc::Rc};
+
+        struct RcValidator {
+            hits: Rc<RefCell<u8>>,
+        }
+
+        impl Validator for RcValidator {
+            fn validate(&self, _value: &Value, _ctx: &Context) -> Result {
+                *self.hits.borrow_mut() += 1;
+                Ok(())
+            }
+        }
+
+        let hits = Rc::new(RefCell::new(0));
+        let validator: BoxedValidator = Arc::new(RcValidator {
+            hits: Rc::clone(&hits),
+        });
+
+        assert!(
+            validator
+                .validate(&Value::Text(String::new()), &Context::standalone("x"))
+                .is_ok()
+        );
+        assert_eq!(*hits.borrow(), 1);
     }
 
     #[test]

--- a/crates/ars-forms/src/validation/validator.rs
+++ b/crates/ars-forms/src/validation/validator.rs
@@ -4,10 +4,31 @@
 //! [`BoxedValidator`] for type-erased storage, and [`Context`]
 //! which provides cross-field access during validation.
 
-use std::collections::BTreeMap;
+use std::{
+    collections::BTreeMap,
+    sync::{Arc, LazyLock},
+};
+
+use ars_i18n::Locale;
 
 use super::result::Result;
 use crate::field::Value;
+
+/// Default locale for built-in validators when no locale is provided via [`Context`].
+///
+/// Built-in validators fall back to English (`"en"`) when `Context.locale` is
+/// `None`. This produces correct English validation messages but may produce
+/// incorrect pluralization for other languages until callers supply a
+/// locale-aware context.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "built-in validators introduced in the next forms task use this fallback"
+    )
+)]
+static DEFAULT_VALIDATOR_LOCALE: LazyLock<Locale> =
+    LazyLock::new(|| Locale::parse("en").expect("valid locale"));
 
 /// Context available to validators during validation.
 ///
@@ -24,7 +45,7 @@ pub struct Context<'a> {
     pub form_values: &'a BTreeMap<String, Value>,
 
     /// The current locale (for locale-aware messages).
-    pub locale: Option<&'a ars_i18n::Locale>,
+    pub locale: Option<&'a Locale>,
 }
 
 /// An owned version of [`Context`] that can outlive the borrow scope.
@@ -35,10 +56,12 @@ pub struct Context<'a> {
 pub struct OwnedContext {
     /// The name of the field being validated.
     pub field_name: String,
+
     /// All current form values.
     pub form_values: BTreeMap<String, Value>,
+
     /// The current locale.
-    pub locale: Option<ars_i18n::Locale>,
+    pub locale: Option<Locale>,
 }
 
 impl OwnedContext {
@@ -70,7 +93,9 @@ impl<'a> Context<'a> {
     /// sufficient for single-field validation without cross-field dependencies.
     pub fn standalone(field_name: &'a str) -> Self {
         use std::sync::LazyLock;
+
         static EMPTY_MAP: LazyLock<BTreeMap<String, Value>> = LazyLock::new(BTreeMap::new);
+
         Self {
             field_name,
             form_values: &EMPTY_MAP,
@@ -81,23 +106,9 @@ impl<'a> Context<'a> {
 
 /// A synchronous field validator.
 ///
-/// **Platform-dependent bounds:** On native targets, `Validator` requires
-/// `Send + Sync` so that [`BoxedValidator`] (`Arc<dyn Validator + Send + Sync>`)
-/// can wrap any implementor. On WASM (single-threaded), no extra bounds are
-/// required. All built-in validators satisfy both bound sets.
-#[cfg(not(target_arch = "wasm32"))]
+/// Validators are always `Send + Sync`, so the same trait object shape works
+/// on every target without cfg-gated API differences.
 pub trait Validator: Send + Sync {
-    /// Validates the given value and returns a result with any errors found.
-    ///
-    /// # Errors
-    ///
-    /// Returns `Err(Errors)` when the value fails validation.
-    fn validate(&self, value: &Value, ctx: &Context) -> Result;
-}
-
-/// A synchronous field validator (WASM variant without `Send + Sync`).
-#[cfg(target_arch = "wasm32")]
-pub trait Validator {
     /// Validates the given value and returns a result with any errors found.
     ///
     /// # Errors
@@ -108,25 +119,12 @@ pub trait Validator {
 
 /// A type-erased synchronous validator.
 ///
-/// Uses `Arc` instead of `Box` for cheap cloning across reactive signals.
-/// On WASM targets, uses `Rc` to avoid unnecessary atomic overhead.
-#[cfg(not(target_arch = "wasm32"))]
-pub type BoxedValidator = std::sync::Arc<dyn Validator + Send + Sync>;
+/// Uses [`Arc`](std::sync::Arc) on all targets for cheap shared ownership.
+pub type BoxedValidator = Arc<dyn Validator + Send + Sync>;
 
-/// A type-erased synchronous validator (WASM variant using `Rc`).
-#[cfg(target_arch = "wasm32")]
-pub type BoxedValidator = std::rc::Rc<dyn Validator>;
-
-/// Helper to wrap a [`Validator`] into the correct smart pointer for the platform.
+/// Helper to wrap a [`Validator`] into the standard shared pointer type.
 pub fn boxed_validator(v: impl Validator + 'static) -> BoxedValidator {
-    #[cfg(not(target_arch = "wasm32"))]
-    {
-        std::sync::Arc::new(v)
-    }
-    #[cfg(target_arch = "wasm32")]
-    {
-        std::rc::Rc::new(v)
-    }
+    Arc::new(v)
 }
 
 #[cfg(test)]
@@ -138,14 +136,15 @@ mod tests {
 
     impl Validator for RequiredValidator {
         fn validate(&self, value: &Value, _ctx: &Context) -> Result {
-            if let Some(text) = value.as_text() {
-                if text.trim().is_empty() {
-                    return Err(Errors(vec![Error {
-                        code: ErrorCode::Required,
-                        message: "Value is required".to_string(),
-                    }]));
-                }
+            if let Some(text) = value.as_text()
+                && text.trim().is_empty()
+            {
+                return Err(Errors(vec![Error {
+                    code: ErrorCode::Required,
+                    message: "Value is required".to_string(),
+                }]));
             }
+
             Ok(())
         }
     }
@@ -153,6 +152,7 @@ mod tests {
     #[test]
     fn validator_trait_can_be_implemented() {
         let validator = RequiredValidator;
+
         let ctx = Context::standalone("test");
 
         assert!(
@@ -170,6 +170,7 @@ mod tests {
     #[test]
     fn standalone_context_has_empty_values() {
         let ctx = Context::standalone("email");
+
         assert!(ctx.form_values.is_empty());
         assert!(ctx.locale.is_none());
         assert_eq!(ctx.field_name, "email");
@@ -180,7 +181,9 @@ mod tests {
         let values = [("name".to_string(), Value::Text("Alice".to_string()))]
             .into_iter()
             .collect();
+
         let locale = ars_i18n::locales::en_us();
+
         let ctx = Context {
             field_name: "name",
             form_values: &values,
@@ -188,14 +191,11 @@ mod tests {
         };
 
         let owned = ctx.snapshot();
+
         assert_eq!(owned.field_name, "name");
         assert_eq!(owned.form_values.len(), 1);
         assert_eq!(
-            owned
-                .locale
-                .as_ref()
-                .map(ars_i18n::Locale::to_bcp47)
-                .as_deref(),
+            owned.locale.as_ref().map(Locale::to_bcp47).as_deref(),
             Some("en-US")
         );
     }
@@ -207,11 +207,13 @@ mod tests {
             form_values: BTreeMap::new(),
             locale: Some(ars_i18n::locales::fr()),
         };
+
         let borrowed = owned.as_ref();
+
         assert_eq!(borrowed.field_name, "email");
         assert!(borrowed.form_values.is_empty());
         assert_eq!(
-            borrowed.locale.map(ars_i18n::Locale::to_bcp47).as_deref(),
+            borrowed.locale.map(Locale::to_bcp47).as_deref(),
             Some("fr-FR")
         );
     }
@@ -219,8 +221,15 @@ mod tests {
     #[test]
     fn boxed_validator_wraps_correctly() {
         let boxed = boxed_validator(RequiredValidator);
+
         let ctx = Context::standalone("test");
+
         assert!(boxed.validate(&Value::Text(String::new()), &ctx).is_err());
         assert!(boxed.validate(&Value::Text("ok".to_string()), &ctx).is_ok());
+    }
+
+    #[test]
+    fn default_validator_locale_is_en() {
+        assert_eq!(DEFAULT_VALIDATOR_LOCALE.to_bcp47(), "en");
     }
 }

--- a/crates/ars-interactions/src/hover.rs
+++ b/crates/ars-interactions/src/hover.rs
@@ -23,6 +23,7 @@ pub enum HoverState {
     /// Pointer is not over the element.
     #[default]
     NotHovered,
+
     /// Pointer is over the element.
     Hovered,
 }
@@ -44,6 +45,7 @@ impl HoverState {
 pub enum HoverEventType {
     /// The pointer entered the element.
     HoverStart,
+
     /// The pointer left the element.
     HoverEnd,
 }
@@ -70,9 +72,8 @@ pub struct HoverEvent {
 /// Configuration for hover interaction behavior.
 ///
 /// Controls how the hover interaction responds to pointer enter/leave events.
-/// Callbacks use [`Callback`] for automatic platform-appropriate pointer type
-/// (`Rc` on wasm, `Arc` on native) and built-in `Clone`, `Debug`, and
-/// `PartialEq` (by pointer identity).
+/// Callbacks use [`Callback`] for shared Arc-backed ownership plus built-in
+/// `Clone`, `Debug`, and `PartialEq` (by pointer identity).
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct HoverConfig {
     /// Whether the element is disabled. Disabled elements receive no hover events.
@@ -136,6 +137,7 @@ pub(crate) fn had_pointer_interaction(modality: &dyn ModalityContext) -> bool {
 pub struct HoverResult {
     /// Whether the element is currently hovered (reactive signal in adapter).
     pub hovered: bool,
+
     /// Internal state handle — use [`current_attrs()`](Self::current_attrs) to
     /// produce a live `AttrMap`.
     state: SharedState<HoverState>,
@@ -149,11 +151,13 @@ impl HoverResult {
     #[must_use]
     pub fn current_attrs(&self) -> AttrMap {
         let mut attrs = AttrMap::new();
+
         self.state.with(|s| {
             if s.is_hovered() {
                 attrs.set_bool(HtmlAttr::Data("ars-hovered"), true);
             }
         });
+
         attrs
     }
 }
@@ -174,6 +178,7 @@ impl HoverResult {
 )]
 pub fn use_hover(config: HoverConfig) -> HoverResult {
     let state = SharedState::new(HoverState::NotHovered);
+
     let _is_disabled = config.disabled;
 
     let hovered = state.get().is_hovered();
@@ -197,6 +202,7 @@ mod tests {
     #[test]
     fn hover_config_default_values() {
         let config = HoverConfig::default();
+
         assert!(!config.disabled);
         assert!(config.on_hover_start.is_none());
         assert!(config.on_hover_end.is_none());
@@ -206,7 +212,9 @@ mod tests {
     #[test]
     fn hover_config_debug_default_shows_none_callbacks() {
         let config = HoverConfig::default();
+
         let debug = format!("{config:?}");
+
         assert!(debug.contains("disabled: false"));
         assert!(debug.contains("on_hover_start: None"));
         assert!(debug.contains("on_hover_end: None"));
@@ -216,40 +224,51 @@ mod tests {
     #[test]
     fn hover_config_debug_with_callbacks_shows_callback() {
         let start_calls = Arc::new(AtomicUsize::new(0));
+
         let end_calls = Arc::new(AtomicUsize::new(0));
+
         let change_calls = Arc::new(AtomicUsize::new(0));
+
         let config = HoverConfig {
             on_hover_start: Some({
                 let start_calls = Arc::clone(&start_calls);
+
                 Callback::new(move |_: HoverEvent| {
                     start_calls.fetch_add(1, Ordering::SeqCst);
                 })
             }),
             on_hover_end: Some({
                 let end_calls = Arc::clone(&end_calls);
+
                 Callback::new(move |_: HoverEvent| {
                     end_calls.fetch_add(1, Ordering::SeqCst);
                 })
             }),
             on_hover_change: Some({
                 let change_calls = Arc::clone(&change_calls);
+
                 Callback::new(move |_: bool| {
                     change_calls.fetch_add(1, Ordering::SeqCst);
                 })
             }),
             ..HoverConfig::default()
         };
+
         let debug = format!("{config:?}");
+
         assert!(debug.contains("on_hover_start: Some(Callback(..))"));
         assert!(debug.contains("on_hover_end: Some(Callback(..))"));
         assert!(debug.contains("on_hover_change: Some(Callback(..))"));
+
         let event = HoverEvent {
             pointer_type: PointerType::Mouse,
             event_type: HoverEventType::HoverStart,
         };
+
         config.on_hover_start.as_ref().expect("callback")(event.clone());
         config.on_hover_end.as_ref().expect("callback")(event);
         config.on_hover_change.as_ref().expect("callback")(true);
+
         assert_eq!(start_calls.load(Ordering::SeqCst), 1);
         assert_eq!(end_calls.load(Ordering::SeqCst), 1);
         assert_eq!(change_calls.load(Ordering::SeqCst), 1);
@@ -258,68 +277,87 @@ mod tests {
     #[test]
     fn hover_config_clone_preserves_disabled_and_shares_callbacks() {
         let calls = Arc::new(AtomicUsize::new(0));
+
         let config = HoverConfig {
             disabled: true,
             on_hover_start: Some({
                 let calls = Arc::clone(&calls);
+
                 Callback::new(move |_: HoverEvent| {
                     calls.fetch_add(1, Ordering::SeqCst);
                 })
             }),
             ..HoverConfig::default()
         };
+
         let cloned = config.clone();
+
         assert!(cloned.disabled);
+
         // Callback clone shares the same allocation (pointer identity)
         assert_eq!(config.on_hover_start, cloned.on_hover_start);
+
         cloned.on_hover_start.as_ref().expect("callback")(HoverEvent {
             pointer_type: PointerType::Pen,
             event_type: HoverEventType::HoverStart,
         });
+
         assert_eq!(calls.load(Ordering::SeqCst), 1);
     }
 
     #[test]
     fn hover_config_partial_eq_uses_pointer_identity_for_callbacks() {
         let shared_calls = Arc::new(AtomicUsize::new(0));
+
         let cb = {
             let shared_calls = Arc::clone(&shared_calls);
+
             Callback::new(move |_: HoverEvent| {
                 shared_calls.fetch_add(1, Ordering::SeqCst);
             })
         };
+
         let config1 = HoverConfig {
             on_hover_start: Some(cb.clone()),
             ..HoverConfig::default()
         };
+
         let config2 = HoverConfig {
             on_hover_start: Some(cb),
             ..HoverConfig::default()
         };
+
         // Same callback allocation → equal
         assert_eq!(config1, config2);
+
         config2.on_hover_start.as_ref().expect("callback")(HoverEvent {
             pointer_type: PointerType::Touch,
             event_type: HoverEventType::HoverStart,
         });
+
         assert_eq!(shared_calls.load(Ordering::SeqCst), 1);
 
         // Different callback allocation → not equal (even if same closure body)
         let different_calls = Arc::new(AtomicUsize::new(0));
+
         let config3 = HoverConfig {
             on_hover_start: Some({
                 let different_calls = Arc::clone(&different_calls);
+
                 Callback::new(move |_: HoverEvent| {
                     different_calls.fetch_add(1, Ordering::SeqCst);
                 })
             }),
             ..HoverConfig::default()
         };
+
         assert_ne!(config1, config3);
+
         config3.on_hover_start.as_ref().expect("callback")(HoverEvent {
             pointer_type: PointerType::Mouse,
             event_type: HoverEventType::HoverStart,
         });
+
         assert_eq!(different_calls.load(Ordering::SeqCst), 1);
     }
 
@@ -333,7 +371,9 @@ mod tests {
     #[test]
     fn hover_event_type_is_copy() {
         let t = HoverEventType::HoverStart;
+
         let t2 = t;
+
         assert_eq!(t, t2);
     }
 
@@ -345,6 +385,7 @@ mod tests {
             pointer_type: PointerType::Mouse,
             event_type: HoverEventType::HoverStart,
         };
+
         assert_eq!(event.pointer_type, PointerType::Mouse);
         assert_eq!(event.event_type, HoverEventType::HoverStart);
     }
@@ -355,6 +396,7 @@ mod tests {
             pointer_type: PointerType::Pen,
             event_type: HoverEventType::HoverEnd,
         };
+
         assert_eq!(event.pointer_type, PointerType::Pen);
         assert_eq!(event.event_type, HoverEventType::HoverEnd);
     }
@@ -365,7 +407,9 @@ mod tests {
             pointer_type: PointerType::Mouse,
             event_type: HoverEventType::HoverStart,
         };
+
         let cloned = event.clone();
+
         assert_eq!(cloned.pointer_type, PointerType::Mouse);
         assert_eq!(cloned.event_type, HoverEventType::HoverStart);
     }
@@ -395,7 +439,9 @@ mod tests {
             state: SharedState::new(HoverState::NotHovered),
             hovered: false,
         };
+
         let attrs = result.current_attrs();
+
         assert!(!attrs.contains(&HtmlAttr::Data("ars-hovered")));
     }
 
@@ -405,7 +451,9 @@ mod tests {
             state: SharedState::new(HoverState::Hovered),
             hovered: true,
         };
+
         let attrs = result.current_attrs();
+
         assert!(attrs.contains(&HtmlAttr::Data("ars-hovered")));
         assert_eq!(
             attrs.get_value(&HtmlAttr::Data("ars-hovered")),
@@ -416,6 +464,7 @@ mod tests {
     #[test]
     fn hover_result_current_attrs_reflects_live_state_mutation() {
         let state = SharedState::new(HoverState::NotHovered);
+
         let result = HoverResult {
             state: state.clone(),
             hovered: false,
@@ -433,6 +482,7 @@ mod tests {
 
         // current_attrs() must reflect the live state, not a stale snapshot
         let attrs = result.current_attrs();
+
         assert!(attrs.contains(&HtmlAttr::Data("ars-hovered")));
         assert_eq!(
             attrs.get_value(&HtmlAttr::Data("ars-hovered")),
@@ -441,6 +491,7 @@ mod tests {
 
         // Mutate back to NotHovered
         state.set(HoverState::NotHovered);
+
         assert!(
             !result
                 .current_attrs()
@@ -453,12 +504,14 @@ mod tests {
     #[test]
     fn use_hover_returns_not_hovered_state() {
         let result = use_hover(HoverConfig::default());
+
         assert_eq!(result.state.get(), HoverState::NotHovered);
     }
 
     #[test]
     fn use_hover_returns_hovered_false() {
         let result = use_hover(HoverConfig::default());
+
         assert!(!result.hovered);
     }
 
@@ -468,7 +521,9 @@ mod tests {
             disabled: true,
             ..HoverConfig::default()
         };
+
         let result = use_hover(config);
+
         assert_eq!(result.state.get(), HoverState::NotHovered);
         assert!(!result.hovered);
     }
@@ -478,26 +533,32 @@ mod tests {
     #[test]
     fn should_clear_hover_false_when_no_press() {
         let modality = DefaultModalityContext::new();
+
         assert!(!should_clear_hover(&modality));
     }
 
     #[test]
     fn should_clear_hover_true_when_press_active() {
         let modality = DefaultModalityContext::new();
+
         modality.set_global_press_active(true);
+
         assert!(should_clear_hover(&modality));
     }
 
     #[test]
     fn had_pointer_interaction_false_initially() {
         let modality = DefaultModalityContext::new();
+
         assert!(!had_pointer_interaction(&modality));
     }
 
     #[test]
     fn had_pointer_interaction_true_after_pointer_down() {
         let modality = DefaultModalityContext::new();
+
         modality.on_pointer_down(PointerType::Mouse);
+
         assert!(had_pointer_interaction(&modality));
     }
 }

--- a/crates/ars-interactions/src/press.rs
+++ b/crates/ars-interactions/src/press.rs
@@ -30,8 +30,10 @@ pub enum PressState {
     PressedInside {
         /// The pointer modality that initiated the press.
         pointer_type: PointerType,
+
         /// The x-coordinate where the press originated, if available.
         origin_x: Option<f64>,
+
         /// The y-coordinate where the press originated, if available.
         origin_y: Option<f64>,
     },
@@ -86,9 +88,8 @@ struct ActivePress {
 /// Configuration for press interaction behavior.
 ///
 /// Controls how the press interaction responds to pointer, touch, and keyboard
-/// input. Callbacks use [`Callback`] for automatic platform-appropriate pointer
-/// type (`Rc` on wasm, `Arc` on native) and built-in `Clone`, `Debug`, and
-/// `PartialEq` (by pointer identity).
+/// input. Callbacks use [`Callback`] for shared Arc-backed ownership plus
+/// built-in `Clone`, `Debug`, and `PartialEq` (by pointer identity).
 #[derive(Clone, Debug, PartialEq)]
 pub struct PressConfig {
     /// Whether the element is disabled. Disabled elements receive no press events.
@@ -170,10 +171,13 @@ impl Default for PressConfig {
 pub enum PressEventType {
     /// The press started (pointer down / key down within the element).
     PressStart,
+
     /// The press ended (any conclusion: release, cancel, blur).
     PressEnd,
+
     /// Activation: the press was released inside the element.
     Press,
+
     /// Fired when a press is released (pointer up / key up / touch end),
     /// regardless of whether the release was inside or outside the element.
     /// Distinct from `PressEnd` (fires on any press conclusion) and `Press`
@@ -285,16 +289,20 @@ impl PressResult {
     #[must_use]
     pub fn current_attrs(&self, config: &PressConfig) -> AttrMap {
         let state = self.state.borrow();
+
         let mut attrs = AttrMap::new();
+
         if state.is_pressed_inside() {
             attrs.set_bool(HtmlAttr::Data("ars-pressed"), true);
         }
+
         if PressState::is_disabled(config) {
             attrs.set_bool(HtmlAttr::Data("ars-disabled"), true);
             // Disabled elements use aria-disabled="true" instead of HTML disabled
             // to allow tooltip on hover. Do NOT set pointer-events:none here.
             // Adapters prevent interaction via event handler removal.
         }
+
         // Note: data-ars-active is managed by the adapter layer (not current_attrs)
         // because it requires RAF-deferred removal after pointerup.
         attrs
@@ -324,6 +332,7 @@ impl PressResult {
 
         let (next_state, pressed) = {
             let mut active_presses = self.active_presses.borrow_mut();
+
             if active_presses
                 .iter()
                 .any(|press| press.pointer_type == pointer_type)
@@ -353,6 +362,7 @@ impl PressResult {
         };
 
         *self.state.borrow_mut() = next_state;
+
         self.pressed = pressed;
 
         if within_element {
@@ -382,6 +392,7 @@ impl PressResult {
     ) {
         let (changed, next_state, pressed) = {
             let mut active_presses = self.active_presses.borrow_mut();
+
             let Some(active_press) = active_presses
                 .iter_mut()
                 .find(|press| press.pointer_type == pointer_type)
@@ -390,10 +401,13 @@ impl PressResult {
             };
 
             let changed = active_press.is_within_element != within_element;
+
             active_press.is_within_element = within_element;
+
             if active_press.origin_x.is_none() {
                 active_press.origin_x = client_x;
             }
+
             if active_press.origin_y.is_none() {
                 active_press.origin_y = client_y;
             }
@@ -406,6 +420,7 @@ impl PressResult {
         };
 
         *self.state.borrow_mut() = next_state;
+
         self.pressed = pressed;
 
         if changed {
@@ -430,19 +445,27 @@ impl PressResult {
     ) -> bool {
         let (is_within_element, activation_candidate, suppress_activation, next_state, pressed) = {
             let mut active_presses = self.active_presses.borrow_mut();
+
             let Some(index) = active_presses
                 .iter()
                 .position(|press| press.pointer_type == pointer_type)
             else {
                 return false;
             };
+
             let released_press = active_presses.remove(index);
+
             let is_within_element = released_press.is_within_element;
+
             let activation_candidate = is_within_element
                 || (self.config.allow_press_on_exit && !released_press.is_within_element);
+
             let long_press_canceled = self.consume_long_press_cancel_flag(pointer_type);
+
             let suppress_activation = activation_candidate && long_press_canceled;
+
             let next_state = derive_press_state(&active_presses);
+
             let pressed = active_presses.iter().any(|press| press.is_within_element);
 
             (
@@ -455,6 +478,7 @@ impl PressResult {
         };
 
         *self.state.borrow_mut() = next_state;
+
         self.pressed = pressed;
 
         self.fire_press_event(
@@ -465,6 +489,7 @@ impl PressResult {
             modifiers,
             is_within_element,
         );
+
         self.fire_press_event(
             PressEventType::PressEnd,
             pointer_type,
@@ -502,12 +527,14 @@ impl PressResult {
     ) {
         let (is_within_element, next_state, pressed) = {
             let mut active_presses = self.active_presses.borrow_mut();
+
             let Some(index) = active_presses
                 .iter()
                 .position(|press| press.pointer_type == pointer_type)
             else {
                 return;
             };
+
             let cancelled_press = active_presses.remove(index);
 
             (
@@ -518,7 +545,9 @@ impl PressResult {
         };
 
         *self.state.borrow_mut() = next_state;
+
         self.pressed = pressed;
+
         self.clear_long_press_cancel_flag(pointer_type);
 
         self.fire_press_event(
@@ -537,9 +566,11 @@ impl PressResult {
         };
 
         let should_cancel = flag.get() == Some(pointer_type);
+
         if should_cancel {
             flag.set(None);
         }
+
         should_cancel
     }
 
@@ -578,16 +609,19 @@ impl PressResult {
                     callback(event);
                 }
             }
+
             PressEventType::PressEnd => {
                 if let Some(callback) = &self.config.on_press_end {
                     callback(event);
                 }
             }
+
             PressEventType::Press => {
                 if let Some(callback) = &self.config.on_press {
                     callback(event);
                 }
             }
+
             PressEventType::PressUp => {
                 if let Some(callback) = &self.config.on_press_up {
                     callback(event);
@@ -609,6 +643,7 @@ impl PressResult {
 #[must_use]
 pub fn use_press(config: PressConfig) -> PressResult {
     let state = Rc::new(RefCell::new(PressState::Idle));
+
     let pressed = state.borrow().is_pressed_inside();
 
     PressResult {
@@ -672,6 +707,7 @@ mod tests {
             origin_x: Some(10.0),
             origin_y: Some(20.0),
         };
+
         assert!(state.is_pressed());
         assert!(state.is_pressed_inside());
     }
@@ -681,6 +717,7 @@ mod tests {
         let state = PressState::PressedOutside {
             pointer_type: PointerType::Touch,
         };
+
         assert!(!state.is_pressed());
         assert!(!state.is_pressed_inside());
     }
@@ -690,6 +727,7 @@ mod tests {
         let state = PressState::Pressing {
             pointer_type: PointerType::Touch,
         };
+
         assert!(!state.is_pressed());
     }
 
@@ -698,7 +736,9 @@ mod tests {
     #[test]
     fn press_config_debug_default_shows_none_callbacks() {
         let config = PressConfig::default();
+
         let debug = format!("{config:?}");
+
         assert!(debug.contains("disabled: false"));
         assert!(debug.contains("on_press_start: None"));
         assert!(debug.contains("on_press: None"));
@@ -709,16 +749,20 @@ mod tests {
     #[test]
     fn press_config_debug_with_callbacks_shows_callback() {
         let press_calls = Arc::new(AtomicUsize::new(0));
+
         let change_calls = Arc::new(AtomicUsize::new(0));
+
         let config = PressConfig {
             on_press: Some({
                 let press_calls = Arc::clone(&press_calls);
+
                 Callback::new(move |_: PressEvent| {
                     press_calls.fetch_add(1, Ordering::SeqCst);
                 })
             }),
             on_press_change: Some({
                 let change_calls = Arc::clone(&change_calls);
+
                 Callback::new(move |_: bool| {
                     change_calls.fetch_add(1, Ordering::SeqCst);
                 })
@@ -726,10 +770,13 @@ mod tests {
             long_press_cancel_flag: Some(SharedState::new(Some(PointerType::Touch))),
             ..PressConfig::default()
         };
+
         let debug = format!("{config:?}");
+
         assert!(debug.contains("on_press: Some(Callback(..))"));
         assert!(debug.contains("on_press_change: Some(Callback(..))"));
         assert!(debug.contains("long_press_cancel_flag: Some(SharedState(Some(Touch)))"));
+
         let event = PressEvent {
             pointer_type: PointerType::Mouse,
             event_type: PressEventType::Press,
@@ -739,8 +786,10 @@ mod tests {
             is_within_element: true,
             continue_propagation: SharedFlag::new(false),
         };
+
         config.on_press.as_ref().expect("callback")(event);
         config.on_press_change.as_ref().expect("callback")(true);
+
         assert_eq!(press_calls.load(Ordering::SeqCst), 1);
         assert_eq!(change_calls.load(Ordering::SeqCst), 1);
     }
@@ -748,6 +797,7 @@ mod tests {
     #[test]
     fn press_config_default_values() {
         let config = PressConfig::default();
+
         assert!(!config.disabled);
         assert!(config.prevent_text_selection);
         assert!(!config.allow_press_on_exit);
@@ -776,7 +826,9 @@ mod tests {
     #[test]
     fn press_event_type_is_copy() {
         let t = PressEventType::Press;
+
         let t2 = t;
+
         assert_eq!(t, t2);
     }
 
@@ -793,6 +845,7 @@ mod tests {
             is_within_element: true,
             continue_propagation: SharedFlag::new(false),
         };
+
         assert!(!event.should_propagate());
     }
 
@@ -807,7 +860,9 @@ mod tests {
             is_within_element: true,
             continue_propagation: SharedFlag::new(false),
         };
+
         event.continue_propagation();
+
         assert!(event.should_propagate());
     }
 
@@ -822,16 +877,19 @@ mod tests {
             is_within_element: true,
             continue_propagation: SharedFlag::new(false),
         };
+
         let child = parent.create_child_event();
 
         // Mutating child affects parent
         child.continue_propagation();
+
         assert!(parent.should_propagate());
     }
 
     #[test]
     fn press_event_should_propagate_reflects_shared_state() {
         let flag = SharedFlag::new(false);
+
         let event1 = PressEvent {
             pointer_type: PointerType::Mouse,
             event_type: PressEventType::Press,
@@ -841,6 +899,7 @@ mod tests {
             is_within_element: true,
             continue_propagation: flag.clone(),
         };
+
         let event2 = event1.clone();
 
         // Both start with propagation stopped
@@ -849,6 +908,7 @@ mod tests {
 
         // Setting on clone affects both
         event2.continue_propagation();
+
         assert!(event1.should_propagate());
         assert!(event2.should_propagate());
     }
@@ -858,12 +918,14 @@ mod tests {
     #[test]
     fn press_state_is_disabled_reads_config() {
         let enabled = PressConfig::default();
+
         assert!(!PressState::is_disabled(&enabled));
 
         let disabled = PressConfig {
             disabled: true,
             ..PressConfig::default()
         };
+
         assert!(PressState::is_disabled(&disabled));
     }
 
@@ -877,8 +939,11 @@ mod tests {
             config: PressConfig::default(),
             pressed: false,
         };
+
         let config = PressConfig::default();
+
         let attrs = result.current_attrs(&config);
+
         assert!(!attrs.contains(&HtmlAttr::Data("ars-pressed")));
         assert!(!attrs.contains(&HtmlAttr::Data("ars-disabled")));
     }
@@ -900,8 +965,11 @@ mod tests {
             config: PressConfig::default(),
             pressed: true,
         };
+
         let config = PressConfig::default();
+
         let attrs = result.current_attrs(&config);
+
         assert!(attrs.contains(&HtmlAttr::Data("ars-pressed")));
         assert_eq!(
             attrs.get_value(&HtmlAttr::Data("ars-pressed")),
@@ -917,11 +985,14 @@ mod tests {
             config: PressConfig::default(),
             pressed: false,
         };
+
         let config = PressConfig {
             disabled: true,
             ..PressConfig::default()
         };
+
         let attrs = result.current_attrs(&config);
+
         assert!(attrs.contains(&HtmlAttr::Data("ars-disabled")));
         assert_eq!(
             attrs.get_value(&HtmlAttr::Data("ars-disabled")),
@@ -946,11 +1017,14 @@ mod tests {
             config: PressConfig::default(),
             pressed: true,
         };
+
         let config = PressConfig {
             disabled: true,
             ..PressConfig::default()
         };
+
         let attrs = result.current_attrs(&config);
+
         assert!(attrs.contains(&HtmlAttr::Data("ars-pressed")));
         assert!(attrs.contains(&HtmlAttr::Data("ars-disabled")));
     }
@@ -970,8 +1044,11 @@ mod tests {
             config: PressConfig::default(),
             pressed: false,
         };
+
         let config = PressConfig::default();
+
         let attrs = result.current_attrs(&config);
+
         assert!(!attrs.contains(&HtmlAttr::Data("ars-pressed")));
     }
 
@@ -980,12 +1057,14 @@ mod tests {
     #[test]
     fn use_press_returns_idle_state() {
         let result = use_press(PressConfig::default());
+
         assert_eq!(*result.state.borrow(), PressState::Idle);
     }
 
     #[test]
     fn use_press_returns_pressed_false() {
         let result = use_press(PressConfig::default());
+
         assert!(!result.pressed);
     }
 
@@ -995,7 +1074,9 @@ mod tests {
             disabled: true,
             ..PressConfig::default()
         };
+
         let result = use_press(config);
+
         assert_eq!(*result.state.borrow(), PressState::Idle);
         assert!(!result.pressed);
     }
@@ -1003,6 +1084,7 @@ mod tests {
     #[test]
     fn begin_press_enters_pressed_inside_and_fires_start_callback() {
         let start_events = Arc::new(std::sync::Mutex::new(Vec::<PressEvent>::new()));
+
         let config = PressConfig {
             on_press_start: Some({
                 let start_events = Arc::clone(&start_events);
@@ -1012,6 +1094,7 @@ mod tests {
             }),
             ..PressConfig::default()
         };
+
         let mut result = use_press(config);
 
         result.begin_press(
@@ -1037,8 +1120,11 @@ mod tests {
         );
         assert!(result.pressed);
         assert_eq!(start_events.lock().expect("poisoned").len(), 1);
+
         let start_events = start_events.lock().expect("poisoned");
+
         let event = &start_events[0];
+
         assert_eq!(event.pointer_type, PointerType::Mouse);
         assert_eq!(event.event_type, PressEventType::PressStart);
         assert_eq!(event.client_x, Some(12.0));
@@ -1059,16 +1145,19 @@ mod tests {
     #[test]
     fn begin_press_disabled_is_ignored() {
         let start_count = Arc::new(AtomicUsize::new(0));
+
         let config = PressConfig {
             disabled: true,
             on_press_start: Some({
                 let start_count = Arc::clone(&start_count);
+
                 Callback::new(move |_: PressEvent| {
                     start_count.fetch_add(1, Ordering::SeqCst);
                 })
             }),
             ..PressConfig::default()
         };
+
         let mut result = use_press(config);
 
         result.begin_press(
@@ -1087,15 +1176,18 @@ mod tests {
     #[test]
     fn duplicate_begin_press_for_same_modality_is_ignored() {
         let start_count = Arc::new(AtomicUsize::new(0));
+
         let config = PressConfig {
             on_press_start: Some({
                 let start_count = Arc::clone(&start_count);
+
                 Callback::new(move |_: PressEvent| {
                     start_count.fetch_add(1, Ordering::SeqCst);
                 })
             }),
             ..PressConfig::default()
         };
+
         let mut result = use_press(config);
 
         result.begin_press(
@@ -1105,6 +1197,7 @@ mod tests {
             KeyModifiers::default(),
             true,
         );
+
         result.begin_press(
             PointerType::Touch,
             Some(9.0),
@@ -1128,16 +1221,20 @@ mod tests {
     #[test]
     fn update_pressed_bounds_emits_change_events_for_leave_and_reenter() {
         let changes = Arc::new(std::sync::Mutex::new(Vec::<bool>::new()));
+
         let config = PressConfig {
             on_press_change: Some({
                 let changes = Arc::clone(&changes);
+
                 Callback::new(move |inside: bool| {
                     changes.lock().expect("poisoned").push(inside);
                 })
             }),
             ..PressConfig::default()
         };
+
         let mut result = use_press(config);
+
         result.begin_press(
             PointerType::Touch,
             Some(1.0),
@@ -1147,6 +1244,7 @@ mod tests {
         );
 
         result.update_pressed_bounds(PointerType::Touch, false, Some(10.0), Some(11.0));
+
         assert_eq!(
             result.current_state(),
             PressState::PressedOutside {
@@ -1156,6 +1254,7 @@ mod tests {
         assert!(!result.pressed);
 
         result.update_pressed_bounds(PointerType::Touch, true, Some(12.0), Some(13.0));
+
         assert_eq!(
             result.current_state(),
             PressState::PressedInside {
@@ -1171,16 +1270,20 @@ mod tests {
     #[test]
     fn update_pressed_bounds_with_unknown_modality_is_noop() {
         let changes = Arc::new(std::sync::Mutex::new(Vec::<bool>::new()));
+
         let config = PressConfig {
             on_press_change: Some({
                 let changes = Arc::clone(&changes);
+
                 Callback::new(move |inside: bool| {
                     changes.lock().expect("poisoned").push(inside);
                 })
             }),
             ..PressConfig::default()
         };
+
         let mut result = use_press(config);
+
         result.begin_press(
             PointerType::Mouse,
             Some(2.0),
@@ -1206,16 +1309,20 @@ mod tests {
     #[test]
     fn update_pressed_bounds_without_change_does_not_emit_callback() {
         let changes = Arc::new(std::sync::Mutex::new(Vec::<bool>::new()));
+
         let config = PressConfig {
             on_press_change: Some({
                 let changes = Arc::clone(&changes);
+
                 Callback::new(move |inside: bool| {
                     changes.lock().expect("poisoned").push(inside);
                 })
             }),
             ..PressConfig::default()
         };
+
         let mut result = use_press(config);
+
         result.begin_press(
             PointerType::Pen,
             Some(3.0),
@@ -1240,6 +1347,7 @@ mod tests {
     #[test]
     fn update_pressed_bounds_backfills_origin_when_begin_had_no_coordinates() {
         let config = PressConfig::default();
+
         let mut result = use_press(config);
 
         // Begin press with no coordinates (keyboard-initiated press).
@@ -1250,6 +1358,7 @@ mod tests {
             KeyModifiers::default(),
             true,
         );
+
         assert_eq!(
             result.current_state(),
             PressState::PressedInside {
@@ -1275,15 +1384,18 @@ mod tests {
     #[test]
     fn begin_press_outside_emits_initial_press_change_false() {
         let changes = Arc::new(std::sync::Mutex::new(Vec::<bool>::new()));
+
         let config = PressConfig {
             on_press_change: Some({
                 let changes = Arc::clone(&changes);
+
                 Callback::new(move |inside: bool| {
                     changes.lock().expect("poisoned").push(inside);
                 })
             }),
             ..PressConfig::default()
         };
+
         let mut result = use_press(config);
 
         result.begin_press(
@@ -1307,6 +1419,7 @@ mod tests {
     #[test]
     fn begin_press_from_idle_clears_stale_long_press_flag() {
         let shared_flag = SharedState::new(Some(PointerType::Mouse));
+
         let mut result = use_press(PressConfig {
             long_press_cancel_flag: Some(shared_flag.clone()),
             ..PressConfig::default()
@@ -1327,11 +1440,15 @@ mod tests {
     #[test]
     fn end_press_fires_activation_when_inside() {
         let end_events = Arc::new(std::sync::Mutex::new(Vec::<PressEvent>::new()));
+
         let press_events = Arc::new(std::sync::Mutex::new(Vec::<PressEvent>::new()));
+
         let up_events = Arc::new(std::sync::Mutex::new(Vec::<PressEvent>::new()));
+
         let config = PressConfig {
             on_press_end: Some({
                 let end_events = Arc::clone(&end_events);
+
                 Callback::new(move |event: PressEvent| {
                     end_events.lock().expect("poisoned").push(event);
                 })
@@ -1350,7 +1467,9 @@ mod tests {
             }),
             ..PressConfig::default()
         };
+
         let mut result = use_press(config);
+
         result.begin_press(
             PointerType::Keyboard,
             None,
@@ -1376,11 +1495,15 @@ mod tests {
     #[test]
     fn end_press_outside_without_allow_press_on_exit_does_not_activate() {
         let up_events = Arc::new(std::sync::Mutex::new(Vec::<PressEvent>::new()));
+
         let end_events = Arc::new(std::sync::Mutex::new(Vec::<PressEvent>::new()));
+
         let press_count = Arc::new(AtomicUsize::new(0));
+
         let config = PressConfig {
             on_press_up: Some({
                 let up_events = Arc::clone(&up_events);
+
                 Callback::new(move |event: PressEvent| {
                     up_events.lock().expect("poisoned").push(event);
                 })
@@ -1399,7 +1522,9 @@ mod tests {
             }),
             ..PressConfig::default()
         };
+
         let mut result = use_press(config);
+
         result.begin_press(
             PointerType::Mouse,
             Some(5.0),
@@ -1407,6 +1532,7 @@ mod tests {
             KeyModifiers::default(),
             true,
         );
+
         result.update_pressed_bounds(PointerType::Mouse, false, Some(20.0), Some(21.0));
 
         let activated = result.end_press(
@@ -1429,6 +1555,7 @@ mod tests {
     #[test]
     fn end_press_outside_activates_when_allow_press_on_exit_is_enabled() {
         let activation_count = Arc::new(AtomicUsize::new(0));
+
         let config = PressConfig {
             allow_press_on_exit: true,
             on_press: Some({
@@ -1439,7 +1566,9 @@ mod tests {
             }),
             ..PressConfig::default()
         };
+
         let mut result = use_press(config);
+
         result.begin_press(
             PointerType::Mouse,
             Some(5.0),
@@ -1447,6 +1576,7 @@ mod tests {
             KeyModifiers::default(),
             true,
         );
+
         result.update_pressed_bounds(PointerType::Mouse, false, Some(20.0), Some(21.0));
 
         let activated = result.end_press(
@@ -1465,25 +1595,32 @@ mod tests {
     #[test]
     fn end_press_suppresses_activation_when_long_press_flag_is_set() {
         let activation_count = Arc::new(AtomicUsize::new(0));
+
         let shared_flag = SharedState::new(Some(PointerType::Touch));
+
         let config = PressConfig {
             long_press_cancel_flag: Some(shared_flag.clone()),
             on_press: Some({
                 let activation_count = Arc::clone(&activation_count);
+
                 Callback::new(move |_: PressEvent| {
                     activation_count.fetch_add(1, Ordering::SeqCst);
                 })
             }),
             ..PressConfig::default()
         };
+
         let mut result = use_press(config);
+
         result.active_presses.borrow_mut().push(ActivePress {
             pointer_type: PointerType::Touch,
             origin_x: Some(8.0),
             origin_y: Some(9.0),
             is_within_element: true,
         });
+
         *result.state.borrow_mut() = derive_press_state(&result.active_presses.borrow());
+
         result.pressed = true;
 
         let activated = result.end_press(
@@ -1502,6 +1639,7 @@ mod tests {
     #[test]
     fn end_press_with_unknown_modality_returns_false() {
         let mut result = use_press(PressConfig::default());
+
         result.begin_press(
             PointerType::Touch,
             Some(8.0),
@@ -1528,23 +1666,29 @@ mod tests {
     #[test]
     fn cancel_press_resets_state_and_fires_end_without_activation() {
         let end_count = Arc::new(AtomicUsize::new(0));
+
         let press_count = Arc::new(AtomicUsize::new(0));
+
         let config = PressConfig {
             on_press_end: Some({
                 let end_count = Arc::clone(&end_count);
+
                 Callback::new(move |_: PressEvent| {
                     end_count.fetch_add(1, Ordering::SeqCst);
                 })
             }),
             on_press: Some({
                 let press_count = Arc::clone(&press_count);
+
                 Callback::new(move |_: PressEvent| {
                     press_count.fetch_add(1, Ordering::SeqCst);
                 })
             }),
             ..PressConfig::default()
         };
+
         let mut result = use_press(config);
+
         result.begin_press(
             PointerType::Pen,
             Some(2.0),
@@ -1569,16 +1713,20 @@ mod tests {
     #[test]
     fn cancel_press_with_unknown_modality_is_noop() {
         let end_count = Arc::new(AtomicUsize::new(0));
+
         let config = PressConfig {
             on_press_end: Some({
                 let end_count = Arc::clone(&end_count);
+
                 Callback::new(move |_: PressEvent| {
                     end_count.fetch_add(1, Ordering::SeqCst);
                 })
             }),
             ..PressConfig::default()
         };
+
         let mut result = use_press(config);
+
         result.begin_press(
             PointerType::Pen,
             Some(2.0),
@@ -1609,15 +1757,18 @@ mod tests {
     #[test]
     fn simultaneous_pointer_and_keyboard_presses_are_tracked_independently() {
         let activation_count = Arc::new(AtomicUsize::new(0));
+
         let config = PressConfig {
             on_press: Some({
                 let activation_count = Arc::clone(&activation_count);
+
                 Callback::new(move |_: PressEvent| {
                     activation_count.fetch_add(1, Ordering::SeqCst);
                 })
             }),
             ..PressConfig::default()
         };
+
         let mut result = use_press(config);
 
         result.begin_press(
@@ -1627,6 +1778,7 @@ mod tests {
             KeyModifiers::default(),
             true,
         );
+
         result.begin_press(
             PointerType::Keyboard,
             None,
@@ -1665,18 +1817,23 @@ mod tests {
     #[test]
     fn second_modality_begin_does_not_clear_pending_long_press_suppression() {
         let activation_count = Arc::new(AtomicUsize::new(0));
+
         let shared_flag = SharedState::new(None);
+
         let config = PressConfig {
             long_press_cancel_flag: Some(shared_flag.clone()),
             on_press: Some({
                 let activation_count = Arc::clone(&activation_count);
+
                 Callback::new(move |_: PressEvent| {
                     activation_count.fetch_add(1, Ordering::SeqCst);
                 })
             }),
             ..PressConfig::default()
         };
+
         let mut result = use_press(config);
+
         result.begin_press(
             PointerType::Touch,
             Some(4.0),
@@ -1684,6 +1841,7 @@ mod tests {
             KeyModifiers::default(),
             true,
         );
+
         shared_flag.set(Some(PointerType::Touch));
 
         result.begin_press(
@@ -1718,17 +1876,21 @@ mod tests {
     #[test]
     fn outside_release_consumes_long_press_suppression_before_other_modality_activates() {
         let activation_count = Arc::new(AtomicUsize::new(0));
+
         let shared_flag = SharedState::new(None);
+
         let config = PressConfig {
             long_press_cancel_flag: Some(shared_flag.clone()),
             on_press: Some({
                 let activation_count = Arc::clone(&activation_count);
+
                 Callback::new(move |_: PressEvent| {
                     activation_count.fetch_add(1, Ordering::SeqCst);
                 })
             }),
             ..PressConfig::default()
         };
+
         let mut result = use_press(config);
 
         result.begin_press(
@@ -1738,6 +1900,7 @@ mod tests {
             KeyModifiers::default(),
             true,
         );
+
         result.begin_press(
             PointerType::Keyboard,
             None,
@@ -1747,6 +1910,7 @@ mod tests {
         );
 
         result.update_pressed_bounds(PointerType::Touch, false, Some(40.0), Some(50.0));
+
         shared_flag.set(Some(PointerType::Touch));
 
         let touch_activated = result.end_press(
@@ -1755,6 +1919,7 @@ mod tests {
             Some(50.0),
             KeyModifiers::default(),
         );
+
         let keyboard_activated =
             result.end_press(PointerType::Keyboard, None, None, KeyModifiers::default());
 
@@ -1769,17 +1934,21 @@ mod tests {
     #[test]
     fn long_press_suppression_is_consumed_only_by_matching_modality_release() {
         let activation_count = Arc::new(AtomicUsize::new(0));
+
         let shared_flag = SharedState::new(None);
+
         let config = PressConfig {
             long_press_cancel_flag: Some(shared_flag.clone()),
             on_press: Some({
                 let activation_count = Arc::clone(&activation_count);
+
                 Callback::new(move |_: PressEvent| {
                     activation_count.fetch_add(1, Ordering::SeqCst);
                 })
             }),
             ..PressConfig::default()
         };
+
         let mut result = use_press(config);
 
         result.begin_press(
@@ -1789,6 +1958,7 @@ mod tests {
             KeyModifiers::default(),
             true,
         );
+
         result.begin_press(
             PointerType::Keyboard,
             None,
@@ -1801,6 +1971,7 @@ mod tests {
 
         let keyboard_activated =
             result.end_press(PointerType::Keyboard, None, None, KeyModifiers::default());
+
         let touch_activated = result.end_press(
             PointerType::Touch,
             Some(4.0),
@@ -1819,17 +1990,21 @@ mod tests {
     #[test]
     fn cancel_press_clears_matching_long_press_suppression() {
         let activation_count = Arc::new(AtomicUsize::new(0));
+
         let shared_flag = SharedState::new(None);
+
         let config = PressConfig {
             long_press_cancel_flag: Some(shared_flag.clone()),
             on_press: Some({
                 let activation_count = Arc::clone(&activation_count);
+
                 Callback::new(move |_: PressEvent| {
                     activation_count.fetch_add(1, Ordering::SeqCst);
                 })
             }),
             ..PressConfig::default()
         };
+
         let mut result = use_press(config);
 
         result.begin_press(
@@ -1839,6 +2014,7 @@ mod tests {
             KeyModifiers::default(),
             true,
         );
+
         shared_flag.set(Some(PointerType::Touch));
 
         result.cancel_press(
@@ -1877,16 +2053,20 @@ mod tests {
     #[test]
     fn pointer_exit_does_not_clear_pressed_while_keyboard_press_remains_active() {
         let changes = Arc::new(std::sync::Mutex::new(Vec::<bool>::new()));
+
         let config = PressConfig {
             on_press_change: Some({
                 let changes = Arc::clone(&changes);
+
                 Callback::new(move |inside: bool| {
                     changes.lock().expect("poisoned").push(inside);
                 })
             }),
             ..PressConfig::default()
         };
+
         let mut result = use_press(config);
+
         result.begin_press(
             PointerType::Mouse,
             Some(1.0),

--- a/spec/foundation/01-architecture.md
+++ b/spec/foundation/01-architecture.md
@@ -145,7 +145,7 @@ ssr = ["dioxus/server", "dep:ars-dom", "ars-dom/ssr"]
 
 > **Debug logging:** `ars-core` provides an optional `debug` feature flag that enables the `log` crate facade. When enabled, state transitions, guard evaluations, and effect dispatches emit trace-level log events. Adapters must initialize a logger (e.g., `console_log` for WASM, `env_logger` for native). Without the feature flag, all logging is compiled out. This resolves the `no_std` limitation on debug output.
 >
-> **Design note — `Rc` and single-threaded model:** On WASM targets, `ars-core` uses `Rc` (not `Arc`) throughout, including for the `send` callback in `PendingEffect::setup`. This is intentional — WASM environments are single-threaded and `Rc` avoids atomic overhead. On native targets, cfg-gated `Arc` variants are used (see `Callback<T>` in §2.2). Desktop adapters (e.g., Dioxus Desktop) must still ensure machine mutation remains on a single thread.
+> **Design note — single-threaded machine mutation:** `ars-core` machine services are still driven from a single logical thread, even though shared callback handles such as `Callback<T>` and the `send` callback passed to `PendingEffect::setup` use `Arc` on all targets. Desktop adapters (e.g., Dioxus Desktop) must still ensure machine mutation remains on one thread at a time.
 
 #### 1.4.1 Thread Safety for Desktop Adapters
 
@@ -295,11 +295,9 @@ use core::{fmt::Debug, hash::Hash};
 // SAFETY/THREADING: Machine instances use `Rc` (not `Arc`) and are NOT thread-safe.
 // Each machine instance must remain on its originating thread. For multi-threaded
 // applications, create separate machine instances per thread.
-use alloc::rc::Rc;
-// Arc is only used on native targets (where the `std` feature is active)
-// for Callback wrappers that cross thread boundaries. On WASM, Rc suffices.
+
+// Arc is used for shared callback wrappers on every target.
 // Note: native targets always enable the `std` feature, making alloc::sync available.
-#[cfg(not(target_arch = "wasm32"))]
 use alloc::sync::{Arc, Weak};
 
 /// Trait for props that carry a component ID.
@@ -608,6 +606,8 @@ This enables `data-ars-state` values and Service debug logging.
 > `TransitionPlan::to(State::Open).apply(|ctx| ctx.count += 1).with_effect(...)`.
 
 ````rust
+type ApplyFn<M> = dyn FnOnce(&mut <M as Machine>::Context);
+
 /// A transition plan describes what should happen in response to an event.
 /// Built using a fluent builder pattern.
 pub struct TransitionPlan<M: Machine> {
@@ -617,7 +617,7 @@ pub struct TransitionPlan<M: Machine> {
     /// Uses `FnOnce` — apply is called exactly once, immediately after transition
     /// selection. Using FnOnce enforces single-invocation semantics.
     /// `pub(crate)` — construct via `.apply()` / `.context_only()` builder methods.
-    pub(crate) apply: Option<Box<dyn FnOnce(&mut M::Context)>>,
+    pub(crate) apply: Option<Box<ApplyFn<M>>>,
     /// Events to enqueue after this transition completes.
     pub then_send: Vec<M::Event>,
     /// Optional human-readable description of the apply closure's purpose.

--- a/spec/foundation/04-internationalization.md
+++ b/spec/foundation/04-internationalization.md
@@ -2494,7 +2494,7 @@ function stores `env.locale.clone()` in the machine's `Context` struct. Connect
 functions then access it via `self.ctx.locale`. See `01-architecture.md` §6.4.3
 for the environment resolution rule.
 
-**Closure fields** use `MessageFn<dyn Fn>` (`Arc` on native, `Rc` on WASM — not `Box`) so the struct remains `Clone`.
+**Closure fields** use `MessageFn<dyn Fn>` (`Arc` on all targets — not `Box`) so the struct remains `Clone`.
 `MessageFn<T>` implements `Debug` by printing `"<closure>"`, so all Messages structs
 can `#[derive(Clone, Debug)]` uniformly — no manual `Debug` impls needed.
 
@@ -2615,10 +2615,9 @@ impl MessageFn<dyn Fn(&Locale) -> String + Send + Sync> {
 - For signatures outside the shared `ars-core` set, first coerce the closure into a typed `Arc<dyn Fn(...) + Send + Sync>` and then pass that `Arc` to `MessageFn::new`. This is the escape hatch for downstream crates that define their own event or domain-specific parameter types.
 
 > **Design note — All `MessageFn` trait objects include `+ Send + Sync`.**
-> This avoids cfg-gated dual struct definitions for every `*Messages` type. On WASM,
-> `Rc<dyn Fn(...) + Send + Sync>` is valid — the bound constrains the closure type, not
-> the wrapper. Most closures satisfy `Send + Sync` by default. If WASM gains threading,
-> the migration to `Arc` is a single-line change in the `MessageFn` typedef.
+> This avoids cfg-gated dual struct definitions for every `*Messages` type.
+> `MessageFn` uses `Arc` on all targets, and most closures satisfy `Send + Sync`
+> by default, so message structs stay uniform across native and WASM builds.
 
 ```rust
 /// The pattern all component message structs follow.

--- a/spec/foundation/05-interactions.md
+++ b/spec/foundation/05-interactions.md
@@ -129,8 +129,8 @@ use crate::PointerType;
 
 /// Configuration for press interaction behavior.
 ///
-/// Callbacks use [`Callback`] (not raw `Rc`/`Arc`) for automatic
-/// platform-appropriate pointer type and built-in `Clone`, `Debug`,
+/// Callbacks use [`Callback`] (not raw `Rc`/`Arc`) for shared Arc-backed
+/// ownership and built-in `Clone`, `Debug`,
 /// and `PartialEq` (by pointer identity).
 #[derive(Clone, Debug, PartialEq)]
 pub struct PressConfig {
@@ -845,8 +845,8 @@ use crate::PointerType;
 /// Configuration for hover interaction behavior.
 ///
 /// Controls how the hover interaction responds to pointer enter/leave events.
-/// Callbacks use [`Callback`] for automatic platform-appropriate pointer type
-/// (`Rc` on wasm, `Arc` on native) and built-in `Clone`, `Debug`, and
+/// Callbacks use [`Callback`] for shared Arc-backed ownership plus built-in
+/// `Clone`, `Debug`, and
 /// `PartialEq` (by pointer identity).
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct HoverConfig {
@@ -2310,13 +2310,14 @@ pub struct KeyboardDropTarget {
 /// Follows the canonical `MessageFn` pattern from `ars-i18n` (`04-internationalization.md` §7.1):
 /// cfg-gated `Rc`/`Arc` wrapper, `+ Send + Sync` on all targets, `&Locale` parameter.
 ///
-/// All closure fields use `MessageFn::new()` which delegates to the cfg-gated `From` impls
-/// defined in `04-internationalization.md` §7.1 — `Rc` on WASM, `Arc` on native.
+/// All closure fields use `MessageFn::new()` which delegates to the `From` impls
+/// defined in `04-internationalization.md` §7.1 and stores closures in `Arc`
+/// on every target.
 ///
 /// **`+ Send + Sync` bounds:** All `MessageFn` closures include `+ Send + Sync` as a
-/// deliberate project-wide convention. On WASM targets the `MessageFn` wrapper uses `Rc`
-/// (non-atomic), but the trait object bounds remain `Send + Sync` so that closures are
-/// thread-safe for native desktop targets without cfg-gated API differences. See the
+/// deliberate project-wide convention. The trait object bounds remain `Send + Sync`
+/// so that closures are thread-safe for native desktop targets without cfg-gated API
+/// differences. See the
 /// `MessageFn` definition in `04-internationalization.md` §7.1 for the full rationale.
 #[derive(Clone)]
 pub struct DragAnnouncements {

--- a/spec/foundation/06-collections.md
+++ b/spec/foundation/06-collections.md
@@ -6106,12 +6106,12 @@ Each component's state machine gains an optional `dnd_enabled: bool` config fiel
 ```rust
 /// Localizable messages for collection-level drag-and-drop operations.
 /// Follows the ComponentMessages pattern from `04-internationalization.md` §7.1.
-/// `CollectionDndMessages` uses `MessageFn` (cfg-gated: `Rc` on WASM, `Arc` on native)
+/// `CollectionDndMessages` uses `MessageFn` (`Arc` on all targets)
 /// for closure fields, consistent with the Messages convention in `04-internationalization.md` §7.1.
 ///
 /// `MessageFn::new(closure)` accepts any closure matching the field's function signature.
 /// The `MessageFn<dyn Fn(A, B, ...) -> String + Send + Sync>` wrapper provides a
-/// type-erased, cfg-gated (Rc on WASM / Arc on native) container. Each closure signature
+/// type-erased, Arc-backed container. Each closure signature
 /// requires a corresponding `From` impl in the `MessageFn` infrastructure (see
 /// `04-internationalization.md` §7.1).
 // Manual Debug impl prints closure fields as "<closure>".

--- a/spec/foundation/07-forms.md
+++ b/spec/foundation/07-forms.md
@@ -475,10 +475,7 @@ impl State {
 ### 3.1 Synchronous Validator
 
 ````rust
-#[cfg(not(target_arch = "wasm32"))]
 use std::sync::Arc;
-#[cfg(target_arch = "wasm32")]
-use std::rc::Rc;
 use std::fmt;
 
 /// Context available to validators during validation.
@@ -555,48 +552,23 @@ impl<'a> Context<'a> {
 
 /// A synchronous field validator.
 ///
-/// **Platform-dependent bounds:** On native targets, `Validator`
-/// requires `Send + Sync` so that `BoxedValidator = Arc<dyn Validator + Send + Sync>`
-/// can wrap any implementor. On WASM (single-threaded), no extra bounds are required.
-/// All built-in validators satisfy both bound sets. Custom validators created via
-/// `FnValidator` or `ValidatorsBuilder::add()` automatically pick up the correct
-/// bounds through cfg-gated signatures.
-#[cfg(not(target_arch = "wasm32"))]
+/// Validators are always `Send + Sync`, so the same trait object shape works
+/// on every target without cfg-gated API differences. Custom validators created via
+/// `FnValidator` or `ValidatorsBuilder::add()` automatically pick up the same bounds.
 pub trait Validator: Send + Sync {
-    fn validate(&self, value: &Value, ctx: &Context) -> Result;
-}
-
-#[cfg(target_arch = "wasm32")]
-pub trait Validator {
     fn validate(&self, value: &Value, ctx: &Context) -> Result;
 }
 
 /// A type-erased synchronous validator.
 /// Uses `Arc` instead of `Box` for cheap cloning across reactive signals.
-///
-/// On WASM targets, `Send + Sync` are not available (single-threaded),
-/// so we use `Rc` instead of `Arc` to avoid unnecessary atomic overhead.
-///
-/// The `BoxedValidator` bounds match the `Validator` trait bounds per platform,
-/// so `Arc::from(Box::new(v))` / `Rc::new(v)` in `ValidatorsBuilder::add()`
-/// always compiles without additional where-clause gymnastics.
-#[cfg(not(target_arch = "wasm32"))]
 pub type BoxedValidator = Arc<dyn Validator + Send + Sync>;
-#[cfg(target_arch = "wasm32")]
-pub type BoxedValidator = Rc<dyn Validator>;
 
-/// Helper to wrap a Validator into the correct smart pointer for the platform.
+/// Helper to wrap a Validator into the standard shared pointer type.
 pub fn boxed_validator(v: impl Validator + 'static) -> BoxedValidator {
-    #[cfg(not(target_arch = "wasm32"))]
-    { Arc::new(v) }
-    #[cfg(target_arch = "wasm32")]
-    { Rc::new(v) }
+    Arc::new(v)
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 pub type BoxedAsyncValidator = Arc<dyn AsyncValidator + Send + Sync>;
-#[cfg(target_arch = "wasm32")]
-pub type BoxedAsyncValidator = Rc<dyn AsyncValidator>;
 ````
 
 ### 3.2 Built-in Validators
@@ -895,28 +867,10 @@ fn is_valid_url(s: &str) -> bool {
 }
 
 /// Validator created from a closure.
-///
-/// On non-WASM targets, `F` must also be `Send + Sync` so that
-/// `BoxedValidator = Arc<dyn Validator + Send + Sync>` can wrap it.
-#[cfg(not(target_arch = "wasm32"))]
 pub struct FnValidator<F: Fn(&Value, &Context) -> Result + Send + Sync> {
     pub f: F,
 }
-
-#[cfg(target_arch = "wasm32")]
-pub struct FnValidator<F: Fn(&Value, &Context) -> Result> {
-    pub f: F,
-}
-
-#[cfg(not(target_arch = "wasm32"))]
 impl<F: Fn(&Value, &Context) -> Result + Send + Sync> Validator for FnValidator<F> {
-    fn validate(&self, value: &Value, ctx: &Context) -> Result {
-        (self.f)(value, ctx)
-    }
-}
-
-#[cfg(target_arch = "wasm32")]
-impl<F: Fn(&Value, &Context) -> Result> Validator for FnValidator<F> {
     fn validate(&self, value: &Value, ctx: &Context) -> Result {
         (self.f)(value, ctx)
     }
@@ -931,18 +885,8 @@ impl<F: Fn(&Value, &Context) -> Result> Validator for FnValidator<F> {
 /// ];
 /// ```
 /// The `Validator` trait is object-safe. `FnValidator` erases the closure type.
-/// Use `.boxed()` to create the correct smart pointer type (`Arc` on native, `Rc` on WASM).
-/// When closures capture `Rc<RefCell<T>>`, ensure the capture is `Clone`-compatible
-/// with the platform-specific `BoxedValidator` bounds.
-
-#[cfg(not(target_arch = "wasm32"))]
+/// Use `.boxed()` to create the standard shared smart pointer type.
 impl<F: Fn(&Value, &Context) -> Result + Send + Sync + 'static> FnValidator<F> {
-    pub fn new(f: F) -> Self { Self { f } }
-    pub fn boxed(self) -> BoxedValidator { boxed_validator(self) }
-}
-
-#[cfg(target_arch = "wasm32")]
-impl<F: Fn(&Value, &Context) -> Result + 'static> FnValidator<F> {
     pub fn new(f: F) -> Self { Self { f } }
     pub fn boxed(self) -> BoxedValidator { boxed_validator(self) }
 }
@@ -971,21 +915,13 @@ impl ValidatorsBuilder {
         Self { validators: Vec::new() }
     }
 
-    /// Add a validator. The `Validator` trait itself carries `Send + Sync` on
-    /// native targets (cfg-gated), so the bound here is simply `Validator + 'static`
-    /// and the conversion to `BoxedValidator` compiles on all platforms without
-    /// additional where clauses.
+    /// Add a validator. The `Validator` trait itself always carries
+    /// `Send + Sync`, so the bound here is simply `Validator + 'static`
+    /// and the conversion to `BoxedValidator` compiles on all platforms
+    /// without additional where clauses.
     pub fn add(mut self, v: impl Validator + 'static) -> Self {
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            // `Validator: Send + Sync` on native, so this cast is valid.
-            let v: Box<dyn Validator + Send + Sync> = Box::new(v);
-            self.validators.push(Arc::from(v));
-        }
-        #[cfg(target_arch = "wasm32")]
-        {
-            self.validators.push(Rc::new(v));
-        }
+        let v: Box<dyn Validator + Send + Sync> = Box::new(v);
+        self.validators.push(Arc::from(v));
         self
     }
 
@@ -1038,18 +974,9 @@ impl ValidatorsBuilder {
 
     // NOTE: `any()` moved to `AnyValidator::new()` — see below.
 
-    #[cfg(not(target_arch = "wasm32"))]
     pub fn custom<F>(self, f: F) -> Self
     where
         F: Fn(&Value, &Context) -> Result + Send + Sync + 'static,
-    {
-        self.add(FnValidator { f })
-    }
-
-    #[cfg(target_arch = "wasm32")]
-    pub fn custom<F>(self, f: F) -> Self
-    where
-        F: Fn(&Value, &Context) -> Result + 'static,
     {
         self.add(FnValidator { f })
     }
@@ -1110,9 +1037,10 @@ use core::pin::Pin;
 use std::collections::BTreeMap;
 use ars_i18n::Locale;
 
-/// Async validation trait. On non-WASM targets, returned futures must be `Send`.
-/// On WASM (single-threaded), the `Send` bound is relaxed.
-#[cfg(not(target_arch = "wasm32"))]
+/// Async validation trait.
+///
+/// Async validators are always `Send + Sync`, and returned futures are always
+/// `Send`, so the same trait object shape works on every target.
 pub trait AsyncValidator: Send + Sync {
     fn validate_async<'a>(
         &'a self,
@@ -1121,21 +1049,11 @@ pub trait AsyncValidator: Send + Sync {
     ) -> Pin<Box<dyn Future<Output = Result> + Send + 'a>>;
 }
 
-#[cfg(target_arch = "wasm32")]
-pub trait AsyncValidator {
-    fn validate_async<'a>(
-        &'a self,
-        value: &'a Value,
-        ctx: &'a Context<'a>,
-    ) -> Pin<Box<dyn Future<Output = Result> + 'a>>;
-}
-
 /// Wrap a closure as an async validator.
 pub struct AsyncFnValidator<F> {
     pub f: F,
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 impl<F, Fut> AsyncValidator for AsyncFnValidator<F>
 where
     F: Fn(String, OwnedContext) -> Fut + Send + Sync,
@@ -1153,50 +1071,17 @@ where
     }
 }
 
-#[cfg(target_arch = "wasm32")]
-impl<F, Fut> AsyncValidator for AsyncFnValidator<F>
-where
-    F: Fn(String, OwnedContext) -> Fut,
-    Fut: Future<Output = Result> + 'static,
-{
-    fn validate_async<'a>(
-        &'a self,
-        value: &'a Value,
-        ctx: &'a Context<'a>,
-    ) -> Pin<Box<dyn Future<Output = Result> + 'a>> {
-        let text = value.to_string_for_validation();
-        let owned_ctx = ctx.snapshot();
-        let fut = (self.f)(text, owned_ctx);
-        Box::pin(fut)
-    }
-}
-
 /// Debounced async validator — waits for `delay` of inactivity before calling.
-///
-/// Uses cfg-gated trait object: `Arc<dyn AsyncValidator + Send + Sync>` on native,
-/// `Rc<dyn AsyncValidator>` on WASM.
-#[cfg(not(target_arch = "wasm32"))]
 pub struct DebouncedAsyncValidator {
-    pub validator: Arc<dyn AsyncValidator + Send + Sync>,
+    pub validator: Arc<dyn AsyncValidator>,
     pub delay_ms: u32,
     /// Adapter-provided callback that spawns an async future to completion.
     /// On native: wraps `tokio::spawn`; on WASM: wraps `wasm_bindgen_futures::spawn_local`.
     /// The callback takes ownership of the `OwnedContext` and the future,
     /// avoiding lifetime issues with borrowed `Context`.
-    pub spawn_async_validation: Arc<dyn Fn(Arc<dyn AsyncValidator + Send + Sync>, Value, OwnedContext) + Send + Sync>,
+    pub spawn_async_validation: Arc<dyn Fn(Arc<dyn AsyncValidator>, Value, OwnedContext) + Send + Sync>,
     /// Handle to the currently pending debounce timer, if any.
     /// Used to cancel the previous timer when new input arrives.
-    pending_timer: Option<TimerHandle>,
-}
-
-#[cfg(target_arch = "wasm32")]
-pub struct DebouncedAsyncValidator {
-    pub validator: Rc<dyn AsyncValidator>,
-    pub delay_ms: u32,
-    /// Adapter-provided callback that spawns an async future to completion.
-    /// On WASM: wraps `wasm_bindgen_futures::spawn_local`.
-    /// Takes ownership of validator, value, and context to avoid lifetime issues.
-    pub spawn_async_validation: Rc<dyn Fn(Rc<dyn AsyncValidator>, Value, OwnedContext)>,
     pending_timer: Option<TimerHandle>,
 }
 
@@ -1323,7 +1208,7 @@ pub struct Context {
     #[doc(hidden)]
     validators: BTreeMap<String, BoxedValidator>,
 
-    /// Async validators per field. Uses `BoxedAsyncValidator` type alias (cfg-gated).
+    /// Async validators per field. Uses `BoxedAsyncValidator` for shared ownership.
     #[doc(hidden)]
     async_validators: BTreeMap<String, BoxedAsyncValidator>,
 
@@ -1448,7 +1333,6 @@ impl Validator for AnyValidator {
 /// ```rust
 /// let confirm = CrossFieldValidator {
 ///     depends_on: vec!["password".into()],
-///     // cfg-gated: use Rc::new(...) on WASM targets instead of Arc::new(...)
 ///     validate_fn: Arc::new(|value, ctx| {
 ///         let password = ctx.form_values.get("password")
 ///             .and_then(|v| v.as_text());
@@ -1463,12 +1347,8 @@ impl Validator for AnyValidator {
 /// };
 /// ```
 // Type alias avoids clippy::type_complexity on the struct field.
-#[cfg(not(target_arch = "wasm32"))]
 type CrossFieldValidateFn =
     Arc<dyn Fn(&Value, &Context) -> Result + Send + Sync>;
-#[cfg(target_arch = "wasm32")]
-type CrossFieldValidateFn =
-    Rc<dyn Fn(&Value, &Context) -> Result>;
 
 #[derive(Clone)]
 pub struct CrossFieldValidator {
@@ -1776,10 +1656,8 @@ impl Context {
     /// **Note:** `is_submitting` is only meaningful for the duration of the synchronous
     /// `handler` call. For async submission, use `form_submit::Machine` (§8) or
     /// `form::Machine` (§14), which properly manage the Submitting state across async boundaries.
-    /// Note: Adapter wrappers (e.g., `use_form`) may add platform-specific bounds
-    /// to the submit handler closure. On native targets (desktop Leptos/Dioxus),
-    /// the adapter wraps this with `+ Send` to satisfy multi-threaded runtime requirements.
-    /// See the adapter files (08-adapter-leptos.md, 09-adapter-dioxus.md) for cfg-gated Send bounds.
+    /// Note: adapter wrappers may require the submit handler closure to be `Send`
+    /// so it can be used uniformly across targets and runtimes.
     /// Submit the form with a synchronous handler.
     /// For fallible/async handlers, use `form_submit::Machine` (§8) which provides
     /// `SubmitError` event handling and proper async state management.
@@ -2221,10 +2099,7 @@ template expressions (e.g., conditionally showing a "clear" button when
 ```rust
 use ars_core::{TransitionPlan, PendingEffect, WeakSend, ConnectApi, AttrMap, HtmlAttr, AriaAttr};
 use ars_core::ComponentIds;
-#[cfg(not(target_arch = "wasm32"))]
 use std::sync::Arc;
-#[cfg(target_arch = "wasm32")]
-use std::rc::Rc;
 
 pub mod form_submit {
     use super::*;
@@ -2361,25 +2236,16 @@ pub mod form_submit {
                             // so the closure will run before the next user interaction.
                             // A CancellationToken guards against stale dispatch if the
                             // component unmounts between schedule and execution.
-                            #[cfg(not(target_arch = "wasm32"))]
                             let cancelled = Arc::new(std::sync::atomic::AtomicBool::new(false));
-                            #[cfg(target_arch = "wasm32")]
-                            let cancelled = Rc::new(std::cell::Cell::new(false));
                             let cancelled_clone = cancelled.clone();
                             (props.schedule_microtask)(Box::new(move || {
-                                #[cfg(not(target_arch = "wasm32"))]
                                 let is_cancelled = cancelled_clone.load(std::sync::atomic::Ordering::Relaxed);
-                                #[cfg(target_arch = "wasm32")]
-                                let is_cancelled = cancelled_clone.get();
                                 if !is_cancelled {
                                     send.call_if_alive(event);
                                 }
                             }));
                             Box::new(move || {
-                                #[cfg(not(target_arch = "wasm32"))]
                                 cancelled.store(true, std::sync::atomic::Ordering::Relaxed);
-                                #[cfg(target_arch = "wasm32")]
-                                cancelled.set(true);
                             })
                         }
                     })))
@@ -2484,6 +2350,10 @@ pub mod form_submit {
     /// Note: `id` must be set by the adapter layer (via `use_id`/`use_stable_id`);
     /// the Default empty string is a builder placeholder.
     // Adapters provide default no-op implementations; end-users never construct Props directly.
+    type SpawnAsyncValidationInput = (Vec<(String, BoxedAsyncValidator)>, WeakSend<Event>);
+    type SpawnAsyncValidationFn = dyn Fn(SpawnAsyncValidationInput) -> Box<dyn FnOnce()>;
+    type ScheduleMicrotaskFn = dyn Fn(Box<dyn FnOnce()>);
+
     #[derive(Clone, HasId)]
     pub struct Props {
         pub id: String,
@@ -2492,10 +2362,10 @@ pub mod form_submit {
         /// Signature: (validators, send) -> CleanupFn.
         /// Leptos: wraps `spawn_local`; Dioxus: wraps `spawn`.
         // Tuple parameter: Callback::new() supports single-arg closures; multi-param fns use a tuple.
-        pub spawn_async_validation: Callback<dyn Fn((Vec<(String, BoxedAsyncValidator)>, WeakSend<Event>)) -> Box<dyn FnOnce()>>,
+        pub spawn_async_validation: Callback<SpawnAsyncValidationFn>,
         /// Adapter-provided microtask scheduler for deferred event dispatch.
         /// WASM: wraps `queueMicrotask`; native: wraps `tokio::spawn` or equivalent.
-        pub schedule_microtask: Callback<dyn Fn(Box<dyn FnOnce()>)>,
+        pub schedule_microtask: Callback<ScheduleMicrotaskFn>,
         // On native targets (tokio), the boxed closure must be Send.
         // Adapters targeting native should use: Box<dyn FnOnce() + Send>
         // WASM targets (single-threaded) do not require Send.
@@ -4132,14 +4002,14 @@ Framework adapters must:
 ```rust
 /// Localizable messages for Form component announcements.
 /// Follows the ComponentMessages pattern from `04-internationalization.md` §7.1.
-/// `FormMessages` uses `MessageFn` (`Rc` on WASM, `Arc` on native) for closure fields
+/// `FormMessages` uses `MessageFn` (`Arc` on all targets) for closure fields
 /// so the struct can derive `Clone`. `MessageFn<T>` implements `Debug` by printing
 /// `"<closure>"`, so `#[derive(Debug)]` works without a manual impl.
 ///
 /// Trait objects include `+ Send + Sync` in their type signature on all targets.
-/// On WASM, `MessageFn` uses `Rc` internally (not `Arc`), so `FormMessages` itself
-/// is `!Send + !Sync` on WASM — this is expected and matches the single-threaded
-/// WASM execution model. See `04-internationalization.md` §7.1.
+/// `MessageFn` uses shared `Arc` ownership internally, matching the callback
+/// and validator closure patterns elsewhere in the codebase. See
+/// `04-internationalization.md` §7.1.
 
 #[derive(Clone, Debug)]
 pub struct FormMessages {
@@ -4248,8 +4118,6 @@ use std::sync::Arc;
 use ars_i18n::{plural_category, PluralCategory};
 
 // Build FormMessages from an i18n catalog for the active locale.
-// NOTE: This example uses Arc for brevity. On WASM targets, substitute Rc
-// (matching the cfg-gated MessageFn inner type).
 fn form_messages_for_locale(locale: &Locale) -> FormMessages {
     let catalog = Arc::new(load_catalog(locale));
     let c1 = Arc::clone(&catalog);

--- a/spec/foundation/07-forms.md
+++ b/spec/foundation/07-forms.md
@@ -553,23 +553,28 @@ impl<'a> Context<'a> {
 
 /// A synchronous field validator.
 ///
-/// Validators are always `Send + Sync`, so the same trait object shape works
-/// on every target without cfg-gated API differences. Custom validators created via
-/// `FnValidator` or `ValidatorsBuilder::add()` automatically pick up the same bounds.
+/// Native targets require validators to be `Send + Sync`; `wasm32` allows
+/// single-threaded validators that capture browser-only state.
+#[cfg(target_arch = "wasm32")]
+pub trait Validator {
+    fn validate(&self, value: &Value, ctx: &Context) -> Result;
+}
+
+#[cfg(not(target_arch = "wasm32"))]
 pub trait Validator: Send + Sync {
     fn validate(&self, value: &Value, ctx: &Context) -> Result;
 }
 
 /// A type-erased synchronous validator.
 /// Uses `Arc` instead of `Box` for cheap cloning across reactive signals.
-pub type BoxedValidator = Arc<dyn Validator + Send + Sync>;
+pub type BoxedValidator = Arc<dyn Validator>;
 
 /// Helper to wrap a Validator into the standard shared pointer type.
 pub fn boxed_validator(v: impl Validator + 'static) -> BoxedValidator {
     Arc::new(v)
 }
 
-pub type BoxedAsyncValidator = Arc<dyn AsyncValidator + Send + Sync>;
+pub type BoxedAsyncValidator = Arc<dyn AsyncValidator>;
 ````
 
 ### 3.2 Built-in Validators
@@ -918,15 +923,14 @@ impl ValidatorsBuilder {
         Self { validators: Vec::new() }
     }
 
-    /// Add a validator. The `Validator` trait itself always carries
-    /// `Send + Sync`, so the bound here is simply `Validator + 'static`
-    /// and the conversion to `BoxedValidator` compiles on all platforms
-    /// without additional where clauses.
-    pub fn add(mut self, v: impl Validator + 'static) -> Self {
-        let v: Box<dyn Validator + Send + Sync> = Box::new(v);
-        self.validators.push(Arc::from(v));
-        self
-    }
+/// Add a validator. Native targets still require `Send + Sync`, while
+/// `wasm32` accepts single-threaded validators as long as they implement
+/// the shared `Validator` contract.
+pub fn add(mut self, v: impl Validator + 'static) -> Self {
+    let v: Box<dyn Validator> = Box::new(v);
+    self.validators.push(Arc::from(v));
+    self
+}
 
     pub fn required(self) -> Self {
         self.add(RequiredValidator { message: None })
@@ -979,7 +983,7 @@ impl ValidatorsBuilder {
 
     pub fn custom<F>(self, f: F) -> Self
     where
-        F: Fn(&Value, &Context) -> Result + Send + Sync + 'static,
+        F: Fn(&Value, &Context) -> Result + 'static,
     {
         self.add(FnValidator { f })
     }
@@ -1042,8 +1046,18 @@ use ars_i18n::Locale;
 
 /// Async validation trait.
 ///
-/// Async validators are always `Send + Sync`, and returned futures are always
-/// `Send`, so the same trait object shape works on every target.
+/// Native targets require async validators and their returned futures to be
+/// `Send`; `wasm32` preserves browser futures that are intentionally `!Send`.
+#[cfg(target_arch = "wasm32")]
+pub trait AsyncValidator {
+    fn validate_async<'a>(
+        &'a self,
+        value: &'a Value,
+        ctx: &'a Context<'a>,
+    ) -> Pin<Box<dyn Future<Output = Result> + 'a>>;
+}
+
+#[cfg(not(target_arch = "wasm32"))]
 pub trait AsyncValidator: Send + Sync {
     fn validate_async<'a>(
         &'a self,
@@ -1059,14 +1073,31 @@ pub struct AsyncFnValidator<F> {
 
 impl<F, Fut> AsyncValidator for AsyncFnValidator<F>
 where
-    F: Fn(String, OwnedContext) -> Fut + Send + Sync,
-    Fut: Future<Output = Result> + Send + 'static,
+    F: Fn(String, OwnedContext) -> Fut + 'static,
+    Fut: Future<Output = Result> + 'static,
 {
+    #[cfg(target_arch = "wasm32")]
     fn validate_async<'a>(
         &'a self,
         value: &'a Value,
         ctx: &'a Context<'a>,
-    ) -> Pin<Box<dyn Future<Output = Result> + Send + 'a>> {
+    ) -> Pin<Box<dyn Future<Output = Result> + 'a>> {
+        let text = value.to_string_for_validation();
+        let owned_ctx = ctx.snapshot();
+        let fut = (self.f)(text, owned_ctx);
+        Box::pin(fut)
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn validate_async<'a>(
+        &'a self,
+        value: &'a Value,
+        ctx: &'a Context<'a>,
+    ) -> Pin<Box<dyn Future<Output = Result> + Send + 'a>>
+    where
+        F: Send + Sync,
+        Fut: Send,
+    {
         let text = value.to_string_for_validation();
         let owned_ctx = ctx.snapshot();
         let fut = (self.f)(text, owned_ctx);
@@ -1350,6 +1381,11 @@ impl Validator for AnyValidator {
 /// };
 /// ```
 // Type alias avoids clippy::type_complexity on the struct field.
+#[cfg(target_arch = "wasm32")]
+type CrossFieldValidateFn =
+    Arc<dyn Fn(&Value, &Context) -> Result>;
+
+#[cfg(not(target_arch = "wasm32"))]
 type CrossFieldValidateFn =
     Arc<dyn Fn(&Value, &Context) -> Result + Send + Sync>;
 

--- a/spec/foundation/07-forms.md
+++ b/spec/foundation/07-forms.md
@@ -158,13 +158,14 @@ impl Error {
     }
 
     /// Creates a "pattern" validation error.
-    pub fn pattern(messages: &FormMessages, locale: &ars_i18n::Locale) -> Self {
+    pub fn pattern(
+        pattern: impl Into<String>,
+        messages: &FormMessages,
+        locale: &ars_i18n::Locale,
+    ) -> Self {
         Self {
             message: (messages.pattern_error)(locale),
-            // Note: Pattern string is intentionally omitted from the error code —
-            // regex patterns are opaque implementation details not suitable for error codes.
-            // The pattern is documented in the validator setup, not the error.
-            code: ErrorCode::Pattern(String::new()),
+            code: ErrorCode::Pattern(pattern.into()),
         }
     }
 
@@ -741,7 +742,9 @@ impl Validator for PatternValidator {
                     .map(|m| Error { message: m, code: ErrorCode::Pattern(self.pattern.clone()) })
                     // Do not expose raw regex to users — it is incomprehensible
                     // in any language. Callers should provide a custom `message`.
-                    .unwrap_or_else(|| Error::pattern(&FormMessages::default(), locale))
+                    .unwrap_or_else(|| {
+                        Error::pattern(self.pattern.clone(), &FormMessages::default(), locale)
+                    })
             ]))
         } else {
             Ok(())

--- a/spec/shared/selection-patterns.md
+++ b/spec/shared/selection-patterns.md
@@ -397,11 +397,7 @@ pub enum FilterMode {
     StartsWith,
     /// Custom filter function. Receives the input text and an item label,
     /// returns `true` if the item should be visible.
-    /// Uses the same cfg-gate pattern as `MessageFn` (see 04-internationalization.md §7):
-    /// `Rc` on WASM, `Arc + Send + Sync` on native.
-    #[cfg(target_arch = "wasm32")]
-    Custom(Rc<dyn Fn(&str, &str) -> bool>),
-    #[cfg(not(target_arch = "wasm32"))]
+    /// Uses shared `Arc` ownership on all targets.
     Custom(Arc<dyn Fn(&str, &str) -> bool + Send + Sync>),
     /// No filtering — show all items always.
     None,

--- a/spec/testing/02-integration-tests.md
+++ b/spec/testing/02-integration-tests.md
@@ -254,8 +254,7 @@ fn effect_cleanup_runs_on_state_change() {
     assert!(!open_result.pending_effects.is_empty());
 
     // Run effects, collecting cleanups
-    // Note: Rc on WASM; use Arc<dyn Fn(Event) + Send + Sync> on native targets
-    let send_fn: Rc<dyn Fn(dialog::Event)> = Rc::new(|_: dialog::Event| {});
+    let send_fn: Arc<dyn Fn(dialog::Event) + Send + Sync> = Arc::new(|_: dialog::Event| {});
     use ars_core::CleanupFn;
 
     let mut active_cleanups: Vec<CleanupFn> = Vec::new();

--- a/spec/testing/05-adapter-harness.md
+++ b/spec/testing/05-adapter-harness.md
@@ -373,15 +373,9 @@ fn aria_parity_search_input() {
 ### 6.2.1 FilterMode::Custom Cfg-Gate Compilation Test
 
 ```rust
-/// Verify FilterMode::Custom compiles and works under both cfg targets.
-/// shared/selection-patterns.md now cfg-gates Custom: Rc on WASM, Arc + Send + Sync on native.
+/// Verify FilterMode::Custom compiles and works with shared `Arc` ownership.
 #[test]
 fn filter_mode_custom_compiles_on_both_targets() {
-    #[cfg(target_arch = "wasm32")]
-    let filter = FilterMode::Custom(Rc::new(|input: &str, label: &str| {
-        label.to_lowercase().contains(&input.to_lowercase())
-    }));
-    #[cfg(not(target_arch = "wasm32"))]
     let filter = FilterMode::Custom(Arc::new(|input: &str, label: &str| {
         label.to_lowercase().contains(&input.to_lowercase())
     }));

--- a/spec/testing/11-form-validation.md
+++ b/spec/testing/11-form-validation.md
@@ -66,21 +66,11 @@ impl AsyncValidators {
     pub fn new() -> Self { Self { rules: vec![] } }
     pub fn unique_username(mut self) -> Self { /* adds async uniqueness check */ self }
     pub fn custom_async(mut self, f: impl AsyncValidator + 'static) -> Self {
-        #[cfg(target_arch = "wasm32")]
-        self.rules.push(Rc::new(f));
-        #[cfg(not(target_arch = "wasm32"))]
         self.rules.push(Arc::new(f));
         self
     }
 
     /// Build a composed async validator that runs all registered rules.
-    #[cfg(target_arch = "wasm32")]
-    pub fn build(self) -> BoxedAsyncValidator {
-        let rules = self.rules;
-        Rc::new(ComposedAsyncValidator { rules })
-    }
-
-    #[cfg(not(target_arch = "wasm32"))]
     pub fn build(self) -> BoxedAsyncValidator {
         let rules = self.rules;
         Arc::new(ComposedAsyncValidator { rules })
@@ -479,7 +469,7 @@ fn cascading_validation_on_dependency_change() {
 
     form.register_cross_field_validator("zip", CrossFieldValidator {
         depends_on: vec!["country".into()],
-        validate_fn: Rc::new(|value: &FieldValue, ctx: &ValidationContext| -> ValidationResult {
+        validate_fn: Arc::new(|value: &FieldValue, ctx: &ValidationContext| -> ValidationResult {
             let country = ctx.form_values.get("country");
             match (country, value) {
                 (Some(FieldValue::Text(c)), FieldValue::Text(zip)) if c == "US" => {
@@ -524,7 +514,7 @@ fn cross_field_validator_auto_revalidates_on_dependency_change() {
     form.register("confirm_password", FieldValue::Text("abc123".into()), Some(Validators::new().build()), None);
     form.register_cross_field_validator("confirm_password", CrossFieldValidator {
         depends_on: vec!["password".into()],
-        validate_fn: Rc::new(|value: &FieldValue, ctx: &ValidationContext| -> ValidationResult {
+        validate_fn: Arc::new(|value: &FieldValue, ctx: &ValidationContext| -> ValidationResult {
             let password = ctx.form_values.get("password");
             if Some(value) != password {
                 ValidationResult::Invalid(ValidationErrors(vec![

--- a/spec/testing/12-advanced.md
+++ b/spec/testing/12-advanced.md
@@ -345,11 +345,6 @@ mod leak_tests {
         let mut svc = Service::<dialog::Machine>::new(props);
         let mut active_cleanups: Vec<Box<dyn FnOnce()>> = Vec::new();
 
-        // PendingEffect::run() takes Rc<dyn Fn(M::Event)> on wasm32,
-        // Arc<dyn Fn(M::Event) + Send + Sync> on native.
-        #[cfg(target_arch = "wasm32")]
-        let send_fn: Rc<dyn Fn(dialog::Event)> = Rc::new(|_| {});
-        #[cfg(not(target_arch = "wasm32"))]
         let send_fn: Arc<dyn Fn(dialog::Event) + Send + Sync> = Arc::new(|_| {});
 
         for _ in 0..100 {
@@ -389,11 +384,6 @@ mod leak_tests {
         let props = dialog::Props { id: "rc-test".into(), ..Default::default() };
         let mut svc = Service::<dialog::Machine>::new(props);
 
-        // PendingEffect::run() takes Rc<dyn Fn(M::Event)> on wasm32,
-        // Arc<dyn Fn(M::Event) + Send + Sync> on native.
-        #[cfg(target_arch = "wasm32")]
-        let send_fn: Rc<dyn Fn(dialog::Event)> = Rc::new(|_| {});
-        #[cfg(not(target_arch = "wasm32"))]
         let send_fn: Arc<dyn Fn(dialog::Event) + Send + Sync> = Arc::new(|_| {});
 
         #[cfg(target_arch = "wasm32")]
@@ -473,11 +463,6 @@ fn effects_balanced_on_lifecycle() {
 
     let props = dialog::Props { id: "balance-test".into(), ..Default::default() };
     let mut svc = Service::<dialog::Machine>::new(props);
-    // PendingEffect::run() takes Rc<dyn Fn(M::Event)> on wasm32,
-    // Arc<dyn Fn(M::Event) + Send + Sync> on native.
-    #[cfg(target_arch = "wasm32")]
-    let send_fn: Rc<dyn Fn(dialog::Event)> = Rc::new(|_| {});
-    #[cfg(not(target_arch = "wasm32"))]
     let send_fn: Arc<dyn Fn(dialog::Event) + Send + Sync> = Arc::new(|_| {});
     let mut active_cleanups: Vec<CleanupFn> = Vec::new();
 
@@ -532,11 +517,6 @@ fn dialog_cleanup_on_unmount() {
     let cleanup_ran = Rc::new(Cell::new(false));
     let props = dialog::Props { id: "unmount-test".into(), ..Default::default() };
     let mut svc = Service::<dialog::Machine>::new(props);
-    // PendingEffect::run() takes Rc<dyn Fn(M::Event)> on wasm32,
-    // Arc<dyn Fn(M::Event) + Send + Sync> on native.
-    #[cfg(target_arch = "wasm32")]
-    let send_fn: Rc<dyn Fn(dialog::Event)> = Rc::new(|_| {});
-    #[cfg(not(target_arch = "wasm32"))]
     let send_fn: Arc<dyn Fn(dialog::Event) + Send + Sync> = Arc::new(|_| {});
 
     let result = svc.send(dialog::Event::Open);
@@ -577,11 +557,6 @@ fn dialog_cleanup_on_unmount() {
 async fn interleaved_effect_setup_and_cancel() {
     let props = tooltip::Props { open_delay_ms: 500, ..Default::default() };
     let mut svc = Service::new(props, Env::default(), Default::default());
-    // PendingEffect::run() takes Rc<dyn Fn(M::Event)> on wasm32,
-    // Arc<dyn Fn(M::Event) + Send + Sync> on native.
-    #[cfg(target_arch = "wasm32")]
-    let send_fn: Rc<dyn Fn(tooltip::Event)> = Rc::new(|_| {});
-    #[cfg(not(target_arch = "wasm32"))]
     let send_fn: Arc<dyn Fn(tooltip::Event) + Send + Sync> = Arc::new(|_| {});
 
     // Send N: hover triggers delayed open effect


### PR DESCRIPTION
## Summary

- add `FormMessages`, localized validation error factories, and `DEFAULT_VALIDATOR_LOCALE` in `ars-forms`
- refine form submit/context behavior and sync the relevant spec and testing docs to the implemented contract
- include smaller interaction/core follow-up adjustments required by the same review pass

## Verification

- `cargo xci`

Closes #165