### PR TITLE
Implement overlay stack registry for nested overlay dismissal

### DIFF
--- a/crates/ars-dom/src/lib.rs
+++ b/crates/ars-dom/src/lib.rs
@@ -1,9 +1,10 @@
 //! DOM utilities for focus management, scroll control, z-index allocation,
-//! and platform feature detection.
+//! overlay stack tracking, and platform feature detection.
 //!
 //! This crate provides browser-level helpers shared across framework adapters,
-//! including focus management, scroll lock management for modal overlays, and
-//! platform capability detection.
+//! including focus management, scroll lock management for modal overlays,
+//! overlay stack registration for nested dismissal, and platform capability
+//! detection.
 
 // Many ars-dom functions have cfg-gated web implementations that call
 // web_sys/js_sys APIs at runtime. The non-web stubs look const-eligible
@@ -17,6 +18,7 @@ mod announcer;
 pub mod focus;
 pub mod media;
 pub mod modality;
+pub mod overlay_stack;
 pub mod portal;
 pub mod positioning;
 mod scroll;
@@ -39,6 +41,10 @@ pub use media::{
     prefers_reduced_motion, prefers_reduced_transparency,
 };
 pub use modality::ModalityManager;
+pub use overlay_stack::{
+    OverlayEntry, OverlayKind, is_above, is_topmost, overlay_count, overlays_above, push_overlay,
+    remove_overlay, reset_overlay_stack, topmost_overlay,
+};
 #[cfg(feature = "web")]
 pub use portal::{
     ensure_portal_mount_root, get_or_create_portal_root, remove_inert_from_siblings,
@@ -57,7 +63,7 @@ pub use scroll_lock::{
 #[cfg(all(feature = "web", target_arch = "wasm32"))]
 pub use scroll_lock::{needs_ios_workaround, scrollbar_width};
 pub use url::{SafeUrl, UnsafeUrlError, is_safe_url, sanitize_url};
-pub use z_index::{ZIndexAllocator, next_z_index, reset_z_index};
+pub use z_index::{ZIndexAllocator, next_z_index, reset_z_index, supports_top_layer};
 
 /// Describes the platform capabilities available to the current runtime.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]

--- a/crates/ars-dom/src/overlay_stack.rs
+++ b/crates/ars-dom/src/overlay_stack.rs
@@ -1,0 +1,624 @@
+//! Global overlay stack registry for nested overlay dismissal.
+//!
+//! Overlay components (Dialog, Popover, Menu, Tooltip, etc.) register themselves
+//! on this stack when they open and deregister when they close. The stack tracks
+//! stacking order and provides queries used by `InteractOutside` to determine:
+//!
+//! - Which overlay is **topmost** (for Escape-key and outside-click dismissal).
+//! - Whether a click target is **inside a child overlay** (to suppress the
+//!   parent's outside-interaction handler).
+//! - **LIFO close ordering** — Escape / outside-click dismiss the topmost
+//!   overlay first; parent overlays remain open.
+//!
+//! # Design
+//!
+//! The stack is a thread-local `Vec<OverlayEntry>` with LIFO semantics.
+//! `last()` is the topmost overlay. This matches the single-threaded,
+//! `Rc`-based WASM-first design used throughout `ars-dom`.
+//!
+//! The stack is **platform-agnostic** — no DOM access, no cfg-gating.
+//! It tracks pure metadata; the decision of whether to allocate a z-index
+//! (vs. using native top-layer) is made by the overlay component at mount
+//! time and recorded in [`OverlayEntry::z_index`].
+//!
+//! # Spec references
+//!
+//! - `spec/foundation/11-dom-utilities.md` §6.3 "Usage Pattern"
+//! - `spec/foundation/11-dom-utilities.md` §6.5 "CSS top-layer Note"
+//! - `spec/foundation/05-interactions.md` §12.8 "Nested Overlay Handling"
+
+use std::cell::RefCell;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/// Whether an overlay is modal (blocks interaction with background) or
+/// non-modal (background content remains interactive).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OverlayKind {
+    /// Modal overlay: blocks interaction with background content.
+    /// Examples: Dialog, `AlertDialog`.
+    Modal,
+
+    /// Non-modal overlay: background content remains interactive.
+    /// Examples: Popover, Tooltip, Menu.
+    NonModal,
+}
+
+/// Metadata for a single overlay registered in the global stack.
+///
+/// Each overlay component creates an `OverlayEntry` when it opens and passes
+/// it to [`push_overlay()`]. The entry tracks the overlay's identity, stacking
+/// value, and modality for use by dismissal logic.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OverlayEntry {
+    /// Unique identifier for the overlay instance.
+    ///
+    /// Typically matches the portal owner ID or the component's unique
+    /// instance ID (e.g., `"dialog-1"`, `"menu-2"`).
+    pub id: String,
+
+    /// The z-index assigned to this overlay, or `None` when the overlay uses
+    /// the browser's native top-layer (via `<dialog>.showModal()` or the
+    /// `popover` attribute).
+    ///
+    /// When `Some`, the value comes from [`next_z_index()`](crate::z_index::next_z_index).
+    pub z_index: Option<u32>,
+
+    /// Whether this overlay is modal or non-modal.
+    pub kind: OverlayKind,
+}
+
+// ---------------------------------------------------------------------------
+// Thread-local stack
+// ---------------------------------------------------------------------------
+
+thread_local! {
+    /// Global overlay stack tracking all open overlays in stacking order.
+    /// The last element is the topmost overlay.
+    static OVERLAY_STACK: RefCell<Vec<OverlayEntry>> = const { RefCell::new(Vec::new()) };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Register an overlay on the global stack.
+///
+/// The overlay is pushed to the top of the stack. If an overlay with the
+/// same `id` is already registered, this is a no-op (idempotent).
+pub fn push_overlay(entry: OverlayEntry) {
+    OVERLAY_STACK.with(|stack| {
+        let mut stack = stack.borrow_mut();
+
+        if !stack.iter().any(|e| e.id == entry.id) {
+            stack.push(entry);
+        }
+    });
+}
+
+/// Remove an overlay from the global stack by ID.
+///
+/// Returns the removed entry, or `None` if no overlay with that ID was
+/// registered. Supports out-of-order close — removal is by ID, not by
+/// position.
+pub fn remove_overlay(id: &str) -> Option<OverlayEntry> {
+    OVERLAY_STACK.with(|stack| {
+        let mut stack = stack.borrow_mut();
+
+        stack
+            .iter()
+            .position(|e| e.id == id)
+            .map(|pos| stack.remove(pos))
+    })
+}
+
+/// Returns the topmost (most recently pushed) overlay entry, or `None` if
+/// the stack is empty.
+#[must_use]
+pub fn topmost_overlay() -> Option<OverlayEntry> {
+    OVERLAY_STACK.with(|stack| stack.borrow().last().cloned())
+}
+
+/// Returns `true` if the given overlay ID is the topmost in the stack.
+///
+/// Returns `false` if the stack is empty or the ID is not registered.
+#[must_use]
+pub fn is_topmost(id: &str) -> bool {
+    OVERLAY_STACK.with(|stack| stack.borrow().last().is_some_and(|e| e.id == id))
+}
+
+/// Returns the current number of overlays in the stack.
+#[must_use]
+pub fn overlay_count() -> usize {
+    OVERLAY_STACK.with(|stack| stack.borrow().len())
+}
+
+/// Returns `true` if the overlay with `child_id` is above the overlay with
+/// `parent_id` in the stack.
+///
+/// Used by `InteractOutside` to determine whether a click inside a child
+/// overlay should suppress the parent's outside-interaction handler per
+/// `spec/foundation/05-interactions.md` §12.8.
+///
+/// Returns `false` if either ID is not registered, or if both IDs are the
+/// same.
+#[must_use]
+pub fn is_above(child_id: &str, parent_id: &str) -> bool {
+    if child_id == parent_id {
+        return false;
+    }
+
+    OVERLAY_STACK.with(|stack| {
+        let stack = stack.borrow();
+
+        let child_pos = stack.iter().position(|e| e.id == child_id);
+
+        let parent_pos = stack.iter().position(|e| e.id == parent_id);
+
+        if let (Some(c), Some(p)) = (child_pos, parent_pos) {
+            c > p
+        } else {
+            false
+        }
+    })
+}
+
+/// Returns all overlay IDs that are above the given overlay ID in the stack.
+///
+/// Used to determine if a click target is inside any child overlay of the
+/// given parent. Returns an empty `Vec` if the ID is the topmost overlay
+/// or is not registered.
+#[must_use]
+pub fn overlays_above(id: &str) -> Vec<String> {
+    OVERLAY_STACK.with(|stack| {
+        let stack = stack.borrow();
+
+        let Some(pos) = stack.iter().position(|e| e.id == id) else {
+            return Vec::new();
+        };
+
+        stack[pos + 1..].iter().map(|e| e.id.clone()).collect()
+    })
+}
+
+/// Reset the overlay stack, removing all entries.
+///
+/// Intended for tests and application-level teardown (e.g., full-page
+/// navigation in an SPA).
+pub fn reset_overlay_stack() {
+    OVERLAY_STACK.with(|stack| stack.borrow_mut().clear());
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/// Reset the thread-local overlay stack.
+/// Called by [`tests::serial_reset()`] before each test.
+#[cfg(test)]
+fn reset_global_state() {
+    OVERLAY_STACK.with(|stack| stack.borrow_mut().clear());
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Mutex, MutexGuard};
+
+    use super::*;
+
+    /// Serializes overlay stack tests so they don't run in parallel.
+    ///
+    /// Although `thread_local!` is per-thread, the Rust test runner may reuse
+    /// threads across tests. Each test calls [`serial_reset()`] which acquires
+    /// this lock and clears global state before the test body runs. The
+    /// returned guard holds the lock for the test's lifetime.
+    static TEST_SERIAL: Mutex<()> = Mutex::new(());
+
+    /// Acquire the serialization lock and reset global state.
+    ///
+    /// Returns a [`MutexGuard`] that keeps the lock held until dropped
+    /// (end of the calling test).
+    fn serial_reset() -> MutexGuard<'static, ()> {
+        let guard = TEST_SERIAL
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        reset_global_state();
+
+        guard
+    }
+
+    /// Create a non-modal overlay entry with the given ID and z-index.
+    fn entry(id: &str, z: u32) -> OverlayEntry {
+        OverlayEntry {
+            id: id.to_owned(),
+            z_index: Some(z),
+            kind: OverlayKind::NonModal,
+        }
+    }
+
+    /// Create a modal overlay entry with the given ID and z-index.
+    fn modal_entry(id: &str, z: u32) -> OverlayEntry {
+        OverlayEntry {
+            id: id.to_owned(),
+            z_index: Some(z),
+            kind: OverlayKind::Modal,
+        }
+    }
+
+    // == A. Push/pop operations =================================================
+
+    #[test]
+    fn push_increases_count() {
+        let _g = serial_reset();
+
+        assert_eq!(overlay_count(), 0);
+
+        push_overlay(entry("dialog-1", 1000));
+
+        assert_eq!(overlay_count(), 1);
+    }
+
+    #[test]
+    fn push_idempotent_same_id() {
+        let _g = serial_reset();
+
+        push_overlay(entry("dialog-1", 1000));
+        push_overlay(entry("dialog-1", 1001));
+
+        assert_eq!(
+            overlay_count(),
+            1,
+            "duplicate ID should not add second entry"
+        );
+    }
+
+    #[test]
+    fn remove_decreases_count() {
+        let _g = serial_reset();
+
+        push_overlay(entry("dialog-1", 1000));
+
+        assert_eq!(overlay_count(), 1);
+
+        remove_overlay("dialog-1");
+
+        assert_eq!(overlay_count(), 0);
+    }
+
+    #[test]
+    fn remove_returns_entry() {
+        let _g = serial_reset();
+
+        push_overlay(entry("dialog-1", 1000));
+
+        let removed = remove_overlay("dialog-1");
+
+        assert_eq!(removed, Some(entry("dialog-1", 1000)));
+    }
+
+    #[test]
+    fn remove_unknown_returns_none() {
+        let _g = serial_reset();
+
+        assert_eq!(remove_overlay("nonexistent"), None);
+    }
+
+    // == B. Modal vs non-modal distinction ======================================
+
+    #[test]
+    fn modal_and_non_modal_coexist() {
+        let _g = serial_reset();
+
+        push_overlay(modal_entry("dialog-1", 1000));
+        push_overlay(entry("menu-1", 1001));
+
+        assert_eq!(overlay_count(), 2);
+    }
+
+    #[test]
+    fn kind_is_preserved() {
+        let _g = serial_reset();
+
+        push_overlay(modal_entry("dialog-1", 1000));
+
+        let top = topmost_overlay().expect("stack should not be empty");
+
+        assert_eq!(top.kind, OverlayKind::Modal);
+    }
+
+    // == C. Topmost overlay detection ===========================================
+
+    #[test]
+    fn topmost_returns_last_pushed() {
+        let _g = serial_reset();
+
+        push_overlay(entry("dialog-1", 1000));
+        push_overlay(entry("menu-1", 1001));
+
+        let top = topmost_overlay().expect("stack should not be empty");
+
+        assert_eq!(top.id, "menu-1");
+    }
+
+    #[test]
+    fn topmost_none_when_empty() {
+        let _g = serial_reset();
+
+        assert_eq!(topmost_overlay(), None);
+    }
+
+    #[test]
+    fn is_topmost_true_for_last() {
+        let _g = serial_reset();
+
+        push_overlay(entry("dialog-1", 1000));
+        push_overlay(entry("menu-1", 1001));
+
+        assert!(is_topmost("menu-1"));
+    }
+
+    #[test]
+    fn is_topmost_false_for_non_topmost() {
+        let _g = serial_reset();
+
+        push_overlay(entry("dialog-1", 1000));
+        push_overlay(entry("menu-1", 1001));
+
+        assert!(!is_topmost("dialog-1"));
+    }
+
+    #[test]
+    fn is_topmost_false_for_unknown() {
+        let _g = serial_reset();
+
+        push_overlay(entry("dialog-1", 1000));
+
+        assert!(!is_topmost("nonexistent"));
+    }
+
+    // == D. LIFO close ordering =================================================
+
+    #[test]
+    fn lifo_close_reveals_previous() {
+        let _g = serial_reset();
+
+        push_overlay(entry("dialog-1", 1000));
+        push_overlay(entry("menu-1", 1001));
+        push_overlay(entry("tooltip-1", 1002));
+
+        remove_overlay("tooltip-1");
+
+        let top = topmost_overlay().expect("stack should not be empty");
+
+        assert_eq!(top.id, "menu-1");
+    }
+
+    #[test]
+    fn lifo_close_full_sequence() {
+        let _g = serial_reset();
+
+        push_overlay(entry("a", 1000));
+        push_overlay(entry("b", 1001));
+        push_overlay(entry("c", 1002));
+
+        remove_overlay("c");
+        remove_overlay("b");
+        remove_overlay("a");
+
+        assert_eq!(overlay_count(), 0);
+        assert_eq!(topmost_overlay(), None);
+    }
+
+    // == E. Nested overlay suppression (is_above / overlays_above) ==============
+
+    #[test]
+    fn is_above_child_above_parent() {
+        let _g = serial_reset();
+
+        push_overlay(entry("parent", 1000));
+        push_overlay(entry("child", 1001));
+
+        assert!(is_above("child", "parent"));
+    }
+
+    #[test]
+    fn is_above_parent_not_above_child() {
+        let _g = serial_reset();
+
+        push_overlay(entry("parent", 1000));
+        push_overlay(entry("child", 1001));
+
+        assert!(!is_above("parent", "child"));
+    }
+
+    #[test]
+    fn is_above_same_id_false() {
+        let _g = serial_reset();
+
+        push_overlay(entry("dialog-1", 1000));
+
+        assert!(!is_above("dialog-1", "dialog-1"));
+    }
+
+    #[test]
+    fn is_above_unknown_false() {
+        let _g = serial_reset();
+
+        push_overlay(entry("dialog-1", 1000));
+
+        assert!(!is_above("nonexistent", "dialog-1"));
+        assert!(!is_above("dialog-1", "nonexistent"));
+        assert!(!is_above("foo", "bar"));
+    }
+
+    #[test]
+    fn overlays_above_returns_children() {
+        let _g = serial_reset();
+
+        push_overlay(entry("a", 1000));
+        push_overlay(entry("b", 1001));
+        push_overlay(entry("c", 1002));
+
+        let above = overlays_above("a");
+
+        assert_eq!(above, vec!["b", "c"]);
+    }
+
+    #[test]
+    fn overlays_above_topmost_empty() {
+        let _g = serial_reset();
+
+        push_overlay(entry("a", 1000));
+        push_overlay(entry("b", 1001));
+
+        let above = overlays_above("b");
+
+        assert!(above.is_empty());
+    }
+
+    #[test]
+    fn overlays_above_unknown_empty() {
+        let _g = serial_reset();
+
+        push_overlay(entry("a", 1000));
+
+        let above = overlays_above("nonexistent");
+
+        assert!(above.is_empty());
+    }
+
+    // == F. Out-of-order removal ================================================
+
+    #[test]
+    fn out_of_order_preserves_remaining() {
+        let _g = serial_reset();
+
+        push_overlay(entry("a", 1000));
+        push_overlay(entry("b", 1001));
+        push_overlay(entry("c", 1002));
+
+        // Remove middle entry
+        remove_overlay("b");
+
+        assert_eq!(overlay_count(), 2);
+
+        let top = topmost_overlay().expect("stack should not be empty");
+
+        assert_eq!(top.id, "c");
+
+        // Remove top
+        remove_overlay("c");
+
+        let top = topmost_overlay().expect("stack should not be empty");
+
+        assert_eq!(top.id, "a");
+    }
+
+    #[test]
+    fn out_of_order_is_above_still_works() {
+        let _g = serial_reset();
+
+        push_overlay(entry("a", 1000));
+        push_overlay(entry("b", 1001));
+        push_overlay(entry("c", 1002));
+
+        // Remove middle entry
+        remove_overlay("b");
+
+        // c is still above a
+        assert!(is_above("c", "a"));
+    }
+
+    // == G. Reset ===============================================================
+
+    #[test]
+    fn reset_clears_entire_stack() {
+        let _g = serial_reset();
+
+        push_overlay(entry("a", 1000));
+        push_overlay(entry("b", 1001));
+        push_overlay(entry("c", 1002));
+
+        reset_overlay_stack();
+
+        assert_eq!(overlay_count(), 0);
+        assert_eq!(topmost_overlay(), None);
+    }
+
+    // == H. Z-index metadata ====================================================
+
+    #[test]
+    fn z_index_preserved() {
+        let _g = serial_reset();
+
+        push_overlay(entry("dialog-1", 1042));
+
+        let top = topmost_overlay().expect("stack should not be empty");
+
+        assert_eq!(top.z_index, Some(1042));
+    }
+
+    #[test]
+    fn z_index_none_for_top_layer() {
+        let _g = serial_reset();
+
+        push_overlay(OverlayEntry {
+            id: "dialog-1".to_owned(),
+            z_index: None,
+            kind: OverlayKind::Modal,
+        });
+
+        let top = topmost_overlay().expect("stack should not be empty");
+
+        assert_eq!(top.z_index, None);
+    }
+
+    // == I. Trait implementations ===============================================
+
+    #[test]
+    fn overlay_kind_debug() {
+        assert_eq!(format!("{:?}", OverlayKind::Modal), "Modal");
+        assert_eq!(format!("{:?}", OverlayKind::NonModal), "NonModal");
+    }
+
+    #[test]
+    fn overlay_entry_debug() {
+        let e = entry("dialog-1", 1000);
+
+        let debug = format!("{e:?}");
+
+        assert!(
+            debug.contains("OverlayEntry"),
+            "Debug output should contain the type name"
+        );
+        assert!(debug.contains("dialog-1"));
+    }
+
+    #[test]
+    fn overlay_kind_clone_copy() {
+        let kind = OverlayKind::Modal;
+
+        #[expect(clippy::clone_on_copy, reason = "explicitly testing Clone impl")]
+        let cloned = kind.clone();
+        let copied = kind;
+
+        assert_eq!(kind, cloned);
+        assert_eq!(kind, copied);
+    }
+
+    #[test]
+    fn overlay_entry_clone() {
+        let e = entry("dialog-1", 1000);
+
+        let cloned = e.clone();
+
+        assert_eq!(e, cloned);
+    }
+}

