### PR TITLE
Implement overlay stack registry and supports_top_layer

### DIFF
--- a/crates/ars-dom/src/lib.rs
+++ b/crates/ars-dom/src/lib.rs
@@ -1,9 +1,10 @@
 //! DOM utilities for focus management, scroll control, z-index allocation,
-//! and platform feature detection.
+//! overlay stacking, and platform feature detection.
 //!
 //! This crate provides browser-level helpers shared across framework adapters,
-//! including focus management, scroll lock management for modal overlays, and
-//! platform capability detection.
+//! including focus management, scroll lock management for modal overlays,
+//! overlay stack registry for nested overlay dismissal, and platform capability
+//! detection.
 
 // Many ars-dom functions have cfg-gated web implementations that call
 // web_sys/js_sys APIs at runtime. The non-web stubs look const-eligible
@@ -17,6 +18,7 @@ mod announcer;
 pub mod focus;
 pub mod media;
 pub mod modality;
+pub mod overlay_stack;
 pub mod portal;
 pub mod positioning;
 mod scroll;
@@ -39,6 +41,10 @@ pub use media::{
     prefers_reduced_motion, prefers_reduced_transparency,
 };
 pub use modality::ModalityManager;
+pub use overlay_stack::{
+    OverlayEntry, contains_overlay, is_topmost, overlay_count, overlays_above, push_overlay,
+    remove_overlay, reset_overlay_stack, topmost_overlay,
+};
 #[cfg(feature = "web")]
 pub use portal::{
     ensure_portal_mount_root, get_or_create_portal_root, remove_inert_from_siblings,
@@ -57,7 +63,7 @@ pub use scroll_lock::{
 #[cfg(all(feature = "web", target_arch = "wasm32"))]
 pub use scroll_lock::{needs_ios_workaround, scrollbar_width};
 pub use url::{SafeUrl, UnsafeUrlError, is_safe_url, sanitize_url};
-pub use z_index::{ZIndexAllocator, next_z_index, reset_z_index};
+pub use z_index::{ZIndexAllocator, next_z_index, reset_z_index, supports_top_layer};
 
 /// Describes the platform capabilities available to the current runtime.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]

--- a/crates/ars-dom/src/overlay_stack.rs
+++ b/crates/ars-dom/src/overlay_stack.rs
@@ -1,0 +1,584 @@
+//! Global overlay stack registry for nested overlay dismissal.
+//!
+//! Overlay components (Dialog, Popover, Menu, Tooltip, etc.) register with a
+//! thread-local stack when they mount and deregister when they unmount. The
+//! stack determines:
+//!
+//! - **Topmost overlay** — only the topmost overlay responds to outside
+//!   interactions and Escape-key dismissal (spec §12.8 rule 1).
+//! - **Child overlay membership** — a click inside a child overlay does NOT
+//!   trigger `InteractOutside` on the parent (spec §12.8 rule 2).
+//! - **LIFO close ordering** — Escape / outside-click dismisses the topmost
+//!   overlay first; the parent remains open (spec §12.8 rule 3).
+//!
+//! # Thread-local design
+//!
+//! The stack is stored in a `thread_local!` `RefCell<Vec<OverlayEntry>>`.
+//! This is consistent with the z-index allocator (`z_index.rs`) and the
+//! library's `Rc`-based, single-threaded WASM-first design. Each thread
+//! maintains its own overlay stack.
+//!
+//! # Spec references
+//!
+//! - `spec/foundation/11-dom-utilities.md` §9 — Overlay Stack Registry
+//! - `spec/foundation/05-interactions.md` §12.8 — Nested Overlay Handling
+
+use std::cell::RefCell;
+
+// ---------------------------------------------------------------------------
+// Thread-local state
+// ---------------------------------------------------------------------------
+
+thread_local! {
+    /// Per-thread overlay stack. Entries are ordered by mount time: the last
+    /// entry is the topmost (most recently opened) overlay.
+    static OVERLAY_STACK: RefCell<Vec<OverlayEntry>> = const { RefCell::new(Vec::new()) };
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/// Metadata for a registered overlay in the global stack.
+///
+/// Each overlay component creates an `OverlayEntry` when it mounts and passes
+/// it to [`push_overlay`]. The entry records whether the overlay is modal
+/// (triggering scroll lock and background inert) and the allocated z-index
+/// (or `None` when using native CSS top-layer).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OverlayEntry {
+    /// Unique overlay identifier (matches the component's DOM id).
+    pub id: String,
+
+    /// Whether this overlay is modal (triggers scroll lock + background inert).
+    pub modal: bool,
+
+    /// Allocated z-index from [`super::z_index::next_z_index`], or `None` when
+    /// the overlay uses native CSS top-layer (see
+    /// [`super::z_index::supports_top_layer`]).
+    pub z_index: Option<u32>,
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Register an overlay on the global stack.
+///
+/// Called when an overlay component mounts. If an entry with the same `id`
+/// already exists, the call is a no-op to prevent double-registration from
+/// framework re-renders.
+///
+/// # Spec reference
+///
+/// `spec/foundation/11-dom-utilities.md` §9.3 — Overlay Stack Public API.
+/// `spec/foundation/05-interactions.md` §12.8 rule 4 — "Each overlay registers
+/// itself with a global overlay stack on mount."
+pub fn push_overlay(entry: OverlayEntry) {
+    OVERLAY_STACK.with(|stack| {
+        let mut stack = stack.borrow_mut();
+
+        if !stack.iter().any(|e| e.id == entry.id) {
+            stack.push(entry);
+        }
+    });
+}
+
+/// Deregister an overlay from the global stack.
+///
+/// Removes the entry with the given `id` regardless of its position in the
+/// stack (not limited to the topmost entry). Called when an overlay component
+/// unmounts. If no entry with the given `id` exists, the call is a no-op
+/// (safe to call multiple times).
+///
+/// # Spec reference
+///
+/// `spec/foundation/11-dom-utilities.md` §9.3 — Overlay Stack Public API.
+/// `spec/foundation/05-interactions.md` §12.8 rule 4 — "…and deregisters on
+/// unmount."
+pub fn remove_overlay(id: &str) {
+    OVERLAY_STACK.with(|stack| {
+        stack.borrow_mut().retain(|e| e.id != id);
+    });
+}
+
+/// Return the topmost (most recently opened) overlay, or `None` if the stack
+/// is empty.
+///
+/// The topmost overlay is the one that responds to outside interactions and
+/// Escape-key dismissal.
+///
+/// # Spec reference
+///
+/// `spec/foundation/05-interactions.md` §12.8 rule 1 — "Only the topmost
+/// overlay responds to outside interactions."
+#[must_use]
+pub fn topmost_overlay() -> Option<OverlayEntry> {
+    OVERLAY_STACK.with(|stack| stack.borrow().last().cloned())
+}
+
+/// Check whether the overlay with the given `id` is the topmost overlay.
+///
+/// Convenience wrapper around [`topmost_overlay`].
+#[must_use]
+pub fn is_topmost(id: &str) -> bool {
+    OVERLAY_STACK.with(|stack| stack.borrow().last().is_some_and(|entry| entry.id == id))
+}
+
+/// Return the IDs of all overlays stacked above the overlay with the given
+/// `id`.
+///
+/// Used by `InteractOutside` to determine whether a click target is inside a
+/// child overlay. If the `id` is not found in the stack, returns an empty
+/// `Vec`.
+///
+/// # Spec reference
+///
+/// `spec/foundation/05-interactions.md` §12.8 rule 2 — "A click inside a child
+/// overlay does NOT trigger `InteractOutside` on the parent."
+#[must_use]
+pub fn overlays_above(id: &str) -> Vec<String> {
+    OVERLAY_STACK.with(|stack| {
+        let stack = stack.borrow();
+
+        stack
+            .iter()
+            .position(|e| e.id == id)
+            .map_or_else(Vec::new, |idx| {
+                stack[idx + 1..]
+                    .iter()
+                    .map(|entry| entry.id.clone())
+                    .collect()
+            })
+    })
+}
+
+/// Check whether an overlay with the given `id` is currently registered.
+#[must_use]
+pub fn contains_overlay(id: &str) -> bool {
+    OVERLAY_STACK.with(|stack| stack.borrow().iter().any(|e| e.id == id))
+}
+
+/// Return the number of overlays currently on the stack.
+#[must_use]
+pub fn overlay_count() -> usize {
+    OVERLAY_STACK.with(|stack| stack.borrow().len())
+}
+
+/// Clear the overlay stack.
+///
+/// Intended for tests and application-level teardown (e.g., full-page
+/// navigation in an SPA). Matches [`super::z_index::reset_z_index`] in
+/// purpose.
+pub fn reset_overlay_stack() {
+    OVERLAY_STACK.with(|stack| stack.borrow_mut().clear());
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Mutex, MutexGuard};
+
+    use super::*;
+
+    /// Serializes overlay stack tests so they don't run in parallel.
+    ///
+    /// Although `thread_local!` is per-thread, the Rust test runner may reuse
+    /// threads across tests. Each test calls [`serial_reset()`] which acquires
+    /// this lock and clears thread-local state before the test body runs.
+    static TEST_SERIAL: Mutex<()> = Mutex::new(());
+
+    /// Acquire the serialization lock and reset global state.
+    ///
+    /// Returns a [`MutexGuard`] that keeps the lock held until dropped
+    /// (end of the calling test).
+    fn serial_reset() -> MutexGuard<'static, ()> {
+        let guard = TEST_SERIAL
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        reset_overlay_stack();
+
+        guard
+    }
+
+    /// Helper: create an `OverlayEntry` with sensible defaults.
+    fn entry(id: &str, modal: bool, z_index: Option<u32>) -> OverlayEntry {
+        OverlayEntry {
+            id: id.to_owned(),
+            modal,
+            z_index,
+        }
+    }
+
+    // == A. Push/pop operations =============================================
+
+    #[test]
+    fn push_adds_to_stack() {
+        let _g = serial_reset();
+
+        push_overlay(entry("dialog-1", false, Some(1000)));
+
+        assert_eq!(overlay_count(), 1);
+    }
+
+    #[test]
+    fn push_duplicate_id_is_noop() {
+        let _g = serial_reset();
+
+        push_overlay(entry("dialog-1", false, Some(1000)));
+        push_overlay(entry("dialog-1", true, Some(1001)));
+
+        assert_eq!(
+            overlay_count(),
+            1,
+            "duplicate ID must not add a second entry"
+        );
+    }
+
+    #[test]
+    fn push_duplicate_preserves_original_entry() {
+        let _g = serial_reset();
+
+        push_overlay(entry("dialog-1", false, Some(1000)));
+
+        // Attempt to re-register with different modal + z_index:
+        push_overlay(entry("dialog-1", true, Some(9999)));
+
+        let top = topmost_overlay().expect("stack not empty");
+
+        assert!(!top.modal, "original modal flag must be preserved");
+        assert_eq!(
+            top.z_index,
+            Some(1000),
+            "original z_index must be preserved"
+        );
+    }
+
+    #[test]
+    fn pop_removes_entry() {
+        let _g = serial_reset();
+
+        push_overlay(entry("dialog-1", false, Some(1000)));
+
+        assert_eq!(overlay_count(), 1);
+
+        remove_overlay("dialog-1");
+
+        assert_eq!(overlay_count(), 0);
+    }
+
+    #[test]
+    fn pop_unknown_id_is_noop() {
+        let _g = serial_reset();
+
+        push_overlay(entry("dialog-1", false, Some(1000)));
+
+        remove_overlay("nonexistent");
+
+        assert_eq!(
+            overlay_count(),
+            1,
+            "popping unknown ID must not remove anything"
+        );
+    }
+
+    #[test]
+    fn pop_mid_stack_preserves_order() {
+        let _g = serial_reset();
+
+        push_overlay(entry("a", false, Some(1000)));
+        push_overlay(entry("b", false, Some(1001)));
+        push_overlay(entry("c", false, Some(1002)));
+
+        remove_overlay("b");
+
+        assert_eq!(overlay_count(), 2);
+
+        // Remaining order: a, c
+        assert_eq!(
+            topmost_overlay().expect("stack not empty").id,
+            "c",
+            "topmost after mid-stack removal must be the last pushed"
+        );
+
+        assert!(contains_overlay("a"));
+        assert!(!contains_overlay("b"));
+    }
+
+    #[test]
+    fn double_pop_is_noop() {
+        let _g = serial_reset();
+
+        push_overlay(entry("dialog-1", false, Some(1000)));
+
+        remove_overlay("dialog-1");
+        remove_overlay("dialog-1"); // second pop — should not panic
+
+        assert_eq!(overlay_count(), 0);
+    }
+
+    // == B. Modal vs non-modal ==============================================
+
+    #[test]
+    fn push_modal_preserves_flag() {
+        let _g = serial_reset();
+
+        push_overlay(entry("modal-dialog", true, Some(1000)));
+
+        let top = topmost_overlay().expect("stack not empty");
+
+        assert!(top.modal, "modal flag must be preserved");
+    }
+
+    #[test]
+    fn push_non_modal_preserves_flag() {
+        let _g = serial_reset();
+
+        push_overlay(entry("popover-1", false, Some(1000)));
+
+        let top = topmost_overlay().expect("stack not empty");
+
+        assert!(!top.modal, "non-modal flag must be preserved");
+    }
+
+    // == C. Topmost overlay detection =======================================
+
+    #[test]
+    fn topmost_returns_last_pushed() {
+        let _g = serial_reset();
+
+        push_overlay(entry("a", false, Some(1000)));
+        push_overlay(entry("b", false, Some(1001)));
+
+        assert_eq!(topmost_overlay().expect("stack not empty").id, "b");
+    }
+
+    #[test]
+    fn topmost_returns_none_when_empty() {
+        let _g = serial_reset();
+
+        assert!(topmost_overlay().is_none());
+    }
+
+    #[test]
+    fn is_topmost_true_for_single_entry() {
+        let _g = serial_reset();
+
+        push_overlay(entry("only", false, Some(1000)));
+
+        assert!(is_topmost("only"));
+    }
+
+    #[test]
+    fn is_topmost_true_for_last() {
+        let _g = serial_reset();
+
+        push_overlay(entry("a", false, Some(1000)));
+        push_overlay(entry("b", false, Some(1001)));
+
+        assert!(is_topmost("b"));
+    }
+
+    #[test]
+    fn is_topmost_false_for_non_topmost() {
+        let _g = serial_reset();
+
+        push_overlay(entry("a", false, Some(1000)));
+        push_overlay(entry("b", false, Some(1001)));
+
+        assert!(!is_topmost("a"));
+    }
+
+    #[test]
+    fn is_topmost_false_when_empty() {
+        let _g = serial_reset();
+
+        assert!(!is_topmost("anything"));
+    }
+
+    #[test]
+    fn topmost_after_pop_returns_previous() {
+        let _g = serial_reset();
+
+        push_overlay(entry("a", false, Some(1000)));
+        push_overlay(entry("b", false, Some(1001)));
+
+        remove_overlay("b");
+
+        assert_eq!(topmost_overlay().expect("stack not empty").id, "a");
+    }
+
+    // == D. LIFO close ordering =============================================
+
+    #[test]
+    fn lifo_close_ordering() {
+        let _g = serial_reset();
+
+        push_overlay(entry("a", false, Some(1000)));
+        push_overlay(entry("b", false, Some(1001)));
+        push_overlay(entry("c", false, Some(1002)));
+
+        // Pop topmost first (LIFO)
+        assert_eq!(topmost_overlay().expect("not empty").id, "c");
+        remove_overlay("c");
+
+        assert_eq!(topmost_overlay().expect("not empty").id, "b");
+        remove_overlay("b");
+
+        assert_eq!(topmost_overlay().expect("not empty").id, "a");
+        remove_overlay("a");
+
+        assert!(topmost_overlay().is_none());
+    }
+
+    // == E. Child overlay queries ===========================================
+
+    #[test]
+    fn overlays_above_returns_children() {
+        let _g = serial_reset();
+
+        push_overlay(entry("dialog", true, Some(1000)));
+        push_overlay(entry("menu", false, Some(1001)));
+        push_overlay(entry("tooltip", false, Some(1002)));
+
+        let above = overlays_above("dialog");
+
+        assert_eq!(above, vec!["menu", "tooltip"]);
+    }
+
+    #[test]
+    fn overlays_above_empty_for_topmost() {
+        let _g = serial_reset();
+
+        push_overlay(entry("dialog", true, Some(1000)));
+        push_overlay(entry("menu", false, Some(1001)));
+
+        let above = overlays_above("menu");
+
+        assert!(above.is_empty(), "topmost overlay has no children above it");
+    }
+
+    #[test]
+    fn overlays_above_empty_for_unknown_id() {
+        let _g = serial_reset();
+
+        push_overlay(entry("dialog", true, Some(1000)));
+
+        let above = overlays_above("nonexistent");
+
+        assert!(above.is_empty(), "unknown ID must return empty vec");
+    }
+
+    #[test]
+    fn overlays_above_does_not_include_parent_or_below() {
+        let _g = serial_reset();
+
+        push_overlay(entry("a", false, Some(1000)));
+        push_overlay(entry("b", false, Some(1001)));
+        push_overlay(entry("c", false, Some(1002)));
+
+        let above_b = overlays_above("b");
+
+        assert_eq!(
+            above_b,
+            vec!["c"],
+            "must not include 'b' itself or 'a' below it"
+        );
+    }
+
+    // == F. Utility =========================================================
+
+    #[test]
+    fn contains_overlay_true_when_registered() {
+        let _g = serial_reset();
+
+        push_overlay(entry("dialog-1", false, Some(1000)));
+
+        assert!(contains_overlay("dialog-1"));
+    }
+
+    #[test]
+    fn contains_overlay_false_when_not() {
+        let _g = serial_reset();
+
+        assert!(!contains_overlay("dialog-1"));
+    }
+
+    #[test]
+    fn overlay_count_tracks_depth() {
+        let _g = serial_reset();
+
+        assert_eq!(overlay_count(), 0);
+
+        push_overlay(entry("a", false, Some(1000)));
+
+        assert_eq!(overlay_count(), 1);
+
+        push_overlay(entry("b", false, Some(1001)));
+
+        assert_eq!(overlay_count(), 2);
+
+        remove_overlay("a");
+
+        assert_eq!(overlay_count(), 1);
+    }
+
+    #[test]
+    fn reset_clears_all() {
+        let _g = serial_reset();
+
+        push_overlay(entry("a", false, Some(1000)));
+        push_overlay(entry("b", true, Some(1001)));
+
+        assert_eq!(overlay_count(), 2);
+
+        reset_overlay_stack();
+
+        assert_eq!(overlay_count(), 0);
+        assert!(topmost_overlay().is_none());
+    }
+
+    // == G. Z-index integration =============================================
+
+    #[test]
+    fn entry_carries_z_index() {
+        let _g = serial_reset();
+
+        push_overlay(entry("dialog", true, Some(1000)));
+
+        let top = topmost_overlay().expect("stack not empty");
+
+        assert_eq!(top.z_index, Some(1000));
+    }
+
+    #[test]
+    fn entry_z_index_none_for_top_layer() {
+        let _g = serial_reset();
+
+        push_overlay(entry("dialog", true, None));
+
+        let top = topmost_overlay().expect("stack not empty");
+
+        assert_eq!(top.z_index, None, "top-layer overlays have no z-index");
+    }
+
+    #[test]
+    fn entry_debug_format() {
+        let e = entry("dlg-1", true, Some(1000));
+
+        let debug = format!("{e:?}");
+
+        assert!(
+            debug.contains("OverlayEntry"),
+            "Debug output should contain the type name"
+        );
+        assert!(
+            debug.contains("dlg-1"),
+            "Debug output should contain the id"
+        );
+    }
+}

--- a/crates/ars-dom/src/z_index.rs
+++ b/crates/ars-dom/src/z_index.rs
@@ -69,6 +69,7 @@ thread_local! {
 pub fn next_z_index() -> u32 {
     NEXT_Z_INDEX.with(|z| {
         let val = z.get();
+
         if val >= Z_INDEX_CEILING {
             // Returning Z_INDEX_BASE here and storing BASE + 1 keeps the
             // sequence monotonic from the caller's perspective after wrap:
@@ -80,10 +81,13 @@ pub fn next_z_index() -> u32 {
                 "[ars-dom] z-index counter reached ceiling ({Z_INDEX_CEILING}), \
                  resetting to base ({Z_INDEX_BASE})"
             );
+
             z.set(Z_INDEX_BASE + 1);
+
             Z_INDEX_BASE
         } else {
             z.set(val + 1);
+
             val
         }
     })
@@ -124,10 +128,14 @@ pub fn reset_z_index(base: u32) {
 /// use ars_dom::z_index::{ZIndexAllocator, reset_z_index};
 ///
 /// reset_z_index(1000);
+///
 /// let allocator = ZIndexAllocator::new();
+///
 /// let z1 = allocator.allocate(); // 1000
 /// let z2 = allocator.allocate(); // 1001
+///
 /// allocator.release(z1);         // removes from tracking, does not reuse
+///
 /// let z3 = allocator.allocate(); // 1002 (not 1000)
 /// ```
 #[derive(Debug)]
@@ -157,7 +165,9 @@ impl ZIndexAllocator {
     #[must_use]
     pub fn allocate(&self) -> u32 {
         let z = next_z_index();
+
         self.allocated.borrow_mut().push(z);
+
         z
     }
 
@@ -177,6 +187,7 @@ impl ZIndexAllocator {
     /// navigation in an SPA).
     pub fn reset(&self) {
         self.allocated.borrow_mut().clear();
+
         reset_z_index(Z_INDEX_BASE);
     }
 }
@@ -185,6 +196,69 @@ impl Default for ZIndexAllocator {
     fn default() -> Self {
         Self::new()
     }
+}
+
+// ---------------------------------------------------------------------------
+// Top-layer detection
+// ---------------------------------------------------------------------------
+
+/// Check whether the browser supports the CSS top-layer (native `<dialog>` or
+/// Popover API).
+///
+/// Detected once per thread and cached. When top-layer is supported, overlay
+/// components can skip z-index allocation and rely on the browser's native
+/// stacking. Returns `false` in non-browser environments (SSR, native desktop,
+/// tests).
+///
+/// # Spec reference
+///
+/// `spec/foundation/11-dom-utilities.md` §6.5 — CSS `top-layer` Note.
+///
+/// # Examples
+///
+/// ```
+/// use ars_dom::z_index::supports_top_layer;
+///
+/// // In non-browser test environment, always returns false.
+/// assert!(!supports_top_layer());
+/// ```
+#[must_use]
+pub fn supports_top_layer() -> bool {
+    supports_top_layer_impl()
+}
+
+/// Web implementation: creates a temporary `<dialog>` element and checks for
+/// the `showModal` method via `js_sys::Reflect::has`. The result is cached in a
+/// thread-local `Cell<Option<bool>>` so the feature probe runs at most once per
+/// thread.
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
+fn supports_top_layer_impl() -> bool {
+    use std::cell::Cell;
+
+    thread_local! {
+        static CACHED: Cell<Option<bool>> = const { Cell::new(None) };
+    }
+
+    CACHED.with(|c| {
+        if let Some(v) = c.get() {
+            return v;
+        }
+
+        let supported = web_sys::window()
+            .and_then(|w| w.document())
+            .and_then(|d| d.create_element("dialog").ok())
+            .is_some_and(|el| js_sys::Reflect::has(&el, &"showModal".into()).unwrap_or(false));
+
+        c.set(Some(supported));
+
+        supported
+    })
+}
+
+/// Non-web fallback: top-layer is a browser-only concept.
+#[cfg(not(all(feature = "web", target_arch = "wasm32")))]
+const fn supports_top_layer_impl() -> bool {
+    false
 }
 
 // ---------------------------------------------------------------------------
@@ -225,7 +299,9 @@ mod tests {
         let guard = TEST_SERIAL
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
+
         reset_global_state();
+
         guard
     }
 
@@ -243,15 +319,18 @@ mod tests {
     #[test]
     fn next_z_index_starts_at_base() {
         let _g = serial_reset();
+
         assert_eq!(next_z_index(), 1000);
     }
 
     #[test]
     fn next_z_index_is_monotonically_increasing() {
         let _g = serial_reset();
+
         let z1 = next_z_index();
         let z2 = next_z_index();
         let z3 = next_z_index();
+
         assert_eq!(z1, 1000);
         assert_eq!(z2, 1001);
         assert_eq!(z3, 1002);
@@ -262,17 +341,24 @@ mod tests {
     #[test]
     fn next_z_index_wraps_at_ceiling() {
         let _g = serial_reset();
+
         reset_z_index(Z_INDEX_CEILING);
+
         let z = next_z_index();
+
         assert_eq!(z, Z_INDEX_BASE, "ceiling hit should return Z_INDEX_BASE");
     }
 
     #[test]
     fn next_z_index_resumes_after_wrap() {
         let _g = serial_reset();
+
         reset_z_index(Z_INDEX_CEILING);
+
         let _ = next_z_index(); // triggers wrap, returns Z_INDEX_BASE
+
         let z = next_z_index();
+
         assert_eq!(
             z,
             Z_INDEX_BASE + 1,
@@ -283,10 +369,15 @@ mod tests {
     #[test]
     fn next_z_index_one_below_ceiling_then_wraps() {
         let _g = serial_reset();
+
         reset_z_index(Z_INDEX_CEILING - 1);
+
         let z1 = next_z_index();
+
         assert_eq!(z1, Z_INDEX_CEILING - 1, "one below ceiling is still normal");
+
         let z2 = next_z_index();
+
         assert_eq!(z2, Z_INDEX_BASE, "next call hits ceiling and wraps");
     }
 
@@ -295,7 +386,9 @@ mod tests {
     #[test]
     fn reset_z_index_changes_next_value() {
         let _g = serial_reset();
+
         reset_z_index(5000);
+
         assert_eq!(next_z_index(), 5000);
         assert_eq!(next_z_index(), 5001);
     }
@@ -303,11 +396,14 @@ mod tests {
     #[test]
     fn reset_z_index_to_base_restores_default() {
         let _g = serial_reset();
+
         // Move counter forward
         let _ = next_z_index(); // 1000
         let _ = next_z_index(); // 1001
+
         // Reset back to base
         reset_z_index(Z_INDEX_BASE);
+
         assert_eq!(next_z_index(), 1000);
     }
 
@@ -316,10 +412,13 @@ mod tests {
     #[test]
     fn allocator_allocate_returns_increasing_values() {
         let _g = serial_reset();
+
         let alloc = ZIndexAllocator::new();
+
         let z1 = alloc.allocate();
         let z2 = alloc.allocate();
         let z3 = alloc.allocate();
+
         assert_eq!(z1, 1000);
         assert_eq!(z2, 1001);
         assert_eq!(z3, 1002);
@@ -328,11 +427,17 @@ mod tests {
     #[test]
     fn allocator_allocate_wraps_at_ceiling() {
         let _g = serial_reset();
+
         reset_z_index(Z_INDEX_CEILING);
+
         let alloc = ZIndexAllocator::new();
+
         let z1 = alloc.allocate();
+
         assert_eq!(z1, Z_INDEX_BASE, "allocator must wrap at ceiling");
+
         let z2 = alloc.allocate();
+
         assert_eq!(z2, Z_INDEX_BASE + 1, "allocator must resume after wrap");
         assert_eq!(alloc.tracked_count(), 2);
     }
@@ -340,12 +445,15 @@ mod tests {
     #[test]
     fn allocator_allocate_delegates_to_thread_local() {
         let _g = serial_reset();
+
         let alloc = ZIndexAllocator::new();
+
         // Interleave bare next_z_index() with allocator
         let z1 = next_z_index(); // 1000 (bare)
         let z2 = alloc.allocate(); // 1001 (allocator)
         let z3 = next_z_index(); // 1002 (bare)
         let z4 = alloc.allocate(); // 1003 (allocator)
+
         assert_eq!(z1, 1000);
         assert_eq!(z2, 1001);
         assert_eq!(z3, 1002);
@@ -357,44 +465,64 @@ mod tests {
     #[test]
     fn allocator_release_removes_from_tracked() {
         let _g = serial_reset();
+
         let alloc = ZIndexAllocator::new();
+
         let z1 = alloc.allocate();
         let _z2 = alloc.allocate();
+
         assert_eq!(alloc.tracked_count(), 2);
+
         alloc.release(z1);
+
         assert_eq!(alloc.tracked_count(), 1);
     }
 
     #[test]
     fn allocator_release_unknown_is_noop() {
         let _g = serial_reset();
+
         let alloc = ZIndexAllocator::new();
+
         // Release a value that was never allocated — should not panic.
         alloc.release(9999);
+
         assert_eq!(alloc.tracked_count(), 0);
     }
 
     #[test]
     fn allocator_release_does_not_affect_counter() {
         let _g = serial_reset();
+
         let alloc = ZIndexAllocator::new();
+
         let z1 = alloc.allocate(); // 1000
+
         alloc.release(z1);
+
         let z2 = alloc.allocate(); // 1001, NOT 1000 (values never reused)
+
         assert_eq!(z2, 1001);
     }
 
     #[test]
     fn allocator_double_release_is_noop() {
         let _g = serial_reset();
+
         let alloc = ZIndexAllocator::new();
+
         let z1 = alloc.allocate();
         let _z2 = alloc.allocate();
+
         assert_eq!(alloc.tracked_count(), 2);
+
         alloc.release(z1);
+
         assert_eq!(alloc.tracked_count(), 1);
+
         // Second release of same value — already removed, no panic.
         alloc.release(z1);
+
         assert_eq!(
             alloc.tracked_count(),
             1,
@@ -405,12 +533,18 @@ mod tests {
     #[test]
     fn allocator_release_after_reset_is_noop() {
         let _g = serial_reset();
+
         let alloc = ZIndexAllocator::new();
+
         let z1 = alloc.allocate();
+
         alloc.reset();
+
         assert_eq!(alloc.tracked_count(), 0);
+
         // Release a value that was cleared by reset — should not panic.
         alloc.release(z1);
+
         assert_eq!(alloc.tracked_count(), 0);
     }
 
@@ -419,12 +553,18 @@ mod tests {
     #[test]
     fn allocator_reset_clears_tracked_and_resets_counter() {
         let _g = serial_reset();
+
         let alloc = ZIndexAllocator::new();
+
         let _ = alloc.allocate(); // 1000
         let _ = alloc.allocate(); // 1001
+
         assert_eq!(alloc.tracked_count(), 2);
+
         alloc.reset();
+
         assert_eq!(alloc.tracked_count(), 0);
+
         // Counter should be back at base
         assert_eq!(alloc.allocate(), 1000);
     }
@@ -434,18 +574,73 @@ mod tests {
     #[test]
     fn allocator_default_is_empty() {
         let _g = serial_reset();
+
         let alloc = ZIndexAllocator::default();
+
         assert_eq!(alloc.tracked_count(), 0);
     }
 
     #[test]
     fn allocator_debug_format() {
         let _g = serial_reset();
+
         let alloc = ZIndexAllocator::new();
+
         let debug = format!("{alloc:?}");
+
         assert!(
             debug.contains("ZIndexAllocator"),
             "Debug output should contain the type name"
         );
+    }
+
+    // == G. supports_top_layer() ============================================
+
+    #[test]
+    fn supports_top_layer_returns_false_in_test_environment() {
+        // Native test runner (not wasm32) has no browser — always false.
+        assert!(!supports_top_layer());
+    }
+
+    #[test]
+    fn supports_top_layer_is_idempotent() {
+        // Multiple calls must return the same value (tests caching contract).
+        let first = supports_top_layer();
+
+        let second = supports_top_layer();
+
+        assert_eq!(first, second);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// WASM browser tests
+// ---------------------------------------------------------------------------
+
+#[cfg(all(test, feature = "web", target_arch = "wasm32"))]
+mod wasm_tests {
+    use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+
+    use super::*;
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    // == supports_top_layer() in a real browser =============================
+
+    #[wasm_bindgen_test]
+    fn supports_top_layer_returns_true_in_modern_browser() {
+        // Modern headless browsers (Chrome, Firefox) support <dialog>.showModal()
+        // and therefore the CSS top-layer. The function must detect this.
+        assert!(supports_top_layer());
+    }
+
+    #[wasm_bindgen_test]
+    fn supports_top_layer_caches_across_calls() {
+        // Exercises the Cell<Option<bool>> cache-hit path inside the web impl.
+        let first = supports_top_layer();
+
+        let second = supports_top_layer();
+
+        assert_eq!(first, second);
     }
 }

--- a/spec/foundation/03-accessibility.md
+++ b/spec/foundation/03-accessibility.md
@@ -3239,7 +3239,7 @@ Windows High Contrast Mode (WHCM) and CSS `forced-colors` media feature apply a 
 3. Focus indicators must use `Highlight` or `ButtonText` in forced-colors mode — never `transparent`.
 4. Custom SVG icons must have `fill: currentColor` or `forced-color-adjust: auto` to inherit system colors.
 
-> **Canonical location:** `11-dom-utilities.md` §9 — media query utilities including
+> **Canonical location:** `11-dom-utilities.md` §10 — media query utilities including
 > `is_forced_colors_active()`, `prefers_reduced_motion()`, `prefers_reduced_transparency()`,
 > and `prefers_color_scheme()`. These live in `ars-dom` because they depend on `web_sys::window()`.
 > Components import directly from `ars_dom::media`. (The `ars-a11y` re-export originally planned
@@ -3330,7 +3330,7 @@ pub fn resolve_opaque_backdrop(override_: Option<bool>) -> bool {
 }
 ```
 
-> **Note:** `prefers-reduced-transparency` has limited browser support (Chrome 118+, no Firefox/Safari as of 2026). The `prefers_reduced_transparency()` function in `11-dom-utilities.md` §9 returns `false` when unsupported, so the fallback behavior is safe — components render normally on browsers that don't support the media query.
+> **Note:** `prefers-reduced-transparency` has limited browser support (Chrome 118+, no Firefox/Safari as of 2026). The `prefers_reduced_transparency()` function in `11-dom-utilities.md` §10 returns `false` when unsupported, so the fallback behavior is safe — components render normally on browsers that don't support the media query.
 
 ### 6.4 Focus Indicator Contrast Requirements
 

--- a/spec/foundation/05-interactions.md
+++ b/spec/foundation/05-interactions.md
@@ -3073,7 +3073,7 @@ pub use ars_dom::media::is_forced_colors_active;
 
 Components that apply inline styles for visual feedback (e.g., drag preview opacity, hover background) SHOULD check `is_forced_colors_active()` and skip custom color overrides when forced colors are active, allowing the system colors to take effect.
 
-> **`matchMedia()` Caching:** Cache the `MediaQueryList` **object** (not the boolean result) in a `thread_local! { static MQL: OnceCell<Option<web_sys::MediaQueryList>> }`. On each call, read `.matches()` from the cached object — this is a live property that always reflects the current state, so no explicit `change` event listener is needed. See `11-dom-utilities.md` §9 for the canonical caching pattern.
+> **`matchMedia()` Caching:** Cache the `MediaQueryList` **object** (not the boolean result) in a `thread_local! { static MQL: OnceCell<Option<web_sys::MediaQueryList>> }`. On each call, read `.matches()` from the cached object — this is a live property that always reflects the current state, so no explicit `change` event listener is needed. See `11-dom-utilities.md` §10 for the canonical caching pattern.
 
 ### 10.5 Forced-Colors Testing Requirements
 
@@ -4350,10 +4350,10 @@ Portal-rendered content is DOM-detached from the component tree. The detection a
 
 When overlays are nested (e.g., a Menu opens a sub-menu, or a Dialog contains a Select dropdown):
 
-1. **Only the topmost overlay responds to outside interactions.** The overlay stack (managed by the z-index system, `11-dom-utilities.md` §6) determines ordering.
-2. **A click inside a child overlay does NOT trigger `InteractOutside` on the parent.** The detection algorithm checks the full overlay stack, not just direct DOM containment.
+1. **Only the topmost overlay responds to outside interactions.** The overlay stack (`11-dom-utilities.md` §9) determines ordering via `is_topmost()`.
+2. **A click inside a child overlay does NOT trigger `InteractOutside` on the parent.** The detection algorithm checks `overlays_above()` (`11-dom-utilities.md` §9.3), not just direct DOM containment.
 3. **Closing order is top-down.** Escape key and outside-click dismiss the topmost overlay first. The parent overlay remains open until it receives its own dismiss signal.
-4. **Stack registration:** Each overlay registers itself with a global overlay stack on mount and deregisters on unmount. `InteractOutside` consults this stack to determine whether the `elementFromPoint()`-resolved element (from §12.3 step 2) is inside any child overlay. Note: `event.target` is unreliable during pointer capture.
+4. **Stack registration:** Each overlay registers itself with the global overlay stack (`push_overlay()`) on mount and deregisters (`remove_overlay()`) on unmount. `InteractOutside` consults this stack to determine whether the `elementFromPoint()`-resolved element (from §12.3 step 2) is inside any child overlay. Note: `event.target` is unreliable during pointer capture. See `11-dom-utilities.md` §9.4 for the full integration pattern.
 
 ### 12.9 Component Cross-References
 

--- a/spec/foundation/11-dom-utilities.md
+++ b/spec/foundation/11-dom-utilities.md
@@ -2484,7 +2484,7 @@ The library detects top-layer support at runtime. When available, overlay compon
 /// This is detected once and cached.
 pub fn supports_top_layer() -> bool {
     thread_local! {
-        static CACHED: Cell<Option<bool>> = Cell::new(None);
+        static CACHED: Cell<Option<bool>> = const { Cell::new(None) };
     }
     CACHED.with(|c| {
         if let Some(v) = c.get() {
@@ -2493,8 +2493,9 @@ pub fn supports_top_layer() -> bool {
         let supported = web_sys::window()
             .and_then(|w| w.document())
             .and_then(|d| d.create_element("dialog").ok())
-            .map(|el| js_sys::Reflect::has(&el, &"showModal".into()).unwrap_or(false))
-            .unwrap_or(false);
+            .is_some_and(|el| {
+                js_sys::Reflect::has(&el, &"showModal".into()).unwrap_or(false)
+            });
         c.set(Some(supported));
         supported
     })
@@ -2721,7 +2722,170 @@ impl ModalityManager {
 
 ---
 
-## 9. Media Query Utilities
+## 9. Overlay Stack Registry
+
+### 9.1 Overview
+
+Overlay components (Dialog, Popover, Menu, Tooltip, etc.) register with a global thread-local stack when they mount and deregister when they unmount. The stack determines:
+
+- **Topmost overlay** — only the topmost overlay responds to outside interactions and Escape-key dismissal (`05-interactions.md` §12.8 rule 1).
+- **Child overlay membership** — a click inside a child overlay does NOT trigger `InteractOutside` on the parent (`05-interactions.md` §12.8 rule 2).
+- **LIFO close ordering** — Escape / outside-click dismisses the topmost overlay first; the parent remains open (`05-interactions.md` §12.8 rule 3).
+
+The overlay stack is distinct from the z-index allocator (§6). The allocator assigns stacking-order values; the overlay stack tracks which overlays are currently open and their nesting relationship. Overlay components use both: `next_z_index()` for visual stacking order and the overlay stack for dismissal logic.
+
+### 9.2 Thread-Local Design
+
+The stack is stored in a `thread_local!` `RefCell<Vec<OverlayEntry>>`, consistent with the z-index allocator (§6.2) and the library's `Rc`-based, single-threaded WASM-first design. Each thread maintains its own overlay stack.
+
+### 9.3 Types and Public API
+
+```rust
+// ars-dom/src/overlay_stack.rs
+
+use std::cell::RefCell;
+
+thread_local! {
+    /// Per-thread overlay stack. Entries are ordered by mount time: the last
+    /// entry is the topmost (most recently opened) overlay.
+    static OVERLAY_STACK: RefCell<Vec<OverlayEntry>> = const { RefCell::new(Vec::new()) };
+}
+
+/// Metadata for a registered overlay in the global stack.
+///
+/// Each overlay component creates an `OverlayEntry` when it mounts and passes
+/// it to `push_overlay()`. The entry records whether the overlay is modal
+/// (triggering scroll lock and background inert) and the allocated z-index
+/// (or `None` when using native CSS top-layer).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OverlayEntry {
+    /// Unique overlay identifier (matches the component's DOM id).
+    pub id: String,
+
+    /// Whether this overlay is modal (triggers scroll lock + background inert).
+    pub modal: bool,
+
+    /// Allocated z-index from `next_z_index()` (§6), or `None` when the overlay
+    /// uses native CSS top-layer (see `supports_top_layer()` in §6.5).
+    pub z_index: Option<u32>,
+}
+
+/// Register an overlay on the global stack.
+///
+/// Called when an overlay component mounts. If an entry with the same `id`
+/// already exists, the call is a no-op to prevent double-registration from
+/// framework re-renders.
+pub fn push_overlay(entry: OverlayEntry) {
+    OVERLAY_STACK.with(|stack| {
+        let mut stack = stack.borrow_mut();
+        if !stack.iter().any(|e| e.id == entry.id) {
+            stack.push(entry);
+        }
+    });
+}
+
+/// Deregister an overlay from the global stack.
+///
+/// Removes the entry with the given `id` regardless of its position in the
+/// stack (not limited to the topmost entry). Called when an overlay component
+/// unmounts. If no entry with the given `id` exists, the call is a no-op
+/// (safe to call multiple times).
+pub fn remove_overlay(id: &str) {
+    OVERLAY_STACK.with(|stack| {
+        stack.borrow_mut().retain(|e| e.id != id);
+    });
+}
+
+/// Return the topmost (most recently opened) overlay, or `None` if the stack
+/// is empty.
+pub fn topmost_overlay() -> Option<OverlayEntry> {
+    OVERLAY_STACK.with(|stack| stack.borrow().last().cloned())
+}
+
+/// Check whether the overlay with the given `id` is the topmost overlay.
+pub fn is_topmost(id: &str) -> bool {
+    OVERLAY_STACK.with(|stack| stack.borrow().last().is_some_and(|entry| entry.id == id))
+}
+
+/// Return the IDs of all overlays stacked above the overlay with the given
+/// `id`. Used by `InteractOutside` to determine whether a click target is
+/// inside a child overlay. Returns an empty `Vec` if `id` is not found.
+pub fn overlays_above(id: &str) -> Vec<String> {
+    OVERLAY_STACK.with(|stack| {
+        let stack = stack.borrow();
+        let pos = stack.iter().position(|e| e.id == id);
+        match pos {
+            Some(idx) => stack[idx + 1..].iter().map(|e| e.id.clone()).collect(),
+            None => Vec::new(),
+        }
+    })
+}
+
+/// Check whether an overlay with the given `id` is currently registered.
+pub fn contains_overlay(id: &str) -> bool {
+    OVERLAY_STACK.with(|stack| stack.borrow().iter().any(|e| e.id == id))
+}
+
+/// Return the number of overlays currently on the stack.
+pub fn overlay_count() -> usize {
+    OVERLAY_STACK.with(|stack| stack.borrow().len())
+}
+
+/// Clear the overlay stack.
+///
+/// Intended for tests and application-level teardown (e.g., full-page
+/// navigation in an SPA). Matches `reset_z_index()` (§6.2) in purpose.
+pub fn reset_overlay_stack() {
+    OVERLAY_STACK.with(|stack| stack.borrow_mut().clear());
+}
+```
+
+### 9.4 Usage by Overlay Components
+
+Each overlay component calls `push_overlay()` when it mounts (opens) and `remove_overlay()` when it unmounts (closes):
+
+```rust
+// Inside an overlay component's connect function:
+let z = if supports_top_layer() {
+    None
+} else {
+    Some(next_z_index())
+};
+
+push_overlay(OverlayEntry {
+    id: ids.base.clone(),
+    modal: true,
+    z_index: z,
+});
+
+// On unmount (effect cleanup):
+remove_overlay(&ids.base);
+```
+
+`InteractOutside` (see `05-interactions.md` §12.8) consults the overlay stack via `is_topmost()` and `overlays_above()` to implement nested overlay dismissal:
+
+1. Before processing an outside interaction, check `is_topmost(my_id)` — only the topmost overlay responds.
+2. Before firing `InteractOutsideEvent::PointerOutside`, check whether the resolved element is inside any ID returned by `overlays_above(my_id)` — clicks inside child overlays are not "outside."
+
+### 9.5 Components That Use the Overlay Stack
+
+All components listed in §6.4 (Z-Index Allocator users) also register with the overlay stack:
+
+- Dialog (modal and non-modal)
+- AlertDialog
+- Popover
+- Menu
+- Tooltip
+- Toast
+- HoverCard
+- Select (listbox overlay)
+- Combobox (listbox overlay)
+- DatePicker (calendar overlay)
+- Drawer
+
+---
+
+## 10. Media Query Utilities
 
 ```rust
 // crates/ars-dom/src/media.rs
@@ -2778,7 +2942,7 @@ pub enum ColorScheme { Light, Dark }
 
 ---
 
-## 10. URL Sanitization
+## 11. URL Sanitization
 
 All URL-valued attributes (`HtmlAttr::Href`, `HtmlAttr::Action`, `HtmlAttr::FormAction`) must be validated before rendering to prevent URL injection attacks (e.g., `javascript:`, `data:`, `vbscript:` schemes).
 


### PR DESCRIPTION
## Summary

- **New `overlay_stack` module** in `ars-dom` — global thread-local registry for nested overlay dismissal (`push_overlay`, `remove_overlay`, `topmost_overlay`, `is_topmost`, `overlays_above`, `contains_overlay`, `overlay_count`, `reset_overlay_stack`, `OverlayEntry`)
- **New `supports_top_layer()` function** in `z_index.rs` — runtime detection of CSS top-layer support via `<dialog>.showModal` probe, with cfg-gated web/non-web implementations and thread-local caching
- **Spec §9 added** to `11-dom-utilities.md` — Overlay Stack Registry (§9.1–§9.5) with types, public API, usage patterns, and component list; renumbered downstream sections and updated all cross-references in `03-accessibility.md`, `05-interactions.md`, and `11-dom-utilities.md`
- **Clippy fix**: `.map().unwrap_or(false)` → `.is_some_and()` in web `supports_top_layer_impl`, synced back to spec §6.5 code example

## Test plan

- [x] 28 native unit tests for overlay stack (push/pop/duplicate/mid-stack removal/LIFO ordering/child queries/modal flags/debug format/z-index integration)
- [x] 2 `wasm_bindgen_test` browser tests for `supports_top_layer` (true-in-modern-browser + cache-hit path)
- [x] 2 native tests for `supports_top_layer` (false-in-test-env + idempotent caching)
- [x] All 202 native tests + 4 doctests pass
- [x] Clippy clean on both native and `wasm32-unknown-unknown`
- [x] Spec validation passes (`cargo xtask spec validate`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)