### PR TITLE
[codex] Implement web-intl i18n backend and adapter helpers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,21 @@ jobs:
       - name: Unit Tests
         run: cargo xtest unit
 
+  i18n-browser:
+    name: I18n Browser Tests
+    needs: [unit]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+      - name: Install wasm-pack
+        run: cargo install wasm-pack --locked --version 0.14.0
+      - name: I18n Browser Tests
+        run: cargo xtest i18n-browser
+
   release:
     name: Release Verification
     needs: [unit]
@@ -74,10 +89,19 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@nextest
       - uses: ./.github/actions/install-dioxus-desktop-deps
-      - name: Release Compile Check
-        run: cargo check -p ars-i18n --release --all-targets --no-default-features --features icu4x
-      - name: Release Tests
-        run: cargo xtest release
+      - name: Release Verification
+        run: cargo xtask ci release
+
+  mutual-exclusion:
+    name: Mutual Exclusion Guard
+    needs: [check]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Mutual Exclusion Guard
+        run: cargo xtask ci mutual-exclusion
 
   integration:
     name: Integration Tests

--- a/crates/ars-dioxus/src/lib.rs
+++ b/crates/ars-dioxus/src/lib.rs
@@ -33,7 +33,7 @@ pub use provider::DesktopPlatform;
 pub use provider::WebPlatform;
 pub use provider::{
     ArsContext, DioxusPlatform, DragData, FilePickerOptions, NullPlatform, t, use_icu_provider,
-    use_locale, use_messages, use_platform, warn_missing_provider,
+    use_locale, use_messages, use_number_formatter, use_platform, warn_missing_provider,
 };
 pub use use_machine::{UseMachineReturn, use_machine, use_machine_with_reactive_props};
 

--- a/crates/ars-dioxus/src/prelude.rs
+++ b/crates/ars-dioxus/src/prelude.rs
@@ -49,7 +49,7 @@
 pub use ars_i18n::{Direction, Locale, Orientation, ResolvedDirection, Translate};
 
 // -- User-facing helpers --
-pub use crate::t;
+pub use crate::{t, use_number_formatter};
 
 // -- Component modules --
 // (none yet — added as components are implemented, e.g.:

--- a/crates/ars-dioxus/src/provider.rs
+++ b/crates/ars-dioxus/src/provider.rs
@@ -7,7 +7,10 @@ use ars_core::{
     resolve_messages as core_resolve_messages,
 };
 use ars_forms::field::FileRef;
-use ars_i18n::{Direction, IcuProvider, Locale, StubIcuProvider, Translate, locales};
+use ars_i18n::{
+    Direction, IcuProvider, Locale, NumberFormatOptions, NumberFormatter, StubIcuProvider,
+    Translate, locales,
+};
 use dioxus::prelude::*;
 
 /// Options for opening a platform file picker.