--- a/crates/ars-dom/src/z_index.rs
+++ b/crates/ars-dom/src/z_index.rs
@@ -188,6 +188,57 @@ impl Default for ZIndexAllocator {
 }
 
 // ---------------------------------------------------------------------------
+// Top-layer detection
+// ---------------------------------------------------------------------------
+
+/// Check whether the browser supports the CSS top-layer (native `<dialog>` or
+/// popover API).
+///
+/// When `true`, overlay components can skip [`next_z_index()`] and rely on the
+/// browser's native stacking via `<dialog>.showModal()` or the `popover`
+/// attribute. When `false`, components fall back to z-index-based stacking.
+///
+/// The result is detected once per thread and cached. Subsequent calls return
+/// the cached value without DOM access.
+///
+/// Returns `false` on non-wasm targets and when `window()` is unavailable
+/// (SSR, Web Worker).
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
+#[must_use]
+pub fn supports_top_layer() -> bool {
+    thread_local! {
+        static CACHED: Cell<Option<bool>> = const { Cell::new(None) };
+    }
+
+    CACHED.with(|c| {
+        if let Some(v) = c.get() {
+            return v;
+        }
+
+        let supported = web_sys::window()
+            .and_then(|w| w.document())
+            .and_then(|d| d.create_element("dialog").ok())
+            .is_some_and(|el| {
+                js_sys::Reflect::has(&el, &wasm_bindgen::JsValue::from_str("showModal"))
+                    .unwrap_or(false)
+            });
+
+        c.set(Some(supported));
+
+        supported
+    })
+}
+
+/// Check whether the browser supports the CSS top-layer.
+///
+/// Returns `false` on non-wasm targets — top-layer is a browser-only concept.
+#[cfg(not(all(feature = "web", target_arch = "wasm32")))]
+#[must_use]
+pub const fn supports_top_layer() -> bool {
+    false
+}
+
+// ---------------------------------------------------------------------------
 // Test helpers
 // ---------------------------------------------------------------------------
 
