### PR TITLE
Implement ars-forms fieldset machine

### DIFF
--- a/crates/ars-forms/src/fieldset.rs
+++ b/crates/ars-forms/src/fieldset.rs
@@ -17,7 +17,7 @@ use crate::validation::Error;
 /// Single state for the fieldset machine.
 ///
 /// `Fieldset` is effectively stateless. All meaningful changes are stored in
-/// [`Context`] and applied through context-only transitions.
+/// [`MachineContext`] and applied through context-only transitions.
 #[derive(Clone, Debug, PartialEq)]
 pub enum State {
     /// The fieldset is mounted and ready to expose its current context.
@@ -405,20 +405,11 @@ impl<'a> Api<'a> {
 }
 
 /// Framework-context payload propagated from a fieldset to descendant fields.
-#[derive(Clone, Debug, Default, PartialEq)]
-pub struct Context {
-    /// Optional group name inherited by child field components.
-    pub name: Option<String>,
-
-    /// Whether the parent fieldset is disabled.
-    pub disabled: bool,
-
-    /// Whether the parent fieldset is invalid.
-    pub invalid: bool,
-
-    /// Whether the parent fieldset is read-only.
-    pub readonly: bool,
-}
+///
+/// This aliases the shared [`crate::field::Context`] type so framework context
+/// lookup stays consistent across `Fieldset`, `CheckboxGroup`, `RadioGroup`,
+/// and descendant `Field` components.
+pub type Context = crate::field::Context;
 
 #[cfg(test)]
 mod tests {
@@ -626,11 +617,11 @@ mod tests {
 
     #[test]
     fn fieldset_context_propagation() {
-        let ctx = Context::default();
+        let ctx: crate::field::Context = Context::default();
 
         assert_eq!(
             ctx,
-            Context {
+            crate::field::Context {
                 name: None,
                 disabled: false,
                 invalid: false,
@@ -638,7 +629,7 @@ mod tests {
             }
         );
 
-        let named = Context {
+        let named: Context = crate::field::Context {
             name: Some("address".to_string()),
             disabled: true,
             invalid: true,

--- a/crates/ars-forms/src/fieldset.rs
+++ b/crates/ars-forms/src/fieldset.rs
@@ -155,10 +155,11 @@ impl ars_core::Machine for Machine {
         match event {
             Event::SetErrors(errors) => {
                 let errors = errors.clone();
+                let base_invalid = props.invalid;
                 Some(TransitionPlan::context_only(
                     move |ctx: &mut MachineContext| {
                         ctx.errors = errors;
-                        ctx.invalid = !ctx.errors.is_empty();
+                        ctx.invalid = base_invalid || !ctx.errors.is_empty();
                     },
                 ))
             }
@@ -647,6 +648,17 @@ mod tests {
 
         drop(service.send(Event::SetErrors(vec![custom_error()])));
         drop(service.send(Event::ClearErrors));
+
+        assert!(service.context().errors.is_empty());
+        assert!(service.context().invalid);
+    }
+
+    #[test]
+    fn fieldset_set_errors_empty_preserves_prop_invalid() {
+        let mut service = Service::<Machine>::new(test_props_with_invalid(), &Env::default(), &());
+
+        drop(service.send(Event::SetErrors(vec![custom_error()])));
+        drop(service.send(Event::SetErrors(vec![])));
 
         assert!(service.context().errors.is_empty());
         assert!(service.context().invalid);

--- a/crates/ars-forms/src/fieldset.rs
+++ b/crates/ars-forms/src/fieldset.rs
@@ -78,6 +78,9 @@ pub struct MachineContext {
 #[derive(Clone, Debug, Default, PartialEq, ars_core::HasId)]
 pub struct Props {
     /// Adapter-provided base ID for the fieldset root.
+    ///
+    /// This ID is immutable for the lifetime of a machine instance because
+    /// [`MachineContext::ids`] caches the derived part IDs during initialization.
     pub id: String,
 
     /// Whether the entire fieldset and all contained inputs are disabled.
@@ -125,6 +128,11 @@ impl ars_core::Machine for Machine {
     }
 
     fn on_props_changed(old: &Self::Props, new: &Self::Props) -> Vec<Self::Event> {
+        assert_eq!(
+            old.id, new.id,
+            "fieldset Props.id must remain stable after init"
+        );
+
         let mut events = Vec::new();
 
         if old.disabled != new.disabled {
@@ -516,7 +524,7 @@ mod tests {
         };
 
         let new = Props {
-            id: "shipping".to_string(),
+            id: "billing".to_string(),
             disabled: true,
             invalid: true,
             readonly: true,
@@ -530,6 +538,17 @@ mod tests {
         assert!(matches!(events[1], Event::SetInvalid(true)));
         assert!(matches!(events[2], Event::SetReadonly(true)));
         assert!(matches!(events[3], Event::SetDir(Some(Direction::Rtl))));
+    }
+
+    #[test]
+    #[should_panic(expected = "fieldset Props.id must remain stable after init")]
+    fn fieldset_set_props_panics_when_id_changes() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        let mut next = test_props();
+        next.id = "shipping".to_string();
+
+        drop(service.set_props(next));
     }
 
     #[test]

--- a/crates/ars-forms/src/fieldset.rs
+++ b/crates/ars-forms/src/fieldset.rs
@@ -1,0 +1,756 @@
+//! Fieldset component state machine and connect API.
+//!
+//! This module implements the framework-agnostic `Fieldset` machine defined in
+//! `spec/foundation/07-forms.md` §12. The machine is intentionally stateless
+//! at the state-enum level and instead tracks disabled, invalid, readonly, and
+//! description/error wiring in its context.
+
+use core::fmt::{self, Debug};
+
+use ars_core::{
+    AriaAttr, AttrMap, ComponentIds, ComponentPart, ConnectApi, Direction, Env, HtmlAttr,
+    TransitionPlan,
+};
+
+use crate::validation::Error;
+
+/// Single state for the fieldset machine.
+///
+/// `Fieldset` is effectively stateless. All meaningful changes are stored in
+/// [`Context`] and applied through context-only transitions.
+#[derive(Clone, Debug, PartialEq)]
+pub enum State {
+    /// The fieldset is mounted and ready to expose its current context.
+    Idle,
+}
+
+/// Events that update fieldset context.
+#[derive(Clone, Debug)]
+pub enum Event {
+    /// Replaces the current fieldset-level validation errors.
+    SetErrors(Vec<Error>),
+
+    /// Clears all fieldset-level validation errors.
+    ClearErrors,
+
+    /// Synchronizes the disabled state from props.
+    SetDisabled(bool),
+
+    /// Synchronizes the invalid state from props.
+    SetInvalid(bool),
+
+    /// Synchronizes the readonly state from props.
+    SetReadonly(bool),
+
+    /// Synchronizes the layout direction from props.
+    SetDir(Option<Direction>),
+
+    /// Tracks whether a description part is currently rendered.
+    SetHasDescription(bool),
+}
+
+/// Mutable machine context for the fieldset component.
+#[derive(Clone, Debug, PartialEq)]
+pub struct MachineContext {
+    /// Whether the entire fieldset and all contained inputs are disabled.
+    pub disabled: bool,
+
+    /// Whether the fieldset is currently invalid.
+    pub invalid: bool,
+
+    /// Whether the fieldset is read-only.
+    pub readonly: bool,
+
+    /// The configured text direction for RTL-aware rendering.
+    pub dir: Option<Direction>,
+
+    /// Fieldset-level validation errors.
+    pub errors: Vec<Error>,
+
+    /// Whether a description part is rendered and should be referenced by ARIA.
+    pub has_description: bool,
+
+    /// Stable IDs derived from the adapter-provided base ID.
+    pub ids: ComponentIds,
+}
+
+/// Immutable configuration for a fieldset machine instance.
+#[derive(Clone, Debug, Default, PartialEq, ars_core::HasId)]
+pub struct Props {
+    /// Adapter-provided base ID for the fieldset root.
+    pub id: String,
+
+    /// Whether the entire fieldset and all contained inputs are disabled.
+    pub disabled: bool,
+
+    /// Whether the fieldset is invalid before error-driven state is applied.
+    pub invalid: bool,
+
+    /// Whether the fieldset is read-only.
+    pub readonly: bool,
+
+    /// The configured text direction for RTL-aware rendering.
+    pub dir: Option<Direction>,
+}
+
+/// Framework-agnostic fieldset state machine.
+#[derive(Debug)]
+pub struct Machine;
+
+impl ars_core::Machine for Machine {
+    type State = State;
+    type Event = Event;
+    type Context = MachineContext;
+    type Props = Props;
+    type Messages = ();
+    type Api<'a> = Api<'a>;
+
+    fn init(
+        props: &Self::Props,
+        _env: &Env,
+        _messages: &Self::Messages,
+    ) -> (Self::State, Self::Context) {
+        (
+            State::Idle,
+            MachineContext {
+                disabled: props.disabled,
+                invalid: props.invalid,
+                readonly: props.readonly,
+                dir: props.dir,
+                errors: Vec::new(),
+                has_description: false,
+                ids: ComponentIds::from_id(&props.id),
+            },
+        )
+    }
+
+    fn on_props_changed(old: &Self::Props, new: &Self::Props) -> Vec<Self::Event> {
+        let mut events = Vec::new();
+
+        if old.disabled != new.disabled {
+            events.push(Event::SetDisabled(new.disabled));
+        }
+
+        if old.invalid != new.invalid {
+            events.push(Event::SetInvalid(new.invalid));
+        }
+
+        if old.readonly != new.readonly {
+            events.push(Event::SetReadonly(new.readonly));
+        }
+
+        if old.dir != new.dir {
+            events.push(Event::SetDir(new.dir));
+        }
+
+        events
+    }
+
+    fn transition(
+        _state: &Self::State,
+        event: &Self::Event,
+        _ctx: &Self::Context,
+        props: &Self::Props,
+    ) -> Option<TransitionPlan<Self>> {
+        match event {
+            Event::SetErrors(errors) => {
+                let errors = errors.clone();
+                Some(TransitionPlan::context_only(
+                    move |ctx: &mut MachineContext| {
+                        ctx.errors = errors;
+                        ctx.invalid = !ctx.errors.is_empty();
+                    },
+                ))
+            }
+
+            Event::ClearErrors => {
+                let base_invalid = props.invalid;
+                Some(TransitionPlan::context_only(
+                    move |ctx: &mut MachineContext| {
+                        ctx.errors.clear();
+                        ctx.invalid = base_invalid;
+                    },
+                ))
+            }
+
+            Event::SetDisabled(disabled) => {
+                let disabled = *disabled;
+                Some(TransitionPlan::context_only(
+                    move |ctx: &mut MachineContext| {
+                        ctx.disabled = disabled;
+                    },
+                ))
+            }
+
+            Event::SetInvalid(invalid) => {
+                let invalid = *invalid;
+                Some(TransitionPlan::context_only(
+                    move |ctx: &mut MachineContext| {
+                        ctx.invalid = invalid || !ctx.errors.is_empty();
+                    },
+                ))
+            }
+
+            Event::SetReadonly(readonly) => {
+                let readonly = *readonly;
+                Some(TransitionPlan::context_only(
+                    move |ctx: &mut MachineContext| {
+                        ctx.readonly = readonly;
+                    },
+                ))
+            }
+
+            Event::SetDir(dir) => {
+                let dir = *dir;
+                Some(TransitionPlan::context_only(
+                    move |ctx: &mut MachineContext| {
+                        ctx.dir = dir;
+                    },
+                ))
+            }
+
+            Event::SetHasDescription(has_description) => {
+                let has_description = *has_description;
+                Some(TransitionPlan::context_only(
+                    move |ctx: &mut MachineContext| {
+                        ctx.has_description = has_description;
+                    },
+                ))
+            }
+        }
+    }
+
+    fn connect<'a>(
+        _state: &'a Self::State,
+        ctx: &'a Self::Context,
+        _props: &'a Self::Props,
+        _send: &'a dyn Fn(Self::Event),
+    ) -> Self::Api<'a> {
+        Api { ctx }
+    }
+}
+
+/// Snapshot connect API for deriving fieldset DOM attributes.
+pub struct Api<'a> {
+    ctx: &'a MachineContext,
+}
+
+impl Debug for Api<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Api").field("ctx", &self.ctx).finish()
+    }
+}
+
+/// Structural parts exposed by the fieldset connect API.
+#[derive(ComponentPart)]
+#[scope = "fieldset"]
+pub enum Part {
+    /// The root `<fieldset>` element.
+    Root,
+
+    /// The `<legend>` element naming the fieldset.
+    Legend,
+
+    /// The optional descriptive text element.
+    Description,
+
+    /// The fieldset-level error message element.
+    ErrorMessage,
+
+    /// The content wrapper for descendant fields.
+    Content,
+}
+
+impl ConnectApi for Api<'_> {
+    type Part = Part;
+
+    fn part_attrs(&self, part: Self::Part) -> AttrMap {
+        match part {
+            Part::Root => self.root_attrs(),
+            Part::Legend => self.legend_attrs(),
+            Part::Description => self.description_attrs(),
+            Part::ErrorMessage => self.error_message_attrs(),
+            Part::Content => self.content_attrs(),
+        }
+    }
+}
+
+impl<'a> Api<'a> {
+    /// Returns attributes for the root `<fieldset>` element.
+    #[must_use]
+    pub fn root_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Root.data_attrs();
+
+        attrs.set(HtmlAttr::Id, self.ctx.ids.id());
+        attrs.set(scope_attr, scope_val);
+        attrs.set(part_attr, part_val);
+
+        if self.ctx.disabled {
+            attrs.set_bool(HtmlAttr::Disabled, true);
+        }
+
+        if let Some(dir) = self.ctx.dir {
+            attrs.set(HtmlAttr::Dir, dir.as_html_attr());
+        }
+
+        let mut described_by_ids = Vec::new();
+
+        if self.ctx.has_description {
+            described_by_ids.push(self.ctx.ids.part("description"));
+        }
+
+        if !self.ctx.errors.is_empty() {
+            described_by_ids.push(self.ctx.ids.part("error-message"));
+        }
+
+        if !described_by_ids.is_empty() {
+            attrs.set(
+                HtmlAttr::Aria(AriaAttr::DescribedBy),
+                described_by_ids.join(" "),
+            );
+        }
+
+        attrs
+    }
+
+    /// Returns attributes for the `<legend>` element.
+    #[must_use]
+    pub fn legend_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Legend.data_attrs();
+
+        attrs.set(HtmlAttr::Id, self.ctx.ids.part("legend"));
+        attrs.set(scope_attr, scope_val);
+        attrs.set(part_attr, part_val);
+
+        attrs
+    }
+
+    /// Returns attributes for the description element.
+    #[must_use]
+    pub fn description_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Description.data_attrs();
+
+        attrs.set(HtmlAttr::Id, self.ctx.ids.part("description"));
+        attrs.set(scope_attr, scope_val);
+        attrs.set(part_attr, part_val);
+
+        attrs
+    }
+
+    /// Returns attributes for the fieldset error message element.
+    #[must_use]
+    pub fn error_message_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::ErrorMessage.data_attrs();
+
+        attrs.set(HtmlAttr::Id, self.ctx.ids.part("error-message"));
+        attrs.set(HtmlAttr::Role, "alert");
+        attrs.set(scope_attr, scope_val);
+        attrs.set(part_attr, part_val);
+
+        if self.ctx.errors.is_empty() {
+            attrs.set_bool(HtmlAttr::Hidden, true);
+        }
+
+        attrs
+    }
+
+    /// Returns attributes for the content wrapper.
+    #[must_use]
+    pub fn content_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Content.data_attrs();
+
+        attrs.set(scope_attr, scope_val);
+        attrs.set(part_attr, part_val);
+
+        attrs
+    }
+
+    /// Returns the current fieldset-level validation errors.
+    #[must_use]
+    pub fn errors(&self) -> &[Error] {
+        &self.ctx.errors
+    }
+
+    /// Returns whether the fieldset is disabled.
+    #[must_use]
+    pub const fn is_disabled(&self) -> bool {
+        self.ctx.disabled
+    }
+
+    /// Returns whether the fieldset is invalid.
+    #[must_use]
+    pub const fn is_invalid(&self) -> bool {
+        self.ctx.invalid
+    }
+
+    /// Returns whether the fieldset is read-only.
+    #[must_use]
+    pub const fn is_readonly(&self) -> bool {
+        self.ctx.readonly
+    }
+}
+
+/// Framework-context payload propagated from a fieldset to descendant fields.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct Context {
+    /// Optional group name inherited by child field components.
+    pub name: Option<String>,
+
+    /// Whether the parent fieldset is disabled.
+    pub disabled: bool,
+
+    /// Whether the parent fieldset is invalid.
+    pub invalid: bool,
+
+    /// Whether the parent fieldset is read-only.
+    pub readonly: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use ars_core::{ConnectApi, Service};
+
+    use super::*;
+
+    fn test_props() -> Props {
+        Props {
+            id: "billing".to_string(),
+            ..Props::default()
+        }
+    }
+
+    fn test_props_with_invalid() -> Props {
+        Props {
+            invalid: true,
+            ..test_props()
+        }
+    }
+
+    fn custom_error() -> Error {
+        Error::custom("group", "Group is invalid")
+    }
+
+    #[test]
+    fn fieldset_init_default_props() {
+        let service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        assert_eq!(service.state(), &State::Idle);
+        assert!(!service.context().disabled);
+        assert!(!service.context().invalid);
+        assert!(!service.context().readonly);
+        assert_eq!(service.context().dir, None);
+        assert!(service.context().errors.is_empty());
+        assert!(!service.context().has_description);
+        assert_eq!(service.context().ids.id(), "billing");
+        assert_eq!(service.context().ids.part("legend"), "billing-legend");
+    }
+
+    #[test]
+    fn fieldset_set_disabled_updates_context() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        let result = service.send(Event::SetDisabled(true));
+
+        assert!(!result.state_changed);
+        assert!(result.context_changed);
+        assert!(service.context().disabled);
+    }
+
+    #[test]
+    fn fieldset_set_invalid_updates_context_without_errors() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        let result = service.send(Event::SetInvalid(true));
+
+        assert!(!result.state_changed);
+        assert!(result.context_changed);
+        assert!(service.context().invalid);
+    }
+
+    #[test]
+    fn fieldset_set_invalid_preserves_error_driven_invalidity() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        drop(service.send(Event::SetErrors(vec![custom_error()])));
+        drop(service.send(Event::SetInvalid(false)));
+
+        assert!(service.context().invalid);
+    }
+
+    #[test]
+    fn fieldset_set_readonly_updates_context() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        let result = service.send(Event::SetReadonly(true));
+
+        assert!(!result.state_changed);
+        assert!(result.context_changed);
+        assert!(service.context().readonly);
+    }
+
+    #[test]
+    fn fieldset_set_dir_updates_context() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        let result = service.send(Event::SetDir(Some(Direction::Rtl)));
+
+        assert!(!result.state_changed);
+        assert!(result.context_changed);
+        assert_eq!(service.context().dir, Some(Direction::Rtl));
+    }
+
+    #[test]
+    fn fieldset_on_props_changed_emits_events() {
+        let old = Props {
+            id: "billing".to_string(),
+            disabled: false,
+            invalid: false,
+            readonly: false,
+            dir: None,
+        };
+
+        let new = Props {
+            id: "shipping".to_string(),
+            disabled: true,
+            invalid: true,
+            readonly: true,
+            dir: Some(Direction::Rtl),
+        };
+
+        let events = <Machine as ars_core::Machine>::on_props_changed(&old, &new);
+
+        assert_eq!(events.len(), 4);
+        assert!(matches!(events[0], Event::SetDisabled(true)));
+        assert!(matches!(events[1], Event::SetInvalid(true)));
+        assert!(matches!(events[2], Event::SetReadonly(true)));
+        assert!(matches!(events[3], Event::SetDir(Some(Direction::Rtl))));
+    }
+
+    #[test]
+    fn fieldset_root_attrs_disabled() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        drop(service.send(Event::SetDisabled(true)));
+
+        let api = service.connect(&|_| {});
+
+        let attrs = api.root_attrs();
+
+        assert_eq!(attrs.get(&HtmlAttr::Disabled), Some("true"));
+        assert!(!attrs.contains(&HtmlAttr::Aria(AriaAttr::Disabled)));
+    }
+
+    #[test]
+    fn fieldset_root_attrs_dir() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        drop(service.send(Event::SetDir(Some(Direction::Rtl))));
+
+        let api = service.connect(&|_| {});
+        let attrs = api.root_attrs();
+
+        assert_eq!(attrs.get(&HtmlAttr::Dir), Some("rtl"));
+    }
+
+    #[test]
+    fn fieldset_error_message_hidden_when_no_errors() {
+        let service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        let api = service.connect(&|_| {});
+
+        let attrs = api.error_message_attrs();
+
+        assert_eq!(attrs.get(&HtmlAttr::Hidden), Some("true"));
+    }
+
+    #[test]
+    fn fieldset_description_attrs_id() {
+        let service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        let api = service.connect(&|_| {});
+
+        let attrs = api.description_attrs();
+
+        assert_eq!(attrs.get(&HtmlAttr::Id), Some("billing-description"));
+    }
+
+    #[test]
+    fn fieldset_legend_attrs_id_and_data_attrs() {
+        let service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        let api = service.connect(&|_| {});
+
+        let attrs = api.legend_attrs();
+
+        assert_eq!(attrs.get(&HtmlAttr::Id), Some("billing-legend"));
+        assert_eq!(attrs.get(&HtmlAttr::Data("ars-scope")), Some("fieldset"));
+        assert_eq!(attrs.get(&HtmlAttr::Data("ars-part")), Some("legend"));
+    }
+
+    #[test]
+    fn fieldset_content_attrs_data_attrs() {
+        let service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        let api = service.connect(&|_| {});
+
+        let attrs = api.content_attrs();
+
+        assert_eq!(attrs.get(&HtmlAttr::Data("ars-scope")), Some("fieldset"));
+        assert_eq!(attrs.get(&HtmlAttr::Data("ars-part")), Some("content"));
+    }
+
+    #[test]
+    fn fieldset_context_propagation() {
+        let ctx = Context::default();
+
+        assert_eq!(
+            ctx,
+            Context {
+                name: None,
+                disabled: false,
+                invalid: false,
+                readonly: false,
+            }
+        );
+
+        let named = Context {
+            name: Some("address".to_string()),
+            disabled: true,
+            invalid: true,
+            readonly: true,
+        };
+
+        assert_eq!(named.name.as_deref(), Some("address"));
+        assert!(named.disabled);
+        assert!(named.invalid);
+        assert!(named.readonly);
+    }
+
+    #[test]
+    fn fieldset_set_errors_forces_invalid() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        drop(service.send(Event::SetErrors(vec![custom_error()])));
+
+        assert!(service.context().invalid);
+        assert_eq!(service.context().errors.len(), 1);
+    }
+
+    #[test]
+    fn fieldset_clear_errors_restores_prop_invalid() {
+        let mut service = Service::<Machine>::new(test_props_with_invalid(), &Env::default(), &());
+
+        drop(service.send(Event::SetErrors(vec![custom_error()])));
+        drop(service.send(Event::ClearErrors));
+
+        assert!(service.context().errors.is_empty());
+        assert!(service.context().invalid);
+    }
+
+    #[test]
+    fn fieldset_root_attrs_describedby_description_only() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        drop(service.send(Event::SetHasDescription(true)));
+
+        let api = service.connect(&|_| {});
+
+        let attrs = api.root_attrs();
+
+        assert_eq!(
+            attrs.get(&HtmlAttr::Aria(AriaAttr::DescribedBy)),
+            Some("billing-description")
+        );
+    }
+
+    #[test]
+    fn fieldset_root_attrs_describedby_description_and_error() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        drop(service.send(Event::SetHasDescription(true)));
+        drop(service.send(Event::SetErrors(vec![custom_error()])));
+
+        let api = service.connect(&|_| {});
+
+        let attrs = api.root_attrs();
+
+        assert_eq!(
+            attrs.get(&HtmlAttr::Aria(AriaAttr::DescribedBy)),
+            Some("billing-description billing-error-message")
+        );
+    }
+
+    #[test]
+    fn fieldset_root_attrs_omits_aria_invalid() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        drop(service.send(Event::SetErrors(vec![custom_error()])));
+
+        let api = service.connect(&|_| {});
+
+        let attrs = api.root_attrs();
+
+        assert!(!attrs.contains(&HtmlAttr::Aria(AriaAttr::Invalid)));
+    }
+
+    #[test]
+    fn fieldset_error_message_attrs_role_alert() {
+        let service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        let api = service.connect(&|_| {});
+
+        let attrs = api.error_message_attrs();
+
+        assert_eq!(attrs.get(&HtmlAttr::Role), Some("alert"));
+    }
+
+    #[test]
+    fn fieldset_part_attrs_delegate_for_all_parts() {
+        let service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        let api = service.connect(&|_| {});
+
+        assert_eq!(api.part_attrs(Part::Root), api.root_attrs());
+        assert_eq!(api.part_attrs(Part::Legend), api.legend_attrs());
+        assert_eq!(api.part_attrs(Part::Description), api.description_attrs());
+        assert_eq!(
+            api.part_attrs(Part::ErrorMessage),
+            api.error_message_attrs()
+        );
+        assert_eq!(api.part_attrs(Part::Content), api.content_attrs());
+    }
+
+    #[test]
+    fn fieldset_api_debug_is_stable() {
+        let service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        let api = service.connect(&|_| {});
+
+        let debug = format!("{api:?}");
+
+        assert!(debug.contains("Api"));
+        assert!(debug.contains("billing"));
+        assert!(debug.contains("MachineContext"));
+    }
+
+    #[test]
+    fn fieldset_getters_reflect_context() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        drop(service.send(Event::SetDisabled(true)));
+        drop(service.send(Event::SetReadonly(true)));
+        drop(service.send(Event::SetErrors(vec![custom_error()])));
+
+        let api = service.connect(&|_| {});
+
+        assert!(api.is_disabled());
+        assert!(api.is_invalid());
+        assert!(api.is_readonly());
+        assert_eq!(api.errors(), &[custom_error()]);
+    }
+}

