### PR TITLE
Add ars-collections edge-case test coverage

### DIFF
--- a/crates/ars-collections/src/selection.rs
+++ b/crates/ars-collections/src/selection.rs
@@ -634,6 +634,45 @@ mod tests {
     }
 
     #[test]
+    fn select_in_none_mode_with_non_default_state_is_identity() {
+        // Even when anchor_key, focused_key, and selection_mode_active are all
+        // populated, a `Mode::None` state must return an identical clone from
+        // `select()` — the early-return at the top of the function preserves
+        // every field, not just the mode.
+        let state = State {
+            mode: Mode::None,
+            selected_keys: Set::Multiple(BTreeSet::from([Key::int(2)])),
+            anchor_key: Some(Key::int(2)),
+            focused_key: Some(Key::int(2)),
+            selection_mode_active: true,
+            ..multiple_toggle_state()
+        };
+
+        assert_eq!(state.select(Key::int(1)), state);
+    }
+
+    #[test]
+    fn deselect_from_all_delegates_to_deselect_for_multiple_set() {
+        // When `selected_keys` is not `Set::All`, `deselect_from_all` must
+        // delegate to `deselect()` — covering the `_` arm of the inner match.
+        let collection = fixture_collection();
+
+        let state = State {
+            selected_keys: Set::Multiple(BTreeSet::from([Key::int(1), Key::int(2)])),
+            selection_mode_active: true,
+            ..multiple_toggle_state()
+        };
+
+        let next = state.deselect_from_all(&Key::int(1), &collection);
+
+        assert_eq!(
+            next.selected_keys,
+            Set::Multiple(BTreeSet::from([Key::int(2)]))
+        );
+        assert!(next.selection_mode_active);
+    }
+
+    #[test]
     fn toggle_from_all_uses_collection_complement() {
         let collection = fixture_collection();
         let state = State {

--- a/crates/ars-collections/src/tree_collection.rs
+++ b/crates/ars-collections/src/tree_collection.rs
@@ -2122,6 +2122,56 @@ mod tests {
     }
 
     #[test]
+    fn reparent_ancestor_under_descendant_restores_tree() {
+        // Tree: parent(1) -> child(2) -> grandchild(3). Uses TreeFruit values
+        // because `reparent` requires `T: CollectionItem` — the `leaf`/`branch`
+        // helpers in this module produce `&'static str` values, which don't
+        // satisfy the bound.
+        let mut tree = TreeCollection::new(vec![TreeItemConfig {
+            key: Key::int(1),
+            text_value: "Parent".to_string(),
+            value: TreeFruit::new(1, "Parent"),
+            children: vec![TreeItemConfig {
+                key: Key::int(2),
+                text_value: "Child".to_string(),
+                value: TreeFruit::new(2, "Child"),
+                children: vec![TreeItemConfig {
+                    key: Key::int(3),
+                    text_value: "Grandchild".to_string(),
+                    value: TreeFruit::new(3, "Grandchild"),
+                    children: Vec::new(),
+                    default_expanded: false,
+                }],
+                default_expanded: true,
+            }],
+            default_expanded: true,
+        }]);
+
+        // Attempting to reparent an ancestor (1) beneath its own descendant
+        // (3) would create a cycle. The cycle guard must reject the move and
+        // restore the extracted subtree so the tree stays well-formed.
+        let result = tree.reparent(&Key::int(1), Some(&Key::int(3)), 0);
+
+        assert_eq!(result, None);
+        assert_eq!(tree.all_nodes.len(), 3);
+
+        let parent = tree.get(&Key::int(1)).expect("Parent restored");
+
+        assert_eq!(parent.level, 0);
+        assert_eq!(parent.parent_key, None);
+
+        let child = tree.get(&Key::int(2)).expect("Child restored");
+
+        assert_eq!(child.level, 1);
+        assert_eq!(child.parent_key, Some(Key::int(1)));
+
+        let grandchild = tree.get(&Key::int(3)).expect("Grandchild restored");
+
+        assert_eq!(grandchild.level, 2);
+        assert_eq!(grandchild.parent_key, Some(Key::int(2)));
+    }
+
+    #[test]
     fn tree_item_config_debug() {
         let config = leaf(1, "Apple");
 

--- a/crates/ars-collections/src/virtualization.rs
+++ b/crates/ars-collections/src/virtualization.rs
@@ -1524,6 +1524,32 @@ mod tests {
     }
 
     #[test]
+    fn waterfall_layout_visible_range_returns_empty_when_all_items_offscreen() {
+        // 3 uniform columns of 45px items with 12px gap produce rows at y=0,
+        // y=57, y=114. Positioning the viewport inside the 45→57 gap means
+        // every item fails the `item_bottom > scroll_offset && y < scroll +
+        // viewport` predicate, leaving `first = total_count` and `last = 0`.
+        // The `if first > last` reset branch then collapses the range to
+        // `(0, 0)` so `visible_range()` is empty.
+        let mut virt = Virtualizer::new(
+            9,
+            LayoutStrategy::WaterfallLayout {
+                min_item_width: 120.0,
+                max_item_width: 240.0,
+                min_item_height: 45.0,
+                gap: 12.0,
+            },
+        );
+
+        // viewport_width=400 → 3 columns. scroll_top=46 with height=10 sits
+        // entirely inside the 45→57 gap between row 0 and row 1.
+        virt.set_scroll_state_mut(46.0, 0.0, 10.0, 400.0);
+        virt.overscan = 0;
+
+        assert_eq!(virt.visible_range(), 0..0);
+    }
+
+    #[test]
     fn waterfall_layout_empty_collection() {
         let virt = Virtualizer::new(
             0,


### PR DESCRIPTION
## Summary

- Adds four targeted unit tests in `ars-collections` that exercise previously uncovered branches across `selection`, `tree_collection`, and `virtualization`.
- `cargo llvm-cov test -p ars-collections` missed-lines count drops **30 → 27**, below the #550 acceptance bar of `< 33`.
- No production code changed — these are pure test additions.

### Tests added
- `selection::tests::select_in_none_mode_with_non_default_state_is_identity` — locks the identity contract of `State::select` in `Mode::None` on a state with non-default anchor/focused/selected_keys fields.
- `selection::tests::deselect_from_all_delegates_to_deselect_for_multiple_set` — covers the `_ => self.deselect(key)` delegation arm of `deselect_from_all`.
- `tree_collection::tests::reparent_ancestor_under_descendant_restores_tree` — asserts `TreeCollection::reparent` rejects `reparent(parent, grandchild, 0)` and restores the original three-level subtree with all parent/level relationships intact.
- `virtualization::tests::waterfall_layout_visible_range_returns_empty_when_all_items_offscreen` — places the viewport inside the inter-row gap of a `WaterfallLayout`, exercising the `first > last` reset branch of `Virtualizer::visible_range`.

## Test plan

- [x] `cargo test -p ars-collections` — 549 passed (+4 vs. prior 545)
- [x] `cargo llvm-cov test -p ars-collections --summary-only` — TOTAL missed lines: 30 → 27
- [x] `cargo clippy -p ars-collections --all-targets -- -D warnings` — clean
- [x] `cargo xci` — all 13 steps passed (fmt, check, clippy, unit, release, integration, adapter, coverage, feature matrices)

Closes #550

🤖 Generated with [Claude Code](https://claude.com/claude-code)