@@ -447,5 +498,55 @@ mod tests {
             debug.contains("ZIndexAllocator"),
             "Debug output should contain the type name"
         );
+    }
+
+    // == G. supports_top_layer() ================================================
+
+    #[test]
+    fn supports_top_layer_returns_false_without_browser() {
+        // Non-wasm targets always return false — top-layer is a browser-only concept.
+        assert!(!supports_top_layer());
+    }
+
+    #[test]
+    fn supports_top_layer_is_idempotent() {
+        // Repeated calls must return the same value (exercises cache path).
+        let first = supports_top_layer();
+
+        let second = supports_top_layer();
+
+        assert_eq!(first, second);
+    }
+}
+
+#[cfg(all(test, feature = "web", target_arch = "wasm32"))]
+mod wasm_tests {
+    use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+
+    use super::*;
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    // ── supports_top_layer ─────────────────────────────────────────────
+
+    #[wasm_bindgen_test]
+    fn supports_top_layer_returns_true_in_modern_browser() {
+        // Modern test browsers (Chrome, Firefox, Safari 15.4+) support
+        // native <dialog> with showModal, so this should return true.
+        // The important thing is that the function executes without panic
+        // and exercises the window → document → createElement → Reflect path.
+        let result = supports_top_layer();
+
+        assert!(result, "modern browsers should support top-layer");
+    }
+
+    #[wasm_bindgen_test]
+    fn supports_top_layer_caches_across_calls() {
+        // Calling twice exercises the Cell<Option<bool>> cache-hit path.
+        let first = supports_top_layer();
+
+        let second = supports_top_layer();
+
+        assert_eq!(first, second);
     }
 }