--- a/crates/ars-forms/src/lib.rs
+++ b/crates/ars-forms/src/lib.rs
@@ -8,6 +8,8 @@
 //!
 //! - **[`field`]** — [`field::State`], [`field::Value`], [`field::Context`],
 //!   [`field::Descriptors`], [`field::InputAria`], [`field::ValueExt`]
+//! - **[`fieldset`]** — [`fieldset::State`], [`fieldset::Props`],
+//!   [`fieldset::Context`], [`fieldset::Part`]
 //! - **[`validation`]** — [`validation::Error`], [`validation::Result`],
 //!   [`validation::ResultExt`], [`validation::Validator`],
 //!   [`validation::BoxedValidator`], [`validation::Context`],
@@ -19,6 +21,7 @@
 //!   [`hidden_input::attrs()`], [`hidden_input::multi_attrs()`]
 
 pub mod field;
+pub mod fieldset;
 pub mod form;
 pub mod form_messages;
 pub mod form_submit;

--- a/spec/components/utility/fieldset.md
+++ b/spec/components/utility/fieldset.md
@@ -120,7 +120,7 @@ Fieldset
 ├── Root          <fieldset>  data-ars-scope="fieldset" data-ars-part="root"
 ├── Legend         <legend>   data-ars-part="legend"
 ├── Description   <div>      data-ars-part="description" (optional)
