### PR TITLE
[codex] Implement built-in validators for ars-forms

### DIFF
--- a/crates/ars-forms/Cargo.toml
+++ b/crates/ars-forms/Cargo.toml
@@ -8,14 +8,23 @@ repository.workspace   = true
 rust-version.workspace = true
 
 [features]
-default = []
-serde   = []
+default          = ["email-validation", "url-validation"]
+email-validation = ["dep:addr-spec"]
+url-validation   = ["dep:url"]
+serde            = []
 
 [dependencies]
 ars-collections = { path = "../ars-collections" }
 ars-core        = { path = "../ars-core" }
 ars-i18n        = { path = "../ars-i18n" }
-indexmap        = "2"
+indexmap        = "2.14"
+regex           = "1.12"
+url             = { version = "2.5", optional = true }
+
+[dependencies.addr-spec]
+version  = "0.9.1"
+optional = true
+features = ["normalization", "comments", "white-spaces", "literals"]
 
 [lints]
 workspace = true

--- a/crates/ars-forms/src/form/context.rs
+++ b/crates/ars-forms/src/form/context.rs
@@ -200,13 +200,6 @@ impl Validator for AnyValidator {
 /// A type-erased cross-field validation function.
 ///
 /// Uses [`Arc`](std::sync::Arc) on all targets for shared ownership.
-#[cfg(target_arch = "wasm32")]
-type CrossFieldValidateFn = Arc<dyn Fn(&Value, &ValContext) -> Result>;
-
-/// A type-erased cross-field validation function.
-///
-/// Uses [`Arc`](std::sync::Arc) on all targets for shared ownership.
-#[cfg(not(target_arch = "wasm32"))]
 type CrossFieldValidateFn = Arc<dyn Fn(&Value, &ValContext) -> Result + Send + Sync>;
 
 /// Validates a field using values from other fields in the form.
@@ -1303,27 +1296,16 @@ mod tests {
         assert_eq!(collected[0].0, "email");
     }
 
-    #[cfg(target_arch = "wasm32")]
     #[test]
-    #[expect(
-        clippy::arc_with_non_send_sync,
-        reason = "CrossFieldValidateFn intentionally preserves single-threaded wasm closures"
-    )]
-    fn cross_field_validator_allows_non_send_captures_on_wasm() {
-        use std::{cell::RefCell, rc::Rc};
+    fn cross_field_validator_is_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
 
-        let hits = Rc::new(RefCell::new(0_u8));
         let validator = CrossFieldValidator {
             depends_on: vec![String::from("password")],
-            validate_fn: Arc::new({
-                let hits = Rc::clone(&hits);
-                move |_value, _ctx| {
-                    *hits.borrow_mut() += 1;
-                    Ok(())
-                }
-            }),
+            validate_fn: Arc::new(|_value, _ctx| Ok(())),
         };
 
+        assert_send_sync::<CrossFieldValidator>();
         assert!(
             validator
                 .validate(
@@ -1332,7 +1314,6 @@ mod tests {
                 )
                 .is_ok()
         );
-        assert_eq!(*hits.borrow(), 1);
     }
 
     // ── validate_all true path ──────────────────────────────────────────

--- a/crates/ars-forms/src/validation/built_in.rs
+++ b/crates/ars-forms/src/validation/built_in.rs
@@ -188,7 +188,7 @@ impl Validator for MinValidator {
 
         let locale = ctx.locale.unwrap_or(&DEFAULT_VALIDATOR_LOCALE);
 
-        if !number.is_finite() || number < self.min {
+        if !number.is_finite() || !self.min.is_finite() || number < self.min {
             let error = self.message.clone().map_or_else(
                 || Error::min(self.min, &FormMessages::default(), locale),
                 |message| Error {
@@ -237,7 +237,7 @@ impl Validator for MaxValidator {
 
         let locale = ctx.locale.unwrap_or(&DEFAULT_VALIDATOR_LOCALE);
 
-        if !number.is_finite() || number > self.max {
+        if !number.is_finite() || !self.max.is_finite() || number > self.max {
             let error = self.message.clone().map_or_else(
                 || Error::max(self.max, &FormMessages::default(), locale),
                 |message| Error {
@@ -506,7 +506,7 @@ impl Validator for StepValidator {
 
             let quotient = (number - self.step_base) / self.step;
             let nearest_step = quotient.round();
-            let tolerance = quotient.abs().max(1.0) * f64::EPSILON * 16.0;
+            let tolerance = (quotient.abs().max(1.0) * f64::EPSILON * 16.0).min(1e-9);
 
             if (quotient - nearest_step).abs() > tolerance {
                 let locale = ctx.locale.unwrap_or(&DEFAULT_VALIDATOR_LOCALE);
@@ -867,6 +867,16 @@ mod tests {
     }
 
     #[test]
+    fn min_nan_bound_fails() {
+        let validator = MinValidator::with_value(f64::NAN);
+
+        assert!(matches!(
+            error_code(validator.validate(&Value::Number(Some(1.0)), &Context::standalone("x"))),
+            ErrorCode::Min(min) if min.is_nan()
+        ));
+    }
+
+    #[test]
     fn max_nan_fails() {
         let validator = MaxValidator::with_value(10.0);
 
@@ -876,6 +886,16 @@ mod tests {
             ),
             ErrorCode::Max(10.0)
         );
+    }
+
+    #[test]
+    fn max_nan_bound_fails() {
+        let validator = MaxValidator::with_value(f64::NAN);
+
+        assert!(matches!(
+            error_code(validator.validate(&Value::Number(Some(1.0)), &Context::standalone("x"))),
+            ErrorCode::Max(max) if max.is_nan()
+        ));
     }
 
     #[test]
@@ -1104,6 +1124,19 @@ mod tests {
     }
 
     #[test]
+    fn step_large_off_grid_value_fails() {
+        let validator = StepValidator::new(0.1);
+
+        assert_eq!(
+            error_code(validator.validate(
+                &Value::Number(Some(10_000_000_000_000.03)),
+                &Context::standalone("x")
+            )),
+            ErrorCode::Step(0.1)
+        );
+    }
+
+    #[test]
     fn step_zero_fails() {
         let validator = StepValidator::new(0.0);
 
@@ -1251,7 +1284,7 @@ mod tests {
         assert_eq!(
             error_code(validator.validate(
                 &Value::Text("://example.com".into()),
-                 &Context::standalone("x")
+                &Context::standalone("x")
             )),
             ErrorCode::Url
         );

--- a/crates/ars-forms/src/validation/built_in.rs
+++ b/crates/ars-forms/src/validation/built_in.rs
@@ -188,7 +188,7 @@ impl Validator for MinValidator {
 
         let locale = ctx.locale.unwrap_or(&DEFAULT_VALIDATOR_LOCALE);
 
-        if number < self.min {
+        if !number.is_finite() || number < self.min {
             let error = self.message.clone().map_or_else(
                 || Error::min(self.min, &FormMessages::default(), locale),
                 |message| Error {
@@ -237,7 +237,7 @@ impl Validator for MaxValidator {
 
         let locale = ctx.locale.unwrap_or(&DEFAULT_VALIDATOR_LOCALE);
 
-        if number > self.max {
+        if !number.is_finite() || number > self.max {
             let error = self.message.clone().map_or_else(
                 || Error::max(self.max, &FormMessages::default(), locale),
                 |message| Error {
@@ -504,9 +504,11 @@ impl Validator for StepValidator {
                 return Err(Errors(vec![error]));
             }
 
-            let remainder = ((number - self.step_base) % self.step).abs();
+            let quotient = (number - self.step_base) / self.step;
+            let nearest_step = quotient.round();
+            let tolerance = quotient.abs().max(1.0) * f64::EPSILON * 16.0;
 
-            if remainder > f64::EPSILON && (self.step - remainder) > f64::EPSILON {
+            if (quotient - nearest_step).abs() > tolerance {
                 let locale = ctx.locale.unwrap_or(&DEFAULT_VALIDATOR_LOCALE);
 
                 let error = self.message.clone().map_or_else(
@@ -615,6 +617,10 @@ fn is_valid_url(value: &str) -> bool {
 #[cfg(not(feature = "url-validation"))]
 fn is_valid_url(value: &str) -> bool {
     value.find("://").is_some_and(|position| {
+        if position == 0 {
+            return false;
+        }
+
         let authority_and_rest = &value[position + 3..];
 
         let authority = authority_and_rest
@@ -849,6 +855,30 @@ mod tests {
     }
 
     #[test]
+    fn min_nan_fails() {
+        let validator = MinValidator::with_value(10.0);
+
+        assert_eq!(
+            error_code(
+                validator.validate(&Value::Number(Some(f64::NAN)), &Context::standalone("x"))
+            ),
+            ErrorCode::Min(10.0)
+        );
+    }
+
+    #[test]
+    fn max_nan_fails() {
+        let validator = MaxValidator::with_value(10.0);
+
+        assert_eq!(
+            error_code(
+                validator.validate(&Value::Number(Some(f64::NAN)), &Context::standalone("x"))
+            ),
+            ErrorCode::Max(10.0)
+        );
+    }
+
+    #[test]
     fn pattern_no_match_fails() {
         let validator = PatternValidator::new(r"[a-z]+").expect("valid pattern");
 
@@ -1063,6 +1093,17 @@ mod tests {
     }
 
     #[test]
+    fn step_large_decimal_multiple_passes() {
+        let validator = StepValidator::new(0.1);
+
+        assert!(
+            validator
+                .validate(&Value::Number(Some(100.0)), &Context::standalone("x"))
+                .is_ok()
+        );
+    }
+
+    #[test]
     fn step_zero_fails() {
         let validator = StepValidator::new(0.0);
 
@@ -1197,6 +1238,20 @@ mod tests {
             error_code(validator.validate(
                 &Value::Text("http://?q=1".into()),
                 &Context::standalone("x")
+            )),
+            ErrorCode::Url
+        );
+    }
+
+    #[cfg(not(feature = "url-validation"))]
+    #[test]
+    fn url_missing_scheme_fails_under_fallback_validation() {
+        let validator = UrlValidator::new();
+
+        assert_eq!(
+            error_code(validator.validate(
+                &Value::Text("://example.com".into()),
+                 &Context::standalone("x")
             )),
             ErrorCode::Url
         );

--- a/crates/ars-forms/src/validation/built_in.rs
+++ b/crates/ars-forms/src/validation/built_in.rs
@@ -1,0 +1,1295 @@
+//! Built-in synchronous validators for common form constraints.
+//!
+//! These validators implement the spec-defined rules for required values,
+//! length constraints, numeric bounds, pattern matching, email addresses,
+//! step increments, URLs, and closure-backed custom logic.
+
+use std::fmt::{self, Display};
+
+use regex::Regex;
+
+use super::{
+    BoxedValidator, Context, Error, ErrorCode, Errors, Result, Validator, boxed_validator,
+    validator::DEFAULT_VALIDATOR_LOCALE,
+};
+use crate::{field::Value, form_messages::FormMessages};
+
+/// Fails when a field's value is considered empty by the forms contract.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct RequiredValidator {
+    /// Optional custom message overriding the localized default.
+    pub message: Option<String>,
+}
+
+impl RequiredValidator {
+    /// Returns a copy configured to use a custom error message.
+    #[must_use]
+    pub fn with_message(mut self, message: impl Into<String>) -> Self {
+        self.message = Some(message.into());
+        self
+    }
+}
+
+impl Validator for RequiredValidator {
+    fn validate(&self, value: &Value, ctx: &Context) -> Result {
+        let is_empty = match value {
+            Value::Text(s) => s.trim().is_empty(),
+            Value::Number(None) | Value::Bool(false) => true,
+            Value::Number(Some(_)) | Value::Bool(true) => false,
+            Value::MultipleText(values) => values.is_empty(),
+            Value::File(files) => files.is_empty(),
+            Value::Date(date) => date.is_none(),
+            Value::Time(time) => time.is_none(),
+            Value::DateRange(range) => range.is_none(),
+        };
+
+        if is_empty {
+            let locale = ctx.locale.unwrap_or(&DEFAULT_VALIDATOR_LOCALE);
+
+            let error = self.message.as_ref().map_or_else(
+                || Error::required(&FormMessages::default(), locale),
+                |message| Error {
+                    message: message.clone(),
+                    code: ErrorCode::Required,
+                },
+            );
+
+            Err(Errors(vec![error]))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+/// Fails when the stringified value is shorter than the configured minimum.
+#[derive(Clone, Debug, PartialEq)]
+pub struct MinLengthValidator {
+    /// Minimum number of Unicode scalar values required.
+    pub min: usize,
+
+    /// Optional custom message overriding the localized default.
+    pub message: Option<String>,
+}
+
+impl MinLengthValidator {
+    /// Creates a minimum-length validator with the default localized message.
+    #[must_use]
+    pub const fn with_length(min: usize) -> Self {
+        Self { min, message: None }
+    }
+
+    /// Returns a copy configured to use a custom error message.
+    #[must_use]
+    pub fn with_message(mut self, message: impl Into<String>) -> Self {
+        self.message = Some(message.into());
+        self
+    }
+}
+
+impl Validator for MinLengthValidator {
+    fn validate(&self, value: &Value, ctx: &Context) -> Result {
+        let value = value.to_string_for_validation();
+
+        let locale = ctx.locale.unwrap_or(&DEFAULT_VALIDATOR_LOCALE);
+
+        if value.chars().count() < self.min {
+            let error = self.message.clone().map_or_else(
+                || Error::min_length(self.min, &FormMessages::default(), locale),
+                |message| Error {
+                    message,
+                    code: ErrorCode::MinLength(self.min),
+                },
+            );
+
+            Err(Errors(vec![error]))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+/// Fails when the stringified value exceeds the configured maximum length.
+#[derive(Clone, Debug, PartialEq)]
+pub struct MaxLengthValidator {
+    /// Maximum number of Unicode scalar values allowed.
+    pub max: usize,
+
+    /// Optional custom message overriding the localized default.
+    pub message: Option<String>,
+}
+
+impl MaxLengthValidator {
+    /// Creates a maximum-length validator with the default localized message.
+    #[must_use]
+    pub const fn with_length(max: usize) -> Self {
+        Self { max, message: None }
+    }
+
+    /// Returns a copy configured to use a custom error message.
+    #[must_use]
+    pub fn with_message(mut self, message: impl Into<String>) -> Self {
+        self.message = Some(message.into());
+        self
+    }
+}
+
+impl Validator for MaxLengthValidator {
+    fn validate(&self, value: &Value, ctx: &Context) -> Result {
+        let value = value.to_string_for_validation();
+
+        let locale = ctx.locale.unwrap_or(&DEFAULT_VALIDATOR_LOCALE);
+
+        if value.chars().count() > self.max {
+            let error = self.message.clone().map_or_else(
+                || Error::max_length(self.max, &FormMessages::default(), locale),
+                |message| Error {
+                    message,
+                    code: ErrorCode::MaxLength(self.max),
+                },
+            );
+
+            Err(Errors(vec![error]))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+/// Fails when a numeric value is smaller than the configured minimum.
+#[derive(Clone, Debug, PartialEq)]
+pub struct MinValidator {
+    /// Inclusive minimum numeric value.
+    pub min: f64,
+
+    /// Optional custom message overriding the localized default.
+    pub message: Option<String>,
+}
+
+impl MinValidator {
+    /// Creates a minimum-value validator with the default localized message.
+    #[must_use]
+    pub const fn with_value(min: f64) -> Self {
+        Self { min, message: None }
+    }
+
+    /// Returns a copy configured to use a custom error message.
+    #[must_use]
+    pub fn with_message(mut self, message: impl Into<String>) -> Self {
+        self.message = Some(message.into());
+        self
+    }
+}
+
+impl Validator for MinValidator {
+    fn validate(&self, value: &Value, ctx: &Context) -> Result {
+        let Some(number) = value.as_number() else {
+            return Ok(());
+        };
+
+        let locale = ctx.locale.unwrap_or(&DEFAULT_VALIDATOR_LOCALE);
+
+        if number < self.min {
+            let error = self.message.clone().map_or_else(
+                || Error::min(self.min, &FormMessages::default(), locale),
+                |message| Error {
+                    message,
+                    code: ErrorCode::Min(self.min),
+                },
+            );
+
+            Err(Errors(vec![error]))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+/// Fails when a numeric value is larger than the configured maximum.
+#[derive(Clone, Debug, PartialEq)]
+pub struct MaxValidator {
+    /// Inclusive maximum numeric value.
+    pub max: f64,
+
+    /// Optional custom message overriding the localized default.
+    pub message: Option<String>,
+}
+
+impl MaxValidator {
+    /// Creates a maximum-value validator with the default localized message.
+    #[must_use]
+    pub const fn with_value(max: f64) -> Self {
+        Self { max, message: None }
+    }
+
+    /// Returns a copy configured to use a custom error message.
+    #[must_use]
+    pub fn with_message(mut self, message: impl Into<String>) -> Self {
+        self.message = Some(message.into());
+        self
+    }
+}
+
+impl Validator for MaxValidator {
+    fn validate(&self, value: &Value, ctx: &Context) -> Result {
+        let Some(number) = value.as_number() else {
+            return Ok(());
+        };
+
+        let locale = ctx.locale.unwrap_or(&DEFAULT_VALIDATOR_LOCALE);
+
+        if number > self.max {
+            let error = self.message.clone().map_or_else(
+                || Error::max(self.max, &FormMessages::default(), locale),
+                |message| Error {
+                    message,
+                    code: ErrorCode::Max(self.max),
+                },
+            );
+
+            Err(Errors(vec![error]))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+/// Regex-based validator that matches the entire field value.
+#[derive(Clone, Debug)]
+pub struct PatternValidator {
+    /// Cached compiled regex using an anchored `^(?:...)$` pattern.
+    pub compiled: Regex,
+
+    /// Original unanchored pattern retained for error reporting.
+    pub pattern: String,
+
+    /// Optional custom message overriding the localized default.
+    pub message: Option<String>,
+}
+
+/// Error returned when a [`PatternValidator`] cannot be constructed.
+#[derive(Debug)]
+pub enum PatternValidatorError {
+    /// The pattern exceeded the maximum accepted UTF-8 byte length.
+    PatternTooLong {
+        /// Maximum accepted UTF-8 byte length.
+        max_bytes: usize,
+
+        /// Actual UTF-8 byte length of the provided pattern.
+        actual_bytes: usize,
+    },
+
+    /// The pattern was not valid `regex` syntax after anchoring.
+    InvalidRegex {
+        /// Source error returned by the `regex` crate.
+        source: regex::Error,
+    },
+}
+
+impl Display for PatternValidatorError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::PatternTooLong {
+                max_bytes,
+                actual_bytes,
+            } => {
+                write!(
+                    f,
+                    "pattern exceeds {max_bytes} bytes (got {actual_bytes} bytes)"
+                )
+            }
+            Self::InvalidRegex { source } => write!(f, "invalid regex pattern: {source}"),
+        }
+    }
+}
+
+impl std::error::Error for PatternValidatorError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::PatternTooLong { .. } => None,
+            Self::InvalidRegex { source } => Some(source),
+        }
+    }
+}
+
+impl PatternValidator {
+    /// Creates a validator and eagerly compiles the pattern.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PatternValidatorError::PatternTooLong`] when `pattern`
+    /// exceeds 1024 UTF-8 bytes, or [`PatternValidatorError::InvalidRegex`]
+    /// when the anchored pattern is not valid `regex` syntax.
+    pub fn new(pattern: impl Into<String>) -> std::result::Result<Self, PatternValidatorError> {
+        let pattern = pattern.into();
+
+        const MAX_PATTERN_LEN: usize = 1024;
+
+        if pattern.len() > MAX_PATTERN_LEN {
+            return Err(PatternValidatorError::PatternTooLong {
+                max_bytes: MAX_PATTERN_LEN,
+                actual_bytes: pattern.len(),
+            });
+        }
+
+        let anchored = format!("^(?:{pattern})$");
+
+        let compiled = Regex::new(&anchored)
+            .map_err(|source| PatternValidatorError::InvalidRegex { source })?;
+
+        Ok(Self {
+            compiled,
+            pattern,
+            message: None,
+        })
+    }
+
+    /// Creates a validator from a hardcoded pattern and panics on invalid syntax.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `pattern` exceeds 1024 bytes or is not valid regex syntax.
+    #[must_use]
+    pub fn new_from_static(pattern: &'static str) -> Self {
+        Self::new(pattern).unwrap_or_else(|err| panic!("PatternValidator::new_from_static: {err}"))
+    }
+
+    /// Returns a copy configured to use a custom error message.
+    #[must_use]
+    pub fn with_message(mut self, message: impl Into<String>) -> Self {
+        self.message = Some(message.into());
+        self
+    }
+}
+
+impl Validator for PatternValidator {
+    fn validate(&self, value: &Value, ctx: &Context) -> Result {
+        let value = value.to_string_for_validation();
+
+        if value.is_empty() {
+            return Ok(());
+        }
+
+        if self.compiled.is_match(&value) {
+            Ok(())
+        } else {
+            let locale = ctx.locale.unwrap_or(&DEFAULT_VALIDATOR_LOCALE);
+
+            let error = self.message.clone().map_or_else(
+                || Error::pattern(self.pattern.clone(), &FormMessages::default(), locale),
+                |message| Error {
+                    message,
+                    code: ErrorCode::Pattern(self.pattern.clone()),
+                },
+            );
+
+            Err(Errors(vec![error]))
+        }
+    }
+}
+
+/// Email validator with RFC-style parsing when the default
+/// `email-validation` feature is enabled.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct EmailValidator {
+    /// Optional custom message overriding the localized default.
+    pub message: Option<String>,
+}
+
+impl EmailValidator {
+    /// Returns a copy configured to use a custom error message.
+    #[must_use]
+    pub fn with_message(mut self, message: impl Into<String>) -> Self {
+        self.message = Some(message.into());
+        self
+    }
+}
+
+impl Validator for EmailValidator {
+    fn validate(&self, value: &Value, ctx: &Context) -> Result {
+        let value = value.to_string_for_validation();
+
+        if value.is_empty() {
+            return Ok(());
+        }
+
+        let valid = is_valid_email(&value);
+
+        if valid {
+            return Ok(());
+        }
+
+        let locale = ctx.locale.unwrap_or(&DEFAULT_VALIDATOR_LOCALE);
+
+        let error = self.message.clone().map_or_else(
+            || Error::email(&FormMessages::default(), locale),
+            |message| Error {
+                message,
+                code: ErrorCode::Email,
+            },
+        );
+
+        Err(Errors(vec![error]))
+    }
+}
+
+#[cfg(feature = "email-validation")]
+fn is_valid_email(value: &str) -> bool {
+    value.parse::<addr_spec::AddrSpec>().is_ok()
+}
+
+#[cfg(not(feature = "email-validation"))]
+fn is_valid_email(value: &str) -> bool {
+    value
+        .split_once('@')
+        .is_some_and(|(local, domain)| !local.is_empty() && domain.contains('.'))
+}
+
+/// Validates that a numeric value falls on a configured step increment.
+#[derive(Clone, Debug, PartialEq)]
+pub struct StepValidator {
+    /// Step increment used to validate numeric values.
+    pub step: f64,
+
+    /// Base offset from which step increments are measured.
+    pub step_base: f64,
+
+    /// Optional custom message overriding the localized default.
+    pub message: Option<String>,
+}
+
+impl StepValidator {
+    /// Creates a step validator using `0.0` as the initial base.
+    #[must_use]
+    pub const fn new(step: f64) -> Self {
+        Self {
+            step,
+            step_base: 0.0,
+            message: None,
+        }
+    }
+
+    /// Returns a copy configured to measure steps from `base`.
+    #[must_use]
+    pub const fn with_base(mut self, base: f64) -> Self {
+        self.step_base = base;
+        self
+    }
+
+    /// Returns a copy configured to use a custom error message.
+    #[must_use]
+    pub fn with_message(mut self, message: impl Into<String>) -> Self {
+        self.message = Some(message.into());
+        self
+    }
+}
+
+impl Validator for StepValidator {
+    fn validate(&self, value: &Value, ctx: &Context) -> Result {
+        if let Some(number) = value.as_number() {
+            let remainder = ((number - self.step_base) % self.step).abs();
+
+            if remainder > f64::EPSILON && (self.step - remainder) > f64::EPSILON {
+                if let Some(message) = &self.message {
+                    return Err(Errors(vec![Error::custom("step", message.clone())]));
+                }
+
+                let locale = ctx.locale.unwrap_or(&DEFAULT_VALIDATOR_LOCALE);
+
+                return Err(Errors(vec![Error::step(
+                    self.step,
+                    &FormMessages::default(),
+                    locale,
+                )]));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// URL validator using WHATWG parsing when the default
+/// `url-validation` feature is enabled.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct UrlValidator {
+    /// Optional custom message overriding the localized default.
+    pub message: Option<String>,
+}
+
+impl UrlValidator {
+    /// Creates a URL validator with the default localized error message.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self { message: None }
+    }
+
+    /// Returns a copy configured to use a custom error message.
+    #[must_use]
+    pub fn with_message(mut self, message: impl Into<String>) -> Self {
+        self.message = Some(message.into());
+        self
+    }
+}
+
+impl Validator for UrlValidator {
+    fn validate(&self, value: &Value, ctx: &Context) -> Result {
+        if let Some(value) = value.as_text()
+            && !value.is_empty()
+            && !is_valid_url(value)
+        {
+            if let Some(message) = &self.message {
+                return Err(Errors(vec![Error::custom("url", message.clone())]));
+            }
+
+            let locale = ctx.locale.unwrap_or(&DEFAULT_VALIDATOR_LOCALE);
+
+            return Err(Errors(vec![Error::url(&FormMessages::default(), locale)]));
+        }
+
+        Ok(())
+    }
+}
+
+/// Closure-backed validator for custom synchronous validation logic.
+#[derive(Clone, Debug)]
+pub struct FnValidator<F>
+where
+    F: Fn(&Value, &Context) -> Result + Send + Sync,
+{
+    /// The closure implementing validation behavior.
+    pub f: F,
+}
+
+impl<F> Validator for FnValidator<F>
+where
+    F: Fn(&Value, &Context) -> Result + Send + Sync,
+{
+    fn validate(&self, value: &Value, ctx: &Context) -> Result {
+        (self.f)(value, ctx)
+    }
+}
+
+impl<F> FnValidator<F>
+where
+    F: Fn(&Value, &Context) -> Result + Send + Sync + 'static,
+{
+    /// Wraps a closure as a validator value.
+    #[must_use]
+    pub const fn new(f: F) -> Self {
+        Self { f }
+    }
+
+    /// Boxes the validator behind the standard shared pointer type.
+    #[must_use]
+    pub fn boxed(self) -> BoxedValidator {
+        boxed_validator(self)
+    }
+}
+
+#[cfg(feature = "url-validation")]
+fn is_valid_url(value: &str) -> bool {
+    url::Url::parse(value).is_ok()
+}
+
+#[cfg(not(feature = "url-validation"))]
+fn is_valid_url(value: &str) -> bool {
+    value
+        .find("://")
+        .is_some_and(|position| value.len() > position + 3)
+}
+
+#[cfg(test)]
+mod tests {
+    use ars_i18n::locales;
+
+    use super::*;
+    use crate::field::FileRef;
+
+    fn error_code(result: Result) -> ErrorCode {
+        result.expect_err("validation should fail").0[0]
+            .code
+            .clone()
+    }
+
+    fn error_message(result: Result) -> String {
+        result.expect_err("validation should fail").0[0]
+            .message
+            .clone()
+    }
+
+    #[test]
+    fn required_empty_text_fails() {
+        let validator = RequiredValidator::default();
+
+        assert_eq!(
+            error_code(validator.validate(&Value::Text("   ".into()), &Context::standalone("x"))),
+            ErrorCode::Required
+        );
+    }
+
+    #[test]
+    fn required_nonempty_text_passes() {
+        let validator = RequiredValidator::default();
+
+        assert!(
+            validator
+                .validate(&Value::Text("hello".into()), &Context::standalone("x"))
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn required_none_number_fails() {
+        let validator = RequiredValidator::default();
+
+        assert_eq!(
+            error_code(validator.validate(&Value::Number(None), &Context::standalone("x"))),
+            ErrorCode::Required
+        );
+    }
+
+    #[test]
+    fn required_some_number_passes() {
+        let validator = RequiredValidator::default();
+
+        assert!(
+            validator
+                .validate(&Value::Number(Some(1.0)), &Context::standalone("x"))
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn required_false_bool_fails() {
+        let validator = RequiredValidator::default();
+
+        assert_eq!(
+            error_code(validator.validate(&Value::Bool(false), &Context::standalone("x"))),
+            ErrorCode::Required
+        );
+    }
+
+    #[test]
+    fn required_true_bool_passes() {
+        let validator = RequiredValidator::default();
+
+        assert!(
+            validator
+                .validate(&Value::Bool(true), &Context::standalone("x"))
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn required_empty_multiple_text_fails() {
+        let validator = RequiredValidator::default();
+
+        assert_eq!(
+            error_code(validator.validate(&Value::MultipleText(vec![]), &Context::standalone("x"))),
+            ErrorCode::Required
+        );
+    }
+
+    #[test]
+    fn required_empty_file_list_fails() {
+        let validator = RequiredValidator::default();
+
+        assert_eq!(
+            error_code(validator.validate(&Value::File(vec![]), &Context::standalone("x"))),
+            ErrorCode::Required
+        );
+    }
+
+    #[test]
+    fn required_missing_temporal_values_fail() {
+        let validator = RequiredValidator::default();
+
+        let ctx = Context::standalone("x");
+
+        assert_eq!(
+            error_code(validator.validate(&Value::Date(None), &ctx)),
+            ErrorCode::Required
+        );
+        assert_eq!(
+            error_code(validator.validate(&Value::Time(None), &ctx)),
+            ErrorCode::Required
+        );
+        assert_eq!(
+            error_code(validator.validate(&Value::DateRange(None), &ctx)),
+            ErrorCode::Required
+        );
+    }
+
+    #[test]
+    fn min_length_short_fails() {
+        let validator = MinLengthValidator::with_length(3);
+
+        assert_eq!(
+            error_code(validator.validate(&Value::Text("hi".into()), &Context::standalone("x"))),
+            ErrorCode::MinLength(3)
+        );
+    }
+
+    #[test]
+    fn min_length_exact_passes() {
+        let validator = MinLengthValidator::with_length(3);
+
+        assert!(
+            validator
+                .validate(&Value::Text("hey".into()), &Context::standalone("x"))
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn max_length_long_fails() {
+        let validator = MaxLengthValidator::with_length(3);
+
+        assert_eq!(
+            error_code(validator.validate(&Value::Text("long".into()), &Context::standalone("x"))),
+            ErrorCode::MaxLength(3)
+        );
+    }
+
+    #[test]
+    fn max_length_exact_passes() {
+        let validator = MaxLengthValidator::with_length(4);
+
+        assert!(
+            validator
+                .validate(&Value::Text("long".into()), &Context::standalone("x"))
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn min_below_fails() {
+        let validator = MinValidator::with_value(10.0);
+
+        assert_eq!(
+            error_code(validator.validate(&Value::Number(Some(9.0)), &Context::standalone("x"))),
+            ErrorCode::Min(10.0)
+        );
+    }
+
+    #[test]
+    fn min_at_boundary_passes() {
+        let validator = MinValidator::with_value(10.0);
+
+        assert!(
+            validator
+                .validate(&Value::Number(Some(10.0)), &Context::standalone("x"))
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn max_above_fails() {
+        let validator = MaxValidator::with_value(10.0);
+
+        assert_eq!(
+            error_code(validator.validate(&Value::Number(Some(11.0)), &Context::standalone("x"))),
+            ErrorCode::Max(10.0)
+        );
+    }
+
+    #[test]
+    fn max_at_boundary_passes() {
+        let validator = MaxValidator::with_value(10.0);
+
+        assert!(
+            validator
+                .validate(&Value::Number(Some(10.0)), &Context::standalone("x"))
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn min_and_max_skip_non_numbers() {
+        let ctx = Context::standalone("x");
+
+        assert!(
+            MinValidator::with_value(1.0)
+                .validate(&Value::Text("not-a-number".into()), &ctx)
+                .is_ok()
+        );
+        assert!(
+            MaxValidator::with_value(1.0)
+                .validate(&Value::Text("not-a-number".into()), &ctx)
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn pattern_no_match_fails() {
+        let validator = PatternValidator::new(r"[a-z]+").expect("valid pattern");
+
+        assert_eq!(
+            error_code(validator.validate(&Value::Text("123".into()), &Context::standalone("x"))),
+            ErrorCode::Pattern("[a-z]+".into())
+        );
+    }
+
+    #[test]
+    fn pattern_match_passes() {
+        let validator = PatternValidator::new(r"[a-z]+").expect("valid pattern");
+
+        assert!(
+            validator
+                .validate(&Value::Text("abc".into()), &Context::standalone("x"))
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn pattern_empty_skips() {
+        let validator = PatternValidator::new(r"[a-z]+").expect("valid pattern");
+
+        assert!(
+            validator
+                .validate(&Value::Text(String::new()), &Context::standalone("x"))
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn invalid_regex_pattern_is_rejected() {
+        assert!(matches!(
+            PatternValidator::new("("),
+            Err(PatternValidatorError::InvalidRegex { .. })
+        ));
+    }
+
+    #[test]
+    fn oversized_regex_pattern_is_rejected() {
+        assert!(matches!(
+            PatternValidator::new("a".repeat(1025)),
+            Err(PatternValidatorError::PatternTooLong {
+                max_bytes: 1024,
+                actual_bytes: 1025,
+            })
+        ));
+    }
+
+    #[test]
+    #[should_panic(expected = "PatternValidator::new_from_static: invalid regex pattern")]
+    fn invalid_static_regex_pattern_panics() {
+        drop(PatternValidator::new_from_static("("));
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "PatternValidator::new_from_static: pattern exceeds 1024 bytes (got 1025 bytes)"
+    )]
+    fn oversized_static_regex_pattern_panics() {
+        const OVERSIZED_PATTERN: &str = concat!(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "a"
+        );
+
+        drop(PatternValidator::new_from_static(OVERSIZED_PATTERN));
+    }
+
+    #[test]
+    fn email_invalid_fails() {
+        let validator = EmailValidator::default();
+
+        assert_eq!(
+            error_code(
+                validator.validate(&Value::Text("bad-email".into()), &Context::standalone("x"))
+            ),
+            ErrorCode::Email
+        );
+    }
+
+    #[test]
+    fn email_empty_local_part_fails() {
+        let validator = EmailValidator::default();
+
+        assert_eq!(
+            error_code(validator.validate(
+                &Value::Text("@example.com".into()),
+                &Context::standalone("x")
+            )),
+            ErrorCode::Email
+        );
+    }
+
+    #[test]
+    fn email_valid_passes() {
+        let validator = EmailValidator::default();
+
+        assert!(
+            validator
+                .validate(
+                    &Value::Text("user@example.com".into()),
+                    &Context::standalone("x")
+                )
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn email_empty_skips() {
+        let validator = EmailValidator::default();
+
+        assert!(
+            validator
+                .validate(&Value::Text(String::new()), &Context::standalone("x"))
+                .is_ok()
+        );
+    }
+
+    #[cfg(feature = "email-validation")]
+    #[test]
+    fn email_quoted_local_part_passes() {
+        let validator = EmailValidator::default();
+
+        assert!(
+            validator
+                .validate(
+                    &Value::Text(r#""quoted local"@example.com"#.into()),
+                    &Context::standalone("x")
+                )
+                .is_ok()
+        );
+    }
+
+    #[cfg(feature = "email-validation")]
+    #[test]
+    fn email_domain_literal_passes() {
+        let validator = EmailValidator::default();
+
+        assert!(
+            validator
+                .validate(
+                    &Value::Text("user@[127.0.0.1]".into()),
+                    &Context::standalone("x")
+                )
+                .is_ok()
+        );
+    }
+
+    #[cfg(feature = "email-validation")]
+    #[test]
+    fn email_invalid_domain_fails_under_full_validation() {
+        let validator = EmailValidator::default();
+
+        assert_eq!(
+            error_code(validator.validate(
+                &Value::Text("user@.example.com".into()),
+                &Context::standalone("x")
+            )),
+            ErrorCode::Email
+        );
+    }
+
+    #[test]
+    fn step_mismatch_fails() {
+        let validator = StepValidator::new(0.5);
+
+        assert_eq!(
+            error_code(validator.validate(&Value::Number(Some(0.3)), &Context::standalone("x"))),
+            ErrorCode::Step(0.5)
+        );
+    }
+
+    #[test]
+    fn step_match_passes() {
+        let validator = StepValidator::new(0.5);
+
+        assert!(
+            validator
+                .validate(&Value::Number(Some(1.5)), &Context::standalone("x"))
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn step_with_base() {
+        let validator = StepValidator::new(2.0).with_base(1.0);
+
+        assert!(
+            validator
+                .validate(&Value::Number(Some(5.0)), &Context::standalone("x"))
+                .is_ok()
+        );
+        assert_eq!(
+            error_code(validator.validate(&Value::Number(Some(4.0)), &Context::standalone("x"))),
+            ErrorCode::Step(2.0)
+        );
+    }
+
+    #[test]
+    fn step_rounding_boundary_passes() {
+        let validator = StepValidator::new(0.1);
+
+        assert!(
+            validator
+                .validate(&Value::Number(Some(-55.2)), &Context::standalone("x"))
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn step_none_number_skips() {
+        let validator = StepValidator::new(0.5);
+
+        assert!(
+            validator
+                .validate(&Value::Number(None), &Context::standalone("x"))
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn step_non_number_skips() {
+        let validator = StepValidator::new(0.5);
+
+        assert!(
+            validator
+                .validate(
+                    &Value::Text("not-a-number".into()),
+                    &Context::standalone("x")
+                )
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn url_invalid_fails() {
+        let validator = UrlValidator::new();
+
+        assert_eq!(
+            error_code(
+                validator.validate(&Value::Text("notaurl".into()), &Context::standalone("x"))
+            ),
+            ErrorCode::Url
+        );
+    }
+
+    #[test]
+    fn url_non_text_skips() {
+        let validator = UrlValidator::new();
+
+        assert!(
+            validator
+                .validate(&Value::Bool(true), &Context::standalone("x"))
+                .is_ok()
+        );
+    }
+
+    #[cfg(feature = "url-validation")]
+    #[test]
+    fn url_mailto_scheme_passes() {
+        let validator = UrlValidator::new();
+
+        assert!(
+            validator
+                .validate(
+                    &Value::Text("mailto:user@example.com".into()),
+                    &Context::standalone("x")
+                )
+                .is_ok()
+        );
+    }
+
+    #[cfg(feature = "url-validation")]
+    #[test]
+    fn url_invalid_host_fails_under_full_validation() {
+        let validator = UrlValidator::new();
+
+        assert_eq!(
+            error_code(validator.validate(
+                &Value::Text("https://exa mple.com".into()),
+                &Context::standalone("x")
+            )),
+            ErrorCode::Url
+        );
+    }
+
+    #[test]
+    fn url_valid_passes() {
+        let validator = UrlValidator::new();
+
+        assert!(
+            validator
+                .validate(
+                    &Value::Text("https://example.com".into()),
+                    &Context::standalone("x")
+                )
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn url_empty_skips() {
+        let validator = UrlValidator::new();
+
+        assert!(
+            validator
+                .validate(&Value::Text(String::new()), &Context::standalone("x"))
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn fn_validator_custom_logic() {
+        let validator = FnValidator::new(|value, _ctx| {
+            if value.as_text() == Some("ok") {
+                Ok(())
+            } else {
+                Err(Errors(vec![Error::custom("custom", "custom failure")]))
+            }
+        });
+
+        assert!(
+            validator
+                .validate(&Value::Text("ok".into()), &Context::standalone("x"))
+                .is_ok()
+        );
+        assert_eq!(
+            error_code(validator.validate(&Value::Text("nope".into()), &Context::standalone("x"))),
+            ErrorCode::Custom("custom".into())
+        );
+    }
+
+    #[test]
+    fn fn_validator_boxed() {
+        let validator = FnValidator::new(|_value, _ctx| Ok(())).boxed();
+
+        assert!(
+            validator
+                .validate(&Value::Text("anything".into()), &Context::standalone("x"))
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn custom_message_overrides_default() {
+        let ctx = Context::standalone("x");
+
+        let required_result = RequiredValidator::default()
+            .with_message("required override")
+            .validate(&Value::Text(String::new()), &ctx);
+
+        let min_length_result = MinLengthValidator::with_length(3)
+            .with_message("min override")
+            .validate(&Value::Text("hi".into()), &ctx);
+
+        let max_length_result = MaxLengthValidator::with_length(1)
+            .with_message("max override")
+            .validate(&Value::Text("hi".into()), &ctx);
+
+        let min_result = MinValidator::with_value(10.0)
+            .with_message("min number override")
+            .validate(&Value::Number(Some(9.0)), &ctx);
+
+        let max_result = MaxValidator::with_value(1.0)
+            .with_message("max number override")
+            .validate(&Value::Number(Some(2.0)), &ctx);
+
+        let pattern_result = PatternValidator::new(r"[a-z]+")
+            .expect("valid pattern")
+            .with_message("pattern override")
+            .validate(&Value::Text("123".into()), &ctx);
+
+        let email_result = EmailValidator::default()
+            .with_message("email override")
+            .validate(&Value::Text("invalid".into()), &ctx);
+
+        let step_result = StepValidator::new(2.0)
+            .with_message("step override")
+            .validate(&Value::Number(Some(3.0)), &ctx);
+
+        let url_result = UrlValidator::new()
+            .with_message("url override")
+            .validate(&Value::Text("invalid".into()), &ctx);
+
+        let required_message = error_message(required_result.clone());
+
+        let min_length_message = error_message(min_length_result.clone());
+
+        let max_length_message = error_message(max_length_result.clone());
+
+        let min_message = error_message(min_result.clone());
+
+        let max_message = error_message(max_result.clone());
+
+        let pattern_message = error_message(pattern_result.clone());
+
+        let email_message = error_message(email_result.clone());
+
+        let step_message = error_message(step_result.clone());
+
+        let url_message = error_message(url_result.clone());
+
+        assert_eq!(error_code(required_result), ErrorCode::Required);
+        assert_eq!(error_code(min_length_result), ErrorCode::MinLength(3));
+        assert_eq!(error_code(max_length_result), ErrorCode::MaxLength(1));
+        assert_eq!(error_code(min_result), ErrorCode::Min(10.0));
+        assert_eq!(error_code(max_result), ErrorCode::Max(1.0));
+        assert_eq!(
+            error_code(pattern_result),
+            ErrorCode::Pattern("[a-z]+".into())
+        );
+        assert_eq!(error_code(email_result), ErrorCode::Email);
+        assert_eq!(error_code(step_result), ErrorCode::Custom("step".into()));
+        assert_eq!(error_code(url_result), ErrorCode::Custom("url".into()));
+
+        assert_eq!(required_message, "required override");
+        assert_eq!(min_length_message, "min override");
+        assert_eq!(max_length_message, "max override");
+        assert_eq!(min_message, "min number override");
+        assert_eq!(max_message, "max number override");
+        assert_eq!(pattern_message, "pattern override");
+        assert_eq!(email_message, "email override");
+        assert_eq!(step_message, "step override");
+        assert_eq!(url_message, "url override");
+    }
+
+    #[test]
+    fn defaults_use_english_locale_fallback() {
+        let message = error_message(
+            RequiredValidator::default()
+                .validate(&Value::Text(String::new()), &Context::standalone("x")),
+        );
+
+        assert_eq!(message, "This field is required");
+    }
+
+    #[test]
+    fn defaults_use_context_locale_when_present() {
+        let locale = locales::en();
+
+        let ctx = Context {
+            field_name: "x",
+            form_values: &std::collections::BTreeMap::new(),
+            locale: Some(&locale),
+        };
+
+        let message =
+            error_message(EmailValidator::default().validate(&Value::Text("bad".into()), &ctx));
+
+        assert_eq!(message, "Must be a valid email address");
+    }
+
+    #[test]
+    fn required_nonempty_file_passes() {
+        let validator = RequiredValidator::default();
+
+        let files = vec![FileRef {
+            name: "file.txt".into(),
+            size: 1,
+            mime_type: "text/plain".into(),
+        }];
+
+        assert!(
+            validator
+                .validate(&Value::File(files), &Context::standalone("x"))
+                .is_ok()
+        );
+    }
+}

--- a/crates/ars-forms/src/validation/built_in.rs
+++ b/crates/ars-forms/src/validation/built_in.rs
@@ -486,20 +486,34 @@ impl StepValidator {
 impl Validator for StepValidator {
     fn validate(&self, value: &Value, ctx: &Context) -> Result {
         if let Some(number) = value.as_number() {
+            if !self.step.is_finite() || self.step <= 0.0 {
+                let locale = ctx.locale.unwrap_or(&DEFAULT_VALIDATOR_LOCALE);
+
+                let error = self.message.clone().map_or_else(
+                    || Error::step(self.step, &FormMessages::default(), locale),
+                    |message| Error {
+                        message,
+                        code: ErrorCode::Step(self.step),
+                    },
+                );
+
+                return Err(Errors(vec![error]));
+            }
+
             let remainder = ((number - self.step_base) % self.step).abs();
 
             if remainder > f64::EPSILON && (self.step - remainder) > f64::EPSILON {
-                if let Some(message) = &self.message {
-                    return Err(Errors(vec![Error::custom("step", message.clone())]));
-                }
-
                 let locale = ctx.locale.unwrap_or(&DEFAULT_VALIDATOR_LOCALE);
 
-                return Err(Errors(vec![Error::step(
-                    self.step,
-                    &FormMessages::default(),
-                    locale,
-                )]));
+                let error = self.message.clone().map_or_else(
+                    || Error::step(self.step, &FormMessages::default(), locale),
+                    |message| Error {
+                        message,
+                        code: ErrorCode::Step(self.step),
+                    },
+                );
+
+                return Err(Errors(vec![error]));
             }
         }
 
@@ -536,13 +550,17 @@ impl Validator for UrlValidator {
             && !value.is_empty()
             && !is_valid_url(value)
         {
-            if let Some(message) = &self.message {
-                return Err(Errors(vec![Error::custom("url", message.clone())]));
-            }
-
             let locale = ctx.locale.unwrap_or(&DEFAULT_VALIDATOR_LOCALE);
 
-            return Err(Errors(vec![Error::url(&FormMessages::default(), locale)]));
+            let error = self.message.clone().map_or_else(
+                || Error::url(&FormMessages::default(), locale),
+                |message| Error {
+                    message,
+                    code: ErrorCode::Url,
+                },
+            );
+
+            return Err(Errors(vec![error]));
         }
 
         Ok(())
@@ -1034,6 +1052,26 @@ mod tests {
     }
 
     #[test]
+    fn step_zero_fails() {
+        let validator = StepValidator::new(0.0);
+
+        assert_eq!(
+            error_code(validator.validate(&Value::Number(Some(1.0)), &Context::standalone("x"))),
+            ErrorCode::Step(0.0)
+        );
+    }
+
+    #[test]
+    fn step_infinite_fails() {
+        let validator = StepValidator::new(f64::INFINITY);
+
+        assert_eq!(
+            error_code(validator.validate(&Value::Number(Some(1.0)), &Context::standalone("x"))),
+            ErrorCode::Step(f64::INFINITY)
+        );
+    }
+
+    #[test]
     fn step_none_number_skips() {
         let validator = StepValidator::new(0.5);
 
@@ -1236,8 +1274,8 @@ mod tests {
             ErrorCode::Pattern("[a-z]+".into())
         );
         assert_eq!(error_code(email_result), ErrorCode::Email);
-        assert_eq!(error_code(step_result), ErrorCode::Custom("step".into()));
-        assert_eq!(error_code(url_result), ErrorCode::Custom("url".into()));
+        assert_eq!(error_code(step_result), ErrorCode::Step(2.0));
+        assert_eq!(error_code(url_result), ErrorCode::Url);
 
         assert_eq!(required_message, "required override");
         assert_eq!(min_length_message, "min override");

--- a/crates/ars-forms/src/validation/built_in.rs
+++ b/crates/ars-forms/src/validation/built_in.rs
@@ -486,7 +486,11 @@ impl StepValidator {
 impl Validator for StepValidator {
     fn validate(&self, value: &Value, ctx: &Context) -> Result {
         if let Some(number) = value.as_number() {
-            if !self.step.is_finite() || self.step <= 0.0 {
+            if !number.is_finite()
+                || !self.step_base.is_finite()
+                || !self.step.is_finite()
+                || self.step <= 0.0
+            {
                 let locale = ctx.locale.unwrap_or(&DEFAULT_VALIDATOR_LOCALE);
 
                 let error = self.message.clone().map_or_else(
@@ -610,9 +614,16 @@ fn is_valid_url(value: &str) -> bool {
 
 #[cfg(not(feature = "url-validation"))]
 fn is_valid_url(value: &str) -> bool {
-    value
-        .find("://")
-        .is_some_and(|position| value.len() > position + 3)
+    value.find("://").is_some_and(|position| {
+        let authority_and_rest = &value[position + 3..];
+
+        let authority = authority_and_rest
+            .split(['/', '?', '#'])
+            .next()
+            .unwrap_or("");
+
+        !authority.is_empty()
+    })
 }
 
 #[cfg(test)]
@@ -1072,6 +1083,28 @@ mod tests {
     }
 
     #[test]
+    fn step_nan_base_fails() {
+        let validator = StepValidator::new(1.0).with_base(f64::NAN);
+
+        assert_eq!(
+            error_code(validator.validate(&Value::Number(Some(1.0)), &Context::standalone("x"))),
+            ErrorCode::Step(1.0)
+        );
+    }
+
+    #[test]
+    fn step_nan_number_fails() {
+        let validator = StepValidator::new(1.0);
+
+        assert_eq!(
+            error_code(
+                validator.validate(&Value::Number(Some(f64::NAN)), &Context::standalone("x"))
+            ),
+            ErrorCode::Step(1.0)
+        );
+    }
+
+    #[test]
     fn step_none_number_skips() {
         let validator = StepValidator::new(0.5);
 
@@ -1142,6 +1175,27 @@ mod tests {
         assert_eq!(
             error_code(validator.validate(
                 &Value::Text("https://exa mple.com".into()),
+                &Context::standalone("x")
+            )),
+            ErrorCode::Url
+        );
+    }
+
+    #[cfg(not(feature = "url-validation"))]
+    #[test]
+    fn url_missing_authority_fails_under_fallback_validation() {
+        let validator = UrlValidator::new();
+
+        assert_eq!(
+            error_code(validator.validate(
+                &Value::Text("https:///path".into()),
+                &Context::standalone("x")
+            )),
+            ErrorCode::Url
+        );
+        assert_eq!(
+            error_code(validator.validate(
+                &Value::Text("http://?q=1".into()),
                 &Context::standalone("x")
             )),
             ErrorCode::Url

--- a/crates/ars-forms/src/validation/mod.rs
+++ b/crates/ars-forms/src/validation/mod.rs
@@ -1,11 +1,17 @@
 //! Validation errors, results, validator traits, and context.
 
 mod async_validator;
+mod built_in;
 mod error;
 mod result;
 mod validator;
 
 pub use async_validator::{AsyncValidator, BoxedAsyncValidator};
+pub use built_in::{
+    EmailValidator, FnValidator, MaxLengthValidator, MaxValidator, MinLengthValidator,
+    MinValidator, PatternValidator, PatternValidatorError, RequiredValidator, StepValidator,
+    UrlValidator,
+};
 pub use error::{Error, ErrorCode, Errors};
 pub use result::{Result, ResultExt};
 pub use validator::{BoxedValidator, Context, OwnedContext, Validator, boxed_validator};

--- a/crates/ars-forms/src/validation/validator.rs
+++ b/crates/ars-forms/src/validation/validator.rs
@@ -20,14 +20,7 @@ use crate::field::Value;
 /// `None`. This produces correct English validation messages but may produce
 /// incorrect pluralization for other languages until callers supply a
 /// locale-aware context.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "built-in validators introduced in the next forms task use this fallback"
-    )
-)]
-static DEFAULT_VALIDATOR_LOCALE: LazyLock<Locale> =
+pub(super) static DEFAULT_VALIDATOR_LOCALE: LazyLock<Locale> =
     LazyLock::new(|| Locale::parse("en").expect("valid locale"));
 
 /// Context available to validators during validation.
@@ -106,23 +99,8 @@ impl<'a> Context<'a> {
 
 /// A synchronous field validator.
 ///
-/// Native targets require validators to be `Send + Sync`, while `wasm32`
-/// preserves single-threaded validators that capture browser-only state.
-#[cfg(target_arch = "wasm32")]
-pub trait Validator {
-    /// Validates the given value and returns a result with any errors found.
-    ///
-    /// # Errors
-    ///
-    /// Returns `Err(Errors)` when the value fails validation.
-    fn validate(&self, value: &Value, ctx: &Context) -> Result;
-}
-
-/// A synchronous field validator.
-///
-/// Native targets require validators to be `Send + Sync`, while `wasm32`
-/// preserves single-threaded validators that capture browser-only state.
-#[cfg(not(target_arch = "wasm32"))]
+/// Validators are always `Send + Sync`, including on `wasm32`, because the
+/// forms engine stores them behind shared [`Arc`](std::sync::Arc) pointers.
 pub trait Validator: Send + Sync {
     /// Validates the given value and returns a result with any errors found.
     ///
@@ -241,39 +219,6 @@ mod tests {
 
         assert!(boxed.validate(&Value::Text(String::new()), &ctx).is_err());
         assert!(boxed.validate(&Value::Text("ok".to_string()), &ctx).is_ok());
-    }
-
-    #[cfg(target_arch = "wasm32")]
-    #[test]
-    #[expect(
-        clippy::arc_with_non_send_sync,
-        reason = "BoxedValidator intentionally preserves single-threaded wasm validators"
-    )]
-    fn boxed_validator_allows_non_send_captures_on_wasm() {
-        use std::{cell::RefCell, rc::Rc};
-
-        struct RcValidator {
-            hits: Rc<RefCell<u8>>,
-        }
-
-        impl Validator for RcValidator {
-            fn validate(&self, _value: &Value, _ctx: &Context) -> Result {
-                *self.hits.borrow_mut() += 1;
-                Ok(())
-            }
-        }
-
-        let hits = Rc::new(RefCell::new(0));
-        let validator: BoxedValidator = Arc::new(RcValidator {
-            hits: Rc::clone(&hits),
-        });
-
-        assert!(
-            validator
-                .validate(&Value::Text(String::new()), &Context::standalone("x"))
-                .is_ok()
-        );
-        assert_eq!(*hits.borrow(), 1);
     }
 
     #[test]

--- a/spec/foundation/07-forms.md
+++ b/spec/foundation/07-forms.md
@@ -706,7 +706,7 @@ impl Validator for MinValidator {
             None => return Ok(()), // Let RequiredValidator handle None
         };
         let locale = ctx.locale.unwrap_or(&DEFAULT_VALIDATOR_LOCALE);
-        if !n.is_finite() || n < self.min {
+        if !n.is_finite() || !self.min.is_finite() || n < self.min {
             Err(Errors(vec![
                 self.message.clone()
                     .map(|m| Error { message: m, code: ErrorCode::Min(self.min) })
@@ -738,7 +738,7 @@ impl Validator for MaxValidator {
             None => return Ok(()),
         };
         let locale = ctx.locale.unwrap_or(&DEFAULT_VALIDATOR_LOCALE);
-        if !n.is_finite() || n > self.max {
+        if !n.is_finite() || !self.max.is_finite() || n > self.max {
             Err(Errors(vec![
                 self.message.clone()
                     .map(|m| Error { message: m, code: ErrorCode::Max(self.max) })
@@ -921,7 +921,7 @@ impl Validator for StepValidator {
 
             let quotient = (num - self.step_base) / self.step;
             let nearest_step = quotient.round();
-            let tolerance = quotient.abs().max(1.0) * f64::EPSILON * 16.0;
+            let tolerance = (quotient.abs().max(1.0) * f64::EPSILON * 16.0).min(1e-9);
             if (quotient - nearest_step).abs() > tolerance {
                 let locale = ctx.locale.unwrap_or(&DEFAULT_VALIDATOR_LOCALE);
                 return Err(Errors(vec![

--- a/spec/foundation/07-forms.md
+++ b/spec/foundation/07-forms.md
@@ -706,7 +706,7 @@ impl Validator for MinValidator {
             None => return Ok(()), // Let RequiredValidator handle None
         };
         let locale = ctx.locale.unwrap_or(&DEFAULT_VALIDATOR_LOCALE);
-        if n < self.min {
+        if !n.is_finite() || n < self.min {
             Err(Errors(vec![
                 self.message.clone()
                     .map(|m| Error { message: m, code: ErrorCode::Min(self.min) })
@@ -738,7 +738,7 @@ impl Validator for MaxValidator {
             None => return Ok(()),
         };
         let locale = ctx.locale.unwrap_or(&DEFAULT_VALIDATOR_LOCALE);
-        if n > self.max {
+        if !n.is_finite() || n > self.max {
             Err(Errors(vec![
                 self.message.clone()
                     .map(|m| Error { message: m, code: ErrorCode::Max(self.max) })
@@ -919,8 +919,10 @@ impl Validator for StepValidator {
                 ]));
             }
 
-            let remainder = ((num - self.step_base) % self.step).abs();
-            if remainder > f64::EPSILON && (self.step - remainder) > f64::EPSILON {
+            let quotient = (num - self.step_base) / self.step;
+            let nearest_step = quotient.round();
+            let tolerance = quotient.abs().max(1.0) * f64::EPSILON * 16.0;
+            if (quotient - nearest_step).abs() > tolerance {
                 let locale = ctx.locale.unwrap_or(&DEFAULT_VALIDATOR_LOCALE);
                 return Err(Errors(vec![
                     self.message.clone()
@@ -983,6 +985,10 @@ fn is_valid_url(s: &str) -> bool {
 #[cfg(not(feature = "url-validation"))]
 fn is_valid_url(s: &str) -> bool {
     s.find("://").is_some_and(|pos| {
+        if pos == 0 {
+            return false;
+        }
+
         let authority_and_rest = &s[pos + 3..];
         let authority = authority_and_rest
             .split(['/', '?', '#'])

--- a/spec/foundation/07-forms.md
+++ b/spec/foundation/07-forms.md
@@ -906,7 +906,11 @@ impl StepValidator {
 impl Validator for StepValidator {
     fn validate(&self, value: &Value, ctx: &Context) -> Result {
         if let Some(num) = value.as_number() {
-            if !self.step.is_finite() || self.step <= 0.0 {
+            if !num.is_finite()
+                || !self.step_base.is_finite()
+                || !self.step.is_finite()
+                || self.step <= 0.0
+            {
                 let locale = ctx.locale.unwrap_or(&DEFAULT_VALIDATOR_LOCALE);
                 return Err(Errors(vec![
                     self.message.clone()
@@ -978,7 +982,15 @@ fn is_valid_url(s: &str) -> bool {
 
 #[cfg(not(feature = "url-validation"))]
 fn is_valid_url(s: &str) -> bool {
-    s.find("://").map_or(false, |pos| s.len() > pos + 3)
+    s.find("://").is_some_and(|pos| {
+        let authority_and_rest = &s[pos + 3..];
+        let authority = authority_and_rest
+            .split(['/', '?', '#'])
+            .next()
+            .unwrap_or("");
+
+        !authority.is_empty()
+    })
 }
 
 /// Validator created from a closure.

--- a/spec/foundation/07-forms.md
+++ b/spec/foundation/07-forms.md
@@ -553,14 +553,8 @@ impl<'a> Context<'a> {
 
 /// A synchronous field validator.
 ///
-/// Native targets require validators to be `Send + Sync`; `wasm32` allows
-/// single-threaded validators that capture browser-only state.
-#[cfg(target_arch = "wasm32")]
-pub trait Validator {
-    fn validate(&self, value: &Value, ctx: &Context) -> Result;
-}
-
-#[cfg(not(target_arch = "wasm32"))]
+/// Validators are always `Send + Sync`, including on `wasm32`, because the
+/// forms engine stores them behind shared `Arc` pointers.
 pub trait Validator: Send + Sync {
     fn validate(&self, value: &Value, ctx: &Context) -> Result;
 }
@@ -579,10 +573,22 @@ pub type BoxedAsyncValidator = Arc<dyn AsyncValidator>;
 
 ### 3.2 Built-in Validators
 
+Message-only validators such as `RequiredValidator` and `EmailValidator`
+implement `Default`, and parameterized validators expose semantic constructors
+plus `.with_message(...)` so callers do not need to write `message: None`
+struct literals repeatedly.
+
 ```rust
 /// Fails if the value is empty.
 pub struct RequiredValidator {
     pub message: Option<String>,
+}
+
+impl RequiredValidator {
+    pub fn with_message(mut self, message: impl Into<String>) -> Self {
+        self.message = Some(message.into());
+        self
+    }
 }
 
 impl Validator for RequiredValidator {
@@ -624,6 +630,17 @@ static DEFAULT_VALIDATOR_LOCALE: std::sync::LazyLock<ars_i18n::Locale> =
 
 pub struct MinLengthValidator { pub min: usize, pub message: Option<String> }
 
+impl MinLengthValidator {
+    pub fn with_length(min: usize) -> Self {
+        Self { min, message: None }
+    }
+
+    pub fn with_message(mut self, message: impl Into<String>) -> Self {
+        self.message = Some(message.into());
+        self
+    }
+}
+
 impl Validator for MinLengthValidator {
     fn validate(&self, value: &Value, ctx: &Context) -> Result {
         let s = value.to_string_for_validation();
@@ -642,6 +659,17 @@ impl Validator for MinLengthValidator {
 
 pub struct MaxLengthValidator { pub max: usize, pub message: Option<String> }
 
+impl MaxLengthValidator {
+    pub fn with_length(max: usize) -> Self {
+        Self { max, message: None }
+    }
+
+    pub fn with_message(mut self, message: impl Into<String>) -> Self {
+        self.message = Some(message.into());
+        self
+    }
+}
+
 impl Validator for MaxLengthValidator {
     fn validate(&self, value: &Value, ctx: &Context) -> Result {
         let s = value.to_string_for_validation();
@@ -659,6 +687,17 @@ impl Validator for MaxLengthValidator {
 }
 
 pub struct MinValidator { pub min: f64, pub message: Option<String> }
+
+impl MinValidator {
+    pub fn with_value(min: f64) -> Self {
+        Self { min, message: None }
+    }
+
+    pub fn with_message(mut self, message: impl Into<String>) -> Self {
+        self.message = Some(message.into());
+        self
+    }
+}
 
 impl Validator for MinValidator {
     fn validate(&self, value: &Value, ctx: &Context) -> Result {
@@ -680,6 +719,17 @@ impl Validator for MinValidator {
 }
 
 pub struct MaxValidator { pub max: f64, pub message: Option<String> }
+
+impl MaxValidator {
+    pub fn with_value(max: f64) -> Self {
+        Self { max, message: None }
+    }
+
+    pub fn with_message(mut self, message: impl Into<String>) -> Self {
+        self.message = Some(message.into());
+        self
+    }
+}
 
 impl Validator for MaxValidator {
     fn validate(&self, value: &Value, ctx: &Context) -> Result {
@@ -705,9 +755,6 @@ impl Validator for MaxValidator {
 /// The `Regex` is compiled once at construction time and cached in `compiled`.
 /// This avoids re-compiling on every `validate()` call, which was
 /// the previous behavior of the per-call `regex_matches()` helper.
-///
-/// Construction panics if the pattern is invalid — callers should validate
-/// patterns at build time (e.g., in `ValidatorsBuilder::pattern()`).
 pub struct PatternValidator {
     /// The cached, compiled regex (anchored with `^(?:...)$`).
     pub compiled: regex::Regex,
@@ -716,22 +763,40 @@ pub struct PatternValidator {
     pub message: Option<String>,
 }
 
+pub enum PatternValidatorError {
+    PatternTooLong { max_bytes: usize, actual_bytes: usize },
+    InvalidRegex(regex::Error),
+}
+
 impl PatternValidator {
     /// Create a new `PatternValidator`, compiling the regex eagerly.
+    pub fn new(pattern: impl Into<String>) -> std::result::Result<Self, PatternValidatorError> {
+        let pattern = pattern.into();
+        const MAX_PATTERN_LEN: usize = 1024;
+        if pattern.len() > MAX_PATTERN_LEN {
+            return Err(PatternValidatorError::PatternTooLong {
+                max_bytes: MAX_PATTERN_LEN,
+                actual_bytes: pattern.len(),
+            });
+        }
+        let anchored = format!("^(?:{})$", pattern);
+        let compiled = regex::Regex::new(&anchored)
+            .map_err(PatternValidatorError::InvalidRegex)?;
+        Ok(Self { compiled, pattern, message: None })
+    }
+
+    /// Create a `PatternValidator` from a hardcoded regex literal.
     ///
     /// # Panics
     /// Panics if `pattern` exceeds 1024 bytes or is not a valid regex.
-    pub fn new(pattern: impl Into<String>, message: Option<String>) -> Self {
-        let pattern = pattern.into();
-        const MAX_PATTERN_LEN: usize = 1024;
-        assert!(
-            pattern.len() <= MAX_PATTERN_LEN,
-            "PatternValidator: pattern exceeds {} bytes", MAX_PATTERN_LEN
-        );
-        let anchored = format!("^(?:{})$", pattern);
-        let compiled = regex::Regex::new(&anchored)
-            .expect("PatternValidator: invalid regex pattern");
-        Self { compiled, pattern, message }
+    pub fn new_from_static(pattern: &'static str) -> Self {
+        Self::new(pattern)
+            .unwrap_or_else(|err| panic!("PatternValidator::new_from_static: {err}"))
+    }
+
+    pub fn with_message(mut self, message: impl Into<String>) -> Self {
+        self.message = Some(message.into());
+        self
     }
 }
 
@@ -765,18 +830,27 @@ impl Validator for PatternValidator {
 
 ````rust
 
+> `EmailValidator` uses RFC-grade address parsing when the `ars-forms`
+> `email-validation` Cargo feature is enabled. That feature is enabled by
+> default and SHOULD use the `addr-spec` crate. If consumers disable the
+> feature to avoid the parser dependency, `EmailValidator` falls back to the
+> baseline `@`/`.` shape check so the public API remains available.
+
 pub struct EmailValidator { pub message: Option<String> }
+
+impl EmailValidator {
+    pub fn with_message(mut self, message: impl Into<String>) -> Self {
+        self.message = Some(message.into());
+        self
+    }
+}
 
 impl Validator for EmailValidator {
     fn validate(&self, value: &Value, ctx: &Context) -> Result {
         let s = value.to_string_for_validation();
         if s.is_empty() { return Ok(()); }
 
-        // Simple email validation: must contain @ and have something before and after
-        let valid = s.contains('@') && {
-            let parts: Vec<&str> = s.splitn(2, '@').collect();
-            parts.len() == 2 && !parts[0].is_empty() && parts[1].contains('.')
-        };
+        let valid = is_valid_email(&s);
 
         if !valid {
             let locale = ctx.locale.unwrap_or(&DEFAULT_VALIDATOR_LOCALE);
@@ -789,6 +863,17 @@ impl Validator for EmailValidator {
             Ok(())
         }
     }
+}
+
+#[cfg(feature = "email-validation")]
+fn is_valid_email(value: &str) -> bool {
+    value.parse::<addr_spec::AddrSpec>().is_ok()
+}
+
+#[cfg(not(feature = "email-validation"))]
+fn is_valid_email(value: &str) -> bool {
+    value.split_once('@')
+        .is_some_and(|(local, domain)| !local.is_empty() && domain.contains('.'))
 }
 
 /// Validates that a numeric value is a multiple of the given step,
@@ -809,6 +894,11 @@ impl StepValidator {
 
     pub fn with_base(mut self, base: f64) -> Self {
         self.step_base = base;
+        self
+    }
+
+    pub fn with_message(mut self, message: impl Into<String>) -> Self {
+        self.message = Some(message.into());
         self
     }
 }
@@ -835,6 +925,12 @@ impl Validator for StepValidator {
 
 /// Validates that a string value is a well-formed URL.
 /// Uses the WHATWG URL Standard parsing algorithm.
+///
+/// `UrlValidator` uses WHATWG parsing when the `ars-forms`
+/// `url-validation` Cargo feature is enabled. That feature is enabled by
+/// default and SHOULD use the `url` crate. If consumers disable the feature
+/// to avoid the parser dependency, `UrlValidator` falls back to a baseline
+/// `scheme://authority` shape check so the public API remains available.
 pub struct UrlValidator {
     /// Optional custom error message, overriding the default.
     pub message: Option<String>,
@@ -843,6 +939,11 @@ pub struct UrlValidator {
 impl UrlValidator {
     pub fn new() -> Self {
         Self { message: None }
+    }
+
+    pub fn with_message(mut self, message: impl Into<String>) -> Self {
+        self.message = Some(message.into());
+        self
     }
 }
 
@@ -866,11 +967,14 @@ impl Validator for UrlValidator {
 }
 
 /// Check whether `s` is a valid URL per the WHATWG URL Standard.
-/// In browser targets, delegates to the `URL` constructor via `web_sys`.
-/// In non-browser targets, performs a basic scheme + authority check.
+/// Uses the `url` crate when the default `url-validation` feature is enabled.
+#[cfg(feature = "url-validation")]
 fn is_valid_url(s: &str) -> bool {
-    // Minimal validation: must have a scheme followed by "://" and a non-empty authority.
-    // Full WHATWG parsing is delegated to the platform URL parser at runtime.
+    url::Url::parse(s).is_ok()
+}
+
+#[cfg(not(feature = "url-validation"))]
+fn is_valid_url(s: &str) -> bool {
     s.find("://").map_or(false, |pos| s.len() > pos + 3)
 }
 
@@ -911,7 +1015,7 @@ impl<F: Fn(&Value, &Context) -> Result + Send + Sync + 'static> FnValidator<F> {
 ///     .required()
 ///     .min_length(3)
 ///     .max_length(50)
-///     .pattern(r"^[a-zA-Z0-9_]+$")
+///     .pattern_static(r"^[a-zA-Z0-9_]+$")
 ///     .build();
 /// ```
 pub struct ValidatorsBuilder {
@@ -923,9 +1027,7 @@ impl ValidatorsBuilder {
         Self { validators: Vec::new() }
     }
 
-/// Add a validator. Native targets still require `Send + Sync`, while
-/// `wasm32` accepts single-threaded validators as long as they implement
-/// the shared `Validator` contract.
+/// Add a validator.
 pub fn add(mut self, v: impl Validator + 'static) -> Self {
     let v: Box<dyn Validator> = Box::new(v);
     self.validators.push(Arc::from(v));
@@ -933,35 +1035,42 @@ pub fn add(mut self, v: impl Validator + 'static) -> Self {
 }
 
     pub fn required(self) -> Self {
-        self.add(RequiredValidator { message: None })
+        self.add(RequiredValidator::default())
     }
 
     pub fn required_msg(self, msg: impl Into<String>) -> Self {
-        self.add(RequiredValidator { message: Some(msg.into()) })
+        self.add(RequiredValidator::default().with_message(msg))
     }
 
     pub fn min_length(self, n: usize) -> Self {
-        self.add(MinLengthValidator { min: n, message: None })
+        self.add(MinLengthValidator::with_length(n))
     }
 
     pub fn max_length(self, n: usize) -> Self {
-        self.add(MaxLengthValidator { max: n, message: None })
+        self.add(MaxLengthValidator::with_length(n))
     }
 
     pub fn min(self, n: f64) -> Self {
-        self.add(MinValidator { min: n, message: None })
+        self.add(MinValidator::with_value(n))
     }
 
     pub fn max(self, n: f64) -> Self {
-        self.add(MaxValidator { max: n, message: None })
+        self.add(MaxValidator::with_value(n))
     }
 
-    pub fn pattern(self, regex: impl Into<String>) -> Self {
-        self.add(PatternValidator::new(regex, None))
+    pub fn pattern_static(self, regex: &'static str) -> Self {
+        self.add(PatternValidator::new_from_static(regex))
+    }
+
+    pub fn try_pattern(
+        self,
+        regex: impl Into<String>,
+    ) -> std::result::Result<Self, PatternValidatorError> {
+        Ok(self.add(PatternValidator::new(regex)?))
     }
 
     pub fn email(self) -> Self {
-        self.add(EmailValidator { message: None })
+        self.add(EmailValidator::default())
     }
 
     /// Add a step validation rule.
@@ -976,16 +1085,16 @@ pub fn add(mut self, v: impl Validator + 'static) -> Self {
 
     /// Add URL validation.
     pub fn url(self) -> Self {
-        self.add(UrlValidator { message: None })
+        self.add(UrlValidator::new())
     }
 
     // NOTE: `any()` moved to `AnyValidator::new()` — see below.
 
     pub fn custom<F>(self, f: F) -> Self
     where
-        F: Fn(&Value, &Context) -> Result + 'static,
+        F: Fn(&Value, &Context) -> Result + Send + Sync + 'static,
     {
-        self.add(FnValidator { f })
+        self.add(FnValidator::new(f))
     }
 
     /// Run all validators and collect ALL errors.
@@ -1351,8 +1460,8 @@ impl Validator for AnyValidator {
 //
 // // OR: at least one must pass
 // let v = AnyValidator::new(vec![
-//     boxed_validator(EmailValidator { message: None }),
-//     boxed_validator(PatternValidator::new(r"^\+\d+$", None)),
+//     boxed_validator(EmailValidator::default()),
+//     boxed_validator(PatternValidator::new_from_static(r"^\+\d+$")),
 // ]);
 // ```
 
@@ -1381,11 +1490,6 @@ impl Validator for AnyValidator {
 /// };
 /// ```
 // Type alias avoids clippy::type_complexity on the struct field.
-#[cfg(target_arch = "wasm32")]
-type CrossFieldValidateFn =
-    Arc<dyn Fn(&Value, &Context) -> Result>;
-
-#[cfg(not(target_arch = "wasm32"))]
 type CrossFieldValidateFn =
     Arc<dyn Fn(&Value, &Context) -> Result + Send + Sync>;
 
@@ -2723,7 +2827,7 @@ mod tests {
 
     #[test]
     fn test_required_validator() {
-        let v = RequiredValidator { message: None };
+        let v = RequiredValidator::default();
         let ctx = Context::standalone("test");
         let messages = FormMessages::default();
 
@@ -2741,7 +2845,7 @@ mod tests {
 
     #[test]
     fn test_min_length_validator() {
-        let v = MinLengthValidator { min: 3, message: None };
+        let v = MinLengthValidator::with_length(3);
         let ctx = Context::standalone("test");
 
         let short_value = Value::Text("ab".into());

--- a/spec/foundation/07-forms.md
+++ b/spec/foundation/07-forms.md
@@ -906,16 +906,22 @@ impl StepValidator {
 impl Validator for StepValidator {
     fn validate(&self, value: &Value, ctx: &Context) -> Result {
         if let Some(num) = value.as_number() {
-            let remainder = ((num - self.step_base) % self.step).abs();
-            if remainder > f64::EPSILON && (self.step - remainder) > f64::EPSILON {
-                if let Some(ref msg) = self.message {
-                    return Err(Errors(vec![
-                        Error::custom("step", msg.clone())
-                    ]));
-                }
+            if !self.step.is_finite() || self.step <= 0.0 {
                 let locale = ctx.locale.unwrap_or(&DEFAULT_VALIDATOR_LOCALE);
                 return Err(Errors(vec![
-                    Error::step(self.step, &FormMessages::default(), locale)
+                    self.message.clone()
+                        .map(|m| Error { message: m, code: ErrorCode::Step(self.step) })
+                        .unwrap_or_else(|| Error::step(self.step, &FormMessages::default(), locale))
+                ]));
+            }
+
+            let remainder = ((num - self.step_base) % self.step).abs();
+            if remainder > f64::EPSILON && (self.step - remainder) > f64::EPSILON {
+                let locale = ctx.locale.unwrap_or(&DEFAULT_VALIDATOR_LOCALE);
+                return Err(Errors(vec![
+                    self.message.clone()
+                        .map(|m| Error { message: m, code: ErrorCode::Step(self.step) })
+                        .unwrap_or_else(|| Error::step(self.step, &FormMessages::default(), locale))
                 ]));
             }
         }
@@ -951,14 +957,11 @@ impl Validator for UrlValidator {
     fn validate(&self, value: &Value, ctx: &Context) -> Result {
         if let Some(s) = value.as_text() {
             if !s.is_empty() && !is_valid_url(s) {
-                if let Some(ref msg) = self.message {
-                    return Err(Errors(vec![
-                        Error::custom("url", msg.clone())
-                    ]));
-                }
                 let locale = ctx.locale.unwrap_or(&DEFAULT_VALIDATOR_LOCALE);
                 return Err(Errors(vec![
-                    Error::url(&FormMessages::default(), locale)
+                    self.message.clone()
+                        .map(|m| Error { message: m, code: ErrorCode::Url })
+                        .unwrap_or_else(|| Error::url(&FormMessages::default(), locale))
                 ]));
             }
         }


### PR DESCRIPTION
## Summary
- implement the built-in synchronous validators and `FnValidator` for `ars-forms`
- add regex-backed pattern validation plus feature-gated full email and URL validation
- improve validator ergonomics with semantic constructors, `Default`, and `.with_message(...)`
- align cross-field validator callbacks with the crate-wide `Send + Sync` validator contract
- update the forms spec to match the shipped validator APIs and construction behavior

## Validation
- cargo test -p ars-forms --lib
- cargo test -p ars-forms --lib --no-default-features
- cargo clippy -p ars-forms --lib --tests --no-deps
- cargo clippy -p ars-forms --lib --tests --no-deps --no-default-features
- cargo xci

Closes #166