@@ -194,28 +197,41 @@ fn default_dioxus_platform() -> Arc<dyn DioxusPlatform> {
 pub struct ArsContext {
     /// Active locale for this subtree.
     pub locale: Signal<Locale>,
+
     /// Resolved reading direction for this subtree.
     pub direction: Memo<Direction>,
+
     /// Active color mode for descendants.
     pub color_mode: Signal<ColorMode>,
+
     /// Whether interactive descendants should render as disabled.
     pub disabled: Signal<bool>,
+
     /// Whether descendant form fields should render as read-only.
     pub read_only: Signal<bool>,
+
     /// Optional generated-ID prefix.
     pub id_prefix: Signal<Option<String>>,
+
     /// Optional portal container element ID.
     pub portal_container_id: Signal<Option<String>>,
+
     /// Optional focus/portal root node ID.
     pub root_node_id: Signal<Option<String>>,
+
     /// Platform side-effect capabilities.
     pub platform: Arc<dyn PlatformEffects>,
+
     /// ICU-backed locale data provider.
     pub icu_provider: Arc<dyn IcuProvider>,
+
     /// Application-owned message registries.
     pub i18n_registries: Arc<I18nRegistries>,
+
     /// Dioxus-specific platform services.
     pub dioxus_platform: Arc<dyn DioxusPlatform>,
+
+    /// CSS style injection strategy for all descendant ars components.
     style_strategy: StyleStrategy,
 }
 
@@ -261,24 +277,15 @@ impl ArsContext {
         dioxus_platform: Arc<dyn DioxusPlatform>,
         style_strategy: StyleStrategy,
     ) -> Self {
-        let locale_signal = Signal::new(locale);
-        let direction_signal = Memo::new(move || direction);
-        let color_mode = Signal::new(color_mode);
-        let disabled = Signal::new(disabled);
-        let read_only = Signal::new(read_only);
-        let id_prefix = Signal::new(id_prefix);
-        let portal_container_id = Signal::new(portal_container_id);
-        let root_node_id = Signal::new(root_node_id);
-
         Self {
-            locale: locale_signal,
-            direction: direction_signal,
-            color_mode,
-            disabled,
-            read_only,
-            id_prefix,
-            portal_container_id,
-            root_node_id,
+            locale: Signal::new(locale),
+            direction: Memo::new(move || direction),
+            color_mode: Signal::new(color_mode),
+            disabled: Signal::new(disabled),
+            read_only: Signal::new(read_only),
+            id_prefix: Signal::new(id_prefix),
+            portal_container_id: Signal::new(portal_container_id),
+            root_node_id: Signal::new(root_node_id),
             platform,
             icu_provider,
             i18n_registries,
@@ -310,9 +317,11 @@ pub const fn warn_missing_provider(_hook: &str) {}
 #[must_use]
 pub fn use_locale() -> Signal<Locale> {
     let fallback = use_signal(locales::en_us);
+
     try_use_context::<ArsContext>().map_or_else(
         || {
             warn_missing_provider("use_locale");
+
             fallback
         },
         |ctx| ctx.locale,
@@ -327,12 +336,44 @@ pub(crate) fn resolve_locale(adapter_props_locale: Option<&Locale>) -> Locale {
         .unwrap_or_else(|| use_locale().read().clone())
 }
 
+/// Resolves a memoized number formatter from the current provider locale.
+#[must_use]
+pub fn use_number_formatter<F>(options: F) -> Memo<NumberFormatter>
+where
+    F: Fn() -> NumberFormatOptions + 'static,
+{
+    use_resolved_number_formatter(None, options)
+}
+
+/// Resolves a memoized number formatter from an explicit locale or provider context.
+#[must_use]
+pub(crate) fn use_resolved_number_formatter<F>(
+    adapter_props_locale: Option<&Locale>,
+    options: F,
+) -> Memo<NumberFormatter>
+where
+    F: Fn() -> NumberFormatOptions + 'static,
+{
+    let explicit_locale = adapter_props_locale.cloned();
+
+    let locale = use_locale();
+
+    use_memo(move || {
+        let resolved_locale = explicit_locale
+            .clone()
+            .unwrap_or_else(|| locale.read().clone());
+
+        NumberFormatter::new(&resolved_locale, options())
+    })
+}
+
 /// Resolves the current ICU provider from provider context.
 #[must_use]
 pub fn use_icu_provider() -> Arc<dyn IcuProvider> {
     try_use_context::<ArsContext>().map_or_else(
         || -> Arc<dyn IcuProvider> {
             warn_missing_provider("use_icu_provider");
+
             Arc::new(StubIcuProvider)
         },
         |ctx| -> Arc<dyn IcuProvider> { Arc::clone(&ctx.icu_provider) },
@@ -346,10 +387,12 @@ pub fn use_messages<M: ars_core::ComponentMessages + Send + Sync + 'static>(
     adapter_props_locale: Option<&Locale>,
 ) -> M {
     let locale = resolve_locale(adapter_props_locale);
+
     let registries = try_use_context::<ArsContext>().map_or_else(
         || Arc::new(I18nRegistries::new()),
         |ctx| Arc::clone(&ctx.i18n_registries),
     );
+
     core_resolve_messages(adapter_props_messages, registries.as_ref(), &locale)
 }
 
@@ -359,6 +402,7 @@ pub fn use_platform() -> Arc<dyn DioxusPlatform> {
     try_use_context::<ArsContext>().map_or_else(
         || {
             warn_missing_provider("use_platform");
+
             default_dioxus_platform()
         },
         |ctx| Arc::clone(&ctx.dioxus_platform),
@@ -375,7 +419,9 @@ pub fn t<T: Translate>(msg: T) -> String {
     try_use_context::<ArsContext>().map_or_else(
         || {
             warn_missing_provider("t");
+
             let fallback = locales::en_us();
+
             msg.translate(&fallback, &StubIcuProvider)
         },
         |ctx| msg.translate(&ctx.locale.read(), &*ctx.icu_provider),
@@ -389,11 +435,13 @@ mod tests {
         pin::Pin,
         rc::Rc,
         sync::Arc,
-        task::{Context, Poll, Wake, Waker},
+        task::{Context, Poll, Waker},
     };
 
     use ars_core::{ColorMode, I18nRegistries, NullPlatformEffects, StyleStrategy};
-    use ars_i18n::{Direction, IcuProvider, Locale, StubIcuProvider, Translate, locales};
+    use ars_i18n::{
+        Direction, IcuProvider, Locale, NumberFormatOptions, StubIcuProvider, Translate, locales,
+    };
     use dioxus::dioxus_core::{NoOpMutations, ScopeId};
 
     use super::*;
@@ -413,6 +461,7 @@ mod tests {
     }
 
     struct TestIcuProvider;
+
     impl IcuProvider for TestIcuProvider {}
 
     #[derive(Clone, Debug, PartialEq)]
@@ -485,14 +534,8 @@ mod tests {
     }
 
     fn block_on_ready<T>(mut future: Pin<Box<dyn Future<Output = T>>>) -> T {
-        struct NoopWake;
+        let mut context = Context::from_waker(Waker::noop());
 
-        impl Wake for NoopWake {
-            fn wake(self: Arc<Self>) {}
-        }
-
-        let waker = Waker::from(Arc::new(NoopWake));
-        let mut context = Context::from_waker(&waker);
         match future.as_mut().poll(&mut context) {
             Poll::Ready(value) => value,
             Poll::Pending => panic!("test future unexpectedly returned Pending"),
@@ -503,12 +546,14 @@ mod tests {
     fn use_locale_falls_back_without_provider() {
         fn app() -> Element {
             assert_eq!(use_locale()().to_bcp47(), "en-US");
+
             rsx! {
                 div {}
             }
         }
 
         let mut dom = VirtualDom::new(app);
+
         dom.rebuild_in_place();
     }
 
@@ -516,16 +561,19 @@ mod tests {
     fn use_icu_provider_falls_back_without_provider() {
         fn app() -> Element {
             let provider = use_icu_provider();
+
             assert_eq!(
                 AppText::Greeting.translate(&locales::en_us(), provider.as_ref()),
                 "Hello"
             );
+
             rsx! {
                 div {}
             }
         }
 
         let mut dom = VirtualDom::new(app);
+
         dom.rebuild_in_place();
     }
 
@@ -533,6 +581,7 @@ mod tests {
     fn use_icu_provider_reads_context_value() {
         fn app() -> Element {
             let expected: Arc<dyn IcuProvider> = Arc::new(TestIcuProvider);
+
             let ctx = ArsContext::new(
                 locales::en_us(),
                 Direction::Ltr,
@@ -548,14 +597,18 @@ mod tests {
                 Arc::new(NullPlatform),
                 StyleStrategy::Inline,
             );
+
             use_context_provider(|| ctx);
+
             assert!(Arc::ptr_eq(&use_icu_provider(), &expected));
+
             rsx! {
                 div {}
             }
         }
 
         let mut dom = VirtualDom::new(app);
+
         dom.rebuild_in_place();
     }
 
@@ -563,6 +616,7 @@ mod tests {
     fn use_messages_reads_provider_registry_bundle() {
         fn app() -> Element {
             let mut registries = I18nRegistries::new();
+
             registries.register(
                 ars_core::MessagesRegistry::new(TestMessages::default()).register(
                     "es",
@@ -571,6 +625,7 @@ mod tests {
                     },
                 ),
             );
+
             let ctx = ArsContext::new(
                 Locale::parse("es-MX").expect("locale should parse"),
                 Direction::Ltr,
@@ -586,15 +641,22 @@ mod tests {
                 Arc::new(NullPlatform),
                 StyleStrategy::Inline,
             );
+
             use_context_provider(|| ctx);
 
             let locale = Locale::parse("es-MX").expect("locale should parse");
+
             let resolved = use_messages::<TestMessages>(None, None);
+
             assert_eq!((resolved.label)(&locale), "Etiqueta");
-            rsx! { div {} }
+
+            rsx! {
+                div {}
+            }
         }
 
         let mut dom = VirtualDom::new(app);
+
         dom.rebuild_in_place();
     }
 
@@ -602,12 +664,119 @@ mod tests {
     fn use_messages_falls_back_without_provider() {
         fn app() -> Element {
             let locale = Locale::parse("pt-BR").expect("locale should parse");
+
             let resolved = use_messages::<TestMessages>(None, Some(&locale));
+
             assert_eq!((resolved.label)(&locale), "Default");
-            rsx! { div {} }
+
+            rsx! {
+                div {}
+            }
         }
 
         let mut dom = VirtualDom::new(app);
+
+        dom.rebuild_in_place();
+    }
+
+    #[test]
+    fn use_number_formatter_falls_back_without_provider() {
+        fn app() -> Element {
+            let formatter = use_number_formatter(NumberFormatOptions::default);
+
+            assert_eq!(formatter.read().format(1234.56), "1,234.56");
+
+            rsx! {
+                div {}
+            }
+        }
+
+        let mut dom = VirtualDom::new(app);
+
+        dom.rebuild_in_place();
+    }
+
+    #[test]
+    fn use_number_formatter_reads_context_locale() {
+        fn app() -> Element {
+            let ctx = test_context(locales::de_de(), Arc::new(StubIcuProvider));
+
+            use_context_provider(|| ctx);
+
+            let formatter = use_number_formatter(NumberFormatOptions::default);
+
+            assert_eq!(formatter.read().format(1234.56), "1.234,56");
+
+            rsx! {
+                div {}
+            }
+        }
+
+        let mut dom = VirtualDom::new(app);
+
+        dom.rebuild_in_place();
+    }
+
+    #[test]
+    fn use_number_formatter_recomputes_when_locale_changes() {
+        let outputs = Rc::new(RefCell::new(Vec::new()));
+
+        #[expect(
+            clippy::needless_pass_by_value,
+            reason = "Dioxus root props are moved into the render function."
+        )]
+        fn app(outputs: Rc<RefCell<Vec<String>>>) -> Element {
+            let mut ctx =
+                use_context_provider(|| test_context(locales::en_us(), Arc::new(StubIcuProvider)));
+
+            let mut phase = use_signal(|| 0u8);
+
+            let formatter = use_number_formatter(NumberFormatOptions::default);
+
+            outputs.borrow_mut().push(formatter.read().format(1234.56));
+
+            if phase() == 0 {
+                phase.set(1);
+                ctx.locale.set(locales::de_de());
+            }
+
+            rsx! {
+                div {}
+            }
+        }
+
+        let mut dom = VirtualDom::new_with_props(app, Rc::clone(&outputs));
+
+        dom.rebuild_in_place();
+
+        dom.mark_dirty(ScopeId::APP);
+
+        dom.render_immediate(&mut NoOpMutations);
+
+        assert_eq!(outputs.borrow().as_slice(), ["1,234.56", "1.234,56"]);
+    }
+
+    #[test]
+    fn use_resolved_number_formatter_prefers_explicit_override() {
+        fn app() -> Element {
+            let ctx = test_context(locales::fr(), Arc::new(StubIcuProvider));
+
+            use_context_provider(|| ctx);
+
+            let explicit = locales::de_de();
+
+            let formatter =
+                use_resolved_number_formatter(Some(&explicit), NumberFormatOptions::default);
+
+            assert_eq!(formatter.read().format(1234.56), "1.234,56");
+
+            rsx! {
+                div {}
+            }
+        }
+
+        let mut dom = VirtualDom::new(app);
+
         dom.rebuild_in_place();
     }
 
@@ -637,25 +806,31 @@ mod tests {
                     StyleStrategy::Inline,
                 )
             });
+
             let mut phase = use_signal(|| 0u8);
+
             let text = t(AppText::Greeting);
+
             outputs.borrow_mut().push(text.clone());
 
             if phase() == 0 {
                 phase.set(1);
+
                 ctx.locale
                     .set(Locale::parse("es-ES").expect("locale should parse"));
             }
 
             rsx! {
                 div { "{text}" }
-
             }
         }
 
         let mut dom = VirtualDom::new_with_props(app, Rc::clone(&outputs));
+
         dom.rebuild_in_place();
+
         dom.mark_dirty(ScopeId::APP);
+
         dom.render_immediate(&mut NoOpMutations);
 
         assert_eq!(outputs.borrow().as_slice(), ["Hello", "Hola"]);
@@ -665,27 +840,37 @@ mod tests {
     fn t_falls_back_without_provider() {
         fn app() -> Element {
             assert_eq!(t(AppText::Greeting), "Hello");
+
             rsx! {
                 div {}
             }
         }
 
         let mut dom = VirtualDom::new(app);
+
         dom.rebuild_in_place();
     }
 
     #[test]
     fn prelude_exports_compile() {
         fn app() -> Element {
+            use crate::prelude::use_number_formatter as prelude_use_number_formatter;
+
             let ctx = test_context(locales::en_us(), Arc::new(StubIcuProvider));
+
             use_context_provider(|| ctx);
+
             drop(t(AppText::Greeting));
+
+            let _ = prelude_use_number_formatter(NumberFormatOptions::default);
+
             rsx! {
                 div {}
             }
         }
 
         let mut dom = VirtualDom::new(app);
+
         dom.rebuild_in_place();
     }
 
@@ -696,17 +881,21 @@ mod tests {
                 Locale::parse("fr-FR").expect("locale should parse"),
                 Arc::new(StubIcuProvider),
             );
+
             use_context_provider(|| ctx);
 
             let explicit = Locale::parse("es-ES").expect("locale should parse");
+
             assert_eq!(resolve_locale(Some(&explicit)).to_bcp47(), "es-ES");
             assert_eq!(resolve_locale(None).to_bcp47(), "fr-FR");
+
             rsx! {
                 div {}
             }
         }
 
         let mut dom = VirtualDom::new(app);
+
         dom.rebuild_in_place();
     }
 
@@ -714,6 +903,7 @@ mod tests {
     fn use_platform_reads_context_value() {
         fn app() -> Element {
             let expected: Arc<dyn DioxusPlatform> = Arc::new(TestPlatform);
+
             let ctx = ArsContext::new(
                 locales::en_us(),
                 Direction::Ltr,
@@ -729,22 +919,31 @@ mod tests {
                 Arc::clone(&expected),
                 StyleStrategy::Inline,
             );
+
             use_context_provider(|| ctx);
+
             let platform = use_platform();
+
             assert!(Arc::ptr_eq(&platform, &expected));
+
             platform.focus_element("target");
+
             assert!(platform.get_bounding_rect("target").is_none());
+
             platform.scroll_into_view("target");
+
             assert_eq!(block_on_ready(platform.set_clipboard("hello")), Ok(()));
             assert!(block_on_ready(platform.open_file_picker(FilePickerOptions)).is_empty());
             assert_eq!(platform.new_id(), "test-platform-id");
             assert!(platform.create_drag_data(&()).is_none());
+
             rsx! {
                 div {}
             }
         }
 
         let mut dom = VirtualDom::new(app);
+
         dom.rebuild_in_place();
     }
 
@@ -752,17 +951,22 @@ mod tests {
     fn use_platform_falls_back_without_provider() {
         fn app() -> Element {
             let platform = use_platform();
+
             let first = platform.new_id();
+
             let second = platform.new_id();
+
             assert!(first.starts_with("null-id-"));
             assert!(second.starts_with("null-id-"));
             assert_ne!(first, second);
+
             rsx! {
                 div {}
             }
         }
 
         let mut dom = VirtualDom::new(app);
+
         dom.rebuild_in_place();
     }
 
@@ -771,8 +975,11 @@ mod tests {
         let platform = NullPlatform;
 
         platform.focus_element("missing");
+
         assert!(platform.get_bounding_rect("missing").is_none());
+
         platform.scroll_into_view("missing");
+
         assert_eq!(block_on_ready(platform.set_clipboard("text")), Ok(()));
         assert!(block_on_ready(platform.open_file_picker(FilePickerOptions)).is_empty());
         assert_eq!(platform.now_ms(), 0.0);
@@ -784,13 +991,16 @@ mod tests {
     fn ars_context_debug_includes_struct_name() {
         fn app() -> Element {
             let ctx = test_context(locales::en_us(), Arc::new(StubIcuProvider));
+
             assert!(format!("{ctx:?}").contains("ArsContext"));
+
             rsx! {
                 div {}
             }
         }
 
         let mut dom = VirtualDom::new(app);
+
         dom.rebuild_in_place();
     }
 }
@@ -800,7 +1010,9 @@ mod wasm_tests {
     use std::{cell::RefCell, rc::Rc, sync::Arc};
 
     use ars_core::{ColorMode, I18nRegistries, NullPlatformEffects, StyleStrategy};
-    use ars_i18n::{Direction, IcuProvider, Locale, StubIcuProvider, Translate, locales};
+    use ars_i18n::{
+        Direction, IcuProvider, Locale, NumberFormatOptions, StubIcuProvider, Translate, locales,
+    };
     use dioxus::dioxus_core::{NoOpMutations, ScopeId};
     use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
 
@@ -823,6 +1035,7 @@ mod wasm_tests {
     }
 
     struct TestIcuProvider;
+
     impl IcuProvider for TestIcuProvider {}
 
     fn test_context(locale: Locale, icu_provider: Arc<dyn IcuProvider>) -> ArsContext {
@@ -846,8 +1059,10 @@ mod wasm_tests {
     #[wasm_bindgen_test]
     fn default_dioxus_platform_uses_web_feature_path() {
         let platform = default_dioxus_platform();
+
         platform.focus_element("missing");
         platform.scroll_into_view("missing");
+
         assert!(platform.get_bounding_rect("missing").is_none());
         assert!(platform.new_id().starts_with("null-id-"));
         assert!(platform.create_drag_data(&()).is_none());
@@ -857,17 +1072,25 @@ mod wasm_tests {
     fn use_locale_and_icu_provider_fall_back_without_provider_on_wasm() {
         fn app() -> Element {
             assert_eq!(use_locale()().to_bcp47(), "en-US");
+
             let provider = use_icu_provider();
+
             assert_eq!(
                 AppText::Greeting.translate(&locales::en_us(), &*provider),
                 "Hello"
             );
+
+            let formatter = use_number_formatter(NumberFormatOptions::default);
+
+            assert_eq!(formatter.read().format(1234.56), "1,234.56");
+
             rsx! {
                 div {}
             }
         }
 
         let mut dom = VirtualDom::new(app);
+
         dom.rebuild_in_place();
     }
 
@@ -882,25 +1105,31 @@ mod wasm_tests {
         fn app(outputs: Rc<RefCell<Vec<String>>>) -> Element {
             let mut ctx =
                 use_context_provider(|| test_context(locales::en_us(), Arc::new(StubIcuProvider)));
+
             let mut phase = use_signal(|| 0u8);
+
             let text = t(AppText::Greeting);
+
             outputs.borrow_mut().push(text.clone());
 
             if phase() == 0 {
                 phase.set(1);
+
                 ctx.locale
                     .set(Locale::parse("es-ES").expect("locale should parse"));
             }
 
             rsx! {
                 div { "{text}" }
-
             }
         }
 
         let mut dom = VirtualDom::new_with_props(app, Rc::clone(&outputs));
+
         dom.rebuild_in_place();
+
         dom.mark_dirty(ScopeId::APP);
+
         dom.render_immediate(&mut NoOpMutations);
 
         assert_eq!(outputs.borrow().as_slice(), ["Hello", "Hola"]);
@@ -910,28 +1139,74 @@ mod wasm_tests {
     fn use_platform_and_explicit_locale_work_on_wasm() {
         fn app() -> Element {
             let expected: Arc<dyn IcuProvider> = Arc::new(TestIcuProvider);
+
             let ctx = test_context(locales::en_us(), Arc::clone(&expected));
+
             use_context_provider(|| ctx);
 
             let explicit = Locale::parse("pt-BR").expect("locale should parse");
+
             assert_eq!(resolve_locale(Some(&explicit)).to_bcp47(), "pt-BR");
             assert_eq!(resolve_locale(None).to_bcp47(), "en-US");
             assert!(Arc::ptr_eq(&use_icu_provider(), &expected));
 
             let platform = use_platform();
+
             let first = platform.new_id();
+
             let second = platform.new_id();
+
             assert!(first.starts_with("null-id-"));
             assert!(second.starts_with("null-id-"));
             assert_ne!(first, second);
 
             rsx! {
                 div {}
-
             }
         }
 
         let mut dom = VirtualDom::new(app);
+
         dom.rebuild_in_place();
+    }
+
+    #[wasm_bindgen_test]
+    fn use_number_formatter_recomputes_when_locale_changes_on_wasm() {
+        let outputs = Rc::new(RefCell::new(Vec::new()));
+
+        #[expect(
+            clippy::needless_pass_by_value,
+            reason = "Dioxus root props are moved into the render function."
+        )]
+        fn app(outputs: Rc<RefCell<Vec<String>>>) -> Element {
+            let mut ctx =
+                use_context_provider(|| test_context(locales::en_us(), Arc::new(StubIcuProvider)));
+
+            let mut phase = use_signal(|| 0u8);
+
+            let formatter = use_number_formatter(NumberFormatOptions::default);
+
+            outputs.borrow_mut().push(formatter.read().format(1234.56));
+
+            if phase() == 0 {
+                phase.set(1);
+
+                ctx.locale.set(locales::de_de());
+            }
+
+            rsx! {
+                div {}
+            }
+        }
+
+        let mut dom = VirtualDom::new_with_props(app, Rc::clone(&outputs));
+
+        dom.rebuild_in_place();
+
+        dom.mark_dirty(ScopeId::APP);
+
+        dom.render_immediate(&mut NoOpMutations);
+
+        assert_eq!(outputs.borrow().as_slice(), ["1,234.56", "1.234,56"]);
     }
 }

--- a/crates/ars-dioxus/src/provider.rs
+++ b/crates/ars-dioxus/src/provider.rs
@@ -355,16 +355,16 @@ where
     F: Fn() -> NumberFormatOptions + 'static,
 {
     let explicit_locale = adapter_props_locale.cloned();
-
     let locale = use_locale();
+    let resolved_options = options();
 
-    use_memo(move || {
+    use_memo(use_reactive!(|explicit_locale, resolved_options| {
         let resolved_locale = explicit_locale
             .clone()
             .unwrap_or_else(|| locale.read().clone());
 
-        NumberFormatter::new(&resolved_locale, options())
-    })
+        NumberFormatter::new(&resolved_locale, resolved_options.clone())
+    }))
 }
 
 /// Resolves the current ICU provider from provider context.
@@ -778,6 +778,106 @@ mod tests {
         let mut dom = VirtualDom::new(app);
 
         dom.rebuild_in_place();
+    }
+
+    #[test]
+    fn use_resolved_number_formatter_recomputes_when_explicit_locale_changes() {
+        let outputs = Rc::new(RefCell::new(Vec::new()));
+
+        #[expect(
+            clippy::needless_pass_by_value,
+            reason = "Dioxus root props are moved into the render function."
+        )]
+        fn app(outputs: Rc<RefCell<Vec<String>>>) -> Element {
+            let ctx = test_context(locales::fr(), Arc::new(StubIcuProvider));
+
+            use_context_provider(|| ctx);
+
+            let mut phase = use_signal(|| 0u8);
+            let mut use_german_locale = use_signal(|| false);
+
+            let explicit = if use_german_locale() {
+                locales::de_de()
+            } else {
+                locales::en_us()
+            };
+
+            let formatter =
+                use_resolved_number_formatter(Some(&explicit), NumberFormatOptions::default);
+
+            outputs.borrow_mut().push(formatter.read().format(1234.56));
+
+            if phase() == 0 {
+                phase.set(1);
+                use_german_locale.set(true);
+            }
+
+            rsx! {
+                div {}
+            }
+        }
+
+        let mut dom = VirtualDom::new_with_props(app, Rc::clone(&outputs));
+
+        dom.rebuild_in_place();
+
+        dom.mark_dirty(ScopeId::APP);
+
+        dom.render_immediate(&mut NoOpMutations);
+
+        assert_eq!(outputs.borrow().as_slice(), ["1,234.56", "1.234,56"]);
+    }
+
+    #[test]
+    fn use_number_formatter_recomputes_when_non_reactive_options_change() {
+        let outputs = Rc::new(RefCell::new(Vec::new()));
+
+        #[expect(
+            clippy::needless_pass_by_value,
+            reason = "Dioxus root props are moved into the render function."
+        )]
+        fn app(outputs: Rc<RefCell<Vec<String>>>) -> Element {
+            let _ctx =
+                use_context_provider(|| test_context(locales::en_us(), Arc::new(StubIcuProvider)));
+
+            let mut phase = use_signal(|| 0u8);
+            let mut use_percent = use_signal(|| false);
+
+            let options = if use_percent() {
+                NumberFormatOptions {
+                    style: ars_i18n::NumberStyle::Percent,
+                    ..NumberFormatOptions::default()
+                }
+            } else {
+                NumberFormatOptions::default()
+            };
+
+            let formatter = use_number_formatter({
+                let options = options.clone();
+                move || options.clone()
+            });
+
+            outputs.borrow_mut().push(formatter.read().format(0.47));
+
+            if phase() == 0 {
+                phase.set(1);
+                use_percent.set(true);
+            }
+
+            rsx! {
+                div {}
+            }
+        }
+
+        let mut dom = VirtualDom::new_with_props(app, Rc::clone(&outputs));
+
+        dom.rebuild_in_place();
+
+        dom.mark_dirty(ScopeId::APP);
+
+        dom.render_immediate(&mut NoOpMutations);
+
+        assert_eq!(outputs.borrow().as_slice(), ["0.47", "47%"]);
     }
 
     #[test]

--- a/crates/ars-forms/src/validation/async_validator.rs
+++ b/crates/ars-forms/src/validation/async_validator.rs
@@ -55,24 +55,16 @@ mod tests {
         pin::Pin,
         task::{Context as TaskContext, Poll, Waker},
     };
-    use std::{sync::Arc, task::Wake};
+    use std::sync::Arc;
 
     use super::*;
     use crate::field::Value;
-
-    struct NoopWake;
-
-    impl Wake for NoopWake {
-        fn wake(self: Arc<Self>) {}
-    }
 
     fn block_on_ready<F>(future: F) -> F::Output
     where
         F: Future,
     {
-        let waker = Waker::from(Arc::new(NoopWake));
-
-        let mut context = TaskContext::from_waker(&waker);
+        let mut context = TaskContext::from_waker(Waker::noop());
 
         let mut future = Pin::from(Box::new(future));
 

--- a/crates/ars-i18n/src/lib.rs
+++ b/crates/ars-i18n/src/lib.rs
@@ -56,8 +56,6 @@ pub use detect::locale_from_accept_language;
 pub use layout::{LogicalRect, LogicalSide, PhysicalRect, PhysicalSide};
 pub use locale::{Locale, LocaleParseError, locales};
 pub use locale_stack::LocaleStack;
-#[cfg(feature = "std")]
-pub use number::get_number_formatter;
 pub use number::{
     CurrencyCode, MeasureUnit, NumberFormatOptions, NumberFormatter, NumberStyle, RoundingMode,
     SignDisplay, UnitDisplay, decimal_and_group_separators, normalize_digits, parse_locale_number,

--- a/crates/ars-i18n/src/number.rs
+++ b/crates/ars-i18n/src/number.rs
@@ -8,10 +8,16 @@ use core::{
 pub use icu_experimental::measure::measureunit::MeasureUnit;
 #[cfg(any(feature = "icu4x", all(feature = "web-intl", target_arch = "wasm32")))]
 use {alloc::sync::Arc, icu_experimental::measure::parser::ids::CLDR_IDS_TRIE};
-#[cfg(feature = "icu4x")]
+#[cfg(any(
+    feature = "icu4x",
+    not(all(feature = "web-intl", target_arch = "wasm32"))
+))]
 use {
     core::str::FromStr,
     fixed_decimal::{Decimal, SignDisplay as FixedSignDisplay},
+};
+#[cfg(feature = "icu4x")]
+use {
     icu::decimal::DecimalFormatter,
     icu::decimal::{
         DecimalFormatterPreferences,
@@ -387,7 +393,10 @@ impl NumberFormatter {
         format!("{}{}{}", self.format(start), separator, self.format(end))
     }
 
-    #[cfg(feature = "icu4x")]
+    #[cfg(any(
+        feature = "icu4x",
+        not(all(feature = "web-intl", target_arch = "wasm32"))
+    ))]
     fn prepare_decimal(&self, value: f64) -> Decimal {
         let rounded = self.prepare_numeric_value(value, true);
 
@@ -837,15 +846,7 @@ fn fallback_separators(locale: &Locale) -> (char, char) {
 
 #[cfg(not(any(feature = "icu4x", all(feature = "web-intl", target_arch = "wasm32"))))]
 fn fallback_format(value: f64, formatter: &NumberFormatter) -> String {
-    let precision = usize::from(formatter.options.max_fraction_digits);
-
-    let rounded = formatter.prepare_numeric_value(value, true);
-
-    let mut output = if precision == 0 {
-        format!("{rounded:.0}")
-    } else {
-        format!("{rounded:.precision$}")
-    };
+    let mut output = formatter.prepare_decimal(value).to_string();
 
     if formatter.decimal_separator != '.' {
         output = output.replace('.', &String::from(formatter.decimal_separator));
@@ -855,7 +856,10 @@ fn fallback_format(value: f64, formatter: &NumberFormatter) -> String {
 }
 
 impl SignDisplay {
-    #[cfg(feature = "icu4x")]
+    #[cfg(any(
+        feature = "icu4x",
+        not(all(feature = "web-intl", target_arch = "wasm32"))
+    ))]
     const fn into_fixed_decimal(self) -> FixedSignDisplay {
         match self {
             Self::Auto => FixedSignDisplay::Auto,
@@ -1228,6 +1232,55 @@ mod tests {
             Decimal::default()
         );
         assert_eq!(formatter.prepare_decimal(f64::NAN), Decimal::default());
+    }
+
+    #[cfg(not(any(feature = "icu4x", all(feature = "web-intl", target_arch = "wasm32"))))]
+    #[test]
+    fn fallback_format_preserves_digit_padding_and_sign_display() {
+        let formatter = NumberFormatter::new(
+            &locales::de_de(),
+            NumberFormatOptions {
+                min_integer_digits: NonZeroU8::new(3).expect("hardcoded nonzero"),
+                min_fraction_digits: 1,
+                max_fraction_digits: 3,
+                sign_display: SignDisplay::Always,
+                ..NumberFormatOptions::default()
+            },
+        );
+
+        assert_eq!(formatter.format(5.2), "+005,2");
+        assert_eq!(formatter.format(5.0), "+005,0");
+    }
+
+    #[cfg(not(any(feature = "icu4x", all(feature = "web-intl", target_arch = "wasm32"))))]
+    #[test]
+    fn fallback_format_respects_negative_zero_sign_policies() {
+        let auto = NumberFormatter::new(
+            &locales::en_us(),
+            NumberFormatOptions {
+                sign_display: SignDisplay::Auto,
+                ..NumberFormatOptions::default()
+            },
+        );
+        let negative = NumberFormatter::new(
+            &locales::en_us(),
+            NumberFormatOptions {
+                sign_display: SignDisplay::Negative,
+                ..NumberFormatOptions::default()
+            },
+        );
+        let except_zero = NumberFormatter::new(
+            &locales::en_us(),
+            NumberFormatOptions {
+                sign_display: SignDisplay::ExceptZero,
+                ..NumberFormatOptions::default()
+            },
+        );
+
+        assert_eq!(auto.format(-0.0), "-0");
+        assert_eq!(negative.format(-0.0), "0");
+        assert_eq!(except_zero.format(12.0), "+12");
+        assert_eq!(except_zero.format(0.0), "0");
     }
 
     #[test]

--- a/crates/ars-i18n/src/number.rs
+++ b/crates/ars-i18n/src/number.rs
@@ -1,59 +1,69 @@
-use alloc::{format, rc::Rc, string::String};
-use core::{fmt, num::NonZeroU8, str::FromStr};
+use alloc::{format, string::String};
+use core::{
+    fmt::{self, Debug},
+    num::NonZeroU8,
+    str,
+};
 
-use fixed_decimal::{Decimal, SignDisplay as FixedSignDisplay};
-use icu::decimal::DecimalFormatter;
 pub use icu_experimental::measure::measureunit::MeasureUnit;
-#[cfg(feature = "std")]
-use {alloc::collections::BTreeMap, std::cell::RefCell};
+#[cfg(any(feature = "icu4x", all(feature = "web-intl", target_arch = "wasm32")))]
+use {alloc::sync::Arc, icu_experimental::measure::parser::ids::CLDR_IDS_TRIE};
 #[cfg(feature = "icu4x")]
 use {
+    core::str::FromStr,
+    fixed_decimal::{Decimal, SignDisplay as FixedSignDisplay},
+    icu::decimal::DecimalFormatter,
     icu::decimal::{
         DecimalFormatterPreferences,
         options::{DecimalFormatterOptions, GroupingStrategy},
     },
-    icu_experimental::{
-        dimension::{
-            currency::{
-                CurrencyCode as IcuCurrencyCode,
-                formatter::{
-                    CurrencyFormatter as IcuCurrencyFormatter, CurrencyFormatterPreferences,
-                },
-                options::CurrencyFormatterOptions,
-            },
-            percent::{
-                formatter::{PercentFormatter, PercentFormatterPreferences},
-                options::PercentFormatterOptions,
-            },
-            units::{
-                formatter::{UnitsFormatter, UnitsFormatterPreferences},
-                options::{UnitsFormatterOptions, Width},
-            },
+    icu_experimental::dimension::{
+        currency::{
+            CurrencyCode as IcuCurrencyCode,
+            formatter::{CurrencyFormatter as IcuCurrencyFormatter, CurrencyFormatterPreferences},
+            options::CurrencyFormatterOptions,
         },
-        measure::parser::ids::CLDR_IDS_TRIE,
+        percent::{
+            formatter::{PercentFormatter, PercentFormatterPreferences},
+            options::PercentFormatterOptions,
+        },
+        units::{
+            formatter::{UnitsFormatter, UnitsFormatterPreferences},
+            options::{UnitsFormatterOptions, Width},
+        },
     },
     tinystr::TinyAsciiStr,
 };
 
 use crate::Locale;
 
+#[cfg(all(feature = "web-intl", target_arch = "wasm32"))]
+mod web_intl;
+
 /// Options controlling locale-aware number formatting.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct NumberFormatOptions {
     /// The high-level number style to format.
     pub style: NumberStyle,
+
     /// The display width to use when formatting [`NumberStyle::Unit`] values.
     pub unit_display: UnitDisplay,
+
     /// The minimum number of digits to display before the decimal separator.
     pub min_integer_digits: NonZeroU8,
+
     /// The minimum number of digits to display after the decimal separator.
     pub min_fraction_digits: u8,
+
     /// The maximum number of digits to display after the decimal separator.
     pub max_fraction_digits: u8,
+
     /// Whether locale-appropriate grouping separators should be emitted.
     pub use_grouping: bool,
+
     /// How positive, negative, and zero values should display a sign.
     pub sign_display: SignDisplay,
+
     /// The rounding rule to apply before the number is formatted.
     pub rounding_mode: RoundingMode,
 }
@@ -63,10 +73,13 @@ pub struct NumberFormatOptions {
 pub enum NumberStyle {
     /// A plain decimal number.
     Decimal,
+
     /// A percentage value.
     Percent,
+
     /// A monetary value in the given ISO 4217 currency.
     Currency(CurrencyCode),
+
     /// A measurement value in the given CLDR unit.
     Unit(MeasureUnit),
 }
@@ -76,9 +89,11 @@ pub enum NumberStyle {
 pub enum UnitDisplay {
     /// Locale-appropriate long unit names.
     Long,
+
     /// Locale-appropriate short unit names.
     #[default]
     Short,
+
     /// Locale-appropriate narrow unit names.
     Narrow,
 }
@@ -88,12 +103,16 @@ pub enum UnitDisplay {
 pub enum SignDisplay {
     /// Show a sign only for negative values.
     Auto,
+
     /// Always show a sign for non-negative and negative values.
     Always,
+
     /// Never show a sign.
     Never,
+
     /// Show a sign for non-zero values only.
     ExceptZero,
+
     /// Show only the negative sign.
     Negative,
 }
@@ -104,14 +123,19 @@ pub enum RoundingMode {
     /// Round to nearest, with ties resolved to the nearest even digit.
     #[default]
     HalfEven,
+
     /// Round to nearest, with ties resolved away from zero.
     HalfUp,
+
     /// Round to nearest, with ties resolved toward zero.
     HalfDown,
+
     /// Round toward positive infinity.
     Ceiling,
+
     /// Round toward negative infinity.
     Floor,
+
     /// Round toward zero.
     Truncate,
 }
@@ -126,12 +150,16 @@ pub struct CurrencyCode(
 impl CurrencyCode {
     /// United States Dollar.
     pub const USD: Self = Self(*b"USD");
+
     /// Euro.
     pub const EUR: Self = Self(*b"EUR");
+
     /// British Pound Sterling.
     pub const GBP: Self = Self(*b"GBP");
+
     /// Japanese Yen.
     pub const JPY: Self = Self(*b"JPY");
+
     /// Chinese Yuan Renminbi.
     pub const CNY: Self = Self(*b"CNY");
 
@@ -143,6 +171,7 @@ impl CurrencyCode {
     )]
     pub fn from_str(s: &str) -> Option<Self> {
         let bytes = s.as_bytes();
+
         if bytes.len() != 3 || !bytes.iter().all(u8::is_ascii_uppercase) {
             return None;
         }
@@ -153,13 +182,14 @@ impl CurrencyCode {
     /// Return this currency code as text.
     #[must_use]
     pub fn as_str(&self) -> &str {
-        core::str::from_utf8(&self.0).expect("CurrencyCode contains valid ASCII")
+        str::from_utf8(&self.0).expect("CurrencyCode contains valid ASCII")
     }
 
     #[cfg(feature = "icu4x")]
     fn as_icu(self) -> IcuCurrencyCode {
         let code = TinyAsciiStr::<3>::try_from_utf8(self.as_str().as_bytes())
             .expect("CurrencyCode contains a valid TinyAsciiStr");
+
         IcuCurrencyCode(code)
     }
 }
@@ -191,22 +221,26 @@ pub struct NumberFormatter {
 
 #[derive(Clone)]
 enum FormatterBackend {
-    Decimal(Rc<DecimalFormatter>),
     #[cfg(feature = "icu4x")]
-    Percent(Rc<PercentFormatter<DecimalFormatter>>),
-    #[cfg(not(feature = "icu4x"))]
-    Percent,
+    Decimal(Arc<DecimalFormatter>),
+
     #[cfg(feature = "icu4x")]
-    Currency(Rc<IcuCurrencyFormatter>),
-    #[cfg(not(feature = "icu4x"))]
-    Currency,
+    Percent(Arc<PercentFormatter<DecimalFormatter>>),
+
     #[cfg(feature = "icu4x")]
-    Unit(Rc<UnitsFormatter>),
-    #[cfg(not(feature = "icu4x"))]
-    Unit,
+    Currency(Arc<IcuCurrencyFormatter>),
+
+    #[cfg(feature = "icu4x")]
+    Unit(Arc<UnitsFormatter>),
+
+    #[cfg(all(feature = "web-intl", target_arch = "wasm32"))]
+    WebIntl(Arc<web_intl::WebIntlNumberFormatter>),
+
+    #[cfg(not(any(feature = "icu4x", all(feature = "web-intl", target_arch = "wasm32"))))]
+    Fallback,
 }
 
-impl fmt::Debug for NumberFormatter {
+impl Debug for NumberFormatter {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("NumberFormatter")
             .field("locale", &self.locale)
@@ -217,38 +251,25 @@ impl fmt::Debug for NumberFormatter {
     }
 }
 
-#[cfg(feature = "std")]
-thread_local! {
-    static NUMBER_FORMATTER_CACHE: RefCell<BTreeMap<String, NumberFormatter>> =
-        const { RefCell::new(BTreeMap::new()) };
+impl PartialEq for NumberFormatter {
+    fn eq(&self, other: &Self) -> bool {
+        self.locale == other.locale
+            && self.options == other.options
+            && self.decimal_separator == other.decimal_separator
+            && self.grouping_separator == other.grouping_separator
+    }
 }
 
-/// Return a cached formatter for the given locale and options.
-///
-/// On `std` builds ars-i18n keeps a process-local cache keyed by locale and
-/// format options so repeated formatter construction can be avoided.
-#[cfg(feature = "std")]
-#[must_use]
-pub fn get_number_formatter(locale: &Locale, options: &NumberFormatOptions) -> NumberFormatter {
-    let key = format!("{:?}-{:?}", locale.to_bcp47(), options);
-    NUMBER_FORMATTER_CACHE.with(|cache| {
-        let mut cache = cache.borrow_mut();
-        if let Some(existing) = cache.get(&key) {
-            return existing.clone();
-        }
-
-        let formatter = NumberFormatter::new(locale, options.clone());
-        cache.insert(key, formatter.clone());
-        formatter
-    })
-}
+impl Eq for NumberFormatter {}
 
 impl NumberFormatter {
     /// Create a new locale-aware formatter for the given locale and options.
     #[must_use]
     pub fn new(locale: &Locale, options: NumberFormatOptions) -> Self {
         let options = normalize_style_defaults(options);
+
         let (decimal_separator, grouping_separator) = decimal_and_group_separators(locale);
+
         let backend = FormatterBackend::for_locale_and_style(locale, &options);
 
         Self {
@@ -263,14 +284,22 @@ impl NumberFormatter {
     /// Format a numeric value according to this formatter's locale and style.
     #[must_use]
     pub fn format(&self, value: f64) -> String {
-        let decimal = self.prepare_decimal(value);
-
         match &self.backend {
-            FormatterBackend::Decimal(formatter) => formatter.format(&decimal).to_string(),
+            #[cfg(all(feature = "web-intl", target_arch = "wasm32"))]
+            FormatterBackend::WebIntl(formatter) => {
+                formatter.format(self.prepare_browser_value(value))
+            }
+
             #[cfg(feature = "icu4x")]
-            FormatterBackend::Percent(formatter) => formatter.format(&decimal).to_string(),
-            #[cfg(not(feature = "icu4x"))]
-            FormatterBackend::Percent => fallback_format(&decimal, self),
+            FormatterBackend::Decimal(formatter) => {
+                formatter.format(&self.prepare_decimal(value)).to_string()
+            }
+
+            #[cfg(feature = "icu4x")]
+            FormatterBackend::Percent(formatter) => {
+                formatter.format(&self.prepare_decimal(value)).to_string()
+            }
+
             #[cfg(feature = "icu4x")]
             FormatterBackend::Currency(formatter) => {
                 #[cfg(not(feature = "std"))]
@@ -279,24 +308,26 @@ impl NumberFormatter {
                 let NumberStyle::Currency(code) = self.options.style else {
                     unreachable!("currency backend must match currency style");
                 };
+
                 formatter
-                    .format_fixed_decimal(&decimal, &code.as_icu())
+                    .format_fixed_decimal(&self.prepare_decimal(value), &code.as_icu())
                     .to_string()
             }
-            #[cfg(not(feature = "icu4x"))]
-            FormatterBackend::Currency => fallback_format(&decimal, self),
+
             #[cfg(feature = "icu4x")]
-            FormatterBackend::Unit(formatter) => {
-                formatter.format_fixed_decimal(&decimal).to_string()
-            }
-            #[cfg(not(feature = "icu4x"))]
-            FormatterBackend::Unit => fallback_format(&decimal, self),
+            FormatterBackend::Unit(formatter) => formatter
+                .format_fixed_decimal(&self.prepare_decimal(value))
+                .to_string(),
+
+            #[cfg(not(any(feature = "icu4x", all(feature = "web-intl", target_arch = "wasm32"))))]
+            FormatterBackend::Fallback => fallback_format(value, self),
         }
     }
 
     /// Parse a locale-formatted number back into a numeric value.
     pub fn parse(&self, input: &str) -> Option<f64> {
         let parsed = parse_locale_number(input, &self.locale)?;
+
         if matches!(self.options.style, NumberStyle::Percent) {
             Some(parsed / 100.0)
         } else {
@@ -320,9 +351,11 @@ impl NumberFormatter {
     #[must_use]
     pub fn format_currency(&self, amount: f64, currency_code: &str) -> String {
         let code = CurrencyCode::from_str(currency_code).expect("invalid ISO 4217 currency code");
+
         let precision = iso4217_minor_units(code);
 
         let mut options = self.options.clone();
+
         options.style = NumberStyle::Currency(code);
         options.min_fraction_digits = precision;
         options.max_fraction_digits = precision;
@@ -334,6 +367,7 @@ impl NumberFormatter {
     #[must_use]
     pub fn format_percent(&self, value: f64, max_fraction_digits: Option<u8>) -> String {
         let mut options = self.options.clone();
+
         options.style = NumberStyle::Percent;
         options.min_fraction_digits = 0;
         options.max_fraction_digits = max_fraction_digits.unwrap_or(0);
@@ -353,23 +387,12 @@ impl NumberFormatter {
         format!("{}{}{}", self.format(start), separator, self.format(end))
     }
 
+    #[cfg(feature = "icu4x")]
     fn prepare_decimal(&self, value: f64) -> Decimal {
-        let scaled = if matches!(self.options.style, NumberStyle::Percent) {
-            value * 100.0
-        } else {
-            value
-        };
+        let rounded = self.prepare_numeric_value(value, true);
 
-        if !scaled.is_finite() {
-            return Decimal::default();
-        }
-
-        let rounded = round_value(
-            scaled,
-            self.options.max_fraction_digits,
-            self.options.rounding_mode,
-        );
         let precision = usize::from(self.options.max_fraction_digits);
+
         let decimal_literal = if precision == 0 {
             format!("{rounded:.0}")
         } else {
@@ -377,63 +400,109 @@ impl NumberFormatter {
         };
 
         let mut decimal = Decimal::from_str(&decimal_literal).unwrap_or_default();
+
         decimal.absolute.trim_end();
+
         decimal
             .absolute
             .pad_end(-i16::from(self.options.min_fraction_digits));
+
         decimal
             .absolute
             .pad_start(i16::from(self.options.min_integer_digits.get()));
+
         decimal.apply_sign_display(self.options.sign_display.into_fixed_decimal());
+
         decimal
+    }
+
+    #[cfg(all(feature = "web-intl", target_arch = "wasm32"))]
+    const fn prepare_browser_value(&self, value: f64) -> f64 {
+        if value.is_finite() { value } else { 0.0 }
+    }
+
+    #[cfg(not(all(feature = "web-intl", target_arch = "wasm32")))]
+    fn prepare_numeric_value(&self, value: f64, scale_percent: bool) -> f64 {
+        let scaled = if scale_percent && matches!(self.options.style, NumberStyle::Percent) {
+            value * 100.0
+        } else {
+            value
+        };
+
+        if !scaled.is_finite() {
+            return 0.0;
+        }
+
+        round_value(
+            scaled,
+            self.options.max_fraction_digits,
+            self.options.rounding_mode,
+        )
     }
 }
 
 impl FormatterBackend {
+    #[cfg(feature = "icu4x")]
+    #[expect(
+        clippy::arc_with_non_send_sync,
+        reason = "Formatter clones share backend state, but ICU4X formatter handles are still thread-affine here."
+    )]
     fn for_locale_and_style(locale: &Locale, options: &NumberFormatOptions) -> Self {
         match &options.style {
             NumberStyle::Decimal => {
-                Self::Decimal(Rc::new(build_decimal_formatter(locale, options)))
+                Self::Decimal(Arc::new(build_decimal_formatter(locale, options)))
             }
-            #[cfg(feature = "icu4x")]
+
             NumberStyle::Percent => {
                 let formatter = PercentFormatter::try_new(
                     PercentFormatterPreferences::from(locale.as_icu()),
                     PercentFormatterOptions::default(),
                 )
                 .expect("compiled_data guarantees percent formatter availability");
-                Self::Percent(Rc::new(formatter))
+
+                Self::Percent(Arc::new(formatter))
             }
-            #[cfg(not(feature = "icu4x"))]
-            NumberStyle::Percent => Self::Percent,
-            #[cfg(feature = "icu4x")]
+
             NumberStyle::Currency(_) => {
                 let formatter = IcuCurrencyFormatter::try_new(
                     CurrencyFormatterPreferences::from(locale.as_icu()),
                     CurrencyFormatterOptions::default(),
                 )
                 .expect("compiled_data guarantees currency formatter availability");
-                Self::Currency(Rc::new(formatter))
+
+                Self::Currency(Arc::new(formatter))
             }
-            #[cfg(not(feature = "icu4x"))]
-            NumberStyle::Currency(_) => Self::Currency,
-            #[cfg(feature = "icu4x")]
+
             NumberStyle::Unit(unit) => {
                 let unit_id = resolve_measure_unit_id(unit)
                     .expect("unit formatter requires a resolvable CLDR unit id");
+
                 let mut formatter_options = UnitsFormatterOptions::default();
+
                 formatter_options.width = options.unit_display.into_icu_width();
+
                 let formatter = UnitsFormatter::try_new(
                     UnitsFormatterPreferences::from(locale.as_icu()),
                     &unit_id,
                     formatter_options,
                 )
                 .expect("compiled_data guarantees unit formatter availability");
-                Self::Unit(Rc::new(formatter))
+
+                Self::Unit(Arc::new(formatter))
             }
-            #[cfg(not(feature = "icu4x"))]
-            NumberStyle::Unit(_) => Self::Unit,
         }
+    }
+
+    #[cfg(all(not(feature = "icu4x"), feature = "web-intl", target_arch = "wasm32"))]
+    fn for_locale_and_style(locale: &Locale, options: &NumberFormatOptions) -> Self {
+        let formatter = web_intl::WebIntlNumberFormatter::new(locale, options);
+
+        Self::WebIntl(Arc::new(formatter))
+    }
+
+    #[cfg(not(any(feature = "icu4x", all(feature = "web-intl", target_arch = "wasm32"))))]
+    const fn for_locale_and_style(_locale: &Locale, _options: &NumberFormatOptions) -> Self {
+        Self::Fallback
     }
 }
 
@@ -463,10 +532,15 @@ pub fn normalize_digits(input: &str) -> String {
 /// Parse a locale-aware numeric string.
 pub fn parse_locale_number(input: &str, locale: &Locale) -> Option<f64> {
     let transliterated = normalize_digits(input);
+
     let (decimal_sep, group_sep) = decimal_and_group_separators(locale);
+
     let filtered = filter_numeric_characters(&transliterated, decimal_sep, group_sep);
+
     let chosen_decimal = choose_decimal_separator(&filtered, decimal_sep, group_sep);
+
     let normalized = normalize_numeric_syntax(&filtered, chosen_decimal);
+
     normalized.parse::<f64>().ok()
 }
 
@@ -480,6 +554,7 @@ pub fn decimal_and_group_separators(locale: &Locale) -> (char, char) {
             DecimalFormatterOptions::default(),
         )
         .expect("compiled_data guarantees decimal formatter availability");
+
         let formatted = formatter
             .format(&Decimal::from_str("12345.6").expect("static decimal string must parse"))
             .to_string();
@@ -487,7 +562,12 @@ pub fn decimal_and_group_separators(locale: &Locale) -> (char, char) {
         parse_separators(&formatted)
     }
 
-    #[cfg(not(feature = "icu4x"))]
+    #[cfg(all(not(feature = "icu4x"), feature = "web-intl", target_arch = "wasm32"))]
+    {
+        web_intl::decimal_and_group_separators(locale)
+    }
+
+    #[cfg(not(any(feature = "icu4x", all(feature = "web-intl", target_arch = "wasm32"))))]
     {
         fallback_separators(locale)
     }
@@ -509,6 +589,7 @@ fn filter_numeric_characters(input: &str, decimal_sep: char, group_sep: char) ->
 
 fn normalize_numeric_syntax(input: &str, decimal_separator: Option<char>) -> String {
     let mut normalized = String::with_capacity(input.len());
+
     let mut seen_sign = false;
 
     for c in input.chars() {
@@ -516,6 +597,7 @@ fn normalize_numeric_syntax(input: &str, decimal_separator: Option<char>) -> Str
             normalized.push(c);
         } else if matches!(c, '+' | '-') && !seen_sign && normalized.is_empty() {
             normalized.push(c);
+
             seen_sign = true;
         } else if Some(c) == decimal_separator {
             normalized.push('.');
@@ -527,6 +609,7 @@ fn normalize_numeric_syntax(input: &str, decimal_separator: Option<char>) -> Str
 
 fn choose_decimal_separator(input: &str, locale_decimal: char, locale_group: char) -> Option<char> {
     let locale_decimal_occurs = input.contains(locale_decimal);
+
     if locale_decimal_occurs {
         return Some(locale_decimal);
     }
@@ -539,13 +622,16 @@ fn choose_decimal_separator(input: &str, locale_decimal: char, locale_group: cha
         .char_indices()
         .rev()
         .find(|(_, c)| matches!(*c, '.' | ',' | '\u{066B}'));
+
     let (idx, separator) = last?;
 
     let digits_after = input[idx + separator.len_utf8()..]
         .chars()
         .filter(char::is_ascii_digit)
         .count();
+
     let occurrences = input.chars().filter(|c| *c == separator).count();
+
     let other_separator_present = input
         .chars()
         .any(|c| matches!(c, '.' | ',' | '\u{066B}') && c != separator);
@@ -568,6 +654,7 @@ fn choose_decimal_separator(input: &str, locale_decimal: char, locale_group: cha
 #[cfg(feature = "icu4x")]
 fn parse_separators(formatted: &str) -> (char, char) {
     let mut decimal_sep = '.';
+
     let mut group_sep = ',';
 
     if let Some((idx, ch)) = formatted
@@ -578,12 +665,14 @@ fn parse_separators(formatted: &str) -> (char, char) {
         let has_digit_after = formatted[idx + ch.len_utf8()..]
             .chars()
             .any(char::is_numeric);
+
         if has_digit_after {
             decimal_sep = ch;
         }
     }
 
     let integer_part = formatted.split(decimal_sep).next().unwrap_or(formatted);
+
     if let Some(ch) = integer_part
         .chars()
         .find(|c| !c.is_numeric() && !matches!(*c, '+' | '-'))
@@ -600,11 +689,15 @@ fn normalize_style_defaults(mut options: NumberFormatOptions) -> NumberFormatOpt
             NumberStyle::Percent => {
                 options.max_fraction_digits = 0;
             }
+
             NumberStyle::Currency(code) => {
                 let precision = iso4217_minor_units(code);
+
                 options.min_fraction_digits = precision;
+
                 options.max_fraction_digits = precision;
             }
+
             NumberStyle::Decimal | NumberStyle::Unit(_) => {}
         }
     }
@@ -615,14 +708,17 @@ fn normalize_style_defaults(mut options: NumberFormatOptions) -> NumberFormatOpt
 fn iso4217_minor_units(code: CurrencyCode) -> u8 {
     match code.as_str() {
         "BHD" | "KWD" | "OMR" | "IQD" | "LYD" | "TND" => 3,
+
         "CLF" | "UYW" => 4,
+
         "JPY" | "KRW" | "VND" | "ISK" | "CLP" | "UGX" | "GNF" | "XOF" | "XAF" | "XPF" | "RWF"
         | "DJF" | "KMF" | "VUV" | "PYG" => 0,
+
         _ => 2,
     }
 }
 
-#[cfg(feature = "icu4x")]
+#[cfg(any(feature = "icu4x", all(feature = "web-intl", target_arch = "wasm32")))]
 fn resolve_measure_unit_id(unit: &MeasureUnit) -> Option<String> {
     #[cfg(not(feature = "std"))]
     use alloc::borrow::ToOwned as _;
@@ -635,6 +731,7 @@ fn resolve_measure_unit_id(unit: &MeasureUnit) -> Option<String> {
         let Ok(parsed) = MeasureUnit::try_from_str(&candidate) else {
             continue;
         };
+
         if parsed == *unit {
             return Some(candidate);
         }
@@ -646,6 +743,7 @@ fn resolve_measure_unit_id(unit: &MeasureUnit) -> Option<String> {
 #[cfg(feature = "icu4x")]
 fn build_decimal_formatter(locale: &Locale, options: &NumberFormatOptions) -> DecimalFormatter {
     let mut formatter_options = DecimalFormatterOptions::default();
+
     formatter_options.grouping_strategy = Some(if options.use_grouping {
         GroupingStrategy::Auto
     } else {
@@ -659,14 +757,12 @@ fn build_decimal_formatter(locale: &Locale, options: &NumberFormatOptions) -> De
     .expect("compiled_data guarantees decimal formatter availability")
 }
 
-#[cfg(not(feature = "icu4x"))]
-fn build_decimal_formatter(_locale: &Locale, _options: &NumberFormatOptions) -> DecimalFormatter {
-    unreachable!("decimal formatters are only constructed when the icu4x feature is enabled")
-}
-
+#[cfg(any(test, not(all(feature = "web-intl", target_arch = "wasm32"))))]
 fn round_value(value: f64, fraction_digits: u8, mode: RoundingMode) -> f64 {
     let factor = core_maths::CoreFloat::powi(10_f64, i32::from(fraction_digits));
+
     let scaled = value * factor;
+
     let rounded = match mode {
         RoundingMode::HalfEven => round_half_even(scaled),
         RoundingMode::HalfUp => round_half_away_from_zero(scaled),
@@ -679,10 +775,14 @@ fn round_value(value: f64, fraction_digits: u8, mode: RoundingMode) -> f64 {
     rounded / factor
 }
 
+#[cfg(any(test, not(all(feature = "web-intl", target_arch = "wasm32"))))]
 fn round_half_even(value: f64) -> f64 {
     let abs = value.abs();
+
     let floor = core_maths::CoreFloat::floor(abs);
+
     let fraction = abs - floor;
+
     let rounded = if fraction < 0.5 {
         floor
     } else if fraction > 0.5 {
@@ -696,42 +796,66 @@ fn round_half_even(value: f64) -> f64 {
     rounded.copysign(value)
 }
 
+#[cfg(any(test, not(all(feature = "web-intl", target_arch = "wasm32"))))]
 fn round_half_away_from_zero(value: f64) -> f64 {
     let abs = value.abs();
+
     let floor = core_maths::CoreFloat::floor(abs);
+
     let fraction = abs - floor;
+
     let rounded = if fraction >= 0.5 { floor + 1.0 } else { floor };
+
     rounded.copysign(value)
 }
 
+#[cfg(any(test, not(all(feature = "web-intl", target_arch = "wasm32"))))]
 fn round_half_toward_zero(value: f64) -> f64 {
     let abs = value.abs();
+
     let floor = core_maths::CoreFloat::floor(abs);
+
     let fraction = abs - floor;
+
     let rounded = if fraction > 0.5 { floor + 1.0 } else { floor };
+
     rounded.copysign(value)
 }
 
-#[cfg(not(feature = "icu4x"))]
+#[cfg(not(any(feature = "icu4x", all(feature = "web-intl", target_arch = "wasm32"))))]
 fn fallback_separators(locale: &Locale) -> (char, char) {
     match locale.language() {
         "de" | "pt" => (',', '.'),
+
         "fr" => (',', ' '),
+
         "ar" => ('٫', '٬'),
+
         _ => ('.', ','),
     }
 }
 
-#[cfg(not(feature = "icu4x"))]
-fn fallback_format(decimal: &Decimal, formatter: &NumberFormatter) -> String {
-    let mut output = decimal.to_string();
+#[cfg(not(any(feature = "icu4x", all(feature = "web-intl", target_arch = "wasm32"))))]
+fn fallback_format(value: f64, formatter: &NumberFormatter) -> String {
+    let precision = usize::from(formatter.options.max_fraction_digits);
+
+    let rounded = formatter.prepare_numeric_value(value, true);
+
+    let mut output = if precision == 0 {
+        format!("{rounded:.0}")
+    } else {
+        format!("{rounded:.precision$}")
+    };
+
     if formatter.decimal_separator != '.' {
         output = output.replace('.', &String::from(formatter.decimal_separator));
     }
+
     output
 }
 
 impl SignDisplay {
+    #[cfg(feature = "icu4x")]
     const fn into_fixed_decimal(self) -> FixedSignDisplay {
         match self {
             Self::Auto => FixedSignDisplay::Auto,
@@ -753,6 +877,10 @@ impl UnitDisplay {
         }
     }
 }
+
+#[cfg(all(test, feature = "web-intl", target_arch = "wasm32"))]
+#[path = "../tests/unit/number_web_intl.rs"]
+mod number_web_intl_tests;
 
 #[cfg(test)]
 mod tests {
@@ -795,6 +923,7 @@ mod tests {
     #[test]
     fn formats_grouping_and_decimal_separators_for_en_us_and_de_de() {
         let en_us = NumberFormatter::new(&locales::en_us(), NumberFormatOptions::default());
+
         let de_de = NumberFormatter::new(&locales::de_de(), NumberFormatOptions::default());
 
         assert_eq!(en_us.format(1234.56), "1,234.56");
@@ -805,6 +934,7 @@ mod tests {
     #[test]
     fn round_trips_parse_for_en_us_and_de_de() {
         let en_us = NumberFormatter::new(&locales::en_us(), NumberFormatOptions::default());
+
         let de_de = NumberFormatter::new(&locales::de_de(), NumberFormatOptions::default());
 
         assert_eq!(en_us.parse("1,234.56"), Some(1234.56));
@@ -816,6 +946,7 @@ mod tests {
     #[test]
     fn exposes_decimal_and_grouping_separator_accessors() {
         let en_us = NumberFormatter::new(&locales::en_us(), NumberFormatOptions::default());
+
         let de_de = NumberFormatter::new(&locales::de_de(), NumberFormatOptions::default());
 
         assert_eq!(en_us.decimal_separator(), '.');
@@ -831,7 +962,9 @@ mod tests {
             style: NumberStyle::Percent,
             ..NumberFormatOptions::default()
         };
+
         let en_us = NumberFormatter::new(&locales::en_us(), options.clone());
+
         let de_de = NumberFormatter::new(&locales::de_de(), options);
 
         assert_eq!(en_us.format(0.47), "47%");
@@ -846,6 +979,7 @@ mod tests {
             style: NumberStyle::Percent,
             ..NumberFormatOptions::default()
         };
+
         let formatter = NumberFormatter::new(&locales::en_us(), options);
 
         assert_eq!(formatter.parse("47%"), Some(0.47));
@@ -855,7 +989,9 @@ mod tests {
     #[test]
     fn formats_currency_with_locale_correct_symbol_placement() {
         let base = NumberFormatter::new(&locales::en_us(), NumberFormatOptions::default());
+
         let de = NumberFormatter::new(&locales::de_de(), NumberFormatOptions::default());
+
         let ja = NumberFormatter::new(&locales::ja_jp(), NumberFormatOptions::default());
 
         assert_eq!(base.format_currency(1234.5, "USD"), "$1,234.50");
@@ -877,6 +1013,7 @@ mod tests {
             },
         )
         .format(5.0);
+
         let short = NumberFormatter::new(
             &locales::en_us(),
             NumberFormatOptions {
@@ -886,6 +1023,7 @@ mod tests {
             },
         )
         .format(5.0);
+
         let narrow = NumberFormatter::new(
             &locales::en_us(),
             NumberFormatOptions {
@@ -906,7 +1044,9 @@ mod tests {
     #[test]
     fn parses_numeric_core_from_currency_or_unit_affixed_strings() {
         let currency = NumberFormatter::new(&locales::en_us(), NumberFormatOptions::default());
+
         let unit = MeasureUnit::try_from_str("celsius").expect("celsius is a valid CLDR unit");
+
         let unit_formatter = NumberFormatter::new(
             &locales::de_de(),
             NumberFormatOptions {
@@ -919,6 +1059,7 @@ mod tests {
         );
 
         let currency_text = currency.format_currency(1234.5, "USD");
+
         let unit_text = unit_formatter.format(37.0);
 
         assert_eq!(currency.parse(&currency_text), Some(1234.5));
@@ -937,15 +1078,24 @@ mod tests {
     #[test]
     fn normalizes_arabic_indic_digits_during_parse() {
         let locale = locales::ar();
+
         let formatter = NumberFormatter::new(&locale, NumberFormatOptions::default());
 
         assert_eq!(formatter.parse("١٬٢٣٤٫٥٦"), Some(1234.56));
+    }
+
+    #[test]
+    fn normalize_digits_supports_multiple_unicode_decimal_sets() {
+        assert_eq!(normalize_digits("۱۲۳۴۵۶۷۸۹۰"), "1234567890");
+        assert_eq!(normalize_digits("१२३४५६७८९०"), "1234567890");
+        assert_eq!(normalize_digits("১২৩৪৫৬৭৮৯০"), "1234567890");
     }
 
     #[cfg(feature = "icu4x")]
     #[test]
     fn respects_non_uniform_grouping() {
         let locale = Locale::parse("en-IN").expect("en-IN is a valid locale");
+
         let formatter = NumberFormatter::new(&locale, NumberFormatOptions::default());
 
         assert_eq!(formatter.format(1234567.0), "12,34,567");
@@ -978,6 +1128,7 @@ mod tests {
         assert_eq!(round_value(-1.29, 1, RoundingMode::Truncate), -1.2);
     }
 
+    #[cfg(feature = "icu4x")]
     #[test]
     fn sign_display_variants_map_to_fixed_decimal_policies() {
         assert_eq!(
@@ -1008,10 +1159,12 @@ mod tests {
             style: NumberStyle::Currency(CurrencyCode::from_str("BHD").expect("valid code")),
             ..NumberFormatOptions::default()
         });
+
         let clf = normalize_style_defaults(NumberFormatOptions {
             style: NumberStyle::Currency(CurrencyCode::from_str("CLF").expect("valid code")),
             ..NumberFormatOptions::default()
         });
+
         let jpy = normalize_style_defaults(NumberFormatOptions {
             style: NumberStyle::Currency(CurrencyCode::JPY),
             ..NumberFormatOptions::default()
@@ -1026,7 +1179,9 @@ mod tests {
     #[test]
     fn parses_signed_and_grouped_numbers_with_locale_heuristics() {
         let en_us = locales::en_us();
+
         let de_de = locales::de_de();
+
         let ar = locales::ar();
 
         assert_eq!(parse_locale_number("-1,234.56", &en_us), Some(-1234.56));
@@ -1035,36 +1190,21 @@ mod tests {
         assert_eq!(parse_locale_number("١٬٢٣٤", &ar), Some(1234.0));
     }
 
-    #[cfg(all(feature = "std", feature = "icu4x"))]
+    #[cfg(feature = "icu4x")]
     #[test]
-    fn caches_number_formatters_by_locale_and_options() {
+    fn cloned_number_formatters_preserve_formatting_behavior() {
         let options = NumberFormatOptions {
             min_fraction_digits: 2,
             max_fraction_digits: 2,
             ..NumberFormatOptions::default()
         };
 
-        let cached = get_number_formatter(&locales::en_us(), &options);
-        let direct = NumberFormatter::new(&locales::en_us(), options);
+        let formatter = NumberFormatter::new(&locales::en_us(), options);
+        let cloned = formatter.clone();
 
-        assert_eq!(cached.format(1234.5), direct.format(1234.5));
-        assert_eq!(cached.decimal_separator(), direct.decimal_separator());
-        assert_eq!(cached.grouping_separator(), direct.grouping_separator());
-    }
-
-    #[cfg(all(feature = "std", feature = "icu4x"))]
-    #[test]
-    fn repeated_cached_formatter_lookups_reuse_existing_entries() {
-        let options = NumberFormatOptions {
-            use_grouping: false,
-            ..NumberFormatOptions::default()
-        };
-
-        let first = get_number_formatter(&locales::en_us(), &options);
-        let second = get_number_formatter(&locales::en_us(), &options);
-
-        assert_eq!(first.format(1234.56), second.format(1234.56));
-        assert_eq!(first.grouping_separator(), second.grouping_separator());
+        assert_eq!(formatter.format(1234.5), cloned.format(1234.5));
+        assert_eq!(formatter.decimal_separator(), cloned.decimal_separator());
+        assert_eq!(formatter.grouping_separator(), cloned.grouping_separator());
     }
 
     #[cfg(feature = "icu4x")]
@@ -1111,6 +1251,7 @@ mod tests {
     fn resolve_measure_unit_id_uses_embedded_cldr_id_when_present() {
         let mut unit =
             MeasureUnit::try_from_str("kilogram").expect("kilogram is a valid CLDR unit");
+
         unit.id = Some("kilogram");
 
         assert_eq!(

--- a/crates/ars-i18n/src/number.rs
+++ b/crates/ars-i18n/src/number.rs
@@ -588,6 +588,7 @@ fn filter_numeric_characters(input: &str, decimal_sep: char, group_sep: char) ->
         .filter(|c| {
             c.is_ascii_digit()
                 || matches!(*c, '+' | '-' | '.' | ',')
+                || *c == '\u{2212}'
                 || matches!(*c, '\u{066B}' | '\u{066C}' | '\u{00A0}' | '\u{202F}')
                 || c.is_ascii_whitespace()
                 || *c == decimal_sep
@@ -604,8 +605,8 @@ fn normalize_numeric_syntax(input: &str, decimal_separator: Option<char>) -> Str
     for c in input.chars() {
         if c.is_ascii_digit() {
             normalized.push(c);
-        } else if matches!(c, '+' | '-') && !seen_sign && normalized.is_empty() {
-            normalized.push(c);
+        } else if matches!(c, '+' | '-' | '\u{2212}') && !seen_sign && normalized.is_empty() {
+            normalized.push(if c == '\u{2212}' { '-' } else { c });
 
             seen_sign = true;
         } else if Some(c) == decimal_separator {
@@ -1189,6 +1190,7 @@ mod tests {
         let ar = locales::ar();
 
         assert_eq!(parse_locale_number("-1,234.56", &en_us), Some(-1234.56));
+        assert_eq!(parse_locale_number("−1,234.56", &en_us), Some(-1234.56));
         assert_eq!(parse_locale_number("+1,234,567", &en_us), Some(1234567.0));
         assert_eq!(parse_locale_number("+1.234", &de_de), Some(1234.0));
         assert_eq!(parse_locale_number("١٬٢٣٤", &ar), Some(1234.0));

--- a/crates/ars-i18n/src/number/web_intl.rs
+++ b/crates/ars-i18n/src/number/web_intl.rs
@@ -1,6 +1,8 @@
 //! Browser-backed `NumberFormatter` helpers for `web-intl` builds on `wasm32`.
 
 use alloc::{string::String, vec::Vec};
+#[cfg(test)]
+use core::sync::atomic::{AtomicI8, Ordering};
 
 use js_sys::{
     Array, Function,
@@ -9,7 +11,7 @@ use js_sys::{
         NumberFormatPart, NumberFormatPartType, NumberFormatStyle, RoundingMode as JsRoundingMode,
         SignDisplay as JsSignDisplay, UnitDisplay as JsUnitDisplay, UseGrouping,
     },
-    Reflect,
+    Object, Reflect,
 };
 use wasm_bindgen::{JsCast, JsValue};
 
@@ -18,6 +20,9 @@ use super::{
     resolve_measure_unit_id,
 };
 use crate::Locale;
+
+#[cfg(test)]
+static NEGATIVE_SIGN_DISPLAY_SUPPORT_OVERRIDE: AtomicI8 = AtomicI8::new(-1);
 
 /// Browser-backed formatter for the public `NumberFormatter` API.
 #[derive(Clone, Debug)]
@@ -96,9 +101,11 @@ pub(super) fn decimal_and_group_separators(locale: &Locale) -> (char, char) {
 fn build_options(options: &NumberFormatOptions) -> JsNumberFormatOptions {
     let js_options = JsNumberFormatOptions::new();
 
-    let (min_fraction_digits, max_fraction_digits) = normalized_fraction_digit_bounds(options);
+    let min_integer_digits = clamped_minimum_integer_digits(options);
 
-    js_options.set_minimum_integer_digits(options.min_integer_digits.get());
+    let (min_fraction_digits, max_fraction_digits) = clamped_fraction_digit_bounds(options);
+
+    js_options.set_minimum_integer_digits(min_integer_digits);
 
     js_options.set_minimum_fraction_digits(min_fraction_digits);
 
@@ -121,7 +128,7 @@ fn build_options(options: &NumberFormatOptions) -> JsNumberFormatOptions {
 
     if let Some(sign_display) = options.sign_display.into_js() {
         js_options.set_sign_display(sign_display);
-    } else {
+    } else if browser_supports_negative_sign_display() {
         // `js-sys` does not expose the Intl `"negative"` variant yet, so
         // set it through the raw options bag to preserve the spec-level
         // distinction from `"auto"` for cases like negative zero.
@@ -178,6 +185,16 @@ fn normalized_fraction_digit_bounds(options: &NumberFormatOptions) -> (u8, u8) {
     )
 }
 
+fn clamped_minimum_integer_digits(options: &NumberFormatOptions) -> u8 {
+    options.min_integer_digits.get().clamp(1, 21)
+}
+
+fn clamped_fraction_digit_bounds(options: &NumberFormatOptions) -> (u8, u8) {
+    let (min_fraction_digits, max_fraction_digits) = normalized_fraction_digit_bounds(options);
+
+    (min_fraction_digits.min(100), max_fraction_digits.min(100))
+}
+
 fn browser_supports_unit(unit_id: &str) -> bool {
     let Ok(intl) = Reflect::get(&js_sys::global(), &JsValue::from_str("Intl")) else {
         return false;
@@ -200,6 +217,73 @@ fn browser_supports_unit(unit_id: &str) -> bool {
         .iter()
         .filter_map(|value| value.as_string())
         .any(|supported| supported == unit_id)
+}
+
+fn browser_supports_negative_sign_display() -> bool {
+    #[cfg(test)]
+    if let Some(supported) = decode_negative_sign_display_support_override(
+        NEGATIVE_SIGN_DISPLAY_SUPPORT_OVERRIDE.load(Ordering::Relaxed),
+    ) {
+        return supported;
+    }
+
+    let Ok(intl) = Reflect::get(&js_sys::global(), &JsValue::from_str("Intl")) else {
+        return false;
+    };
+
+    let Ok(number_format) = Reflect::get(&intl, &JsValue::from_str("NumberFormat")) else {
+        return false;
+    };
+
+    let Some(number_format) = number_format.dyn_ref::<Function>() else {
+        return false;
+    };
+
+    let options = Object::new();
+
+    if Reflect::set(
+        &options,
+        &JsValue::from_str("signDisplay"),
+        &JsValue::from_str("negative"),
+    )
+    .is_err()
+    {
+        return false;
+    }
+
+    let args = Array::new();
+
+    args.push(&Array::new());
+    args.push(&options);
+
+    Reflect::construct(number_format, &args).is_ok()
+}
+
+#[cfg(test)]
+pub(super) fn replace_negative_sign_display_support_override(value: Option<bool>) -> Option<bool> {
+    decode_negative_sign_display_support_override(NEGATIVE_SIGN_DISPLAY_SUPPORT_OVERRIDE.swap(
+        encode_negative_sign_display_support_override(value),
+        Ordering::Relaxed,
+    ))
+}
+
+#[cfg(test)]
+const fn encode_negative_sign_display_support_override(value: Option<bool>) -> i8 {
+    match value {
+        None => -1,
+        Some(false) => 0,
+        Some(true) => 1,
+    }
+}
+
+#[cfg(test)]
+const fn decode_negative_sign_display_support_override(value: i8) -> Option<bool> {
+    match value {
+        -1 => None,
+        0 => Some(false),
+        1 => Some(true),
+        _ => None,
+    }
 }
 
 fn first_char(value: &js_sys::JsString) -> Option<char> {

--- a/crates/ars-i18n/src/number/web_intl.rs
+++ b/crates/ars-i18n/src/number/web_intl.rs
@@ -1,0 +1,205 @@
+//! Browser-backed `NumberFormatter` helpers for `web-intl` builds on `wasm32`.
+
+use alloc::{string::String, vec::Vec};
+
+use js_sys::{
+    Array, Function,
+    Intl::{
+        CurrencyDisplay, CurrencySign, NumberFormat, NumberFormatOptions as JsNumberFormatOptions,
+        NumberFormatPart, NumberFormatPartType, NumberFormatStyle, RoundingMode as JsRoundingMode,
+        SignDisplay as JsSignDisplay, UnitDisplay as JsUnitDisplay, UseGrouping,
+    },
+    Reflect,
+};
+use wasm_bindgen::{JsCast, JsValue};
+
+use super::{
+    NumberFormatOptions, NumberStyle, RoundingMode, SignDisplay, UnitDisplay,
+    resolve_measure_unit_id,
+};
+use crate::Locale;
+
+/// Browser-backed formatter for the public `NumberFormatter` API.
+#[derive(Clone, Debug)]
+pub(super) struct WebIntlNumberFormatter {
+    inner: NumberFormat,
+}
+
+impl WebIntlNumberFormatter {
+    /// Construct a browser-backed formatter using `Intl.NumberFormat`.
+    pub(super) fn new(locale: &Locale, options: &NumberFormatOptions) -> Self {
+        let locales = Array::of1(&JsValue::from_str(&locale.to_bcp47()));
+
+        let js_options = build_options(options);
+
+        let inner = NumberFormat::new(&locales, &js_options);
+
+        Self { inner }
+    }
+
+    /// Format the given numeric value through the browser formatter.
+    pub(super) fn format(&self, value: f64) -> String {
+        let format_fn: Function = self.inner.format();
+
+        format_fn
+            .call1(&JsValue::UNDEFINED, &JsValue::from_f64(value))
+            .ok()
+            .and_then(|value| value.as_string())
+            .unwrap_or_default()
+    }
+
+    fn format_to_parts(&self, value: f64) -> Vec<NumberFormatPart> {
+        self.inner
+            .format_to_parts(value)
+            .iter()
+            .map(JsCast::unchecked_into::<NumberFormatPart>)
+            .collect()
+    }
+}
+
+/// Extract decimal and grouping separators from `Intl.NumberFormat::formatToParts`.
+#[must_use]
+pub(super) fn decimal_and_group_separators(locale: &Locale) -> (char, char) {
+    let formatter = WebIntlNumberFormatter::new(locale, &NumberFormatOptions::default());
+
+    let mut decimal_separator = '.';
+
+    let mut grouping_separator = None;
+
+    for part in formatter.format_to_parts(12345.6) {
+        match part.type_() {
+            NumberFormatPartType::Decimal => {
+                decimal_separator = first_char(&part.value()).unwrap_or('.');
+            }
+
+            NumberFormatPartType::Group if grouping_separator.is_none() => {
+                grouping_separator = first_char(&part.value());
+            }
+
+            _ => {}
+        }
+    }
+
+    let fallback_group = match locale.language() {
+        "de" | "pt" => '.',
+        "fr" => ' ',
+        "ar" => '٬',
+        _ => ',',
+    };
+
+    (
+        decimal_separator,
+        grouping_separator.unwrap_or(fallback_group),
+    )
+}
+
+fn build_options(options: &NumberFormatOptions) -> JsNumberFormatOptions {
+    let js_options = JsNumberFormatOptions::new();
+
+    js_options.set_minimum_integer_digits(options.min_integer_digits.get());
+
+    js_options.set_minimum_fraction_digits(options.min_fraction_digits);
+
+    js_options.set_maximum_fraction_digits(options.max_fraction_digits);
+
+    js_options.set_use_grouping(if options.use_grouping {
+        UseGrouping::True
+    } else {
+        UseGrouping::False
+    });
+
+    Reflect::set(
+        js_options.as_ref(),
+        &JsValue::from_str("useGrouping"),
+        &JsValue::from_bool(options.use_grouping),
+    )
+    .expect("setting Intl.NumberFormat useGrouping should succeed");
+
+    js_options.set_rounding_mode(options.rounding_mode.into_js());
+
+    if let Some(sign_display) = options.sign_display.into_js() {
+        js_options.set_sign_display(sign_display);
+    } else {
+        // `js-sys` does not expose the Intl `"negative"` variant yet, so
+        // set it through the raw options bag to preserve the spec-level
+        // distinction from `"auto"` for cases like negative zero.
+        Reflect::set(
+            js_options.as_ref(),
+            &JsValue::from_str("signDisplay"),
+            &JsValue::from_str("negative"),
+        )
+        .expect("setting Intl.NumberFormat signDisplay should succeed");
+    }
+
+    match &options.style {
+        NumberStyle::Decimal => {
+            js_options.set_style(NumberFormatStyle::Decimal);
+        }
+
+        NumberStyle::Percent => {
+            js_options.set_style(NumberFormatStyle::Percent);
+        }
+
+        NumberStyle::Currency(code) => {
+            js_options.set_style(NumberFormatStyle::Currency);
+
+            js_options.set_currency(code.as_str());
+
+            js_options.set_currency_display(CurrencyDisplay::Symbol);
+
+            js_options.set_currency_sign(CurrencySign::Standard);
+        }
+
+        NumberStyle::Unit(unit) => {
+            let unit_id = resolve_measure_unit_id(unit)
+                .expect("unit formatter requires a resolvable CLDR unit id");
+
+            js_options.set_style(NumberFormatStyle::Unit);
+
+            js_options.set_unit(&unit_id);
+
+            js_options.set_unit_display(options.unit_display.into_js());
+        }
+    }
+
+    js_options
+}
+
+fn first_char(value: &js_sys::JsString) -> Option<char> {
+    String::from(value.clone()).chars().next()
+}
+
+impl RoundingMode {
+    const fn into_js(self) -> JsRoundingMode {
+        match self {
+            Self::HalfEven => JsRoundingMode::HalfEven,
+            Self::HalfUp => JsRoundingMode::HalfExpand,
+            Self::HalfDown => JsRoundingMode::HalfTrunc,
+            Self::Ceiling => JsRoundingMode::Ceil,
+            Self::Floor => JsRoundingMode::Floor,
+            Self::Truncate => JsRoundingMode::Trunc,
+        }
+    }
+}
+
+impl SignDisplay {
+    const fn into_js(self) -> Option<JsSignDisplay> {
+        match self {
+            Self::Auto => Some(JsSignDisplay::Auto),
+            Self::Always => Some(JsSignDisplay::Always),
+            Self::Never => Some(JsSignDisplay::Never),
+            Self::ExceptZero => Some(JsSignDisplay::ExceptZero),
+            Self::Negative => None,
+        }
+    }
+}
+
+impl UnitDisplay {
+    const fn into_js(self) -> JsUnitDisplay {
+        match self {
+            Self::Long => JsUnitDisplay::Long,
+            Self::Short => JsUnitDisplay::Short,
+            Self::Narrow => JsUnitDisplay::Narrow,
+        }
+    }
+}

--- a/crates/ars-i18n/src/number/web_intl.rs
+++ b/crates/ars-i18n/src/number/web_intl.rs
@@ -7,7 +7,8 @@ use js_sys::{
     Intl::{
         CurrencyDisplay, CurrencySign, NumberFormat, NumberFormatOptions as JsNumberFormatOptions,
         NumberFormatPart, NumberFormatPartType, NumberFormatStyle, RoundingMode as JsRoundingMode,
-        SignDisplay as JsSignDisplay, UnitDisplay as JsUnitDisplay, UseGrouping,
+        SignDisplay as JsSignDisplay, SupportedValuesKey, UnitDisplay as JsUnitDisplay,
+        UseGrouping, supported_values_of,
     },
     Reflect,
 };
@@ -96,11 +97,13 @@ pub(super) fn decimal_and_group_separators(locale: &Locale) -> (char, char) {
 fn build_options(options: &NumberFormatOptions) -> JsNumberFormatOptions {
     let js_options = JsNumberFormatOptions::new();
 
+    let (min_fraction_digits, max_fraction_digits) = normalized_fraction_digit_bounds(options);
+
     js_options.set_minimum_integer_digits(options.min_integer_digits.get());
 
-    js_options.set_minimum_fraction_digits(options.min_fraction_digits);
+    js_options.set_minimum_fraction_digits(min_fraction_digits);
 
-    js_options.set_maximum_fraction_digits(options.max_fraction_digits);
+    js_options.set_maximum_fraction_digits(max_fraction_digits);
 
     js_options.set_use_grouping(if options.use_grouping {
         UseGrouping::True
@@ -154,15 +157,33 @@ fn build_options(options: &NumberFormatOptions) -> JsNumberFormatOptions {
             let unit_id = resolve_measure_unit_id(unit)
                 .expect("unit formatter requires a resolvable CLDR unit id");
 
-            js_options.set_style(NumberFormatStyle::Unit);
+            if browser_supports_unit(&unit_id) {
+                js_options.set_style(NumberFormatStyle::Unit);
 
-            js_options.set_unit(&unit_id);
+                js_options.set_unit(&unit_id);
 
-            js_options.set_unit_display(options.unit_display.into_js());
+                js_options.set_unit_display(options.unit_display.into_js());
+            } else {
+                js_options.set_style(NumberFormatStyle::Decimal);
+            }
         }
     }
 
     js_options
+}
+
+fn normalized_fraction_digit_bounds(options: &NumberFormatOptions) -> (u8, u8) {
+    (
+        options.min_fraction_digits,
+        options.max_fraction_digits.max(options.min_fraction_digits),
+    )
+}
+
+fn browser_supports_unit(unit_id: &str) -> bool {
+    supported_values_of(SupportedValuesKey::Unit)
+        .iter()
+        .filter_map(|value| value.as_string())
+        .any(|supported| supported == unit_id)
 }
 
 fn first_char(value: &js_sys::JsString) -> Option<char> {

--- a/crates/ars-i18n/src/number/web_intl.rs
+++ b/crates/ars-i18n/src/number/web_intl.rs
@@ -7,8 +7,7 @@ use js_sys::{
     Intl::{
         CurrencyDisplay, CurrencySign, NumberFormat, NumberFormatOptions as JsNumberFormatOptions,
         NumberFormatPart, NumberFormatPartType, NumberFormatStyle, RoundingMode as JsRoundingMode,
-        SignDisplay as JsSignDisplay, SupportedValuesKey, UnitDisplay as JsUnitDisplay,
-        UseGrouping, supported_values_of,
+        SignDisplay as JsSignDisplay, UnitDisplay as JsUnitDisplay, UseGrouping,
     },
     Reflect,
 };
@@ -180,7 +179,24 @@ fn normalized_fraction_digit_bounds(options: &NumberFormatOptions) -> (u8, u8) {
 }
 
 fn browser_supports_unit(unit_id: &str) -> bool {
-    supported_values_of(SupportedValuesKey::Unit)
+    let Ok(intl) = Reflect::get(&js_sys::global(), &JsValue::from_str("Intl")) else {
+        return false;
+    };
+
+    let Ok(supported_values_of) = Reflect::get(&intl, &JsValue::from_str("supportedValuesOf"))
+    else {
+        return false;
+    };
+
+    let Some(supported_values_of) = supported_values_of.dyn_ref::<Function>() else {
+        return false;
+    };
+
+    let Ok(supported_units) = supported_values_of.call1(&intl, &JsValue::from_str("unit")) else {
+        return false;
+    };
+
+    Array::from(&supported_units)
         .iter()
         .filter_map(|value| value.as_string())
         .any(|supported| supported == unit_id)

--- a/crates/ars-i18n/tests/unit/number_web_intl.rs
+++ b/crates/ars-i18n/tests/unit/number_web_intl.rs
@@ -3,7 +3,7 @@
 //! Run with:
 //! `wasm-pack test --headless --chrome crates/ars-i18n --no-default-features --features std,web-intl`.
 
-use alloc::{collections::BTreeSet, string::String};
+use alloc::{collections::BTreeSet, format, string::String};
 use core::num::NonZeroU8;
 
 use js_sys::{
@@ -168,6 +168,21 @@ fn web_intl_currency_and_decimal_output_round_trip_through_parse() {
 
     assert_eq!(de.parse(&decimal_text), Some(1234.56));
     assert_eq!(currency.parse(&currency_text), Some(1234.5));
+}
+
+#[wasm_bindgen_test]
+fn web_intl_parse_accepts_unicode_minus_from_browser_shaped_output() {
+    let formatter = NumberFormatter::new(&locale("sv-SE"), ArsNumberFormatOptions::default());
+
+    let positive = formatter.format(1234.5);
+    let negative = formatter.format(-1234.5);
+    let browser_shaped_negative = if negative.contains('\u{2212}') {
+        negative
+    } else {
+        format!("−{positive}")
+    };
+
+    assert_eq!(formatter.parse(&browser_shaped_negative), Some(-1234.5));
 }
 
 #[wasm_bindgen_test]

--- a/crates/ars-i18n/tests/unit/number_web_intl.rs
+++ b/crates/ars-i18n/tests/unit/number_web_intl.rs
@@ -5,7 +5,11 @@
 
 use alloc::{collections::BTreeSet, string::String};
 
-use js_sys::Intl::{NumberFormat, NumberFormatOptions, SupportedValuesKey, supported_values_of};
+use js_sys::{
+    Intl::{NumberFormat, NumberFormatOptions, SupportedValuesKey, supported_values_of},
+    Reflect,
+};
+use wasm_bindgen::JsValue;
 use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
 
 use crate::{
@@ -45,6 +49,43 @@ fn unsupported_browser_measure_unit() -> (crate::MeasureUnit, String) {
     }
 
     panic!("expected a CLDR unit that Intl.NumberFormat does not sanction");
+}
+
+struct SupportedValuesOfGuard {
+    original: JsValue,
+}
+
+impl SupportedValuesOfGuard {
+    fn remove() -> Self {
+        let intl = Reflect::get(&js_sys::global(), &JsValue::from_str("Intl"))
+            .expect("global Intl should exist");
+
+        let original = Reflect::get(&intl, &JsValue::from_str("supportedValuesOf"))
+            .expect("reading Intl.supportedValuesOf should succeed");
+
+        Reflect::set(
+            &intl,
+            &JsValue::from_str("supportedValuesOf"),
+            &JsValue::UNDEFINED,
+        )
+        .expect("overriding Intl.supportedValuesOf should succeed");
+
+        Self { original }
+    }
+}
+
+impl Drop for SupportedValuesOfGuard {
+    fn drop(&mut self) {
+        let intl = Reflect::get(&js_sys::global(), &JsValue::from_str("Intl"))
+            .expect("global Intl should exist");
+
+        Reflect::set(
+            &intl,
+            &JsValue::from_str("supportedValuesOf"),
+            &self.original,
+        )
+        .expect("restoring Intl.supportedValuesOf should succeed");
+    }
 }
 
 #[wasm_bindgen_test]
@@ -147,6 +188,30 @@ fn web_intl_unsupported_units_fall_back_to_decimal_formatting() {
         formatter.format(5.0),
         decimal.format(5.0),
         "expected unsupported unit {unit_id:?} to fall back to decimal formatting"
+    );
+}
+
+#[wasm_bindgen_test]
+fn web_intl_units_fall_back_to_decimal_when_supported_values_of_is_unavailable() {
+    let _guard = SupportedValuesOfGuard::remove();
+
+    let unit = crate::MeasureUnit::try_from_str("kilogram").expect("kilogram should parse");
+
+    let decimal = NumberFormatter::new(&locale("en-US"), ArsNumberFormatOptions::default());
+
+    let formatter = NumberFormatter::new(
+        &locale("en-US"),
+        ArsNumberFormatOptions {
+            style: NumberStyle::Unit(unit),
+            unit_display: UnitDisplay::Short,
+            ..ArsNumberFormatOptions::default()
+        },
+    );
+
+    assert_eq!(
+        formatter.format(5.0),
+        decimal.format(5.0),
+        "expected missing Intl.supportedValuesOf to fall back to decimal formatting"
     );
 }
 
@@ -318,13 +383,13 @@ fn web_intl_style_specific_formatters_resolve_expected_browser_options() {
     opts.set_style(js_sys::Intl::NumberFormatStyle::Currency);
     opts.set_currency(CurrencyCode::USD.as_str());
 
-    let locales = js_sys::Array::of1(&wasm_bindgen::JsValue::from_str("en-US"));
+    let locales = js_sys::Array::of1(&JsValue::from_str("en-US"));
 
     let formatter = NumberFormat::new(&locales, opts.as_ref());
 
     let resolved = formatter.resolved_options();
 
-    let currency = js_sys::Reflect::get(resolved.as_ref(), &"currency".into())
+    let currency = Reflect::get(resolved.as_ref(), &"currency".into())
         .ok()
         .and_then(|value| value.as_string());
 

--- a/crates/ars-i18n/tests/unit/number_web_intl.rs
+++ b/crates/ars-i18n/tests/unit/number_web_intl.rs
@@ -3,7 +3,9 @@
 //! Run with:
 //! `wasm-pack test --headless --chrome crates/ars-i18n --no-default-features --features std,web-intl`.
 
-use js_sys::Intl::{NumberFormat, NumberFormatOptions};
+use alloc::{collections::BTreeSet, string::String};
+
+use js_sys::Intl::{NumberFormat, NumberFormatOptions, SupportedValuesKey, supported_values_of};
 use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
 
 use crate::{
@@ -22,6 +24,27 @@ fn style_options(style: NumberStyle) -> ArsNumberFormatOptions {
         style,
         ..ArsNumberFormatOptions::default()
     }
+}
+
+fn unsupported_browser_measure_unit() -> (crate::MeasureUnit, String) {
+    let supported_units = supported_values_of(SupportedValuesKey::Unit)
+        .iter()
+        .filter_map(|value| value.as_string())
+        .collect::<BTreeSet<_>>();
+
+    for (candidate, _) in super::CLDR_IDS_TRIE.iter() {
+        if supported_units.contains(candidate.as_str()) {
+            continue;
+        }
+
+        let Ok(unit) = crate::MeasureUnit::try_from_str(&candidate) else {
+            continue;
+        };
+
+        return (unit, candidate);
+    }
+
+    panic!("expected a CLDR unit that Intl.NumberFormat does not sanction");
 }
 
 #[wasm_bindgen_test]
@@ -106,6 +129,28 @@ fn web_intl_unit_formatting_uses_browser_backend() {
 }
 
 #[wasm_bindgen_test]
+fn web_intl_unsupported_units_fall_back_to_decimal_formatting() {
+    let (unit, unit_id) = unsupported_browser_measure_unit();
+
+    let decimal = NumberFormatter::new(&locale("en-US"), ArsNumberFormatOptions::default());
+
+    let formatter = NumberFormatter::new(
+        &locale("en-US"),
+        ArsNumberFormatOptions {
+            style: NumberStyle::Unit(unit),
+            unit_display: UnitDisplay::Short,
+            ..ArsNumberFormatOptions::default()
+        },
+    );
+
+    assert_eq!(
+        formatter.format(5.0),
+        decimal.format(5.0),
+        "expected unsupported unit {unit_id:?} to fall back to decimal formatting"
+    );
+}
+
+#[wasm_bindgen_test]
 fn web_intl_rounding_modes_cover_remaining_browser_mappings() {
     let cases = [
         (RoundingMode::HalfUp, 1.25, "1.3"),
@@ -141,6 +186,20 @@ fn web_intl_grouping_flag_is_reflected_in_output() {
 
     assert_eq!(formatter.format(1234.56), "1234.56");
     assert_eq!(formatter.grouping_separator(), Some(','));
+}
+
+#[wasm_bindgen_test]
+fn web_intl_normalizes_inverted_fraction_digit_bounds_before_formatting() {
+    let formatter = NumberFormatter::new(
+        &locale("en-US"),
+        ArsNumberFormatOptions {
+            min_fraction_digits: 3,
+            max_fraction_digits: 1,
+            ..ArsNumberFormatOptions::default()
+        },
+    );
+
+    assert_eq!(formatter.format(1.2), "1.200");
 }
 
 #[wasm_bindgen_test]

--- a/crates/ars-i18n/tests/unit/number_web_intl.rs
+++ b/crates/ars-i18n/tests/unit/number_web_intl.rs
@@ -1,0 +1,273 @@
+//! WASM `NumberFormatter` tests for the `web-intl` backend.
+//!
+//! Run with:
+//! `wasm-pack test --headless --chrome crates/ars-i18n --no-default-features --features std,web-intl`.
+
+use js_sys::Intl::{NumberFormat, NumberFormatOptions};
+use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+
+use crate::{
+    CurrencyCode, Locale, NumberFormatOptions as ArsNumberFormatOptions, NumberFormatter,
+    NumberStyle, RoundingMode, SignDisplay, UnitDisplay,
+};
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+fn locale(tag: &str) -> Locale {
+    Locale::parse(tag).expect("test locale should parse")
+}
+
+fn style_options(style: NumberStyle) -> ArsNumberFormatOptions {
+    ArsNumberFormatOptions {
+        style,
+        ..ArsNumberFormatOptions::default()
+    }
+}
+
+#[wasm_bindgen_test]
+fn web_intl_decimal_formats_en_us_with_grouping_and_decimal_separator() {
+    let formatter = NumberFormatter::new(&locale("en-US"), ArsNumberFormatOptions::default());
+
+    assert_eq!(formatter.format(1234.56), "1,234.56");
+    assert_eq!(formatter.decimal_separator(), '.');
+    assert_eq!(formatter.grouping_separator(), Some(','));
+}
+
+#[wasm_bindgen_test]
+fn web_intl_decimal_formats_de_de_with_locale_separators() {
+    let formatter = NumberFormatter::new(&locale("de-DE"), ArsNumberFormatOptions::default());
+
+    assert_eq!(formatter.format(1234.56), "1.234,56");
+    assert_eq!(formatter.decimal_separator(), ',');
+    assert_eq!(formatter.grouping_separator(), Some('.'));
+}
+
+#[wasm_bindgen_test]
+fn web_intl_decimal_formats_arabic_indic_digits() {
+    let formatter = NumberFormatter::new(&locale("ar-EG"), ArsNumberFormatOptions::default());
+
+    let formatted = formatter.format(1234.56);
+
+    assert_eq!(formatted, "١٬٢٣٤٫٥٦");
+    assert_eq!(formatter.decimal_separator(), '٫');
+    assert_eq!(formatter.grouping_separator(), Some('٬'));
+}
+
+#[wasm_bindgen_test]
+fn web_intl_percent_preserves_fractional_input_semantics() {
+    let formatter = NumberFormatter::new(&locale("en-US"), style_options(NumberStyle::Percent));
+
+    assert_eq!(formatter.format(0.47), "47%");
+    assert_eq!(formatter.format_percent(0.47, None), "47%");
+    assert_eq!(formatter.format_percent(0.475, Some(1)), "47.5%");
+    assert_eq!(formatter.parse("47%"), Some(0.47));
+}
+
+#[wasm_bindgen_test]
+fn web_intl_currency_uses_iso_minor_unit_defaults() {
+    let en = NumberFormatter::new(&locale("en-US"), ArsNumberFormatOptions::default());
+
+    let ja = NumberFormatter::new(&locale("ja-JP"), ArsNumberFormatOptions::default());
+
+    assert_eq!(en.format_currency(1234.5, "USD"), "$1,234.50");
+    assert_eq!(ja.format_currency(1234.5, "JPY"), "￥1,234");
+}
+
+#[wasm_bindgen_test]
+fn web_intl_currency_and_decimal_output_round_trip_through_parse() {
+    let de = NumberFormatter::new(&locale("de-DE"), ArsNumberFormatOptions::default());
+
+    let currency = NumberFormatter::new(&locale("en-US"), ArsNumberFormatOptions::default());
+
+    let decimal_text = de.format(1234.56);
+
+    let currency_text = currency.format_currency(1234.5, "USD");
+
+    assert_eq!(de.parse(&decimal_text), Some(1234.56));
+    assert_eq!(currency.parse(&currency_text), Some(1234.5));
+}
+
+#[wasm_bindgen_test]
+fn web_intl_unit_formatting_uses_browser_backend() {
+    let unit = crate::MeasureUnit::try_from_str("kilogram").expect("kilogram should parse");
+
+    let formatter = NumberFormatter::new(
+        &locale("en-US"),
+        ArsNumberFormatOptions {
+            style: NumberStyle::Unit(unit),
+            unit_display: UnitDisplay::Short,
+            ..ArsNumberFormatOptions::default()
+        },
+    );
+
+    let formatted = formatter.format(5.0);
+
+    assert!(formatted.contains("kg"), "expected kg in {formatted:?}");
+}
+
+#[wasm_bindgen_test]
+fn web_intl_rounding_modes_cover_remaining_browser_mappings() {
+    let cases = [
+        (RoundingMode::HalfUp, 1.25, "1.3"),
+        (RoundingMode::HalfDown, 1.25, "1.2"),
+        (RoundingMode::Ceiling, 1.21, "1.3"),
+        (RoundingMode::Floor, 1.29, "1.2"),
+        (RoundingMode::Truncate, 1.29, "1.2"),
+    ];
+
+    for (rounding_mode, value, expected) in cases {
+        let formatter = NumberFormatter::new(
+            &locale("en-US"),
+            ArsNumberFormatOptions {
+                max_fraction_digits: 1,
+                rounding_mode,
+                ..ArsNumberFormatOptions::default()
+            },
+        );
+
+        assert_eq!(formatter.format(value), expected, "case {rounding_mode:?}");
+    }
+}
+
+#[wasm_bindgen_test]
+fn web_intl_grouping_flag_is_reflected_in_output() {
+    let formatter = NumberFormatter::new(
+        &locale("en-US"),
+        ArsNumberFormatOptions {
+            use_grouping: false,
+            ..ArsNumberFormatOptions::default()
+        },
+    );
+
+    assert_eq!(formatter.format(1234.56), "1234.56");
+    assert_eq!(formatter.grouping_separator(), Some(','));
+}
+
+#[wasm_bindgen_test]
+fn web_intl_sign_display_is_reflected_in_output() {
+    let formatter = NumberFormatter::new(
+        &locale("en-US"),
+        ArsNumberFormatOptions {
+            sign_display: SignDisplay::Always,
+            ..ArsNumberFormatOptions::default()
+        },
+    );
+
+    assert_eq!(formatter.format(12.0), "+12");
+}
+
+#[wasm_bindgen_test]
+fn web_intl_other_sign_display_variants_are_preserved() {
+    let never = NumberFormatter::new(
+        &locale("en-US"),
+        ArsNumberFormatOptions {
+            sign_display: SignDisplay::Never,
+            ..ArsNumberFormatOptions::default()
+        },
+    );
+
+    let except_zero = NumberFormatter::new(
+        &locale("en-US"),
+        ArsNumberFormatOptions {
+            sign_display: SignDisplay::ExceptZero,
+            ..ArsNumberFormatOptions::default()
+        },
+    );
+
+    assert_eq!(never.format(-12.0), "12");
+    assert_eq!(except_zero.format(12.0), "+12");
+    assert_eq!(except_zero.format(0.0), "0");
+}
+
+#[wasm_bindgen_test]
+fn web_intl_negative_sign_display_differs_from_auto_for_negative_zero() {
+    let auto = NumberFormatter::new(
+        &locale("en-US"),
+        ArsNumberFormatOptions {
+            sign_display: SignDisplay::Auto,
+            ..ArsNumberFormatOptions::default()
+        },
+    );
+
+    let negative = NumberFormatter::new(
+        &locale("en-US"),
+        ArsNumberFormatOptions {
+            sign_display: SignDisplay::Negative,
+            ..ArsNumberFormatOptions::default()
+        },
+    );
+
+    assert_eq!(auto.format(-0.0), "-0");
+    assert_eq!(negative.format(-0.0), "0");
+}
+
+#[wasm_bindgen_test]
+fn web_intl_rounding_mode_half_even_matches_browser_support() {
+    let formatter = NumberFormatter::new(
+        &locale("en-US"),
+        ArsNumberFormatOptions {
+            max_fraction_digits: 1,
+            rounding_mode: RoundingMode::HalfEven,
+            ..ArsNumberFormatOptions::default()
+        },
+    );
+
+    assert_eq!(formatter.format(1.25), "1.2");
+    assert_eq!(formatter.format(1.35), "1.4");
+}
+
+#[wasm_bindgen_test]
+fn web_intl_unit_display_variants_cover_browser_option_mapping() {
+    let unit = crate::MeasureUnit::try_from_str("kilogram").expect("kilogram should parse");
+
+    let long = NumberFormatter::new(
+        &locale("en-US"),
+        ArsNumberFormatOptions {
+            style: NumberStyle::Unit(unit.clone()),
+            unit_display: UnitDisplay::Long,
+            ..ArsNumberFormatOptions::default()
+        },
+    );
+
+    let narrow = NumberFormatter::new(
+        &locale("en-US"),
+        ArsNumberFormatOptions {
+            style: NumberStyle::Unit(unit),
+            unit_display: UnitDisplay::Narrow,
+            ..ArsNumberFormatOptions::default()
+        },
+    );
+
+    let long_formatted = long.format(5.0);
+
+    let narrow_formatted = narrow.format(5.0);
+
+    assert!(
+        long_formatted.contains("kilogram"),
+        "expected long unit name in {long_formatted:?}"
+    );
+    assert!(
+        narrow_formatted.contains("kg"),
+        "expected narrow unit abbreviation in {narrow_formatted:?}"
+    );
+}
+
+#[wasm_bindgen_test]
+fn web_intl_style_specific_formatters_resolve_expected_browser_options() {
+    let opts = NumberFormatOptions::new();
+
+    opts.set_style(js_sys::Intl::NumberFormatStyle::Currency);
+    opts.set_currency(CurrencyCode::USD.as_str());
+
+    let locales = js_sys::Array::of1(&wasm_bindgen::JsValue::from_str("en-US"));
+
+    let formatter = NumberFormat::new(&locales, opts.as_ref());
+
+    let resolved = formatter.resolved_options();
+
+    let currency = js_sys::Reflect::get(resolved.as_ref(), &"currency".into())
+        .ok()
+        .and_then(|value| value.as_string());
+
+    assert_eq!(currency.as_deref(), Some("USD"));
+}

--- a/crates/ars-i18n/tests/unit/number_web_intl.rs
+++ b/crates/ars-i18n/tests/unit/number_web_intl.rs
@@ -4,6 +4,7 @@
 //! `wasm-pack test --headless --chrome crates/ars-i18n --no-default-features --features std,web-intl`.
 
 use alloc::{collections::BTreeSet, string::String};
+use core::num::NonZeroU8;
 
 use js_sys::{
     Intl::{NumberFormat, NumberFormatOptions, SupportedValuesKey, supported_values_of},
@@ -85,6 +86,24 @@ impl Drop for SupportedValuesOfGuard {
             &self.original,
         )
         .expect("restoring Intl.supportedValuesOf should succeed");
+    }
+}
+
+struct NegativeSignDisplaySupportGuard {
+    original: Option<bool>,
+}
+
+impl NegativeSignDisplaySupportGuard {
+    fn unsupported() -> Self {
+        Self {
+            original: super::web_intl::replace_negative_sign_display_support_override(Some(false)),
+        }
+    }
+}
+
+impl Drop for NegativeSignDisplaySupportGuard {
+    fn drop(&mut self) {
+        super::web_intl::replace_negative_sign_display_support_override(self.original);
     }
 }
 
@@ -268,6 +287,31 @@ fn web_intl_normalizes_inverted_fraction_digit_bounds_before_formatting() {
 }
 
 #[wasm_bindgen_test]
+fn web_intl_clamps_out_of_range_digit_bounds_before_formatting() {
+    let actual = NumberFormatter::new(
+        &locale("en-US"),
+        ArsNumberFormatOptions {
+            min_integer_digits: NonZeroU8::new(42).expect("42 should be non-zero"),
+            min_fraction_digits: 150,
+            max_fraction_digits: 200,
+            ..ArsNumberFormatOptions::default()
+        },
+    );
+
+    let expected = NumberFormatter::new(
+        &locale("en-US"),
+        ArsNumberFormatOptions {
+            min_integer_digits: NonZeroU8::new(21).expect("21 should be non-zero"),
+            min_fraction_digits: 100,
+            max_fraction_digits: 100,
+            ..ArsNumberFormatOptions::default()
+        },
+    );
+
+    assert_eq!(actual.format(1.5), expected.format(1.5));
+}
+
+#[wasm_bindgen_test]
 fn web_intl_sign_display_is_reflected_in_output() {
     let formatter = NumberFormatter::new(
         &locale("en-US"),
@@ -323,6 +367,21 @@ fn web_intl_negative_sign_display_differs_from_auto_for_negative_zero() {
 
     assert_eq!(auto.format(-0.0), "-0");
     assert_eq!(negative.format(-0.0), "0");
+}
+
+#[wasm_bindgen_test]
+fn web_intl_negative_sign_display_falls_back_when_browser_rejects_it() {
+    let _guard = NegativeSignDisplaySupportGuard::unsupported();
+
+    let formatter = NumberFormatter::new(
+        &locale("en-US"),
+        ArsNumberFormatOptions {
+            sign_display: SignDisplay::Negative,
+            ..ArsNumberFormatOptions::default()
+        },
+    );
+
+    assert_eq!(formatter.format(-0.0), "-0");
 }
 
 #[wasm_bindgen_test]

--- a/crates/ars-leptos/src/lib.rs
+++ b/crates/ars-leptos/src/lib.rs
@@ -28,7 +28,7 @@ pub use id::reset_id_counter;
 pub use id::use_id;
 pub use provider::{
     ArsContext, provide_ars_context, resolve_locale, t, use_icu_provider, use_locale, use_messages,
-    warn_missing_provider,
+    use_number_formatter, warn_missing_provider,
 };
 pub use use_machine::{UseMachineReturn, use_machine, use_machine_with_reactive_props};
 

--- a/crates/ars-leptos/src/prelude.rs
+++ b/crates/ars-leptos/src/prelude.rs
@@ -49,7 +49,7 @@
 pub use ars_i18n::{Direction, Locale, Orientation, ResolvedDirection, Translate};
 
 // -- User-facing helpers --
-pub use crate::t;
+pub use crate::{t, use_number_formatter};
 
 // -- Component modules --
 // (none yet — added as components are implemented, e.g.:

--- a/crates/ars-leptos/src/provider.rs
+++ b/crates/ars-leptos/src/provider.rs
@@ -10,34 +10,49 @@ use ars_core::{
     ColorMode, I18nRegistries, PlatformEffects, StyleStrategy,
     resolve_messages as core_resolve_messages,
 };
-use ars_i18n::{Direction, IcuProvider, Locale, StubIcuProvider, Translate, locales};
-use leptos::prelude::*;
+use ars_i18n::{
+    Direction, IcuProvider, Locale, NumberFormatOptions, NumberFormatter, StubIcuProvider,
+    Translate, locales,
+};
+use leptos::{prelude::*, reactive::owner::LocalStorage};
 
 /// Reactive environment context published by the Leptos `ArsProvider`.
 #[derive(Clone)]
 pub struct ArsContext {
     /// Active locale for this subtree.
     pub locale: Signal<Locale>,
+
     /// Resolved reading direction for this subtree.
     pub direction: Memo<Direction>,
+
     /// Active color mode for descendants.
     pub color_mode: Signal<ColorMode>,
+
     /// Whether interactive descendants should render as disabled.
     pub disabled: Signal<bool>,
+
     /// Whether descendant form fields should render as read-only.
     pub read_only: Signal<bool>,
+
     /// Optional generated-ID prefix.
     pub id_prefix: Signal<Option<String>>,
+
     /// Optional portal container element ID.
     pub portal_container_id: Signal<Option<String>>,
+
     /// Optional focus/portal root node ID.
     pub root_node_id: Signal<Option<String>>,
+
     /// Platform side-effect capabilities.
     pub platform: Arc<dyn PlatformEffects>,
+
     /// ICU-backed locale data provider.
     pub icu_provider: Arc<dyn IcuProvider>,
+
     /// Application-owned message registries.
     pub i18n_registries: Arc<I18nRegistries>,
+
+    /// CSS style injection strategy for all descendant ars components.
     style_strategy: StyleStrategy,
 }
 
@@ -81,24 +96,15 @@ impl ArsContext {
         i18n_registries: Arc<I18nRegistries>,
         style_strategy: StyleStrategy,
     ) -> Self {
-        let locale = Signal::stored(locale);
-        let color_mode = Signal::stored(color_mode);
-        let disabled = Signal::stored(disabled);
-        let read_only = Signal::stored(read_only);
-        let id_prefix = Signal::stored(id_prefix);
-        let portal_container_id = Signal::stored(portal_container_id);
-        let root_node_id = Signal::stored(root_node_id);
-        let direction = Memo::new(move |_| direction);
-
         Self {
-            locale,
-            direction,
-            color_mode,
-            disabled,
-            read_only,
-            id_prefix,
-            portal_container_id,
-            root_node_id,
+            locale: Signal::stored(locale),
+            direction: Memo::new(move |_| direction),
+            color_mode: Signal::stored(color_mode),
+            disabled: Signal::stored(disabled),
+            read_only: Signal::stored(read_only),
+            id_prefix: Signal::stored(id_prefix),
+            portal_container_id: Signal::stored(portal_container_id),
+            root_node_id: Signal::stored(root_node_id),
             platform,
             icu_provider,
             i18n_registries,
@@ -140,6 +146,7 @@ pub fn use_locale() -> Signal<Locale> {
     current_ars_context().map_or_else(
         || {
             warn_missing_provider("use_locale");
+
             Signal::stored(locales::en_us())
         },
         |ctx| ctx.locale,
@@ -152,10 +159,69 @@ pub fn use_icu_provider() -> Arc<dyn IcuProvider> {
     current_ars_context().map_or_else(
         || -> Arc<dyn IcuProvider> {
             warn_missing_provider("use_icu_provider");
+
             Arc::new(StubIcuProvider)
         },
         |ctx| -> Arc<dyn IcuProvider> { Arc::clone(&ctx.icu_provider) },
     )
+}
+
+/// Resolves a provider-derived number formatter from the current provider locale.
+///
+/// Leptos 0.8 only exposes public `Memo` constructors for `Send + Sync` values.
+/// `NumberFormatter` is intentionally not guaranteed to be thread-safe on every
+/// backend, so the adapter uses a local derived signal plus component-local
+/// cache to preserve provider-derived reuse semantics without inventing
+/// unsupported thread-safe guarantees.
+#[must_use]
+pub fn use_number_formatter<F>(options: F) -> Signal<NumberFormatter, LocalStorage>
+where
+    F: Fn() -> NumberFormatOptions + 'static,
+{
+    use_resolved_number_formatter(None, options)
+}
+
+/// Resolves a provider-derived number formatter from an explicit locale or provider context.
+#[must_use]
+pub(crate) fn use_resolved_number_formatter<F>(
+    adapter_props_locale: Option<&Locale>,
+    options: F,
+) -> Signal<NumberFormatter, LocalStorage>
+where
+    F: Fn() -> NumberFormatOptions + 'static,
+{
+    let explicit_locale = adapter_props_locale.cloned();
+    let locale = use_locale();
+    let cache =
+        StoredValue::<Option<(Locale, NumberFormatOptions, NumberFormatter)>, LocalStorage>::new_local(
+            None,
+        );
+
+    Signal::derive_local(move || {
+        let resolved_locale = explicit_locale.clone().unwrap_or_else(|| locale.get());
+
+        let resolved_options = options();
+
+        let mut resolved_formatter = None;
+
+        cache.update_value(|cached| {
+            if let Some((cached_locale, cached_options, cached_formatter)) = cached {
+                if *cached_locale == resolved_locale && *cached_options == resolved_options {
+                    resolved_formatter = Some(cached_formatter.clone());
+
+                    return;
+                }
+            }
+
+            let next_formatter = NumberFormatter::new(&resolved_locale, resolved_options.clone());
+
+            *cached = Some((resolved_locale, resolved_options, next_formatter.clone()));
+
+            resolved_formatter = Some(next_formatter);
+        });
+
+        resolved_formatter.expect("formatter cache should always produce a formatter")
+    })
 }
 
 /// Resolves the effective locale for an adapter component instance.
@@ -173,16 +239,20 @@ pub fn use_messages<M: ars_core::ComponentMessages + Send + Sync + 'static>(
     adapter_props_locale: Option<&Locale>,
 ) -> M {
     let locale = resolve_locale(adapter_props_locale);
+
     let registries = current_ars_context().map_or_else(
         || Arc::new(I18nRegistries::new()),
         |ctx| Arc::clone(&ctx.i18n_registries),
     );
+
     core_resolve_messages(adapter_props_messages, registries.as_ref(), &locale)
 }
 
 fn translated_text<T: Translate + Send + Sync + 'static>(msg: T) -> impl Fn() -> String {
     let locale = use_locale();
+
     let icu = use_icu_provider();
+
     move || msg.translate(&locale.get(), &*icu)
 }
 
@@ -198,12 +268,14 @@ mod tests {
     use std::sync::Arc;
 
     use ars_core::{ColorMode, I18nRegistries, NullPlatformEffects, StyleStrategy};
-    use ars_i18n::{Direction, IcuProvider, Locale, StubIcuProvider, Translate, locales};
+    use ars_i18n::{
+        Direction, IcuProvider, Locale, NumberFormatOptions, StubIcuProvider, Translate, locales,
+    };
     use leptos::prelude::{Get, GetUntracked, Memo, Owner, RwSignal, Set, Signal};
 
     use super::{
         ArsContext, current_ars_context, resolve_locale, t, translated_text, use_icu_provider,
-        use_locale, use_messages,
+        use_locale, use_messages, use_number_formatter, use_resolved_number_formatter,
     };
 
     #[derive(Clone, Debug, PartialEq)]
@@ -236,6 +308,7 @@ mod tests {
     }
 
     struct TestIcuProvider;
+
     impl IcuProvider for TestIcuProvider {}
 
     fn reactive_test_context(
@@ -243,6 +316,7 @@ mod tests {
         icu_provider: Arc<dyn IcuProvider>,
     ) -> (ArsContext, RwSignal<Locale>) {
         let locale_signal = RwSignal::new(locale);
+
         let context = ArsContext {
             locale: locale_signal.into(),
             direction: Memo::new(move |_| direction_from_locale(&locale_signal.get())),
@@ -274,12 +348,14 @@ mod tests {
         icu_provider: Arc<dyn IcuProvider>,
     ) -> ArsContext {
         let (context, _) = reactive_test_context(locale, icu_provider);
+
         context
     }
 
     #[test]
     fn use_locale_falls_back_to_en_us_without_provider() {
         let owner = Owner::new();
+
         owner.with(|| {
             assert_eq!(use_locale().get_untracked().to_bcp47(), "en-US");
         });
@@ -288,6 +364,7 @@ mod tests {
     #[test]
     fn resolve_locale_prefers_explicit_override() {
         let owner = Owner::new();
+
         owner.with(|| {
             crate::provide_ars_context(test_context_with_defaults(
                 Locale::parse("fr-FR").expect("locale should parse"),
@@ -295,6 +372,7 @@ mod tests {
             ));
 
             let override_locale = Locale::parse("pt-BR").expect("locale should parse");
+
             assert_eq!(resolve_locale(Some(&override_locale)).to_bcp47(), "pt-BR");
             assert_eq!(resolve_locale(None).to_bcp47(), "fr-FR");
         });
@@ -303,6 +381,7 @@ mod tests {
     #[test]
     fn current_ars_context_round_trips_through_leptos_context() {
         let owner = Owner::new();
+
         owner.with(|| {
             assert!(current_ars_context().is_none());
 
@@ -312,6 +391,7 @@ mod tests {
             ));
 
             let current = current_ars_context().expect("provider context should exist");
+
             assert_eq!(current.locale.get_untracked().to_bcp47(), "fr-FR");
         });
     }
@@ -319,8 +399,10 @@ mod tests {
     #[test]
     fn use_icu_provider_reads_context_value() {
         let owner = Owner::new();
+
         owner.with(|| {
             let expected: Arc<dyn IcuProvider> = Arc::new(TestIcuProvider);
+
             crate::provide_ars_context(test_context_with_defaults(
                 locales::en_us(),
                 Arc::clone(&expected),
@@ -333,8 +415,10 @@ mod tests {
     #[test]
     fn use_icu_provider_falls_back_without_provider() {
         let owner = Owner::new();
+
         owner.with(|| {
             let provider = use_icu_provider();
+
             assert_eq!(
                 AppText::Greeting.translate(&locales::en_us(), &*provider),
                 "Hello"
@@ -345,8 +429,10 @@ mod tests {
     #[test]
     fn use_messages_uses_provider_registry_bundle() {
         let owner = Owner::new();
+
         owner.with(|| {
             let mut registries = I18nRegistries::new();
+
             registries.register(
                 ars_core::MessagesRegistry::new(TestMessages::default()).register(
                     "es",
@@ -355,6 +441,7 @@ mod tests {
                     },
                 ),
             );
+
             crate::provide_ars_context(ArsContext::new(
                 Locale::parse("es-MX").expect("locale should parse"),
                 Direction::Ltr,
@@ -371,7 +458,9 @@ mod tests {
             ));
 
             let resolved = use_messages::<TestMessages>(None, None);
+
             let locale = Locale::parse("es-MX").expect("locale should parse");
+
             assert_eq!((resolved.label)(&locale), "Etiqueta");
         });
     }
@@ -379,9 +468,12 @@ mod tests {
     #[test]
     fn use_messages_falls_back_without_provider() {
         let owner = Owner::new();
+
         owner.with(|| {
             let locale = Locale::parse("pt-BR").expect("locale should parse");
+
             let resolved = use_messages::<TestMessages>(None, Some(&locale));
+
             assert_eq!((resolved.label)(&locale), "Default");
         });
     }
@@ -389,28 +481,104 @@ mod tests {
     #[test]
     fn translated_text_reacts_to_locale_changes() {
         let owner = Owner::new();
+
         owner.with(|| {
             let (context, locale_signal) =
                 reactive_test_context(locales::en_us(), Arc::new(StubIcuProvider));
+
             crate::provide_ars_context(context);
+
             let text = translated_text(AppText::Greeting);
 
             assert_eq!(text(), "Hello");
+
             locale_signal.set(Locale::parse("es-ES").expect("locale should parse"));
+
             assert_eq!(text(), "Hola");
+        });
+    }
+
+    #[test]
+    fn use_number_formatter_falls_back_without_provider() {
+        let owner = Owner::new();
+
+        owner.with(|| {
+            let formatter = use_number_formatter(NumberFormatOptions::default);
+
+            assert_eq!(formatter.get().format(1234.56), "1,234.56");
+        });
+    }
+
+    #[test]
+    fn use_number_formatter_reads_context_locale() {
+        let owner = Owner::new();
+
+        owner.with(|| {
+            crate::provide_ars_context(test_context_with_defaults(
+                locales::de_de(),
+                Arc::new(StubIcuProvider),
+            ));
+
+            let formatter = use_number_formatter(NumberFormatOptions::default);
+
+            assert_eq!(formatter.get().format(1234.56), "1.234,56");
+        });
+    }
+
+    #[test]
+    fn use_number_formatter_recomputes_when_locale_changes() {
+        let owner = Owner::new();
+
+        owner.with(|| {
+            let (context, locale_signal) =
+                reactive_test_context(locales::en_us(), Arc::new(StubIcuProvider));
+
+            crate::provide_ars_context(context);
+
+            let formatter = use_number_formatter(NumberFormatOptions::default);
+
+            assert_eq!(formatter.get().format(1234.56), "1,234.56");
+
+            locale_signal.set(locales::de_de());
+
+            assert_eq!(formatter.get().format(1234.56), "1.234,56");
+        });
+    }
+
+    #[test]
+    fn use_resolved_number_formatter_prefers_explicit_locale_override() {
+        let owner = Owner::new();
+
+        owner.with(|| {
+            crate::provide_ars_context(test_context_with_defaults(
+                locales::fr(),
+                Arc::new(StubIcuProvider),
+            ));
+
+            let explicit = locales::de_de();
+
+            let formatter =
+                use_resolved_number_formatter(Some(&explicit), NumberFormatOptions::default);
+
+            assert_eq!(formatter.get().format(1234.56), "1.234,56");
         });
     }
 
     #[test]
     fn prelude_t_reexport_compiles() {
         let owner = Owner::new();
+
         owner.with(|| {
             crate::provide_ars_context(test_context_with_defaults(
                 locales::en_us(),
                 Arc::new(StubIcuProvider),
             ));
+
             drop(t(AppText::Greeting));
-            drop(t(AppText::Greeting));
+
+            use crate::prelude::use_number_formatter as prelude_use_number_formatter;
+
+            let _ = prelude_use_number_formatter(NumberFormatOptions::default);
         });
     }
 }
@@ -420,13 +588,15 @@ mod wasm_tests {
     use std::sync::Arc;
 
     use ars_core::{ColorMode, I18nRegistries, NullPlatformEffects, StyleStrategy};
-    use ars_i18n::{Direction, IcuProvider, Locale, StubIcuProvider, Translate, locales};
+    use ars_i18n::{
+        Direction, IcuProvider, Locale, NumberFormatOptions, StubIcuProvider, Translate, locales,
+    };
     use leptos::prelude::{Get, GetUntracked, Memo, Owner, RwSignal, Set, Signal};
     use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
 
     use super::{
         ArsContext, current_ars_context, resolve_locale, t, translated_text, use_icu_provider,
-        use_locale,
+        use_locale, use_number_formatter,
     };
 
     wasm_bindgen_test_configure!(run_in_browser);
@@ -446,6 +616,7 @@ mod wasm_tests {
     }
 
     struct TestIcuProvider;
+
     impl IcuProvider for TestIcuProvider {}
 
     fn direction_from_locale(locale: &Locale) -> Direction {
@@ -461,6 +632,7 @@ mod wasm_tests {
         icu_provider: Arc<dyn IcuProvider>,
     ) -> (ArsContext, RwSignal<Locale>) {
         let locale_signal = RwSignal::new(locale);
+
         let context = ArsContext {
             locale: locale_signal.into(),
             direction: Memo::new(move |_| direction_from_locale(&locale_signal.get())),
@@ -482,15 +654,19 @@ mod wasm_tests {
     #[wasm_bindgen_test]
     fn translated_text_reacts_to_locale_changes_on_wasm() {
         let owner = Owner::new();
+
         owner.with(|| {
             let (context, locale_signal) =
                 reactive_test_context(locales::en_us(), Arc::new(StubIcuProvider));
+
             crate::provide_ars_context(context);
 
             let text = translated_text(AppText::Greeting);
+
             assert_eq!(text(), "Hello");
 
             locale_signal.set(Locale::parse("es-ES").expect("locale should parse"));
+
             assert_eq!(text(), "Hola");
 
             drop(t(AppText::Greeting));
@@ -500,13 +676,16 @@ mod wasm_tests {
     #[wasm_bindgen_test]
     fn current_ars_context_round_trips_on_wasm() {
         let owner = Owner::new();
+
         owner.with(|| {
             assert!(current_ars_context().is_none());
 
             let (context, _) = reactive_test_context(locales::en_us(), Arc::new(StubIcuProvider));
+
             crate::provide_ars_context(context);
 
             let current = current_ars_context().expect("provider context should exist");
+
             assert_eq!(current.locale.get_untracked().to_bcp47(), "en-US");
         });
     }
@@ -514,10 +693,13 @@ mod wasm_tests {
     #[wasm_bindgen_test]
     fn locale_and_icu_provider_are_readable_on_wasm() {
         let owner = Owner::new();
+
         owner.with(|| {
             let expected_provider: Arc<dyn IcuProvider> = Arc::new(TestIcuProvider);
+
             let (context, _) =
                 reactive_test_context(locales::en_us(), Arc::clone(&expected_provider));
+
             crate::provide_ars_context(context);
 
             assert_eq!(use_locale().get_untracked().to_bcp47(), "en-US");
@@ -528,6 +710,7 @@ mod wasm_tests {
     #[wasm_bindgen_test]
     fn use_locale_falls_back_without_provider_on_wasm() {
         let owner = Owner::new();
+
         owner.with(|| {
             assert_eq!(use_locale().get_untracked().to_bcp47(), "en-US");
         });
@@ -536,8 +719,10 @@ mod wasm_tests {
     #[wasm_bindgen_test]
     fn use_icu_provider_falls_back_without_provider_on_wasm() {
         let owner = Owner::new();
+
         owner.with(|| {
             let provider = use_icu_provider();
+
             assert_eq!(
                 AppText::Greeting.translate(&locales::en_us(), &*provider),
                 "Hello"
@@ -548,13 +733,47 @@ mod wasm_tests {
     #[wasm_bindgen_test]
     fn resolve_locale_prefers_override_on_wasm() {
         let owner = Owner::new();
+
         owner.with(|| {
             let (context, _) = reactive_test_context(locales::en_us(), Arc::new(StubIcuProvider));
+
             crate::provide_ars_context(context);
 
             let override_locale = Locale::parse("pt-BR").expect("locale should parse");
+
             assert_eq!(resolve_locale(Some(&override_locale)).to_bcp47(), "pt-BR");
             assert_eq!(resolve_locale(None).to_bcp47(), "en-US");
+        });
+    }
+
+    #[wasm_bindgen_test]
+    fn use_number_formatter_falls_back_without_provider_on_wasm() {
+        let owner = Owner::new();
+
+        owner.with(|| {
+            let formatter = use_number_formatter(NumberFormatOptions::default);
+
+            assert_eq!(formatter.get().format(1234.56), "1,234.56");
+        });
+    }
+
+    #[wasm_bindgen_test]
+    fn use_number_formatter_reacts_to_locale_changes_on_wasm() {
+        let owner = Owner::new();
+
+        owner.with(|| {
+            let (context, locale_signal) =
+                reactive_test_context(locales::en_us(), Arc::new(StubIcuProvider));
+
+            crate::provide_ars_context(context);
+
+            let formatter = use_number_formatter(NumberFormatOptions::default);
+
+            assert_eq!(formatter.get().format(1234.56), "1,234.56");
+
+            locale_signal.set(locales::de_de());
+
+            assert_eq!(formatter.get().format(1234.56), "1.234,56");
         });
     }
 }

--- a/spec/components/data-display/badge.md
+++ b/spec/components/data-display/badge.md
@@ -199,18 +199,21 @@ exist).
 ```rust
 /// Formats a count value as a string with a maximum of 99.
 pub fn format_count(value: u64, locale: &Locale) -> String {
+    let formatter = NumberFormatter::new(locale, NumberFormatOptions::default());
     if value > 99 {
-        format!("{}+", NumberFormatter::new(locale, None).format(99.0))
+        format!("{}+", formatter.format(99.0))
     } else {
-        NumberFormatter::new(locale, None).format(value as f64)
+        formatter.format(value as f64)
     }
 }
 ```
 
 ## 4. Internationalization
 
-- Numeric values in badges (e.g. notification counts) are formatted with `NumberFormatter`
-  from `ars-i18n`.
+- Numeric values in badges (e.g. notification counts) are formatted with
+  `NumberFormatter` from `ars-i18n`. When locale is inherited from
+  `ArsProvider`, adapters should derive the formatter through
+  `use_number_formatter(...)`.
 - Textual labels like "New" or "Beta" must come from a localized message catalog; do not
   hard-code English strings.
 - Overflow display ("99+") is locale-aware: the `+` suffix may need to move to prefix in

--- a/spec/components/data-display/progress.md
+++ b/spec/components/data-display/progress.md
@@ -286,7 +286,10 @@ impl<'a> Api<'a> {
         if self.is_complete() {
             return (self.ctx.messages.complete)(&self.ctx.locale);
         }
-        let fmt = NumberFormatter::new(&self.ctx.locale, self.props.format_options.as_ref());
+        let fmt = NumberFormatter::new(
+            &self.ctx.locale,
+            self.props.format_options.clone().unwrap_or_default(),
+        );
         format!("{}% complete", fmt.format_percent(self.ctx.percent / 100.0))
     }
 
@@ -478,7 +481,9 @@ Progress
 ## 4. Internationalization
 
 - `aria-valuetext` uses `NumberFormatter::format_percent()` from `ars-i18n` for locale-aware
-  percentage formatting (e.g. "47 %" in French, "47%" in English).
+  percentage formatting (e.g. "47 %" in French, "47%" in English). When locale
+  is inherited from `ArsProvider`, adapters should derive the formatter through
+  `use_number_formatter(...)`.
 - "Loading…" and "Complete" strings come from `Messages` and should be supplied
   by the host application from a message catalog.
 

--- a/spec/components/data-display/stat.md
+++ b/spec/components/data-display/stat.md
@@ -296,6 +296,9 @@ a `trend` or `change` value is provided. It uses `Trend` enum to indicate direct
   before being passed as the `value` prop; Stat does not format internally.
 - `Change` delta uses `NumberFormatter::format_percent()` for locale-aware percentage
   rendering (e.g. "12,5 %" in French).
+- When Stat formatting is derived from ambient `ArsProvider` locale inside an
+  adapter, adapters should use `use_number_formatter(...)` rather than a
+  thread-local formatter cache.
 - `Messages` keys ("increase", "decrease", "no change"; directional prefixes) are
   localizable strings that the host application supplies from a message catalog.
 - **RTL**: `Root` receives `dir="rtl"` from the adapter when the active locale is

--- a/spec/components/input/number-input.md
+++ b/spec/components/input/number-input.md
@@ -691,7 +691,9 @@ announcements.
   and parsing uses this resolved locale.
 - **Decimal separator**: Uses locale-appropriate separator (`,` vs `.`).
 - **Thousands separator**: Applied when formatting the displayed value.
-- **`aria-valuetext`**: Formatted using `NumberFormatter` from `ars-i18n` with the resolved locale.
+- **`aria-valuetext`**: Adapters derive a memoized formatter from `ArsProvider`
+  via `use_number_formatter(|| NumberFormatOptions::default())` and use it for
+  locale-aware value text.
 - **RTL**: Increment/decrement button positions swap visually (CSS `direction` handles this).
 - **Input parsing**: Must accept both locale-specific input (e.g., `1.234,56` in `de-DE`) and
   canonical format (e.g., `1234.56`). On blur, the value is normalized to the canonical `f64`
@@ -715,6 +717,9 @@ announcements.
 **Non-Uniform Digit Grouping**: Number formatting and parsing delegate to ICU4X
 `NumberFormatter`, which handles locale-specific grouping (including non-uniform patterns
 like Indian numbering: `12,34,567`). The component must not hardcode grouping assumptions.
+When locale is inherited from `ArsProvider`, adapters should resolve this
+through `use_number_formatter(...)` rather than constructing ad hoc ambient
+formatters from a thread-local cache.
 
 **Negative Number Sign Placement**: Negative number display follows locale conventions via
 ICU4X — leading minus, trailing minus, or accounting parentheses. Adapters must not hardcode minus sign position.

--- a/spec/components/utility/ars-provider.md
+++ b/spec/components/utility/ars-provider.md
@@ -163,6 +163,7 @@ let ctx = try_use_context::<ArsContext>();
 Convenience hooks read from `ArsContext` with fallback defaults:
 
 - `use_locale()` — locale, falls back to `en-US`
+- `use_number_formatter()` — locale-aware number formatting derived from the active `ArsProvider` locale
 - `use_platform_effects()` — platform capabilities
 - `use_modality_context()` — provider-scoped input-modality state
 - `use_icu_provider()` — calendar/locale data
@@ -200,6 +201,7 @@ ArsProvider
 | All effect closures      | `platform` — via `use_platform_effects()` for focus, timers, scroll-lock, positioning, DOM queries |
 | Focus / Hover / Press    | `modality` — via `use_modality_context()` for shared modality and global press state               |
 | Date-time components     | `icu_provider` — via `use_icu_provider()` for calendar data (weekday names, month names, etc.)     |
+| Numeric components       | `locale` — via `use_number_formatter()` for provider-derived number formatting                      |
 | All stateful components  | `i18n_registries` — via `resolve_messages::<M>()` for per-component translation lookups            |
 | All rendered components  | `style_strategy` — via `use_style_strategy()` for CSS injection method                             |
 

--- a/spec/foundation/04-internationalization.md
+++ b/spec/foundation/04-internationalization.md
@@ -27,14 +27,13 @@ the lightweight ICU locale/provider crates in all builds, including WASM clients
 The `icu4x` vs `web-intl` split applies to formatter backends and compiled CLDR
 data, not to the core `Locale` wrapper itself.
 
-```rust
-#[cfg(feature = "icu4x")]
-pub type DefaultNumberFormatter = icu4x::Icu4xNumberFormatter;
-#[cfg(feature = "web-intl")]
-pub type DefaultNumberFormatter = web_intl::JsIntlNumberFormatter;
-```
-
-Both backends expose the same concrete formatter surface. Components are backend-agnostic.
+Number formatting does **not** expose a public backend alias. The public type is
+always `NumberFormatter`; `icu4x` and `web-intl` only change the internal
+backend selected by `NumberFormatter::new()`. Components are backend-agnostic.
+Ambient formatter reuse is adapter-scoped: adapters derive memoized formatters
+from `ArsProvider` context through `use_number_formatter(...)`, while
+`NumberFormatter::new()` remains the explicit low-level constructor for
+host-application and non-adapter code.
 
 #### 1.1.1 Number Formatter Context Propagation
 
@@ -1129,12 +1128,13 @@ impl NumberFormatter {
     /// **Implementation backends:**
     /// - `icu4x`: ICU4X 2.x does not yet provide a range formatter. Uses a
     ///   language-match heuristic for locale-specific range separators.
-    /// - `web-intl`: Use `Intl.NumberFormat.prototype.formatRange(start, end)` via
-    ///   `js_sys` / `wasm_bindgen`.
+    /// - `web-intl`: ars-i18n keeps the same language-match heuristic for the
+    ///   public `NumberFormatter` API. `Intl.NumberFormat.prototype.formatRange`
+    ///   is not currently surfaced as a separate delivered backend behavior.
     ///
     /// **Implementation**: Uses a language-match heuristic for locale-correct
-    /// range separators. ICU4X 2.x does not provide a `NumberRangeFormatter`;
-    /// the heuristic below is the specified approach.
+    /// range separators under both backends. ICU4X 2.x does not provide a
+    /// `NumberRangeFormatter`; the heuristic below is the specified approach.
     pub fn format_range(&self, start: f64, end: f64, locale: &Locale) -> String {
         // Language-match heuristic for the most common CLDR range patterns.
         // Does not handle all CLDR range patterns (e.g., Arabic spacing,
@@ -3336,32 +3336,19 @@ types from the crate.
 ### 9.3 Lazy-Loaded Formatters
 
 ```rust
-/// Cache formatters keyed by locale + options to avoid re-creation.
+/// Ambient formatter reuse is handled by adapter hooks rather than a public
+/// global cache API.
 ///
-/// Note: ICU4X formatter handles used inside `NumberFormatter` are not
-/// `Send`, so ars-i18n uses a `std` thread-local cache rather than a process-
-/// wide `Mutex`-guarded static. On `no_std` targets (bare `alloc`),
-/// formatters must be constructed per-call or cached by the application.
-#[cfg(feature = "std")]
-thread_local! {
-    static NUMBER_FORMATTER_CACHE:
-        std::cell::RefCell<alloc::collections::BTreeMap<String, NumberFormatter>> =
-            std::cell::RefCell::new(alloc::collections::BTreeMap::new());
-}
-
-#[cfg(feature = "std")]
-pub fn get_number_formatter(locale: &Locale, options: &NumberFormatOptions) -> NumberFormatter {
-    let key = format!("{:?}-{:?}", locale.to_bcp47(), options);
-    NUMBER_FORMATTER_CACHE.with(|cache| {
-        let mut cache = cache.borrow_mut();
-        if let Some(existing) = cache.get(&key) {
-            return existing.clone();
-        }
-        let formatter = NumberFormatter::new(locale, options.clone());
-        cache.insert(key, formatter.clone());
-        formatter
-    })
-}
+/// `ars-i18n` keeps `NumberFormatter::new()` as the explicit constructor for
+/// any code that already has a resolved `Locale`. Adapters derive memoized
+/// formatters from `ArsProvider` context through `use_number_formatter(...)`
+/// so formatter lifetime follows component/provider scope instead of a
+/// thread-local cache.
+///
+/// `NumberFormatter` may internally use `Arc` to share backend state between
+/// clones, but that ownership cleanup does not by itself guarantee that every
+/// backend is `Send + Sync` on every target. In particular, the `web-intl`
+/// backend still wraps browser `Intl` objects.
 ```
 
 ### 9.4 Browser Intl API Feature Flag (`web-intl`)
@@ -3375,13 +3362,13 @@ on browser `Intl`.
 #### 9.4.1 Feature-flagged type aliases
 
 ```rust
-// ars-i18n/src/lib.rs — zero-cost dispatch via cfg type aliases
+// ars-i18n/src/lib.rs — zero-cost dispatch via cfg type aliases where the
+// public surface is genuinely backend-specific.
 
 // ── Number formatting ──
-#[cfg(feature = "icu4x")]
-pub type DefaultNumberFormatter = icu4x::Icu4xNumberFormatter;
-#[cfg(feature = "web-intl")]
-pub type DefaultNumberFormatter = web_intl::JsIntlNumberFormatter;
+// Number formatting keeps a single public `NumberFormatter` type.
+// Backend selection is internal to `NumberFormatter::new()`, so there is no
+// public `DefaultNumberFormatter` alias and no public backend wrapper type.
 
 // ── Date formatting ──
 #[cfg(feature = "icu4x")]
@@ -3435,40 +3422,46 @@ abstract over.
 #### 9.4.3 `web-intl` backend sketch
 
 ```rust
-#[cfg(feature = "web-intl")]
-pub struct JsIntlNumberFormatter {
+#[cfg(all(feature = "web-intl", target_arch = "wasm32"))]
+pub(crate) struct WebIntlNumberFormatter {
     inner: js_sys::Intl::NumberFormat,
 }
 
-#[cfg(feature = "web-intl")]
-impl JsIntlNumberFormatter {
-    pub fn new(locale: &str, options: &NumberFormatOptions) -> Self {
-        use js_sys::{Array, Object, Reflect, Intl};
+#[cfg(all(feature = "web-intl", target_arch = "wasm32"))]
+impl WebIntlNumberFormatter {
+    pub(crate) fn new(locale: &Locale, options: &NumberFormatOptions) -> Self {
+        use js_sys::{Array, Intl};
         use wasm_bindgen::JsValue;
 
-        let locales = Array::of1(&JsValue::from_str(locale));
-        let js_opts = Object::new();
-
-        // Map our options to Intl.NumberFormat options.
-        Reflect::set(&js_opts, &"minimumFractionDigits".into(),
-            &JsValue::from_f64(options.min_fraction_digits as f64)).expect("Reflect::set on JS object");
-        Reflect::set(&js_opts, &"maximumFractionDigits".into(),
-            &JsValue::from_f64(options.max_fraction_digits as f64)).expect("Reflect::set on JS object");
-        Reflect::set(&js_opts, &"useGrouping".into(),
-            &JsValue::from_bool(options.use_grouping)).expect("Reflect::set on JS object");
-
+        let locales = Array::of1(&JsValue::from_str(&locale.to_bcp47()));
+        let js_opts = build_number_format_options(options);
         let inner = Intl::NumberFormat::new(&locales, &js_opts);
         Self { inner }
     }
-}
 
-#[cfg(feature = "web-intl")]
-impl NumberFormat for JsIntlNumberFormatter {
-    fn format(&self, value: f64) -> String {
-        self.inner.format(value).as_string().unwrap_or_default()
+    pub(crate) fn format(&self, value: f64) -> String {
+        // `Intl.NumberFormat` applies locale rounding, grouping, percent, and
+        // currency semantics directly in the browser.
+        //
+        // Percent formatting receives the original fractional value here, so
+        // `0.47` formats as `47%` rather than being pre-scaled to `4700%`.
+        todo!()
+    }
+
+    pub(crate) fn decimal_and_group_separators(locale: &Locale) -> (char, char) {
+        // Probe `formatToParts(12345.6)` and read the `decimal` / `group` parts
+        // instead of using static fallback tables on wasm32.
+        todo!()
     }
 }
+```
 
+`NumberFormatter::new()` normalizes the public options first, then selects either
+the ICU4X formatter family, the internal browser helper above, or the native
+fallback path. No public `JsIntlNumberFormatter` / `DefaultNumberFormatter`
+surface is exposed for numbers.
+
+```rust
 // ── web-intl collation ──
 // StringCollator's web-intl backend is defined inline in §8 alongside the
 // ICU4X backend. Both use the same public API (new, compare, sort, sort_by_key).

--- a/spec/foundation/08-adapter-leptos.md
+++ b/spec/foundation/08-adapter-leptos.md
@@ -1833,7 +1833,73 @@ pub fn use_locale() -> Signal<Locale> {
 > `derive()` call creates an independent memo that only updates its dependents
 > when its output value actually changes.
 
-### 13.2 resolve_locale() — Adapter Locale Resolution
+### 13.2 use_number_formatter()
+
+```rust
+use ars_i18n::{NumberFormatOptions, NumberFormatter};
+
+/// Resolve a provider-derived number formatter from ArsProvider locale context.
+///
+/// `use_number_formatter()` is the public ambient-locale formatting helper for
+/// Leptos components. The `options` closure may read reactive props/signals;
+/// the formatter rebuilds when either the locale signal or the closure output
+/// changes.
+///
+/// Leptos 0.8 only exposes public `Memo` constructors for `Send + Sync`
+/// values. Because `NumberFormatter` is not guaranteed to be thread-safe on
+/// every backend, the Leptos adapter returns a local derived `Signal` backed
+/// by a component-local cache instead of a `Memo`.
+pub fn use_number_formatter<F>(
+    options: F,
+) -> Signal<NumberFormatter, LocalStorage>
+where
+    F: Fn() -> NumberFormatOptions + 'static,
+{
+    use_resolved_number_formatter(None, options)
+}
+
+/// Resolve a provider-derived formatter from an explicit locale override or the
+/// ambient ArsProvider locale.
+///
+/// This helper is adapter-internal so component implementations with a
+/// `locale` prop can preserve the documented resolution chain without pushing
+/// formatter state into `ars_core::Env`.
+pub(crate) fn use_resolved_number_formatter<F>(
+    adapter_props_locale: Option<&Locale>,
+    options: F,
+) -> Signal<NumberFormatter, LocalStorage>
+where
+    F: Fn() -> NumberFormatOptions + 'static,
+{
+    let explicit_locale = adapter_props_locale.cloned();
+    let locale = use_locale();
+    let cache =
+        StoredValue::<Option<(Locale, NumberFormatOptions, NumberFormatter)>, LocalStorage>::new_local(
+            None,
+        );
+
+    Signal::derive_local(move || {
+        let resolved_locale = explicit_locale.clone().unwrap_or_else(|| locale.get());
+        let resolved_options = options();
+
+        cache.update_value(|cached| {
+            if let Some((cached_locale, cached_options, formatter)) = cached {
+                if *cached_locale == resolved_locale && *cached_options == resolved_options {
+                    return formatter.clone();
+                }
+            }
+
+            let formatter = NumberFormatter::new(&resolved_locale, resolved_options.clone());
+            *cached = Some((resolved_locale, resolved_options, formatter.clone()));
+            formatter
+        })
+    })
+}
+```
+
+**Prelude export:** `pub use crate::use_number_formatter;`
+
+### 13.3 resolve_locale() — Adapter Locale Resolution
 
 An adapter-only utility (not available in core crates) that resolves the effective locale for a component. If the adapter-level component provides a per-instance `locale` prop override, that value is used; otherwise falls back to the `ArsProvider` context locale.
 
@@ -1852,7 +1918,7 @@ fn resolve_locale(adapter_props_locale: Option<&Locale>) -> Locale {
 }
 ```
 
-### 13.3 use_messages() — Adapter Message Resolution
+### 13.4 use_messages() — Adapter Message Resolution
 
 ```rust
 use ars_core::resolve_messages as core_resolve_messages;
@@ -1877,7 +1943,7 @@ pub fn use_messages<M: ComponentMessages + Send + Sync + 'static>(
 }
 ```
 
-### 13.4 t() — Translatable Text Resolver
+### 13.5 t() — Translatable Text Resolver
 
 ```rust
 use ars_i18n::Translate;

--- a/spec/foundation/09-adapter-dioxus.md
+++ b/spec/foundation/09-adapter-dioxus.md
@@ -2198,7 +2198,50 @@ pub fn use_locale() -> Signal<Locale> {
 }
 ```
 
-### 16.2 Environment Resolution Utilities
+### 16.2 use_number_formatter()
+
+```rust
+use ars_i18n::{NumberFormatOptions, NumberFormatter};
+
+/// Resolve a memoized number formatter from ArsProvider locale context.
+///
+/// `use_number_formatter()` is the public ambient-locale formatting helper for
+/// Dioxus components. The `options` closure may read reactive props/signals;
+/// the memo rebuilds when either the locale signal or the closure output
+/// changes.
+pub fn use_number_formatter<F>(options: F) -> Memo<NumberFormatter>
+where
+    F: Fn() -> NumberFormatOptions + 'static,
+{
+    use_resolved_number_formatter(None, options)
+}
+
+/// Resolve a memoized formatter from an explicit locale override or the
+/// ambient ArsProvider locale.
+///
+/// This helper is adapter-internal so component implementations with a
+/// `locale` prop can preserve the documented resolution chain without pushing
+/// formatter state into `ars_core::Env`.
+pub(crate) fn use_resolved_number_formatter<F>(
+    adapter_props_locale: Option<&Locale>,
+    options: F,
+) -> Memo<NumberFormatter>
+where
+    F: Fn() -> NumberFormatOptions + 'static,
+{
+    let explicit_locale = adapter_props_locale.cloned();
+    let locale = use_locale();
+
+    use_memo(move || {
+        let resolved_locale = explicit_locale.clone().unwrap_or_else(|| locale.read().clone());
+        NumberFormatter::new(&resolved_locale, options())
+    })
+}
+```
+
+**Prelude export:** `pub use crate::use_number_formatter;`
+
+### 16.3 Environment Resolution Utilities
 
 These adapter-only utilities resolve environment values from `ArsProvider` context
 before passing them to core code via the `Env` struct and `Messages` parameter.
@@ -2275,7 +2318,7 @@ fn use_messages<M: ComponentMessages + Send + Sync + 'static>(
 }
 ```
 
-### 16.3 t() — Translatable Text Resolver
+### 16.4 t() — Translatable Text Resolver
 
 ```rust
 use ars_i18n::Translate;

--- a/spec/testing/08-i18n-testing.md
+++ b/spec/testing/08-i18n-testing.md
@@ -1311,8 +1311,12 @@ impl Translate for Price {
     fn translate(&self, locale: &Locale, icu: &dyn IcuProvider) -> String {
         match self {
             Self::Total { amount } => {
-                let formatter = ars_i18n::get_number_formatter(
-                    locale, &ars_i18n::NumberFormatOptions::currency("USD"),
+                let formatter = ars_i18n::NumberFormatter::new(
+                    locale,
+                    ars_i18n::NumberFormatOptions {
+                        style: ars_i18n::NumberStyle::Currency(ars_i18n::CurrencyCode::USD),
+                        ..ars_i18n::NumberFormatOptions::default()
+                    },
                 );
                 match locale.language().as_str() {
                     "es" => format!("Total: {}", formatter.format(*amount)),

--- a/spec/testing/14-ci.md
+++ b/spec/testing/14-ci.md
@@ -92,6 +92,33 @@ unit:
         - run: cargo xtest unit
 ```
 
+### 1.3.1 I18n Browser Tests
+
+The `web-intl` number/date/provider paths are not considered covered by the
+`wasm32` cross-check alone. CI MUST execute the browser-backed `ars-i18n`
+surface through `cargo xtest i18n-browser`, which wraps:
+
+```bash
+wasm-pack test --headless --chrome crates/ars-i18n --no-default-features --features std,web-intl
+```
+
+This stage depends on the unit-test gate and exists specifically to exercise
+`Intl.*` behavior rather than only verifying that the code cross-compiles.
+
+```yaml
+i18n-browser:
+    name: I18n Browser Tests
+    needs: [unit]
+    runs-on: ubuntu-latest
+    steps:
+        - uses: actions/checkout@v4
+        - uses: dtolnay/rust-toolchain@stable
+          with:
+              targets: wasm32-unknown-unknown
+        - run: cargo install wasm-pack --locked --version 0.14.0
+        - run: cargo xtest i18n-browser
+```
+
 ### 1.4 Release Verification
 
 Release-mode regressions MUST be caught in CI, even when the debug-profile
@@ -312,7 +339,7 @@ mutual-exclusion:
         - uses: dtolnay/rust-toolchain@stable
         - name: Verify icu4x + web-intl fails to compile
           run: |
-              if cargo check -p ars-i18n --features icu4x,web-intl 2>/dev/null; then
+              if cargo check -p ars-i18n --no-default-features --features icu4x,web-intl 2>/dev/null; then
                 echo "ERROR: icu4x + web-intl compiled successfully — mutual exclusion guard is broken"
                 exit 1
               fi

--- a/xtask/src/ci/mod.rs
+++ b/xtask/src/ci/mod.rs
@@ -7,12 +7,15 @@
 pub(crate) mod feature_matrix;
 
 use std::{
-    fmt, fs, io,
+    fmt::{self, Display},
+    fs, io,
     path::{Path, PathBuf},
     process,
 };
 
 use crate::{coverage, i18n, test};
+
+const MUTUAL_EXCLUSION_GUARD: &str = "features `icu4x` and `web-intl` are mutually exclusive";
 
 /// CI pipeline steps, matching the GitHub Actions job names.
 ///
@@ -24,32 +27,51 @@ use crate::{coverage, i18n, test};
 pub enum Step {
     /// `cargo +nightly fmt --all --check`
     Fmt,
+
     /// `cargo check --workspace --all-features`
     Check,
+
     /// `cargo clippy --workspace --all-targets --all-features -- -D warnings`
     Clippy,
+
     /// Unit tests for core crates.
     Unit,
+
+    /// Browser-executed wasm tests for ars-i18n's web-intl backend.
+    I18nBrowser,
+
     /// Release-profile compile and test smoke checks.
     Release,
+
     /// Integration tests.
     Integration,
+
     /// Adapter harness tests (Leptos + Dioxus).
     Adapter,
+
     /// Generate coverage and check per-crate thresholds.
     Coverage,
+
     /// Meta-step: run all five feature-matrix groups.
     FeatureMatrix,
+
     /// Feature flags — ars-core (15 combos).
     FeatureMatrixCore,
+
     /// Feature flags — ars-i18n (11 combos + wasm32).
     FeatureMatrixI18n,
+
     /// Feature flags — subsystem crates (13 combos + wasm32).
     FeatureMatrixSubsystems,
+
     /// Feature flags — ars-leptos (3 combos).
     FeatureMatrixLeptos,
+
     /// Feature flags — ars-dioxus (4 combos + wasm32).
     FeatureMatrixDioxus,
+
+    /// Verify the mutual-exclusion compile guard for ars-i18n backend features.
+    MutualExclusion,
 }
 
 /// Default pipeline order when no steps are specified.
@@ -61,6 +83,7 @@ const PIPELINE_ORDER: &[Step] = &[
     Step::Check,
     Step::Clippy,
     Step::Unit,
+    Step::I18nBrowser,
     Step::Release,
     Step::Integration,
     Step::Adapter,
@@ -70,6 +93,7 @@ const PIPELINE_ORDER: &[Step] = &[
     Step::FeatureMatrixSubsystems,
     Step::FeatureMatrixLeptos,
     Step::FeatureMatrixDioxus,
+    Step::MutualExclusion,
 ];
 
 /// Errors from CI operations.
@@ -79,25 +103,31 @@ pub enum Error {
     StepFailed {
         /// The step that failed.
         step: Step,
+
         /// The command that was run (for display).
         command: String,
+
         /// Process exit code, if available.
         code: Option<i32>,
     },
+
     /// A required tool is not installed.
     MissingTool {
         /// Human-readable tool name.
         tool: String,
+
         /// How to install it.
         install_hint: String,
     },
+
     /// IO error spawning a subprocess.
     Io(io::Error),
+
     /// Coverage threshold check failed.
     Coverage(coverage::Error),
 }
 
-impl fmt::Display for Error {
+impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::StepFailed {
@@ -111,13 +141,16 @@ impl fmt::Display for Error {
                 }
                 write!(f, ": {command}")
             }
+
             Self::MissingTool { tool, install_hint } => {
                 write!(
                     f,
                     "missing required tool: {tool}\n  install: {install_hint}"
                 )
             }
+
             Self::Io(e) => write!(f, "IO error: {e}"),
+
             Self::Coverage(e) => write!(f, "{e}"),
         }
     }
@@ -148,6 +181,7 @@ pub fn run(steps: Vec<Step>, message_format: Option<&str>) -> Result<(), Error> 
     }
 
     print_summary(&steps);
+
     Ok(())
 }
 
@@ -166,6 +200,7 @@ fn resolve_steps(steps: Vec<Step>) -> Vec<Step> {
     }
 
     let mut resolved = Vec::with_capacity(steps.len());
+
     for step in steps {
         if step == Step::FeatureMatrix {
             resolved.extend_from_slice(&[
@@ -179,6 +214,7 @@ fn resolve_steps(steps: Vec<Step>) -> Vec<Step> {
             resolved.push(step);
         }
     }
+
     resolved
 }
 
@@ -190,23 +226,40 @@ fn resolve_steps(steps: Vec<Step>) -> Vec<Step> {
 fn run_step(step: Step, message_format: Option<&str>) -> Result<(), Error> {
     match step {
         Step::Fmt => run_fmt(),
+
         Step::Check => run_check(message_format),
+
         Step::Clippy => run_clippy(message_format),
+
         Step::Unit => run_unit(),
+
+        Step::I18nBrowser => run_i18n_browser(),
+
         Step::Release => run_release(),
+
         Step::Integration => run_integration(),
+
         Step::Adapter => run_adapter(),
+
         Step::Coverage => run_coverage(),
+
         Step::FeatureMatrix => {
             unreachable!("FeatureMatrix is expanded by resolve_steps")
         }
+
         Step::FeatureMatrixCore => feature_matrix::run_group(feature_matrix::Group::Core),
+
         Step::FeatureMatrixI18n => feature_matrix::run_group(feature_matrix::Group::I18n),
+
         Step::FeatureMatrixSubsystems => {
             feature_matrix::run_group(feature_matrix::Group::Subsystems)
         }
+
         Step::FeatureMatrixLeptos => feature_matrix::run_group(feature_matrix::Group::Leptos),
+
         Step::FeatureMatrixDioxus => feature_matrix::run_group(feature_matrix::Group::Dioxus),
+
+        Step::MutualExclusion => run_mutual_exclusion(),
     }
 }
 
@@ -216,6 +269,7 @@ fn run_step(step: Step, message_format: Option<&str>) -> Result<(), Error> {
 
 fn run_fmt() -> Result<(), Error> {
     preflight_nightly()?;
+
     cargo(Step::Fmt, &["+nightly", "fmt", "--all", "--check"])
 }
 
@@ -236,6 +290,7 @@ fn run_check(message_format: Option<&str>) -> Result<(), Error> {
     )?;
 
     let [icu4x_features, web_intl_features] = i18n::i18n_feature_lists().map_err(Error::Io)?;
+
     for features in [&icu4x_features, &web_intl_features] {
         cargo_with_format(
             Step::Check,
@@ -251,6 +306,7 @@ fn run_check(message_format: Option<&str>) -> Result<(), Error> {
             message_format,
         )?;
     }
+
     Ok(())
 }
 
@@ -279,12 +335,15 @@ pub fn clippy_workspace(message_format: Option<&str>, deny_warnings: bool) -> Re
         "--exclude",
         "ars-i18n",
     ];
+
     if deny_warnings {
         workspace_args.extend_from_slice(&["--", "-D", "warnings"]);
     }
+
     cargo_with_format(Step::Clippy, &workspace_args, message_format)?;
 
     let [icu4x_features, web_intl_features] = i18n::i18n_feature_lists().map_err(Error::Io)?;
+
     for features in [&icu4x_features, &web_intl_features] {
         let mut args = vec![
             "clippy",
@@ -295,16 +354,23 @@ pub fn clippy_workspace(message_format: Option<&str>, deny_warnings: bool) -> Re
             "--features",
             features.as_str(),
         ];
+
         if deny_warnings {
             args.extend_from_slice(&["--", "-D", "warnings"]);
         }
+
         cargo_with_format(Step::Clippy, &args, message_format)?;
     }
+
     Ok(())
 }
 
 fn run_unit() -> Result<(), Error> {
     run_test_stage(Step::Unit, test::Stage::Unit)
+}
+
+fn run_i18n_browser() -> Result<(), Error> {
+    run_test_stage(Step::I18nBrowser, test::Stage::I18nBrowser)
 }
 
 fn run_release() -> Result<(), Error> {
@@ -319,7 +385,9 @@ fn run_release() -> Result<(), Error> {
             "ars-i18n",
         ],
     )?;
+
     let [icu4x_features, web_intl_features] = i18n::i18n_feature_lists().map_err(Error::Io)?;
+
     for features in [&icu4x_features, &web_intl_features] {
         cargo(
             Step::Release,
@@ -335,6 +403,7 @@ fn run_release() -> Result<(), Error> {
             ],
         )?;
     }
+
     run_test_stage(Step::Release, test::Stage::Release)
 }
 
@@ -346,13 +415,64 @@ fn run_adapter() -> Result<(), Error> {
     run_test_stage(Step::Adapter, test::Stage::Adapter)
 }
 
+fn run_mutual_exclusion() -> Result<(), Error> {
+    let args = [
+        "check",
+        "-p",
+        "ars-i18n",
+        "--no-default-features",
+        "--features",
+        "icu4x,web-intl",
+    ];
+
+    let display_cmd = format!("cargo {}", args.join(" "));
+
+    eprintln!("  > {display_cmd}");
+
+    let output = process::Command::new("cargo")
+        .args(args)
+        .output()
+        .map_err(Error::Io)?;
+
+    if output.status.success() {
+        Err(Error::StepFailed {
+            step: Step::MutualExclusion,
+            command: format!("{display_cmd} (unexpected success)"),
+            code: output.status.code(),
+        })
+    } else if is_expected_mutual_exclusion_failure(&String::from_utf8_lossy(&output.stderr)) {
+        Ok(())
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        Err(Error::StepFailed {
+            step: Step::MutualExclusion,
+            command: format!(
+                "{display_cmd} (unexpected failure; missing guard message)\nstderr:\n{}",
+                stderr.trim()
+            ),
+            code: output.status.code(),
+        })
+    }
+}
+
+fn is_expected_mutual_exclusion_failure(stderr: &str) -> bool {
+    stderr.contains(MUTUAL_EXCLUSION_GUARD)
+}
+
 fn run_coverage() -> Result<(), Error> {
     preflight_llvm_cov()?;
+
     preflight_nextest()?;
+
     coverage::preflight_nightly().map_err(Error::Coverage)?;
+
     let coverage_dir = Path::new("target").join("coverage");
+
     fs::create_dir_all(&coverage_dir).map_err(Error::Io)?;
+
     let native_lcov = coverage_dir.join("native.lcov");
+
     let merged_lcov = PathBuf::from("lcov.info");
 
     // Generate native lcov via cargo-llvm-cov + cargo-nextest.
@@ -372,8 +492,10 @@ fn run_coverage() -> Result<(), Error> {
     )?;
 
     let mut reports = vec![native_lcov];
+
     for target in coverage::default_wasm_coverage_targets() {
         let wasm_lcov = coverage_dir.join(format!("{}-wasm.lcov", target.package));
+
         coverage::generate_wasm_lcov(&coverage::WasmCoverageOptions {
             package: target.package.to_owned(),
             output: wasm_lcov.clone(),
@@ -386,6 +508,7 @@ fn run_coverage() -> Result<(), Error> {
             extra_test_args: Vec::new(),
         })
         .map_err(Error::Coverage)?;
+
         reports.push(wasm_lcov);
     }
 
@@ -393,6 +516,7 @@ fn run_coverage() -> Result<(), Error> {
 
     // Check thresholds programmatically (reuses coverage module).
     let thresholds = coverage::default_thresholds();
+
     match coverage::check_all(&merged_lcov, &thresholds) {
         Ok(output) => {
             eprint!("{output}");
@@ -413,12 +537,15 @@ pub(crate) fn map_test_error(step: Step, error: test::Error) -> Error {
         test::Error::MissingTool { tool, install_hint } => {
             Error::MissingTool { tool, install_hint }
         }
+
         test::Error::CommandFailed { command, code } => Error::StepFailed {
             step,
             command,
             code,
         },
+
         test::Error::Io(error) => Error::Io(error),
+
         test::Error::Failed { summary } => Error::Io(io::Error::other(summary)),
     }
 }
@@ -433,24 +560,28 @@ pub(crate) fn map_test_error(step: Step, error: test::Error) -> Error {
 /// lets rust-analyzer's `overrideCommand` request JSON diagnostics via
 /// `cargo xtask ci clippy --message-format=json`.
 fn cargo_with_format(step: Step, args: &[&str], message_format: Option<&str>) -> Result<(), Error> {
-    match message_format {
-        None => cargo(step, args),
-        Some(fmt) => {
-            let fmt_flag = format!("--message-format={fmt}");
-            let mut full_args = Vec::with_capacity(args.len() + 1);
-            let mut inserted = false;
-            for &arg in args {
-                if arg == "--" && !inserted {
-                    full_args.push(fmt_flag.as_str());
-                    inserted = true;
-                }
-                full_args.push(arg);
-            }
-            if !inserted {
+    if let Some(fmt) = message_format {
+        let fmt_flag = format!("--message-format={fmt}");
+
+        let mut full_args = Vec::with_capacity(args.len() + 1);
+
+        let mut inserted = false;
+
+        for &arg in args {
+            if arg == "--" && !inserted {
                 full_args.push(fmt_flag.as_str());
+                inserted = true;
             }
-            cargo(step, &full_args)
+            full_args.push(arg);
         }
+
+        if !inserted {
+            full_args.push(fmt_flag.as_str());
+        }
+
+        cargo(step, &full_args)
+    } else {
+        cargo(step, args)
     }
 }
 
@@ -459,6 +590,7 @@ fn cargo_with_format(step: Step, args: &[&str], message_format: Option<&str>) ->
 /// Returns `Ok(())` on exit-code 0, or `CiError::StepFailed` otherwise.
 pub(crate) fn cargo(step: Step, args: &[&str]) -> Result<(), Error> {
     let display_cmd = format!("cargo {}", args.join(" "));
+
     eprintln!("  > {display_cmd}");
 
     let status = process::Command::new("cargo")
@@ -496,6 +628,7 @@ fn preflight_nightly() -> Result<(), Error> {
             install_hint: "rustup toolchain install nightly".into(),
         });
     }
+
     Ok(())
 }
 
@@ -546,6 +679,7 @@ const fn step_name(step: Step) -> &'static str {
         Step::Check => "check",
         Step::Clippy => "clippy",
         Step::Unit => "unit",
+        Step::I18nBrowser => "i18n-browser",
         Step::Release => "release",
         Step::Integration => "integration",
         Step::Adapter => "adapter",
@@ -556,6 +690,7 @@ const fn step_name(step: Step) -> &'static str {
         Step::FeatureMatrixSubsystems => "feature-matrix-subsystems",
         Step::FeatureMatrixLeptos => "feature-matrix-leptos",
         Step::FeatureMatrixDioxus => "feature-matrix-dioxus",
+        Step::MutualExclusion => "mutual-exclusion",
     }
 }
 
@@ -584,11 +719,15 @@ fn format_pass(step: Step) -> String {
 /// Format the final summary (testable).
 fn format_summary(steps: &[Step]) -> String {
     use fmt::Write as _;
+
     let mut out = String::from("\n=== CI Summary ===\n");
+
     for step in steps {
         writeln!(out, "  {}: passed", step_name(*step)).expect("write to String");
     }
+
     writeln!(out, "\nAll {} steps passed.", steps.len()).expect("write to String");
+
     out
 }
 
@@ -603,19 +742,23 @@ mod tests {
     #[test]
     fn empty_steps_resolve_to_pipeline_order() {
         let resolved = resolve_steps(vec![]);
+
         assert_eq!(resolved, PIPELINE_ORDER);
     }
 
     #[test]
     fn explicit_steps_pass_through() {
         let input = vec![Step::Check, Step::Clippy];
+
         let resolved = resolve_steps(input.clone());
+
         assert_eq!(resolved, input);
     }
 
     #[test]
     fn feature_matrix_expands_to_five_groups() {
         let resolved = resolve_steps(vec![Step::FeatureMatrix]);
+
         assert_eq!(resolved.len(), 5);
         assert_eq!(resolved[0], Step::FeatureMatrixCore);
         assert_eq!(resolved[1], Step::FeatureMatrixI18n);
@@ -627,6 +770,7 @@ mod tests {
     #[test]
     fn feature_matrix_expands_in_context() {
         let resolved = resolve_steps(vec![Step::Fmt, Step::FeatureMatrix, Step::Coverage]);
+
         assert_eq!(resolved.len(), 7); // 1 + 5 + 1
         assert_eq!(resolved[0], Step::Fmt);
         assert_eq!(resolved[6], Step::Coverage);
@@ -644,6 +788,7 @@ mod tests {
     fn step_names_are_kebab_case() {
         for &step in PIPELINE_ORDER {
             let name = step_name(step);
+
             assert!(
                 !name.contains('_') && !name.contains(' '),
                 "step name {name:?} is not kebab-case"
@@ -659,6 +804,7 @@ mod tests {
             Step::Check,
             Step::Clippy,
             Step::Unit,
+            Step::I18nBrowser,
             Step::Release,
             Step::Integration,
             Step::Adapter,
@@ -669,10 +815,26 @@ mod tests {
             Step::FeatureMatrixSubsystems,
             Step::FeatureMatrixLeptos,
             Step::FeatureMatrixDioxus,
+            Step::MutualExclusion,
         ];
+
         for step in all {
             assert!(!step_name(step).is_empty(), "{step:?} has empty name");
         }
+    }
+
+    #[test]
+    fn mutual_exclusion_guard_matches_expected_compile_error() {
+        let stderr = format!("error: {MUTUAL_EXCLUSION_GUARD}");
+
+        assert!(is_expected_mutual_exclusion_failure(&stderr));
+    }
+
+    #[test]
+    fn mutual_exclusion_guard_rejects_unrelated_compile_failures() {
+        assert!(!is_expected_mutual_exclusion_failure(
+            "error[E0432]: unresolved import `missing`"
+        ));
     }
 
     // -- CiError::Display tests -----------------------------------------------
@@ -684,7 +846,9 @@ mod tests {
             command: "cargo clippy".into(),
             code: Some(101),
         };
+
         let msg = err.to_string();
+
         assert!(msg.contains("clippy failed"), "got: {msg}");
         assert!(msg.contains("exit code 101"), "got: {msg}");
         assert!(msg.contains("cargo clippy"), "got: {msg}");
@@ -697,7 +861,9 @@ mod tests {
             command: "cargo +nightly fmt --all --check".into(),
             code: None,
         };
+
         let msg = err.to_string();
+
         assert!(msg.contains("fmt failed"), "got: {msg}");
         assert!(!msg.contains("exit code"), "got: {msg}");
     }
@@ -708,7 +874,9 @@ mod tests {
             tool: "nightly toolchain".into(),
             install_hint: "rustup toolchain install nightly".into(),
         };
+
         let msg = err.to_string();
+
         assert!(msg.contains("nightly toolchain"), "got: {msg}");
         assert!(
             msg.contains("rustup toolchain install nightly"),
@@ -719,7 +887,9 @@ mod tests {
     #[test]
     fn display_io_error() {
         let err = Error::Io(io::Error::new(io::ErrorKind::NotFound, "no cargo"));
+
         let msg = err.to_string();
+
         assert!(msg.contains("IO error"), "got: {msg}");
         assert!(msg.contains("no cargo"), "got: {msg}");
     }
@@ -729,7 +899,9 @@ mod tests {
         let err = Error::Coverage(coverage::Error::NoSourceFiles {
             package: "ars-core".into(),
         });
+
         let msg = err.to_string();
+
         assert!(msg.contains("ars-core"), "got: {msg}");
     }
 
@@ -738,6 +910,7 @@ mod tests {
     #[test]
     fn format_header_contains_step_and_progress() {
         let hdr = format_header(Step::Clippy, 3, 12);
+
         assert!(hdr.contains("[3/12]"), "got: {hdr}");
         assert!(hdr.contains("clippy"), "got: {hdr}");
     }
@@ -745,13 +918,16 @@ mod tests {
     #[test]
     fn format_pass_contains_step_name() {
         let msg = format_pass(Step::Unit);
+
         assert!(msg.contains("unit passed"), "got: {msg}");
     }
 
     #[test]
     fn format_summary_lists_all_steps() {
         let steps = vec![Step::Fmt, Step::Check];
+
         let summary = format_summary(&steps);
+
         assert!(summary.contains("fmt: passed"), "got: {summary}");
         assert!(summary.contains("check: passed"), "got: {summary}");
         assert!(summary.contains("All 2 steps passed"), "got: {summary}");
@@ -760,6 +936,7 @@ mod tests {
     #[test]
     fn format_summary_empty() {
         let summary = format_summary(&[]);
+
         assert!(summary.contains("All 0 steps passed"), "got: {summary}");
     }
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -28,6 +28,7 @@ enum Command {
         #[arg(long)]
         message_format: Option<String>,
     },
+
     /// Run workspace clippy without `-D warnings` (alias: `cargo xclippy`).
     ///
     /// Same ars-i18n backend splitting as `cargo xci clippy`, but warnings
@@ -38,19 +39,23 @@ enum Command {
         #[arg(long)]
         message_format: Option<String>,
     },
+
     /// Start MCP stdio server exposing all workspace tools.
     #[cfg(feature = "mcp")]
     Mcp,
+
     /// Spec navigation commands.
     Spec {
         #[command(subcommand)]
         cmd: SpecCommand,
     },
+
     /// Code coverage threshold enforcement.
     Coverage {
         #[command(subcommand)]
         cmd: CoverageCommand,
     },
+
     /// Run workspace tests through cargo-nextest.
     Test {
         #[command(subcommand)]
@@ -65,43 +70,54 @@ enum CoverageCommand {
         /// Crate name (e.g., "ars-dom").
         #[arg(long)]
         package: String,
+
         /// Path to write the generated lcov file.
         #[arg(long)]
         file: PathBuf,
+
         /// Cargo feature to enable. May be passed multiple times.
         #[arg(long = "feature")]
         features: Vec<String>,
+
         /// Disable default features for the package.
         #[arg(long)]
         no_default_features: bool,
+
         /// Extra arguments forwarded to `cargo test` after `--`.
         #[arg(last = true)]
         extra_test_args: Vec<String>,
     },
+
     /// Merge multiple lcov files without double-counting duplicate lines.
     Merge {
         /// Output lcov path.
         #[arg(long)]
         output: PathBuf,
+
         /// Input lcov files to merge.
         #[arg(long = "file", required = true)]
         files: Vec<PathBuf>,
     },
+
     /// Check a single crate's coverage against thresholds.
     Check {
         /// Path to lcov.info file.
         #[arg(long)]
         file: PathBuf,
+
         /// Crate name (e.g., "ars-core").
         #[arg(long)]
         package: String,
+
         /// Minimum line coverage percentage (0–100).
         #[arg(long)]
         min: f64,
+
         /// Minimum branch coverage percentage (0–100).
         #[arg(long)]
         branch_min: f64,
     },
+
     /// Check all crates against spec-defined thresholds.
     CheckAll {
         /// Path to lcov.info file.
@@ -114,20 +130,31 @@ enum CoverageCommand {
 enum TestCommand {
     /// Run the workspace all-target test stage with ars-i18n backend splitting.
     Unit,
+
+    /// Run browser-executed wasm tests for ars-i18n's web-intl backend.
+    I18nBrowser,
+
     /// Run the release verification test stage.
     Release,
+
     /// Run the integration test stage.
     Integration,
+
     /// Run the adapter and harness test stage.
     Adapter,
+
     /// Run the ars-core feature-matrix tests.
     FeatureMatrixCore,
+
     /// Run the ars-i18n feature-matrix tests.
     FeatureMatrixI18n,
+
     /// Run the subsystem feature-matrix tests.
     FeatureMatrixSubsystems,
+
     /// Run the ars-leptos feature-matrix tests.
     FeatureMatrixLeptos,
+
     /// Run the ars-dioxus feature-matrix tests.
     FeatureMatrixDioxus,
 }
@@ -139,69 +166,85 @@ enum SpecCommand {
         /// Component name (e.g., "checkbox", "date-picker").
         component: String,
     },
+
     /// List all files needed to review a component.
     Deps {
         /// Component name.
         component: String,
     },
+
     /// List all components in a category.
     Category {
         /// Category name (e.g., "selection", "overlay").
         name: String,
     },
+
     /// Find components depending on a shared type.
     Reverse {
         /// Shared type name (e.g., "selection-patterns").
         shared_type: String,
     },
+
     /// List a component and its related components.
     Related {
         /// Component name.
         component: String,
     },
+
     /// List files for a review profile.
     Profile {
         /// Profile name (e.g., "accessibility").
         name: String,
     },
+
     /// Output heading structure of a spec file.
     Toc {
         /// Path to spec file (relative to spec/ or absolute).
         file: String,
     },
+
     /// Validate frontmatter against manifest.
     Validate,
+
     /// List adapter files for a framework.
     Adapters {
         /// Framework: "leptos" or "dioxus".
         framework: String,
     },
+
     /// Get a compact summary of a component.
     Digest {
         /// Component name.
         component: String,
     },
+
     /// Get full implementation context for a component.
     Context {
         /// Component name.
         component: String,
+
         /// Framework: "leptos" or "dioxus" (includes adapter spec).
         #[arg(long)]
         framework: Option<String>,
+
         /// Include testing specs.
         #[arg(long)]
         include_testing: bool,
     },
+
     /// Search spec content by keyword/regex.
     Search {
         /// Regex pattern to search for.
         query: String,
+
         /// Category filter.
         #[arg(long)]
         category: Option<String>,
+
         /// Section filter (states, events, props, accessibility, anatomy, i18n, forms).
         #[arg(long)]
         section: Option<String>,
+
         /// Tier filter (stateless, stateful, complex).
         #[arg(long)]
         tier: Option<String>,
@@ -211,6 +254,7 @@ enum SpecCommand {
 /// Discover the spec root or exit with a diagnostic.
 fn discover_spec_root() -> manifest::SpecRoot {
     let cwd = env::current_dir().expect("cannot read current directory");
+
     match manifest::SpecRoot::discover(&cwd) {
         Ok(r) => r,
         Err(e) => {
@@ -228,22 +272,18 @@ fn main() {
         Command::Ci {
             steps,
             message_format,
-        } => match ci::run(steps, message_format.as_deref()) {
-            Ok(()) => {}
-            Err(e) => {
+        } => {
+            if let Err(e) = ci::run(steps, message_format.as_deref()) {
                 eprintln!("error: {e}");
                 process::exit(1);
             }
-        },
+        }
 
         // ── Clippy (dev) ─────────────────────────────────────────────
         Command::Clippy { message_format } => {
-            match ci::clippy_workspace(message_format.as_deref(), false) {
-                Ok(()) => {}
-                Err(e) => {
-                    eprintln!("error: {e}");
-                    process::exit(1);
-                }
+            if let Err(e) = ci::clippy_workspace(message_format.as_deref(), false) {
+                eprintln!("error: {e}");
+                process::exit(1);
             }
         }
 
@@ -274,16 +314,18 @@ fn main() {
                     no_default_features,
                     extra_test_args,
                 }),
+
                 CoverageCommand::Merge { output, files } => coverage::merge_files(&files, &output),
+
                 CoverageCommand::Check {
                     file,
                     package,
                     min,
                     branch_min,
                 } => coverage::check(&file, &package, min, branch_min),
+
                 CoverageCommand::CheckAll { file } => {
-                    let thresholds = coverage::default_thresholds();
-                    coverage::check_all(&file, &thresholds)
+                    coverage::check_all(&file, &coverage::default_thresholds())
                 }
             };
             match result {
@@ -299,6 +341,7 @@ fn main() {
         Command::Test { cmd } => {
             let stage = cmd.map(|cmd| match cmd {
                 TestCommand::Unit => test::Stage::Unit,
+                TestCommand::I18nBrowser => test::Stage::I18nBrowser,
                 TestCommand::Release => test::Stage::Release,
                 TestCommand::Integration => test::Stage::Integration,
                 TestCommand::Adapter => test::Stage::Adapter,
@@ -308,38 +351,49 @@ fn main() {
                 TestCommand::FeatureMatrixLeptos => test::Stage::FeatureMatrixLeptos,
                 TestCommand::FeatureMatrixDioxus => test::Stage::FeatureMatrixDioxus,
             });
-            match test::run(stage) {
-                Ok(_) => {}
-                Err(e) => {
-                    eprintln!("error: {e}");
-                    process::exit(1);
-                }
+
+            if let Err(e) = test::run(stage) {
+                eprintln!("error: {e}");
+                process::exit(1);
             }
         }
 
         // ── Spec ──────────────────────────────────────────────────────
         Command::Spec { cmd } => {
             let root = discover_spec_root();
+
             let result = match cmd {
                 SpecCommand::Info { component } => spec::info::execute(&root, &component),
+
                 SpecCommand::Deps { component } => spec::deps::execute(&root, &component),
+
                 SpecCommand::Category { name } => spec::category::execute(&root, &name),
+
                 SpecCommand::Reverse { shared_type } => spec::reverse::execute(&root, &shared_type),
+
                 SpecCommand::Related { component } => spec::related::execute(&root, &component),
+
                 SpecCommand::Profile { name } => spec::profile::execute(&root, &name),
+
                 SpecCommand::Toc { file } => spec::toc::execute(&root, &file),
+
                 SpecCommand::Validate => {
                     let report = spec::validate::execute(&root);
-                    if let Ok(ref text) = report {
-                        if text.contains("error(s) found:") {
-                            print!("{text}");
-                            process::exit(1);
-                        }
+
+                    if let Ok(text) = &report
+                        && text.contains("error(s) found:")
+                    {
+                        print!("{text}");
+                        process::exit(1);
                     }
+
                     report
                 }
+
                 SpecCommand::Adapters { framework } => spec::adapters::execute(&root, &framework),
+
                 SpecCommand::Digest { component } => spec::digest::execute(&root, &component),
+
                 SpecCommand::Context {
                     component,
                     framework,
@@ -347,6 +401,7 @@ fn main() {
                 } => {
                     spec::context::execute(&root, &component, framework.as_deref(), include_testing)
                 }
+
                 SpecCommand::Search {
                     query,
                     category,
@@ -360,6 +415,7 @@ fn main() {
                     tier.as_deref(),
                 ),
             };
+
             match result {
                 Ok(output) => print!("{output}"),
                 Err(e) => {

--- a/xtask/src/test.rs
+++ b/xtask/src/test.rs
@@ -6,7 +6,7 @@
 
 use std::{
     ffi::OsStr,
-    fmt,
+    fmt::{self, Display},
     io::{self, Write},
     process::{self, Output},
     sync::OnceLock,
@@ -24,20 +24,31 @@ use crate::{
 pub enum Stage {
     /// Workspace all-target test stage with ars-i18n backend splitting.
     Unit,
+
+    /// Browser-executed wasm tests for ars-i18n's `web-intl` backend.
+    I18nBrowser,
+
     /// Release-profile test verification.
     Release,
+
     /// Integration tests with explicit filters.
     Integration,
+
     /// Adapter and harness tests.
     Adapter,
+
     /// Feature matrix tests for `ars-core`.
     FeatureMatrixCore,
+
     /// Feature matrix tests for `ars-i18n`.
     FeatureMatrixI18n,
+
     /// Feature matrix tests for subsystem crates.
     FeatureMatrixSubsystems,
+
     /// Feature matrix tests for `ars-leptos`.
     FeatureMatrixLeptos,
+
     /// Feature matrix tests for `ars-dioxus`.
     FeatureMatrixDioxus,
 }
@@ -47,6 +58,7 @@ pub enum Stage {
 pub struct Summary {
     /// Total number of tests executed across all stages.
     pub total_run: u64,
+
     /// Total number of tests that passed across all stages.
     pub total_passed: u64,
 }
@@ -65,18 +77,23 @@ pub enum Error {
     MissingTool {
         /// Human-readable tool name.
         tool: String,
+
         /// Suggested install command or hint.
         install_hint: String,
     },
+
     /// A subprocess exited unsuccessfully.
     CommandFailed {
         /// Display form of the command that failed.
         command: String,
+
         /// Exit code, if available.
         code: Option<i32>,
     },
+
     /// IO error while spawning or reading subprocess output.
     Io(io::Error),
+
     /// One or more test invocations failed.
     Failed {
         /// Human-readable summary of totals and failures.
@@ -84,7 +101,7 @@ pub enum Error {
     },
 }
 
-impl fmt::Display for Error {
+impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::MissingTool { tool, install_hint } => {
@@ -93,6 +110,7 @@ impl fmt::Display for Error {
                     "missing required tool: {tool}\n  install: {install_hint}"
                 )
             }
+
             Self::CommandFailed { command, code } => {
                 write!(f, "command failed")?;
                 if let Some(code) = code {
@@ -100,7 +118,9 @@ impl fmt::Display for Error {
                 }
                 write!(f, ": {command}")
             }
+
             Self::Io(error) => write!(f, "IO error: {error}"),
+
             Self::Failed { summary } => write!(f, "{summary}"),
         }
     }
@@ -121,12 +141,11 @@ struct StageResult {
 /// Returns [`Error::Failed`] if any stage command fails, or another error if
 /// required tools are missing or subprocesses cannot be spawned.
 pub fn run(stage: Option<Stage>) -> Result<Summary, Error> {
-    preflight_nextest()?;
-
     let stages = stage.map_or_else(
         || {
             vec![
                 Stage::Unit,
+                Stage::I18nBrowser,
                 Stage::Release,
                 Stage::Integration,
                 Stage::Adapter,
@@ -141,17 +160,22 @@ pub fn run(stage: Option<Stage>) -> Result<Summary, Error> {
     );
 
     let mut totals = Summary::default();
+
     let mut failures = Vec::new();
 
     for stage in stages {
         let result = run_stage_inner(stage)?;
+
         totals.add_assign(result.summary);
+
         failures.extend(result.failures);
     }
 
     let summary = render_summary(&totals, &failures);
+
     if failures.is_empty() {
         print!("{summary}");
+
         Ok(totals)
     } else {
         Err(Error::Failed { summary })
@@ -164,11 +188,13 @@ pub fn run(stage: Option<Stage>) -> Result<Summary, Error> {
 ///
 /// Returns [`Error::Failed`] if any command in the stage fails.
 pub fn run_stage(stage: Stage) -> Result<Summary, Error> {
-    preflight_nextest()?;
     let result = run_stage_inner(stage)?;
+
     let summary = render_summary(&result.summary, &result.failures);
+
     if result.failures.is_empty() {
         print!("{summary}");
+
         Ok(result.summary)
     } else {
         Err(Error::Failed { summary })
@@ -177,10 +203,14 @@ pub fn run_stage(stage: Stage) -> Result<Summary, Error> {
 
 pub(crate) fn run_feature_matrix_group(group: Group) -> Result<Summary, Error> {
     preflight_nextest()?;
+
     let result = run_feature_matrix_group_inner(group)?;
+
     let summary = render_summary(&result.summary, &result.failures);
+
     if result.failures.is_empty() {
         print!("{summary}");
+
         Ok(result.summary)
     } else {
         Err(Error::Failed { summary })
@@ -188,10 +218,13 @@ pub(crate) fn run_feature_matrix_group(group: Group) -> Result<Summary, Error> {
 }
 
 fn run_stage_inner(stage: Stage) -> Result<StageResult, Error> {
+    preflight_for_stage(stage)?;
+
     eprintln!("==> {}", stage_name(stage));
 
     match stage {
         Stage::Unit => run_unit_stage(),
+        Stage::I18nBrowser => run_i18n_browser_stage(),
         Stage::Release => run_release_stage(),
         Stage::Integration => run_invocations(integration_invocations()),
         Stage::Adapter => run_invocations(adapter_invocations()),
@@ -203,9 +236,41 @@ fn run_stage_inner(stage: Stage) -> Result<StageResult, Error> {
     }
 }
 
+fn run_i18n_browser_stage() -> Result<StageResult, Error> {
+    let run = run_shell_command(
+        "i18n browser",
+        "wasm-pack",
+        &[
+            "test",
+            "--headless",
+            "--chrome",
+            "crates/ars-i18n",
+            "--no-default-features",
+            "--features",
+            "std,web-intl",
+        ],
+    )?;
+
+    let mut result = StageResult::default();
+
+    result
+        .summary
+        .add_assign(parse_wasm_pack_summary(&run.output));
+
+    if !run.success {
+        result
+            .failures
+            .push(format_failure("i18n browser", &run.command, run.code));
+    }
+
+    Ok(result)
+}
+
 fn run_unit_stage() -> Result<StageResult, Error> {
     let [icu4x_features, web_intl_features] = i18n::i18n_feature_lists().map_err(Error::Io)?;
+
     let invocations = unit_invocation_specs(&icu4x_features, &web_intl_features);
+
     run_owned_invocations(&invocations)
 }
 
@@ -248,7 +313,9 @@ fn unit_invocation_specs(icu4x_features: &str, web_intl_features: &str) -> Vec<O
 
 fn run_release_stage() -> Result<StageResult, Error> {
     let [icu4x_features, web_intl_features] = i18n::i18n_feature_lists().map_err(Error::Io)?;
+
     let invocations = release_invocation_specs(&icu4x_features, &web_intl_features);
+
     run_owned_invocations(&invocations)
 }
 
@@ -294,8 +361,10 @@ fn release_invocation_specs(icu4x_features: &str, web_intl_features: &str) -> Ve
 
 fn integration_invocations() -> &'static [Invocation<'static>] {
     static INTEGRATION_ARGS: [&str; 3] = ["-p", "ars-core", "service_applies_transitions"];
+
     static INTEGRATION: [Invocation<'static>; 1] =
         [Invocation::nextest("integration", &INTEGRATION_ARGS)];
+
     &INTEGRATION
 }
 
@@ -314,20 +383,28 @@ fn adapter_invocations() -> &'static [Invocation<'static>] {
         "--all-targets",
         "--all-features",
     ];
+
     static ADAPTER: [Invocation<'static>; 1] = [Invocation::nextest("adapter", &ADAPTER_ARGS)];
+
     &ADAPTER
 }
 
 fn run_feature_matrix_group_inner(group: Group) -> Result<StageResult, Error> {
     let mut result = StageResult::default();
+
     let def = group_def(group);
 
     for combo in def.combos {
         let label = format!("feature-test {}", combo.args.join(" "));
+
         let mut args = combo.args.to_vec();
+
         args.push("--lib");
+
         let run = run_nextest_command(&label, &args)?;
+
         result.summary.add_assign(run.summary);
+
         if !run.success {
             result
                 .failures
@@ -345,7 +422,9 @@ fn run_invocations(invocations: &[Invocation<'_>]) -> Result<StageResult, Error>
         match invocation.kind {
             InvocationKind::Nextest => {
                 let run = run_nextest_command(invocation.label, invocation.args)?;
+
                 result.summary.add_assign(run.summary);
+
                 if !run.success {
                     result
                         .failures
@@ -367,8 +446,11 @@ fn run_owned_invocations(invocations: &[OwnedInvocation]) -> Result<StageResult,
             .iter()
             .map(String::as_str)
             .collect::<Vec<_>>();
+
         let run = run_nextest_command(&invocation.label, &args)?;
+
         result.summary.add_assign(run.summary);
+
         if !run.success {
             result
                 .failures
@@ -397,8 +479,42 @@ fn preflight_nextest() -> Result<(), Error> {
     }
 }
 
+fn preflight_wasm_pack() -> Result<(), Error> {
+    let status = process::Command::new("wasm-pack")
+        .arg("--version")
+        .stdout(process::Stdio::null())
+        .stderr(process::Stdio::null())
+        .status()
+        .map_err(Error::Io)?;
+
+    if status.success() {
+        Ok(())
+    } else {
+        Err(Error::MissingTool {
+            tool: "wasm-pack".into(),
+            install_hint: "cargo install wasm-pack --locked".into(),
+        })
+    }
+}
+
+fn preflight_for_stage(stage: Stage) -> Result<(), Error> {
+    match stage {
+        Stage::I18nBrowser => preflight_wasm_pack(),
+        Stage::Unit
+        | Stage::Release
+        | Stage::Integration
+        | Stage::Adapter
+        | Stage::FeatureMatrixCore
+        | Stage::FeatureMatrixI18n
+        | Stage::FeatureMatrixSubsystems
+        | Stage::FeatureMatrixLeptos
+        | Stage::FeatureMatrixDioxus => preflight_nextest(),
+    }
+}
+
 fn nextest_summary_regex() -> &'static Regex {
     static REGEX: OnceLock<Regex> = OnceLock::new();
+
     REGEX.get_or_init(|| {
         Regex::new(r"Summary \[[^\]]+\]\s+(?P<run>\d+) tests? run:\s+(?P<passed>\d+) passed")
             .expect("valid nextest summary regex")
@@ -407,11 +523,13 @@ fn nextest_summary_regex() -> &'static Regex {
 
 fn ansi_escape_regex() -> &'static Regex {
     static REGEX: OnceLock<Regex> = OnceLock::new();
+
     REGEX.get_or_init(|| Regex::new(r"\x1B\[[0-?]*[ -/]*[@-~]").expect("valid ansi escape regex"))
 }
 
 fn parse_nextest_summary(output: &str) -> Summary {
     let normalized = ansi_escape_regex().replace_all(output, "");
+
     nextest_summary_regex()
         .captures_iter(&normalized)
         .last()
@@ -426,16 +544,65 @@ fn parse_nextest_summary(output: &str) -> Summary {
         .unwrap_or_default()
 }
 
+fn wasm_pack_summary_regex() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+
+    REGEX.get_or_init(|| {
+        Regex::new(
+            r"test result: .*? (?P<passed>\d+) passed; (?P<failed>\d+) failed; (?P<ignored>\d+) ignored; (?P<other>\d+) (?:measured|filtered out)",
+        )
+        .expect("valid wasm-pack summary regex")
+    })
+}
+
+fn parse_wasm_pack_summary(output: &str) -> Summary {
+    let normalized = ansi_escape_regex().replace_all(output, "");
+
+    let mut summary = Summary::default();
+
+    for captures in wasm_pack_summary_regex().captures_iter(&normalized) {
+        let passed = captures
+            .name("passed")
+            .and_then(|value| value.as_str().parse::<u64>().ok());
+
+        let failed = captures
+            .name("failed")
+            .and_then(|value| value.as_str().parse::<u64>().ok());
+
+        let ignored = captures
+            .name("ignored")
+            .and_then(|value| value.as_str().parse::<u64>().ok());
+
+        let other = captures
+            .name("other")
+            .and_then(|value| value.as_str().parse::<u64>().ok());
+
+        if let (Some(passed), Some(failed), Some(ignored), Some(other)) =
+            (passed, failed, ignored, other)
+        {
+            summary.total_run += passed + failed + ignored + other;
+            summary.total_passed += passed;
+        }
+    }
+
+    summary
+}
+
 fn run_nextest_command(label: &str, args: &[&str]) -> Result<CommandResult, Error> {
     eprintln!("  [nextest] {label}");
 
     let mut command = process::Command::new("cargo");
+
     command
         .args(["nextest", "run", "--no-fail-fast"])
         .args(args);
+
     configure_color_output(&mut command);
+
     let display = format!("{command:?}");
+
     let output = command.output().map_err(Error::Io)?;
+
     print_output(&output)?;
 
     let combined = format!(
@@ -449,6 +616,39 @@ fn run_nextest_command(label: &str, args: &[&str]) -> Result<CommandResult, Erro
         code: output.status.code(),
         success: output.status.success(),
         summary: parse_nextest_summary(&combined),
+        output: combined,
+    })
+}
+
+fn run_shell_command(label: &str, program: &str, args: &[&str]) -> Result<CommandResult, Error> {
+    eprintln!("  [{program}] {label}");
+
+    let mut command = process::Command::new(program);
+
+    command.args(args);
+
+    let display = format!("{command:?}");
+
+    let output = command.output().map_err(Error::Io)?;
+
+    print_output(&output)?;
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    Ok(CommandResult {
+        command: display,
+        code: output.status.code(),
+        success: output.status.success(),
+        summary: if program == "wasm-pack" {
+            parse_wasm_pack_summary(&combined)
+        } else {
+            Summary::default()
+        },
+        output: combined,
     })
 }
 
@@ -470,20 +670,25 @@ const fn should_force_color_output(
 
 fn print_output(output: &Output) -> Result<(), Error> {
     io::stdout().write_all(&output.stdout).map_err(Error::Io)?;
+
     io::stderr().write_all(&output.stderr).map_err(Error::Io)?;
+
     Ok(())
 }
 
 fn format_failure(label: &str, command: &str, code: Option<i32>) -> String {
     let mut message = format!("{label}: {command}");
+
     if let Some(code) = code {
         message.push_str(&format!(" (exit code {code})"));
     }
+
     message
 }
 
 fn render_summary(summary: &Summary, failures: &[String]) -> String {
     let mut output = String::new();
+
     output.push_str(&format!("Total tests run: {}\n", summary.total_run));
     output.push_str(&format!("Total tests passed: {}\n", summary.total_passed));
 
@@ -491,6 +696,7 @@ fn render_summary(summary: &Summary, failures: &[String]) -> String {
         output.push_str("All test commands passed.\n");
     } else {
         output.push_str(&format!("Failed commands: {}\n", failures.len()));
+
         for failure in failures {
             output.push_str(&format!(" - {failure}\n"));
         }
@@ -502,6 +708,7 @@ fn render_summary(summary: &Summary, failures: &[String]) -> String {
 const fn stage_name(stage: Stage) -> &'static str {
     match stage {
         Stage::Unit => "unit",
+        Stage::I18nBrowser => "i18n-browser",
         Stage::Release => "release",
         Stage::Integration => "integration",
         Stage::Adapter => "adapter",
@@ -546,6 +753,7 @@ struct CommandResult {
     command: String,
     code: Option<i32>,
     success: bool,
+    output: String,
     summary: Summary,
 }
 
@@ -561,6 +769,7 @@ mod tests {
 ";
 
         let summary = parse_nextest_summary(output);
+
         assert_eq!(
             summary,
             Summary {
@@ -578,6 +787,7 @@ mod tests {
     #[test]
     fn parse_nextest_summary_accepts_singular_test_wording() {
         let output = "Summary [   0.010s] 1 test run: 1 passed, 0 failed, 0 skipped";
+
         assert_eq!(
             parse_nextest_summary(output),
             Summary {
@@ -592,6 +802,7 @@ mod tests {
         let output = "\
 \u{1b}[1m\u{1b}[38;5;230m     Summary\u{1b}[0m [   4.010s] \u{1b}[1m875\u{1b}[0m tests run: \u{1b}[1m\u{1b}[38;5;154m875 passed\u{1b}[0m, \u{1b}[1m\u{1b}[38;5;214m0 skipped\u{1b}[0m
 ";
+
         assert_eq!(
             parse_nextest_summary(output),
             Summary {
@@ -607,15 +818,34 @@ mod tests {
             total_run: 12,
             total_passed: 10,
         };
+
         let rendered = render_summary(&summary, &["unit: cargo nextest run".into()]);
+
         assert!(rendered.contains("Total tests run: 12"));
         assert!(rendered.contains("Total tests passed: 10"));
         assert!(rendered.contains("Failed commands: 1"));
     }
 
     #[test]
+    fn parse_wasm_pack_summary_extracts_run_and_passed_counts() {
+        let output = "\
+test result: ok. 11 passed; 0 failed; 0 ignored; 0 filtered out;
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 filtered out;
+";
+
+        assert_eq!(
+            parse_wasm_pack_summary(output),
+            Summary {
+                total_run: 11,
+                total_passed: 11,
+            }
+        );
+    }
+
+    #[test]
     fn unit_stage_splits_workspace_and_i18n_backends() {
         let invocations = unit_invocation_specs("std,icu4x", "std,web-intl");
+
         assert_eq!(invocations.len(), 3);
         assert_eq!(invocations[0].label, "unit workspace");
         assert_eq!(
@@ -644,8 +874,14 @@ mod tests {
     }
 
     #[test]
+    fn stage_name_reports_i18n_browser() {
+        assert_eq!(stage_name(Stage::I18nBrowser), "i18n-browser");
+    }
+
+    #[test]
     fn release_stage_splits_workspace_and_i18n_backends() {
         let invocations = release_invocation_specs("std,icu4x", "std,web-intl");
+
         assert_eq!(invocations.len(), 3);
         assert_eq!(invocations[0].label, "release workspace");
         assert_eq!(


### PR DESCRIPTION
## Summary

This PR adds the browser-backed `web-intl` number formatting backend in `ars-i18n`, wires the `WebIntlProvider`/ambient number formatter access through both adapters, and syncs the affected specs and CI feature-matrix coverage.

## What Changed

- add the wasm `web-intl` `NumberFormatter` backend with dedicated unit/browser coverage
- add adapter-side `use_number_formatter(...)` helpers and finish `t()`/prelude wiring for Leptos and Dioxus
- update `cargo xci` / CI feature-matrix coverage and the related spec sections to match the shipped behavior
- remove a few test helper warning sites uncovered while validating the branch end-to-end

## Impact

WASM client builds can now use browser `Intl.NumberFormat` without changing the public `NumberFormatter` API, and both adapters expose reactive access to locale-aware number formatting and translated application text from `ArsProvider`.

## Validation

- `cargo xci`

Closes #124
Closes #140
Closes #143