-├── {child fields}            Field components inherit disabled state via FieldCtx
+├── {child fields}            Field components inherit disabled state via Context
 └── ErrorMessage  <span>     data-ars-part="error-message" role="alert"
 ```
 
@@ -144,7 +144,7 @@ When rendering as a native `<fieldset>` with `<legend>`, no explicit `aria-label
 
 ## 4. Adapter Context Propagation
 
-Adapters MUST provide `FieldCtx` to descendant fields via framework context (`provide_context` in Leptos, `use_context_provider` in Dioxus). Child Field components consume this context to inherit disabled, invalid, and readonly states from their parent Fieldset.
+Adapters MUST provide `Context` to descendant fields via framework context (`provide_context` in Leptos, `use_context_provider` in Dioxus). Child Field components consume this context to inherit disabled, invalid, and readonly states from their parent Fieldset.
 
 ## 5. Library Parity
 

--- a/spec/foundation/07-forms.md
+++ b/spec/foundation/07-forms.md
@@ -2856,11 +2856,11 @@ pub enum Event {
 }
 ```
 
-#### 12.2.3 Fieldset Component Context
+#### 12.2.3 Fieldset Component MachineContext
 
 ```rust
 #[derive(Clone, Debug, PartialEq)]
-pub struct Context {
+pub struct MachineContext {
     /// Whether the entire fieldset and all contained inputs are disabled.
     pub disabled: bool,
     /// Whether the fieldset is in an invalid state.
@@ -2916,13 +2916,13 @@ pub struct Machine;
 impl ars_core::Machine for Machine {
     type State = State;
     type Event = Event;
-    type Context = Context;
+    type Context = MachineContext;
     type Props = Props;
     type Api<'a> = Api<'a>;
     type Messages = Messages;
 
     fn init(props: &Self::Props, _env: &Env, _messages: &Self::Messages) -> (Self::State, Self::Context) {
-        let ctx = Context {
+        let ctx = MachineContext {
             disabled: props.disabled,
             invalid: props.invalid,
             readonly: props.readonly,
@@ -3002,12 +3002,12 @@ impl ars_core::Machine for Machine {
     }
 
     fn connect<'a>(
-        state: &'a Self::State,
+        _state: &'a Self::State,
         ctx: &'a Self::Context,
-        props: &'a Self::Props,
-        send: &'a dyn Fn(Self::Event),
+        _props: &'a Self::Props,
+        _send: &'a dyn Fn(Self::Event),
     ) -> Self::Api<'a> {
-        Api { state, ctx, props, send }
+        Api { ctx }
     }
 }
 ```
@@ -3016,10 +3016,7 @@ impl ars_core::Machine for Machine {
 
 ```rust
 pub struct Api<'a> {
-    state: &'a State,
-    ctx: &'a Context,
-    props: &'a Props,
-    send: &'a dyn Fn(Event),
+    ctx: &'a MachineContext,
 }
 
 #[derive(ComponentPart)]

--- a/spec/foundation/07-forms.md
+++ b/spec/foundation/07-forms.md
@@ -2954,9 +2954,10 @@ impl ars_core::Machine for Machine {
         match event {
             Event::SetErrors(errors) => {
                 let errors = errors.clone();
+                let base_invalid = props.invalid;
                 Some(TransitionPlan::context_only(move |ctx| {
                     ctx.errors = errors;
-                    ctx.invalid = !ctx.errors.is_empty();
+                    ctx.invalid = base_invalid || !ctx.errors.is_empty();
                 }))
             }
             Event::ClearErrors => {
@@ -3371,9 +3372,10 @@ impl ars_core::Machine for Machine {
         match event {
             Event::SetErrors(errors) => {
                 let errors = errors.clone();
+                let base_invalid = props.invalid;
                 Some(TransitionPlan::context_only(move |ctx| {
                     ctx.errors = errors;
-                    ctx.invalid = !ctx.errors.is_empty();
+                    ctx.invalid = base_invalid || !ctx.errors.is_empty();
                 }))
             }
             Event::ClearErrors => {

--- a/spec/foundation/07-forms.md
+++ b/spec/foundation/07-forms.md
@@ -2884,6 +2884,10 @@ pub struct MachineContext {
 ```rust
 #[derive(Clone, Debug, PartialEq, HasId)]
 pub struct Props {
+    /// Adapter-provided base ID for the fieldset root.
+    ///
+    /// This ID is immutable for the lifetime of a machine instance because
+    /// `MachineContext::ids` caches the derived part IDs during initialization.
     pub id: String,
     /// Whether the entire fieldset and all contained inputs are disabled.
     pub disabled: bool,

--- a/spec/foundation/07-forms.md
+++ b/spec/foundation/07-forms.md
@@ -3193,6 +3193,17 @@ pub struct Context {
 }
 ```
 
+`Fieldset` reuses this shared type directly:
+
+```rust
+/// Framework-context payload propagated from a fieldset to descendant fields.
+///
+/// This aliases the shared `field::Context` type so framework context lookup
+/// stays consistent across `Fieldset`, `CheckboxGroup`, `RadioGroup`, and
+/// descendant `Field` components.
+pub type Context = crate::field::Context;
+```
+
 **Merge semantics**: When a `Field` detects a parent `Context`, it merges via logical OR:
 
 - `effective_disabled = field_props.disabled || field_ctx.disabled`


### PR DESCRIPTION
## Summary
- add the new `ars-forms` fieldset machine module and export it from the crate root
- implement the fieldset connect API, shared descendant context, and spec-aligned tests
- sync the forms/fieldset spec docs with the final public API and behavior

## Verification
- cargo test -p ars-forms fieldset_ --quiet
- cargo test -p ars-forms --quiet
- cargo xtask spec validate
- cargo llvm-cov test -p ars-forms --summary-only
- cargo xci

Closes #169