### PR TITLE
Add is_above() to overlay stack and dom-browser CI stage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,21 @@ jobs:
       - name: I18n Browser Tests
         run: cargo xtest i18n-browser
 
+  dom-browser:
+    name: DOM Browser Tests
+    needs: [unit]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+      - name: Install wasm-pack
+        run: cargo install wasm-pack --locked --version 0.14.0
+      - name: DOM Browser Tests
+        run: cargo xtest dom-browser
+
   release:
     name: Release Verification
     needs: [unit]

--- a/crates/ars-dom/src/lib.rs
+++ b/crates/ars-dom/src/lib.rs
@@ -42,8 +42,8 @@ pub use media::{
 };
 pub use modality::ModalityManager;
 pub use overlay_stack::{
-    OverlayEntry, contains_overlay, is_topmost, overlay_count, overlays_above, push_overlay,
-    remove_overlay, reset_overlay_stack, topmost_overlay,
+    OverlayEntry, contains_overlay, is_above, is_topmost, overlay_count, overlays_above,
+    push_overlay, remove_overlay, reset_overlay_stack, topmost_overlay,
 };
 #[cfg(feature = "web")]
 pub use portal::{

--- a/crates/ars-dom/src/overlay_stack.rs
+++ b/crates/ars-dom/src/overlay_stack.rs
@@ -159,6 +159,32 @@ pub fn contains_overlay(id: &str) -> bool {
     OVERLAY_STACK.with(|stack| stack.borrow().iter().any(|e| e.id == id))
 }
 
+/// Check whether `child_id` is stacked above `parent_id`.
+///
+/// Returns `true` when both IDs are registered and the child appears later
+/// in the stack (i.e., was pushed after the parent). Returns `false` when
+/// either ID is missing or when `child_id == parent_id`.
+///
+/// This is a convenience wrapper for `InteractOutside` suppression logic:
+/// a parent overlay should not fire an outside-interaction event when the
+/// click target belongs to a child overlay that is above it.
+///
+/// # Spec reference
+///
+/// `spec/foundation/05-interactions.md` §12.8 rule 2 — "A click inside a
+/// child overlay does NOT trigger `InteractOutside` on the parent."
+#[must_use]
+pub fn is_above(child_id: &str, parent_id: &str) -> bool {
+    OVERLAY_STACK.with(|stack| {
+        let stack = stack.borrow();
+
+        let parent_pos = stack.iter().position(|e| e.id == parent_id);
+        let child_pos = stack.iter().position(|e| e.id == child_id);
+
+        matches!((parent_pos, child_pos), (Some(p), Some(c)) if c > p)
+    })
+}
+
 /// Return the number of overlays currently on the stack.
 #[must_use]
 pub fn overlay_count() -> usize {
@@ -526,6 +552,80 @@ mod tests {
 
         assert_eq!(overlay_count(), 1);
     }
+
+    // == F2. is_above ==========================================================
+
+    #[test]
+    fn is_above_child_above_parent() {
+        let _g = serial_reset();
+
+        push_overlay(entry("dialog", true, Some(1000)));
+        push_overlay(entry("menu", false, Some(1001)));
+        push_overlay(entry("tooltip", false, Some(1002)));
+
+        assert!(is_above("menu", "dialog"), "menu is above dialog");
+        assert!(is_above("tooltip", "dialog"), "tooltip is above dialog");
+        assert!(is_above("tooltip", "menu"), "tooltip is above menu");
+    }
+
+    #[test]
+    fn is_above_parent_not_above_child() {
+        let _g = serial_reset();
+
+        push_overlay(entry("dialog", true, Some(1000)));
+        push_overlay(entry("menu", false, Some(1001)));
+
+        assert!(!is_above("dialog", "menu"), "parent is not above its child");
+    }
+
+    #[test]
+    fn is_above_same_id_false() {
+        let _g = serial_reset();
+
+        push_overlay(entry("dialog", true, Some(1000)));
+
+        assert!(
+            !is_above("dialog", "dialog"),
+            "an overlay is not above itself"
+        );
+    }
+
+    #[test]
+    fn is_above_unknown_id_false() {
+        let _g = serial_reset();
+
+        push_overlay(entry("dialog", true, Some(1000)));
+
+        assert!(
+            !is_above("nonexistent", "dialog"),
+            "unknown child returns false"
+        );
+        assert!(
+            !is_above("dialog", "nonexistent"),
+            "unknown parent returns false"
+        );
+        assert!(
+            !is_above("ghost-a", "ghost-b"),
+            "both unknown returns false"
+        );
+    }
+
+    #[test]
+    fn is_above_after_out_of_order_removal() {
+        let _g = serial_reset();
+
+        push_overlay(entry("a", false, Some(1000)));
+        push_overlay(entry("b", false, Some(1001)));
+        push_overlay(entry("c", false, Some(1002)));
+
+        // Remove middle overlay
+        remove_overlay("b");
+
+        assert!(is_above("c", "a"), "c is still above a after b removed");
+        assert!(!is_above("b", "a"), "removed overlay is not above anything");
+    }
+
+    // == F3. Reset =============================================================
 
     #[test]
     fn reset_clears_all() {

--- a/spec/foundation/11-dom-utilities.md
+++ b/spec/foundation/11-dom-utilities.md
@@ -2826,6 +2826,24 @@ pub fn contains_overlay(id: &str) -> bool {
     OVERLAY_STACK.with(|stack| stack.borrow().iter().any(|e| e.id == id))
 }
 
+/// Check whether `child_id` is stacked above `parent_id`.
+///
+/// Returns `true` when both IDs are registered and the child appears later
+/// in the stack (i.e., was pushed after the parent). Returns `false` when
+/// either ID is missing or when `child_id == parent_id`.
+///
+/// Convenience wrapper for `InteractOutside` suppression: a parent overlay
+/// should not fire an outside-interaction event when the click target belongs
+/// to a child overlay above it.
+pub fn is_above(child_id: &str, parent_id: &str) -> bool {
+    OVERLAY_STACK.with(|stack| {
+        let stack = stack.borrow();
+        let parent_pos = stack.iter().position(|e| e.id == parent_id);
+        let child_pos = stack.iter().position(|e| e.id == child_id);
+        matches!((parent_pos, child_pos), (Some(p), Some(c)) if c > p)
+    })
+}
+
 /// Return the number of overlays currently on the stack.
 pub fn overlay_count() -> usize {
     OVERLAY_STACK.with(|stack| stack.borrow().len())
@@ -2862,10 +2880,10 @@ push_overlay(OverlayEntry {
 remove_overlay(&ids.base);
 ```
 
-`InteractOutside` (see `05-interactions.md` §12.8) consults the overlay stack via `is_topmost()` and `overlays_above()` to implement nested overlay dismissal:
+`InteractOutside` (see `05-interactions.md` §12.8) consults the overlay stack via `is_topmost()`, `is_above()`, and `overlays_above()` to implement nested overlay dismissal:
 
 1. Before processing an outside interaction, check `is_topmost(my_id)` — only the topmost overlay responds.
-2. Before firing `InteractOutsideEvent::PointerOutside`, check whether the resolved element is inside any ID returned by `overlays_above(my_id)` — clicks inside child overlays are not "outside."
+2. Before firing `InteractOutsideEvent::PointerOutside`, use `is_above(child_id, my_id)` to check whether the click target belongs to a child overlay — clicks inside child overlays are not "outside." For bulk queries, `overlays_above(my_id)` returns all child IDs at once.
 
 ### 9.5 Components That Use the Overlay Stack
 

--- a/spec/testing/14-ci.md
+++ b/spec/testing/14-ci.md
@@ -119,6 +119,36 @@ i18n-browser:
         - run: cargo xtest i18n-browser
 ```
 
+### 1.3.2 DOM Browser Tests
+
+The `web` feature of `ars-dom` gates browser-specific code paths for focus
+management, portal infrastructure, scroll helpers, media queries, z-index
+allocation, and overlay stack support detection. CI MUST exercise these paths
+through `cargo xtest dom-browser`, which wraps:
+
+```bash
+wasm-pack test --headless --chrome crates/ars-dom
+```
+
+This stage uses the crate's default features (`web`), which enable `js-sys`,
+`wasm-bindgen`, and `web-sys`. It verifies that DOM-level helpers behave
+correctly in a real browser environment, not just that they cross-compile to
+`wasm32`.
+
+```yaml
+dom-browser:
+    name: DOM Browser Tests
+    needs: [unit]
+    runs-on: ubuntu-latest
+    steps:
+        - uses: actions/checkout@v4
+        - uses: dtolnay/rust-toolchain@stable
+          with:
+              targets: wasm32-unknown-unknown
+        - run: cargo install wasm-pack --locked --version 0.14.0
+        - run: cargo xtest dom-browser
+```
+
 ### 1.4 Release Verification
 
 Release-mode regressions MUST be caught in CI, even when the debug-profile

--- a/xtask/src/ci/mod.rs
+++ b/xtask/src/ci/mod.rs
@@ -40,6 +40,9 @@ pub enum Step {
     /// Browser-executed wasm tests for ars-i18n's web-intl backend.
     I18nBrowser,
 
+    /// Browser-executed wasm tests for ars-dom's web feature.
+    DomBrowser,
+
     /// Release-profile compile and test smoke checks.
     Release,
 
@@ -84,6 +87,7 @@ const PIPELINE_ORDER: &[Step] = &[
     Step::Clippy,
     Step::Unit,
     Step::I18nBrowser,
+    Step::DomBrowser,
     Step::Release,
     Step::Integration,
     Step::Adapter,
@@ -235,6 +239,8 @@ fn run_step(step: Step, message_format: Option<&str>) -> Result<(), Error> {
 
         Step::I18nBrowser => run_i18n_browser(),
 
+        Step::DomBrowser => run_dom_browser(),
+
         Step::Release => run_release(),
 
         Step::Integration => run_integration(),
@@ -371,6 +377,10 @@ fn run_unit() -> Result<(), Error> {
 
 fn run_i18n_browser() -> Result<(), Error> {
     run_test_stage(Step::I18nBrowser, test::Stage::I18nBrowser)
+}
+
+fn run_dom_browser() -> Result<(), Error> {
+    run_test_stage(Step::DomBrowser, test::Stage::DomBrowser)
 }
 
 fn run_release() -> Result<(), Error> {
@@ -680,6 +690,7 @@ const fn step_name(step: Step) -> &'static str {
         Step::Clippy => "clippy",
         Step::Unit => "unit",
         Step::I18nBrowser => "i18n-browser",
+        Step::DomBrowser => "dom-browser",
         Step::Release => "release",
         Step::Integration => "integration",
         Step::Adapter => "adapter",
@@ -805,6 +816,7 @@ mod tests {
             Step::Clippy,
             Step::Unit,
             Step::I18nBrowser,
+            Step::DomBrowser,
             Step::Release,
             Step::Integration,
             Step::Adapter,

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -134,6 +134,9 @@ enum TestCommand {
     /// Run browser-executed wasm tests for ars-i18n's web-intl backend.
     I18nBrowser,
 
+    /// Run browser-executed wasm tests for ars-dom's web feature.
+    DomBrowser,
+
     /// Run the release verification test stage.
     Release,
 
@@ -342,6 +345,7 @@ fn main() {
             let stage = cmd.map(|cmd| match cmd {
                 TestCommand::Unit => test::Stage::Unit,
                 TestCommand::I18nBrowser => test::Stage::I18nBrowser,
+                TestCommand::DomBrowser => test::Stage::DomBrowser,
                 TestCommand::Release => test::Stage::Release,
                 TestCommand::Integration => test::Stage::Integration,
                 TestCommand::Adapter => test::Stage::Adapter,

--- a/xtask/src/test.rs
+++ b/xtask/src/test.rs
@@ -28,6 +28,9 @@ pub enum Stage {
     /// Browser-executed wasm tests for ars-i18n's `web-intl` backend.
     I18nBrowser,
 
+    /// Browser-executed wasm tests for ars-dom's web feature.
+    DomBrowser,
+
     /// Release-profile test verification.
     Release,
 
@@ -146,6 +149,7 @@ pub fn run(stage: Option<Stage>) -> Result<Summary, Error> {
             vec![
                 Stage::Unit,
                 Stage::I18nBrowser,
+                Stage::DomBrowser,
                 Stage::Release,
                 Stage::Integration,
                 Stage::Adapter,
@@ -225,6 +229,7 @@ fn run_stage_inner(stage: Stage) -> Result<StageResult, Error> {
     match stage {
         Stage::Unit => run_unit_stage(),
         Stage::I18nBrowser => run_i18n_browser_stage(),
+        Stage::DomBrowser => run_dom_browser_stage(),
         Stage::Release => run_release_stage(),
         Stage::Integration => run_invocations(integration_invocations()),
         Stage::Adapter => run_invocations(adapter_invocations()),
@@ -261,6 +266,28 @@ fn run_i18n_browser_stage() -> Result<StageResult, Error> {
         result
             .failures
             .push(format_failure("i18n browser", &run.command, run.code));
+    }
+
+    Ok(result)
+}
+
+fn run_dom_browser_stage() -> Result<StageResult, Error> {
+    let run = run_shell_command(
+        "dom browser",
+        "wasm-pack",
+        &["test", "--headless", "--chrome", "crates/ars-dom"],
+    )?;
+
+    let mut result = StageResult::default();
+
+    result
+        .summary
+        .add_assign(parse_wasm_pack_summary(&run.output));
+
+    if !run.success {
+        result
+            .failures
+            .push(format_failure("dom browser", &run.command, run.code));
     }
 
     Ok(result)
@@ -499,7 +526,7 @@ fn preflight_wasm_pack() -> Result<(), Error> {
 
 fn preflight_for_stage(stage: Stage) -> Result<(), Error> {
     match stage {
-        Stage::I18nBrowser => preflight_wasm_pack(),
+        Stage::I18nBrowser | Stage::DomBrowser => preflight_wasm_pack(),
         Stage::Unit
         | Stage::Release
         | Stage::Integration
@@ -709,6 +736,7 @@ const fn stage_name(stage: Stage) -> &'static str {
     match stage {
         Stage::Unit => "unit",
         Stage::I18nBrowser => "i18n-browser",
+        Stage::DomBrowser => "dom-browser",
         Stage::Release => "release",
         Stage::Integration => "integration",
         Stage::Adapter => "adapter",
@@ -876,6 +904,11 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 filtered out;
     #[test]
     fn stage_name_reports_i18n_browser() {
         assert_eq!(stage_name(Stage::I18nBrowser), "i18n-browser");
+    }
+
+    #[test]
+    fn stage_name_reports_dom_browser() {
+        assert_eq!(stage_name(Stage::DomBrowser), "dom-browser");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `is_above(child_id, parent_id) -> bool` to overlay stack — convenience function for `InteractOutside` suppression that avoids allocating a `Vec` just to check a parent/child relationship
- Add `dom-browser` CI stage (`cargo xtest dom-browser`) that runs all ars-dom wasm tests in headless Chrome via wasm-pack, matching the existing `i18n-browser` pattern
- Spec updates: `is_above()` added to `11-dom-utilities.md` §9.3/§9.4, new §1.3.2 in `14-ci.md`

## Test plan
- [x] 5 new `is_above` tests: child above parent, parent not above child, same-id false, unknown-id false, after out-of-order removal
- [x] `cargo xtest dom-browser` exercises 32 wasm tests in headless Chrome (30 existing + 2 from #573)
- [x] `cargo xci` passes all 16/16 steps (up from 15)
- [x] Zero clippy warnings

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)