--- a/spec/foundation/11-dom-utilities.md
+++ b/spec/foundation/11-dom-utilities.md
@@ -2484,7 +2484,7 @@ The library detects top-layer support at runtime. When available, overlay compon
 /// This is detected once and cached.
 pub fn supports_top_layer() -> bool {
     thread_local! {
-        static CACHED: Cell<Option<bool>> = Cell::new(None);
+        static CACHED: Cell<Option<bool>> = const { Cell::new(None) };
     }
     CACHED.with(|c| {
         if let Some(v) = c.get() {
@@ -2493,7 +2493,10 @@ pub fn supports_top_layer() -> bool {
         let supported = web_sys::window()
             .and_then(|w| w.document())
             .and_then(|d| d.create_element("dialog").ok())
-            .map(|el| js_sys::Reflect::has(&el, &"showModal".into()).unwrap_or(false))
+            .map(|el| {
+                js_sys::Reflect::has(&el, &wasm_bindgen::JsValue::from_str("showModal"))
+                    .unwrap_or(false)
+            })
             .unwrap_or(false);
         c.set(Some(supported));
         supported

--- a/spec/testing/14-ci.md
+++ b/spec/testing/14-ci.md
@@ -119,6 +119,36 @@ i18n-browser:
         - run: cargo xtest i18n-browser
 ```
 
+### 1.3.2 DOM Browser Tests
+
+The `web` feature of `ars-dom` gates browser-specific code paths for focus
+management, portal infrastructure, scroll helpers, media queries, z-index
+allocation, and overlay stack support detection. CI MUST exercise these paths
+through `cargo xtest dom-browser`, which wraps:
+
+```bash
+wasm-pack test --headless --chrome crates/ars-dom
+```
+
+This stage uses the crate's default features (`web`), which enable `js-sys`,
+`wasm-bindgen`, and `web-sys`. It verifies that DOM-level helpers behave
+correctly in a real browser environment, not just that they cross-compile to
+`wasm32`.
+
+```yaml
+dom-browser:
+    name: DOM Browser Tests
+    needs: [unit]
+    runs-on: ubuntu-latest
+    steps:
+        - uses: actions/checkout@v4
+        - uses: dtolnay/rust-toolchain@stable
+          with:
+              targets: wasm32-unknown-unknown
+        - run: cargo install wasm-pack --locked --version 0.14.0
+        - run: cargo xtest dom-browser
+```
+
 ### 1.4 Release Verification
 
 Release-mode regressions MUST be caught in CI, even when the debug-profile

--- a/xtask/src/ci/mod.rs
+++ b/xtask/src/ci/mod.rs
@@ -40,6 +40,9 @@ pub enum Step {
     /// Browser-executed wasm tests for ars-i18n's web-intl backend.
     I18nBrowser,
 
+    /// Browser-executed wasm tests for ars-dom's web feature.
+    DomBrowser,
+
     /// Release-profile compile and test smoke checks.
     Release,
 
@@ -84,6 +87,7 @@ const PIPELINE_ORDER: &[Step] = &[
     Step::Clippy,
     Step::Unit,
     Step::I18nBrowser,
+    Step::DomBrowser,
     Step::Release,
     Step::Integration,
     Step::Adapter,
@@ -235,6 +239,8 @@ fn run_step(step: Step, message_format: Option<&str>) -> Result<(), Error> {
 
         Step::I18nBrowser => run_i18n_browser(),
 
+        Step::DomBrowser => run_dom_browser(),
+
         Step::Release => run_release(),
 
         Step::Integration => run_integration(),
@@ -371,6 +377,10 @@ fn run_unit() -> Result<(), Error> {
 
 fn run_i18n_browser() -> Result<(), Error> {
     run_test_stage(Step::I18nBrowser, test::Stage::I18nBrowser)
+}
+
+fn run_dom_browser() -> Result<(), Error> {
+    run_test_stage(Step::DomBrowser, test::Stage::DomBrowser)
 }
 
 fn run_release() -> Result<(), Error> {
@@ -680,6 +690,7 @@ const fn step_name(step: Step) -> &'static str {
         Step::Clippy => "clippy",
         Step::Unit => "unit",
         Step::I18nBrowser => "i18n-browser",
+        Step::DomBrowser => "dom-browser",
         Step::Release => "release",
         Step::Integration => "integration",
         Step::Adapter => "adapter",
@@ -805,6 +816,7 @@ mod tests {
             Step::Clippy,
             Step::Unit,
             Step::I18nBrowser,
+            Step::DomBrowser,
             Step::Release,
             Step::Integration,
             Step::Adapter,

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -134,6 +134,9 @@ enum TestCommand {
     /// Run browser-executed wasm tests for ars-i18n's web-intl backend.
     I18nBrowser,
 
+    /// Run browser-executed wasm tests for ars-dom's web feature.
+    DomBrowser,
+
     /// Run the release verification test stage.
     Release,
 
@@ -342,6 +345,7 @@ fn main() {
             let stage = cmd.map(|cmd| match cmd {
                 TestCommand::Unit => test::Stage::Unit,
                 TestCommand::I18nBrowser => test::Stage::I18nBrowser,
+                TestCommand::DomBrowser => test::Stage::DomBrowser,
                 TestCommand::Release => test::Stage::Release,
                 TestCommand::Integration => test::Stage::Integration,
                 TestCommand::Adapter => test::Stage::Adapter,

--- a/xtask/src/test.rs
+++ b/xtask/src/test.rs
@@ -28,6 +28,9 @@ pub enum Stage {
     /// Browser-executed wasm tests for ars-i18n's `web-intl` backend.
     I18nBrowser,
 
+    /// Browser-executed wasm tests for ars-dom's web feature.
+    DomBrowser,
+
     /// Release-profile test verification.
     Release,
 
@@ -146,6 +149,7 @@ pub fn run(stage: Option<Stage>) -> Result<Summary, Error> {
             vec![
                 Stage::Unit,
                 Stage::I18nBrowser,
+                Stage::DomBrowser,
                 Stage::Release,
                 Stage::Integration,
                 Stage::Adapter,
@@ -225,6 +229,7 @@ fn run_stage_inner(stage: Stage) -> Result<StageResult, Error> {
     match stage {
         Stage::Unit => run_unit_stage(),
         Stage::I18nBrowser => run_i18n_browser_stage(),
+        Stage::DomBrowser => run_dom_browser_stage(),
         Stage::Release => run_release_stage(),
         Stage::Integration => run_invocations(integration_invocations()),
         Stage::Adapter => run_invocations(adapter_invocations()),
@@ -261,6 +266,28 @@ fn run_i18n_browser_stage() -> Result<StageResult, Error> {
         result
             .failures
             .push(format_failure("i18n browser", &run.command, run.code));
+    }
+
+    Ok(result)
+}
+
+fn run_dom_browser_stage() -> Result<StageResult, Error> {
+    let run = run_shell_command(
+        "dom browser",
+        "wasm-pack",
+        &["test", "--headless", "--chrome", "crates/ars-dom"],
+    )?;
+
+    let mut result = StageResult::default();
+
+    result
+        .summary
+        .add_assign(parse_wasm_pack_summary(&run.output));
+
+    if !run.success {
+        result
+            .failures
+            .push(format_failure("dom browser", &run.command, run.code));
     }
 
     Ok(result)
@@ -499,7 +526,7 @@ fn preflight_wasm_pack() -> Result<(), Error> {
 
 fn preflight_for_stage(stage: Stage) -> Result<(), Error> {
     match stage {
-        Stage::I18nBrowser => preflight_wasm_pack(),
+        Stage::I18nBrowser | Stage::DomBrowser => preflight_wasm_pack(),
         Stage::Unit
         | Stage::Release
         | Stage::Integration
@@ -709,6 +736,7 @@ const fn stage_name(stage: Stage) -> &'static str {
     match stage {
         Stage::Unit => "unit",
         Stage::I18nBrowser => "i18n-browser",
+        Stage::DomBrowser => "dom-browser",
         Stage::Release => "release",
         Stage::Integration => "integration",
         Stage::Adapter => "adapter",
@@ -876,6 +904,11 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 filtered out;
     #[test]
     fn stage_name_reports_i18n_browser() {
         assert_eq!(stage_name(Stage::I18nBrowser), "i18n-browser");
+    }
+
+    #[test]
+    fn stage_name_reports_dom_browser() {
+        assert_eq!(stage_name(Stage::DomBrowser), "dom-browser");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `overlay_stack.rs` with global LIFO overlay stack registry (`push_overlay`, `remove_overlay`, `topmost_overlay`, `is_topmost`, `is_above`, `overlays_above`, `overlay_count`, `reset_overlay_stack`) for nested overlay dismissal ordering
- Add `supports_top_layer()` to `z_index.rs` with cfg-gated browser detection (native `<dialog>` showModal) and thread-local caching
- Add `dom-browser` CI stage (`cargo xtest dom-browser`) to exercise all ars-dom wasm tests in a headless Chrome browser, matching the existing `i18n-browser` pattern
- Sync spec: update `11-dom-utilities.md` §6.5 code example and add `14-ci.md` §1.3.2 documenting the new CI stage

## Test plan
- [x] 30 unit tests in `overlay_stack.rs` covering push/pop, idempotency, LIFO ordering, nested suppression (`is_above`/`overlays_above`), out-of-order removal, reset, z-index metadata, and trait impls
- [x] 2 native + 2 wasm browser tests for `supports_top_layer()` (cold cache, warm cache, browser detection)
- [x] 100% line/region/function coverage for both `overlay_stack.rs` and `z_index.rs`
- [x] `cargo xci` passes all 16/16 steps (including new `dom-browser` stage with 30 wasm tests)
- [x] Zero clippy warnings across workspace

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)