### PR TITLE
[codex] Finalize IntlBackend rename and backend cleanup

### DIFF
--- a/crates/ars-core/src/lib.rs
+++ b/crates/ars-core/src/lib.rs
@@ -53,8 +53,8 @@ pub mod __private {
 pub use ars_derive::{ComponentPart, HasId};
 // ── External re-exports ─────────────────────────────────────────────
 pub use ars_i18n::{
-    Direction, IcuProvider, IsolateDirection, Locale, LocaleParseError, Orientation,
-    ResolvedDirection, StubIcuProvider, Weekday, isolate_text_safe,
+    Direction, IntlBackend, IsolateDirection, Locale, LocaleParseError, Orientation,
+    ResolvedDirection, StubIntlBackend, Weekday, isolate_text_safe,
 };
 // ── Platform-conditional smart pointers (extracted modules) ─────────
 pub use callback::{Callback, callback};
@@ -270,6 +270,7 @@ impl<M: Machine> TransitionPlan<M> {
             })),
             None => Some(Box::new(f)),
         };
+
         self
     }
 
@@ -523,24 +524,24 @@ pub trait ConnectApi {
 ///
 /// The adapter reads these values from `ArsProvider` / `ArsContext` and passes
 /// them to framework-agnostic core code. Core component code **never** calls
-/// framework hooks (`use_locale()`, `use_icu_provider()`, `use_context()`) —
+/// framework hooks (`use_locale()`, `use_intl_backend()`, `use_context()`) —
 /// all environment values arrive through this struct.
 ///
-/// Non-date-time components ignore `icu_provider` (it defaults to [`StubIcuProvider`]).
+/// Non-date-time components ignore `intl_backend` (it defaults to [`StubIntlBackend`]).
 pub struct Env {
     /// The resolved locale from `ArsProvider`.
     pub locale: Locale,
 
     /// Calendar/locale data provider for date-time formatting.
-    /// Defaults to [`StubIcuProvider`] (English-only, zero dependencies).
-    pub icu_provider: Arc<dyn IcuProvider>,
+    /// Defaults to [`StubIntlBackend`] (English-only, zero dependencies).
+    pub intl_backend: Arc<dyn IntlBackend>,
 }
 
 impl Debug for Env {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Env")
             .field("locale", &self.locale)
-            .field("icu_provider", &"Arc(..)")
+            .field("intl_backend", &"Arc(..)")
             .finish()
     }
 }
@@ -549,7 +550,7 @@ impl Default for Env {
     fn default() -> Self {
         Self {
             locale: ars_i18n::locales::en_us(),
-            icu_provider: Arc::new(StubIcuProvider),
+            intl_backend: Arc::new(StubIntlBackend),
         }
     }
 }
@@ -639,6 +640,7 @@ fn format_effect_names<M: Machine>(effects: &[PendingEffect<M>]) -> String {
         if index > 0 {
             formatted.push_str(", ");
         }
+
         formatted.push_str(effect.name);
     }
 
@@ -654,17 +656,19 @@ fn format_follow_up_events<Event: Debug>(events: &[Event]) -> String {
 
 #[cfg(feature = "debug")]
 fn format_target_state<State: Debug>(target: Option<&State>) -> String {
-    match target {
-        Some(next) => format!("{next:?}"),
-        None => String::from("(same)"),
+    if let Some(next) = target {
+        format!("{next:?}")
+    } else {
+        String::from("(same)")
     }
 }
 
 #[cfg(feature = "debug")]
 fn format_apply_description(description: Option<&'static str>) -> String {
-    match description {
-        Some(description) => format!("{description:?}"),
-        None => String::from("\"none\""),
+    if let Some(description) = description {
+        format!("{description:?}")
+    } else {
+        String::from("\"none\"")
     }
 }
 
@@ -970,6 +974,7 @@ impl<M: Machine> Service<M> {
 
                 // Collect effects, tagged with the target state.
                 let target = self.state.clone();
+
                 pending_effects.extend(plan.effects.into_iter().map(|mut e| {
                     e.target_state = Some(target.clone());
                     e
@@ -1137,6 +1142,7 @@ mod tests {
     fn init_test_logger() {
         LOGGER_INIT.call_once(|| {
             log::set_logger(&TEST_LOGGER).expect("test logger should install once");
+
             log::set_max_level(log::LevelFilter::Trace);
         });
     }
@@ -1676,6 +1682,7 @@ mod tests {
                             .with_effect(PendingEffect::named("focus"))
                             .with_effect(PendingEffect::named("announce")),
                     ),
+
                     _ => None,
                 }
             }
@@ -2040,6 +2047,7 @@ mod tests {
                     (ToggleState::Off, LoopEvent::Continue) => {
                         Some(TransitionPlan::to(ToggleState::On).then(LoopEvent::Continue))
                     }
+
                     (ToggleState::On, LoopEvent::Continue) => {
                         Some(TransitionPlan::to(ToggleState::Off).then(LoopEvent::Continue))
                     }
@@ -2319,6 +2327,7 @@ mod tests {
 
         let logs = capture_logs(|| {
             let result = service.send(LoopEvent::Continue);
+
             assert!(result.truncated);
             assert!(!result.state_changed);
             assert!(result.context_changed);

--- a/crates/ars-dioxus/src/attrs.rs
+++ b/crates/ars-dioxus/src/attrs.rs
@@ -36,14 +36,20 @@ pub fn intern_attr_name(attr: &HtmlAttr) -> &'static str {
     if let Some(name) = attr.static_name() {
         return name;
     }
+
     // Slow path: Data(...) attributes — intern the formatted string.
     let name = attr.to_string(); // e.g., "data-ars-state"
+
     let mut pool = ATTR_NAMES.lock().expect("attr name pool");
+
     if let Some(&existing) = pool.get(name.as_str()) {
         return existing;
     }
+
     let leaked: &'static str = Box::leak(name.into_boxed_str());
+
     pool.insert(leaked);
+
     leaked
 }
 
@@ -54,9 +60,11 @@ pub fn intern_attr_name(attr: &HtmlAttr) -> &'static str {
 pub struct DioxusAttrResult {
     /// Dioxus dynamic attributes ready for spreading via `..attrs`.
     pub attrs: Vec<Attribute>,
+
     /// Styles to apply via CSSOM (`element.style().set_property()`).
     /// Non-empty only when strategy is [`StyleStrategy::Cssom`].
     pub cssom_styles: Vec<(CssProperty, String)>,
+
     /// CSS rule text to inject into a `<style nonce="...">` block.
     /// Non-empty only when strategy is [`StyleStrategy::Nonce`].
     pub nonce_css: String,
@@ -107,6 +115,7 @@ pub fn attr_map_to_dioxus(
                     .map(|(prop, val)| format!("{prop}: {val};"))
                     .collect::<Vec<_>>()
                     .join(" ");
+
                 result.push(Attribute::new(
                     "style",
                     AttributeValue::Text(style_str),
@@ -115,18 +124,22 @@ pub fn attr_map_to_dioxus(
                 ));
             }
         }
+
         StyleStrategy::Cssom => {
             cssom_styles = styles;
         }
+
         StyleStrategy::Nonce(_) => {
             if !styles.is_empty() {
                 let id = element_id.expect("element_id is required for Nonce style strategy");
+
                 result.push(Attribute::new(
                     "data-ars-style-id",
                     AttributeValue::Text(id.to_string()),
                     None,
                     false,
                 ));
+
                 nonce_css = styles_to_nonce_css(id, &styles);
             }
         }
@@ -148,6 +161,7 @@ pub fn attr_map_to_dioxus(
 #[cfg(feature = "web")]
 pub fn apply_styles_cssom(el: &web_sys::HtmlElement, styles: &[(CssProperty, String)]) {
     let style = el.style();
+
     for (prop, val) in styles {
         if let Err(error) = style.set_property(&prop.to_string(), val) {
             #[cfg(debug_assertions)]
@@ -166,6 +180,7 @@ fn styles_to_nonce_css(id: &str, styles: &[(CssProperty, String)]) -> String {
         .iter()
         .map(|(prop, val)| format!("  {prop}: {val};"))
         .collect::<Vec<_>>();
+
     format!("[data-ars-style-id=\"{id}\"] {{\n{}\n}}", decls.join("\n"))
 }
 
@@ -191,6 +206,7 @@ pub struct ArsNonceCssCtx {
 #[component]
 pub fn ArsNonceStyle(nonce: String) -> Element {
     let rules = use_signal(Vec::<String>::new);
+
     use_context_provider(|| ArsNonceCssCtx { rules });
 
     let css_text = use_memo(move || rules.read().join("\n"));
@@ -237,6 +253,7 @@ pub fn use_style_strategy() -> StyleStrategy {
 /// ```rust,ignore
 /// let attrs = api.root_attrs();
 /// let strategy = use_style_strategy();
+///
 /// rsx! {
 ///     div { ..attr_map_to_dioxus(attrs, &strategy, Some("my-el")).attrs, {children} }
 /// }
@@ -275,6 +292,7 @@ mod tests {
     fn intern_attr_name_slow_path_interns_data_attributes() {
         let first = intern_attr_name(&HtmlAttr::Data("ars-state"));
         let second = intern_attr_name(&HtmlAttr::Data("ars-state"));
+
         assert_eq!(first, "data-ars-state");
         assert_eq!(second, "data-ars-state");
         // Same pointer — proves the pool returns the existing leaked reference.
@@ -285,6 +303,7 @@ mod tests {
     fn intern_attr_name_data_distinct_values_differ() {
         let foo = intern_attr_name(&HtmlAttr::Data("foo"));
         let bar = intern_attr_name(&HtmlAttr::Data("bar"));
+
         assert_eq!(foo, "data-foo");
         assert_eq!(bar, "data-bar");
         assert_ne!(foo, bar);
@@ -307,8 +326,10 @@ mod tests {
 
     fn build_test_map() -> AttrMap {
         let mut map = AttrMap::new();
+
         map.set(HtmlAttr::Class, "btn");
         map.set_style(CssProperty::Width, "100px");
+
         map
     }
 
@@ -317,9 +338,11 @@ mod tests {
         let result = attr_map_to_dioxus(build_test_map(), &StyleStrategy::Inline, None);
 
         let class_attr = find_attr(&result.attrs, "class").expect("class attr present");
+
         assert_eq!(text_value(class_attr), Some("btn"));
 
         let style_attr = find_attr(&result.attrs, "style").expect("style attr present");
+
         assert_eq!(text_value(style_attr), Some("width: 100px;"));
 
         assert!(result.cssom_styles.is_empty());
@@ -354,6 +377,7 @@ mod tests {
         // data-ars-style-id injected
         let id_attr =
             find_attr(&result.attrs, "data-ars-style-id").expect("data-ars-style-id present");
+
         assert_eq!(text_value(id_attr), Some("el-1"));
 
         // nonce CSS rule generated
@@ -365,18 +389,22 @@ mod tests {
     #[test]
     fn attr_map_to_dioxus_value_mapping_filters_false_and_none() {
         let mut map = AttrMap::new();
+
         map.set(HtmlAttr::Id, "x");
         map.set_bool(HtmlAttr::Disabled, true);
         map.set_bool(HtmlAttr::Hidden, false);
+
         // AttrValue::None via set then remove pattern: set Inert then override
         // We can test None by checking that Bool(false) is filtered.
 
         let result = attr_map_to_dioxus(map, &StyleStrategy::Inline, None);
 
         let id_attr = find_attr(&result.attrs, "id").expect("id attr present");
+
         assert_eq!(text_value(id_attr), Some("x"));
 
         let disabled_attr = find_attr(&result.attrs, "disabled").expect("disabled attr present");
+
         assert_eq!(text_value(disabled_attr), Some(""));
 
         // Bool(false) attributes are filtered out
@@ -389,7 +417,9 @@ mod tests {
     #[test]
     fn attr_map_to_dioxus_empty_styles_omit_style_attribute() {
         let mut map = AttrMap::new();
+
         map.set(HtmlAttr::Class, "btn");
+
         // No styles
 
         let result = attr_map_to_dioxus(map, &StyleStrategy::Inline, None);
@@ -404,8 +434,11 @@ mod tests {
             (CssProperty::Width, "100px".to_string()),
             (CssProperty::Color, "red".to_string()),
         ];
+
         let css = styles_to_nonce_css("el-1", &styles);
+
         let expected = "[data-ars-style-id=\"el-1\"] {\n  width: 100px;\n  color: red;\n}";
+
         assert_eq!(css, expected);
     }
 
@@ -414,6 +447,7 @@ mod tests {
     #[test]
     fn dioxus_attrs_macro_delegates_to_function() {
         let map = build_test_map();
+
         let result = dioxus_attrs!(map, &StyleStrategy::Inline, None);
 
         // Verify it produces a DioxusAttrResult with expected content
@@ -424,7 +458,9 @@ mod tests {
     #[test]
     fn attr_map_to_dioxus_nonce_strategy_empty_styles_is_noop() {
         let mut map = AttrMap::new();
+
         map.set(HtmlAttr::Class, "btn");
+
         // No styles — Nonce should not inject data-ars-style-id or generate CSS.
 
         let result = attr_map_to_dioxus(map, &StyleStrategy::Nonce("n456".into()), Some("el-2"));
@@ -438,7 +474,9 @@ mod tests {
     #[test]
     fn attr_map_to_dioxus_attr_value_none_is_filtered() {
         let mut map = AttrMap::new();
+
         map.set(HtmlAttr::Id, "x");
+
         // Setting then removing produces AttrValue::None internally via set(_, AttrValue::None).
         map.set(HtmlAttr::Title, AttrValue::None);
 
@@ -460,6 +498,7 @@ mod tests {
         }
 
         let mut dom = VirtualDom::new(app);
+
         dom.rebuild_in_place();
     }
 
@@ -480,11 +519,11 @@ mod tests {
 
             rsx! {
                 div {}
-
             }
         }
 
         let mut dom = VirtualDom::new(app);
+
         dom.rebuild_in_place();
     }
 
@@ -493,12 +532,14 @@ mod tests {
         fn app() -> Element {
             // No ArsNonceCssCtx provided — should silently do nothing.
             append_nonce_css("orphan rule".into());
+
             rsx! {
                 div {}
             }
         }
 
         let mut dom = VirtualDom::new(app);
+
         dom.rebuild_in_place();
     }
 
@@ -508,13 +549,16 @@ mod tests {
     fn use_style_strategy_defaults_without_provider() {
         fn app() -> Element {
             let strategy = use_style_strategy();
+
             assert_eq!(strategy, StyleStrategy::Inline);
+
             rsx! {
                 div {}
             }
         }
 
         let mut dom = VirtualDom::new(app);
+
         dom.rebuild_in_place();
     }
 
@@ -536,21 +580,25 @@ mod tests {
                 None,
                 None,
                 Arc::new(NullPlatformEffects),
-                Arc::new(ars_i18n::StubIcuProvider),
+                Arc::new(ars_i18n::StubIntlBackend),
                 Arc::new(I18nRegistries::new()),
                 Arc::new(crate::provider::NullPlatform),
                 StyleStrategy::Cssom,
             );
+
             use_context_provider(|| ctx);
 
             let strategy = use_style_strategy();
+
             assert_eq!(strategy, StyleStrategy::Cssom);
+
             rsx! {
                 div {}
             }
         }
 
         let mut dom = VirtualDom::new(app);
+
         dom.rebuild_in_place();
     }
 }
@@ -577,6 +625,7 @@ mod wasm_tests {
             .expect("create_element should succeed")
             .dyn_into::<web_sys::HtmlElement>()
             .expect("element should cast to HtmlElement");
+
         let styles = vec![
             (CssProperty::Width, String::from("120px")),
             (CssProperty::Display, String::from("block")),
@@ -585,6 +634,7 @@ mod wasm_tests {
         apply_styles_cssom(&element, &styles);
 
         let style = element.style();
+
         assert_eq!(
             style
                 .get_property_value("width")

--- a/crates/ars-dioxus/src/lib.rs
+++ b/crates/ars-dioxus/src/lib.rs
@@ -32,7 +32,7 @@ pub use provider::DesktopPlatform;
 #[cfg(feature = "web")]
 pub use provider::WebPlatform;
 pub use provider::{
-    ArsContext, DioxusPlatform, DragData, FilePickerOptions, NullPlatform, t, use_icu_provider,
+    ArsContext, DioxusPlatform, DragData, FilePickerOptions, NullPlatform, t, use_intl_backend,
     use_locale, use_messages, use_number_formatter, use_platform, warn_missing_provider,
 };
 pub use use_machine::{UseMachineReturn, use_machine, use_machine_with_reactive_props};
@@ -45,8 +45,10 @@ pub const ADAPTER_NAME: &str = "dioxus";
 pub struct AdapterCapabilities {
     /// `true` if web (WASM) rendering is enabled.
     pub web: bool,
+
     /// `true` if native desktop rendering is enabled.
     pub desktop: bool,
+
     /// `true` if server-side rendering is enabled.
     pub ssr: bool,
 }

--- a/crates/ars-dioxus/src/provider.rs
+++ b/crates/ars-dioxus/src/provider.rs
@@ -1,6 +1,11 @@
 //! Reactive `ArsProvider` context helpers for the Dioxus adapter.
 
-use std::{any::Any, pin::Pin, sync::Arc};
+use std::{
+    any::Any,
+    fmt::{self, Debug},
+    pin::Pin,
+    sync::Arc,
+};
 
 use ars_core::{
     ColorMode, I18nRegistries, PlatformEffects, Rect, StyleStrategy,
@@ -8,7 +13,7 @@ use ars_core::{
 };
 use ars_forms::field::FileRef;
 use ars_i18n::{
-    Direction, IcuProvider, Locale, NumberFormatOptions, NumberFormatter, StubIcuProvider,
+    Direction, IntlBackend, Locale, NumberFormatOptions, NumberFormatter, StubIntlBackend,
     Translate, locales,
 };
 use dioxus::prelude::*;
@@ -169,6 +174,7 @@ impl DioxusPlatform for NullPlatform {
         use std::sync::atomic::{AtomicUsize, Ordering};
 
         static COUNTER: AtomicUsize = AtomicUsize::new(0);
+
         format!("null-id-{}", COUNTER.fetch_add(1, Ordering::Relaxed))
     }
 
@@ -182,10 +188,12 @@ fn default_dioxus_platform() -> Arc<dyn DioxusPlatform> {
     {
         Arc::new(WebPlatform)
     }
+
     #[cfg(all(feature = "desktop", not(feature = "web")))]
     {
         Arc::new(DesktopPlatform)
     }
+
     #[cfg(not(any(feature = "web", feature = "desktop")))]
     {
         Arc::new(NullPlatform)
@@ -223,7 +231,7 @@ pub struct ArsContext {
     pub platform: Arc<dyn PlatformEffects>,
 
     /// ICU-backed locale data provider.
-    pub icu_provider: Arc<dyn IcuProvider>,
+    pub intl_backend: Arc<dyn IntlBackend>,
 
     /// Application-owned message registries.
     pub i18n_registries: Arc<I18nRegistries>,
@@ -235,8 +243,8 @@ pub struct ArsContext {
     style_strategy: StyleStrategy,
 }
 
-impl std::fmt::Debug for ArsContext {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Debug for ArsContext {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ArsContext")
             .field("locale", &self.locale)
             .field("direction", &self.direction)
@@ -247,7 +255,7 @@ impl std::fmt::Debug for ArsContext {
             .field("portal_container_id", &self.portal_container_id)
             .field("root_node_id", &self.root_node_id)
             .field("platform", &"Arc(..)")
-            .field("icu_provider", &"Arc(..)")
+            .field("intl_backend", &"Arc(..)")
             .field("i18n_registries", &"Arc(..)")
             .field("dioxus_platform", &"Arc(..)")
             .field("style_strategy", &self.style_strategy)
@@ -272,7 +280,7 @@ impl ArsContext {
         portal_container_id: Option<String>,
         root_node_id: Option<String>,
         platform: Arc<dyn PlatformEffects>,
-        icu_provider: Arc<dyn IcuProvider>,
+        intl_backend: Arc<dyn IntlBackend>,
         i18n_registries: Arc<I18nRegistries>,
         dioxus_platform: Arc<dyn DioxusPlatform>,
         style_strategy: StyleStrategy,
@@ -287,7 +295,7 @@ impl ArsContext {
             portal_container_id: Signal::new(portal_container_id),
             root_node_id: Signal::new(root_node_id),
             platform,
-            icu_provider,
+            intl_backend,
             i18n_registries,
             dioxus_platform,
             style_strategy,
@@ -355,7 +363,9 @@ where
     F: Fn() -> NumberFormatOptions + 'static,
 {
     let explicit_locale = adapter_props_locale.cloned();
+
     let locale = use_locale();
+
     let resolved_options = options();
 
     use_memo(use_reactive!(|explicit_locale, resolved_options| {
@@ -369,14 +379,14 @@ where
 
 /// Resolves the current ICU provider from provider context.
 #[must_use]
-pub fn use_icu_provider() -> Arc<dyn IcuProvider> {
+pub fn use_intl_backend() -> Arc<dyn IntlBackend> {
     try_use_context::<ArsContext>().map_or_else(
-        || -> Arc<dyn IcuProvider> {
-            warn_missing_provider("use_icu_provider");
+        || -> Arc<dyn IntlBackend> {
+            warn_missing_provider("use_intl_backend");
 
-            Arc::new(StubIcuProvider)
+            Arc::new(StubIntlBackend)
         },
-        |ctx| -> Arc<dyn IcuProvider> { Arc::clone(&ctx.icu_provider) },
+        |ctx| -> Arc<dyn IntlBackend> { Arc::clone(&ctx.intl_backend) },
     )
 }
 
@@ -422,9 +432,9 @@ pub fn t<T: Translate>(msg: T) -> String {
 
             let fallback = locales::en_us();
 
-            msg.translate(&fallback, &StubIcuProvider)
+            msg.translate(&fallback, &StubIntlBackend)
         },
-        |ctx| msg.translate(&ctx.locale.read(), &*ctx.icu_provider),
+        |ctx| msg.translate(&ctx.locale.read(), &*ctx.intl_backend),
     )
 }
 
@@ -440,7 +450,7 @@ mod tests {
 
     use ars_core::{ColorMode, I18nRegistries, NullPlatformEffects, StyleStrategy};
     use ars_i18n::{
-        Direction, IcuProvider, Locale, NumberFormatOptions, StubIcuProvider, Translate, locales,
+        Direction, IntlBackend, Locale, NumberFormatOptions, StubIntlBackend, Translate, locales,
     };
     use dioxus::dioxus_core::{NoOpMutations, ScopeId};
 
@@ -452,7 +462,7 @@ mod tests {
     }
 
     impl Translate for AppText {
-        fn translate(&self, locale: &Locale, _icu: &dyn IcuProvider) -> String {
+        fn translate(&self, locale: &Locale, _intl: &dyn IntlBackend) -> String {
             match locale.language() {
                 "es" => String::from("Hola"),
                 _ => String::from("Hello"),
@@ -460,9 +470,46 @@ mod tests {
         }
     }
 
-    struct TestIcuProvider;
+    struct TestIntlBackend;
 
-    impl IcuProvider for TestIcuProvider {}
+    impl IntlBackend for TestIntlBackend {
+        fn weekday_short_label(&self, weekday: ars_i18n::Weekday, locale: &Locale) -> String {
+            StubIntlBackend.weekday_short_label(weekday, locale)
+        }
+
+        fn weekday_long_label(&self, weekday: ars_i18n::Weekday, locale: &Locale) -> String {
+            StubIntlBackend.weekday_long_label(weekday, locale)
+        }
+
+        fn month_long_name(&self, month: u8, locale: &Locale) -> String {
+            StubIntlBackend.month_long_name(month, locale)
+        }
+
+        fn day_period_label(&self, is_pm: bool, locale: &Locale) -> String {
+            StubIntlBackend.day_period_label(is_pm, locale)
+        }
+
+        fn day_period_from_char(&self, ch: char, locale: &Locale) -> Option<bool> {
+            StubIntlBackend.day_period_from_char(ch, locale)
+        }
+
+        fn format_segment_digits(
+            &self,
+            value: u32,
+            min_digits: core::num::NonZero<u8>,
+            locale: &Locale,
+        ) -> String {
+            StubIntlBackend.format_segment_digits(value, min_digits, locale)
+        }
+
+        fn hour_cycle(&self, locale: &Locale) -> ars_i18n::HourCycle {
+            StubIntlBackend.hour_cycle(locale)
+        }
+
+        fn week_info(&self, locale: &Locale) -> ars_i18n::WeekInfo {
+            StubIntlBackend.week_info(locale)
+        }
+    }
 
     #[derive(Clone, Debug, PartialEq)]
     struct TestMessages {
@@ -515,7 +562,7 @@ mod tests {
         }
     }
 
-    fn test_context(locale: Locale, icu_provider: Arc<dyn IcuProvider>) -> ArsContext {
+    fn test_context(locale: Locale, intl_backend: Arc<dyn IntlBackend>) -> ArsContext {
         ArsContext::new(
             locale,
             Direction::Ltr,
@@ -526,7 +573,7 @@ mod tests {
             None,
             None,
             Arc::new(NullPlatformEffects),
-            icu_provider,
+            intl_backend,
             Arc::new(I18nRegistries::new()),
             Arc::new(NullPlatform),
             StyleStrategy::Inline,
@@ -558,12 +605,12 @@ mod tests {
     }
 
     #[test]
-    fn use_icu_provider_falls_back_without_provider() {
+    fn use_intl_backend_falls_back_without_provider() {
         fn app() -> Element {
-            let provider = use_icu_provider();
+            let backend = use_intl_backend();
 
             assert_eq!(
-                AppText::Greeting.translate(&locales::en_us(), provider.as_ref()),
+                AppText::Greeting.translate(&locales::en_us(), backend.as_ref()),
                 "Hello"
             );
 
@@ -578,9 +625,9 @@ mod tests {
     }
 
     #[test]
-    fn use_icu_provider_reads_context_value() {
+    fn use_intl_backend_reads_context_value() {
         fn app() -> Element {
-            let expected: Arc<dyn IcuProvider> = Arc::new(TestIcuProvider);
+            let expected: Arc<dyn IntlBackend> = Arc::new(TestIntlBackend);
 
             let ctx = ArsContext::new(
                 locales::en_us(),
@@ -600,7 +647,7 @@ mod tests {
 
             use_context_provider(|| ctx);
 
-            assert!(Arc::ptr_eq(&use_icu_provider(), &expected));
+            assert!(Arc::ptr_eq(&use_intl_backend(), &expected));
 
             rsx! {
                 div {}
@@ -636,7 +683,7 @@ mod tests {
                 None,
                 None,
                 Arc::new(NullPlatformEffects),
-                Arc::new(StubIcuProvider),
+                Arc::new(StubIntlBackend),
                 Arc::new(registries),
                 Arc::new(NullPlatform),
                 StyleStrategy::Inline,
@@ -699,7 +746,7 @@ mod tests {
     #[test]
     fn use_number_formatter_reads_context_locale() {
         fn app() -> Element {
-            let ctx = test_context(locales::de_de(), Arc::new(StubIcuProvider));
+            let ctx = test_context(locales::de_de(), Arc::new(StubIntlBackend));
 
             use_context_provider(|| ctx);
 
@@ -727,7 +774,7 @@ mod tests {
         )]
         fn app(outputs: Rc<RefCell<Vec<String>>>) -> Element {
             let mut ctx =
-                use_context_provider(|| test_context(locales::en_us(), Arc::new(StubIcuProvider)));
+                use_context_provider(|| test_context(locales::en_us(), Arc::new(StubIntlBackend)));
 
             let mut phase = use_signal(|| 0u8);
 
@@ -759,7 +806,7 @@ mod tests {
     #[test]
     fn use_resolved_number_formatter_prefers_explicit_override() {
         fn app() -> Element {
-            let ctx = test_context(locales::fr(), Arc::new(StubIcuProvider));
+            let ctx = test_context(locales::fr(), Arc::new(StubIntlBackend));
 
             use_context_provider(|| ctx);
 
@@ -789,11 +836,12 @@ mod tests {
             reason = "Dioxus root props are moved into the render function."
         )]
         fn app(outputs: Rc<RefCell<Vec<String>>>) -> Element {
-            let ctx = test_context(locales::fr(), Arc::new(StubIcuProvider));
+            let ctx = test_context(locales::fr(), Arc::new(StubIntlBackend));
 
             use_context_provider(|| ctx);
 
             let mut phase = use_signal(|| 0u8);
+
             let mut use_german_locale = use_signal(|| false);
 
             let explicit = if use_german_locale() {
@@ -809,6 +857,7 @@ mod tests {
 
             if phase() == 0 {
                 phase.set(1);
+
                 use_german_locale.set(true);
             }
 
@@ -820,9 +869,7 @@ mod tests {
         let mut dom = VirtualDom::new_with_props(app, Rc::clone(&outputs));
 
         dom.rebuild_in_place();
-
         dom.mark_dirty(ScopeId::APP);
-
         dom.render_immediate(&mut NoOpMutations);
 
         assert_eq!(outputs.borrow().as_slice(), ["1,234.56", "1.234,56"]);
@@ -838,9 +885,10 @@ mod tests {
         )]
         fn app(outputs: Rc<RefCell<Vec<String>>>) -> Element {
             let _ctx =
-                use_context_provider(|| test_context(locales::en_us(), Arc::new(StubIcuProvider)));
+                use_context_provider(|| test_context(locales::en_us(), Arc::new(StubIntlBackend)));
 
             let mut phase = use_signal(|| 0u8);
+
             let mut use_percent = use_signal(|| false);
 
             let options = if use_percent() {
@@ -861,6 +909,7 @@ mod tests {
 
             if phase() == 0 {
                 phase.set(1);
+
                 use_percent.set(true);
             }
 
@@ -872,9 +921,7 @@ mod tests {
         let mut dom = VirtualDom::new_with_props(app, Rc::clone(&outputs));
 
         dom.rebuild_in_place();
-
         dom.mark_dirty(ScopeId::APP);
-
         dom.render_immediate(&mut NoOpMutations);
 
         assert_eq!(outputs.borrow().as_slice(), ["0.47", "47%"]);
@@ -900,7 +947,7 @@ mod tests {
                     None,
                     None,
                     Arc::new(NullPlatformEffects),
-                    Arc::new(StubIcuProvider),
+                    Arc::new(StubIntlBackend),
                     Arc::new(I18nRegistries::new()),
                     Arc::new(NullPlatform),
                     StyleStrategy::Inline,
@@ -928,9 +975,7 @@ mod tests {
         let mut dom = VirtualDom::new_with_props(app, Rc::clone(&outputs));
 
         dom.rebuild_in_place();
-
         dom.mark_dirty(ScopeId::APP);
-
         dom.render_immediate(&mut NoOpMutations);
 
         assert_eq!(outputs.borrow().as_slice(), ["Hello", "Hola"]);
@@ -956,7 +1001,7 @@ mod tests {
         fn app() -> Element {
             use crate::prelude::use_number_formatter as prelude_use_number_formatter;
 
-            let ctx = test_context(locales::en_us(), Arc::new(StubIcuProvider));
+            let ctx = test_context(locales::en_us(), Arc::new(StubIntlBackend));
 
             use_context_provider(|| ctx);
 
@@ -979,7 +1024,7 @@ mod tests {
         fn app() -> Element {
             let ctx = test_context(
                 Locale::parse("fr-FR").expect("locale should parse"),
-                Arc::new(StubIcuProvider),
+                Arc::new(StubIntlBackend),
             );
 
             use_context_provider(|| ctx);
@@ -1014,7 +1059,7 @@ mod tests {
                 None,
                 None,
                 Arc::new(NullPlatformEffects),
-                Arc::new(StubIcuProvider),
+                Arc::new(StubIntlBackend),
                 Arc::new(I18nRegistries::new()),
                 Arc::clone(&expected),
                 StyleStrategy::Inline,
@@ -1090,7 +1135,7 @@ mod tests {
     #[test]
     fn ars_context_debug_includes_struct_name() {
         fn app() -> Element {
-            let ctx = test_context(locales::en_us(), Arc::new(StubIcuProvider));
+            let ctx = test_context(locales::en_us(), Arc::new(StubIntlBackend));
 
             assert!(format!("{ctx:?}").contains("ArsContext"));
 
@@ -1111,7 +1156,7 @@ mod wasm_tests {
 
     use ars_core::{ColorMode, I18nRegistries, NullPlatformEffects, StyleStrategy};
     use ars_i18n::{
-        Direction, IcuProvider, Locale, NumberFormatOptions, StubIcuProvider, Translate, locales,
+        Direction, IntlBackend, Locale, NumberFormatOptions, StubIntlBackend, Translate, locales,
     };
     use dioxus::dioxus_core::{NoOpMutations, ScopeId};
     use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
@@ -1126,7 +1171,7 @@ mod wasm_tests {
     }
 
     impl Translate for AppText {
-        fn translate(&self, locale: &Locale, _icu: &dyn IcuProvider) -> String {
+        fn translate(&self, locale: &Locale, _intl: &dyn IntlBackend) -> String {
             match locale.language() {
                 "es" => String::from("Hola"),
                 _ => String::from("Hello"),
@@ -1134,11 +1179,48 @@ mod wasm_tests {
         }
     }
 
-    struct TestIcuProvider;
+    struct TestIntlBackend;
 
-    impl IcuProvider for TestIcuProvider {}
+    impl IntlBackend for TestIntlBackend {
+        fn weekday_short_label(&self, weekday: ars_i18n::Weekday, locale: &Locale) -> String {
+            StubIntlBackend.weekday_short_label(weekday, locale)
+        }
 
-    fn test_context(locale: Locale, icu_provider: Arc<dyn IcuProvider>) -> ArsContext {
+        fn weekday_long_label(&self, weekday: ars_i18n::Weekday, locale: &Locale) -> String {
+            StubIntlBackend.weekday_long_label(weekday, locale)
+        }
+
+        fn month_long_name(&self, month: u8, locale: &Locale) -> String {
+            StubIntlBackend.month_long_name(month, locale)
+        }
+
+        fn day_period_label(&self, is_pm: bool, locale: &Locale) -> String {
+            StubIntlBackend.day_period_label(is_pm, locale)
+        }
+
+        fn day_period_from_char(&self, ch: char, locale: &Locale) -> Option<bool> {
+            StubIntlBackend.day_period_from_char(ch, locale)
+        }
+
+        fn format_segment_digits(
+            &self,
+            value: u32,
+            min_digits: core::num::NonZero<u8>,
+            locale: &Locale,
+        ) -> String {
+            StubIntlBackend.format_segment_digits(value, min_digits, locale)
+        }
+
+        fn hour_cycle(&self, locale: &Locale) -> ars_i18n::HourCycle {
+            StubIntlBackend.hour_cycle(locale)
+        }
+
+        fn week_info(&self, locale: &Locale) -> ars_i18n::WeekInfo {
+            StubIntlBackend.week_info(locale)
+        }
+    }
+
+    fn test_context(locale: Locale, intl_backend: Arc<dyn IntlBackend>) -> ArsContext {
         ArsContext::new(
             locale,
             Direction::Ltr,
@@ -1149,7 +1231,7 @@ mod wasm_tests {
             None,
             None,
             Arc::new(NullPlatformEffects),
-            icu_provider,
+            intl_backend,
             Arc::new(I18nRegistries::new()),
             Arc::new(NullPlatform),
             StyleStrategy::Inline,
@@ -1169,14 +1251,14 @@ mod wasm_tests {
     }
 
     #[wasm_bindgen_test]
-    fn use_locale_and_icu_provider_fall_back_without_provider_on_wasm() {
+    fn use_locale_and_intl_backend_fall_back_without_provider_on_wasm() {
         fn app() -> Element {
             assert_eq!(use_locale()().to_bcp47(), "en-US");
 
-            let provider = use_icu_provider();
+            let backend = use_intl_backend();
 
             assert_eq!(
-                AppText::Greeting.translate(&locales::en_us(), &*provider),
+                AppText::Greeting.translate(&locales::en_us(), &*backend),
                 "Hello"
             );
 
@@ -1204,7 +1286,7 @@ mod wasm_tests {
         )]
         fn app(outputs: Rc<RefCell<Vec<String>>>) -> Element {
             let mut ctx =
-                use_context_provider(|| test_context(locales::en_us(), Arc::new(StubIcuProvider)));
+                use_context_provider(|| test_context(locales::en_us(), Arc::new(StubIntlBackend)));
 
             let mut phase = use_signal(|| 0u8);
 
@@ -1227,9 +1309,7 @@ mod wasm_tests {
         let mut dom = VirtualDom::new_with_props(app, Rc::clone(&outputs));
 
         dom.rebuild_in_place();
-
         dom.mark_dirty(ScopeId::APP);
-
         dom.render_immediate(&mut NoOpMutations);
 
         assert_eq!(outputs.borrow().as_slice(), ["Hello", "Hola"]);
@@ -1238,7 +1318,7 @@ mod wasm_tests {
     #[wasm_bindgen_test]
     fn use_platform_and_explicit_locale_work_on_wasm() {
         fn app() -> Element {
-            let expected: Arc<dyn IcuProvider> = Arc::new(TestIcuProvider);
+            let expected: Arc<dyn IntlBackend> = Arc::new(TestIntlBackend);
 
             let ctx = test_context(locales::en_us(), Arc::clone(&expected));
 
@@ -1248,7 +1328,7 @@ mod wasm_tests {
 
             assert_eq!(resolve_locale(Some(&explicit)).to_bcp47(), "pt-BR");
             assert_eq!(resolve_locale(None).to_bcp47(), "en-US");
-            assert!(Arc::ptr_eq(&use_icu_provider(), &expected));
+            assert!(Arc::ptr_eq(&use_intl_backend(), &expected));
 
             let platform = use_platform();
 
@@ -1280,7 +1360,7 @@ mod wasm_tests {
         )]
         fn app(outputs: Rc<RefCell<Vec<String>>>) -> Element {
             let mut ctx =
-                use_context_provider(|| test_context(locales::en_us(), Arc::new(StubIcuProvider)));
+                use_context_provider(|| test_context(locales::en_us(), Arc::new(StubIntlBackend)));
 
             let mut phase = use_signal(|| 0u8);
 
@@ -1302,9 +1382,7 @@ mod wasm_tests {
         let mut dom = VirtualDom::new_with_props(app, Rc::clone(&outputs));
 
         dom.rebuild_in_place();
-
         dom.mark_dirty(ScopeId::APP);
-
         dom.render_immediate(&mut NoOpMutations);
 
         assert_eq!(outputs.borrow().as_slice(), ["1,234.56", "1.234,56"]);

--- a/crates/ars-dioxus/src/use_machine.rs
+++ b/crates/ars-dioxus/src/use_machine.rs
@@ -6,7 +6,7 @@
 
 use std::{
     collections::HashMap,
-    fmt,
+    fmt::{self, Debug},
     sync::{Arc, Mutex},
 };
 
@@ -15,7 +15,7 @@ use dioxus::prelude::*;
 
 use crate::{
     ephemeral::EphemeralRef,
-    provider::{resolve_locale, use_icu_provider, use_messages},
+    provider::{resolve_locale, use_intl_backend, use_messages},
     use_id,
 };
 
@@ -100,7 +100,7 @@ where
 {
 }
 
-impl<M: Machine + 'static> fmt::Debug for UseMachineReturn<M>
+impl<M: Machine + 'static> Debug for UseMachineReturn<M>
 where
     M::State: Clone + PartialEq + 'static,
     M::Context: Clone + 'static,
@@ -131,10 +131,12 @@ where
     /// cause a re-entrant borrow panic.
     pub fn with_api_snapshot<T>(&self, f: impl Fn(&M::Api<'_>) -> T) -> T {
         let svc = self.service.peek();
+
         let api = svc.connect(&|_e| {
             #[cfg(debug_assertions)]
             panic!("Cannot send events inside with_api_snapshot — use event handlers instead");
         });
+
         f(&api)
     }
 
@@ -154,18 +156,23 @@ where
         f: impl Fn(&M::Api<'_>) -> T + 'static,
     ) -> Memo<T> {
         let state = self.state;
+
         let context_version = self.context_version;
+
         let service = self.service;
         use_memo(move || {
             // Subscribe to both state and context_version so the memo
             // re-computes when either changes.
             let _ = &*state.read();
             let _ = &*context_version.read();
+
             let svc = service.peek();
+
             let api = svc.connect(&|_e| {
                 #[cfg(debug_assertions)]
                 panic!("Cannot send events inside derive() — use event handlers instead");
             });
+
             f(&api)
         })
     }
@@ -179,9 +186,13 @@ where
     /// For reactive derived values, use [`derive()`](Self::derive) instead.
     pub fn with_api_ephemeral<R>(&self, f: impl Fn(EphemeralRef<'_, M::Api<'_>>) -> R) -> R {
         let send = self.send;
+
         let svc = self.service.peek();
+
         let send_fn = move |e| send.call(e);
+
         let api = svc.connect(&send_fn);
+
         f(EphemeralRef::new(api))
     }
 }
@@ -199,6 +210,7 @@ where
 /// pub fn Toggle() -> Element {
 ///     let machine = use_machine::<toggle::Machine>(toggle::Props::default());
 ///     let is_on = machine.derive(|api| api.is_on());
+///
 ///     rsx! {
 ///         button {
 ///             onclick: move |_| machine.send.call(toggle::Event::Toggle),
@@ -216,6 +228,7 @@ where
     M::Messages: Send + Sync + 'static,
 {
     let (result, ..) = use_machine_inner::<M>(props);
+
     result
 }
 
@@ -251,21 +264,28 @@ where
     M::Messages: Send + Sync + 'static,
 {
     let generated_id = use_hook(|| use_id("component"));
+
     let props = {
         let mut props = props;
+
         if props.id().is_empty() {
             props.set_id(generated_id);
         }
+
         props
     };
 
     let locale = resolve_locale(None);
-    let icu_provider = use_icu_provider();
+
+    let intl_backend = use_intl_backend();
+
     let env = Env {
         locale,
-        icu_provider,
+        intl_backend,
     };
+
     let messages = use_messages::<M::Messages>(None, Some(&env.locale));
+
     let props_for_sync = props.clone();
 
     // Create the service once — use_signal runs its closure only on first mount.
@@ -274,6 +294,7 @@ where
     // Create a signal tracking the current state.
     // Use .peek() to avoid subscribing the component to service_signal changes.
     let initial_state = service_signal.peek().state().clone();
+
     let state_signal = use_signal::<M::State>(|| initial_state);
 
     // Context version counter — incremented on every context change so that
@@ -281,7 +302,9 @@ where
     let context_version = use_signal(|| 0u64);
 
     let effect_cleanups = use_signal(HashMap::<&'static str, CleanupFn>::new);
+
     let pending_events = use_hook(|| Arc::new(Mutex::new(Vec::<M::Event>::new())));
+
     let runtime = MachineRuntime {
         service: service_signal,
         state: state_signal,
@@ -309,6 +332,7 @@ where
 
     // Clean up effects when the component unmounts.
     let mut cleanup_runtime = runtime.clone();
+
     use_drop(move || {
         let cleanups = drain_effect_cleanups(cleanup_runtime.effect_cleanups);
         cleanup_runtime.service.write().unmount(cleanups);
@@ -336,29 +360,38 @@ where
     M::Event: Send + 'static,
 {
     let mut prev_props = use_signal(|| None::<M::Props>);
+
     let previous = prev_props.peek().clone();
 
     if previous.as_ref() != Some(&current_props) {
         if previous.is_some() {
             let (send_result, ctx, props) = {
                 let mut service = runtime.service.write();
+
                 let send_result = service.set_props(current_props.clone());
+
                 if send_result.state_changed {
                     runtime.state.set(service.state().clone());
                 }
+
                 if send_result.context_changed {
                     *runtime.context_version.write() += 1;
                 }
+
                 let ctx = service.context().clone();
+
                 let props = service.props().clone();
+
                 (send_result, ctx, props)
             };
 
             #[cfg(feature = "ssr")]
             handle_effects::<M>(&send_result, &ctx, &props, &runtime);
+
             #[cfg(not(feature = "ssr"))]
             handle_effects::<M>(send_result, &ctx, &props, runtime.clone());
         }
+
         prev_props.set(Some(current_props));
     }
 }
@@ -372,6 +405,7 @@ where
 {
     let (result, ctx, props) = {
         let mut service = runtime.service.write();
+
         let result = service.send(event);
 
         if result.state_changed {
@@ -383,12 +417,15 @@ where
         }
 
         let ctx = service.context().clone();
+
         let props = service.props().clone();
+
         (result, ctx, props)
     };
 
     #[cfg(feature = "ssr")]
     handle_effects::<M>(&result, &ctx, &props, &runtime);
+
     #[cfg(not(feature = "ssr"))]
     handle_effects::<M>(result, &ctx, &props, runtime);
 }
@@ -397,9 +434,11 @@ fn drain_effect_cleanups(
     mut effect_cleanups: Signal<HashMap<&'static str, CleanupFn>>,
 ) -> Vec<CleanupFn> {
     let mut pending = Vec::new();
+
     for (_, cleanup) in effect_cleanups.write().drain() {
         pending.push(cleanup);
     }
+
     pending
 }
 
@@ -435,11 +474,13 @@ fn handle_effects<M: Machine + 'static>(
     } else if !send_result.cancel_effects.is_empty() || !send_result.pending_effects.is_empty() {
         {
             let mut active_cleanups = runtime.effect_cleanups.write();
+
             for name in send_result.cancel_effects.iter().copied() {
                 if let Some(cleanup) = active_cleanups.remove(name) {
                     cleanups_to_run.push(cleanup);
                 }
             }
+
             for effect in &send_result.pending_effects {
                 if let Some(cleanup) = active_cleanups.remove(effect.name) {
                     cleanups_to_run.push(cleanup);
@@ -458,6 +499,7 @@ fn handle_effects<M: Machine + 'static>(
 
     let send_handle: Arc<dyn Fn(M::Event) + Send + Sync> = Arc::new({
         let pending_events = Arc::clone(&runtime.pending_events);
+
         move |event| {
             pending_events
                 .lock()
@@ -468,7 +510,9 @@ fn handle_effects<M: Machine + 'static>(
 
     for effect in send_result.pending_effects {
         let name = effect.name;
+
         let cleanup = effect.run(ctx, props, Arc::clone(&send_handle));
+
         runtime.effect_cleanups.write().insert(name, cleanup);
     }
 
@@ -477,6 +521,7 @@ fn handle_effects<M: Machine + 'static>(
             .pending_events
             .lock()
             .expect("pending event queue mutex should not be poisoned");
+
         pending.drain(..).collect::<Vec<_>>()
     };
 
@@ -495,7 +540,7 @@ mod tests {
         AriaAttr, AttrMap, ComponentPart, ConnectApi, HasId, HtmlAttr, I18nRegistries, MessageFn,
         NullPlatformEffects,
     };
-    use ars_i18n::{Direction, IcuProvider, Locale};
+    use ars_i18n::{Direction, IntlBackend, Locale, StubIntlBackend};
     use dioxus::dioxus_core::{NoOpMutations, ScopeId};
 
     use super::*;
@@ -564,7 +609,9 @@ mod tests {
 
         fn part_attrs(&self, _part: Self::Part) -> AttrMap {
             let mut attrs = AttrMap::new();
+
             attrs.set(HtmlAttr::Aria(AriaAttr::Pressed), self.is_on.to_string());
+
             attrs
         }
     }
@@ -614,15 +661,52 @@ mod tests {
     // --- Tests ---
 
     #[derive(Clone)]
-    struct TestIcuProvider;
+    struct TestIntlBackend;
 
-    impl fmt::Debug for TestIcuProvider {
+    impl Debug for TestIntlBackend {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            f.write_str("TestIcuProvider")
+            f.write_str("TestIntlBackend")
         }
     }
 
-    impl IcuProvider for TestIcuProvider {}
+    impl IntlBackend for TestIntlBackend {
+        fn weekday_short_label(&self, weekday: ars_i18n::Weekday, locale: &Locale) -> String {
+            StubIntlBackend.weekday_short_label(weekday, locale)
+        }
+
+        fn weekday_long_label(&self, weekday: ars_i18n::Weekday, locale: &Locale) -> String {
+            StubIntlBackend.weekday_long_label(weekday, locale)
+        }
+
+        fn month_long_name(&self, month: u8, locale: &Locale) -> String {
+            StubIntlBackend.month_long_name(month, locale)
+        }
+
+        fn day_period_label(&self, is_pm: bool, locale: &Locale) -> String {
+            StubIntlBackend.day_period_label(is_pm, locale)
+        }
+
+        fn day_period_from_char(&self, ch: char, locale: &Locale) -> Option<bool> {
+            StubIntlBackend.day_period_from_char(ch, locale)
+        }
+
+        fn format_segment_digits(
+            &self,
+            value: u32,
+            min_digits: core::num::NonZero<u8>,
+            locale: &Locale,
+        ) -> String {
+            StubIntlBackend.format_segment_digits(value, min_digits, locale)
+        }
+
+        fn hour_cycle(&self, locale: &Locale) -> ars_i18n::HourCycle {
+            StubIntlBackend.hour_cycle(locale)
+        }
+
+        fn week_info(&self, locale: &Locale) -> ars_i18n::WeekInfo {
+            StubIntlBackend.week_info(locale)
+        }
+    }
 
     #[derive(Clone, Debug, PartialEq)]
     struct EnvMessages {
@@ -642,15 +726,15 @@ mod tests {
     #[derive(Clone)]
     struct EnvContext {
         locale: String,
-        icu_provider: Arc<dyn IcuProvider>,
+        intl_backend: Arc<dyn IntlBackend>,
         label: String,
     }
 
-    impl fmt::Debug for EnvContext {
+    impl Debug for EnvContext {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             f.debug_struct("EnvContext")
                 .field("locale", &self.locale)
-                .field("icu_provider", &"Arc(..)")
+                .field("intl_backend", &"Arc(..)")
                 .field("label", &self.label)
                 .finish()
         }
@@ -694,7 +778,7 @@ mod tests {
                 (),
                 EnvContext {
                     locale: env.locale.to_bcp47(),
-                    icu_provider: Arc::clone(&env.icu_provider),
+                    intl_backend: Arc::clone(&env.intl_backend),
                     label: (messages.label)(&env.locale),
                 },
             )
@@ -794,6 +878,7 @@ mod tests {
                 } else {
                     PropState::Off
                 })),
+
                 PropEvent::SyncLabel => Some(ars_core::TransitionPlan::new().apply(
                     |ctx: &mut PropContext| {
                         ctx.sync_count += 1;
@@ -815,12 +900,15 @@ mod tests {
 
         fn on_props_changed(old: &Self::Props, new: &Self::Props) -> Vec<Self::Event> {
             let mut events = Vec::new();
+
             if old.checked != new.checked {
                 events.push(PropEvent::SetChecked(new.checked));
             }
+
             if old.label != new.label {
                 events.push(PropEvent::SyncLabel);
             }
+
             events
         }
     }
@@ -952,6 +1040,7 @@ mod tests {
                             .with_effect(tracked_effect("timer", "setup:start", "cleanup:start")),
                     )
                 }
+
                 EffectEvent::Replace => {
                     Some(ars_core::TransitionPlan::new().with_effect(tracked_effect(
                         "timer",
@@ -959,8 +1048,11 @@ mod tests {
                         "cleanup:replace",
                     )))
                 }
+
                 EffectEvent::Cancel => Some(ars_core::TransitionPlan::new().cancel_effect("timer")),
+
                 EffectEvent::Stop => Some(ars_core::TransitionPlan::to(EffectState::Idle)),
+
                 EffectEvent::Notify => Some(ars_core::TransitionPlan::new().apply(
                     |ctx: &mut EffectContext| {
                         ctx.notify_count += 1;
@@ -1005,7 +1097,9 @@ mod tests {
                     .lock()
                     .expect("log mutex should not be poisoned")
                     .push(setup_label);
+
                 let log = Arc::clone(&ctx.log);
+
                 Box::new(move || {
                     log.lock()
                         .expect("log mutex should not be poisoned")
@@ -1100,6 +1194,7 @@ mod tests {
                     DerivedState::Off => DerivedState::On,
                     DerivedState::On => DerivedState::Off,
                 })),
+
                 DerivedEvent::BumpContext => Some(ars_core::TransitionPlan::new().apply(
                     |ctx: &mut DerivedContext| {
                         ctx.count += 1;
@@ -1123,7 +1218,7 @@ mod tests {
 
     fn provide_test_context(
         locale: &str,
-        icu_provider: Arc<dyn IcuProvider>,
+        intl_backend: Arc<dyn IntlBackend>,
         registries: Arc<I18nRegistries>,
     ) -> ArsContext {
         ArsContext::new(
@@ -1136,7 +1231,7 @@ mod tests {
             None,
             None,
             Arc::new(NullPlatformEffects),
-            icu_provider,
+            intl_backend,
             registries,
             Arc::new(NullPlatform),
             ars_core::StyleStrategy::Inline,
@@ -1149,6 +1244,7 @@ mod tests {
         // This is a compile-time check — if UseMachineReturn<ToggleMachine> is
         // not Copy, this function won't compile.
         fn assert_copy<T: Copy>() {}
+
         assert_copy::<UseMachineReturn<ToggleMachine>>();
     }
 
@@ -1164,16 +1260,17 @@ mod tests {
                 reason = "This test intentionally exercises the manual Clone impl."
             )]
             let clone = machine.clone();
+
             assert_eq!(*clone.state.peek(), ToggleState::Off);
             assert!(format!("{machine:?}").contains("UseMachineReturn"));
 
             rsx! {
                 div {}
-
             }
         }
 
         let mut dom = VirtualDom::new(app);
+
         dom.rebuild_in_place();
     }
 
@@ -1196,6 +1293,7 @@ mod tests {
         }
 
         let mut dom = VirtualDom::new(app);
+
         dom.rebuild_in_place();
     }
 
@@ -1209,9 +1307,11 @@ mod tests {
             assert_eq!(*machine.state.peek(), ToggleState::Off);
 
             machine.send.call(ToggleEvent::Toggle);
+
             assert_eq!(*machine.state.peek(), ToggleState::On);
 
             machine.send.call(ToggleEvent::Toggle);
+
             assert_eq!(*machine.state.peek(), ToggleState::Off);
 
             rsx! {
@@ -1220,6 +1320,7 @@ mod tests {
         }
 
         let mut dom = VirtualDom::new(app);
+
         dom.rebuild_in_place();
     }
 
@@ -1231,11 +1332,13 @@ mod tests {
             });
 
             let is_on = machine.with_api_snapshot(|api| api.is_on);
+
             assert!(!is_on);
 
             machine.send.call(ToggleEvent::Toggle);
 
             let is_on = machine.with_api_snapshot(|api| api.is_on);
+
             assert!(is_on);
 
             rsx! {
@@ -1244,6 +1347,7 @@ mod tests {
         }
 
         let mut dom = VirtualDom::new(app);
+
         dom.rebuild_in_place();
     }
 
@@ -1255,11 +1359,13 @@ mod tests {
             });
 
             let is_on = machine.with_api_ephemeral(|api| api.get().is_on);
+
             assert!(!is_on);
 
             machine.send.call(ToggleEvent::Toggle);
 
             let is_on = machine.with_api_ephemeral(|api| api.get().is_on);
+
             assert!(is_on);
 
             rsx! {
@@ -1268,6 +1374,7 @@ mod tests {
         }
 
         let mut dom = VirtualDom::new(app);
+
         dom.rebuild_in_place();
     }
 
@@ -1281,9 +1388,11 @@ mod tests {
             assert_eq!(*machine.context_version.peek(), 0);
 
             machine.send.call(ToggleEvent::Toggle);
+
             assert_eq!(*machine.context_version.peek(), 0);
 
             machine.send.call(ToggleEvent::Toggle);
+
             assert_eq!(*machine.context_version.peek(), 0);
 
             rsx! {
@@ -1292,6 +1401,7 @@ mod tests {
         }
 
         let mut dom = VirtualDom::new(app);
+
         dom.rebuild_in_place();
     }
 
@@ -1303,7 +1413,9 @@ mod tests {
             });
 
             assert_eq!(*machine.context_version.peek(), 0);
+
             machine.send.call(DerivedEvent::BumpContext);
+
             assert_eq!(*machine.context_version.peek(), 1);
             assert_eq!(*machine.state.peek(), DerivedState::Off);
 
@@ -1313,6 +1425,7 @@ mod tests {
         }
 
         let mut dom = VirtualDom::new(app);
+
         dom.rebuild_in_place();
     }
 
@@ -1328,26 +1441,30 @@ mod tests {
             let machine = use_machine::<DerivedMachine>(DerivedProps {
                 id: String::from("derived"),
             });
+
             let derived = machine.derive(|api| (api.is_on, api.count));
+
             let mut phase = use_signal(|| 0u8);
 
             snapshots.borrow_mut().push(derived());
 
             if phase() == 0 {
                 phase.set(1);
+
                 machine.send.call(DerivedEvent::BumpContext);
             } else if phase() == 1 {
                 phase.set(2);
+
                 machine.send.call(DerivedEvent::Toggle);
             }
 
             rsx! {
                 div {}
-
             }
         }
 
         let mut dom = VirtualDom::new_with_props(app, Rc::clone(&snapshots));
+
         dom.rebuild_in_place();
         dom.mark_dirty(ScopeId::APP);
         dom.render_immediate(&mut NoOpMutations);
@@ -1363,8 +1480,10 @@ mod tests {
     #[test]
     fn use_machine_inner_resolves_locale_icu_and_messages_from_context() {
         fn app() -> Element {
-            let expected_provider: Arc<dyn IcuProvider> = Arc::new(TestIcuProvider);
+            let expected_backend: Arc<dyn IntlBackend> = Arc::new(TestIntlBackend);
+
             let mut registries = I18nRegistries::new();
+
             registries.register(
                 ars_core::MessagesRegistry::new(EnvMessages::default()).register(
                     "es",
@@ -1373,30 +1492,31 @@ mod tests {
                     },
                 ),
             );
-            let ctx = provide_test_context(
-                "es-ES",
-                Arc::clone(&expected_provider),
-                Arc::new(registries),
-            );
+
+            let ctx =
+                provide_test_context("es-ES", Arc::clone(&expected_backend), Arc::new(registries));
+
             use_context_provider(|| ctx);
 
             let machine = use_machine::<EnvMachine>(EnvProps { id: String::new() });
+
             let service = machine.service.peek();
+
             assert!(service.props().id().starts_with("component-"));
             assert_eq!(service.context().locale, "es-ES");
             assert!(Arc::ptr_eq(
-                &service.context().icu_provider,
-                &expected_provider
+                &service.context().intl_backend,
+                &expected_backend
             ));
             assert_eq!(service.context().label, "Hola");
 
             rsx! {
                 div {}
-
             }
         }
 
         let mut dom = VirtualDom::new(app);
+
         dom.rebuild_in_place();
     }
 
@@ -1414,10 +1534,13 @@ mod tests {
                 checked: false,
                 label: "a",
             });
+
             let mut phase = use_signal(|| 0u8);
 
             let machine = use_machine::<PropMachine>(props());
+
             let sync_count = machine.service.peek().context().sync_count;
+
             snapshots.borrow_mut().push((
                 *machine.state.peek(),
                 *machine.context_version.peek(),
@@ -1426,6 +1549,7 @@ mod tests {
 
             if phase() == 0 {
                 phase.set(1);
+
                 props.set(PropProps {
                     id: String::from("toggle"),
                     checked: true,
@@ -1433,6 +1557,7 @@ mod tests {
                 });
             } else if phase() == 1 {
                 phase.set(2);
+
                 props.set(PropProps {
                     id: String::from("toggle"),
                     checked: true,
@@ -1446,6 +1571,7 @@ mod tests {
         }
 
         let mut dom = VirtualDom::new_with_props(app, Rc::clone(&snapshots));
+
         dom.rebuild_in_place();
         dom.mark_dirty(ScopeId::APP);
         dom.render_immediate(&mut NoOpMutations);
@@ -1472,6 +1598,7 @@ mod tests {
         )]
         fn app(snapshots: Rc<RefCell<Vec<String>>>) -> Element {
             let mut phase = use_signal(|| 0u8);
+
             let machine = use_machine::<ToggleMachine>(ToggleProps { id: String::new() });
 
             snapshots
@@ -1488,6 +1615,7 @@ mod tests {
         }
 
         let mut dom = VirtualDom::new_with_props(app, Rc::clone(&snapshots));
+
         dom.rebuild_in_place();
         dom.mark_dirty(ScopeId::APP);
         dom.render_immediate(&mut NoOpMutations);
@@ -1495,6 +1623,7 @@ mod tests {
         dom.render_immediate(&mut NoOpMutations);
 
         let snapshots = snapshots.borrow();
+
         assert_eq!(snapshots.len(), 3);
         assert!(snapshots[0].starts_with("component-"));
         assert_eq!(snapshots[0], snapshots[1]);
@@ -1515,10 +1644,13 @@ mod tests {
                 checked: false,
                 label: "a",
             });
+
             let mut phase = use_signal(|| 0u8);
 
             let machine = use_machine_with_reactive_props::<PropMachine>(props);
+
             let sync_count = machine.service.peek().context().sync_count;
+
             snapshots.borrow_mut().push((
                 *machine.state.peek(),
                 *machine.context_version.peek(),
@@ -1527,6 +1659,7 @@ mod tests {
 
             if phase() == 0 {
                 phase.set(1);
+
                 props.set(PropProps {
                     id: String::from("toggle"),
                     checked: true,
@@ -1534,6 +1667,7 @@ mod tests {
                 });
             } else if phase() == 1 {
                 phase.set(2);
+
                 props.set(PropProps {
                     id: String::from("toggle"),
                     checked: true,
@@ -1547,6 +1681,7 @@ mod tests {
         }
 
         let mut dom = VirtualDom::new_with_props(app, Rc::clone(&snapshots));
+
         dom.rebuild_in_place();
         dom.mark_dirty(ScopeId::APP);
         dom.render_immediate(&mut NoOpMutations);
@@ -1578,11 +1713,14 @@ mod tests {
                 action: EffectAction::None,
                 log: Arc::clone(&log),
             });
+
             let mut phase = use_signal(|| 0u8);
 
             let _machine = use_machine_with_reactive_props::<EffectMachine>(props);
+
             if phase() == 0 {
                 phase.set(1);
+
                 props.set(EffectProps {
                     id: String::from("effects"),
                     action: EffectAction::Start,
@@ -1590,6 +1728,7 @@ mod tests {
                 });
             } else if phase() == 1 {
                 phase.set(2);
+
                 props.set(EffectProps {
                     id: String::from("effects"),
                     action: EffectAction::Replace,
@@ -1597,6 +1736,7 @@ mod tests {
                 });
             } else if phase() == 2 {
                 phase.set(3);
+
                 props.set(EffectProps {
                     id: String::from("effects"),
                     action: EffectAction::Cancel,
@@ -1610,6 +1750,7 @@ mod tests {
         }
 
         let mut dom = VirtualDom::new_with_props(app, Arc::clone(&log));
+
         dom.rebuild_in_place();
         dom.mark_dirty(ScopeId::APP);
         dom.render_immediate(&mut NoOpMutations);
@@ -1646,7 +1787,9 @@ mod tests {
             });
 
             let state = *machine.state.peek();
+
             let notify_count = machine.service.peek().context().notify_count;
+
             if state == EffectState::Idle && notify_count == 0 {
                 machine.send.call(EffectEvent::Start);
             } else if state == EffectState::Active && notify_count == 0 {
@@ -1660,9 +1803,11 @@ mod tests {
         }
 
         let mut dom = VirtualDom::new_with_props(app, Arc::clone(&log));
+
         dom.rebuild_in_place();
         dom.mark_dirty(ScopeId::APP);
         dom.render_immediate(&mut NoOpMutations);
+
         drop(dom);
 
         assert_eq!(effect_log(&log), vec!["setup:start", "cleanup:start"]);
@@ -1881,6 +2026,7 @@ mod wasm_tests {
                 } else {
                     PropState::Off
                 })),
+
                 PropEvent::SyncLabel => Some(ars_core::TransitionPlan::new().apply(
                     |ctx: &mut PropContext| {
                         ctx.sync_count += 1;
@@ -1903,12 +2049,15 @@ mod wasm_tests {
 
         fn on_props_changed(old: &Self::Props, new: &Self::Props) -> Vec<Self::Event> {
             let mut events = Vec::new();
+
             if old.checked != new.checked {
                 events.push(PropEvent::SetChecked(new.checked));
             }
+
             if old.label != new.label {
                 events.push(PropEvent::SyncLabel);
             }
+
             events
         }
     }
@@ -1993,6 +2142,7 @@ mod wasm_tests {
                     DerivedState::Off => DerivedState::On,
                     DerivedState::On => DerivedState::Off,
                 })),
+
                 DerivedEvent::BumpContext => Some(ars_core::TransitionPlan::new().apply(
                     |ctx: &mut DerivedContext| {
                         ctx.count += 1;
@@ -2026,7 +2176,9 @@ mod wasm_tests {
             let machine = use_machine::<ToggleMachine>(ToggleProps {
                 id: String::from("toggle"),
             });
+
             let mut phase = use_signal(|| 0u8);
+
             snapshots
                 .borrow_mut()
                 .push(machine.derive(|api| api.is_on)());
@@ -2042,6 +2194,7 @@ mod wasm_tests {
         }
 
         let mut dom = VirtualDom::new_with_props(app, Rc::clone(&snapshots));
+
         dom.rebuild_in_place();
         dom.mark_dirty(ScopeId::APP);
         dom.render_immediate(&mut NoOpMutations);
@@ -2059,15 +2212,18 @@ mod wasm_tests {
         )]
         fn app(snapshots: Rc<RefCell<Vec<String>>>) -> Element {
             let machine = use_machine::<ToggleMachine>(ToggleProps { id: String::new() });
+
             snapshots
                 .borrow_mut()
                 .push(machine.service.peek().props().id().to_owned());
+
             rsx! {
                 div {}
             }
         }
 
         let mut dom = VirtualDom::new_with_props(app, Rc::clone(&snapshots));
+
         dom.rebuild_in_place();
 
         assert_eq!(snapshots.borrow().len(), 1);
@@ -2088,10 +2244,13 @@ mod wasm_tests {
                 checked: false,
                 label: "a",
             });
+
             let mut phase = use_signal(|| 0u8);
 
             let machine = use_machine_with_reactive_props::<PropMachine>(props);
+
             let derived = machine.derive(PropApi::snapshot);
+
             snapshots.borrow_mut().push((
                 derived(),
                 *machine.state.peek(),
@@ -2100,6 +2259,7 @@ mod wasm_tests {
 
             if phase() == 0 {
                 phase.set(1);
+
                 props.set(PropProps {
                     id: String::from("toggle"),
                     checked: true,
@@ -2107,6 +2267,7 @@ mod wasm_tests {
                 });
             } else if phase() == 1 {
                 phase.set(2);
+
                 props.set(PropProps {
                     id: String::from("toggle"),
                     checked: true,
@@ -2120,6 +2281,7 @@ mod wasm_tests {
         }
 
         let mut dom = VirtualDom::new_with_props(app, Rc::clone(&snapshots));
+
         dom.rebuild_in_place();
         dom.mark_dirty(ScopeId::APP);
         dom.render_immediate(&mut NoOpMutations);
@@ -2148,16 +2310,20 @@ mod wasm_tests {
             let machine = use_machine::<DerivedMachine>(DerivedProps {
                 id: String::from("derived"),
             });
+
             let derived = machine.derive(|api| (api.is_on, api.count));
+
             let mut phase = use_signal(|| 0u8);
 
             snapshots.borrow_mut().push(derived());
 
             if phase() == 0 {
                 phase.set(1);
+
                 machine.send.call(DerivedEvent::BumpContext);
             } else if phase() == 1 {
                 phase.set(2);
+
                 machine.send.call(DerivedEvent::Toggle);
             }
 
@@ -2167,6 +2333,7 @@ mod wasm_tests {
         }
 
         let mut dom = VirtualDom::new_with_props(app, Rc::clone(&snapshots));
+
         dom.rebuild_in_place();
         dom.mark_dirty(ScopeId::APP);
         dom.render_immediate(&mut NoOpMutations);

--- a/crates/ars-i18n/src/calendar/date.rs
+++ b/crates/ars-i18n/src/calendar/date.rs
@@ -384,12 +384,15 @@ impl CalendarDate {
                 if options.wrap {
                     let minimum_month = i32::from(self.minimum_month_in_year());
                     let maximum_month = i32::from(self.calendar.months_in_year(self));
+
                     let months_in_year = maximum_month - minimum_month + 1;
 
                     let next_month = (i32::from(self.month) - minimum_month + amount)
                         .rem_euclid(months_in_year)
                         + minimum_month;
+
                     let current = temporal_date_for(self)?;
+
                     let next = current
                         .with(
                             CalendarFields::new()
@@ -424,12 +427,15 @@ impl CalendarDate {
                 if options.wrap {
                     let minimum_day = i32::from(self.minimum_day_in_month());
                     let maximum_day = i32::from(self.calendar.days_in_month(self));
+
                     let days_in_month = maximum_day - minimum_day + 1;
 
                     let next_day = (i32::from(self.day) - minimum_day + amount)
                         .rem_euclid(days_in_month)
                         + minimum_day;
+
                     let current = temporal_date_for(self)?;
+
                     let next = current
                         .with(
                             CalendarFields::new().with_optional_day(Some(
@@ -703,6 +709,7 @@ impl Time {
     #[must_use]
     pub fn to_iso8601(&self) -> String {
         let whole_seconds = format!("{:02}:{:02}:{:02}", self.hour, self.minute, self.second);
+
         let fractional = u32::from(self.millisecond) * 1_000_000
             + u32::from(self.microsecond) * 1_000
             + u32::from(self.nanosecond);
@@ -1109,6 +1116,7 @@ impl ZonedDateTime {
         let temporal_time_zone = time_zone.to_temporal()?;
 
         let temporal_date_time = temporal_date_time_for(date_time)?;
+
         let calendar_fields = temporal_calendar_fields(&CalendarDateFields {
             era: date_time.date.era.clone(),
             year: Some(date_time.date.year()),
@@ -1274,12 +1282,12 @@ pub fn to_zoned(
 }
 
 /// Converts a local date-time into a zoned date-time using the requested disambiguation.
-#[cfg(feature = "std")]
 ///
 /// # Errors
 ///
 /// Returns an error if the time zone is invalid or the local date-time cannot
 /// be resolved using the requested disambiguation strategy.
+#[cfg(feature = "std")]
 pub fn to_zoned_date_time(
     date_time: &CalendarDateTime,
     time_zone: &TimeZoneId,
@@ -1774,7 +1782,7 @@ fn format_iso_year(year: i32) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Locale, StubIcuProvider};
+    use crate::{Locale, StubIntlBackend};
 
     fn gregorian_date(year: i32, month: u8, day: u8) -> CalendarDate {
         CalendarDate::new_gregorian(year, month, day).expect("Gregorian fixture should validate")
@@ -1828,6 +1836,7 @@ mod tests {
     #[test]
     fn calendar_date_to_iso8601_uses_expanded_years_outside_four_digit_range() {
         let bce = gregorian_date(-50, 1, 2);
+
         let large = gregorian_date(10_000, 12, 31);
 
         assert_eq!(bce.to_iso8601(), "-000050-01-02");
@@ -1943,6 +1952,7 @@ mod tests {
     #[test]
     fn time_helpers_cover_subtract_set_and_non_wrapping_cycles() {
         let time = Time::new(9, 30, 45, 125).expect("time should validate");
+
         let precise = time
             .set(TimeFields {
                 microsecond: Some(222),
@@ -2189,6 +2199,7 @@ mod tests {
             Overflow::Reject,
         )
         .expect("Reiwa start should validate");
+
         assert_eq!(
             reiwa_start
                 .cycle(DateField::Month, -1, CycleOptions { wrap: true })
@@ -2212,6 +2223,7 @@ mod tests {
             Overflow::Reject,
         )
         .expect("Heisei start month should validate");
+
         assert_eq!(
             heisei_start_month
                 .cycle(DateField::Day, -1, CycleOptions { wrap: true })
@@ -2395,6 +2407,7 @@ mod tests {
         .expect("BCE Gregorian fixture should validate");
 
         let time = Time::new(9, 30, 0, 0).expect("time should validate");
+
         let utc = TimeZoneId::new("UTC").expect("UTC should validate");
 
         let japanese_zoned = ZonedDateTime::new(
@@ -2497,15 +2510,15 @@ mod tests {
 
     #[test]
     fn provider_locale_semantics_cover_week_info_sensitive_calendar_helpers() {
-        let provider = StubIcuProvider;
+        let backend = StubIntlBackend;
 
         let locale = Locale::parse("en-US-u-fw-mon").expect("test locale should parse");
 
         let date = gregorian_date(2024, 3, 10);
 
-        let start = crate::calendar::queries::start_of_week(&date, &locale, &provider);
+        let start = crate::calendar::queries::start_of_week(&date, &locale, &backend);
 
-        let end = crate::calendar::queries::end_of_week(&date, &locale, &provider);
+        let end = crate::calendar::queries::end_of_week(&date, &locale, &backend);
 
         assert_eq!(start.to_iso8601(), "2024-03-04");
         assert_eq!(end.to_iso8601(), "2024-03-10");

--- a/crates/ars-i18n/src/calendar/parse.rs
+++ b/crates/ars-i18n/src/calendar/parse.rs
@@ -366,6 +366,21 @@ mod tests {
         assert_eq!(japanese_date_time.time().minute(), 30);
     }
 
+    #[test]
+    fn parsing_helpers_reject_unsupported_calendar_annotations() {
+        let date_error = parse_date("2024-03-15[u-ca=islamic-tbla]")
+            .expect_err("unsupported calendar must fail");
+        let date_time_error = parse_date_time("2024-03-15T09:30:00[u-ca=islamic-tbla]")
+            .expect_err("unsupported calendar must fail");
+
+        assert!(
+            matches!(date_error, CalendarError::Arithmetic(message) if message.contains("parsed calendar is not representable"))
+        );
+        assert!(
+            matches!(date_time_error, CalendarError::Arithmetic(message) if message.contains("parsed calendar is not representable"))
+        );
+    }
+
     #[cfg(feature = "std")]
     #[test]
     fn zoned_and_absolute_parsing_reject_invalid_inputs() {
@@ -378,6 +393,23 @@ mod tests {
         );
         assert!(parse_absolute("2024-03-10T07:45:00", &time_zone).is_err());
         assert!(parse_absolute_to_local("not-a-timestamp").is_err());
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn zoned_and_absolute_parsing_accept_valid_inputs() {
+        let time_zone = TimeZoneId::new("America/New_York").expect("zone should validate");
+
+        let zoned = parse_zoned_date_time("2024-03-10T01:30-05:00[America/New_York]")
+            .expect("zoned date-time should parse");
+        let absolute = parse_absolute("2024-03-10T07:45:00Z", &time_zone)
+            .expect("absolute timestamp should parse");
+
+        assert_eq!(zoned.calendar, CalendarSystem::Iso8601);
+        assert_eq!(zoned.time_zone().as_str(), "America/New_York");
+        assert_eq!(absolute.calendar, CalendarSystem::Iso8601);
+        assert_eq!(absolute.time_zone().as_str(), "America/New_York");
+        assert_eq!(absolute.offset_minutes(), -240);
     }
 
     #[cfg(feature = "std")]

--- a/crates/ars-i18n/src/calendar/queries.rs
+++ b/crates/ars-i18n/src/calendar/queries.rs
@@ -3,7 +3,7 @@
 use super::{CalendarDate, DateValue};
 #[cfg(feature = "std")]
 use super::{CalendarDateTime, DateDuration, Disambiguation, Time, TimeZoneId};
-use crate::{CalendarSystem, IcuProvider, Locale, Weekday};
+use crate::{CalendarSystem, IntlBackend, Locale, Weekday};
 
 /// Returns `true` when two values represent the same day in the first value's calendar.
 #[must_use]
@@ -159,10 +159,10 @@ pub fn end_of_year<T: DateValue>(date: &T) -> T {
 
 /// Returns the first day of the locale week containing the date.
 #[must_use]
-pub fn start_of_week<T: DateValue>(date: &T, locale: &Locale, provider: &dyn IcuProvider) -> T {
+pub fn start_of_week<T: DateValue>(date: &T, locale: &Locale, backend: &dyn IntlBackend) -> T {
     let current = date.date_value();
 
-    let first_day = provider.first_day_of_week(locale);
+    let first_day = backend.first_day_of_week(locale);
 
     let delta = weekday_index(current.weekday()) - weekday_index(first_day);
 
@@ -175,8 +175,8 @@ pub fn start_of_week<T: DateValue>(date: &T, locale: &Locale, provider: &dyn Icu
 
 /// Returns the last day of the locale week containing the date.
 #[must_use]
-pub fn end_of_week<T: DateValue>(date: &T, locale: &Locale, provider: &dyn IcuProvider) -> T {
-    let start = start_of_week(date, locale, provider).date_value();
+pub fn end_of_week<T: DateValue>(date: &T, locale: &Locale, backend: &dyn IntlBackend) -> T {
+    let start = start_of_week(date, locale, backend).date_value();
 
     let next = start.add_days(6).unwrap_or(start.clone());
 
@@ -185,8 +185,8 @@ pub fn end_of_week<T: DateValue>(date: &T, locale: &Locale, provider: &dyn IcuPr
 
 /// Returns the weekday index relative to the locale's first day of week.
 #[must_use]
-pub fn get_day_of_week(date: &CalendarDate, locale: &Locale, provider: &dyn IcuProvider) -> u8 {
-    let first_day = provider.week_info(locale).first_day;
+pub fn get_day_of_week(date: &CalendarDate, locale: &Locale, backend: &dyn IntlBackend) -> u8 {
+    let first_day = backend.week_info(locale).first_day;
 
     let offset = (weekday_index(date.weekday()) - weekday_index(first_day)).rem_euclid(7);
 
@@ -195,14 +195,14 @@ pub fn get_day_of_week(date: &CalendarDate, locale: &Locale, provider: &dyn IcuP
 
 /// Returns the number of calendar weeks that intersect the month.
 #[must_use]
-pub fn get_weeks_in_month(date: &CalendarDate, locale: &Locale, provider: &dyn IcuProvider) -> u8 {
+pub fn get_weeks_in_month(date: &CalendarDate, locale: &Locale, backend: &dyn IntlBackend) -> u8 {
     let month_start = start_of_month(date);
 
     let month_end = end_of_month(date);
 
-    let first_week_start = start_of_week(&month_start, locale, provider).date_value();
+    let first_week_start = start_of_week(&month_start, locale, backend).date_value();
 
-    let last_week_end = end_of_week(&month_end, locale, provider).date_value();
+    let last_week_end = end_of_week(&month_end, locale, backend).date_value();
 
     first_week_start
         .days_until(&last_week_end)
@@ -268,8 +268,8 @@ pub fn max_date<T: DateValue>(a: &T, b: &T) -> T {
 
 /// Returns `true` when the given date falls on the locale weekend.
 #[must_use]
-pub fn is_weekend(date: &CalendarDate, locale: &Locale, provider: &dyn IcuProvider) -> bool {
-    let week_info = provider.week_info(locale);
+pub fn is_weekend(date: &CalendarDate, locale: &Locale, backend: &dyn IntlBackend) -> bool {
+    let week_info = backend.week_info(locale);
 
     let day = weekday_index(date.weekday());
 
@@ -286,8 +286,8 @@ pub fn is_weekend(date: &CalendarDate, locale: &Locale, provider: &dyn IcuProvid
 
 /// Returns `true` when the given date is not on the locale weekend.
 #[must_use]
-pub fn is_weekday(date: &CalendarDate, locale: &Locale, provider: &dyn IcuProvider) -> bool {
-    !is_weekend(date, locale, provider)
+pub fn is_weekday(date: &CalendarDate, locale: &Locale, backend: &dyn IntlBackend) -> bool {
+    !is_weekend(date, locale, backend)
 }
 
 const fn weekday_index(value: Weekday) -> i32 {
@@ -327,11 +327,44 @@ mod tests {
     use super::*;
     #[cfg(feature = "std")]
     use crate::TimeZoneId;
-    use crate::{CalendarDateFields, CalendarDateTime, Era, StubIcuProvider, Time};
+    use crate::{CalendarDateFields, CalendarDateTime, Era, StubIntlBackend, Time};
 
     struct WrapWeekendProvider;
 
-    impl IcuProvider for WrapWeekendProvider {
+    impl IntlBackend for WrapWeekendProvider {
+        fn weekday_short_label(&self, weekday: Weekday, locale: &Locale) -> String {
+            StubIntlBackend.weekday_short_label(weekday, locale)
+        }
+
+        fn weekday_long_label(&self, weekday: Weekday, locale: &Locale) -> String {
+            StubIntlBackend.weekday_long_label(weekday, locale)
+        }
+
+        fn month_long_name(&self, month: u8, locale: &Locale) -> String {
+            StubIntlBackend.month_long_name(month, locale)
+        }
+
+        fn day_period_label(&self, is_pm: bool, locale: &Locale) -> String {
+            StubIntlBackend.day_period_label(is_pm, locale)
+        }
+
+        fn day_period_from_char(&self, ch: char, locale: &Locale) -> Option<bool> {
+            StubIntlBackend.day_period_from_char(ch, locale)
+        }
+
+        fn format_segment_digits(
+            &self,
+            value: u32,
+            min_digits: core::num::NonZero<u8>,
+            locale: &Locale,
+        ) -> String {
+            StubIntlBackend.format_segment_digits(value, min_digits, locale)
+        }
+
+        fn hour_cycle(&self, locale: &Locale) -> crate::HourCycle {
+            StubIntlBackend.hour_cycle(locale)
+        }
+
         fn week_info(&self, _locale: &Locale) -> crate::WeekInfo {
             crate::WeekInfo {
                 first_day: Weekday::Monday,
@@ -420,7 +453,7 @@ mod tests {
 
     #[test]
     fn week_helpers_preserve_time_components_and_cover_weekend_wrap_logic() {
-        let provider = StubIcuProvider;
+        let backend = StubIntlBackend;
 
         let locale = Locale::parse("ar-AE").expect("locale should parse");
 
@@ -429,19 +462,15 @@ mod tests {
             Time::new(9, 30, 0, 0).expect("time should validate"),
         );
 
-        let start = start_of_week(&date_time, &locale, &provider);
-        let end = end_of_week(&date_time, &locale, &provider);
+        let start = start_of_week(&date_time, &locale, &backend);
+        let end = end_of_week(&date_time, &locale, &backend);
 
         assert_eq!(start.time().hour(), 9);
         assert_eq!(start.time().minute(), 30);
         assert_eq!(end.time().hour(), 9);
-        assert!(is_weekend(&gregorian_date(2024, 3, 15), &locale, &provider));
-        assert!(is_weekend(&gregorian_date(2024, 3, 16), &locale, &provider));
-        assert!(!is_weekday(
-            &gregorian_date(2024, 3, 15),
-            &locale,
-            &provider
-        ));
+        assert!(is_weekend(&gregorian_date(2024, 3, 15), &locale, &backend));
+        assert!(is_weekend(&gregorian_date(2024, 3, 16), &locale, &backend));
+        assert!(!is_weekday(&gregorian_date(2024, 3, 15), &locale, &backend));
     }
 
     #[cfg(feature = "std")]
@@ -465,7 +494,7 @@ mod tests {
 
     #[test]
     fn comparison_and_weekend_helpers_cover_remaining_branch_shapes() {
-        let provider = StubIcuProvider;
+        let backend = StubIntlBackend;
 
         let wrap_provider = WrapWeekendProvider;
 
@@ -494,7 +523,7 @@ mod tests {
         assert_eq!(min_date(&same_day, &same_day).to_iso8601(), "2024-03-15");
         assert_eq!(max_date(&same_day, &same_day).to_iso8601(), "2024-03-15");
 
-        assert_eq!(get_day_of_week(&same_day, &locale, &provider), 5);
+        assert_eq!(get_day_of_week(&same_day, &locale, &backend), 5);
         assert!(is_weekend(
             &gregorian_date(2024, 3, 10),
             &locale,

--- a/crates/ars-i18n/src/date.rs
+++ b/crates/ars-i18n/src/date.rs
@@ -44,8 +44,8 @@ use crate::calendar::internal::CalendarDate as InternalCalendarDate;
 #[cfg(feature = "std")]
 use crate::to_zoned_date_time;
 use crate::{
-    CalendarDate, CalendarDateTime, CalendarSystem, Era, HourCycle, IcuProvider, Locale, Time,
-    TimeZoneId, Weekday, default_provider,
+    CalendarDate, CalendarDateTime, CalendarSystem, Era, HourCycle, IntlBackend, Locale, Time,
+    TimeZoneId, Weekday, default_backend,
 };
 
 /// Length of the formatted date/time string.
@@ -476,12 +476,12 @@ impl DateFormatter {
     /// Formats a calendar date into semantic parts.
     #[must_use]
     pub fn format_date_to_parts(&self, value: &CalendarDate) -> Vec<DateFormatterPart> {
-        let provider = default_provider();
+        let backend = default_backend();
 
         let date = self.convert_date_for_display(value);
 
         render_date_parts(
-            provider.as_ref(),
+            backend.as_ref(),
             &self.locale,
             &date,
             self.effective_date_fields(),
@@ -491,19 +491,19 @@ impl DateFormatter {
     /// Formats a calendar date-time into semantic parts.
     #[must_use]
     pub fn format_date_time_to_parts(&self, value: &CalendarDateTime) -> Vec<DateFormatterPart> {
-        let provider = default_provider();
+        let backend = default_backend();
 
         let date = self.convert_date_for_display(value.date());
 
         let mut parts = render_date_parts(
-            provider.as_ref(),
+            backend.as_ref(),
             &self.locale,
             &date,
             self.effective_date_fields(),
         );
 
         let time_parts = render_time_parts(
-            provider.as_ref(),
+            backend.as_ref(),
             &self.locale,
             value.time(),
             self.effective_time_fields(),
@@ -530,10 +530,10 @@ impl DateFormatter {
     /// Formats a wall-clock time into semantic parts.
     #[must_use]
     pub fn format_time_to_parts(&self, value: &Time) -> Vec<DateFormatterPart> {
-        let provider = default_provider();
+        let backend = default_backend();
 
         render_time_parts(
-            provider.as_ref(),
+            backend.as_ref(),
             &self.locale,
             value,
             self.effective_time_fields(),
@@ -552,7 +552,7 @@ impl DateFormatter {
     #[cfg(feature = "std")]
     #[must_use]
     pub fn format_zoned_to_parts(&self, value: &ZonedDateTime) -> Vec<DateFormatterPart> {
-        let provider = default_provider();
+        let backend = default_backend();
 
         let zoned = self.convert_zoned_for_display(value);
 
@@ -561,14 +561,14 @@ impl DateFormatter {
         let time = time_from_zoned(&zoned);
 
         let mut parts = render_date_parts(
-            provider.as_ref(),
+            backend.as_ref(),
             &self.locale,
             &date,
             self.effective_date_fields(),
         );
 
         let time_parts = render_time_parts(
-            provider.as_ref(),
+            backend.as_ref(),
             &self.locale,
             &time,
             self.effective_time_fields(),
@@ -766,7 +766,7 @@ fn resolve_options(
     locale: &Locale,
     options: &DateFormatterOptions,
 ) -> ResolvedDateFormatterOptions {
-    let provider = default_provider();
+    let backend = default_backend();
 
     let uses_time = options.time_style.is_some()
         || options.hour.is_some()
@@ -785,7 +785,7 @@ fn resolve_options(
         hour_cycle: uses_time.then(|| {
             options
                 .hour_cycle
-                .unwrap_or_else(|| locale.hour_cycle(provider.as_ref()))
+                .unwrap_or_else(|| locale.hour_cycle(backend.as_ref()))
         }),
         date_style: options.date_style,
         time_style: options.time_style,
@@ -927,7 +927,7 @@ fn format_js_date(
 }
 
 fn render_date_parts(
-    provider: &dyn IcuProvider,
+    backend: &dyn IntlBackend,
     locale: &Locale,
     date: &CalendarDate,
     fields: EffectiveDateFields,
@@ -937,7 +937,7 @@ fn render_date_parts(
     if let Some(weekday_width) = fields.weekday {
         parts.push(DateFormatterPart {
             kind: DateFormatterPartKind::Weekday,
-            value: weekday_label(provider, date.weekday(), locale, weekday_width),
+            value: weekday_label(backend, date.weekday(), locale, weekday_width),
         });
 
         if fields.era.is_some()
@@ -966,7 +966,7 @@ fn render_date_parts(
                 &mut ordered,
                 fields.month.map(|month| DateFormatterPart {
                     kind: DateFormatterPartKind::Month,
-                    value: format_month(provider, locale, date.month(), month),
+                    value: format_month(backend, locale, date.month(), month),
                 }),
                 " ",
             );
@@ -1004,7 +1004,7 @@ fn render_date_parts(
                 &mut ordered,
                 fields.month.map(|month| DateFormatterPart {
                     kind: DateFormatterPartKind::Month,
-                    value: format_month(provider, locale, date.month(), month),
+                    value: format_month(backend, locale, date.month(), month),
                 }),
                 " ",
             );
@@ -1033,7 +1033,7 @@ fn render_date_parts(
                 &mut ordered,
                 fields.month.map(|month| DateFormatterPart {
                     kind: DateFormatterPartKind::Month,
-                    value: format_month(provider, locale, date.month(), month),
+                    value: format_month(backend, locale, date.month(), month),
                 }),
                 " ",
             );
@@ -1055,7 +1055,7 @@ fn render_date_parts(
 }
 
 fn render_time_parts(
-    provider: &dyn IcuProvider,
+    backend: &dyn IntlBackend,
     locale: &Locale,
     time: &Time,
     fields: EffectiveTimeFields,
@@ -1097,7 +1097,7 @@ fn render_time_parts(
 
         parts.push(DateFormatterPart {
             kind: DateFormatterPartKind::DayPeriod,
-            value: provider.day_period_label(time.hour() >= 12, locale),
+            value: backend.day_period_label(time.hour() >= 12, locale),
         });
     }
     if let Some(zone_format) = fields.time_zone_name
@@ -1259,16 +1259,22 @@ fn date_order(locale: &Locale) -> DateOrder {
 #[cfg(feature = "icu4x")]
 fn icu_date_order(locale: &Locale) -> Option<DateOrder> {
     let probe = CalendarDate::new_gregorian(2006, 11, 22).ok()?;
+
     let formatter = build_icu_date_formatter(locale, FormatLength::Short);
+
     let formatted = format_icu_date(locale, FormatLength::Short, &formatter, &probe);
+
     numeric_field_order_from_formatted(&formatted)
 }
 
 #[cfg(all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")))]
 fn js_date_order(locale: &Locale) -> Option<DateOrder> {
     let probe = CalendarDate::new_gregorian(2006, 11, 22).ok()?;
+
     let formatter = build_js_date_formatter(locale, FormatLength::Short);
+
     let formatted = format_js_date(locale, FormatLength::Short, &formatter, &probe);
+
     numeric_field_order_from_formatted(&formatted)
 }
 
@@ -1279,7 +1285,9 @@ fn fallback_date_order(locale: &Locale) -> DateOrder {
 
     match locale.region() {
         Some("US" | "FM" | "PW") => DateOrder::MonthDayYear,
+
         Some("CA" | "CN" | "HU" | "JP" | "KR" | "LT" | "MN" | "TW") => DateOrder::YearMonthDay,
+
         _ => DateOrder::DayMonthYear,
     }
 }
@@ -1297,6 +1305,7 @@ fn numeric_field_order_from_formatted(formatted: &str) -> Option<DateOrder> {
     }
 
     let mut numeric_runs = Vec::new();
+
     let mut current: Option<u32> = None;
 
     for ch in formatted.chars() {
@@ -1327,16 +1336,19 @@ fn numeric_field_order_from_formatted(formatted: &str) -> Option<DateOrder> {
             DateComponent::Day,
             DateComponent::Year,
         ] => Some(DateOrder::MonthDayYear),
+
         [
             DateComponent::Day,
             DateComponent::Month,
             DateComponent::Year,
         ] => Some(DateOrder::DayMonthYear),
+
         [
             DateComponent::Year,
             DateComponent::Month,
             DateComponent::Day,
         ] => Some(DateOrder::YearMonthDay),
+
         _ => None,
     }
 }
@@ -1379,7 +1391,7 @@ fn format_hour(hour: u8, width: NumericWidth, cycle: HourCycle) -> String {
 }
 
 fn format_month(
-    provider: &dyn IcuProvider,
+    backend: &dyn IntlBackend,
     locale: &Locale,
     month: u8,
     format_kind: MonthFormat,
@@ -1387,22 +1399,22 @@ fn format_month(
     match format_kind {
         MonthFormat::Numeric => month.to_string(),
         MonthFormat::TwoDigit => format!("{month:02}"),
-        MonthFormat::Long => provider.month_long_name(month, locale),
-        MonthFormat::Short => truncate_graphemes(&provider.month_long_name(month, locale), 3),
-        MonthFormat::Narrow => truncate_graphemes(&provider.month_long_name(month, locale), 1),
+        MonthFormat::Long => backend.month_long_name(month, locale),
+        MonthFormat::Short => truncate_graphemes(&backend.month_long_name(month, locale), 3),
+        MonthFormat::Narrow => truncate_graphemes(&backend.month_long_name(month, locale), 1),
     }
 }
 
 fn weekday_label(
-    provider: &dyn IcuProvider,
+    backend: &dyn IntlBackend,
     weekday: Weekday,
     locale: &Locale,
     width: TextWidth,
 ) -> String {
     match width {
-        TextWidth::Long => provider.weekday_long_label(weekday, locale),
-        TextWidth::Short => provider.weekday_short_label(weekday, locale),
-        TextWidth::Narrow => truncate_graphemes(&provider.weekday_short_label(weekday, locale), 1),
+        TextWidth::Long => backend.weekday_long_label(weekday, locale),
+        TextWidth::Short => backend.weekday_short_label(weekday, locale),
+        TextWidth::Narrow => truncate_graphemes(&backend.weekday_short_label(weekday, locale), 1),
     }
 }
 
@@ -1424,10 +1436,12 @@ fn format_time_zone_name(
 ) -> String {
     match format_kind {
         TimeZoneNameFormat::Short | TimeZoneNameFormat::Long => String::from(time_zone.as_str()),
+
         TimeZoneNameFormat::ShortOffset => utc_offset_minutes.map_or_else(
             || format!("GMT {}", time_zone.as_str()),
             |minutes| format_utc_offset(minutes, false),
         ),
+
         TimeZoneNameFormat::LongOffset => utc_offset_minutes.map_or_else(
             || format!("GMT offset {}", time_zone.as_str()),
             |minutes| format_utc_offset(minutes, true),
@@ -1457,8 +1471,11 @@ fn format_utc_offset(utc_offset_minutes: i32, long: bool) -> String {
     } else {
         '+'
     };
+
     let absolute_minutes = utc_offset_minutes.abs();
+
     let hours = absolute_minutes / 60;
+
     let minutes = absolute_minutes % 60;
 
     if long {
@@ -1575,6 +1592,7 @@ fn fallback_format_date(_locale: &Locale, length: FormatLength, date: &CalendarD
     let month = date.month;
 
     let day = date.day;
+
     let (display_year, era_suffix) = fallback_gregorian_year_for_display(date);
 
     match length {
@@ -1718,7 +1736,7 @@ mod tests {
         fallback_format_date,
     };
     #[cfg(feature = "icu4x")]
-    use crate::StubIcuProvider;
+    use crate::StubIntlBackend;
     #[cfg(any(
         not(any(feature = "icu4x", feature = "web-intl")),
         all(
@@ -2310,7 +2328,7 @@ mod tests {
     #[cfg(feature = "icu4x")]
     #[test]
     fn low_level_part_rendering_helpers_cover_shared_and_distinct_ranges() {
-        let provider = StubIcuProvider;
+        let backend = StubIntlBackend;
 
         let locale = locales::en_us();
 
@@ -2319,7 +2337,7 @@ mod tests {
         let time = Time::new(17, 5, 9, 0).expect("time should validate");
 
         let date_parts = render_date_parts(
-            &provider,
+            &backend,
             &locale,
             &date,
             EffectiveDateFields {
@@ -2332,7 +2350,7 @@ mod tests {
         );
 
         let time_parts = render_time_parts(
-            &provider,
+            &backend,
             &locale,
             &time,
             EffectiveTimeFields {
@@ -2468,6 +2486,7 @@ mod tests {
         );
 
         let time = Time::new(17, 5, 9, 0).expect("time should validate");
+
         let formatted_utc = formatter.format_time(&time);
 
         assert!(formatted_utc.contains("GMT"));
@@ -2492,7 +2511,7 @@ mod tests {
     #[cfg(all(feature = "std", feature = "icu4x"))]
     #[test]
     fn formatter_primitives_cover_numeric_and_projection_helpers() {
-        let provider = StubIcuProvider;
+        let backend = StubIntlBackend;
 
         let locale = locales::en_us();
 
@@ -2541,27 +2560,24 @@ mod tests {
         assert_eq!(format_hour(17, NumericWidth::Numeric, HourCycle::H23), "17");
         assert_eq!(format_hour(0, NumericWidth::Numeric, HourCycle::H24), "24");
         assert_eq!(
-            format_month(&provider, &locale, 3, MonthFormat::Numeric),
+            format_month(&backend, &locale, 3, MonthFormat::Numeric),
             "3"
         );
         assert_eq!(
-            format_month(&provider, &locale, 3, MonthFormat::TwoDigit),
+            format_month(&backend, &locale, 3, MonthFormat::TwoDigit),
             "03"
         );
         assert_eq!(
-            format_month(&provider, &locale, 3, MonthFormat::Long),
+            format_month(&backend, &locale, 3, MonthFormat::Long),
             "March"
         );
         assert_eq!(
-            format_month(&provider, &locale, 3, MonthFormat::Short),
+            format_month(&backend, &locale, 3, MonthFormat::Short),
             "Mar"
         );
+        assert_eq!(format_month(&backend, &locale, 3, MonthFormat::Narrow), "M");
         assert_eq!(
-            format_month(&provider, &locale, 3, MonthFormat::Narrow),
-            "M"
-        );
-        assert_eq!(
-            weekday_label(&provider, Weekday::Friday, &locale, TextWidth::Narrow),
+            weekday_label(&backend, Weekday::Friday, &locale, TextWidth::Narrow),
             "F"
         );
         assert_eq!(era_label(&era, TextWidth::Narrow), "R");
@@ -2605,6 +2621,7 @@ mod tests {
     #[test]
     fn formatter_uses_locale_derived_date_field_order_for_option_based_dates() {
         let locale = Locale::parse("en-CA").expect("locale should parse");
+
         let formatter = DateFormatter::new_with_options(
             &locale,
             DateFormatterOptions {
@@ -2614,7 +2631,9 @@ mod tests {
                 ..DateFormatterOptions::default()
             },
         );
+
         let date = CalendarDate::new_gregorian(2006, 11, 22).expect("fixture should validate");
+
         let kinds: Vec<_> = formatter
             .format_date_to_parts(&date)
             .into_iter()
@@ -2890,7 +2909,9 @@ mod web_intl_tests {
     #[wasm_bindgen_test]
     fn web_intl_date_formatter_preserves_bce_gregorian_dates() {
         let locale = locales::en_us();
+
         let formatter = DateFormatter::new(&locale, FormatLength::Long);
+
         let date = CalendarDate::new(
             CalendarSystem::Gregorian,
             &crate::CalendarDateFields {
@@ -2908,6 +2929,7 @@ mod web_intl_tests {
 
         let converted =
             js_date_from_calendar(&date).expect("BCE Gregorian fixture should map to a Date");
+
         let expected = direct_browser_format_for_js_date(
             &locale,
             FormatLength::Long,

--- a/crates/ars-i18n/src/lib.rs
+++ b/crates/ars-i18n/src/lib.rs
@@ -9,7 +9,7 @@
 //! layout axes, RTL-aware layout geometry types ([`LogicalSide`],
 //! [`PhysicalSide`], [`LogicalRect`], [`PhysicalRect`]), plural and ordinal
 //! helpers, locale-aware [`to_uppercase`] and [`to_lowercase`] helpers, and
-//! the [`IcuProvider`] trait for calendar/locale data abstraction.
+//! the [`IntlBackend`] trait for calendar/locale data abstraction.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
@@ -18,10 +18,7 @@ compile_error!("features `icu4x` and `web-intl` are mutually exclusive");
 
 extern crate alloc;
 
-use alloc::{
-    format,
-    string::{String, ToString},
-};
+use alloc::string::{String, ToString};
 use core::num::NonZero;
 
 mod bidi;
@@ -80,10 +77,10 @@ pub use plural::{
     select_plural,
 };
 #[cfg(feature = "icu4x")]
-pub use provider::Icu4xProvider;
+pub use provider::Icu4xBackend;
 #[cfg(all(feature = "web-intl", target_arch = "wasm32"))]
-pub use provider::WebIntlProvider;
-pub use provider::{StubIcuProvider, default_provider};
+pub use provider::WebIntlBackend;
+pub use provider::{StubIntlBackend, default_backend};
 pub use relative_time::{NumericOption, RelativeTimeFormatter};
 pub use translate::Translate;
 pub use weekday::Weekday;
@@ -211,91 +208,51 @@ pub enum Orientation {
 }
 
 // ────────────────────────────────────────────────────────────────────
-// ICU data provider abstraction
+// Locale/calendar backend abstraction
 // ────────────────────────────────────────────────────────────────────
 
-/// Trait abstracting ICU4X data provider for calendar/locale operations.
+/// Trait abstracting locale/calendar data providers for formatting and metadata.
 ///
-/// Production uses `Icu4xProvider` with CLDR data; tests and non-date-time
-/// components use [`StubIcuProvider`]. The trait is object-safe so it can be
-/// stored as `Arc<dyn IcuProvider>` in `Env`.
+/// Production uses `Icu4xBackend` with CLDR data; tests and non-date-time
+/// components use [`StubIntlBackend`]. The trait is object-safe so it can be
+/// stored as `Arc<dyn IntlBackend>` in `Env`.
+///
+/// Locale-facing formatting and metadata methods are required provider
+/// responsibilities. Calendar compatibility helpers remain canonical defaults
+/// over the public [`CalendarDate`] / [`CalendarSystem`] model so providers can
+/// reuse the shared implementation when they do not need backend-specific
+/// overrides.
 ///
 /// Requires `Send + Sync` on every target so adapters and shared ownership
-/// abstractions can treat ICU providers uniformly across native and wasm
-/// builds.
-pub trait IcuProvider: Send + Sync + 'static {
+/// abstractions can treat locale/calendar backends uniformly across native and
+/// wasm builds.
+///
+/// ```compile_fail
+/// use ars_i18n::IntlBackend;
+///
+/// struct IncompleteProvider;
+///
+/// impl IntlBackend for IncompleteProvider {}
+/// ```
+pub trait IntlBackend: Send + Sync + 'static {
     /// Short weekday label (abbreviated format): `Mo`, `Tu`, `We`, ...
-    fn weekday_short_label(&self, weekday: Weekday, _locale: &Locale) -> String {
-        match weekday {
-            Weekday::Sunday => String::from("Su"),
-            Weekday::Monday => String::from("Mo"),
-            Weekday::Tuesday => String::from("Tu"),
-            Weekday::Wednesday => String::from("We"),
-            Weekday::Thursday => String::from("Th"),
-            Weekday::Friday => String::from("Fr"),
-            Weekday::Saturday => String::from("Sa"),
-        }
-    }
+    fn weekday_short_label(&self, weekday: Weekday, locale: &Locale) -> String;
 
     /// Long weekday label (wide format): `Monday`, `Tuesday`, ...
-    fn weekday_long_label(&self, weekday: Weekday, _locale: &Locale) -> String {
-        match weekday {
-            Weekday::Sunday => String::from("Sunday"),
-            Weekday::Monday => String::from("Monday"),
-            Weekday::Tuesday => String::from("Tuesday"),
-            Weekday::Wednesday => String::from("Wednesday"),
-            Weekday::Thursday => String::from("Thursday"),
-            Weekday::Friday => String::from("Friday"),
-            Weekday::Saturday => String::from("Saturday"),
-        }
-    }
+    fn weekday_long_label(&self, weekday: Weekday, locale: &Locale) -> String;
 
     /// Full month name in the locale.
-    fn month_long_name(&self, month: u8, _locale: &Locale) -> String {
-        match month {
-            1 => String::from("January"),
-            2 => String::from("February"),
-            3 => String::from("March"),
-            4 => String::from("April"),
-            5 => String::from("May"),
-            6 => String::from("June"),
-            7 => String::from("July"),
-            8 => String::from("August"),
-            9 => String::from("September"),
-            10 => String::from("October"),
-            11 => String::from("November"),
-            12 => String::from("December"),
-            _ => String::from("Unknown"),
-        }
-    }
+    fn month_long_name(&self, month: u8, locale: &Locale) -> String;
 
     /// Localized day-period label.
-    fn day_period_label(&self, is_pm: bool, _locale: &Locale) -> String {
-        if is_pm {
-            String::from("PM")
-        } else {
-            String::from("AM")
-        }
-    }
+    fn day_period_label(&self, is_pm: bool, locale: &Locale) -> String;
 
     /// Reverse-maps a typed character to AM/PM.
-    fn day_period_from_char(&self, ch: char, _locale: &Locale) -> Option<bool> {
-        match ch.to_ascii_lowercase() {
-            'a' => Some(false),
-            'p' => Some(true),
-            _ => None,
-        }
-    }
+    fn day_period_from_char(&self, ch: char, locale: &Locale) -> Option<bool>;
 
     /// Formats a numeric segment with locale-appropriate zero-padding.
-    fn format_segment_digits(
-        &self,
-        value: u32,
-        min_digits: NonZero<u8>,
-        _locale: &Locale,
-    ) -> String {
-        format!("{value:0width$}", width = usize::from(min_digits.get()))
-    }
+    fn format_segment_digits(&self, value: u32, min_digits: NonZero<u8>, locale: &Locale)
+    -> String;
 
     /// Maximum number of months in a year for the given calendar and year.
     fn max_months_in_year(&self, calendar: &CalendarSystem, year: i32, era: Option<&str>) -> u8 {
@@ -374,17 +331,10 @@ pub trait IcuProvider: Send + Sync + 'static {
     }
 
     /// Preferred hour cycle for the locale.
-    fn hour_cycle(&self, locale: &Locale) -> HourCycle {
-        match locale.language() {
-            "en" | "ko" => HourCycle::H12,
-            _ => HourCycle::H23,
-        }
-    }
+    fn hour_cycle(&self, locale: &Locale) -> HourCycle;
 
     /// Locale week information including first-day and weekend metadata.
-    fn week_info(&self, locale: &Locale) -> WeekInfo {
-        WeekInfo::for_locale(locale)
-    }
+    fn week_info(&self, locale: &Locale) -> WeekInfo;
 
     /// First day of the week for the locale.
     fn first_day_of_week(&self, locale: &Locale) -> Weekday {
@@ -678,10 +628,10 @@ mod tests {
     fn locale_wrapper_helpers_delegate_to_stub_provider_defaults() {
         let locale = Locale::parse("en-US").expect("en-US is valid");
 
-        let provider = StubIcuProvider;
+        let backend = StubIntlBackend;
 
-        assert_eq!(locale.first_day_of_week(&provider), Weekday::Sunday);
-        assert_eq!(locale.hour_cycle(&provider), HourCycle::H12);
+        assert_eq!(locale.first_day_of_week(&backend), Weekday::Sunday);
+        assert_eq!(locale.hour_cycle(&backend), HourCycle::H12);
     }
 
     #[test]
@@ -690,8 +640,8 @@ mod tests {
     }
 
     #[test]
-    fn stub_icu_provider_default_helpers_cover_fallback_paths() {
-        let provider = StubIcuProvider;
+    fn stub_intl_backend_default_helpers_cover_fallback_paths() {
+        let backend = StubIntlBackend;
 
         let locale = Locale::parse("en-US").expect("en-US is valid");
 
@@ -704,8 +654,8 @@ mod tests {
             (Weekday::Friday, "Fr", "Friday"),
             (Weekday::Saturday, "Sa", "Saturday"),
         ] {
-            assert_eq!(provider.weekday_short_label(weekday, &locale), short);
-            assert_eq!(provider.weekday_long_label(weekday, &locale), long);
+            assert_eq!(backend.weekday_short_label(weekday, &locale), short);
+            assert_eq!(backend.weekday_long_label(weekday, &locale), long);
         }
 
         for (month, expected) in [
@@ -723,75 +673,75 @@ mod tests {
             (12, "December"),
             (13, "Unknown"),
         ] {
-            assert_eq!(provider.month_long_name(month, &locale), expected);
+            assert_eq!(backend.month_long_name(month, &locale), expected);
         }
 
-        assert_eq!(provider.day_period_label(false, &locale), "AM");
-        assert_eq!(provider.day_period_label(true, &locale), "PM");
-        assert_eq!(provider.day_period_from_char('a', &locale), Some(false));
-        assert_eq!(provider.day_period_from_char('A', &locale), Some(false));
-        assert_eq!(provider.day_period_from_char('p', &locale), Some(true));
-        assert_eq!(provider.day_period_from_char('P', &locale), Some(true));
-        assert_eq!(provider.day_period_from_char('x', &locale), None);
+        assert_eq!(backend.day_period_label(false, &locale), "AM");
+        assert_eq!(backend.day_period_label(true, &locale), "PM");
+        assert_eq!(backend.day_period_from_char('a', &locale), Some(false));
+        assert_eq!(backend.day_period_from_char('A', &locale), Some(false));
+        assert_eq!(backend.day_period_from_char('p', &locale), Some(true));
+        assert_eq!(backend.day_period_from_char('P', &locale), Some(true));
+        assert_eq!(backend.day_period_from_char('x', &locale), None);
 
         assert_eq!(
-            provider.format_segment_digits(7, NonZero::new(2).expect("nonzero"), &locale),
+            backend.format_segment_digits(7, NonZero::new(2).expect("nonzero"), &locale),
             "07"
         );
 
         assert_eq!(
-            provider.max_months_in_year(&CalendarSystem::Hebrew, 5784, None),
+            backend.max_months_in_year(&CalendarSystem::Hebrew, 5784, None),
             13
         );
         assert_eq!(
-            provider.max_months_in_year(&CalendarSystem::Hebrew, 5785, None),
+            backend.max_months_in_year(&CalendarSystem::Hebrew, 5785, None),
             12
         );
         #[cfg(any(feature = "icu4x", all(feature = "web-intl", target_arch = "wasm32")))]
         assert_eq!(
-            provider.max_months_in_year(&CalendarSystem::Dangi, 2024, None),
+            backend.max_months_in_year(&CalendarSystem::Dangi, 2024, None),
             calendar::internal::months_in_year(2024, CalendarSystem::Dangi, None)
                 .expect("ICU4X should resolve Dangi month counts")
         );
         #[cfg(not(any(feature = "icu4x", feature = "web-intl")))]
         assert_eq!(
-            provider.max_months_in_year(&CalendarSystem::Dangi, 2024, None),
+            backend.max_months_in_year(&CalendarSystem::Dangi, 2024, None),
             12
         );
         assert_eq!(
-            provider.max_months_in_year(&CalendarSystem::Gregorian, 2024, None),
+            backend.max_months_in_year(&CalendarSystem::Gregorian, 2024, None),
             12
         );
         assert_eq!(
-            provider.max_months_in_year(&CalendarSystem::Japanese, 31, Some("heisei")),
+            backend.max_months_in_year(&CalendarSystem::Japanese, 31, Some("heisei")),
             4
         );
 
         assert_eq!(
-            provider.days_in_month(&CalendarSystem::Gregorian, 2024, 2, None),
+            backend.days_in_month(&CalendarSystem::Gregorian, 2024, 2, None),
             29
         );
         assert_eq!(
-            provider.days_in_month(&CalendarSystem::Gregorian, 2023, 2, None),
+            backend.days_in_month(&CalendarSystem::Gregorian, 2023, 2, None),
             28
         );
         assert_eq!(
-            provider.days_in_month(&CalendarSystem::Japanese, 1, 5, Some("reiwa")),
+            backend.days_in_month(&CalendarSystem::Japanese, 1, 5, Some("reiwa")),
             31
         );
         assert_eq!(
-            provider.days_in_month(&CalendarSystem::Japanese, 31, 4, Some("heisei")),
+            backend.days_in_month(&CalendarSystem::Japanese, 31, 4, Some("heisei")),
             30
         );
         assert_eq!(
-            provider.default_era(&CalendarSystem::Japanese),
+            backend.default_era(&CalendarSystem::Japanese),
             Some(Era {
                 code: "reiwa".to_string(),
                 display_name: "Reiwa".to_string(),
             })
         );
         assert_eq!(
-            provider.default_era(&CalendarSystem::Gregorian),
+            backend.default_era(&CalendarSystem::Gregorian),
             Some(Era {
                 code: "ad".to_string(),
                 display_name: "AD".to_string(),
@@ -813,42 +763,42 @@ mod tests {
         )
         .expect("Japanese date should validate");
 
-        assert_eq!(provider.years_in_era(&japanese), Some(31));
-        assert_eq!(provider.minimum_month_in_year(&japanese), 1);
-        assert_eq!(provider.minimum_day_in_month(&japanese), 8);
+        assert_eq!(backend.years_in_era(&japanese), Some(31));
+        assert_eq!(backend.minimum_month_in_year(&japanese), 1);
+        assert_eq!(backend.minimum_day_in_month(&japanese), 8);
 
         let gregorian =
             CalendarDate::new_gregorian(2024, 3, 15).expect("Gregorian date should validate");
 
-        assert_eq!(provider.minimum_month_in_year(&gregorian), 1);
-        assert_eq!(provider.minimum_day_in_month(&gregorian), 1);
+        assert_eq!(backend.minimum_month_in_year(&gregorian), 1);
+        assert_eq!(backend.minimum_day_in_month(&gregorian), 1);
 
-        assert_eq!(provider.hour_cycle(&locale), HourCycle::H12);
+        assert_eq!(backend.hour_cycle(&locale), HourCycle::H12);
 
         let german = Locale::parse("de-DE").expect("de-DE is valid");
 
-        assert_eq!(provider.hour_cycle(&german), HourCycle::H23);
-        assert_eq!(provider.first_day_of_week(&locale), Weekday::Sunday);
-        assert_eq!(provider.first_day_of_week(&german), Weekday::Monday);
+        assert_eq!(backend.hour_cycle(&german), HourCycle::H23);
+        assert_eq!(backend.first_day_of_week(&locale), Weekday::Sunday);
+        assert_eq!(backend.first_day_of_week(&german), Weekday::Monday);
 
         assert_eq!(
-            provider.convert_date(&gregorian, CalendarSystem::Gregorian),
+            backend.convert_date(&gregorian, CalendarSystem::Gregorian),
             gregorian
         );
     }
 
     #[cfg(all(feature = "std", any(feature = "icu4x", feature = "web-intl")))]
     #[test]
-    fn stub_icu_provider_convert_date_supports_non_identity_conversions_when_internal_calendar_is_available()
+    fn stub_intl_backend_convert_date_supports_non_identity_conversions_when_internal_calendar_is_available()
      {
-        let provider = StubIcuProvider;
+        let backend = StubIntlBackend;
 
         let gregorian =
             CalendarDate::new_gregorian(2024, 3, 15).expect("Gregorian date should validate");
 
-        let japanese = provider.convert_date(&gregorian, CalendarSystem::Japanese);
+        let japanese = backend.convert_date(&gregorian, CalendarSystem::Japanese);
 
-        let round_trip = provider.convert_date(&japanese, CalendarSystem::Gregorian);
+        let round_trip = backend.convert_date(&japanese, CalendarSystem::Gregorian);
 
         assert_eq!(
             japanese,
@@ -873,8 +823,8 @@ mod tests {
 
     #[cfg(all(feature = "std", any(feature = "icu4x", feature = "web-intl")))]
     #[test]
-    fn stub_icu_provider_convert_date_preserves_bce_gregorian_years() {
-        let provider = StubIcuProvider;
+    fn stub_intl_backend_convert_date_preserves_bce_gregorian_years() {
+        let backend = StubIntlBackend;
 
         let buddhist = CalendarDate::new(
             CalendarSystem::Buddhist,
@@ -887,7 +837,7 @@ mod tests {
         )
         .expect("Buddhist date should validate");
 
-        let gregorian = provider.convert_date(&buddhist, CalendarSystem::Gregorian);
+        let gregorian = backend.convert_date(&buddhist, CalendarSystem::Gregorian);
 
         assert_eq!(
             gregorian,
@@ -913,41 +863,41 @@ mod tests {
             gregorian
         );
         assert_eq!(
-            provider.convert_date(&gregorian, CalendarSystem::Buddhist),
+            backend.convert_date(&gregorian, CalendarSystem::Buddhist),
             buddhist
         );
     }
 
     #[cfg(all(feature = "std", any(feature = "icu4x", feature = "web-intl")))]
     #[test]
-    fn stub_icu_provider_convert_date_falls_back_for_inputs_outside_internal_bridge_range() {
-        let provider = StubIcuProvider;
+    fn stub_intl_backend_convert_date_falls_back_for_inputs_outside_internal_bridge_range() {
+        let backend = StubIntlBackend;
 
         let gregorian =
             CalendarDate::new_gregorian(10_000, 1, 1).expect("Gregorian date should validate");
 
-        let japanese = provider.convert_date(&gregorian, CalendarSystem::Japanese);
+        let japanese = backend.convert_date(&gregorian, CalendarSystem::Japanese);
 
         assert_eq!(japanese.calendar(), CalendarSystem::Japanese);
         assert_eq!(
-            provider.convert_date(&japanese, CalendarSystem::Gregorian),
+            backend.convert_date(&japanese, CalendarSystem::Gregorian),
             gregorian
         );
     }
 
     #[cfg(all(feature = "std", not(any(feature = "icu4x", feature = "web-intl"))))]
     #[test]
-    fn stub_icu_provider_convert_date_uses_public_calendar_conversion_without_calendar_backend() {
-        let provider = StubIcuProvider;
+    fn stub_intl_backend_convert_date_uses_public_calendar_conversion_without_calendar_backend() {
+        let backend = StubIntlBackend;
 
         let gregorian =
             CalendarDate::new_gregorian(2024, 3, 15).expect("Gregorian date should validate");
 
-        let japanese = provider.convert_date(&gregorian, CalendarSystem::Japanese);
+        let japanese = backend.convert_date(&gregorian, CalendarSystem::Japanese);
 
         assert_eq!(japanese.calendar(), CalendarSystem::Japanese);
         assert_eq!(
-            provider.convert_date(&japanese, CalendarSystem::Gregorian),
+            backend.convert_date(&japanese, CalendarSystem::Gregorian),
             gregorian
         );
     }

--- a/crates/ars-i18n/src/locale.rs
+++ b/crates/ars-i18n/src/locale.rs
@@ -1,15 +1,18 @@
 use alloc::string::String;
-use core::{cmp::Ordering, fmt};
+use core::{
+    cmp::Ordering,
+    fmt::{self, Display},
+};
 
 use icu::locale::{LanguageIdentifier, Locale as IcuLocale};
 use icu_provider::DataLocale;
 
-use crate::{HourCycle, IcuProvider, ResolvedDirection, Weekday};
+use crate::{HourCycle, IntlBackend, ResolvedDirection, Weekday};
 
 /// A BCP 47 locale identifier.
 ///
 /// Wraps ICU4X's locale type with ars-ui-specific helpers for directionality,
-/// Unicode extension access, and provider interop.
+/// Unicode extension access, and backend interop.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Locale(IcuLocale);
 
@@ -141,16 +144,16 @@ impl Locale {
             })
     }
 
-    /// Returns the locale's first day of the week through the active provider.
+    /// Returns the locale's first day of the week through the active backend.
     #[must_use]
-    pub fn first_day_of_week(&self, provider: &dyn IcuProvider) -> Weekday {
-        provider.first_day_of_week(self)
+    pub fn first_day_of_week(&self, backend: &dyn IntlBackend) -> Weekday {
+        backend.first_day_of_week(self)
     }
 
-    /// Returns the locale's preferred hour cycle through the active provider.
+    /// Returns the locale's preferred hour cycle through the active backend.
     #[must_use]
-    pub fn hour_cycle(&self, provider: &dyn IcuProvider) -> HourCycle {
-        provider.hour_cycle(self)
+    pub fn hour_cycle(&self, backend: &dyn IntlBackend) -> HourCycle {
+        backend.hour_cycle(self)
     }
 
     /// Converts this locale to the ICU4X provider locale type.
@@ -186,11 +189,17 @@ impl Locale {
     fn script_or_default(&self) -> &str {
         self.script().unwrap_or_else(|| match self.language() {
             "ar" | "fa" | "ur" | "ps" | "ug" | "sd" | "ks" => "Arab",
+
             "he" | "yi" => "Hebr",
+
             "dv" => "Thaa",
+
             "nqo" => "Nkoo",
+
             "pa" if self.region() == Some("PK") => "Arab",
+
             "ku" if self.region() == Some("IQ") => "Arab",
+
             _ => "Latn",
         })
     }
@@ -200,7 +209,7 @@ impl Locale {
 #[derive(Debug)]
 pub struct LocaleParseError(pub icu::locale::ParseError);
 
-impl fmt::Display for LocaleParseError {
+impl Display for LocaleParseError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "ars-ui locale parse error: {}", self.0)
     }
@@ -348,20 +357,56 @@ pub mod locales {
 
 #[cfg(test)]
 mod tests {
+    use alloc::string::String;
+    use core::num::NonZero;
+
     use icu::locale::LanguageIdentifier;
 
     use super::{Locale, RTL_SCRIPTS};
-    use crate::{HourCycle, IcuProvider, ResolvedDirection, Weekday};
+    use crate::{HourCycle, IntlBackend, ResolvedDirection, StubIntlBackend, Weekday};
 
     struct TestLocaleProvider;
 
-    impl IcuProvider for TestLocaleProvider {
-        fn first_day_of_week(&self, _locale: &Locale) -> Weekday {
-            Weekday::Thursday
+    impl IntlBackend for TestLocaleProvider {
+        fn weekday_short_label(&self, weekday: Weekday, locale: &Locale) -> String {
+            StubIntlBackend.weekday_short_label(weekday, locale)
+        }
+
+        fn weekday_long_label(&self, weekday: Weekday, locale: &Locale) -> String {
+            StubIntlBackend.weekday_long_label(weekday, locale)
+        }
+
+        fn month_long_name(&self, month: u8, locale: &Locale) -> String {
+            StubIntlBackend.month_long_name(month, locale)
+        }
+
+        fn day_period_label(&self, is_pm: bool, locale: &Locale) -> String {
+            StubIntlBackend.day_period_label(is_pm, locale)
+        }
+
+        fn day_period_from_char(&self, ch: char, locale: &Locale) -> Option<bool> {
+            StubIntlBackend.day_period_from_char(ch, locale)
+        }
+
+        fn format_segment_digits(
+            &self,
+            value: u32,
+            min_digits: NonZero<u8>,
+            locale: &Locale,
+        ) -> String {
+            StubIntlBackend.format_segment_digits(value, min_digits, locale)
         }
 
         fn hour_cycle(&self, _locale: &Locale) -> HourCycle {
             HourCycle::H11
+        }
+
+        fn week_info(&self, locale: &Locale) -> crate::WeekInfo {
+            let mut info = crate::WeekInfo::for_locale(locale);
+
+            info.first_day = Weekday::Thursday;
+
+            info
         }
     }
 
@@ -381,6 +426,7 @@ mod tests {
     fn locale_direction_infers_default_scripts_for_rtl_languages() {
         for tag in ["dv", "nqo", "pa-PK", "ku-IQ", "yi"] {
             let locale = Locale::parse(tag).expect("RTL locale should parse");
+
             assert_eq!(locale.direction(), ResolvedDirection::Rtl);
             assert!(locale.is_rtl());
         }
@@ -411,12 +457,35 @@ mod tests {
     }
 
     #[test]
-    fn locale_provider_backed_helpers_delegate() {
+    fn locale_backend_helpers_delegate() {
         let locale = Locale::parse("en-US").expect("locale should parse");
-        let provider = TestLocaleProvider;
 
-        assert_eq!(locale.first_day_of_week(&provider), Weekday::Thursday);
-        assert_eq!(locale.hour_cycle(&provider), HourCycle::H11);
+        let backend = TestLocaleProvider;
+
+        assert_eq!(locale.first_day_of_week(&backend), Weekday::Thursday);
+        assert_eq!(locale.hour_cycle(&backend), HourCycle::H11);
+    }
+
+    #[test]
+    fn locale_test_provider_required_methods_delegate_to_stub() {
+        let locale = Locale::parse("en-US").expect("locale should parse");
+
+        let backend = TestLocaleProvider;
+
+        assert_eq!(backend.weekday_short_label(Weekday::Monday, &locale), "Mo");
+        assert_eq!(
+            backend.weekday_long_label(Weekday::Monday, &locale),
+            "Monday"
+        );
+        assert_eq!(backend.month_long_name(1, &locale), "January");
+        assert_eq!(backend.day_period_label(false, &locale), "AM");
+        assert_eq!(backend.day_period_label(true, &locale), "PM");
+        assert_eq!(backend.day_period_from_char('a', &locale), Some(false));
+        assert_eq!(backend.day_period_from_char('P', &locale), Some(true));
+        assert_eq!(
+            backend.format_segment_digits(5, NonZero::new(2).expect("2 is non-zero"), &locale),
+            "05"
+        );
     }
 
     #[test]
@@ -442,10 +511,15 @@ mod web_intl_tests {
     #[wasm_bindgen_test]
     fn numeric_ordering_extension_handles_boolean_forms() {
         let enabled = Locale::parse("en-u-kn").expect("locale should parse");
+
+        let explicit_true = Locale::parse("en-u-kn-true").expect("locale should parse");
+
         let disabled = Locale::parse("en-u-kn-false").expect("locale should parse");
+
         let none = Locale::parse("en-US").expect("locale should parse");
 
         assert_eq!(enabled.numeric_ordering_extension(), Some(true));
+        assert_eq!(explicit_true.numeric_ordering_extension(), Some(true));
         assert_eq!(disabled.numeric_ordering_extension(), Some(false));
         assert_eq!(none.numeric_ordering_extension(), None);
     }

--- a/crates/ars-i18n/src/provider.rs
+++ b/crates/ars-i18n/src/provider.rs
@@ -1,16 +1,16 @@
-//! Concrete [`IcuProvider`](crate::IcuProvider) backends.
+//! Concrete [`IntlBackend`](crate::IntlBackend) backends.
 //!
 //! This module owns the three production-ready provider implementations the
 //! spec calls out in §9.5:
 //!
-//! - [`StubIcuProvider`] — English-only provider for tests and builds without
+//! - [`StubIntlBackend`] — English-only provider for tests and builds without
 //!   any backend feature enabled.
-//! - [`Icu4xProvider`] — ICU4X-backed provider with CLDR data, used on native
+//! - [`Icu4xBackend`] — ICU4X-backed provider with CLDR data, used on native
 //!   builds with the `icu4x` feature.
-//! - [`WebIntlProvider`] — browser-backed provider that delegates to the
+//! - [`WebIntlBackend`] — browser-backed provider that delegates to the
 //!   `Intl.*` APIs, used on WASM client builds with the `web-intl` feature.
 //!
-//! The [`default_provider`] factory returns the preferred backend for the
+//! The [`default_backend`] factory returns the preferred backend for the
 //! current feature-flag configuration.
 
 mod factory;
@@ -23,13 +23,16 @@ mod web_intl;
 #[cfg(all(test, feature = "icu4x"))]
 #[path = "../tests/unit/provider_icu4x.rs"]
 mod provider_icu4x_tests;
+#[cfg(test)]
+#[path = "../tests/unit/provider_stub.rs"]
+mod provider_stub_tests;
 #[cfg(all(test, feature = "web-intl", target_arch = "wasm32"))]
 #[path = "../tests/unit/provider_web_intl.rs"]
 mod provider_web_intl_tests;
 
-pub use factory::default_provider;
+pub use factory::default_backend;
 #[cfg(feature = "icu4x")]
-pub use icu4x::Icu4xProvider;
-pub use stub::StubIcuProvider;
+pub use icu4x::Icu4xBackend;
+pub use stub::StubIntlBackend;
 #[cfg(all(feature = "web-intl", target_arch = "wasm32"))]
-pub use web_intl::WebIntlProvider;
+pub use web_intl::WebIntlBackend;

--- a/crates/ars-i18n/src/provider/factory.rs
+++ b/crates/ars-i18n/src/provider/factory.rs
@@ -1,35 +1,35 @@
-//! [`default_provider`] factory: returns the preferred
-//! [`IcuProvider`](crate::IcuProvider) for the current feature-flag
+//! [`default_backend`] factory: returns the preferred
+//! [`IntlBackend`](crate::IntlBackend) for the current feature-flag
 //! configuration.
 
 use alloc::boxed::Box;
 
-use crate::IcuProvider;
+use crate::IntlBackend;
 
-/// Returns the default [`IcuProvider`] for the current feature flags.
+/// Returns the default [`IntlBackend`] for the current feature flags.
 ///
 /// Precedence matches spec §9.5.3:
 ///
-/// 1. The `icu4x` feature returns an [`Icu4xProvider`](super::Icu4xProvider)
+/// 1. The `icu4x` feature returns an [`Icu4xBackend`](super::Icu4xBackend)
 ///    with full CLDR data.
 /// 2. On `wasm32` targets with the `web-intl` feature (and without `icu4x`),
-///    returns a [`WebIntlProvider`](super::WebIntlProvider) that delegates
+///    returns a [`WebIntlBackend`](super::WebIntlBackend) that delegates
 ///    to the browser.
-/// 3. Otherwise returns the [`StubIcuProvider`](super::StubIcuProvider).
+/// 3. Otherwise returns the [`StubIntlBackend`](super::StubIntlBackend).
 #[must_use]
-pub fn default_provider() -> Box<dyn IcuProvider> {
+pub fn default_backend() -> Box<dyn IntlBackend> {
     #[cfg(feature = "icu4x")]
     {
-        Box::new(super::Icu4xProvider)
+        Box::new(super::Icu4xBackend)
     }
 
     #[cfg(all(feature = "web-intl", target_arch = "wasm32", not(feature = "icu4x")))]
     {
-        Box::new(super::WebIntlProvider)
+        Box::new(super::WebIntlBackend)
     }
 
     #[cfg(not(any(feature = "icu4x", all(feature = "web-intl", target_arch = "wasm32"))))]
     {
-        Box::new(super::StubIcuProvider)
+        Box::new(super::StubIntlBackend)
     }
 }

--- a/crates/ars-i18n/src/provider/icu4x.rs
+++ b/crates/ars-i18n/src/provider/icu4x.rs
@@ -1,6 +1,6 @@
-//! [`Icu4xProvider`] — production provider backed by ICU4X CLDR data.
+//! [`Icu4xBackend`] — production provider backed by ICU4X CLDR data.
 //!
-//! Implements the [`IcuProvider`](crate::IcuProvider) contract using ICU4X 2.x
+//! Implements the [`IntlBackend`](crate::IntlBackend) contract using ICU4X 2.x
 //! compiled data. See spec §9.5.2.
 
 use alloc::{
@@ -28,7 +28,7 @@ use icu::{
 };
 
 use crate::{
-    CalendarDate, CalendarSystem, Era, HourCycle, IcuProvider, Locale, WeekInfo, Weekday,
+    CalendarDate, CalendarSystem, Era, HourCycle, IntlBackend, Locale, WeekInfo, Weekday,
     calendar::{bounded_days_in_month, bounded_months_in_year, default_era_for},
 };
 
@@ -42,9 +42,9 @@ use crate::{
 /// The struct is zero-sized: ICU4X's compiled-data path does not require
 /// runtime data to be carried in the formatter instance.
 #[derive(Clone, Copy, Debug, Default)]
-pub struct Icu4xProvider;
+pub struct Icu4xBackend;
 
-impl Icu4xProvider {
+impl Icu4xBackend {
     /// Maps [`Weekday`] to a January 2024 day-of-month for format-and-extract.
     ///
     /// January 1, 2024 is a Monday and January 7, 2024 is a Sunday, so a
@@ -63,7 +63,7 @@ impl Icu4xProvider {
     }
 }
 
-impl IcuProvider for Icu4xProvider {
+impl IntlBackend for Icu4xBackend {
     fn weekday_short_label(&self, weekday: Weekday, locale: &Locale) -> String {
         let formatter = DateTimeFormatter::try_new(
             DateTimeFormatterPreferences::from(locale.as_icu()),
@@ -113,6 +113,7 @@ impl IcuProvider for Icu4xProvider {
         // 24-hour (e.g., `de-DE`, `fr-FR`, `ja-JP`). Without this
         // override 24-hour locales collapse to numbers only.
         let mut prefs = DateTimeFormatterPreferences::from(locale.as_icu());
+
         prefs.hour_cycle = Some(IcuHourCycle::H12);
 
         let formatter = NoCalendarFormatter::try_new(prefs, T::hm())
@@ -147,9 +148,10 @@ impl IcuProvider for Icu4xProvider {
         // thousand separators. A year like 2024 must format as
         // `"2024"` (or its native-digit equivalent), not `"2,024"` —
         // otherwise downstream parsers that expect a contiguous digit
-        // run break, and behavior diverges from `WebIntlProvider`,
+        // run break, and behavior diverges from `WebIntlBackend`,
         // which already sets `useGrouping: false`.
         let mut options = DecimalFormatterOptions::default();
+
         options.grouping_strategy = Some(GroupingStrategy::Never);
 
         let formatter =

--- a/crates/ars-i18n/src/provider/stub.rs
+++ b/crates/ars-i18n/src/provider/stub.rs
@@ -1,26 +1,99 @@
-//! [`StubIcuProvider`] — English-only fallback provider.
+//! [`StubIntlBackend`] — English-only fallback provider.
 //!
-//! `StubIcuProvider` is the default implementation available on every
-//! target. It inherits the rollout-era default trait method bodies on
-//! [`IcuProvider`](crate::IcuProvider), which match spec §9.5.1 verbatim:
-//! English weekday and month names, `AM`/`PM` day-period labels, locale-
-//! insensitive zero-padded digit formatting, and CLDR-backed calendar
-//! math routed through the shared helpers in `crate::calendar`.
-//!
-//! [Issue #546](https://github.com/fogodev/ars-ui/issues/546) will
-//! remove those rollout defaults and require every provider to implement
-//! the trait explicitly. When that lands, the `impl` block below grows
-//! spec §9.5.1 bodies; today it can stay empty.
+//! `StubIntlBackend` is the default implementation available on every
+//! target. It explicitly supplies the spec §9.5.1 English/default locale
+//! behavior for labels, day periods, digit formatting, hour-cycle fallback,
+//! and locale week metadata while reusing [`IntlBackend`](crate::IntlBackend)'s
+//! canonical calendar helper defaults.
 
-use crate::IcuProvider;
+use alloc::{format, string::String};
+use core::num::NonZero;
+
+use crate::{HourCycle, IntlBackend, Locale, WeekInfo, Weekday};
 
 /// English-only stub provider for tests and builds without a backend feature.
 ///
-/// Every method follows the spec §9.5.1 English/default behavior through
-/// the rollout default method bodies defined on
-/// [`IcuProvider`](crate::IcuProvider). This keeps the stub tiny while
-/// downstream tasks plumb the real backends in.
+/// Locale-facing methods implement the final trait contract explicitly.
+/// Calendar helpers keep using the trait's canonical shared defaults.
 #[derive(Debug, Default)]
-pub struct StubIcuProvider;
+pub struct StubIntlBackend;
 
-impl IcuProvider for StubIcuProvider {}
+impl IntlBackend for StubIntlBackend {
+    fn weekday_short_label(&self, weekday: Weekday, _locale: &Locale) -> String {
+        match weekday {
+            Weekday::Sunday => String::from("Su"),
+            Weekday::Monday => String::from("Mo"),
+            Weekday::Tuesday => String::from("Tu"),
+            Weekday::Wednesday => String::from("We"),
+            Weekday::Thursday => String::from("Th"),
+            Weekday::Friday => String::from("Fr"),
+            Weekday::Saturday => String::from("Sa"),
+        }
+    }
+
+    fn weekday_long_label(&self, weekday: Weekday, _locale: &Locale) -> String {
+        match weekday {
+            Weekday::Sunday => String::from("Sunday"),
+            Weekday::Monday => String::from("Monday"),
+            Weekday::Tuesday => String::from("Tuesday"),
+            Weekday::Wednesday => String::from("Wednesday"),
+            Weekday::Thursday => String::from("Thursday"),
+            Weekday::Friday => String::from("Friday"),
+            Weekday::Saturday => String::from("Saturday"),
+        }
+    }
+
+    fn month_long_name(&self, month: u8, _locale: &Locale) -> String {
+        match month {
+            1 => String::from("January"),
+            2 => String::from("February"),
+            3 => String::from("March"),
+            4 => String::from("April"),
+            5 => String::from("May"),
+            6 => String::from("June"),
+            7 => String::from("July"),
+            8 => String::from("August"),
+            9 => String::from("September"),
+            10 => String::from("October"),
+            11 => String::from("November"),
+            12 => String::from("December"),
+            _ => String::from("Unknown"),
+        }
+    }
+
+    fn day_period_label(&self, is_pm: bool, _locale: &Locale) -> String {
+        if is_pm {
+            String::from("PM")
+        } else {
+            String::from("AM")
+        }
+    }
+
+    fn day_period_from_char(&self, ch: char, _locale: &Locale) -> Option<bool> {
+        match ch.to_ascii_lowercase() {
+            'a' => Some(false),
+            'p' => Some(true),
+            _ => None,
+        }
+    }
+
+    fn format_segment_digits(
+        &self,
+        value: u32,
+        min_digits: NonZero<u8>,
+        _locale: &Locale,
+    ) -> String {
+        format!("{value:0width$}", width = usize::from(min_digits.get()))
+    }
+
+    fn hour_cycle(&self, locale: &Locale) -> HourCycle {
+        match locale.language() {
+            "en" | "ko" => HourCycle::H12,
+            _ => HourCycle::H23,
+        }
+    }
+
+    fn week_info(&self, locale: &Locale) -> WeekInfo {
+        WeekInfo::for_locale(locale)
+    }
+}

--- a/crates/ars-i18n/src/provider/web_intl.rs
+++ b/crates/ars-i18n/src/provider/web_intl.rs
@@ -1,6 +1,6 @@
-//! [`WebIntlProvider`] — browser-backed provider for WASM client builds.
+//! [`WebIntlBackend`] — browser-backed provider for WASM client builds.
 //!
-//! Implements the [`IcuProvider`](crate::IcuProvider) contract using the
+//! Implements the [`IntlBackend`](crate::IntlBackend) contract using the
 //! browser's `Intl.*` APIs. See spec §9.5.4. Available only on `wasm32`
 //! targets with the `web-intl` feature.
 
@@ -15,7 +15,7 @@ use js_sys::{Array, Function, Intl, Object, Reflect};
 use wasm_bindgen::{JsCast, JsValue};
 
 use crate::{
-    CalendarDate, CalendarSystem, Era, HourCycle, IcuProvider, Locale, WeekInfo, Weekday,
+    CalendarDate, CalendarSystem, Era, HourCycle, IntlBackend, Locale, WeekInfo, Weekday,
     calendar::{
         bounded_days_in_month, bounded_months_in_year, build_from_iso_parts, default_era_for,
         gregorian_days_in_month, infer_public_era,
@@ -31,7 +31,7 @@ use crate::{
 /// Calendar arithmetic and era-boundary queries are served by shared
 /// Rust-side helpers because browsers do not expose those directly.
 #[derive(Clone, Copy, Debug, Default)]
-pub struct WebIntlProvider;
+pub struct WebIntlBackend;
 
 #[expect(
     clippy::too_many_arguments,
@@ -75,7 +75,7 @@ fn normalize_public_date(
     })
 }
 
-impl WebIntlProvider {
+impl WebIntlBackend {
     /// Formats a reference date through `Intl.DateTimeFormat` using the
     /// given locale and options bag, returning the formatted string.
     fn format_date_part(locale: &Locale, date: &js_sys::Date, opts: &Object) -> String {
@@ -95,7 +95,7 @@ impl WebIntlProvider {
     /// Builds a JS `Date` whose weekday matches `weekday` in January 2024.
     ///
     /// January 1, 2024 is a Monday, so Monday..=Sunday map to day-of-month
-    /// 1..=7. Mirrors the reference dates used by [`Icu4xProvider`].
+    /// 1..=7. Mirrors the reference dates used by [`Icu4xBackend`].
     fn date_for_weekday(weekday: Weekday) -> js_sys::Date {
         let day = match weekday {
             Weekday::Monday => 1,
@@ -323,7 +323,7 @@ impl WebIntlProvider {
     }
 }
 
-impl IcuProvider for WebIntlProvider {
+impl IntlBackend for WebIntlBackend {
     fn weekday_short_label(&self, weekday: Weekday, locale: &Locale) -> String {
         let opts = Object::new();
 
@@ -619,7 +619,7 @@ impl IcuProvider for WebIntlProvider {
         // under the same feature gate that compiles this provider and
         // does not require the `compiled_data` CLDR payload.
         //
-        // Contract reminder: `IcuProvider::convert_date` returns a
+        // Contract reminder: `IntlBackend::convert_date` returns a
         // [`CalendarDate`] in `target`. Silently returning the source
         // calendar for non-Gregorian inputs violates that contract,
         // breaks public calendar arithmetic assumptions and lets
@@ -1189,7 +1189,7 @@ fn part_value(parts: &Array, part_type: &str) -> Option<String> {
 /// path is always available under the same feature gate as the
 /// provider itself.
 ///
-/// Used in two places in [`WebIntlProvider::convert_date`]:
+/// Used in two places in [`WebIntlBackend::convert_date`]:
 /// - Non-Gregorian sources (the browser path only relabels Gregorian
 ///   instants, so it cannot convert a non-Gregorian source directly).
 /// - Gregorian sources whose browser era label falls outside the
@@ -1296,4 +1296,121 @@ pub(crate) const fn is_hebrew_leap_year(year: i32) -> bool {
     let cycle_year = year.rem_euclid(19);
 
     matches!(cycle_year, 3 | 6 | 8 | 11 | 14 | 17 | 0)
+}
+
+#[cfg(all(test, feature = "web-intl", target_arch = "wasm32"))]
+mod helper_tests {
+    use wasm_bindgen_test::wasm_bindgen_test;
+
+    use super::*;
+
+    fn part(part_type: &str, value: Option<&str>) -> JsValue {
+        let part = Object::new();
+
+        Reflect::set(
+            &part,
+            &JsValue::from_str("type"),
+            &JsValue::from_str(part_type),
+        )
+        .expect("fresh object accepts type");
+
+        if let Some(value) = value {
+            Reflect::set(
+                &part,
+                &JsValue::from_str("value"),
+                &JsValue::from_str(value),
+            )
+            .expect("fresh object accepts value");
+        }
+
+        part.into()
+    }
+
+    #[wasm_bindgen_test]
+    fn normalize_public_date_falls_back_to_epoch_for_invalid_public_fields() {
+        let normalized =
+            normalize_public_date(CalendarSystem::Gregorian, None, 2024, 13, 40, 1970, 1, 1);
+
+        assert_eq!(normalized.calendar(), CalendarSystem::Iso8601);
+        assert_eq!(normalized.year(), 1970);
+        assert_eq!(normalized.month(), 1);
+        assert_eq!(normalized.day(), 1);
+    }
+
+    #[wasm_bindgen_test]
+    fn read_week_info_supports_property_shape_and_weekend_defaults() {
+        let info = Object::new();
+
+        Reflect::set(
+            &info,
+            &JsValue::from_str("firstDay"),
+            &JsValue::from_f64(7.0),
+        )
+        .expect("fresh object accepts firstDay");
+
+        Reflect::set(
+            &info,
+            &JsValue::from_str("weekend"),
+            &JsValue::from_str("invalid"),
+        )
+        .expect("fresh object accepts weekend");
+
+        let locale = Object::new();
+
+        Reflect::set(&locale, &JsValue::from_str("weekInfo"), &info)
+            .expect("fresh object accepts weekInfo");
+
+        let week_info = read_week_info(&JsValue::from(locale)).expect("property shape must parse");
+
+        assert_eq!(week_info.first_day, Weekday::Sunday);
+        assert_eq!(week_info.weekend_start, Weekday::Saturday);
+        assert_eq!(week_info.weekend_end, Weekday::Sunday);
+        assert_eq!(week_info.minimal_days_in_first_week, 1);
+    }
+
+    #[wasm_bindgen_test]
+    fn read_week_info_returns_none_without_supported_shape() {
+        assert_eq!(read_week_info(&JsValue::from(Object::new())), None);
+    }
+
+    #[wasm_bindgen_test]
+    fn weekday_adjacency_helpers_cover_wraparound_cases() {
+        assert_eq!(previous_weekday(Weekday::Monday), Weekday::Sunday);
+        assert_eq!(previous_weekday(Weekday::Thursday), Weekday::Wednesday);
+        assert_eq!(previous_weekday(Weekday::Sunday), Weekday::Saturday);
+
+        assert_eq!(next_weekday(Weekday::Monday), Weekday::Tuesday);
+        assert_eq!(next_weekday(Weekday::Thursday), Weekday::Friday);
+        assert_eq!(next_weekday(Weekday::Sunday), Weekday::Monday);
+    }
+
+    #[wasm_bindgen_test]
+    fn js_iso_year_formats_basic_and_extended_years() {
+        assert_eq!(js_iso_year(2024), "2024");
+        assert_eq!(js_iso_year(-50), "-000050");
+        assert_eq!(js_iso_year(12_345), "+012345");
+    }
+
+    #[wasm_bindgen_test]
+    fn part_helpers_return_empty_or_none_for_missing_values() {
+        let parts_without_month = Array::new();
+
+        parts_without_month.push(&part("weekday", Some("Mon")));
+
+        assert_eq!(month_part_value(&parts_without_month), "");
+        assert_eq!(part_value(&parts_without_month, "hour"), None);
+
+        let parts_with_missing_values = Array::new();
+
+        parts_with_missing_values.push(&part("month", None));
+        parts_with_missing_values.push(&part("hour", None));
+
+        assert_eq!(month_part_value(&parts_with_missing_values), "");
+        assert_eq!(part_value(&parts_with_missing_values, "hour"), None);
+    }
+
+    #[wasm_bindgen_test]
+    fn canonical_era_code_strips_all_supported_macrons() {
+        assert_eq!(canonical_era_code("ĀĒĪŌŪāēīōū"), "aeiouaeiou");
+    }
 }

--- a/crates/ars-i18n/src/translate.rs
+++ b/crates/ars-i18n/src/translate.rs
@@ -6,18 +6,18 @@
 
 use alloc::string::String;
 
-use crate::{IcuProvider, Locale};
+use crate::{IntlBackend, Locale};
 
 /// Trait for user-defined translatable text.
 ///
 /// Users define an enum with one variant per translatable string. Unit variants
 /// cover static strings while data-carrying variants support parameterized text.
 /// Implementations should match on locale first, keep English as the fallback
-/// arm, and use the provided ICU handle for locale-sensitive formatting when
-/// needed.
+/// arm, and use the provided internationalization backend for locale-sensitive
+/// formatting when needed.
 pub trait Translate {
     /// Produces the localized text for this value.
-    fn translate(&self, locale: &Locale, icu: &dyn IcuProvider) -> String;
+    fn translate(&self, locale: &Locale, intl: &dyn IntlBackend) -> String;
 }
 
 #[cfg(test)]
@@ -25,7 +25,7 @@ mod tests {
     use alloc::{format, string::String};
 
     use super::Translate;
-    use crate::{Locale, StubIcuProvider};
+    use crate::{Locale, StubIntlBackend};
 
     #[derive(Clone, Debug, PartialEq, Eq)]
     enum InventoryText {
@@ -35,18 +35,20 @@ mod tests {
     }
 
     impl Translate for InventoryText {
-        fn translate(&self, locale: &Locale, _icu: &dyn crate::IcuProvider) -> String {
+        fn translate(&self, locale: &Locale, _intl: &dyn crate::IntlBackend) -> String {
             match locale.language() {
                 "es" => match self {
                     Self::Title => String::from("Inventario"),
                     Self::Welcome => String::from("Bienvenido"),
                     Self::ItemCount { count } => format!("{count} elementos"),
                 },
+
                 "ar" => match self {
                     Self::Title => String::from("المخزون"),
                     Self::Welcome => String::from("أهلا بك"),
                     Self::ItemCount { count } => format!("{count} عناصر"),
                 },
+
                 _ => match self {
                     Self::Title => String::from("Inventory"),
                     Self::Welcome => String::from("Welcome"),
@@ -59,11 +61,12 @@ mod tests {
     #[test]
     fn translate_trait_supports_unit_and_parameterized_variants() {
         let locale = Locale::parse("en-US").expect("locale should parse");
-        let icu = StubIcuProvider;
 
-        assert_eq!(InventoryText::Title.translate(&locale, &icu), "Inventory");
+        let intl = StubIntlBackend;
+
+        assert_eq!(InventoryText::Title.translate(&locale, &intl), "Inventory");
         assert_eq!(
-            InventoryText::ItemCount { count: 3 }.translate(&locale, &icu),
+            InventoryText::ItemCount { count: 3 }.translate(&locale, &intl),
             "3 items"
         );
     }
@@ -71,43 +74,52 @@ mod tests {
     #[test]
     fn translate_trait_supports_spanish_and_arabic_variants() {
         let spanish = Locale::parse("es-ES").expect("locale should parse");
+
         let arabic = Locale::parse("ar-EG").expect("locale should parse");
-        let icu = StubIcuProvider;
+
+        let intl = StubIntlBackend;
 
         assert_eq!(
-            InventoryText::Welcome.translate(&spanish, &icu),
+            InventoryText::Welcome.translate(&spanish, &intl),
             "Bienvenido"
         );
-        assert_eq!(InventoryText::Title.translate(&arabic, &icu), "المخزون");
+        assert_eq!(InventoryText::Title.translate(&arabic, &intl), "المخزون");
     }
 
     #[test]
     fn translate_trait_covers_remaining_locale_branches() {
         let english = Locale::parse("en-US").expect("locale should parse");
-        let spanish = Locale::parse("es-MX").expect("locale should parse");
-        let arabic = Locale::parse("ar-SA").expect("locale should parse");
-        let icu = StubIcuProvider;
 
-        assert_eq!(InventoryText::Welcome.translate(&english, &icu), "Welcome");
-        assert_eq!(InventoryText::Title.translate(&spanish, &icu), "Inventario");
+        let spanish = Locale::parse("es-MX").expect("locale should parse");
+
+        let arabic = Locale::parse("ar-SA").expect("locale should parse");
+
+        let intl = StubIntlBackend;
+
+        assert_eq!(InventoryText::Welcome.translate(&english, &intl), "Welcome");
         assert_eq!(
-            InventoryText::ItemCount { count: 2 }.translate(&spanish, &icu),
+            InventoryText::Title.translate(&spanish, &intl),
+            "Inventario"
+        );
+        assert_eq!(
+            InventoryText::ItemCount { count: 2 }.translate(&spanish, &intl),
             "2 elementos"
         );
-        assert_eq!(InventoryText::Welcome.translate(&arabic, &icu), "أهلا بك");
+        assert_eq!(InventoryText::Welcome.translate(&arabic, &intl), "أهلا بك");
         assert_eq!(
-            InventoryText::ItemCount { count: 4 }.translate(&arabic, &icu),
+            InventoryText::ItemCount { count: 4 }.translate(&arabic, &intl),
             "4 عناصر"
         );
     }
 
     #[test]
-    fn translate_trait_works_with_stub_icu_provider() {
+    fn translate_trait_works_with_stub_intl_backend() {
         let locale = Locale::parse("en-US").expect("locale should parse");
-        let icu = StubIcuProvider;
+
+        let intl = StubIntlBackend;
 
         assert_eq!(
-            InventoryText::ItemCount { count: 1 }.translate(&locale, &icu),
+            InventoryText::ItemCount { count: 1 }.translate(&locale, &intl),
             "1 items"
         );
     }

--- a/crates/ars-i18n/tests/unit/calendar.rs
+++ b/crates/ars-i18n/tests/unit/calendar.rs
@@ -10,7 +10,7 @@ use super::{
 };
 #[cfg(feature = "std")]
 use super::{Disambiguation, TimeZoneId, to_calendar_date_time, to_zoned, to_zoned_date_time};
-use crate::{Locale, StubIcuProvider};
+use crate::{Locale, StubIntlBackend};
 
 fn gregorian_date(year: i32, month: u8, day: u8) -> CalendarDate {
     CalendarDate::new_gregorian(year, month, day).expect("Gregorian fixture should validate")
@@ -374,7 +374,7 @@ fn time_and_date_time_support_add_set_and_cycle() {
 
 #[test]
 fn query_helpers_operate_on_calendar_dates_and_date_times() {
-    let provider = StubIcuProvider;
+    let backend = StubIntlBackend;
 
     let locale = Locale::parse("en-US").expect("test locale should parse");
 
@@ -401,24 +401,24 @@ fn query_helpers_operate_on_calendar_dates_and_date_times() {
     assert_eq!(year_start.to_iso8601(), "2024-01-01");
     assert_eq!(year_end.to_iso8601(), "2024-12-31");
 
-    let week_start = queries::start_of_week(&date_time, &locale, &provider);
+    let week_start = queries::start_of_week(&date_time, &locale, &backend);
 
-    let week_end = queries::end_of_week(&date_time, &locale, &provider);
+    let week_end = queries::end_of_week(&date_time, &locale, &backend);
 
     assert_eq!(week_start.date().to_iso8601(), "2024-03-10");
     assert_eq!(week_end.date().to_iso8601(), "2024-03-16");
     assert_eq!(week_start.time().hour(), 9);
-    assert_eq!(queries::get_day_of_week(&date, &locale, &provider), 5);
-    assert_eq!(queries::get_weeks_in_month(&date, &locale, &provider), 6);
-    assert!(queries::is_weekday(&date, &locale, &provider));
-    assert!(!queries::is_weekend(&date, &locale, &provider));
+    assert_eq!(queries::get_day_of_week(&date, &locale, &backend), 5);
+    assert_eq!(queries::get_weeks_in_month(&date, &locale, &backend), 6);
+    assert!(queries::is_weekday(&date, &locale, &backend));
+    assert!(!queries::is_weekend(&date, &locale, &backend));
     assert_eq!(queries::min_date(&date, &month_end), date);
     assert_eq!(queries::max_date(&date, &month_end), month_end);
 }
 
 #[test]
 fn query_helpers_follow_react_aria_calendar_and_locale_semantics() {
-    let provider = StubIcuProvider;
+    let backend = StubIntlBackend;
 
     let en_us = Locale::parse("en-US").expect("test locale should parse");
 
@@ -437,27 +437,27 @@ fn query_helpers_follow_react_aria_calendar_and_locale_semantics() {
     assert!(queries::is_same_month(&gregorian, &islamic));
     assert!(!queries::is_equal_month(&gregorian, &islamic));
 
-    assert_eq!(queries::get_day_of_week(&gregorian, &en_us, &provider), 0);
-    assert_eq!(queries::get_day_of_week(&gregorian, &fr_fr, &provider), 6);
+    assert_eq!(queries::get_day_of_week(&gregorian, &en_us, &backend), 0);
+    assert_eq!(queries::get_day_of_week(&gregorian, &fr_fr, &backend), 6);
 
-    assert!(queries::is_weekend(&gregorian, &en_us, &provider));
-    assert!(!queries::is_weekend(&gregorian, &he_il, &provider));
-    assert!(queries::is_weekday(&gregorian, &he_il, &provider));
+    assert!(queries::is_weekend(&gregorian, &en_us, &backend));
+    assert!(!queries::is_weekend(&gregorian, &he_il, &backend));
+    assert!(queries::is_weekday(&gregorian, &he_il, &backend));
     assert_eq!(
-        queries::start_of_week(&gregorian, &en_us_monday, &provider).to_iso8601(),
+        queries::start_of_week(&gregorian, &en_us_monday, &backend).to_iso8601(),
         "2024-03-04"
     );
     assert_eq!(
-        queries::get_day_of_week(&gregorian, &en_us_monday, &provider),
+        queries::get_day_of_week(&gregorian, &en_us_monday, &backend),
         6
     );
 
     let march = gregorian_date(2024, 3, 15);
 
-    assert_eq!(queries::get_weeks_in_month(&march, &en_us, &provider), 6);
-    assert_eq!(queries::get_weeks_in_month(&march, &fr_fr, &provider), 5);
+    assert_eq!(queries::get_weeks_in_month(&march, &en_us, &backend), 6);
+    assert_eq!(queries::get_weeks_in_month(&march, &fr_fr, &backend), 5);
     assert_eq!(
-        queries::get_weeks_in_month(&march, &en_us_monday, &provider),
+        queries::get_weeks_in_month(&march, &en_us_monday, &backend),
         5
     );
 }
@@ -594,6 +594,7 @@ fn native_interop_helpers_convert_to_system_time_without_exposing_temporal_types
 #[test]
 fn zoned_date_time_and_local_zone_override_work() {
     let time_zone = TimeZoneId::new("America/New_York").expect("zone should validate");
+
     let local = CalendarDateTime::new(
         gregorian_date(2024, 3, 10),
         Time::new(1, 30, 0, 0).expect("time should validate"),

--- a/crates/ars-i18n/tests/unit/provider_icu4x.rs
+++ b/crates/ars-i18n/tests/unit/provider_icu4x.rs
@@ -1,11 +1,11 @@
-//! Native `Icu4xProvider` tests (spec §9.5.2).
+//! Native `Icu4xBackend` tests (spec §9.5.2).
 
 use alloc::string::{String, ToString};
 use core::num::NonZero;
 
 use crate::{
-    CalendarDate, CalendarDateFields, CalendarSystem, Era, HourCycle, Icu4xProvider, IcuProvider,
-    Locale, Weekday, default_provider,
+    CalendarDate, CalendarDateFields, CalendarSystem, Era, HourCycle, Icu4xBackend, IntlBackend,
+    Locale, Weekday, default_backend,
 };
 
 fn locale(tag: &str) -> Locale {
@@ -14,9 +14,9 @@ fn locale(tag: &str) -> Locale {
 
 #[test]
 fn icu4x_weekday_short_label_localizes_in_arabic() {
-    let provider = Icu4xProvider;
+    let backend = Icu4xBackend;
 
-    let label = provider.weekday_short_label(Weekday::Monday, &locale("ar"));
+    let label = backend.weekday_short_label(Weekday::Monday, &locale("ar"));
 
     assert!(
         label
@@ -32,9 +32,9 @@ fn icu4x_weekday_short_label_localizes_in_arabic() {
 
 #[test]
 fn icu4x_weekday_long_label_localizes_in_japanese() {
-    let provider = Icu4xProvider;
+    let backend = Icu4xBackend;
 
-    let label = provider.weekday_long_label(Weekday::Monday, &locale("ja"));
+    let label = backend.weekday_long_label(Weekday::Monday, &locale("ja"));
 
     // Japanese long weekday labels always contain the kanji "曜".
     assert!(
@@ -45,16 +45,16 @@ fn icu4x_weekday_long_label_localizes_in_japanese() {
 
 #[test]
 fn icu4x_weekday_short_label_localizes_in_english() {
-    let provider = Icu4xProvider;
+    let backend = Icu4xBackend;
 
-    let label = provider.weekday_short_label(Weekday::Monday, &locale("en-US"));
+    let label = backend.weekday_short_label(Weekday::Monday, &locale("en-US"));
 
     assert_eq!(label, "Mon");
 }
 
 #[test]
 fn icu4x_weekday_short_label_covers_every_weekday() {
-    let provider = Icu4xProvider;
+    let backend = Icu4xBackend;
 
     let en = locale("en-US");
 
@@ -69,7 +69,7 @@ fn icu4x_weekday_short_label_covers_every_weekday() {
         (Weekday::Sunday, "Sun"),
     ] {
         assert_eq!(
-            provider.weekday_short_label(weekday, &en),
+            backend.weekday_short_label(weekday, &en),
             expected,
             "short label for {weekday:?}"
         );
@@ -78,9 +78,9 @@ fn icu4x_weekday_short_label_covers_every_weekday() {
 
 #[test]
 fn icu4x_month_long_name_localizes_in_japanese() {
-    let provider = Icu4xProvider;
+    let backend = Icu4xBackend;
 
-    let name = provider.month_long_name(1, &locale("ja"));
+    let name = backend.month_long_name(1, &locale("ja"));
 
     // CLDR returns "1月" for month 1 in Japanese.
     assert!(
@@ -91,24 +91,24 @@ fn icu4x_month_long_name_localizes_in_japanese() {
 
 #[test]
 fn icu4x_month_long_name_returns_unknown_for_invalid_month() {
-    let provider = Icu4xProvider;
+    let backend = Icu4xBackend;
 
     assert_eq!(
-        provider.month_long_name(0, &locale("en-US")),
+        backend.month_long_name(0, &locale("en-US")),
         String::from("Unknown")
     );
     assert_eq!(
-        provider.month_long_name(13, &locale("en-US")),
+        backend.month_long_name(13, &locale("en-US")),
         String::from("Unknown")
     );
 }
 
 #[test]
 fn icu4x_hour_cycle_reflects_locale() {
-    let provider = Icu4xProvider;
+    let backend = Icu4xBackend;
 
-    assert_eq!(provider.hour_cycle(&locale("en-US")), HourCycle::H12);
-    assert_eq!(provider.hour_cycle(&locale("de-DE")), HourCycle::H23);
+    assert_eq!(backend.hour_cycle(&locale("en-US")), HourCycle::H12);
+    assert_eq!(backend.hour_cycle(&locale("de-DE")), HourCycle::H23);
 }
 
 #[test]
@@ -120,19 +120,19 @@ fn icu4x_hour_cycle_honors_all_four_unicode_extension_overrides() {
     // before running the heuristic and returns the matching
     // `HourCycle` variant — crucial for consumers that distinguish
     // H11 vs H12 (midnight 0 vs 12) or H23 vs H24.
-    let provider = Icu4xProvider;
+    let backend = Icu4xBackend;
 
-    assert_eq!(provider.hour_cycle(&locale("ja-u-hc-h11")), HourCycle::H11);
+    assert_eq!(backend.hour_cycle(&locale("ja-u-hc-h11")), HourCycle::H11);
     assert_eq!(
-        provider.hour_cycle(&locale("en-US-u-hc-h12")),
+        backend.hour_cycle(&locale("en-US-u-hc-h12")),
         HourCycle::H12
     );
     assert_eq!(
-        provider.hour_cycle(&locale("de-DE-u-hc-h23")),
+        backend.hour_cycle(&locale("de-DE-u-hc-h23")),
         HourCycle::H23
     );
     assert_eq!(
-        provider.hour_cycle(&locale("de-DE-u-hc-h24")),
+        backend.hour_cycle(&locale("de-DE-u-hc-h24")),
         HourCycle::H24
     );
 }
@@ -147,10 +147,10 @@ fn icu4x_hour_cycle_ignores_locale_hour_literals() {
     // because of the non-digit trailing text. The new digit-run
     // comparison between the 01:00 and 13:00 probes cannot be fooled
     // by decoration.
-    let provider = Icu4xProvider;
+    let backend = Icu4xBackend;
 
     assert_eq!(
-        provider.hour_cycle(&locale("bg-BG")),
+        backend.hour_cycle(&locale("bg-BG")),
         HourCycle::H23,
         "bg-BG must resolve to 24-hour despite the trailing ч. literal"
     );
@@ -158,7 +158,7 @@ fn icu4x_hour_cycle_ignores_locale_hour_literals() {
     // Explicit `-u-hc-h23` forces 24-hour formatting even for a
     // locale that would normally default to 12-hour.
     assert_eq!(
-        provider.hour_cycle(&locale("en-US-u-hc-h23")),
+        backend.hour_cycle(&locale("en-US-u-hc-h23")),
         HourCycle::H23,
         "en-US-u-hc-h23 must resolve to 24-hour"
     );
@@ -205,13 +205,13 @@ fn icu4x_day_period_label_survives_locale_hour_literals() {
     // `day_period_from_char` collapsed them together. The diff-based
     // extractor peels off everything shared between the two probes,
     // leaving only the day-period marker.
-    let provider = Icu4xProvider;
+    let backend = Icu4xBackend;
 
     let bg = locale("bg-BG");
 
-    let am = provider.day_period_label(false, &bg);
+    let am = backend.day_period_label(false, &bg);
 
-    let pm = provider.day_period_label(true, &bg);
+    let pm = backend.day_period_label(true, &bg);
 
     assert!(!am.is_empty(), "bg-BG AM label empty");
     assert!(!pm.is_empty(), "bg-BG PM label empty");
@@ -226,8 +226,8 @@ fn icu4x_day_period_label_survives_locale_hour_literals() {
 
     let pm_first = pm.chars().next().expect("PM label non-empty");
 
-    assert_eq!(provider.day_period_from_char(am_first, &bg), Some(false));
-    assert_eq!(provider.day_period_from_char(pm_first, &bg), Some(true));
+    assert_eq!(backend.day_period_from_char(am_first, &bg), Some(false));
+    assert_eq!(backend.day_period_from_char(pm_first, &bg), Some(true));
 }
 
 #[test]
@@ -235,9 +235,9 @@ fn icu4x_hour_cycle_ignores_native_digits_in_24h_locales() {
     // Regression: before treating non-ASCII digits as numerals, fa-IR
     // was misclassified as H12 because its 24-hour display uses
     // Persian numerals (۱۳:۰۰) whose characters aren't ASCII digits.
-    let provider = Icu4xProvider;
+    let backend = Icu4xBackend;
 
-    assert_eq!(provider.hour_cycle(&locale("fa-IR")), HourCycle::H23);
+    assert_eq!(backend.hour_cycle(&locale("fa-IR")), HourCycle::H23);
 }
 
 #[test]
@@ -245,13 +245,13 @@ fn icu4x_day_period_from_char_disambiguates_arabic_labels() {
     // Regression: before stripping Unicode numerals from the formatted
     // reference time, ar-EG AM/PM labels both started with `١` and
     // `day_period_from_char` could not distinguish AM from PM.
-    let provider = Icu4xProvider;
+    let backend = Icu4xBackend;
 
     let ar = locale("ar-EG");
 
-    let am_label = provider.day_period_label(false, &ar);
+    let am_label = backend.day_period_label(false, &ar);
 
-    let pm_label = provider.day_period_label(true, &ar);
+    let pm_label = backend.day_period_label(true, &ar);
 
     assert_ne!(
         am_label.chars().next(),
@@ -263,36 +263,31 @@ fn icu4x_day_period_from_char_disambiguates_arabic_labels() {
 
     let pm_char = pm_label.chars().next().expect("PM label is non-empty");
 
-    assert_eq!(provider.day_period_from_char(am_char, &ar), Some(false));
-    assert_eq!(provider.day_period_from_char(pm_char, &ar), Some(true));
+    assert_eq!(backend.day_period_from_char(am_char, &ar), Some(false));
+    assert_eq!(backend.day_period_from_char(pm_char, &ar), Some(true));
 }
 
 #[test]
 fn icu4x_first_day_of_week_from_cldr() {
-    let provider = Icu4xProvider;
+    let backend = Icu4xBackend;
 
-    assert_eq!(
-        provider.first_day_of_week(&locale("en-US")),
-        Weekday::Sunday
-    );
-    assert_eq!(
-        provider.first_day_of_week(&locale("de-DE")),
-        Weekday::Monday
-    );
+    assert_eq!(backend.first_day_of_week(&locale("en-US")), Weekday::Sunday);
+    assert_eq!(backend.first_day_of_week(&locale("de-DE")), Weekday::Monday);
 
     // `-u-fw-` extension overrides the CLDR default.
     assert_eq!(
-        provider.first_day_of_week(&locale("en-US-u-fw-mon")),
+        backend.first_day_of_week(&locale("en-US-u-fw-mon")),
         Weekday::Monday
     );
 }
 
 #[test]
 fn icu4x_week_info_includes_weekend_metadata() {
-    let provider = Icu4xProvider;
+    let backend = Icu4xBackend;
 
-    let us = provider.week_info(&locale("en-US"));
-    let germany = provider.week_info(&locale("de-DE"));
+    let us = backend.week_info(&locale("en-US"));
+
+    let germany = backend.week_info(&locale("de-DE"));
 
     assert_eq!(us.first_day, Weekday::Sunday);
     assert_eq!(us.weekend_start, Weekday::Saturday);
@@ -301,7 +296,7 @@ fn icu4x_week_info_includes_weekend_metadata() {
     assert_eq!(germany.first_day, Weekday::Monday);
     assert_eq!(germany.minimal_days_in_first_week, 4);
 
-    let israel = provider.week_info(&locale("he-IL"));
+    let israel = backend.week_info(&locale("he-IL"));
 
     assert_eq!(israel.first_day, Weekday::Sunday);
     assert_eq!(israel.weekend_start, Weekday::Friday);
@@ -310,13 +305,10 @@ fn icu4x_week_info_includes_weekend_metadata() {
 
 #[test]
 fn icu4x_format_segment_digits_uses_native_digits_in_arabic() {
-    let provider = Icu4xProvider;
+    let backend = Icu4xBackend;
 
-    let formatted = provider.format_segment_digits(
-        5,
-        NonZero::new(2).expect("2 is non-zero"),
-        &locale("ar-EG"),
-    );
+    let formatted =
+        backend.format_segment_digits(5, NonZero::new(2).expect("2 is non-zero"), &locale("ar-EG"));
 
     // ar-EG uses Arabic-Indic native digits (٠١٢٣٤٥٦٧٨٩) by default via CLDR.
     assert_eq!(formatted, "٠٥");
@@ -328,16 +320,16 @@ fn icu4x_format_segment_digits_never_groups_thousands() {
     // grouping enabled, so the segment formatter would happily return
     // `"2,024"` for a year — breaking both the segment contract
     // (contiguous digits with zero-padding only) and parity with
-    // `WebIntlProvider::format_segment_digits`, which passes
+    // `WebIntlBackend::format_segment_digits`, which passes
     // `useGrouping: false`. The provider now sets
     // `grouping_strategy = GroupingStrategy::Never` explicitly.
-    let provider = Icu4xProvider;
+    let backend = Icu4xBackend;
 
     for tag in ["en-US", "de-DE", "fr-FR"] {
         let loc = locale(tag);
 
         let formatted =
-            provider.format_segment_digits(2024, NonZero::new(4).expect("4 is non-zero"), &loc);
+            backend.format_segment_digits(2024, NonZero::new(4).expect("4 is non-zero"), &loc);
 
         assert_eq!(
             formatted, "2024",
@@ -348,13 +340,10 @@ fn icu4x_format_segment_digits_never_groups_thousands() {
 
 #[test]
 fn icu4x_format_segment_digits_preserves_ascii_in_english() {
-    let provider = Icu4xProvider;
+    let backend = Icu4xBackend;
 
-    let formatted = provider.format_segment_digits(
-        7,
-        NonZero::new(2).expect("2 is non-zero"),
-        &locale("en-US"),
-    );
+    let formatted =
+        backend.format_segment_digits(7, NonZero::new(2).expect("2 is non-zero"), &locale("en-US"));
 
     assert_eq!(formatted, "07");
 }
@@ -368,14 +357,14 @@ fn icu4x_day_period_label_nonempty_for_24h_locales() {
     // could not disambiguate AM/PM for those locales. The fix forces
     // `HourCycle::H12` on the day-period formatter so every locale
     // surfaces a non-empty, distinct AM/PM pair.
-    let provider = Icu4xProvider;
+    let backend = Icu4xBackend;
 
     for tag in ["de-DE", "fr-FR", "ja-JP"] {
         let loc = locale(tag);
 
-        let am = provider.day_period_label(false, &loc);
+        let am = backend.day_period_label(false, &loc);
 
-        let pm = provider.day_period_label(true, &loc);
+        let pm = backend.day_period_label(true, &loc);
 
         assert!(!am.is_empty(), "{tag} AM label empty");
         assert!(!pm.is_empty(), "{tag} PM label empty");
@@ -385,11 +374,11 @@ fn icu4x_day_period_label_nonempty_for_24h_locales() {
 
 #[test]
 fn icu4x_day_period_label_returns_nonempty() {
-    let provider = Icu4xProvider;
+    let backend = Icu4xBackend;
 
-    let am = provider.day_period_label(false, &locale("en-US"));
+    let am = backend.day_period_label(false, &locale("en-US"));
 
-    let pm = provider.day_period_label(true, &locale("en-US"));
+    let pm = backend.day_period_label(true, &locale("en-US"));
 
     assert!(!am.is_empty(), "AM label should not be empty");
     assert!(!pm.is_empty(), "PM label should not be empty");
@@ -398,71 +387,71 @@ fn icu4x_day_period_label_returns_nonempty() {
 
 #[test]
 fn icu4x_day_period_from_char_roundtrips_through_labels() {
-    let provider = Icu4xProvider;
+    let backend = Icu4xBackend;
 
     assert_eq!(
-        provider.day_period_from_char('a', &locale("en-US")),
+        backend.day_period_from_char('a', &locale("en-US")),
         Some(false)
     );
     assert_eq!(
-        provider.day_period_from_char('P', &locale("en-US")),
+        backend.day_period_from_char('P', &locale("en-US")),
         Some(true)
     );
-    assert_eq!(provider.day_period_from_char('x', &locale("en-US")), None);
+    assert_eq!(backend.day_period_from_char('x', &locale("en-US")), None);
 }
 
 #[test]
 fn icu4x_max_months_in_year_detects_hebrew_leap() {
-    let provider = Icu4xProvider;
+    let backend = Icu4xBackend;
 
     // 5784 is year 8 of the 19-year Metonic cycle (year % 19 = 8) — a leap
     // year with 13 months.
     assert_eq!(
-        provider.max_months_in_year(&CalendarSystem::Hebrew, 5784, None),
+        backend.max_months_in_year(&CalendarSystem::Hebrew, 5784, None),
         13
     );
 
     // 5785 is year 9 of the cycle — a common year with 12 months.
     assert_eq!(
-        provider.max_months_in_year(&CalendarSystem::Hebrew, 5785, None),
+        backend.max_months_in_year(&CalendarSystem::Hebrew, 5785, None),
         12
     );
 }
 
 #[test]
 fn icu4x_max_months_in_year_clamps_japanese_end_of_era() {
-    let provider = Icu4xProvider;
+    let backend = Icu4xBackend;
 
     // Heisei 31 (2019) ended on 30 April; the final year is capped at 4 months.
     assert_eq!(
-        provider.max_months_in_year(&CalendarSystem::Japanese, 31, Some("heisei")),
+        backend.max_months_in_year(&CalendarSystem::Japanese, 31, Some("heisei")),
         4
     );
 }
 
 #[test]
 fn icu4x_days_in_month_respects_japanese_end_of_era() {
-    let provider = Icu4xProvider;
+    let backend = Icu4xBackend;
 
     // Heisei 31-04 ends on day 30 (final day of the era).
     assert_eq!(
-        provider.days_in_month(&CalendarSystem::Japanese, 31, 4, Some("heisei")),
+        backend.days_in_month(&CalendarSystem::Japanese, 31, 4, Some("heisei")),
         30
     );
 
     // Gregorian February 2024 is 29 days (leap).
     assert_eq!(
-        provider.days_in_month(&CalendarSystem::Gregorian, 2024, 2, None),
+        backend.days_in_month(&CalendarSystem::Gregorian, 2024, 2, None),
         29
     );
 }
 
 #[test]
 fn icu4x_default_era_for_japanese_is_reiwa() {
-    let provider = Icu4xProvider;
+    let backend = Icu4xBackend;
 
     assert_eq!(
-        provider.default_era(&CalendarSystem::Japanese),
+        backend.default_era(&CalendarSystem::Japanese),
         Some(Era {
             code: "reiwa".to_string(),
             display_name: "Reiwa".to_string(),
@@ -472,7 +461,7 @@ fn icu4x_default_era_for_japanese_is_reiwa() {
 
 #[test]
 fn icu4x_era_boundary_queries_match_spec() {
-    let provider = Icu4xProvider;
+    let backend = Icu4xBackend;
 
     let heisei_1_1_8 = CalendarDate::new(
         CalendarSystem::Japanese,
@@ -489,9 +478,9 @@ fn icu4x_era_boundary_queries_match_spec() {
     )
     .expect("Heisei 1-1-8 should validate");
 
-    assert_eq!(provider.years_in_era(&heisei_1_1_8), Some(31));
-    assert_eq!(provider.minimum_month_in_year(&heisei_1_1_8), 1);
-    assert_eq!(provider.minimum_day_in_month(&heisei_1_1_8), 8);
+    assert_eq!(backend.years_in_era(&heisei_1_1_8), Some(31));
+    assert_eq!(backend.minimum_month_in_year(&heisei_1_1_8), 1);
+    assert_eq!(backend.minimum_day_in_month(&heisei_1_1_8), 8);
 
     let reiwa_1_5_1 = CalendarDate::new(
         CalendarSystem::Japanese,
@@ -508,17 +497,17 @@ fn icu4x_era_boundary_queries_match_spec() {
     )
     .expect("Reiwa 1-5-1 should validate");
 
-    assert_eq!(provider.minimum_month_in_year(&reiwa_1_5_1), 5);
+    assert_eq!(backend.minimum_month_in_year(&reiwa_1_5_1), 5);
 }
 
 #[test]
 fn icu4x_convert_date_crosses_calendars() {
-    let provider = Icu4xProvider;
+    let backend = Icu4xBackend;
 
     let gregorian =
         CalendarDate::new_gregorian(2024, 3, 15).expect("Gregorian 2024-03-15 should validate");
 
-    let japanese = provider.convert_date(&gregorian, CalendarSystem::Japanese);
+    let japanese = backend.convert_date(&gregorian, CalendarSystem::Japanese);
 
     assert_eq!(japanese.calendar(), CalendarSystem::Japanese);
     assert_eq!(japanese.year(), 6);
@@ -526,20 +515,20 @@ fn icu4x_convert_date_crosses_calendars() {
     assert_eq!(japanese.day(), 15);
     assert!(japanese.era().is_some());
 
-    // Cross-calendar conversion is reversible through the provider.
-    let round_trip = provider.convert_date(&japanese, CalendarSystem::Gregorian);
+    // Cross-calendar conversion is reversible through the backend.
+    let round_trip = backend.convert_date(&japanese, CalendarSystem::Gregorian);
 
     assert_eq!(round_trip, gregorian);
 }
 
 #[test]
 fn icu4x_convert_date_to_hebrew_yields_valid_date() {
-    let provider = Icu4xProvider;
+    let backend = Icu4xBackend;
 
     let gregorian =
         CalendarDate::new_gregorian(1992, 9, 2).expect("Gregorian 1992-09-02 should validate");
 
-    let hebrew = provider.convert_date(&gregorian, CalendarSystem::Hebrew);
+    let hebrew = backend.convert_date(&gregorian, CalendarSystem::Hebrew);
 
     assert_eq!(hebrew.calendar(), CalendarSystem::Hebrew);
     assert!(hebrew.year() >= 5752 && hebrew.year() <= 5753);
@@ -549,16 +538,16 @@ fn icu4x_convert_date_to_hebrew_yields_valid_date() {
 
 #[test]
 fn icu4x_convert_date_normalizes_early_dates_into_supported_public_eras() {
-    let provider = Icu4xProvider;
+    let backend = Icu4xBackend;
 
     let gregorian =
         CalendarDate::new_gregorian(1, 3, 15).expect("Gregorian 0001-03-15 should validate");
 
-    let japanese = provider.convert_date(&gregorian, CalendarSystem::Japanese);
+    let japanese = backend.convert_date(&gregorian, CalendarSystem::Japanese);
 
-    let islamic = provider.convert_date(&gregorian, CalendarSystem::IslamicUmmAlQura);
+    let islamic = backend.convert_date(&gregorian, CalendarSystem::IslamicUmmAlQura);
 
-    let coptic = provider.convert_date(&gregorian, CalendarSystem::Coptic);
+    let coptic = backend.convert_date(&gregorian, CalendarSystem::Coptic);
 
     assert_eq!(japanese.era().map(|era| era.code.as_str()), Some("ce"));
     assert_eq!(japanese.year(), 1);
@@ -572,7 +561,7 @@ fn icu4x_convert_date_normalizes_early_dates_into_supported_public_eras() {
     assert!((1..=13).contains(&coptic.month()));
     assert!((1..=30).contains(&coptic.day()));
     assert_eq!(
-        provider.convert_date(&coptic, CalendarSystem::Gregorian),
+        backend.convert_date(&coptic, CalendarSystem::Gregorian),
         gregorian
     );
 }
@@ -582,45 +571,45 @@ fn icu4x_convert_date_returns_source_for_out_of_range_year() {
     // The Temporal-backed calendar engine can still project large ISO years
     // into Japanese era years directly. The conversion must remain
     // round-trippable instead of falling back or panicking.
-    let provider = Icu4xProvider;
+    let backend = Icu4xBackend;
 
     let gregorian =
         CalendarDate::new_gregorian(10_000, 1, 1).expect("Gregorian date should validate");
 
-    let converted = provider.convert_date(&gregorian, CalendarSystem::Japanese);
+    let converted = backend.convert_date(&gregorian, CalendarSystem::Japanese);
 
     assert_eq!(converted.calendar(), CalendarSystem::Japanese);
     assert_eq!(
-        provider.convert_date(&converted, CalendarSystem::Gregorian),
+        backend.convert_date(&converted, CalendarSystem::Gregorian),
         gregorian
     );
 }
 
 #[test]
 fn icu4x_convert_date_same_calendar_is_identity() {
-    let provider = Icu4xProvider;
+    let backend = Icu4xBackend;
 
     let gregorian =
         CalendarDate::new_gregorian(2024, 3, 15).expect("Gregorian date should validate");
 
-    let converted = provider.convert_date(&gregorian, CalendarSystem::Gregorian);
+    let converted = backend.convert_date(&gregorian, CalendarSystem::Gregorian);
 
     assert_eq!(converted, gregorian);
 }
 
 #[test]
 fn icu4x_default_provider_under_icu4x_feature() {
-    // With the `icu4x` feature enabled, `default_provider()` selects the
-    // Icu4xProvider branch. The Boxed trait object isn't downcastable
+    // With the `icu4x` feature enabled, `default_backend()` selects the
+    // Icu4xBackend branch. The Boxed trait object isn't downcastable
     // without extra machinery, so we assert observable behavior that the
     // Stub would get wrong.
-    let provider = default_provider();
+    let backend = default_backend();
 
-    let label = provider.weekday_long_label(Weekday::Monday, &locale("ja"));
+    let label = backend.weekday_long_label(Weekday::Monday, &locale("ja"));
 
     assert!(
         label.contains('曜'),
-        "default_provider() under icu4x should return Japanese labels; got {label:?}"
+        "default_backend() under icu4x should return Japanese labels; got {label:?}"
     );
 }
 
@@ -704,13 +693,13 @@ fn icu4x_day_period_label_full_cjk_label_integration_ja_jp() {
     // differ from each other, since CLDR data could evolve; the
     // strict split-around-digits unit tests above pin the semantic
     // contract.
-    let provider = Icu4xProvider;
+    let backend = Icu4xBackend;
 
     let ja = locale("ja-JP");
 
-    let am = provider.day_period_label(false, &ja);
+    let am = backend.day_period_label(false, &ja);
 
-    let pm = provider.day_period_label(true, &ja);
+    let pm = backend.day_period_label(true, &ja);
 
     assert!(
         am.contains('午'),
@@ -728,7 +717,7 @@ fn icu4x_day_period_label_full_cjk_label_integration_ja_jp() {
     let first = am.chars().next().expect("ja-JP AM label is non-empty");
 
     assert_eq!(
-        provider.day_period_from_char(first, &ja),
+        backend.day_period_from_char(first, &ja),
         None,
         "single CJK character must be ambiguous when both labels share their first char"
     );

--- a/crates/ars-i18n/tests/unit/provider_stub.rs
+++ b/crates/ars-i18n/tests/unit/provider_stub.rs
@@ -1,0 +1,128 @@
+//! `StubIntlBackend` tests (spec §9.5.1).
+
+use alloc::string::ToString;
+use core::num::NonZero;
+
+use crate::{
+    CalendarDate, CalendarDateFields, CalendarSystem, Era, HourCycle, IntlBackend, Locale,
+    StubIntlBackend, WeekInfo, Weekday,
+};
+
+fn locale(tag: &str) -> Locale {
+    Locale::parse(tag).expect("test locale should parse")
+}
+
+fn calendar_date(
+    calendar: CalendarSystem,
+    era: Option<Era>,
+    year: i32,
+    month: u8,
+    day: u8,
+) -> CalendarDate {
+    CalendarDate::new(
+        calendar,
+        &CalendarDateFields {
+            era,
+            year: Some(year),
+            month: Some(month),
+            day: Some(day),
+            ..CalendarDateFields::default()
+        },
+    )
+    .expect("calendar test date should validate")
+}
+
+#[test]
+fn stub_provider_explicitly_returns_english_labels() {
+    let backend = StubIntlBackend;
+
+    let locale = locale("en-US");
+
+    assert_eq!(backend.weekday_short_label(Weekday::Monday, &locale), "Mo");
+    assert_eq!(
+        backend.weekday_long_label(Weekday::Monday, &locale),
+        "Monday"
+    );
+    assert_eq!(backend.month_long_name(1, &locale), "January");
+    assert_eq!(backend.month_long_name(13, &locale), "Unknown");
+    assert_eq!(backend.day_period_label(false, &locale), "AM");
+    assert_eq!(backend.day_period_label(true, &locale), "PM");
+}
+
+#[test]
+fn stub_provider_explicitly_parses_day_period_and_formats_digits() {
+    let backend = StubIntlBackend;
+
+    let locale = locale("en-US");
+
+    assert_eq!(backend.day_period_from_char('a', &locale), Some(false));
+    assert_eq!(backend.day_period_from_char('P', &locale), Some(true));
+    assert_eq!(backend.day_period_from_char('x', &locale), None);
+    assert_eq!(
+        backend.format_segment_digits(7, NonZero::new(2).expect("2 is non-zero"), &locale),
+        "07"
+    );
+}
+
+#[test]
+fn stub_provider_explicitly_reports_locale_hour_cycle_and_week_info() {
+    let backend = StubIntlBackend;
+
+    let english = locale("en-US");
+
+    let german = locale("de-DE");
+
+    assert_eq!(backend.hour_cycle(&english), HourCycle::H12);
+    assert_eq!(backend.hour_cycle(&german), HourCycle::H23);
+    assert_eq!(backend.week_info(&english), WeekInfo::for_locale(&english));
+    assert_eq!(backend.week_info(&german), WeekInfo::for_locale(&german));
+    assert_eq!(backend.first_day_of_week(&english), Weekday::Sunday);
+    assert_eq!(backend.first_day_of_week(&german), Weekday::Monday);
+}
+
+#[test]
+fn stub_provider_keeps_calendar_helper_defaults() {
+    let backend = StubIntlBackend;
+
+    assert_eq!(
+        backend.default_era(&CalendarSystem::Japanese),
+        Some(Era {
+            code: "reiwa".to_string(),
+            display_name: "Reiwa".to_string(),
+        })
+    );
+    assert_eq!(
+        backend.max_months_in_year(&CalendarSystem::Japanese, 31, Some("heisei")),
+        4
+    );
+    assert_eq!(
+        backend.days_in_month(&CalendarSystem::Japanese, 31, 4, Some("heisei")),
+        30
+    );
+
+    let heisei = calendar_date(
+        CalendarSystem::Japanese,
+        Some(Era {
+            code: "heisei".to_string(),
+            display_name: "Heisei".to_string(),
+        }),
+        1,
+        1,
+        8,
+    );
+
+    let reiwa = calendar_date(
+        CalendarSystem::Japanese,
+        Some(Era {
+            code: "reiwa".to_string(),
+            display_name: "Reiwa".to_string(),
+        }),
+        1,
+        5,
+        1,
+    );
+
+    assert_eq!(backend.years_in_era(&heisei), Some(31));
+    assert_eq!(backend.minimum_month_in_year(&reiwa), 5);
+    assert_eq!(backend.minimum_day_in_month(&heisei), 8);
+}

--- a/crates/ars-i18n/tests/unit/provider_web_intl.rs
+++ b/crates/ars-i18n/tests/unit/provider_web_intl.rs
@@ -1,7 +1,10 @@
-//! WASM `WebIntlProvider` tests (spec §9.5.4).
+//! WASM `WebIntlBackend` tests (spec §9.5.4).
 //!
 //! Run with:
-//! `wasm-pack test --headless --firefox crates/ars-i18n --no-default-features --features std,web-intl`.
+//! `wasm-pack test --headless --chrome crates/ars-i18n --no-default-features --features std,web-intl`.
+//!
+//! If `chromedriver` is not on `PATH`, pass it explicitly:
+//! `wasm-pack test --headless --chrome --chromedriver /opt/homebrew/bin/chromedriver crates/ars-i18n --no-default-features --features std,web-intl`.
 
 use alloc::{format, string::ToString};
 use core::num::NonZero;
@@ -9,8 +12,8 @@ use core::num::NonZero;
 use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
 
 use crate::{
-    CalendarDate, CalendarDateFields, CalendarSystem, Era, HourCycle, IcuProvider, Locale,
-    WebIntlProvider, Weekday, default_provider,
+    CalendarDate, CalendarDateFields, CalendarSystem, Era, HourCycle, IntlBackend, Locale,
+    WebIntlBackend, Weekday, default_backend,
 };
 
 wasm_bindgen_test_configure!(run_in_browser);
@@ -45,9 +48,9 @@ fn calendar_date(
 
 #[wasm_bindgen_test]
 fn web_intl_weekday_short_label_returns_english() {
-    let provider = WebIntlProvider;
+    let backend = WebIntlBackend;
 
-    let label = provider.weekday_short_label(Weekday::Monday, &locale("en-US"));
+    let label = backend.weekday_short_label(Weekday::Monday, &locale("en-US"));
 
     assert!(!label.is_empty());
 
@@ -60,9 +63,9 @@ fn web_intl_weekday_short_label_returns_english() {
 
 #[wasm_bindgen_test]
 fn web_intl_weekday_long_label_localizes_in_japanese() {
-    let provider = WebIntlProvider;
+    let backend = WebIntlBackend;
 
-    let label = provider.weekday_long_label(Weekday::Monday, &locale("ja"));
+    let label = backend.weekday_long_label(Weekday::Monday, &locale("ja"));
 
     assert!(
         label.contains('曜'),
@@ -72,9 +75,9 @@ fn web_intl_weekday_long_label_localizes_in_japanese() {
 
 #[wasm_bindgen_test]
 fn web_intl_month_long_name_localizes_in_japanese() {
-    let provider = WebIntlProvider;
+    let backend = WebIntlBackend;
 
-    let name = provider.month_long_name(1, &locale("ja"));
+    let name = backend.month_long_name(1, &locale("ja"));
 
     assert!(
         name.contains('月'),
@@ -84,63 +87,57 @@ fn web_intl_month_long_name_localizes_in_japanese() {
 
 #[wasm_bindgen_test]
 fn web_intl_hour_cycle_en_us_is_h12() {
-    let provider = WebIntlProvider;
+    let backend = WebIntlBackend;
 
-    assert_eq!(provider.hour_cycle(&locale("en-US")), HourCycle::H12);
+    assert_eq!(backend.hour_cycle(&locale("en-US")), HourCycle::H12);
 }
 
 #[wasm_bindgen_test]
 fn web_intl_hour_cycle_fr_fr_is_h23() {
-    let provider = WebIntlProvider;
+    let backend = WebIntlBackend;
 
-    assert_eq!(provider.hour_cycle(&locale("fr-FR")), HourCycle::H23);
+    assert_eq!(backend.hour_cycle(&locale("fr-FR")), HourCycle::H23);
 }
 
 #[wasm_bindgen_test]
 fn web_intl_hour_cycle_uses_formatted_parts_not_resolved_options() {
-    let provider = WebIntlProvider;
+    let backend = WebIntlBackend;
 
     // Regression (#583): browser `resolvedOptions().hourCycle` is known
     // to misreport some locales. Force Arabic-Indic digits so the
     // provider must normalize the observed hour part and still infer
     // French 24-hour output correctly.
     assert_eq!(
-        provider.hour_cycle(&locale("fr-FR-u-nu-arab")),
+        backend.hour_cycle(&locale("fr-FR-u-nu-arab")),
         HourCycle::H23
     );
 }
 
 #[wasm_bindgen_test]
 fn web_intl_first_day_of_week_en_us_is_sunday() {
-    let provider = WebIntlProvider;
+    let backend = WebIntlBackend;
 
-    assert_eq!(
-        provider.first_day_of_week(&locale("en-US")),
-        Weekday::Sunday
-    );
+    assert_eq!(backend.first_day_of_week(&locale("en-US")), Weekday::Sunday);
 }
 
 #[wasm_bindgen_test]
 fn web_intl_first_day_of_week_de_is_monday() {
-    let provider = WebIntlProvider;
+    let backend = WebIntlBackend;
 
-    assert_eq!(
-        provider.first_day_of_week(&locale("de-DE")),
-        Weekday::Monday
-    );
+    assert_eq!(backend.first_day_of_week(&locale("de-DE")), Weekday::Monday);
 }
 
 #[wasm_bindgen_test]
 fn web_intl_week_info_reads_first_day_and_weekend_metadata() {
-    let provider = WebIntlProvider;
+    let backend = WebIntlBackend;
 
-    let us = provider.week_info(&locale("en-US"));
+    let us = backend.week_info(&locale("en-US"));
 
     assert_eq!(us.first_day, Weekday::Sunday);
     assert_eq!(us.weekend_start, Weekday::Saturday);
     assert_eq!(us.weekend_end, Weekday::Sunday);
 
-    let israel = provider.week_info(&locale("he-IL"));
+    let israel = backend.week_info(&locale("he-IL"));
 
     assert_eq!(israel.first_day, Weekday::Sunday);
     assert_eq!(israel.weekend_start, Weekday::Friday);
@@ -149,13 +146,10 @@ fn web_intl_week_info_reads_first_day_and_weekend_metadata() {
 
 #[wasm_bindgen_test]
 fn web_intl_format_segment_digits_uses_native_digits_in_arabic() {
-    let provider = WebIntlProvider;
+    let backend = WebIntlBackend;
 
-    let formatted = provider.format_segment_digits(
-        5,
-        NonZero::new(2).expect("2 is non-zero"),
-        &locale("ar-EG"),
-    );
+    let formatted =
+        backend.format_segment_digits(5, NonZero::new(2).expect("2 is non-zero"), &locale("ar-EG"));
 
     // ar-EG formats 05 as Arabic-Indic ٠٥ via `Intl.NumberFormat`.
     assert_eq!(formatted, "٠٥");
@@ -163,24 +157,21 @@ fn web_intl_format_segment_digits_uses_native_digits_in_arabic() {
 
 #[wasm_bindgen_test]
 fn web_intl_format_segment_digits_preserves_ascii_in_english() {
-    let provider = WebIntlProvider;
+    let backend = WebIntlBackend;
 
-    let formatted = provider.format_segment_digits(
-        7,
-        NonZero::new(2).expect("2 is non-zero"),
-        &locale("en-US"),
-    );
+    let formatted =
+        backend.format_segment_digits(7, NonZero::new(2).expect("2 is non-zero"), &locale("en-US"));
 
     assert_eq!(formatted, "07");
 }
 
 #[wasm_bindgen_test]
 fn web_intl_day_period_labels_differ_en_us() {
-    let provider = WebIntlProvider;
+    let backend = WebIntlBackend;
 
-    let am = provider.day_period_label(false, &locale("en-US"));
+    let am = backend.day_period_label(false, &locale("en-US"));
 
-    let pm = provider.day_period_label(true, &locale("en-US"));
+    let pm = backend.day_period_label(true, &locale("en-US"));
 
     assert!(!am.is_empty());
     assert!(!pm.is_empty());
@@ -189,34 +180,34 @@ fn web_intl_day_period_labels_differ_en_us() {
 
 #[wasm_bindgen_test]
 fn web_intl_days_in_month_gregorian_leap_february() {
-    let provider = WebIntlProvider;
+    let backend = WebIntlBackend;
 
     assert_eq!(
-        provider.days_in_month(&CalendarSystem::Gregorian, 2024, 2, None),
+        backend.days_in_month(&CalendarSystem::Gregorian, 2024, 2, None),
         29
     );
     assert_eq!(
-        provider.days_in_month(&CalendarSystem::Gregorian, 2023, 2, None),
+        backend.days_in_month(&CalendarSystem::Gregorian, 2023, 2, None),
         28
     );
 }
 
 #[wasm_bindgen_test]
 fn web_intl_default_provider_under_web_intl() {
-    let provider = default_provider();
+    let backend = default_backend();
 
-    // Japanese localization proves we reached the browser-backed provider.
-    let label = provider.weekday_long_label(Weekday::Monday, &locale("ja"));
+    // Japanese localization proves we reached the browser-backed backend.
+    let label = backend.weekday_long_label(Weekday::Monday, &locale("ja"));
 
     assert!(
         label.contains('曜'),
-        "default_provider() under web-intl should return Japanese labels; got {label:?}"
+        "default_backend() under web-intl should return Japanese labels; got {label:?}"
     );
 }
 
 #[wasm_bindgen_test]
 fn web_intl_weekday_short_label_covers_every_weekday() {
-    let provider = WebIntlProvider;
+    let backend = WebIntlBackend;
 
     let en = locale("en-US");
 
@@ -229,7 +220,7 @@ fn web_intl_weekday_short_label_covers_every_weekday() {
         Weekday::Saturday,
         Weekday::Sunday,
     ] {
-        let label = provider.weekday_short_label(weekday, &en);
+        let label = backend.weekday_short_label(weekday, &en);
 
         assert!(!label.is_empty(), "empty short label for {weekday:?}");
     }
@@ -237,13 +228,13 @@ fn web_intl_weekday_short_label_covers_every_weekday() {
 
 #[wasm_bindgen_test]
 fn web_intl_day_period_from_char_roundtrips_english() {
-    let provider = WebIntlProvider;
+    let backend = WebIntlBackend;
 
     let en = locale("en-US");
 
-    assert_eq!(provider.day_period_from_char('a', &en), Some(false));
-    assert_eq!(provider.day_period_from_char('P', &en), Some(true));
-    assert_eq!(provider.day_period_from_char('x', &en), None);
+    assert_eq!(backend.day_period_from_char('a', &en), Some(false));
+    assert_eq!(backend.day_period_from_char('P', &en), Some(true));
+    assert_eq!(backend.day_period_from_char('x', &en), None);
 }
 
 #[wasm_bindgen_test]
@@ -259,13 +250,13 @@ fn web_intl_day_period_from_char_bails_when_labels_share_prefix() {
     // extractor happens to leave a shared prefix (e.g., a future
     // CLDR revision), the ambiguous char must resolve to `None`; if
     // it doesn't, the happy path is verified end-to-end.
-    let provider = WebIntlProvider;
+    let backend = WebIntlBackend;
 
     let ja = locale("ja-JP");
 
-    let am = provider.day_period_label(false, &ja);
+    let am = backend.day_period_label(false, &ja);
 
-    let pm = provider.day_period_label(true, &ja);
+    let pm = backend.day_period_label(true, &ja);
 
     let am_first = am.chars().next().expect("AM label non-empty");
 
@@ -273,99 +264,99 @@ fn web_intl_day_period_from_char_bails_when_labels_share_prefix() {
 
     if am_first == pm_first {
         assert_eq!(
-            provider.day_period_from_char(am_first, &ja),
+            backend.day_period_from_char(am_first, &ja),
             None,
             "shared first char must not collapse to AM"
         );
     } else {
-        assert_eq!(provider.day_period_from_char(am_first, &ja), Some(false));
-        assert_eq!(provider.day_period_from_char(pm_first, &ja), Some(true));
+        assert_eq!(backend.day_period_from_char(am_first, &ja), Some(false));
+        assert_eq!(backend.day_period_from_char(pm_first, &ja), Some(true));
     }
 }
 
 #[wasm_bindgen_test]
 fn web_intl_month_long_name_returns_unknown_for_invalid_month() {
-    let provider = WebIntlProvider;
+    let backend = WebIntlBackend;
 
-    assert_eq!(provider.month_long_name(0, &locale("en-US")), "Unknown");
-    assert_eq!(provider.month_long_name(13, &locale("en-US")), "Unknown");
+    assert_eq!(backend.month_long_name(0, &locale("en-US")), "Unknown");
+    assert_eq!(backend.month_long_name(13, &locale("en-US")), "Unknown");
 }
 
 #[wasm_bindgen_test]
 fn web_intl_max_months_in_year_detects_hebrew_leap() {
-    let provider = WebIntlProvider;
+    let backend = WebIntlBackend;
 
     // Cycle year 8 is a Hebrew leap year (13 months).
     assert_eq!(
-        provider.max_months_in_year(&CalendarSystem::Hebrew, 5784, None),
+        backend.max_months_in_year(&CalendarSystem::Hebrew, 5784, None),
         13
     );
     // Cycle year 9 is a common year (12 months).
     assert_eq!(
-        provider.max_months_in_year(&CalendarSystem::Hebrew, 5785, None),
+        backend.max_months_in_year(&CalendarSystem::Hebrew, 5785, None),
         12
     );
     // Ethiopic/Coptic calendars always have 13 months.
     assert_eq!(
-        provider.max_months_in_year(&CalendarSystem::Ethiopic, 2017, None),
+        backend.max_months_in_year(&CalendarSystem::Ethiopic, 2017, None),
         13
     );
 }
 
 #[wasm_bindgen_test]
 fn web_intl_max_months_in_year_clamps_japanese_end_of_era() {
-    let provider = WebIntlProvider;
+    let backend = WebIntlBackend;
 
     // End-of-era clamping is served by `bounded_months_in_year`, which the
     // provider calls before the Hebrew/Ethiopic table.
     assert_eq!(
-        provider.max_months_in_year(&CalendarSystem::Japanese, 31, Some("heisei")),
+        backend.max_months_in_year(&CalendarSystem::Japanese, 31, Some("heisei")),
         4
     );
 }
 
 #[wasm_bindgen_test]
 fn web_intl_days_in_month_clamps_japanese_end_of_era() {
-    let provider = WebIntlProvider;
+    let backend = WebIntlBackend;
 
     // Heisei year 31 month 4 is the era's final month; the shared
     // `bounded_days_in_month` helper must clamp to day 30 before the
     // non-Gregorian fallback kicks in.
     assert_eq!(
-        provider.days_in_month(&CalendarSystem::Japanese, 31, 4, Some("heisei")),
+        backend.days_in_month(&CalendarSystem::Japanese, 31, 4, Some("heisei")),
         30
     );
 }
 
 #[wasm_bindgen_test]
 fn web_intl_max_months_in_year_resolves_persian_via_bridge() {
-    let provider = WebIntlProvider;
+    let backend = WebIntlBackend;
 
     // Persian is a 12-month solar calendar with no leap-month year
     // variants. The bridge returns 12 for every year, matching the
     // previous fixed fallback without fabricating it.
     assert_eq!(
-        provider.max_months_in_year(&CalendarSystem::Persian, 1403, None),
+        backend.max_months_in_year(&CalendarSystem::Persian, 1403, None),
         12
     );
 }
 
 #[wasm_bindgen_test]
 fn web_intl_hour_cycle_honors_locale_extension() {
-    let provider = WebIntlProvider;
+    let backend = WebIntlBackend;
 
     // Explicit `-u-hc-*` overrides must short-circuit the probe logic
     // so callers get the exact midnight behavior they requested.
-    assert_eq!(provider.hour_cycle(&locale("ja-u-hc-h11")), HourCycle::H11);
+    assert_eq!(backend.hour_cycle(&locale("ja-u-hc-h11")), HourCycle::H11);
     assert_eq!(
-        provider.hour_cycle(&locale("en-US-u-hc-h12")),
+        backend.hour_cycle(&locale("en-US-u-hc-h12")),
         HourCycle::H12
     );
     assert_eq!(
-        provider.hour_cycle(&locale("de-DE-u-hc-h23")),
+        backend.hour_cycle(&locale("de-DE-u-hc-h23")),
         HourCycle::H23
     );
-    assert_eq!(provider.hour_cycle(&locale("ja-u-hc-h24")), HourCycle::H24);
+    assert_eq!(backend.hour_cycle(&locale("ja-u-hc-h24")), HourCycle::H24);
 }
 
 #[wasm_bindgen_test]
@@ -373,13 +364,13 @@ fn web_intl_convert_date_routes_bce_gregorian_through_bridge() {
     // Regression (Codex PR #563 comment 3103592557, P2): when
     // `u32::try_from(date.year)` rejects a negative Gregorian year,
     // the previous code returned the source date unchanged — a
-    // straight contract violation for `IcuProvider::convert_date`,
+    // straight contract violation for `IntlBackend::convert_date`,
     // which must always return a date in `target`. The fallback now
     // runs `bridge_convert` so BCE Gregorian inputs convert correctly
     // (the ICU4X calendar-arithmetic bridge handles negative year
     // arithmetic natively) or clone the source only when the bridge
     // itself rejects the input.
-    let provider = WebIntlProvider;
+    let backend = WebIntlBackend;
 
     let gregorian = calendar_date(
         CalendarSystem::Gregorian,
@@ -392,7 +383,7 @@ fn web_intl_convert_date_routes_bce_gregorian_through_bridge() {
         15,
     );
 
-    let buddhist = provider.convert_date(&gregorian, CalendarSystem::Buddhist);
+    let buddhist = backend.convert_date(&gregorian, CalendarSystem::Buddhist);
 
     // Buddhist Era year = Gregorian year + 543. -50 CE → Buddhist 493.
     // The browser path must use the canonical ISO year (-50), not the
@@ -424,13 +415,13 @@ fn web_intl_days_in_month_non_gregorian_uses_bridge_not_flat_30() {
     // 31-day months during `CalendarDate::new` validation. We now
     // delegate to the shared ICU4X calendar-arithmetic bridge, which
     // produces the correct per-year month lengths.
-    let provider = WebIntlProvider;
+    let backend = WebIntlBackend;
 
     // Hebrew civil-order month 3 is Kislev, whose length varies
     // between 29 and 30 days by year type (chaser/kesidran/shalem).
     // 28..=30 is the full Hebrew-lunisolar range; assert the bridge
     // returns a real number inside it rather than the fabricated 30.
-    let kislev = provider.days_in_month(&CalendarSystem::Hebrew, 5785, 3, None);
+    let kislev = backend.days_in_month(&CalendarSystem::Hebrew, 5785, 3, None);
 
     assert!(
         (28..=30).contains(&kislev),
@@ -439,7 +430,7 @@ fn web_intl_days_in_month_non_gregorian_uses_bridge_not_flat_30() {
 
     // Chinese month 2 in 2024 is 29 or 30 days — the bridge must
     // pick one, not default to the old flat 30.
-    let chinese_2 = provider.days_in_month(&CalendarSystem::Chinese, 2024, 2, None);
+    let chinese_2 = backend.days_in_month(&CalendarSystem::Chinese, 2024, 2, None);
 
     assert!(
         (29..=30).contains(&chinese_2),
@@ -456,10 +447,10 @@ fn web_intl_max_months_in_year_non_gregorian_uses_bridge_not_flat_12() {
     // validation and normalised civil-ordinal 13 inputs into the
     // following year on `add_months(0)`. The bridge produces the
     // real per-year answer including leap-cycle widenings.
-    let provider = WebIntlProvider;
+    let backend = WebIntlBackend;
 
     // Chinese 2020 is a leap-month year (闰四月, leap 4th) → 13.
-    let months_2020 = provider.max_months_in_year(&CalendarSystem::Chinese, 2020, None);
+    let months_2020 = backend.max_months_in_year(&CalendarSystem::Chinese, 2020, None);
 
     assert_eq!(
         months_2020, 13,
@@ -467,7 +458,7 @@ fn web_intl_max_months_in_year_non_gregorian_uses_bridge_not_flat_12() {
     );
 
     // Chinese 2021 is a non-leap year → 12.
-    let months_2021 = provider.max_months_in_year(&CalendarSystem::Chinese, 2021, None);
+    let months_2021 = backend.max_months_in_year(&CalendarSystem::Chinese, 2021, None);
 
     assert_eq!(
         months_2021, 12,
@@ -477,17 +468,17 @@ fn web_intl_max_months_in_year_non_gregorian_uses_bridge_not_flat_12() {
 
 #[wasm_bindgen_test]
 fn web_intl_era_helpers_match_stub_behavior() {
-    let provider = WebIntlProvider;
+    let backend = WebIntlBackend;
 
     assert_eq!(
-        provider.default_era(&CalendarSystem::Japanese),
+        backend.default_era(&CalendarSystem::Japanese),
         Some(Era {
             code: "reiwa".to_string(),
             display_name: "Reiwa".to_string(),
         })
     );
     assert_eq!(
-        provider.default_era(&CalendarSystem::Gregorian),
+        backend.default_era(&CalendarSystem::Gregorian),
         Some(Era {
             code: "ad".to_string(),
             display_name: "AD".to_string(),
@@ -505,42 +496,42 @@ fn web_intl_era_helpers_match_stub_behavior() {
         8,
     );
 
-    assert_eq!(provider.years_in_era(&heisei), Some(31));
-    assert_eq!(provider.minimum_month_in_year(&heisei), 1);
-    assert_eq!(provider.minimum_day_in_month(&heisei), 8);
+    assert_eq!(backend.years_in_era(&heisei), Some(31));
+    assert_eq!(backend.minimum_month_in_year(&heisei), 1);
+    assert_eq!(backend.minimum_day_in_month(&heisei), 8);
 }
 
 #[wasm_bindgen_test]
 fn web_intl_first_day_of_week_honors_unicode_extension() {
-    let provider = WebIntlProvider;
+    let backend = WebIntlBackend;
 
     // `-u-fw-sat` overrides the region default of Sunday for en-US.
     assert_eq!(
-        provider.first_day_of_week(&locale("en-US-u-fw-sat")),
+        backend.first_day_of_week(&locale("en-US-u-fw-sat")),
         Weekday::Saturday
     );
 }
 
 #[wasm_bindgen_test]
 fn web_intl_convert_date_same_calendar_is_identity() {
-    let provider = WebIntlProvider;
+    let backend = WebIntlBackend;
 
     let gregorian = gregorian_date(2024, 3, 15);
 
-    let converted = provider.convert_date(&gregorian, CalendarSystem::Gregorian);
+    let converted = backend.convert_date(&gregorian, CalendarSystem::Gregorian);
 
     assert_eq!(converted, gregorian);
 }
 
 #[wasm_bindgen_test]
 fn web_intl_convert_date_crosses_calendars_via_browser() {
-    let provider = WebIntlProvider;
+    let backend = WebIntlBackend;
 
     let gregorian = gregorian_date(2024, 3, 15);
 
     // Under `--features web-intl` without `icu4x`, this hits the
     // Intl.DateTimeFormat({ calendar }) → formatToParts reparse path.
-    let japanese = provider.convert_date(&gregorian, CalendarSystem::Japanese);
+    let japanese = backend.convert_date(&gregorian, CalendarSystem::Japanese);
 
     assert_eq!(japanese.calendar(), CalendarSystem::Japanese);
     assert_eq!(japanese.year(), 6);
@@ -555,11 +546,11 @@ fn web_intl_convert_date_preserves_historical_japanese_era() {
     // like 1990 came out with era=Reiwa, year=2 instead of era=Heisei,
     // year=2. The fix requests `era: "long"` from `Intl.DateTimeFormat`
     // and maps the localized label back to the CLDR era code.
-    let provider = WebIntlProvider;
+    let backend = WebIntlBackend;
 
     let gregorian = gregorian_date(1990, 6, 15);
 
-    let japanese = provider.convert_date(&gregorian, CalendarSystem::Japanese);
+    let japanese = backend.convert_date(&gregorian, CalendarSystem::Japanese);
 
     assert_eq!(japanese.calendar(), CalendarSystem::Japanese);
     assert_eq!(japanese.year(), 2);
@@ -586,12 +577,12 @@ fn web_intl_convert_date_canonicalizes_macronized_japanese_eras() {
     // `taisho`). Downstream era-aware helpers then missed the era and
     // silently returned incorrect bounds. `canonical_era_code` strips
     // the known Latin-macron letters before lowercasing.
-    let provider = WebIntlProvider;
+    let backend = WebIntlBackend;
 
     // Shōwa: 1926-12-25 .. 1989-01-07. Gregorian 1970 is deep inside it.
     let gregorian = gregorian_date(1970, 6, 15);
 
-    let japanese = provider.convert_date(&gregorian, CalendarSystem::Japanese);
+    let japanese = backend.convert_date(&gregorian, CalendarSystem::Japanese);
 
     let era = japanese
         .era()
@@ -607,7 +598,7 @@ fn web_intl_convert_date_canonicalizes_macronized_japanese_eras() {
     // Taishō: 1912-07-30 .. 1926-12-25. Gregorian 1920 is inside.
     let gregorian = gregorian_date(1920, 6, 15);
 
-    let japanese = provider.convert_date(&gregorian, CalendarSystem::Japanese);
+    let japanese = backend.convert_date(&gregorian, CalendarSystem::Japanese);
 
     let era = japanese
         .era()
@@ -655,11 +646,11 @@ fn web_intl_convert_date_recovers_chinese_leap_month_ordinal() {
     // the `bis` token, some a localised name), we only assert the
     // weaker post-condition: the converted date must differ from the
     // source and must expose a non-zero month ordinal.
-    let provider = WebIntlProvider;
+    let backend = WebIntlBackend;
 
     let gregorian = gregorian_date(2020, 5, 30);
 
-    let chinese = provider.convert_date(&gregorian, CalendarSystem::Chinese);
+    let chinese = backend.convert_date(&gregorian, CalendarSystem::Chinese);
 
     assert_ne!(
         chinese, gregorian,
@@ -679,11 +670,11 @@ fn web_intl_convert_date_preserves_years_below_100() {
     // `0..=99` as `1900..=1999`. `convert_date` now uses `new Date()`
     // + `setUTCFullYear(..)` so a Gregorian year below 100 is passed
     // to `Intl.DateTimeFormat` as itself.
-    let provider = WebIntlProvider;
+    let backend = WebIntlBackend;
 
     let gregorian = gregorian_date(90, 6, 15);
 
-    let buddhist = provider.convert_date(&gregorian, CalendarSystem::Buddhist);
+    let buddhist = backend.convert_date(&gregorian, CalendarSystem::Buddhist);
 
     assert_eq!(buddhist.calendar(), CalendarSystem::Buddhist);
 
@@ -705,12 +696,12 @@ fn web_intl_convert_date_resolves_hebrew_named_month() {
     // label against a probe loop. This test exercises the named-month
     // resolution path even in browsers that return a numeric month —
     // we just verify the result has a valid 1-based month ordinal.
-    let provider = WebIntlProvider;
+    let backend = WebIntlBackend;
 
     // March 25, 2024 is Adar II 15, 5784 (Hebrew leap year).
     let gregorian = gregorian_date(2024, 3, 25);
 
-    let hebrew = provider.convert_date(&gregorian, CalendarSystem::Hebrew);
+    let hebrew = backend.convert_date(&gregorian, CalendarSystem::Hebrew);
 
     assert_eq!(hebrew.calendar(), CalendarSystem::Hebrew);
     assert_eq!(hebrew.year(), 5784);
@@ -732,7 +723,7 @@ fn web_intl_convert_date_bridges_non_gregorian_sources_under_web_intl() {
     // bridge behind `#[cfg(feature = "icu4x")]` and then returned
     // `date.clone()` for every non-Gregorian source under pure
     // `--features web-intl`. That violated the
-    // `IcuProvider::convert_date` contract — downstream callers
+    // `IntlBackend::convert_date` contract — downstream callers
     // (`CalendarDate::add_days_with_provider`, `TypedCalendarDate::
     // to_calendar`) assumed the returned date lives in `target`.
     // Returning the source calendar panicked the Gregorian-only
@@ -745,11 +736,11 @@ fn web_intl_convert_date_bridges_non_gregorian_sources_under_web_intl() {
     // bridge is now unconditionally active for non-Gregorian sources
     // under this feature, so Buddhist 2567 → Gregorian must resolve
     // to the real Gregorian equivalent, not echo the source back.
-    let provider = WebIntlProvider;
+    let backend = WebIntlBackend;
 
     let buddhist = calendar_date(CalendarSystem::Buddhist, None, 2567, 6, 15);
 
-    let gregorian = provider.convert_date(&buddhist, CalendarSystem::Gregorian);
+    let gregorian = backend.convert_date(&buddhist, CalendarSystem::Gregorian);
 
     assert_eq!(gregorian.calendar(), CalendarSystem::Gregorian);
     assert_eq!(
@@ -799,19 +790,18 @@ fn web_intl_resolve_named_month_returns_calendar_ordinal_not_probe_slot() {
     // numeric months), but when a value is returned it must be the
     // canonical civil-order ordinal.
     if let Some(ordinal) =
-        WebIntlProvider::resolve_named_month(CalendarSystem::Hebrew, 5784, "Adar II")
+        WebIntlBackend::resolve_named_month(CalendarSystem::Hebrew, 5784, "Adar II")
     {
         assert_eq!(ordinal, 7, "Adar II must resolve to civil-order 7");
     }
 
     if let Some(ordinal) =
-        WebIntlProvider::resolve_named_month(CalendarSystem::Hebrew, 5784, "Adar I")
+        WebIntlBackend::resolve_named_month(CalendarSystem::Hebrew, 5784, "Adar I")
     {
         assert_eq!(ordinal, 6, "Adar I must resolve to civil-order 6");
     }
 
-    if let Some(ordinal) =
-        WebIntlProvider::resolve_named_month(CalendarSystem::Hebrew, 5785, "Adar")
+    if let Some(ordinal) = WebIntlBackend::resolve_named_month(CalendarSystem::Hebrew, 5785, "Adar")
     {
         assert_eq!(ordinal, 6, "Common-year Adar must resolve to civil-order 6");
     }
@@ -913,7 +903,7 @@ fn web_intl_resolve_named_month_resolves_english_ordinal_labels_without_probe() 
         "Twelfth Monthbis",
         "Seventh Monthbis",
     ] {
-        let ordinal = WebIntlProvider::resolve_named_month(CalendarSystem::Chinese, 2024, label);
+        let ordinal = WebIntlBackend::resolve_named_month(CalendarSystem::Chinese, 2024, label);
 
         assert!(
             matches!(ordinal, Some(o) if (1..=13).contains(&o)),
@@ -944,7 +934,7 @@ fn web_intl_resolve_named_month_reaches_leap_7_8_10_11_years() {
     let mut any_invalid = false;
 
     for label in candidates {
-        let ordinal = WebIntlProvider::resolve_named_month(CalendarSystem::Chinese, 2024, label);
+        let ordinal = WebIntlBackend::resolve_named_month(CalendarSystem::Chinese, 2024, label);
 
         match ordinal {
             Some(o) if (1..=13).contains(&o) => any_resolved = true,
@@ -976,17 +966,14 @@ fn web_intl_first_day_of_week_reads_week_info_property_shape() {
     // engine at test time, so assert that both pt-BR and en-US
     // resolve to Sunday on real runtimes — whichever shape the
     // browser uses, the answer should be the CLDR value.
-    let provider = WebIntlProvider;
+    let backend = WebIntlBackend;
 
     assert_eq!(
-        provider.first_day_of_week(&locale("pt-BR")),
+        backend.first_day_of_week(&locale("pt-BR")),
         Weekday::Sunday,
         "pt-BR must resolve to Sunday via either getWeekInfo() or weekInfo property"
     );
-    assert_eq!(
-        provider.first_day_of_week(&locale("en-US")),
-        Weekday::Sunday
-    );
+    assert_eq!(backend.first_day_of_week(&locale("en-US")), Weekday::Sunday);
 }
 
 #[wasm_bindgen_test]
@@ -1035,7 +1022,7 @@ fn web_intl_resolve_named_month_sweeps_beyond_24_25() {
 
     let resolved = candidates.iter().any(|label| {
         matches!(
-            WebIntlProvider::resolve_named_month(CalendarSystem::Chinese, 2024, label),
+            WebIntlBackend::resolve_named_month(CalendarSystem::Chinese, 2024, label),
             Some(o) if (1..=13).contains(&o)
         )
     });
@@ -1045,7 +1032,7 @@ fn web_intl_resolve_named_month_sweeps_beyond_24_25() {
     // `None` safely rather than panicking.
     if !resolved {
         assert_eq!(
-            WebIntlProvider::resolve_named_month(
+            WebIntlBackend::resolve_named_month(
                 CalendarSystem::Chinese,
                 2024,
                 "Definitely Not A Month"
@@ -1061,7 +1048,7 @@ fn web_intl_resolve_named_month_matches_common_year_adar() {
     // leap year), so common-year labels like "Adar" never matched and
     // `convert_date` silently fell back. The resolver now sweeps both a
     // leap and a common probe year.
-    let ordinal = WebIntlProvider::resolve_named_month(
+    let ordinal = WebIntlBackend::resolve_named_month(
         CalendarSystem::Hebrew,
         5785, // Common year — `rem_euclid(19) == 9`.
         "Adar",
@@ -1075,7 +1062,7 @@ fn web_intl_resolve_named_month_matches_common_year_adar() {
 
 #[wasm_bindgen_test]
 fn web_intl_resolve_named_month_resolves_known_hebrew_labels() {
-    // Direct coverage for `WebIntlProvider::resolve_named_month`: even if
+    // Direct coverage for `WebIntlBackend::resolve_named_month`: even if
     // Chrome emits a numeric month for Hebrew (bypassing the fallback
     // path in `convert_date`), the probe loop must still be able to
     // recognise the long labels the browser returns under `month: "long"`.
@@ -1091,7 +1078,7 @@ fn web_intl_resolve_named_month_resolves_known_hebrew_labels() {
         "Iyar", "Sivan", "Tammuz", "Av", "Elul",
     ] {
         if let Some(ordinal) =
-            WebIntlProvider::resolve_named_month(CalendarSystem::Hebrew, 5784, label)
+            WebIntlBackend::resolve_named_month(CalendarSystem::Hebrew, 5784, label)
         {
             assert!(
                 (1..=13).contains(&ordinal),
@@ -1102,11 +1089,7 @@ fn web_intl_resolve_named_month_resolves_known_hebrew_labels() {
 
     // A nonsense label must not match any month slot.
     assert_eq!(
-        WebIntlProvider::resolve_named_month(
-            CalendarSystem::Hebrew,
-            5784,
-            "Definitely Not A Month"
-        ),
+        WebIntlBackend::resolve_named_month(CalendarSystem::Hebrew, 5784, "Definitely Not A Month"),
         None
     );
 }
@@ -1225,11 +1208,11 @@ fn web_intl_convert_date_preserves_roc_era_round_trip() {
     // conversion must land in the `roc` era (Republic of China year
     // 113) rather than a bogus `minguo` code that would fail the
     // internal-bridge round-trip.
-    let provider = WebIntlProvider;
+    let backend = WebIntlBackend;
 
     let gregorian = gregorian_date(2024, 6, 15);
 
-    let roc = provider.convert_date(&gregorian, CalendarSystem::Roc);
+    let roc = backend.convert_date(&gregorian, CalendarSystem::Roc);
 
     assert_eq!(roc.calendar(), CalendarSystem::Roc);
 
@@ -1266,11 +1249,11 @@ fn web_intl_convert_date_routes_japanese_historical_eras_through_bridge() {
     // Gregorian 1800-06-15 (inside the Kansei era, 1789–1801)
     // resolves to a valid Japanese date with a Kansei / historical
     // CLDR code — never Reiwa.
-    let provider = WebIntlProvider;
+    let backend = WebIntlBackend;
 
     let gregorian = gregorian_date(1800, 6, 15);
 
-    let japanese = provider.convert_date(&gregorian, CalendarSystem::Japanese);
+    let japanese = backend.convert_date(&gregorian, CalendarSystem::Japanese);
 
     assert_eq!(japanese.calendar(), CalendarSystem::Japanese);
 
@@ -1301,12 +1284,12 @@ fn web_intl_convert_date_preserves_modern_japanese_allow_list_hits() {
     // behavior for the common Reiwa/Heisei/Showa/Taishō/Meiji case,
     // which still runs through `era_code_for_calendar` rather than
     // the bridge fallback.
-    let provider = WebIntlProvider;
+    let backend = WebIntlBackend;
 
     // Gregorian 2020-06-15 is deep inside Reiwa (2019+).
     let gregorian = gregorian_date(2020, 6, 15);
 
-    let japanese = provider.convert_date(&gregorian, CalendarSystem::Japanese);
+    let japanese = backend.convert_date(&gregorian, CalendarSystem::Japanese);
 
     let era = japanese
         .era()
@@ -1376,7 +1359,7 @@ fn web_intl_resolve_named_month_recovers_when_2_digit_returns_names() {
 
     for (label, expected) in labels_and_expected {
         if let Some(ordinal) =
-            WebIntlProvider::resolve_named_month(CalendarSystem::Hebrew, 5784, label)
+            WebIntlBackend::resolve_named_month(CalendarSystem::Hebrew, 5784, label)
         {
             assert_eq!(
                 ordinal, expected,

--- a/crates/ars-leptos/src/attrs.rs
+++ b/crates/ars-leptos/src/attrs.rs
@@ -12,8 +12,10 @@ use crate::provider::{current_ars_context, warn_missing_provider};
 pub struct LeptosAttrResult {
     /// HTML attribute tuples ready to spread onto a Leptos element.
     pub attrs: Vec<(String, String)>,
+
     /// CSS properties to apply via CSSOM when [`StyleStrategy::Cssom`] is active.
     pub cssom_styles: Vec<(CssProperty, String)>,
+
     /// Nonce-safe CSS rule text collected when [`StyleStrategy::Nonce`] is active.
     pub nonce_css: String,
 }
@@ -33,6 +35,7 @@ pub fn attr_map_to_leptos(
     element_id: Option<&str>,
 ) -> LeptosAttrResult {
     let parts = map.into_parts();
+
     let mut attrs = parts
         .attrs
         .into_iter()
@@ -44,6 +47,7 @@ pub fn attr_map_to_leptos(
         .collect::<Vec<_>>();
 
     let mut cssom_styles = Vec::new();
+
     let mut nonce_css = String::new();
 
     match strategy {
@@ -55,16 +59,21 @@ pub fn attr_map_to_leptos(
                     .map(|(property, value)| format!("{property}: {value};"))
                     .collect::<Vec<_>>()
                     .join(" ");
+
                 attrs.push((String::from("style"), style));
             }
         }
+
         StyleStrategy::Cssom => {
             cssom_styles = parts.styles;
         }
+
         StyleStrategy::Nonce(_) => {
             if !parts.styles.is_empty() {
                 let id = element_id.expect("element_id is required for Nonce style strategy");
+
                 attrs.push((String::from("data-ars-style-id"), String::from(id)));
+
                 nonce_css = styles_to_nonce_css(id, &parts.styles);
             }
         }
@@ -81,6 +90,7 @@ pub fn attr_map_to_leptos(
 #[cfg(not(feature = "ssr"))]
 pub fn apply_styles_cssom(el: &leptos::web_sys::HtmlElement, styles: &[(CssProperty, String)]) {
     let style = el.style();
+
     for (property, value) in styles {
         drop(style.set_property(&property.to_string(), value));
     }
@@ -106,6 +116,7 @@ fn styles_to_nonce_css(id: &str, styles: &[(CssProperty, String)]) -> String {
         .map(|(property, value)| format!("  {property}: {value};"))
         .collect::<Vec<_>>()
         .join("\n");
+
     format!("[data-ars-style-id=\"{id}\"] {{\n{declarations}\n}}")
 }
 
@@ -121,6 +132,7 @@ mod tests {
     #[test]
     fn inline_strategy_emits_style_attribute() {
         let mut map = AttrMap::new();
+
         map.set(HtmlAttr::Id, "button-id");
         map.set_style(CssProperty::Display, "inline-flex");
         map.set_style(CssProperty::Width, "10px");
@@ -144,6 +156,7 @@ mod tests {
     #[test]
     fn inline_strategy_skips_style_attribute_when_no_styles_exist() {
         let mut map = AttrMap::new();
+
         map.set(HtmlAttr::Id, "button-id");
 
         let result = attr_map_to_leptos(map, &StyleStrategy::Inline, None);
@@ -159,6 +172,7 @@ mod tests {
     #[test]
     fn cssom_strategy_returns_cssom_styles() {
         let mut map = AttrMap::new();
+
         map.set(HtmlAttr::Title, "tooltip");
         map.set_style(CssProperty::Display, "grid");
         map.set_style(CssProperty::Width, "20px");
@@ -182,6 +196,7 @@ mod tests {
     #[test]
     fn nonce_strategy_emits_selector_and_css_text() {
         let mut map = AttrMap::new();
+
         map.set(HtmlAttr::Class, "root");
         map.set_style(CssProperty::Display, "flex");
 
@@ -211,6 +226,7 @@ mod tests {
     #[test]
     fn nonce_strategy_skips_selector_and_css_when_no_styles_exist() {
         let mut map = AttrMap::new();
+
         map.set(HtmlAttr::Class, "root");
 
         let result = attr_map_to_leptos(
@@ -230,6 +246,7 @@ mod tests {
     #[test]
     fn bool_false_and_none_are_filtered_while_bool_true_is_empty_string() {
         let mut map = AttrMap::new();
+
         map.set_bool(HtmlAttr::Disabled, true);
         map.set_bool(HtmlAttr::Required, false);
         map.set(HtmlAttr::Title, AttrValue::None);
@@ -245,6 +262,7 @@ mod tests {
     #[test]
     fn use_style_strategy_falls_back_to_inline_without_context() {
         let owner = Owner::new();
+
         owner.with(|| {
             assert_eq!(use_style_strategy(), StyleStrategy::Inline);
         });
@@ -253,6 +271,7 @@ mod tests {
     #[test]
     fn use_style_strategy_reads_configured_context_value() {
         let owner = Owner::new();
+
         owner.with(|| {
             crate::provide_ars_context(crate::ArsContext::new(
                 ars_i18n::locales::en_us(),
@@ -264,7 +283,7 @@ mod tests {
                 None,
                 None,
                 Arc::new(NullPlatformEffects),
-                Arc::new(ars_i18n::StubIcuProvider),
+                Arc::new(ars_i18n::StubIntlBackend),
                 Arc::new(I18nRegistries::new()),
                 StyleStrategy::Nonce(String::from("nonce-456")),
             ));
@@ -280,6 +299,7 @@ mod tests {
     #[should_panic(expected = "element_id is required for Nonce style strategy")]
     fn nonce_strategy_requires_element_id() {
         let mut map = AttrMap::new();
+
         map.set_style(CssProperty::Display, "block");
 
         drop(attr_map_to_leptos(
@@ -312,6 +332,7 @@ mod wasm_tests {
             .expect("create_element should succeed")
             .dyn_into::<leptos::web_sys::HtmlElement>()
             .expect("element should cast to HtmlElement");
+
         let styles = vec![
             (CssProperty::Width, String::from("120px")),
             (CssProperty::Display, String::from("block")),
@@ -320,6 +341,7 @@ mod wasm_tests {
         apply_styles_cssom(&element, &styles);
 
         let style = element.style();
+
         assert_eq!(
             style
                 .get_property_value("width")

--- a/crates/ars-leptos/src/lib.rs
+++ b/crates/ars-leptos/src/lib.rs
@@ -27,7 +27,7 @@ pub use ephemeral::EphemeralRef;
 pub use id::reset_id_counter;
 pub use id::use_id;
 pub use provider::{
-    ArsContext, provide_ars_context, resolve_locale, t, use_icu_provider, use_locale, use_messages,
+    ArsContext, provide_ars_context, resolve_locale, t, use_intl_backend, use_locale, use_messages,
     use_number_formatter, warn_missing_provider,
 };
 pub use use_machine::{UseMachineReturn, use_machine, use_machine_with_reactive_props};
@@ -40,6 +40,7 @@ pub const ADAPTER_NAME: &str = "leptos";
 pub struct AdapterCapabilities {
     /// `true` if server-side rendering is enabled.
     pub ssr: bool,
+
     /// `true` if client-side hydration of server-rendered markup is enabled.
     pub hydrate: bool,
 }

--- a/crates/ars-leptos/src/provider.rs
+++ b/crates/ars-leptos/src/provider.rs
@@ -4,14 +4,17 @@
 //! exposes adapter-level helpers for locale, ICU, message resolution, and
 //! reactive application text rendering.
 
-use std::sync::Arc;
+use std::{
+    fmt::{self, Debug},
+    sync::Arc,
+};
 
 use ars_core::{
     ColorMode, I18nRegistries, PlatformEffects, StyleStrategy,
     resolve_messages as core_resolve_messages,
 };
 use ars_i18n::{
-    Direction, IcuProvider, Locale, NumberFormatOptions, NumberFormatter, StubIcuProvider,
+    Direction, IntlBackend, Locale, NumberFormatOptions, NumberFormatter, StubIntlBackend,
     Translate, locales,
 };
 use leptos::{prelude::*, reactive::owner::LocalStorage};
@@ -47,7 +50,7 @@ pub struct ArsContext {
     pub platform: Arc<dyn PlatformEffects>,
 
     /// ICU-backed locale data provider.
-    pub icu_provider: Arc<dyn IcuProvider>,
+    pub intl_backend: Arc<dyn IntlBackend>,
 
     /// Application-owned message registries.
     pub i18n_registries: Arc<I18nRegistries>,
@@ -56,8 +59,8 @@ pub struct ArsContext {
     style_strategy: StyleStrategy,
 }
 
-impl std::fmt::Debug for ArsContext {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Debug for ArsContext {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ArsContext")
             .field("locale", &self.locale)
             .field("direction", &self.direction)
@@ -68,7 +71,7 @@ impl std::fmt::Debug for ArsContext {
             .field("portal_container_id", &self.portal_container_id)
             .field("root_node_id", &self.root_node_id)
             .field("platform", &"Arc(..)")
-            .field("icu_provider", &"Arc(..)")
+            .field("intl_backend", &"Arc(..)")
             .field("i18n_registries", &"Arc(..)")
             .field("style_strategy", &self.style_strategy)
             .finish()
@@ -92,7 +95,7 @@ impl ArsContext {
         portal_container_id: Option<String>,
         root_node_id: Option<String>,
         platform: Arc<dyn PlatformEffects>,
-        icu_provider: Arc<dyn IcuProvider>,
+        intl_backend: Arc<dyn IntlBackend>,
         i18n_registries: Arc<I18nRegistries>,
         style_strategy: StyleStrategy,
     ) -> Self {
@@ -106,7 +109,7 @@ impl ArsContext {
             portal_container_id: Signal::stored(portal_container_id),
             root_node_id: Signal::stored(root_node_id),
             platform,
-            icu_provider,
+            intl_backend,
             i18n_registries,
             style_strategy,
         }
@@ -155,14 +158,14 @@ pub fn use_locale() -> Signal<Locale> {
 
 /// Resolves the current ICU provider from provider context.
 #[must_use]
-pub fn use_icu_provider() -> Arc<dyn IcuProvider> {
+pub fn use_intl_backend() -> Arc<dyn IntlBackend> {
     current_ars_context().map_or_else(
-        || -> Arc<dyn IcuProvider> {
-            warn_missing_provider("use_icu_provider");
+        || -> Arc<dyn IntlBackend> {
+            warn_missing_provider("use_intl_backend");
 
-            Arc::new(StubIcuProvider)
+            Arc::new(StubIntlBackend)
         },
-        |ctx| -> Arc<dyn IcuProvider> { Arc::clone(&ctx.icu_provider) },
+        |ctx| -> Arc<dyn IntlBackend> { Arc::clone(&ctx.intl_backend) },
     )
 }
 
@@ -191,7 +194,9 @@ where
     F: Fn() -> NumberFormatOptions + 'static,
 {
     let explicit_locale = adapter_props_locale.cloned();
+
     let locale = use_locale();
+
     let cache =
         StoredValue::<Option<(Locale, NumberFormatOptions, NumberFormatter)>, LocalStorage>::new_local(
             None,
@@ -252,9 +257,9 @@ pub fn use_messages<M: ars_core::ComponentMessages + Send + Sync + 'static>(
 fn translated_text<T: Translate + Send + Sync + 'static>(msg: T) -> impl Fn() -> String {
     let locale = use_locale();
 
-    let icu = use_icu_provider();
+    let intl_backend = use_intl_backend();
 
-    move || msg.translate(&locale.get(), &*icu)
+    move || msg.translate(&locale.get(), &*intl_backend)
 }
 
 /// Resolves application-owned translatable text into a reactive text node.
@@ -270,12 +275,12 @@ mod tests {
 
     use ars_core::{ColorMode, I18nRegistries, NullPlatformEffects, StyleStrategy};
     use ars_i18n::{
-        Direction, IcuProvider, Locale, NumberFormatOptions, StubIcuProvider, Translate, locales,
+        Direction, IntlBackend, Locale, NumberFormatOptions, StubIntlBackend, Translate, locales,
     };
     use leptos::prelude::{Get, GetUntracked, Memo, Owner, RwSignal, Set, Signal};
 
     use super::{
-        ArsContext, current_ars_context, resolve_locale, t, translated_text, use_icu_provider,
+        ArsContext, current_ars_context, resolve_locale, t, translated_text, use_intl_backend,
         use_locale, use_messages, use_number_formatter, use_resolved_number_formatter,
     };
 
@@ -300,7 +305,7 @@ mod tests {
     }
 
     impl Translate for AppText {
-        fn translate(&self, locale: &Locale, _icu: &dyn IcuProvider) -> String {
+        fn translate(&self, locale: &Locale, _intl: &dyn IntlBackend) -> String {
             match locale.language() {
                 "es" => String::from("Hola"),
                 _ => String::from("Hello"),
@@ -308,13 +313,50 @@ mod tests {
         }
     }
 
-    struct TestIcuProvider;
+    struct TestIntlBackend;
 
-    impl IcuProvider for TestIcuProvider {}
+    impl IntlBackend for TestIntlBackend {
+        fn weekday_short_label(&self, weekday: ars_i18n::Weekday, locale: &Locale) -> String {
+            StubIntlBackend.weekday_short_label(weekday, locale)
+        }
+
+        fn weekday_long_label(&self, weekday: ars_i18n::Weekday, locale: &Locale) -> String {
+            StubIntlBackend.weekday_long_label(weekday, locale)
+        }
+
+        fn month_long_name(&self, month: u8, locale: &Locale) -> String {
+            StubIntlBackend.month_long_name(month, locale)
+        }
+
+        fn day_period_label(&self, is_pm: bool, locale: &Locale) -> String {
+            StubIntlBackend.day_period_label(is_pm, locale)
+        }
+
+        fn day_period_from_char(&self, ch: char, locale: &Locale) -> Option<bool> {
+            StubIntlBackend.day_period_from_char(ch, locale)
+        }
+
+        fn format_segment_digits(
+            &self,
+            value: u32,
+            min_digits: core::num::NonZero<u8>,
+            locale: &Locale,
+        ) -> String {
+            StubIntlBackend.format_segment_digits(value, min_digits, locale)
+        }
+
+        fn hour_cycle(&self, locale: &Locale) -> ars_i18n::HourCycle {
+            StubIntlBackend.hour_cycle(locale)
+        }
+
+        fn week_info(&self, locale: &Locale) -> ars_i18n::WeekInfo {
+            StubIntlBackend.week_info(locale)
+        }
+    }
 
     fn reactive_test_context(
         locale: Locale,
-        icu_provider: Arc<dyn IcuProvider>,
+        intl_backend: Arc<dyn IntlBackend>,
     ) -> (ArsContext, RwSignal<Locale>) {
         let locale_signal = RwSignal::new(locale);
 
@@ -328,12 +370,69 @@ mod tests {
             portal_container_id: Signal::stored(None),
             root_node_id: Signal::stored(None),
             platform: Arc::new(NullPlatformEffects),
-            icu_provider,
+            intl_backend,
             i18n_registries: Arc::new(I18nRegistries::new()),
             style_strategy: StyleStrategy::Inline,
         };
 
         (context, locale_signal)
+    }
+
+    #[test]
+    fn ars_context_debug_redacts_arc_backed_fields() {
+        let owner = Owner::new();
+
+        owner.with(|| {
+            let (context, _) = reactive_test_context(locales::en_us(), Arc::new(TestIntlBackend));
+
+            let debug = format!("{context:?}");
+
+            assert!(debug.contains("ArsContext"));
+            assert!(debug.contains("platform: \"Arc(..)\""));
+            assert!(debug.contains("intl_backend: \"Arc(..)\""));
+            assert!(debug.contains("i18n_registries: \"Arc(..)\""));
+        });
+    }
+
+    #[test]
+    fn test_intl_backend_delegates_required_methods_to_stub() {
+        let backend = TestIntlBackend;
+
+        let locale = locales::en_us();
+
+        assert_eq!(
+            backend.weekday_short_label(ars_i18n::Weekday::Monday, &locale),
+            StubIntlBackend.weekday_short_label(ars_i18n::Weekday::Monday, &locale)
+        );
+        assert_eq!(
+            backend.weekday_long_label(ars_i18n::Weekday::Monday, &locale),
+            StubIntlBackend.weekday_long_label(ars_i18n::Weekday::Monday, &locale)
+        );
+        assert_eq!(
+            backend.month_long_name(5, &locale),
+            StubIntlBackend.month_long_name(5, &locale)
+        );
+        assert_eq!(
+            backend.day_period_label(false, &locale),
+            StubIntlBackend.day_period_label(false, &locale)
+        );
+        assert_eq!(backend.day_period_from_char('p', &locale), Some(true));
+        assert_eq!(
+            backend.format_segment_digits(
+                7,
+                core::num::NonZero::new(2).expect("minimum digits should be non-zero"),
+                &locale,
+            ),
+            "07"
+        );
+        assert_eq!(
+            backend.hour_cycle(&locale),
+            StubIntlBackend.hour_cycle(&locale)
+        );
+        assert_eq!(
+            backend.week_info(&locale),
+            StubIntlBackend.week_info(&locale)
+        );
     }
 
     fn direction_from_locale(locale: &Locale) -> Direction {
@@ -346,9 +445,9 @@ mod tests {
 
     fn test_context_with_defaults(
         locale: Locale,
-        icu_provider: Arc<dyn IcuProvider>,
+        intl_backend: Arc<dyn IntlBackend>,
     ) -> ArsContext {
-        let (context, _) = reactive_test_context(locale, icu_provider);
+        let (context, _) = reactive_test_context(locale, intl_backend);
 
         context
     }
@@ -369,7 +468,7 @@ mod tests {
         owner.with(|| {
             crate::provide_ars_context(test_context_with_defaults(
                 Locale::parse("fr-FR").expect("locale should parse"),
-                Arc::new(StubIcuProvider),
+                Arc::new(StubIntlBackend),
             ));
 
             let override_locale = Locale::parse("pt-BR").expect("locale should parse");
@@ -388,7 +487,7 @@ mod tests {
 
             crate::provide_ars_context(test_context_with_defaults(
                 Locale::parse("fr-FR").expect("locale should parse"),
-                Arc::new(StubIcuProvider),
+                Arc::new(StubIntlBackend),
             ));
 
             let current = current_ars_context().expect("provider context should exist");
@@ -398,30 +497,30 @@ mod tests {
     }
 
     #[test]
-    fn use_icu_provider_reads_context_value() {
+    fn use_intl_backend_reads_context_value() {
         let owner = Owner::new();
 
         owner.with(|| {
-            let expected: Arc<dyn IcuProvider> = Arc::new(TestIcuProvider);
+            let expected: Arc<dyn IntlBackend> = Arc::new(TestIntlBackend);
 
             crate::provide_ars_context(test_context_with_defaults(
                 locales::en_us(),
                 Arc::clone(&expected),
             ));
 
-            assert!(Arc::ptr_eq(&use_icu_provider(), &expected));
+            assert!(Arc::ptr_eq(&use_intl_backend(), &expected));
         });
     }
 
     #[test]
-    fn use_icu_provider_falls_back_without_provider() {
+    fn use_intl_backend_falls_back_without_provider() {
         let owner = Owner::new();
 
         owner.with(|| {
-            let provider = use_icu_provider();
+            let backend = use_intl_backend();
 
             assert_eq!(
-                AppText::Greeting.translate(&locales::en_us(), &*provider),
+                AppText::Greeting.translate(&locales::en_us(), &*backend),
                 "Hello"
             );
         });
@@ -453,7 +552,7 @@ mod tests {
                 None,
                 None,
                 Arc::new(NullPlatformEffects),
-                Arc::new(StubIcuProvider),
+                Arc::new(StubIntlBackend),
                 Arc::new(registries),
                 StyleStrategy::Inline,
             ));
@@ -485,7 +584,7 @@ mod tests {
 
         owner.with(|| {
             let (context, locale_signal) =
-                reactive_test_context(locales::en_us(), Arc::new(StubIcuProvider));
+                reactive_test_context(locales::en_us(), Arc::new(StubIntlBackend));
 
             crate::provide_ars_context(context);
 
@@ -517,7 +616,7 @@ mod tests {
         owner.with(|| {
             crate::provide_ars_context(test_context_with_defaults(
                 locales::de_de(),
-                Arc::new(StubIcuProvider),
+                Arc::new(StubIntlBackend),
             ));
 
             let formatter = use_number_formatter(NumberFormatOptions::default);
@@ -532,7 +631,7 @@ mod tests {
 
         owner.with(|| {
             let (context, locale_signal) =
-                reactive_test_context(locales::en_us(), Arc::new(StubIcuProvider));
+                reactive_test_context(locales::en_us(), Arc::new(StubIntlBackend));
 
             crate::provide_ars_context(context);
 
@@ -547,13 +646,33 @@ mod tests {
     }
 
     #[test]
+    fn use_number_formatter_reuses_cached_formatter_for_identical_inputs() {
+        let owner = Owner::new();
+
+        owner.with(|| {
+            crate::provide_ars_context(test_context_with_defaults(
+                locales::en_us(),
+                Arc::new(StubIntlBackend),
+            ));
+
+            let formatter = use_number_formatter(NumberFormatOptions::default);
+
+            let first = formatter.get_untracked();
+            let second = formatter.get_untracked();
+
+            assert_eq!(first, second);
+            assert_eq!(second.format(1234.56), "1,234.56");
+        });
+    }
+
+    #[test]
     fn use_resolved_number_formatter_prefers_explicit_locale_override() {
         let owner = Owner::new();
 
         owner.with(|| {
             crate::provide_ars_context(test_context_with_defaults(
                 locales::fr(),
-                Arc::new(StubIcuProvider),
+                Arc::new(StubIntlBackend),
             ));
 
             let explicit = locales::de_de();
@@ -572,7 +691,7 @@ mod tests {
         owner.with(|| {
             crate::provide_ars_context(test_context_with_defaults(
                 locales::en_us(),
-                Arc::new(StubIcuProvider),
+                Arc::new(StubIntlBackend),
             ));
 
             drop(t(AppText::Greeting));
@@ -590,13 +709,13 @@ mod wasm_tests {
 
     use ars_core::{ColorMode, I18nRegistries, NullPlatformEffects, StyleStrategy};
     use ars_i18n::{
-        Direction, IcuProvider, Locale, NumberFormatOptions, StubIcuProvider, Translate, locales,
+        Direction, IntlBackend, Locale, NumberFormatOptions, StubIntlBackend, Translate, locales,
     };
     use leptos::prelude::{Get, GetUntracked, Memo, Owner, RwSignal, Set, Signal};
     use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
 
     use super::{
-        ArsContext, current_ars_context, resolve_locale, t, translated_text, use_icu_provider,
+        ArsContext, current_ars_context, resolve_locale, t, translated_text, use_intl_backend,
         use_locale, use_number_formatter,
     };
 
@@ -608,7 +727,7 @@ mod wasm_tests {
     }
 
     impl Translate for AppText {
-        fn translate(&self, locale: &Locale, _icu: &dyn IcuProvider) -> String {
+        fn translate(&self, locale: &Locale, _intl: &dyn IntlBackend) -> String {
             match locale.language() {
                 "es" => String::from("Hola"),
                 _ => String::from("Hello"),
@@ -616,9 +735,46 @@ mod wasm_tests {
         }
     }
 
-    struct TestIcuProvider;
+    struct TestIntlBackend;
 
-    impl IcuProvider for TestIcuProvider {}
+    impl IntlBackend for TestIntlBackend {
+        fn weekday_short_label(&self, weekday: ars_i18n::Weekday, locale: &Locale) -> String {
+            StubIntlBackend.weekday_short_label(weekday, locale)
+        }
+
+        fn weekday_long_label(&self, weekday: ars_i18n::Weekday, locale: &Locale) -> String {
+            StubIntlBackend.weekday_long_label(weekday, locale)
+        }
+
+        fn month_long_name(&self, month: u8, locale: &Locale) -> String {
+            StubIntlBackend.month_long_name(month, locale)
+        }
+
+        fn day_period_label(&self, is_pm: bool, locale: &Locale) -> String {
+            StubIntlBackend.day_period_label(is_pm, locale)
+        }
+
+        fn day_period_from_char(&self, ch: char, locale: &Locale) -> Option<bool> {
+            StubIntlBackend.day_period_from_char(ch, locale)
+        }
+
+        fn format_segment_digits(
+            &self,
+            value: u32,
+            min_digits: core::num::NonZero<u8>,
+            locale: &Locale,
+        ) -> String {
+            StubIntlBackend.format_segment_digits(value, min_digits, locale)
+        }
+
+        fn hour_cycle(&self, locale: &Locale) -> ars_i18n::HourCycle {
+            StubIntlBackend.hour_cycle(locale)
+        }
+
+        fn week_info(&self, locale: &Locale) -> ars_i18n::WeekInfo {
+            StubIntlBackend.week_info(locale)
+        }
+    }
 
     fn direction_from_locale(locale: &Locale) -> Direction {
         if locale.direction().is_rtl() {
@@ -630,7 +786,7 @@ mod wasm_tests {
 
     fn reactive_test_context(
         locale: Locale,
-        icu_provider: Arc<dyn IcuProvider>,
+        intl_backend: Arc<dyn IntlBackend>,
     ) -> (ArsContext, RwSignal<Locale>) {
         let locale_signal = RwSignal::new(locale);
 
@@ -644,7 +800,7 @@ mod wasm_tests {
             portal_container_id: Signal::stored(None),
             root_node_id: Signal::stored(None),
             platform: Arc::new(NullPlatformEffects),
-            icu_provider,
+            intl_backend,
             i18n_registries: Arc::new(I18nRegistries::new()),
             style_strategy: StyleStrategy::Inline,
         };
@@ -658,7 +814,7 @@ mod wasm_tests {
 
         owner.with(|| {
             let (context, locale_signal) =
-                reactive_test_context(locales::en_us(), Arc::new(StubIcuProvider));
+                reactive_test_context(locales::en_us(), Arc::new(StubIntlBackend));
 
             crate::provide_ars_context(context);
 
@@ -681,7 +837,7 @@ mod wasm_tests {
         owner.with(|| {
             assert!(current_ars_context().is_none());
 
-            let (context, _) = reactive_test_context(locales::en_us(), Arc::new(StubIcuProvider));
+            let (context, _) = reactive_test_context(locales::en_us(), Arc::new(StubIntlBackend));
 
             crate::provide_ars_context(context);
 
@@ -692,19 +848,19 @@ mod wasm_tests {
     }
 
     #[wasm_bindgen_test]
-    fn locale_and_icu_provider_are_readable_on_wasm() {
+    fn locale_and_intl_backend_are_readable_on_wasm() {
         let owner = Owner::new();
 
         owner.with(|| {
-            let expected_provider: Arc<dyn IcuProvider> = Arc::new(TestIcuProvider);
+            let expected_backend: Arc<dyn IntlBackend> = Arc::new(TestIntlBackend);
 
             let (context, _) =
-                reactive_test_context(locales::en_us(), Arc::clone(&expected_provider));
+                reactive_test_context(locales::en_us(), Arc::clone(&expected_backend));
 
             crate::provide_ars_context(context);
 
             assert_eq!(use_locale().get_untracked().to_bcp47(), "en-US");
-            assert!(Arc::ptr_eq(&use_icu_provider(), &expected_provider));
+            assert!(Arc::ptr_eq(&use_intl_backend(), &expected_backend));
         });
     }
 
@@ -718,14 +874,14 @@ mod wasm_tests {
     }
 
     #[wasm_bindgen_test]
-    fn use_icu_provider_falls_back_without_provider_on_wasm() {
+    fn use_intl_backend_falls_back_without_provider_on_wasm() {
         let owner = Owner::new();
 
         owner.with(|| {
-            let provider = use_icu_provider();
+            let backend = use_intl_backend();
 
             assert_eq!(
-                AppText::Greeting.translate(&locales::en_us(), &*provider),
+                AppText::Greeting.translate(&locales::en_us(), &*backend),
                 "Hello"
             );
         });
@@ -736,7 +892,7 @@ mod wasm_tests {
         let owner = Owner::new();
 
         owner.with(|| {
-            let (context, _) = reactive_test_context(locales::en_us(), Arc::new(StubIcuProvider));
+            let (context, _) = reactive_test_context(locales::en_us(), Arc::new(StubIntlBackend));
 
             crate::provide_ars_context(context);
 
@@ -764,7 +920,7 @@ mod wasm_tests {
 
         owner.with(|| {
             let (context, locale_signal) =
-                reactive_test_context(locales::en_us(), Arc::new(StubIcuProvider));
+                reactive_test_context(locales::en_us(), Arc::new(StubIntlBackend));
 
             crate::provide_ars_context(context);
 

--- a/crates/ars-leptos/src/use_machine.rs
+++ b/crates/ars-leptos/src/use_machine.rs
@@ -16,7 +16,7 @@ use {ars_core::StrongSend, std::sync::Arc};
 
 use crate::{
     ephemeral::EphemeralRef,
-    provider::{resolve_locale, use_icu_provider, use_messages},
+    provider::{resolve_locale, use_intl_backend, use_messages},
     use_id,
 };
 
@@ -111,6 +111,7 @@ where
                 #[cfg(debug_assertions)]
                 panic!("Cannot send events inside with_api_snapshot — use event handlers instead");
             });
+
             f(&api)
         })
     }
@@ -137,12 +138,15 @@ where
             // Subscribe to both state and context_version so the memo
             // re-computes when either changes.
             state.track();
+
             context_version.track();
+
             service.with_value(|svc| {
                 let api = svc.connect(&|_e| {
                     #[cfg(debug_assertions)]
                     panic!("Cannot send events inside derive() — use event handlers instead");
                 });
+
                 f(&api)
             })
         })
@@ -159,7 +163,9 @@ where
         let send = self.send;
         self.service.with_value(|svc| {
             let send_fn = move |e| send.run(e);
+
             let api = svc.connect(&send_fn);
+
             f(EphemeralRef::new(api))
         })
     }
@@ -178,7 +184,8 @@ where
 /// pub fn Toggle() -> impl IntoView {
 ///     let machine = use_machine::<toggle::Machine>(toggle::Props::default());
 ///     let is_on = machine.derive(|api| api.is_on());
-///     view! {
+///
+///      view! {
 ///         <button on:click=move |_| machine.send.run(toggle::Event::Toggle)>
 ///             {move || if is_on.get() { "ON" } else { "OFF" }}
 ///         </button>
@@ -194,6 +201,7 @@ where
     M::Messages: Send + Sync + 'static,
 {
     let (result, ..) = use_machine_inner::<M>(props);
+
     result
 }
 
@@ -213,42 +221,57 @@ where
     M::Messages: Send + Sync + 'static,
 {
     let initial_props = props_signal.get();
+
     let (result, context_version_write, state_write, send_ref, effect_cleanups) =
         use_machine_inner::<M>(initial_props);
 
     let service = result.service;
+
     let prev_props = StoredValue::<Option<M::Props>>::new(None);
 
     let sync_effect = ImmediateEffect::new_isomorphic(move || {
         let new_props = props_signal.get();
+
         let should_sync = prev_props.with_value(|prev| prev.as_ref() != Some(&new_props));
+
         if should_sync {
             let is_initial = prev_props.with_value(Option::is_none);
+
             if !is_initial {
                 let mut extracted = None;
+
                 service.update_value(|svc| {
                     let send_result = svc.set_props(new_props.clone());
+
                     if send_result.state_changed {
                         state_write.set(svc.state().clone());
                     }
+
                     if send_result.context_changed {
                         context_version_write.update(|version| *version += 1);
                     }
+
                     let ctx = svc.context().clone();
+
                     let props = svc.props().clone();
+
                     extracted = Some((send_result, ctx, props));
                 });
 
                 let (send_result, ctx, props) =
                     extracted.expect("service update should extract send result");
+
                 #[cfg(feature = "ssr")]
                 handle_effects::<M>(&send_result, &ctx, &props, send_ref, effect_cleanups);
+
                 #[cfg(not(feature = "ssr"))]
                 handle_effects::<M>(send_result, &ctx, &props, send_ref, effect_cleanups);
             }
+
             prev_props.set_value(Some(new_props));
         }
     });
+
     on_cleanup(move || drop(sync_effect));
 
     result
@@ -278,18 +301,23 @@ where
 {
     let props = {
         let mut props = props;
+
         if props.id().is_empty() {
             props.set_id(use_id("component"));
         }
+
         props
     };
 
     let locale = resolve_locale(None);
-    let icu_provider = use_icu_provider();
+
+    let intl_backend = use_intl_backend();
+
     let messages = use_messages::<M::Messages>(None, Some(&locale));
+
     let env = Env {
         locale,
-        icu_provider,
+        intl_backend,
     };
 
     // Create the service once — runs only on component initialization.
@@ -297,6 +325,7 @@ where
 
     // Create a signal tracking the current state.
     let initial_state = service.with_value(|s| s.state().clone());
+
     let (state_read, state_write) = signal(initial_state);
 
     // Context version counter — incremented on every context change so that
@@ -304,6 +333,7 @@ where
     let (context_version_read, context_version_write) = signal(0u64);
 
     let effect_cleanups: EffectCleanupStore = StoredValue::new_local(HashMap::new());
+
     let send_ref: SendCallbackRef<M> = StoredValue::new(None);
 
     // Build the send callback. When an event is sent:
@@ -312,22 +342,30 @@ where
     // 3. Update signals if state/context changed
     let send = Callback::new(move |event: M::Event| {
         let mut extracted = None;
+
         service.update_value(|s| {
             let send_result = s.send(event);
+
             if send_result.state_changed {
                 state_write.set(s.state().clone());
             }
+
             if send_result.context_changed {
                 context_version_write.update(|version| *version += 1);
             }
+
             let ctx = s.context().clone();
+
             let props = s.props().clone();
+
             extracted = Some((send_result, ctx, props));
         });
 
         let (send_result, ctx, props) = extracted.expect("service update should extract result");
+
         #[cfg(feature = "ssr")]
         handle_effects::<M>(&send_result, &ctx, &props, send_ref, effect_cleanups);
+
         #[cfg(not(feature = "ssr"))]
         handle_effects::<M>(send_result, &ctx, &props, send_ref, effect_cleanups);
     });
@@ -337,9 +375,11 @@ where
     // Clean up effects when the component unmounts.
     on_cleanup(move || {
         let mut cleanups = Vec::new();
+
         effect_cleanups.update_value(|active| {
             cleanups.extend(active.drain().map(|(_, cleanup)| cleanup));
         });
+
         service.update_value(|svc| {
             svc.unmount(cleanups);
         });
@@ -408,6 +448,7 @@ fn handle_effects<M: Machine + 'static>(
                     cleanup();
                 }
             }
+
             for effect in &send_result.pending_effects {
                 if let Some(cleanup) = cleanups.remove(effect.name) {
                     cleanup();
@@ -422,9 +463,12 @@ fn handle_effects<M: Machine + 'static>(
 
     if let Some(send_callback) = send_ref.with_value(|slot| slot.as_ref().copied()) {
         let send_handle = callback_to_strong_send(send_callback);
+
         for effect in send_result.pending_effects {
             let name = effect.name;
+
             let cleanup = effect.run(ctx, props, Arc::clone(&send_handle));
+
             effect_cleanups.update_value(|cleanups| {
                 cleanups.insert(name, cleanup);
             });
@@ -441,9 +485,10 @@ mod tests {
     #[cfg(not(feature = "ssr"))]
     use ars_core::PendingEffect;
     use ars_core::{
-        AriaAttr, AttrMap, ComponentPart, ConnectApi, HasId, HtmlAttr, I18nRegistries, IcuProvider,
+        AriaAttr, AttrMap, ComponentPart, ConnectApi, HasId, HtmlAttr, I18nRegistries, IntlBackend,
         NullPlatformEffects, TransitionPlan,
     };
+    use ars_i18n::{Locale, StubIntlBackend};
     use leptos::reactive::traits::Get;
 
     use super::*;
@@ -501,6 +546,63 @@ mod tests {
         }
     }
 
+    #[test]
+    fn toggle_helper_types_and_test_backend_cover_contract_helpers() {
+        let mut props = ToggleProps {
+            id: String::from("toggle"),
+        }
+        .with_id(String::from("renamed"));
+
+        let locale = Locale::parse("en-US").expect("locale should parse");
+
+        let backend = TestIntlBackend;
+
+        assert_eq!(props.id(), "renamed");
+
+        props.set_id(String::from("updated"));
+
+        assert_eq!(props.id(), "updated");
+
+        assert_eq!(TogglePart::scope(), "toggle");
+        assert_eq!(TogglePart.name(), "root");
+        assert_eq!(TogglePart::all(), vec![TogglePart]);
+
+        assert_eq!(format!("{backend:?}"), "TestIntlBackend");
+        assert_eq!(
+            backend.weekday_short_label(ars_i18n::Weekday::Monday, &locale),
+            StubIntlBackend.weekday_short_label(ars_i18n::Weekday::Monday, &locale)
+        );
+        assert_eq!(
+            backend.weekday_long_label(ars_i18n::Weekday::Monday, &locale),
+            StubIntlBackend.weekday_long_label(ars_i18n::Weekday::Monday, &locale)
+        );
+        assert_eq!(
+            backend.month_long_name(5, &locale),
+            StubIntlBackend.month_long_name(5, &locale)
+        );
+        assert_eq!(
+            backend.day_period_label(true, &locale),
+            StubIntlBackend.day_period_label(true, &locale)
+        );
+        assert_eq!(backend.day_period_from_char('a', &locale), Some(false));
+        assert_eq!(
+            backend.format_segment_digits(
+                9,
+                core::num::NonZero::new(2).expect("minimum digits should be non-zero"),
+                &locale,
+            ),
+            "09"
+        );
+        assert_eq!(
+            backend.hour_cycle(&locale),
+            StubIntlBackend.hour_cycle(&locale)
+        );
+        assert_eq!(
+            backend.week_info(&locale),
+            StubIntlBackend.week_info(&locale)
+        );
+    }
+
     struct ToggleApi<'a> {
         is_on: bool,
         send: &'a dyn Fn(ToggleEvent),
@@ -521,7 +623,9 @@ mod tests {
 
         fn part_attrs(&self, _part: Self::Part) -> AttrMap {
             let mut attrs = AttrMap::new();
+
             attrs.set(HtmlAttr::Aria(AriaAttr::Pressed), self.is_on.to_string());
+
             attrs
         }
     }
@@ -577,16 +681,19 @@ mod tests {
         // This is a compile-time check — if UseMachineReturn<ToggleMachine> is
         // not Copy, this function won't compile.
         fn assert_copy<T: Copy>() {}
+
         assert_copy::<UseMachineReturn<ToggleMachine>>();
     }
 
     #[test]
     fn use_machine_return_type_clone_delegates_to_copy_fields() {
         let owner = Owner::new();
+
         owner.with(|| {
             let machine = use_machine::<ToggleMachine>(ToggleProps {
                 id: String::from("toggle"),
             });
+
             let cloned = <UseMachineReturn<ToggleMachine> as Clone>::clone(&machine);
 
             cloned.send.run(ToggleEvent::Toggle);
@@ -599,12 +706,14 @@ mod tests {
     #[test]
     fn use_machine_return_debug_names_the_type() {
         let owner = Owner::new();
+
         owner.with(|| {
             let machine = use_machine::<ToggleMachine>(ToggleProps {
                 id: String::from("toggle"),
             });
 
             let debug = format!("{machine:?}");
+
             assert!(debug.contains("UseMachineReturn"));
             assert!(debug.contains("context_version"));
         });
@@ -614,6 +723,7 @@ mod tests {
     fn use_machine_creates_service_with_initial_state() {
         // Test use_machine within a Leptos reactive Owner.
         let owner = Owner::new();
+
         owner.with(|| {
             let machine = use_machine::<ToggleMachine>(ToggleProps {
                 id: String::from("toggle"),
@@ -630,6 +740,7 @@ mod tests {
     #[test]
     fn use_machine_send_updates_state() {
         let owner = Owner::new();
+
         owner.with(|| {
             let machine = use_machine::<ToggleMachine>(ToggleProps {
                 id: String::from("toggle"),
@@ -638,9 +749,11 @@ mod tests {
             assert_eq!(machine.state.get_untracked(), ToggleState::Off);
 
             machine.send.run(ToggleEvent::Toggle);
+
             assert_eq!(machine.state.get_untracked(), ToggleState::On);
 
             machine.send.run(ToggleEvent::Toggle);
+
             assert_eq!(machine.state.get_untracked(), ToggleState::Off);
         });
     }
@@ -652,17 +765,20 @@ mod tests {
     )]
     fn with_api_snapshot_reads_current_state() {
         let owner = Owner::new();
+
         owner.with(|| {
             let machine = use_machine::<ToggleMachine>(ToggleProps {
                 id: String::from("toggle"),
             });
 
             let is_on = machine.with_api_snapshot(|api| api.is_on());
+
             assert!(!is_on);
 
             machine.send.run(ToggleEvent::Toggle);
 
             let is_on = machine.with_api_snapshot(|api| api.is_on());
+
             assert!(is_on);
         });
     }
@@ -675,6 +791,7 @@ mod tests {
     fn with_api_snapshot_rejects_callback_sends_events() {
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let owner = Owner::new();
+
             owner.with(|| {
                 let machine = use_machine::<ToggleMachine>(ToggleProps {
                     id: String::from("toggle"),
@@ -697,10 +814,12 @@ mod tests {
     )]
     fn derive_tracks_connect_output() {
         let owner = Owner::new();
+
         owner.with(|| {
             let machine = use_machine::<ToggleMachine>(ToggleProps {
                 id: String::from("toggle"),
             });
+
             let is_on = machine.derive(|api| api.is_on());
 
             assert!(!is_on.get());
@@ -715,10 +834,12 @@ mod tests {
     fn derive_rejects_callback_sends_events() {
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let owner = Owner::new();
+
             owner.with(|| {
                 let machine = use_machine::<ToggleMachine>(ToggleProps {
                     id: String::from("toggle"),
                 });
+
                 let derived = machine.derive(|api| {
                     api.trigger_toggle();
                     api.is_on()
@@ -737,43 +858,83 @@ mod tests {
     #[test]
     fn with_api_ephemeral_reads_current_state() {
         let owner = Owner::new();
+
         owner.with(|| {
             let machine = use_machine::<ToggleMachine>(ToggleProps {
                 id: String::from("toggle"),
             });
 
             let is_on = machine.with_api_ephemeral(|api| api.get().is_on());
+
             assert!(!is_on);
 
             machine.send.run(ToggleEvent::Toggle);
 
             let attrs = machine.with_api_ephemeral(|api| api.get().part_attrs(TogglePart));
+
             assert_eq!(attrs.get(&HtmlAttr::Aria(AriaAttr::Pressed)), Some("true"));
         });
     }
 
     #[derive(Clone)]
-    struct TestIcuProvider;
+    struct TestIntlBackend;
 
-    impl Debug for TestIcuProvider {
+    impl Debug for TestIntlBackend {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            f.write_str("TestIcuProvider")
+            f.write_str("TestIntlBackend")
         }
     }
 
-    impl IcuProvider for TestIcuProvider {}
+    impl IntlBackend for TestIntlBackend {
+        fn weekday_short_label(&self, weekday: ars_i18n::Weekday, locale: &Locale) -> String {
+            StubIntlBackend.weekday_short_label(weekday, locale)
+        }
+
+        fn weekday_long_label(&self, weekday: ars_i18n::Weekday, locale: &Locale) -> String {
+            StubIntlBackend.weekday_long_label(weekday, locale)
+        }
+
+        fn month_long_name(&self, month: u8, locale: &Locale) -> String {
+            StubIntlBackend.month_long_name(month, locale)
+        }
+
+        fn day_period_label(&self, is_pm: bool, locale: &Locale) -> String {
+            StubIntlBackend.day_period_label(is_pm, locale)
+        }
+
+        fn day_period_from_char(&self, ch: char, locale: &Locale) -> Option<bool> {
+            StubIntlBackend.day_period_from_char(ch, locale)
+        }
+
+        fn format_segment_digits(
+            &self,
+            value: u32,
+            min_digits: core::num::NonZero<u8>,
+            locale: &Locale,
+        ) -> String {
+            StubIntlBackend.format_segment_digits(value, min_digits, locale)
+        }
+
+        fn hour_cycle(&self, locale: &Locale) -> ars_i18n::HourCycle {
+            StubIntlBackend.hour_cycle(locale)
+        }
+
+        fn week_info(&self, locale: &Locale) -> ars_i18n::WeekInfo {
+            StubIntlBackend.week_info(locale)
+        }
+    }
 
     #[derive(Clone)]
     struct EnvContext {
         locale: String,
-        icu_provider: Arc<dyn IcuProvider>,
+        intl_backend: Arc<dyn IntlBackend>,
     }
 
     impl Debug for EnvContext {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             f.debug_struct("EnvContext")
                 .field("locale", &self.locale)
-                .field("icu_provider", &"Arc(..)")
+                .field("intl_backend", &"Arc(..)")
                 .finish()
         }
     }
@@ -816,7 +977,7 @@ mod tests {
                 (),
                 EnvContext {
                     locale: env.locale.to_bcp47(),
-                    icu_provider: Arc::clone(&env.icu_provider),
+                    intl_backend: Arc::clone(&env.intl_backend),
                 },
             )
         }
@@ -925,6 +1086,7 @@ mod tests {
                 } else {
                     PropState::Off
                 })),
+
                 PropEvent::SyncLabel => {
                     Some(TransitionPlan::new().apply(|ctx: &mut PropContext| {
                         ctx.sync_count += 1;
@@ -947,12 +1109,15 @@ mod tests {
 
         fn on_props_changed(old: &Self::Props, new: &Self::Props) -> Vec<Self::Event> {
             let mut events = Vec::new();
+
             if old.checked != new.checked {
                 events.push(PropEvent::SetChecked(new.checked));
             }
+
             if old.label != new.label {
                 events.push(PropEvent::SyncLabel);
             }
+
             events
         }
     }
@@ -973,14 +1138,16 @@ mod tests {
 
         fn part_attrs(&self, _part: Self::Part) -> AttrMap {
             let mut attrs = AttrMap::new();
+
             attrs.set(HtmlAttr::Aria(AriaAttr::Pressed), self.is_on.to_string());
+
             attrs
         }
     }
 
-    fn provide_test_context(locale: &str, icu_provider: Arc<dyn IcuProvider>) {
+    fn provide_test_context(locale: &str, intl_backend: Arc<dyn IntlBackend>) {
         crate::provide_ars_context(crate::ArsContext::new(
-            ars_i18n::Locale::parse(locale).expect("locale should parse"),
+            Locale::parse(locale).expect("locale should parse"),
             ars_i18n::Direction::Ltr,
             ars_core::ColorMode::System,
             false,
@@ -989,26 +1156,29 @@ mod tests {
             None,
             None,
             Arc::new(NullPlatformEffects),
-            icu_provider,
+            intl_backend,
             Arc::new(I18nRegistries::new()),
             ars_core::StyleStrategy::Inline,
         ));
     }
 
     #[test]
-    fn use_machine_inner_resolves_locale_and_icu_provider_from_context() {
+    fn use_machine_inner_resolves_locale_and_intl_backend_from_context() {
         let owner = Owner::new();
+
         owner.with(|| {
-            let expected_provider: Arc<dyn IcuProvider> = Arc::new(TestIcuProvider);
-            provide_test_context("es-ES", Arc::clone(&expected_provider));
+            let expected_backend: Arc<dyn IntlBackend> = Arc::new(TestIntlBackend);
+
+            provide_test_context("es-ES", Arc::clone(&expected_backend));
 
             let machine = use_machine::<EnvMachine>(EnvProps { id: String::new() });
+
             machine.service.with_value(|service| {
                 assert!(service.props().id().starts_with("component-"));
                 assert_eq!(service.context().locale, "es-ES");
                 assert!(Arc::ptr_eq(
-                    &service.context().icu_provider,
-                    &expected_provider
+                    &service.context().intl_backend,
+                    &expected_backend
                 ));
             });
         });
@@ -1017,6 +1187,7 @@ mod tests {
     #[test]
     fn use_machine_injects_generated_id_when_props_id_is_empty() {
         let owner = Owner::new();
+
         owner.with(|| {
             let machine = use_machine::<ToggleMachine>(ToggleProps { id: String::new() });
 
@@ -1029,6 +1200,7 @@ mod tests {
     #[test]
     fn use_machine_with_reactive_props_syncs_state_and_context_changes() {
         let owner = Owner::new();
+
         owner.with(|| {
             let (props, set_props) = signal(PropProps {
                 id: String::from("toggle"),
@@ -1037,6 +1209,7 @@ mod tests {
             });
 
             let machine = use_machine_with_reactive_props::<PropMachine>(props.into());
+
             assert_eq!(machine.state.get_untracked(), PropState::Off);
             assert_eq!(machine.context_version.get_untracked(), 0);
 
@@ -1045,6 +1218,7 @@ mod tests {
                 checked: true,
                 label: "a",
             });
+
             assert_eq!(machine.state.get_untracked(), PropState::On);
             assert_eq!(machine.context_version.get_untracked(), 0);
 
@@ -1053,8 +1227,10 @@ mod tests {
                 checked: true,
                 label: "b",
             });
+
             assert_eq!(machine.state.get_untracked(), PropState::On);
             assert_eq!(machine.context_version.get_untracked(), 1);
+
             machine.service.with_value(|service| {
                 assert_eq!(service.context().sync_count, 1);
             });
@@ -1068,12 +1244,14 @@ mod tests {
     )]
     fn derive_recomputes_when_only_context_changes() {
         let owner = Owner::new();
+
         owner.with(|| {
             let (props, set_props) = signal(PropProps {
                 id: String::from("toggle"),
                 checked: false,
                 label: "a",
             });
+
             let machine = use_machine_with_reactive_props::<PropMachine>(props.into());
             let sync_count = machine.derive(|api| api.sync_count());
 
@@ -1094,6 +1272,7 @@ mod tests {
     #[test]
     fn context_version_only_increments_on_context_changes() {
         let owner = Owner::new();
+
         owner.with(|| {
             let machine = use_machine::<ToggleMachine>(ToggleProps {
                 id: String::from("toggle"),
@@ -1102,9 +1281,11 @@ mod tests {
             assert_eq!(machine.context_version.get_untracked(), 0);
 
             machine.send.run(ToggleEvent::Toggle);
+
             assert_eq!(machine.context_version.get_untracked(), 0);
 
             machine.send.run(ToggleEvent::Toggle);
+
             assert_eq!(machine.context_version.get_untracked(), 0);
         });
     }
@@ -1218,13 +1399,17 @@ mod tests {
                         "cleanup:start",
                     )),
                 ),
+
                 EffectEvent::Replace => Some(TransitionPlan::new().with_effect(tracked_effect(
                     "timer",
                     "setup:replace",
                     "cleanup:replace",
                 ))),
+
                 EffectEvent::Cancel => Some(TransitionPlan::new().cancel_effect("timer")),
+
                 EffectEvent::Stop => Some(TransitionPlan::to(EffectState::Idle)),
+
                 EffectEvent::StartNotify => Some(
                     TransitionPlan::to(EffectState::Active).with_effect(PendingEffect::new(
                         "notify",
@@ -1233,8 +1418,11 @@ mod tests {
                                 .lock()
                                 .expect("log mutex should not be poisoned")
                                 .push("setup:notify");
+
                             send.call_if_alive(EffectEvent::Notify);
+
                             let log = Arc::clone(&ctx.log);
+
                             Box::new(move || {
                                 log.lock()
                                     .expect("log mutex should not be poisoned")
@@ -1243,6 +1431,7 @@ mod tests {
                         },
                     )),
                 ),
+
                 EffectEvent::Notify => {
                     Some(TransitionPlan::new().apply(|ctx: &mut EffectContext| {
                         ctx.notify_count += 1;
@@ -1274,7 +1463,9 @@ mod tests {
                     .lock()
                     .expect("log mutex should not be poisoned")
                     .push(setup_label);
+
                 let log = Arc::clone(&ctx.log);
+
                 Box::new(move || {
                     log.lock()
                         .expect("log mutex should not be poisoned")
@@ -1295,23 +1486,28 @@ mod tests {
     #[test]
     fn effect_lifecycle_replaces_cancels_and_unmounts_cleanups() {
         let owner = Owner::new();
+
         owner.with(|| {
             let log = Arc::new(Mutex::new(Vec::new()));
+
             let machine = use_machine::<EffectMachine>(EffectProps {
                 id: String::from("effects"),
                 log: Arc::clone(&log),
             });
 
             machine.send.run(EffectEvent::Start);
+
             assert_eq!(effect_log(&log), vec!["setup:start"]);
 
             machine.send.run(EffectEvent::Replace);
+
             assert_eq!(
                 effect_log(&log),
                 vec!["setup:start", "cleanup:start", "setup:replace"]
             );
 
             machine.send.run(EffectEvent::Cancel);
+
             assert_eq!(
                 effect_log(&log),
                 vec![
@@ -1323,6 +1519,7 @@ mod tests {
             );
 
             machine.send.run(EffectEvent::Start);
+
             assert_eq!(
                 effect_log(&log),
                 vec![
@@ -1335,6 +1532,7 @@ mod tests {
             );
 
             owner.cleanup();
+
             assert_eq!(
                 effect_log(&log),
                 vec![
@@ -1353,8 +1551,10 @@ mod tests {
     #[test]
     fn state_changes_drain_existing_effect_cleanups() {
         let owner = Owner::new();
+
         owner.with(|| {
             let log = Arc::new(Mutex::new(Vec::new()));
+
             let machine = use_machine::<EffectMachine>(EffectProps {
                 id: String::from("effects"),
                 log: Arc::clone(&log),
@@ -1372,8 +1572,10 @@ mod tests {
     #[test]
     fn effect_send_handle_dispatches_follow_up_events() {
         let owner = Owner::new();
+
         owner.with(|| {
             let log = Arc::new(Mutex::new(Vec::new()));
+
             let machine = use_machine::<EffectMachine>(EffectProps {
                 id: String::from("effects"),
                 log: Arc::clone(&log),
@@ -1383,9 +1585,11 @@ mod tests {
 
             assert_eq!(machine.state.get_untracked(), EffectState::Active);
             assert_eq!(machine.context_version.get_untracked(), 1);
+
             machine.service.with_value(|service| {
                 assert_eq!(service.context().notify_count, 1);
             });
+
             assert_eq!(effect_log(&log), vec!["setup:notify"]);
         });
     }
@@ -1406,7 +1610,9 @@ mod wasm_tests {
     #[wasm_bindgen_test]
     fn callback_to_strong_send_uses_wasm_send_handle() {
         let calls = Arc::new(Mutex::new(Vec::new()));
+
         let callback_calls = Arc::clone(&calls);
+
         let callback = Callback::new(move |event: i32| {
             callback_calls
                 .lock()
@@ -1415,6 +1621,7 @@ mod wasm_tests {
         });
 
         let strong = callback_to_strong_send(callback);
+
         strong(7);
         strong(9);
 
@@ -1532,13 +1739,16 @@ mod wasm_tests {
     #[wasm_bindgen_test]
     fn use_machine_updates_state_on_wasm() {
         let owner = Owner::new();
+
         owner.with(|| {
             let machine = use_machine::<ToggleMachine>(ToggleProps {
                 id: String::from("toggle"),
             });
 
             assert_eq!(machine.state.get_untracked(), ToggleState::Off);
+
             machine.send.run(ToggleEvent::Toggle);
+
             assert_eq!(machine.state.get_untracked(), ToggleState::On);
         });
     }
@@ -1597,7 +1807,9 @@ mod wasm_tests {
 
         fn part_attrs(&self, _part: Self::Part) -> AttrMap {
             let mut attrs = AttrMap::new();
+
             attrs.set(HtmlAttr::Aria(AriaAttr::Pressed), self.is_on.to_string());
+
             attrs
         }
     }
@@ -1639,6 +1851,7 @@ mod wasm_tests {
                 } else {
                     PropState::Off
                 })),
+
                 PropEvent::SyncLabel => {
                     Some(TransitionPlan::new().apply(|ctx: &mut PropContext| {
                         ctx.sync_count += 1;
@@ -1661,12 +1874,15 @@ mod wasm_tests {
 
         fn on_props_changed(old: &Self::Props, new: &Self::Props) -> Vec<Self::Event> {
             let mut events = Vec::new();
+
             if old.checked != new.checked {
                 events.push(PropEvent::SetChecked(new.checked));
             }
+
             if old.label != new.label {
                 events.push(PropEvent::SyncLabel);
             }
+
             events
         }
     }
@@ -1674,6 +1890,7 @@ mod wasm_tests {
     #[wasm_bindgen_test]
     fn reactive_props_sync_state_and_context_on_wasm() {
         let owner = Owner::new();
+
         owner.with(|| {
             let (props, set_props) = signal(PropProps {
                 id: String::from("toggle"),
@@ -1682,6 +1899,7 @@ mod wasm_tests {
             });
 
             let machine = use_machine_with_reactive_props::<PropMachine>(props.into());
+
             assert_eq!(machine.state.get_untracked(), PropState::Off);
             assert_eq!(machine.context_version.get_untracked(), 0);
 
@@ -1690,6 +1908,7 @@ mod wasm_tests {
                 checked: true,
                 label: "a",
             });
+
             assert_eq!(machine.state.get_untracked(), PropState::On);
             assert_eq!(machine.context_version.get_untracked(), 0);
 
@@ -1698,7 +1917,9 @@ mod wasm_tests {
                 checked: true,
                 label: "b",
             });
+
             assert_eq!(machine.context_version.get_untracked(), 1);
+
             machine.service.with_value(|service| {
                 assert_eq!(service.context().sync_count, 1);
             });
@@ -1708,6 +1929,7 @@ mod wasm_tests {
     #[wasm_bindgen_test]
     fn use_machine_injects_generated_id_on_wasm() {
         let owner = Owner::new();
+
         owner.with(|| {
             let machine = use_machine::<ToggleMachine>(ToggleProps { id: String::new() });
 
@@ -1724,13 +1946,16 @@ mod wasm_tests {
     )]
     fn derive_recomputes_when_only_context_changes_on_wasm() {
         let owner = Owner::new();
+
         owner.with(|| {
             let (props, set_props) = signal(PropProps {
                 id: String::from("toggle"),
                 checked: false,
                 label: "a",
             });
+
             let machine = use_machine_with_reactive_props::<PropMachine>(props.into());
+
             let sync_count = machine.derive(|api| api.sync_count());
 
             assert_eq!(sync_count.get(), 0);

--- a/spec/components/date-time/_category.md
+++ b/spec/components/date-time/_category.md
@@ -82,12 +82,12 @@ impl CalendarDate {
     /// - Chinese/Dangi: 12 or 13 months (intercalary month in some years)
     /// - Islamic: Months alternate 29/30 days
     /// - Persian: First 6 months have 31 days, next 5 have 30, last has 29-30
-    pub fn new(provider: &dyn IcuProvider, calendar: CalendarSystem, year: i32, month: u8, day: u8) -> Option<Self> {
-        let max_month = max_months_in_year(provider, calendar, year);
+    pub fn new(backend: &dyn IntlBackend, calendar: CalendarSystem, year: i32, month: u8, day: u8) -> Option<Self> {
+        let max_month = max_months_in_year(backend, calendar, year);
         if !(1..=max_month).contains(&month) {
             return None;
         }
-        let max_day = days_in_month_for_calendar(provider, calendar, year, month);
+        let max_day = days_in_month_for_calendar(backend, calendar, year, month);
         if !(1..=max_day).contains(&day) {
             return None;
         }
@@ -104,17 +104,17 @@ impl CalendarDate {
     }
 
     /// Returns the number of days in the month of the date.
-    pub fn days_in_month(&self, provider: &dyn IcuProvider) -> u8 {
-        days_in_month_for_calendar(provider, self.calendar, self.year, self.month.get())
+    pub fn days_in_month(&self, backend: &dyn IntlBackend) -> u8 {
+        days_in_month_for_calendar(backend, self.calendar, self.year, self.month.get())
     }
 
     /// Adds a number of months to the date.
-    pub fn add_months(&self, provider: &dyn IcuProvider, n: i32) -> CalendarDate {
+    pub fn add_months(&self, backend: &dyn IntlBackend, n: i32) -> CalendarDate {
         let total_months = (self.year * 12 + (self.month.get() as i32 - 1)) + n;
         let new_year  = total_months.div_euclid(12);
         let new_month = (total_months.rem_euclid(12) + 1) as u8;
-        // Use calendar-aware days-in-month via IcuProvider.
-        let max_day = days_in_month_for_calendar(provider, self.calendar, new_year, new_month);
+        // Use calendar-aware days-in-month via IntlBackend.
+        let max_day = days_in_month_for_calendar(backend, self.calendar, new_year, new_month);
         let clamped_day = self.day.get().min(max_day);
         CalendarDate {
             year: new_year,
@@ -219,26 +219,26 @@ fn gregorian_days_in_month(year: i32, month: Month) -> u8 {
 
 /// Maximum number of months in a year for the given calendar system.
 ///
-/// Delegates to `IcuProvider::max_months_in_year()` for calendar-aware computation.
-/// Production (`Icu4xProvider`): uses ICU4X `AnyCalendar::months_in_year()` for
+/// Delegates to `IntlBackend::max_months_in_year()` for calendar-aware computation.
+/// Production (`Icu4xBackend`): uses ICU4X `AnyCalendar::months_in_year()` for
 /// precise results across all calendar systems (Hebrew 13-month leap years,
 /// Chinese/Dangi intercalary months, Ethiopic/Coptic 13th month).
-/// Tests (`StubIcuProvider`): returns hardcoded values matching the original
+/// Tests (`StubIntlBackend`): returns hardcoded values matching the original
 /// English-only logic (see `04-internationalization.md` §9.5).
-fn max_months_in_year(provider: &dyn IcuProvider, calendar: CalendarSystem, year: i32) -> u8 {
-    provider.max_months_in_year(&calendar, year)
+fn max_months_in_year(backend: &dyn IntlBackend, calendar: CalendarSystem, year: i32) -> u8 {
+    backend.max_months_in_year(&calendar, year)
 }
 
 /// Days in a given month for the given calendar system.
 ///
-/// Delegates to `IcuProvider::days_in_month()` for calendar-aware computation.
-/// Production (`Icu4xProvider`): uses ICU4X `AnyCalendar::days_in_month()`
+/// Delegates to `IntlBackend::days_in_month()` for calendar-aware computation.
+/// Production (`Icu4xBackend`): uses ICU4X `AnyCalendar::days_in_month()`
 /// for precise results including observation-based Islamic calendars, Hebrew
 /// deficient/regular/complete year types, and Chinese/Dangi lunation lengths.
-/// Tests (`StubIcuProvider`): falls back to Gregorian logic for all calendars
+/// Tests (`StubIntlBackend`): falls back to Gregorian logic for all calendars
 /// (see `04-internationalization.md` §9.5).
-fn days_in_month_for_calendar(provider: &dyn IcuProvider, calendar: CalendarSystem, year: i32, month: u8) -> u8 {
-    provider.days_in_month(&calendar, year, month)
+fn days_in_month_for_calendar(backend: &dyn IntlBackend, calendar: CalendarSystem, year: i32, month: u8) -> u8 {
+    backend.days_in_month(&calendar, year, month)
 }
 
 /// Inclusive date range.
@@ -433,22 +433,22 @@ impl Locale {
 
     /// First day of week for this locale.
     ///
-    /// Delegates to `IcuProvider::first_day_of_week()`.
+    /// Delegates to `IntlBackend::first_day_of_week()`.
     /// Production: ICU4X `WeekCalculator::first_weekday()` from CLDR `weekData`,
     /// covering all regions (Sunday-start: US, CA, JP, etc.; Saturday-start:
     /// AF, IR, SA, AE, etc.; Monday-start: most of Europe, ISO 8601 default).
     /// Respects the BCP 47 `fw` extension if present (e.g., `en-US-u-fw-mon`).
-    pub fn first_day_of_week(&self, provider: &dyn IcuProvider) -> Weekday {
-        provider.first_day_of_week(self)
+    pub fn first_day_of_week(&self, backend: &dyn IntlBackend) -> Weekday {
+        backend.first_day_of_week(self)
     }
 
     /// Preferred hour cycle for this locale.
     ///
-    /// Delegates to `IcuProvider::hour_cycle()`.
+    /// Delegates to `IntlBackend::hour_cycle()`.
     /// Production: ICU4X `HourCycle` preference from CLDR `timeData`.
     /// Examples: en-US→H12, de→H23, ja→H23, ko→H12, ar→H12, ar-MA→H23.
-    pub fn hour_cycle(&self, provider: &dyn IcuProvider) -> HourCycle {
-        provider.hour_cycle(self)
+    pub fn hour_cycle(&self, backend: &dyn IntlBackend) -> HourCycle {
+        backend.hour_cycle(self)
     }
 }
 

--- a/spec/components/date-time/calendar.md
+++ b/spec/components/date-time/calendar.md
@@ -100,8 +100,8 @@ pub struct Context {
     pub locale: Locale,
     /// Resolved translatable messages.
     pub messages: Messages,
-    /// ICU data provider for locale-dependent formatting (month/weekday names, etc.).
-    pub provider: Arc<dyn IcuProvider>,
+    /// Intl backend for locale-dependent formatting (month/weekday names, etc.).
+    pub intl_backend: Arc<dyn IntlBackend>,
     /// Override for first day of week (falls back to locale default).
     pub first_day_of_week: Weekday,
     /// Right-to-left layout.
@@ -283,7 +283,7 @@ impl Context {
         (0..7)
             .map(|i| {
                 let wd = Weekday::from_u8((start + i) % 7);
-                let label = wd.short_label(&*self.provider, &self.locale);
+                let label = wd.short_label(&*self.intl_backend, &self.locale);
                 (wd, label)
             })
             .collect()
@@ -397,7 +397,7 @@ impl ars_core::Machine for Machine {
             max: props.max.clone(),
             locale,
             messages,
-            provider: env.icu_provider.clone(),
+            intl_backend: env.intl_backend.clone(),
             first_day_of_week: first_day,
             is_rtl: props.is_rtl,
             disabled: props.disabled,
@@ -464,12 +464,12 @@ impl ars_core::Machine for Machine {
                 }).with_effect(PendingEffect::new("announce-month", |ctx, _props, _send| {
                     let platform = use_platform_effects();
                     let label = if ctx.visible_months > 1 {
-                        let first = format!("{} {}", month_long_name(&*ctx.provider, ctx.visible_month, &ctx.locale), ctx.visible_year);
+                        let first = format!("{} {}", month_long_name(&*ctx.intl_backend, ctx.visible_month, &ctx.locale), ctx.visible_year);
                         let (lm, ly) = ctx.month_year_at_offset(ctx.visible_months - 1);
                         let sep = (ctx.messages.month_range_separator)(&ctx.locale);
-                        format!("{}{}{} {}", first, sep, month_long_name(&*ctx.provider, lm, &ctx.locale), ly)
+                        format!("{}{}{} {}", first, sep, month_long_name(&*ctx.intl_backend, lm, &ctx.locale), ly)
                     } else {
-                        format!("{} {}", month_long_name(&*ctx.provider, ctx.visible_month, &ctx.locale), ctx.visible_year)
+                        format!("{} {}", month_long_name(&*ctx.intl_backend, ctx.visible_month, &ctx.locale), ctx.visible_year)
                     };
                     platform.announce(&label);
                     no_cleanup()
@@ -486,12 +486,12 @@ impl ars_core::Machine for Machine {
                 }).with_effect(PendingEffect::new("announce-month", |ctx, _props, _send| {
                     let platform = use_platform_effects();
                     let label = if ctx.visible_months > 1 {
-                        let first = format!("{} {}", month_long_name(&*ctx.provider, ctx.visible_month, &ctx.locale), ctx.visible_year);
+                        let first = format!("{} {}", month_long_name(&*ctx.intl_backend, ctx.visible_month, &ctx.locale), ctx.visible_year);
                         let (lm, ly) = ctx.month_year_at_offset(ctx.visible_months - 1);
                         let sep = (ctx.messages.month_range_separator)(&ctx.locale);
-                        format!("{}{}{} {}", first, sep, month_long_name(&*ctx.provider, lm, &ctx.locale), ly)
+                        format!("{}{}{} {}", first, sep, month_long_name(&*ctx.intl_backend, lm, &ctx.locale), ly)
                     } else {
-                        format!("{} {}", month_long_name(&*ctx.provider, ctx.visible_month, &ctx.locale), ctx.visible_year)
+                        format!("{} {}", month_long_name(&*ctx.intl_backend, ctx.visible_month, &ctx.locale), ctx.visible_year)
                     };
                     platform.announce(&label);
                     no_cleanup()
@@ -750,7 +750,7 @@ impl<'a> Api<'a> {
 
     /// Formatted heading text: e.g. "January 2024".
     pub fn heading_text(&self) -> String {
-        let month_name = month_long_name(&*self.ctx.provider, self.ctx.visible_month, &self.ctx.locale);
+        let month_name = month_long_name(&*self.ctx.intl_backend, self.ctx.visible_month, &self.ctx.locale);
         format!("{} {}", month_name, self.ctx.visible_year)
     }
 
@@ -809,7 +809,7 @@ impl<'a> Api<'a> {
     /// Heading text for the month at the given offset.
     pub fn heading_text_for(&self, offset: usize) -> String {
         let (month, year) = self.ctx.month_year_at_offset(offset);
-        format!("{} {}", month_long_name(&*self.ctx.provider, month, &self.ctx.locale), year)
+        format!("{} {}", month_long_name(&*self.ctx.intl_backend, month, &self.ctx.locale), year)
     }
 
     /// Heading text attributes for a per-grid heading.
@@ -886,7 +886,7 @@ impl<'a> Api<'a> {
         attrs.set(scope_attr, scope_val);
         attrs.set(part_attr, part_val);
         attrs.set(HtmlAttr::Scope, "col");
-        attrs.set(HtmlAttr::Abbr, weekday.long_label(&*self.ctx.provider, &self.ctx.locale));
+        attrs.set(HtmlAttr::Abbr, weekday.long_label(&*self.ctx.intl_backend, &self.ctx.locale));
         attrs
     }
 
@@ -960,10 +960,10 @@ impl<'a> Api<'a> {
         // the restriction without requiring the user to attempt selection.
         let base_label = format!(
             "{} {} {}, {}",
-            month_long_name(&*self.ctx.provider, date.month.get(), &self.ctx.locale),
+            month_long_name(&*self.ctx.intl_backend, date.month.get(), &self.ctx.locale),
             date.day.get(),
             date.year,
-            date.weekday().long_label(&*self.ctx.provider, &self.ctx.locale),
+            date.weekday().long_label(&*self.ctx.intl_backend, &self.ctx.locale),
         );
         let label = if unavailable {
             format!("{} (unavailable)", base_label)
@@ -1269,7 +1269,7 @@ pub struct Messages {
     /// Separator between month names in multi-month range heading (e.g., " – ").
     pub month_range_separator: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
 }
-// Month names, weekday names, and abbreviations are resolved from the IcuProvider
+// Month names, weekday names, and abbreviations are resolved from the IntlBackend
 // (via `month_long_name()`, `wd.short_label()`, etc.) — not stored in Messages.
 
 impl Default for Messages {

--- a/spec/components/date-time/date-field.md
+++ b/spec/components/date-time/date-field.md
@@ -85,8 +85,8 @@ pub struct Context {
     pub type_buffer: String,
     /// The locale.
     pub locale: Locale,
-    /// ICU data provider for locale-dependent formatting.
-    pub provider: Arc<dyn IcuProvider>,
+    /// Intl backend for locale-dependent formatting.
+    pub intl_backend: Arc<dyn IntlBackend>,
     /// Resolved translatable messages.
     pub messages: Messages,
     /// The calendar system.
@@ -196,7 +196,7 @@ impl Context {
             let v = raw.clamp(seg.min, seg.max);
             seg.value = Some(v);
             seg.text = match kind {
-                DateSegmentKind::DayPeriod => day_period_label(&*self.provider, v == 1, &self.locale),
+                DateSegmentKind::DayPeriod => day_period_label(&*self.intl_backend, v == 1, &self.locale),
                 _ if self.force_leading_zeros => {
                     let width = match kind {
                         DateSegmentKind::Year => 4,
@@ -204,8 +204,8 @@ impl Context {
                     };
                     format!("{:0>width$}", v, width = width)
                 }
-                DateSegmentKind::Year => format_segment_digits(&*self.provider, v, 4, &self.locale),
-                _ => format_segment_digits(&*self.provider, v, 2, &self.locale),
+                DateSegmentKind::Year => format_segment_digits(&*self.intl_backend, v, 4, &self.locale),
+                _ => format_segment_digits(&*self.intl_backend, v, 2, &self.locale),
             };
         }
     }
@@ -469,12 +469,12 @@ impl DateSegment {
     }
 
     /// aria-valuetext: human-readable string (e.g., "March" instead of "3").
-    pub fn aria_value_text(&self, provider: &dyn IcuProvider, locale: &Locale) -> Option<String> {
+    pub fn aria_value_text(&self, backend: &dyn IntlBackend, locale: &Locale) -> Option<String> {
         let v = self.value?;
         match self.kind {
-            DateSegmentKind::Month => Some(month_long_name(provider, v as u8, locale)),
+            DateSegmentKind::Month => Some(month_long_name(backend, v as u8, locale)),
             DateSegmentKind::DayPeriod => {
-                Some(day_period_label(provider, v == 1, locale))
+                Some(day_period_label(backend, v == 1, locale))
             }
             _ => Some(v.to_string()),
         }
@@ -483,7 +483,7 @@ impl DateSegment {
 
 /// Format a numeric value with locale-appropriate numerals and zero-padding.
 ///
-/// Delegates to `IcuProvider::format_segment_digits()`.
+/// Delegates to `IntlBackend::format_segment_digits()`.
 ///
 /// **Locale-aware digit formatting.** Some locales use native digit systems:
 /// - Arabic (ar): Arabic-Indic ٠١٢٣٤٥٦٧٨٩
@@ -492,29 +492,29 @@ impl DateSegment {
 /// - Myanmar (my): ၀၁၂၃၄၅၆၇၈၉
 /// - Most others: Western Arabic 0123456789
 ///
-/// Production (`Icu4xProvider`): uses ICU4X `DecimalFormatter` with the
+/// Production (`Icu4xBackend`): uses ICU4X `DecimalFormatter` with the
 /// locale's default numbering system for automatic native digit substitution.
-/// Tests (`StubIcuProvider`): returns zero-padded Western Arabic digits.
-pub fn format_segment_digits(provider: &dyn IcuProvider, value: u32, min_digits: NonZero<u8>, locale: &Locale) -> String {
-    provider.format_segment_digits(value, min_digits, locale)
+/// Tests (`StubIntlBackend`): returns zero-padded Western Arabic digits.
+pub fn format_segment_digits(backend: &dyn IntlBackend, value: u32, min_digits: NonZero<u8>, locale: &Locale) -> String {
+    backend.format_segment_digits(value, min_digits, locale)
 }
 
 /// Returns the full month name for the given locale.
 ///
-/// Delegates to `IcuProvider::month_long_name()`.
-/// Production (`Icu4xProvider`): uses ICU4X `DateSymbols::month_names(FieldLength::Wide)`
+/// Delegates to `IntlBackend::month_long_name()`.
+/// Production (`Icu4xBackend`): uses ICU4X `DateSymbols::month_names(FieldLength::Wide)`
 /// for comprehensive locale coverage. Examples: en->"January", fr->"janvier",
 /// ar->"يناير", ja->"1月", he->"תשרי" (Hebrew calendar).
-/// Tests (`StubIcuProvider`): returns English month names.
-pub fn month_long_name(provider: &dyn IcuProvider, month: u8, locale: &Locale) -> String {
-    provider.month_long_name(month, locale)
+/// Tests (`StubIntlBackend`): returns English month names.
+pub fn month_long_name(backend: &dyn IntlBackend, month: u8, locale: &Locale) -> String {
+    backend.month_long_name(month, locale)
 }
 
 /// Map typed character(s) to a day period value (0=AM, 1=PM) for the given locale.
 /// Returns `None` if the input doesn't match any day period key.
 ///
-/// Delegates to `IcuProvider::day_period_from_input()`.
-/// Production (`Icu4xProvider`): matches against locale-specific AM/PM strings
+/// Delegates to `IntlBackend::day_period_from_input()`.
+/// Production (`Icu4xBackend`): matches against locale-specific AM/PM strings
 /// from ICU4X `DayPeriodNames`.
 ///
 /// ### CJK Locale Handling
@@ -551,7 +551,7 @@ pub fn month_long_name(provider: &dyn IcuProvider, month: u8, locale: &Locale) -
 ///    is shared by 오전 (AM) and 오후 (PM).
 ///
 /// 3. **Second character resolves** -- When the next character arrives, the full
-///    buffer is passed to `day_period_from_buffer(provider, &buffer, locale)`,
+///    buffer is passed to `day_period_from_buffer(backend, &buffer, locale)`,
 ///    which matches against the locale's AM/PM labels and commits. Example:
 ///    buffer `"午前"` -> AM, buffer `"午後"` -> PM.
 ///
@@ -573,26 +573,26 @@ pub fn month_long_name(provider: &dyn IcuProvider, month: u8, locale: &Locale) -
 /// character-by-character matching. Instead, it waits for the `compositionend`
 /// event, then matches the composed string against the locale's AM/PM labels.
 /// This prevents premature matching on intermediate IME candidates.
-pub fn day_period_from_char(provider: &dyn IcuProvider, ch: char, locale: &Locale) -> Option<i32> {
-    provider.day_period_from_char(ch, locale).map(|is_pm| if is_pm { 1 } else { 0 })
+pub fn day_period_from_char(backend: &dyn IntlBackend, ch: char, locale: &Locale) -> Option<i32> {
+    backend.day_period_from_char(ch, locale).map(|is_pm| if is_pm { 1 } else { 0 })
 }
 
 /// Extended day period matching for multi-character input (CJK locales).
 /// Called when `type_buffer` contains more than one character.
 /// Returns `Some(0)` for AM, `Some(1)` for PM, `None` if no match.
-pub fn day_period_from_buffer(provider: &dyn IcuProvider, buffer: &str, locale: &Locale) -> Option<i32> {
-    provider.day_period_from_buffer(buffer, locale).map(|is_pm| if is_pm { 1 } else { 0 })
+pub fn day_period_from_buffer(backend: &dyn IntlBackend, buffer: &str, locale: &Locale) -> Option<i32> {
+    backend.day_period_from_buffer(buffer, locale).map(|is_pm| if is_pm { 1 } else { 0 })
 }
 
 /// Locale-aware AM/PM label.
 ///
-/// Delegates to `IcuProvider::day_period_label()`.
-/// Production (`Icu4xProvider`): uses ICU4X `DayPeriodNames` with
+/// Delegates to `IntlBackend::day_period_label()`.
+/// Production (`Icu4xBackend`): uses ICU4X `DayPeriodNames` with
 /// `FieldLength::Abbreviated` for comprehensive locale coverage.
 /// Examples: en->"AM"/"PM", ja->"午前"/"午後", ko->"오전"/"오후", ar->"ص"/"م".
-/// Tests (`StubIcuProvider`): returns English "AM"/"PM".
-pub fn day_period_label(provider: &dyn IcuProvider, is_pm: bool, locale: &Locale) -> String {
-    provider.day_period_label(is_pm, locale)
+/// Tests (`StubIntlBackend`): returns English "AM"/"PM".
+pub fn day_period_label(backend: &dyn IntlBackend, is_pm: bool, locale: &Locale) -> String {
+    backend.day_period_label(is_pm, locale)
 }
 ```
 
@@ -1170,7 +1170,7 @@ impl ars_core::Machine for Machine {
             focused_segment: None,
             type_buffer: String::new(),
             locale,
-            provider: env.icu_provider.clone(),
+            intl_backend: env.intl_backend.clone(),
             messages,
             calendar: props.calendar,
             granularity: props.granularity,
@@ -1321,7 +1321,7 @@ impl ars_core::Machine for Machine {
                         // - Japanese: '午' starts both 午前/午後 -- further chars disambiguate
                         // - Korean: '오' starts both 오전/오후
                         // Support Latin + Arabic. CJK handled via ArrowUp/Down only.
-                        let period_value = day_period_from_char(&*ctx.provider, ch, &ctx.locale);
+                        let period_value = day_period_from_char(&*ctx.intl_backend, ch, &ctx.locale);
                         let period_value = match period_value {
                             Some(v) => v,
                             None => return None,

--- a/spec/components/date-time/date-time-picker.md
+++ b/spec/components/date-time/date-time-picker.md
@@ -516,7 +516,7 @@ impl ars_core::Machine for Machine {
         let date_value = value.get().as_ref().map(|dt| dt.date.clone());
         let time_value = value.get().as_ref().map(|dt| dt.time);
 
-        let resolved_cycle = props.hour_cycle.unwrap_or_else(|| locale.hour_cycle(&*env.icu_provider));
+        let resolved_cycle = props.hour_cycle.unwrap_or_else(|| locale.hour_cycle(&*env.intl_backend));
 
         let date_segments = Machine::build_date_segments(&locale, &date_value);
         let time_segments = Machine::build_time_segments(

--- a/spec/components/date-time/range-calendar.md
+++ b/spec/components/date-time/range-calendar.md
@@ -101,8 +101,8 @@ pub struct Context {
     pub locale: Locale,
     /// Resolved translatable messages.
     pub messages: Messages,
-    /// ICU data provider for locale-dependent formatting (month/weekday names, etc.).
-    pub provider: Arc<dyn IcuProvider>,
+    /// Intl backend for locale-dependent formatting (month/weekday names, etc.).
+    pub intl_backend: Arc<dyn IntlBackend>,
     /// Override for first day of week (falls back to locale default).
     pub first_day_of_week: Weekday,
     /// Right-to-left layout.
@@ -350,7 +350,7 @@ impl ars_core::Machine for Machine {
             max: props.max.clone(),
             locale,
             messages,
-            provider: env.icu_provider.clone(),
+            intl_backend: env.intl_backend.clone(),
             first_day_of_week: first_day,
             is_rtl: props.is_rtl,
             disabled: props.disabled,
@@ -416,7 +416,7 @@ impl ars_core::Machine for Machine {
                                     if let Some(ref anchor) = ctx.anchor_date {
                                         let platform = use_platform_effects();
                                         let label = (ctx.messages.range_start_label)(
-                                            &format_date_label(anchor, &*ctx.provider, &ctx.locale),
+                                            &format_date_label(anchor, &*ctx.intl_backend, &ctx.locale),
                                             &ctx.locale,
                                         );
                                         platform.announce(&label);
@@ -445,8 +445,8 @@ impl ars_core::Machine for Machine {
                                     if let Some(ref range) = ctx.value.get() {
                                         let platform = use_platform_effects();
                                         let label = (ctx.messages.range_complete_label)(
-                                            &format_date_label(&range.start, &*ctx.provider, &ctx.locale),
-                                            &format_date_label(&range.end, &*ctx.provider, &ctx.locale),
+                                            &format_date_label(&range.start, &*ctx.intl_backend, &ctx.locale),
+                                            &format_date_label(&range.end, &*ctx.intl_backend, &ctx.locale),
                                             &ctx.locale,
                                         );
                                         platform.announce(&label);
@@ -486,11 +486,11 @@ impl ars_core::Machine for Machine {
                 }).with_effect(PendingEffect::new("announce-month", |ctx, _props, _send| {
                     let platform = use_platform_effects();
                     let label = if ctx.visible_months > 1 {
-                        let first = format!("{} {}", month_long_name(&*ctx.provider, ctx.visible_month, &ctx.locale), ctx.visible_year);
+                        let first = format!("{} {}", month_long_name(&*ctx.intl_backend, ctx.visible_month, &ctx.locale), ctx.visible_year);
                         let (lm, ly) = ctx.month_year_at_offset(ctx.visible_months - 1);
-                        format!("{} \u{2013} {} {}", first, month_long_name(&*ctx.provider, lm, &ctx.locale), ly)
+                        format!("{} \u{2013} {} {}", first, month_long_name(&*ctx.intl_backend, lm, &ctx.locale), ly)
                     } else {
-                        format!("{} {}", month_long_name(&*ctx.provider, ctx.visible_month, &ctx.locale), ctx.visible_year)
+                        format!("{} {}", month_long_name(&*ctx.intl_backend, ctx.visible_month, &ctx.locale), ctx.visible_year)
                     };
                     platform.announce(&label);
                     no_cleanup()
@@ -507,11 +507,11 @@ impl ars_core::Machine for Machine {
                 }).with_effect(PendingEffect::new("announce-month", |ctx, _props, _send| {
                     let platform = use_platform_effects();
                     let label = if ctx.visible_months > 1 {
-                        let first = format!("{} {}", month_long_name(&*ctx.provider, ctx.visible_month, &ctx.locale), ctx.visible_year);
+                        let first = format!("{} {}", month_long_name(&*ctx.intl_backend, ctx.visible_month, &ctx.locale), ctx.visible_year);
                         let (lm, ly) = ctx.month_year_at_offset(ctx.visible_months - 1);
-                        format!("{} \u{2013} {} {}", first, month_long_name(&*ctx.provider, lm, &ctx.locale), ly)
+                        format!("{} \u{2013} {} {}", first, month_long_name(&*ctx.intl_backend, lm, &ctx.locale), ly)
                     } else {
-                        format!("{} {}", month_long_name(&*ctx.provider, ctx.visible_month, &ctx.locale), ctx.visible_year)
+                        format!("{} {}", month_long_name(&*ctx.intl_backend, ctx.visible_month, &ctx.locale), ctx.visible_year)
                     };
                     platform.announce(&label);
                     no_cleanup()
@@ -756,16 +756,16 @@ impl<'a> Api<'a> {
     /// Formatted heading text: e.g., "January 2024" or "January -- February 2024".
     pub fn heading_text(&self) -> String {
         if self.ctx.visible_months <= 1 {
-            let month_name = month_long_name(&*self.ctx.provider, self.ctx.visible_month, &self.ctx.locale);
+            let month_name = month_long_name(&*self.ctx.intl_backend, self.ctx.visible_month, &self.ctx.locale);
             return format!("{} {}", month_name, self.ctx.visible_year);
         }
         let first = format!(
             "{} {}",
-            month_long_name(&*self.ctx.provider, self.ctx.visible_month, &self.ctx.locale),
+            month_long_name(&*self.ctx.intl_backend, self.ctx.visible_month, &self.ctx.locale),
             self.ctx.visible_year,
         );
         let (lm, ly) = self.ctx.month_year_at_offset(self.ctx.visible_months - 1);
-        format!("{} \u{2013} {} {}", first, month_long_name(&*self.ctx.provider, lm, &self.ctx.locale), ly)
+        format!("{} \u{2013} {} {}", first, month_long_name(&*self.ctx.intl_backend, lm, &self.ctx.locale), ly)
     }
 
     /// Attributes for the grid group container (role="group").
@@ -817,7 +817,7 @@ impl<'a> Api<'a> {
         attrs.set(scope_attr, scope_val);
         attrs.set(part_attr, part_val);
         attrs.set(HtmlAttr::Scope, "col");
-        attrs.set(HtmlAttr::Abbr, weekday.long_label(&*self.ctx.provider, &self.ctx.locale));
+        attrs.set(HtmlAttr::Abbr, weekday.long_label(&*self.ctx.intl_backend, &self.ctx.locale));
         attrs
     }
 
@@ -906,7 +906,7 @@ impl<'a> Api<'a> {
         }
 
         // aria-label: full date string for screen readers.
-        let base_label = format_date_label(date, &*self.ctx.provider, &self.ctx.locale);
+        let base_label = format_date_label(date, &*self.ctx.intl_backend, &self.ctx.locale);
         let label = if unavailable {
             format!("{} (unavailable)", base_label)
         } else if disabled {
@@ -1003,7 +1003,7 @@ impl<'a> Api<'a> {
     /// Heading text for the month at the given offset.
     pub fn heading_text_for(&self, offset: usize) -> String {
         let (month, year) = self.ctx.month_year_at_offset(offset);
-        format!("{} {}", month_long_name(&*self.ctx.provider, month, &self.ctx.locale), year)
+        format!("{} {}", month_long_name(&*self.ctx.intl_backend, month, &self.ctx.locale), year)
     }
 
     /// Heading text attributes for a per-grid heading.
@@ -1101,13 +1101,13 @@ impl<'a> Api<'a> {
 }
 
 /// Format a date as a human-readable label for screen readers.
-fn format_date_label(date: &CalendarDate, provider: &dyn IcuProvider, locale: &Locale) -> String {
+fn format_date_label(date: &CalendarDate, backend: &dyn IntlBackend, locale: &Locale) -> String {
     format!(
         "{} {} {}, {}",
-        month_long_name(provider, date.month.get(), locale),
+        month_long_name(backend, date.month.get(), locale),
         date.day.get(),
         date.year,
-        date.weekday().long_label(provider, locale),
+        date.weekday().long_label(backend, locale),
     )
 }
 

--- a/spec/components/date-time/time-field.md
+++ b/spec/components/date-time/time-field.md
@@ -77,8 +77,8 @@ pub struct Context {
     pub locale: Locale,
     /// Resolved translatable messages.
     pub messages: Messages,
-    /// ICU data provider for locale-dependent formatting (day period labels, etc.).
-    pub provider: Arc<dyn IcuProvider>,
+    /// Intl backend for locale-dependent formatting (day period labels, etc.).
+    pub intl_backend: Arc<dyn IntlBackend>,
     /// The granularity of the component.
     pub granularity: TimeGranularity,
     /// The hour cycle of the component.
@@ -155,14 +155,14 @@ impl Context {
                 min: 0,
                 max: 1,
                 text: String::new(),
-                placeholder: day_period_label(&*self.provider, false, &self.locale),
+                placeholder: day_period_label(&*self.intl_backend, false, &self.locale),
                 literal: None,
                 is_editable: true,
             };
             if let Some(t) = &value {
                 let is_pm = t.is_pm();
                 period_seg.value = Some(if is_pm { 1 } else { 0 });
-                period_seg.text  = day_period_label(&*self.provider, is_pm, &self.locale);
+                period_seg.text  = day_period_label(&*self.intl_backend, is_pm, &self.locale);
             }
             segs.push(period_seg);
         }
@@ -219,7 +219,7 @@ impl Context {
             let v = raw.clamp(seg.min, seg.max);
             seg.value = Some(v);
             seg.text  = match kind {
-                DateSegmentKind::DayPeriod => day_period_label(&*self.provider, v == 1, &self.locale),
+                DateSegmentKind::DayPeriod => day_period_label(&*self.intl_backend, v == 1, &self.locale),
                 _ if self.force_leading_zeros => format!("{:02}", v),
                 _ => format!("{}", v),
             };
@@ -549,7 +549,7 @@ impl ars_core::Machine for Machine {
     fn init(props: &Self::Props, env: &Env, messages: &Self::Messages) -> (Self::State, Self::Context) {
         let locale = env.locale.clone();
         let messages = messages.clone();
-        let provider = env.icu_provider.clone();
+        let provider = env.intl_backend.clone();
 
         let resolved_cycle = props
             .hour_cycle

--- a/spec/components/utility/ars-provider.md
+++ b/spec/components/utility/ars-provider.md
@@ -13,7 +13,7 @@ references:
 
 `ArsProvider` is the **single root provider** for the ars-ui library. It supplies shared configuration, platform capabilities, provider-scoped modality state, i18n resources, and style strategy to all descendant components. It MUST be rendered at (or near) the application root.
 
-`ArsProvider` subsumes the formerly separate `LocaleProvider`, `PlatformEffectsProvider`, `IcuProvider`, `I18nProvider`, and `ArsStyleProvider`.
+`ArsProvider` subsumes the formerly separate `LocaleProvider`, `PlatformEffectsProvider`, `IntlBackend`, `I18nProvider`, and `ArsStyleProvider`.
 
 ## 1. API
 
@@ -63,9 +63,9 @@ pub struct Props {
     pub modality: Option<Arc<dyn ModalityContext>>,
 
     /// Calendar/locale data provider for date-time components.
-    /// Production uses `Icu4xProvider`; tests use `StubIcuProvider`.
-    /// Defaults to `StubIcuProvider` (English-only).
-    pub icu_provider: Option<Arc<dyn IcuProvider>>,
+    /// Production uses `Icu4xBackend`; tests use `StubIntlBackend`.
+    /// Defaults to `StubIntlBackend` (English-only).
+    pub intl_backend: Option<Arc<dyn IntlBackend>>,
 
     /// Per-component translation message registries.
     /// Defaults to empty (components use built-in English defaults).
@@ -95,7 +95,7 @@ pub struct ArsContext {
     root_node_id: Option<String>,
     platform: Arc<dyn PlatformEffects>,
     modality: Arc<dyn ModalityContext>,
-    icu_provider: Arc<dyn IcuProvider>,
+    intl_backend: Arc<dyn IntlBackend>,
     i18n_registries: Arc<I18nRegistries>,
     style_strategy: StyleStrategy,
 }
@@ -122,7 +122,7 @@ impl ArsContext {
     /// Returns the provider-scoped modality context.
     pub fn modality(&self) -> Arc<dyn ModalityContext> { Arc::clone(&self.modality) }
     /// Returns the ICU calendar/locale data provider.
-    pub fn icu_provider(&self) -> Arc<dyn IcuProvider> { Arc::clone(&self.icu_provider) }
+    pub fn intl_backend(&self) -> Arc<dyn IntlBackend> { Arc::clone(&self.intl_backend) }
     /// Returns the i18n translation registries.
     pub fn i18n_registries(&self) -> &I18nRegistries { &self.i18n_registries }
     /// Returns the active CSS style injection strategy.
@@ -142,7 +142,7 @@ impl Default for ArsContext {
             root_node_id: None,
             platform: Arc::new(NullPlatformEffects),
             modality: Arc::new(DefaultModalityContext::new()),
-            icu_provider: Arc::new(StubIcuProvider),
+            intl_backend: Arc::new(StubIntlBackend),
             i18n_registries: Rc::new(I18nRegistries::new()),
             style_strategy: StyleStrategy::Inline,
         }
@@ -166,7 +166,7 @@ Convenience hooks read from `ArsContext` with fallback defaults:
 - `use_number_formatter()` — locale-aware number formatting derived from the active `ArsProvider` locale
 - `use_platform_effects()` — platform capabilities
 - `use_modality_context()` — provider-scoped input-modality state
-- `use_icu_provider()` — calendar/locale data
+- `use_intl_backend()` — calendar/locale data
 - `use_style_strategy()` — CSS style strategy, falls back to `Inline`
 - `resolve_messages::<M>()` — translation registries
 
@@ -200,8 +200,8 @@ ArsProvider
 | Theme-aware components   | `color_mode` — for conditional rendering based on active color mode                                |
 | All effect closures      | `platform` — via `use_platform_effects()` for focus, timers, scroll-lock, positioning, DOM queries |
 | Focus / Hover / Press    | `modality` — via `use_modality_context()` for shared modality and global press state               |
-| Date-time components     | `icu_provider` — via `use_icu_provider()` for calendar data (weekday names, month names, etc.)     |
-| Numeric components       | `locale` — via `use_number_formatter()` for provider-derived number formatting                      |
+| Date-time components     | `intl_backend` — via `use_intl_backend()` for calendar data (weekday names, month names, etc.)     |
+| Numeric components       | `locale` — via `use_number_formatter()` for provider-derived number formatting                     |
 | All stateful components  | `i18n_registries` — via `resolve_messages::<M>()` for per-component translation lookups            |
 | All rendered components  | `style_strategy` — via `use_style_strategy()` for CSS injection method                             |
 

--- a/spec/dioxus-components/utility/ars-provider.md
+++ b/spec/dioxus-components/utility/ars-provider.md
@@ -36,7 +36,7 @@ pub struct ArsProviderProps {
     #[props(optional)]
     pub platform: Option<Arc<dyn PlatformEffects>>,
     #[props(optional)]
-    pub icu_provider: Option<Arc<dyn IcuProvider>>,
+    pub intl_backend: Option<Arc<dyn IntlBackend>>,
     #[props(optional)]
     pub i18n_registries: Option<Arc<I18nRegistries>>,
     #[props(optional)]
@@ -222,7 +222,7 @@ pub struct ArsProviderSketchProps {
     #[props(optional)]
     pub platform: Option<Arc<dyn PlatformEffects>>,
     #[props(optional)]
-    pub icu_provider: Option<Arc<dyn IcuProvider>>,
+    pub intl_backend: Option<Arc<dyn IntlBackend>>,
     #[props(optional)]
     pub i18n_registries: Option<Arc<I18nRegistries>>,
     #[props(optional)]
@@ -246,7 +246,7 @@ pub fn ArsProvider(props: ArsProviderSketchProps) -> Element {
     let disabled = props.disabled.unwrap_or_else(|| use_signal(|| false));
     let read_only = props.read_only.unwrap_or_else(|| use_signal(|| false));
     let platform = props.platform.unwrap_or_else(|| resolve_platform_for_target());
-    let icu_provider = props.icu_provider.unwrap_or_else(|| Arc::new(StubIcuProvider));
+    let intl_backend = props.intl_backend.unwrap_or_else(|| Arc::new(StubIntlBackend));
     let i18n_registries = props.i18n_registries.unwrap_or_else(|| Rc::new(I18nRegistries::new()));
     let style_strategy = props.style_strategy.unwrap_or(StyleStrategy::Inline);
     let dioxus_platform = props.dioxus_platform.unwrap_or_else(|| {
@@ -268,7 +268,7 @@ pub fn ArsProvider(props: ArsProviderSketchProps) -> Element {
         portal_container_id: use_signal(|| props.portal_container_id),
         root_node_id: use_signal(|| props.root_node_id),
         platform,
-        icu_provider,
+        intl_backend,
         i18n_registries,
         style_strategy,
         dioxus_platform,

--- a/spec/foundation/01-architecture.md
+++ b/spec/foundation/01-architecture.md
@@ -435,23 +435,23 @@ pub trait ConnectApi {
 ///
 /// The adapter reads these values from `ArsProvider` / `ArsContext` and passes
 /// them to framework-agnostic core code. Core component code **never** calls
-/// framework hooks (`use_locale()`, `use_icu_provider()`, `use_context()`) —
+/// framework hooks (`use_locale()`, `use_intl_backend()`, `use_context()`) —
 /// all environment values arrive through this struct.
 ///
-/// Non-date-time components ignore `icu_provider` (it defaults to `StubIcuProvider`).
+/// Non-date-time components ignore `intl_backend` (it defaults to `StubIntlBackend`).
 pub struct Env {
     /// The resolved locale from `ArsProvider`.
     pub locale: Locale,
     /// Calendar/locale data provider for date-time formatting.
-    /// Defaults to `StubIcuProvider` (English-only, zero dependencies).
-    pub icu_provider: Arc<dyn IcuProvider>,
+    /// Defaults to `StubIntlBackend` (English-only, zero dependencies).
+    pub intl_backend: Arc<dyn IntlBackend>,
 }
 
 impl Default for Env {
     fn default() -> Self {
         Self {
             locale: Locale::parse("en-US").expect("en-US is a valid BCP-47 tag"),
-            icu_provider: Arc::new(StubIcuProvider),
+            intl_backend: Arc::new(StubIntlBackend),
         }
     }
 }
@@ -4623,7 +4623,7 @@ configuration, platform capabilities, provider-scoped modality state, i18n resou
 components. It MUST be rendered at (or near) the application root.
 
 `ArsProvider` subsumes the formerly separate `LocaleProvider`, `PlatformEffectsProvider`,
-`IcuProvider`, `I18nProvider`, and `ArsStyleProvider`. Components access configuration
+`IntlBackend`, `I18nProvider`, and `ArsStyleProvider`. Components access configuration
 via `ArsContext` fields and convenience hooks (e.g., `use_locale()`,
 `use_platform_effects()`, `use_modality_context()`, `use_style_strategy()`).
 
@@ -4654,7 +4654,7 @@ pub enum ColorMode {
 | `root_node_id`        | `Option<String>`                            | ID of the root node for focus scope and portal queries. `None` means default.  |
 | `platform`            | `Arc<dyn PlatformEffects>`                  | Platform capabilities for side effects. Defaults to `NullPlatformEffects`.     |
 | `modality`            | `Arc<dyn ModalityContext>`                  | Shared input-modality state for the current provider root.                     |
-| `icu_provider`        | `Arc<dyn IcuProvider>`                      | Calendar/locale data for date-time components. Defaults to `StubIcuProvider`.  |
+| `intl_backend`        | `Arc<dyn IntlBackend>`                      | Calendar/locale data for date-time components. Defaults to `StubIntlBackend`.  |
 | `i18n_registries`     | `Rc<I18nRegistries>`                        | Per-component translation registries. Defaults to empty (English fallbacks).   |
 | `style_strategy`      | `StyleStrategy`                             | CSS style injection strategy. Defaults to `StyleStrategy::Inline`.             |
 
@@ -4664,14 +4664,14 @@ hooks read from `ArsContext` with fallback defaults:
 - `use_locale()` — locale, falls back to `en-US`
 - `use_platform_effects()` — platform capabilities
 - `use_modality_context()` — shared input-modality state
-- `use_icu_provider()` — calendar/locale data
+- `use_intl_backend()` — calendar/locale data
 - `use_style_strategy()` — CSS style strategy, falls back to `Inline`
 - `resolve_messages::<M>()` — translation registries (pure function, not a hook — takes `&I18nRegistries` explicitly)
 
 #### 6.4.3 Environment Resolution Rule
 
 Locale, messages, and ICU provider are **environment context** provided by `ArsProvider`.
-Core component `Props` structs MUST NOT contain `locale`, `messages`, or `icu_provider`
+Core component `Props` structs MUST NOT contain `locale`, `messages`, or `intl_backend`
 fields — these are resolved by the adapter and passed explicitly via the `Env` struct
 and `Messages` parameter.
 

--- a/spec/foundation/04-internationalization.md
+++ b/spec/foundation/04-internationalization.md
@@ -405,11 +405,11 @@ impl LocaleProvider for StaticLocaleProvider {
 
 Locale, messages, and ICU provider are **environment context** resolved by the adapter
 layer — not by core component code. Core `Props` structs MUST NOT contain `locale`,
-`messages`, or `icu_provider` fields. The adapter reads these from `ArsProvider`
+`messages`, or `intl_backend` fields. The adapter reads these from `ArsProvider`
 context and passes them to core code via the `Env` struct and `Messages` parameter
 (see `01-architecture.md` §2.1 for the `Env` definition).
 
-**Missing provider warning:** All adapter context hooks (`use_locale()`, `use_icu_provider()`,
+**Missing provider warning:** All adapter context hooks (`use_locale()`, `use_intl_backend()`,
 `use_style_strategy()`) emit a `log::warn!` diagnostic when the adapter crate's
 `debug` feature is enabled and no `ArsProvider` is found. This helps developers
 catch missing provider setup during development while keeping diagnostics routed
@@ -457,8 +457,8 @@ fn use_locale() -> Locale {
 
 // Adapter usage — resolve env before passing to core:
 let locale = resolve_locale(adapter_props.locale.as_ref());
-let icu_provider = use_icu_provider();
-let env = Env { locale, icu_provider };
+let intl_backend = use_intl_backend();
+let env = Env { locale, intl_backend };
 let messages = resolve_messages::<dialog::Messages>(adapter_props.messages.as_ref(), &registries, &env.locale);
 let service = Service::new(core_props, env, messages);
 ```
@@ -469,33 +469,33 @@ or `use_context()` directly. This ensures framework-agnostic crates (`ars-core`,
 
 #### 2.3.2 Canonical ICU Provider Resolution
 
-Date-time components need locale-aware calendar data (weekday names, month names, hour cycles, etc.) via the `IcuProvider` trait (§9.5). The provider is resolved by the adapter and passed to core code via the `Env` struct — **never called from core code directly**:
+Date-time components need locale-aware calendar data (weekday names, month names, hour cycles, etc.) via the `IntlBackend` trait (§9.5). The provider is resolved by the adapter and passed to core code via the `Env` struct — **never called from core code directly**:
 
-1. **ArsProvider inheritance** — The adapter calls `use_icu_provider()` to read the provider from the nearest `ArsProvider` in the component tree.
-2. **Ultimate fallback** — If no provider is found, the fallback is `StubIcuProvider` (English-only, zero dependencies).
+1. **ArsProvider inheritance** — The adapter calls `use_intl_backend()` to read the provider from the nearest `ArsProvider` in the component tree.
+2. **Ultimate fallback** — If no provider is found, the fallback is `StubIntlBackend` (English-only, zero dependencies).
 
 ```rust
-// use_icu_provider() implementation (in adapter layer):
-fn use_icu_provider() -> Arc<dyn IcuProvider> {
+// use_intl_backend() implementation (in adapter layer):
+fn use_intl_backend() -> Arc<dyn IntlBackend> {
     use_context::<ArsContext>()
-        .map(|ctx| ctx.icu_provider())
+        .map(|ctx| ctx.intl_backend())
         .unwrap_or_else(|| {
-            warn_missing_provider("use_icu_provider");
-            Arc::new(StubIcuProvider)
+            warn_missing_provider("use_intl_backend");
+            Arc::new(StubIntlBackend)
         })
 }
 ```
 
-The adapter calls `use_icu_provider()` and passes the result via `Env.icu_provider`.
-Core component code accesses the provider from `Env` during `init()`:
+The adapter calls `use_intl_backend()` and passes the result via `Env.intl_backend`.
+Core component code accesses the backend from `Env` during `init()`:
 
 ```rust
-// In Props: NO provider field — resolved by the adapter.
+// In Props: NO backend prop — resolved by the adapter.
 // In Context:
-pub provider: Arc<dyn IcuProvider>,
+pub intl_backend: Arc<dyn IntlBackend>,
 
 // In init():
-provider: env.icu_provider.clone(),
+intl_backend: env.intl_backend.clone(),
 ```
 
 This mirrors how React Aria resolves calendar data through its `I18nProvider` and how Ark UI uses the browser's `Intl` API — the data source is an application-level concern, not a per-component prop.
@@ -1378,7 +1378,7 @@ This representation establishes three invariants:
 
 - all cross-calendar comparison is performed through canonical ISO slots
 - the projected calendar fields always match the canonical ISO date exactly
-- pure calendar math does not require `IcuProvider`
+- pure calendar math does not require `IntlBackend`
 
 The public constructor and arithmetic surface is therefore method-oriented and pure:
 
@@ -1610,15 +1610,15 @@ impl WeekInfo {
 week data, but the public type is fixed to these four fields.
 
 Pure calendar queries use the new `calendar::queries` helpers, while locale-sensitive week helpers
-still accept `&dyn IcuProvider`:
+still accept `&dyn IntlBackend`:
 
 ```rust
-pub fn start_of_week<T: DateValue>(date: &T, locale: &Locale, provider: &dyn IcuProvider) -> T;
-pub fn end_of_week<T: DateValue>(date: &T, locale: &Locale, provider: &dyn IcuProvider) -> T;
-pub fn get_day_of_week(date: &CalendarDate, locale: &Locale, provider: &dyn IcuProvider) -> u8;
-pub fn get_weeks_in_month(date: &CalendarDate, locale: &Locale, provider: &dyn IcuProvider) -> u8;
-pub fn is_weekend(date: &CalendarDate, locale: &Locale, provider: &dyn IcuProvider) -> bool;
-pub fn is_weekday(date: &CalendarDate, locale: &Locale, provider: &dyn IcuProvider) -> bool;
+pub fn start_of_week<T: DateValue>(date: &T, locale: &Locale, backend: &dyn IntlBackend) -> T;
+pub fn end_of_week<T: DateValue>(date: &T, locale: &Locale, backend: &dyn IntlBackend) -> T;
+pub fn get_day_of_week(date: &CalendarDate, locale: &Locale, backend: &dyn IntlBackend) -> u8;
+pub fn get_weeks_in_month(date: &CalendarDate, locale: &Locale, backend: &dyn IntlBackend) -> u8;
+pub fn is_weekend(date: &CalendarDate, locale: &Locale, backend: &dyn IntlBackend) -> bool;
+pub fn is_weekday(date: &CalendarDate, locale: &Locale, backend: &dyn IntlBackend) -> bool;
 ```
 
 The locale-sensitive query contract is:
@@ -2227,7 +2227,7 @@ locale. The three patterns for how locale reaches the call site are:
 
 | Component type                                                       | Locale source                                                                                                                                  | Access pattern                                |
 | -------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
-| **Stateful** (has `Machine` + `Context`)                             | Adapter constructs `Env { locale, icu_provider }`, passes to `Machine::init(props, &env, &messages)`. `init()` stores `env.locale` in Context. | `(self.ctx.messages.label)(&self.ctx.locale)` |
+| **Stateful** (has `Machine` + `Context`)                             | Adapter constructs `Env { locale, intl_backend }`, passes to `Machine::init(props, &env, &messages)`. `init()` stores `env.locale` in Context. | `(self.ctx.messages.label)(&self.ctx.locale)` |
 | **Stateless with `Api`** (no state machine, but has an `Api` struct) | Adapter passes `&Env` to `Api::new(props, env, messages)`. Api stores `&env.locale`.                                                           | `(self.messages.label)(self.locale)`          |
 | **Standalone function** (no `Api` struct)                            | Adapter passes `locale: &Locale` directly as a function parameter.                                                                             | `(messages.label)(locale)`                    |
 
@@ -2562,12 +2562,12 @@ fn init(props: &Self::Props, env: &Env, messages: &Self::Messages) -> (Self::Sta
 ```rust
 // In Leptos/Dioxus adapter component:
 let locale = resolve_locale(adapter_props.locale.as_ref());
-let icu_provider = use_icu_provider();
+let intl_backend = use_intl_backend();
 let registries = use_i18n_registries();
 let messages = resolve_messages::<dialog::Messages>(
     adapter_props.messages.as_ref(), &registries, &locale,
 );
-let env = Env { locale, icu_provider };
+let env = Env { locale, intl_backend };
 let service = Service::new(core_props, env, messages);
 ```
 
@@ -2610,15 +2610,15 @@ prelude to render them reactively in views.
 /// Users define an enum with one variant per translatable string.
 /// Data-carrying variants support parameterized text (plurals, interpolation).
 /// The `t()` function (from adapter prelude) wraps enum variants for reactive
-/// rendering in views — locale and ICU provider are resolved from ArsProvider context.
+/// rendering in views — locale and intl backend are resolved from ArsProvider context.
 ///
 /// Named following Rust verb-form trait conventions (`Clone`, `Display`, `Send`).
 pub trait Translate {
     /// Produce the localized text for this variant.
     ///
     /// - `locale`: The active locale (from `ArsProvider` / `use_locale()`)
-    /// - `icu`: The ICU data provider (from `ArsProvider` / `use_icu_provider()`)
-    fn translate(&self, locale: &Locale, icu: &dyn IcuProvider) -> String;
+    /// - `intl`: The active internationalization backend (from `ArsProvider` / `use_intl_backend()`)
+    fn translate(&self, locale: &Locale, intl: &dyn IntlBackend) -> String;
 }
 ```
 
@@ -2630,12 +2630,12 @@ pub trait Translate {
 - **Always include a fallback arm** (`_` → English) as the last locale match arm.
 - Use `ars_i18n::select_plural()` for plural-aware variants.
 - Use `ars_i18n::NumberFormatter` / `DateFormatter` within `translate()` for locale-aware number and date formatting.
-- The `icu` parameter provides access to calendar data, plural rules, and other CLDR data needed inside `translate()`.
+- The `intl` parameter provides access to calendar data, plural rules, and other CLDR data needed inside `translate()`.
 
 #### 7.4.3 Worked Example
 
 ```rust
-use ars_i18n::{Translate, Locale, IcuProvider, PluralCategory, PluralRuleType};
+use ars_i18n::{Translate, Locale, IntlBackend, PluralCategory, PluralRuleType};
 
 /// All translatable text for the inventory page.
 enum Inventory {
@@ -2645,7 +2645,7 @@ enum Inventory {
 }
 
 impl Translate for Inventory {
-    fn translate(&self, locale: &Locale, icu: &dyn IcuProvider) -> String {
+    fn translate(&self, locale: &Locale, intl: &dyn IntlBackend) -> String {
         match locale.language().as_str() {
             "es" => match self {
                 Self::Title => "Inventario".into(),
@@ -2731,7 +2731,7 @@ enum AdminDashboard { Title, UserCount { count: usize } }
 
 There is no registration step — unlike `ComponentMessages` which uses `I18nRegistries`,
 `Translate` enums are resolved directly via `t()` at render time. The `t()` function
-reads locale and ICU provider from `ArsProvider` context and calls `translate()` immediately.
+reads locale and intl backend from `ArsProvider` context and calls `translate()` immediately.
 
 #### 7.4.5 Relationship to ComponentMessages
 
@@ -2746,13 +2746,13 @@ and do not interact — users never register `Translate` enums in `I18nRegistrie
 ### 7.5 The `t()` Function
 
 The `t()` function is the adapter-specific bridge between `Translate` enums and the
-framework's reactive rendering system. It reads locale and ICU provider from `ArsProvider`
+framework's reactive rendering system. It reads locale and intl backend from `ArsProvider`
 context and produces a reactive text node.
 
 ```rust
 /// Resolve a `Translate` value into a reactive text node for rendering.
 ///
-/// Reads the current locale and ICU provider from `ArsProvider` context,
+/// Reads the current locale and intl backend from `ArsProvider` context,
 /// calls `msg.translate()`, and returns a framework-specific reactive view
 /// that updates when the locale changes.
 ///
@@ -2761,8 +2761,8 @@ context and produces a reactive text node.
 /// # Fallback
 ///
 /// If no `ArsProvider` is present in the ancestor tree, falls back to
-/// `en-US` locale and `StubIcuProvider` — matching the default behavior
-/// of `use_locale()` and `use_icu_provider()`.
+/// `en-US` locale and `StubIntlBackend` — matching the default behavior
+/// of `use_locale()` and `use_intl_backend()`.
 ///
 /// # Reactivity
 ///
@@ -3243,22 +3243,24 @@ impl CollationFormat for StringCollator {
 > API available with an English-only fallback. That configuration is supported
 > for backend-free builds and tests, not for full locale-aware production i18n.
 
-### 9.5 Calendar/Locale Provider Trait (`IcuProvider`)
+### 9.5 Calendar/Locale Backend Trait (`IntlBackend`)
 
-`IcuProvider` is no longer the source of truth for calendar arithmetic.
+`IntlBackend` is no longer the source of truth for calendar arithmetic.
 
 The authoritative calendar engine is the pure `CalendarSystem` / `CalendarDate` / `Time` /
-`CalendarDateTime` / `ZonedDateTime` surface backed by `temporal_rs`. `IcuProvider` now serves two
+`CalendarDateTime` / `ZonedDateTime` surface backed by `temporal_rs`. `IntlBackend` now serves two
 roles:
 
 - locale-aware formatting and labels
 - provider-backed labels, formatting, and locale metadata layered over the pure calendar model
 
 The trait therefore remains public, and its calendar methods are adapters over the pure calendar
-model rather than the owner of calendar semantics.
+model rather than the owner of calendar semantics. `IntlBackend` is a backend abstraction:
+concrete implementations may be CLDR-backed (`Icu4xBackend`), browser-backed (`WebIntlBackend`),
+or English/default fallbacks (`StubIntlBackend`).
 
 ```rust
-pub trait IcuProvider: Send + Sync + 'static {
+pub trait IntlBackend: Send + Sync + 'static {
     fn weekday_short_label(&self, weekday: Weekday, locale: &Locale) -> String;
     fn weekday_long_label(&self, weekday: Weekday, locale: &Locale) -> String;
     fn month_long_name(&self, month: u8, locale: &Locale) -> String;
@@ -3282,8 +3284,9 @@ pub trait IcuProvider: Send + Sync + 'static {
 
 Current behavior requirements:
 
-- the pure calendar API must work without `IcuProvider`
-- default trait implementations for calendar methods delegate to the pure calendar API
+- the pure calendar API must work without `IntlBackend`
+- only the pure-calendar adapter methods may use default trait implementations, and those defaults delegate to the pure calendar API
+- locale-facing formatting and metadata methods (`weekday_*`, `month_long_name`, day-period parsing/formatting, digit formatting, `hour_cycle`, and `week_info`) are required provider responsibilities and must be implemented explicitly by each concrete provider
 - backend providers may override those methods for performance or platform normalization, but must preserve the public `CalendarDate` contract
 - locale-week queries such as `start_of_week(...)`, `end_of_week(...)`, and `get_weeks_in_month(...)` still rely on provider week data
 - `week_info(...)` is the provider entry point for locale first-day-of-week and weekend metadata; `first_day_of_week(...)` is a convenience wrapper over it
@@ -3291,13 +3294,13 @@ Current behavior requirements:
 
 #### 9.5.1 Stub implementation
 
-`StubIcuProvider` remains the default no-backend provider. It supplies English fallback labels and delegates calendar compatibility methods to the pure shared calendar API.
+`StubIntlBackend` remains the default no-backend provider. It supplies English fallback labels and delegates calendar compatibility methods to the pure shared calendar API.
 
 #### 9.5.2 ICU4X provider
 
-`Icu4xProvider` is the production locale-data backend for native and compiled-data builds.
+`Icu4xBackend` is the production locale-data backend for native and compiled-data builds.
 It may use ICU4X data for formatting, week info, and locale preferences, but calendar conversion and validation must still resolve to the same public `CalendarDate` semantics as the pure engine.
 
 #### 9.5.3 Web Intl provider
 
-`WebIntlProvider` is the browser-facing formatting backend for `wasm32` builds. It may normalize browser `Intl` output back into ars-i18n's public era and month-code model, but it does not redefine the public calendar contract.
+`WebIntlBackend` is the browser-facing formatting backend for `wasm32` builds. It may normalize browser `Intl` output back into ars-i18n's public era and month-code model, but it does not redefine the public calendar contract.

--- a/spec/foundation/08-adapter-leptos.md
+++ b/spec/foundation/08-adapter-leptos.md
@@ -67,7 +67,7 @@ The central primitive. Creates a `Service<M>`, wraps it in a reactive signal, an
 use std::rc::Rc;
 use leptos::prelude::*;
 use ars_core::{Machine, Service, Env, Arc};
-use ars_i18n::IcuProvider;
+use ars_i18n::IntlBackend;
 
 /// Return type from `use_machine`.
 #[derive(Clone, Copy)]
@@ -288,11 +288,11 @@ where
 
     // Resolve environment values from ArsProvider context.
     // These are snapshot reads — Leptos components run once, so each component
-    // gets the locale/icu_provider/messages at mount time.
+    // gets the locale/intl_backend/messages at mount time.
     let locale = resolve_locale(None);
-    let icu_provider = use_icu_provider();
+    let intl_backend = use_intl_backend();
     let messages = use_messages::<M::Messages>(None, Some(&locale));
-    let env = Env { locale, icu_provider };
+    let env = Env { locale, intl_backend };
 
     // Create the service once — runs only on component initialization.
     // **Safety**: The `init()` function must not call `api.send()` or otherwise
@@ -1759,7 +1759,7 @@ trait object.
 ```rust
 use std::sync::Arc;
 
-use ars_i18n::{Direction,IcuProvider, Locale};
+use ars_i18n::{Direction,IntlBackend, Locale};
 use ars_core::{ColorMode, PlatformEffects, StyleStrategy};
 
 /// Reactive environment context published by the Leptos ArsProvider adapter.
@@ -1774,7 +1774,7 @@ pub struct ArsContext {
     pub portal_container_id: Signal<Option<String>>,
     pub root_node_id: Signal<Option<String>>,
     pub platform: Arc<dyn PlatformEffects>,
-    pub icu_provider: Arc<dyn IcuProvider>,
+    pub intl_backend: Arc<dyn IntlBackend>,
     pub i18n_registries: Arc<I18nRegistries>,
     /// Non-reactive style strategy — set once at provider mount time.
     style_strategy: StyleStrategy,
@@ -1963,8 +1963,8 @@ use ars_i18n::Translate;
 #[must_use]
 pub fn t<T: Translate + Send + Sync + 'static>(msg: T) -> impl IntoView {
     let locale = use_locale();
-    let icu = use_icu_provider();
-    move || msg.translate(&locale.get(), &*icu)
+    let intl_backend = use_intl_backend();
+    move || msg.translate(&locale.get(), &*intl_backend)
 }
 ```
 

--- a/spec/foundation/09-adapter-dioxus.md
+++ b/spec/foundation/09-adapter-dioxus.md
@@ -60,7 +60,7 @@ ssr = ["dioxus/server", "dep:ars-dom", "ars-dom/ssr"]
 use std::sync::Arc;
 use dioxus::prelude::*;
 use ars_core::{Machine, Service, Env};
-use ars_i18n::{Locale, IcuProvider, ComponentMessages, I18nRegistries};
+use ars_i18n::{Locale, IntlBackend, ComponentMessages, I18nRegistries};
 
 /// Return type from `use_machine`.
 ///
@@ -272,8 +272,8 @@ where
     // Resolve environment values from ArsProvider context.
     // These are adapter-only hooks — core code receives Env and Messages as parameters.
     let locale = resolve_locale(None);
-    let icu_provider = use_icu_provider();
-    let env = Env { locale, icu_provider };
+    let intl_backend = use_intl_backend();
+    let env = Env { locale, intl_backend };
 
     // Resolve messages from adapter-level i18n hooks.
     let messages = use_messages::<M::Messages>(None, Some(&env.locale));
@@ -2139,7 +2139,7 @@ The adapter-level context wraps core `ArsContext` values in reactive signals and
 includes the style strategy and the Dioxus-specific platform capabilities trait object.
 
 ```rust
-use ars_i18n::{Direction, IcuProvider, Locale};
+use ars_i18n::{Direction, IntlBackend, Locale};
 use ars_core::{
     ArsContext as CoreCtx, Arc, ColorMode, I18nRegistries, PlatformEffects, StyleStrategy,
 };
@@ -2156,7 +2156,7 @@ pub struct ArsContext {
     pub portal_container_id: Signal<Option<String>>,
     pub root_node_id: Signal<Option<String>>,
     pub platform: Arc<dyn PlatformEffects>,
-    pub icu_provider: Arc<dyn IcuProvider>,
+    pub intl_backend: Arc<dyn IntlBackend>,
     pub i18n_registries: Arc<I18nRegistries>,
     pub style_strategy: StyleStrategy,
     /// Dioxus adapter-specific: platform services for file pickers, clipboard, drag data.
@@ -2177,7 +2177,7 @@ The Dioxus adapter resolves `platform` via feature flags: `WebPlatformEffects` (
 ### 16.1 use_locale()
 
 All ArsProvider fallback helpers in this section (`use_locale()`,
-`use_icu_provider()`, `t()`, and `use_platform()`) route through
+`use_intl_backend()`, `t()`, and `use_platform()`) route through
 `warn_missing_provider()`. That helper emits `log::warn!` only when the
 `ars-dioxus/debug` feature is enabled.
 
@@ -2254,7 +2254,7 @@ See `04-internationalization.md` §2.3.1 for the three-level resolution chain
 use std::sync::Arc;
 
 use ars_core::Env;
-use ars_i18n::{Locale, IcuProvider, StubIcuProvider, ComponentMessages, I18nRegistries};
+use ars_i18n::{Locale, IntlBackend, StubIntlBackend, ComponentMessages, I18nRegistries};
 
 /// Resolve locale from an optional adapter prop override or ArsProvider context.
 ///
@@ -2281,17 +2281,17 @@ fn resolve_locale(adapter_props_locale: Option<&Locale>) -> Locale {
 
 /// Resolve the ICU provider from ArsProvider context.
 ///
-/// Falls back to `StubIcuProvider` (English-only, zero dependencies) if no
+/// Falls back to `StubIntlBackend` (English-only, zero dependencies) if no
 /// `ArsProvider` is present.
 ///
 /// This is an **adapter-only** utility — NOT available in core crates. Core code
-/// receives the provider via `Env.icu_provider`.
-fn use_icu_provider() -> Arc<dyn IcuProvider> {
+/// receives the provider via `Env.intl_backend`.
+fn use_intl_backend() -> Arc<dyn IntlBackend> {
     try_use_context::<ArsContext>()
-        .map(|ctx| ctx.icu_provider.clone())
+        .map(|ctx| ctx.intl_backend.clone())
         .unwrap_or_else(|| {
-            warn_missing_provider("use_icu_provider");
-            Arc::new(StubIcuProvider)
+            warn_missing_provider("use_intl_backend");
+            Arc::new(StubIntlBackend)
         })
 }
 
@@ -2336,11 +2336,11 @@ use ars_i18n::Translate;
 /// and §7.5 for the `t()` function contract.
 pub fn t<T: Translate>(msg: T) -> String {
     try_use_context::<ArsContext>()
-        .map(|ctx| msg.translate(&ctx.locale.read(), &*ctx.icu_provider))
+        .map(|ctx| msg.translate(&ctx.locale.read(), &*ctx.intl_backend))
         .unwrap_or_else(|| {
             warn_missing_provider("t");
             let fallback = Locale::parse("en-US").expect("en-US is always a valid BCP 47 locale");
-            msg.translate(&fallback, &StubIcuProvider)
+            msg.translate(&fallback, &StubIntlBackend)
         })
 }
 ```

--- a/spec/leptos-components/utility/ars-provider.md
+++ b/spec/leptos-components/utility/ars-provider.md
@@ -10,7 +10,7 @@ source_foundation: foundation/08-adapter-leptos.md
 
 ## 1. Purpose and Adapter Scope
 
-This spec maps the core [`ArsProvider`](../../components/utility/ars-provider.md) context contract to Leptos 0.8.x. `ArsProvider` is the single root provider — it subsumes the formerly separate `LocaleProvider`, `PlatformEffectsProvider`, `IcuProvider`, `I18nProvider`, and `ArsStyleProvider`.
+This spec maps the core [`ArsProvider`](../../components/utility/ars-provider.md) context contract to Leptos 0.8.x. `ArsProvider` is the single root provider — it subsumes the formerly separate `LocaleProvider`, `PlatformEffectsProvider`, `IntlBackend`, `I18nProvider`, and `ArsStyleProvider`.
 
 ## 2. Public Adapter API
 
@@ -26,7 +26,7 @@ pub fn ArsProvider(
     #[prop(optional)] portal_container_id: Option<String>,
     #[prop(optional)] root_node_id: Option<String>,
     #[prop(optional)] platform: Option<Arc<dyn PlatformEffects>>,
-    #[prop(optional)] icu_provider: Option<Arc<dyn IcuProvider>>,
+    #[prop(optional)] intl_backend: Option<Arc<dyn IntlBackend>>,
     #[prop(optional)] i18n_registries: Option<Arc<I18nRegistries>>,
     #[prop(optional)] style_strategy: Option<StyleStrategy>,
     children: Children,
@@ -66,7 +66,7 @@ ArsProvider is context-driven rather than event-driven.
 | `color_mode`                                         | controlled | signal change           | update ArsContext.color_mode | theme-aware descendants re-render         |                                                   |
 | `disabled` / `read_only`                             | controlled | signal change           | update ArsContext fields     | descendant components enable/disable      |                                                   |
 | `id_prefix` / `portal_container_id` / `root_node_id` | controlled | prop change after mount | update provided context      | descendants resolve new ID prefix/targets | non-reactive; set once at mount                   |
-| `icu_provider`                                       | controlled | prop at mount           | stored in ArsContext         | date-time components use ICU data         | non-reactive; set once at mount                   |
+| `intl_backend`                                       | controlled | prop at mount           | stored in ArsContext         | date-time components use ICU data         | non-reactive; set once at mount                   |
 | `i18n_registries`                                    | controlled | prop at mount           | stored in ArsContext         | components resolve translated messages    | non-reactive; set once at mount                   |
 | `style_strategy`                                     | controlled | prop at mount           | stored in ArsContext         | components use strategy for CSS injection | non-reactive; defaults to `StyleStrategy::Inline` |
 
@@ -189,7 +189,7 @@ pub fn ArsProvider(
     #[prop(optional)] portal_container_id: Option<String>,
     #[prop(optional)] root_node_id: Option<String>,
     #[prop(optional)] platform: Option<Arc<dyn PlatformEffects>>,
-    #[prop(optional)] icu_provider: Option<Arc<dyn IcuProvider>>,
+    #[prop(optional)] intl_backend: Option<Arc<dyn IntlBackend>>,
     #[prop(optional)] i18n_registries: Option<Arc<I18nRegistries>>,
     #[prop(optional)] style_strategy: Option<StyleStrategy>,
     children: Children,
@@ -206,7 +206,7 @@ pub fn ArsProvider(
     let disabled = disabled.unwrap_or_else(|| Signal::stored(false));
     let read_only = read_only.unwrap_or_else(|| Signal::stored(false));
     let platform = platform.unwrap_or_else(|| Rc::new(WebPlatformEffects));
-    let icu_provider = icu_provider.unwrap_or_else(|| Arc::new(StubIcuProvider));
+    let intl_backend = intl_backend.unwrap_or_else(|| Arc::new(StubIntlBackend));
     let i18n_registries = i18n_registries.unwrap_or_else(|| Rc::new(I18nRegistries::new()));
     let style_strategy = style_strategy.unwrap_or(StyleStrategy::Inline);
 
@@ -220,7 +220,7 @@ pub fn ArsProvider(
         portal_container_id: Signal::stored(portal_container_id),
         root_node_id: Signal::stored(root_node_id),
         platform,
-        icu_provider,
+        intl_backend,
         i18n_registries,
         style_strategy,
     });

--- a/spec/shared/date-time-types.md
+++ b/spec/shared/date-time-types.md
@@ -11,8 +11,8 @@ The current design is intentionally close to React Aria and ECMAScript Temporal:
 
 - calendar identifiers are explicit
 - dates are opaque validated values, not raw public structs
-- pure calendar arithmetic does not depend on `IcuProvider`
-- locale-aware week and formatting queries still use `IcuProvider`
+- pure calendar arithmetic does not depend on `IntlBackend`
+- locale-aware week and formatting queries still use `IntlBackend`
 - zoned and local-time behavior is available on `std` builds
 
 ### 1.1 Shared Types (`ars-i18n`)
@@ -22,7 +22,7 @@ The shared public surface is:
 ```rust
 use core::cmp::Ordering;
 
-use ars_i18n::{CalendarError, CalendarConversionError, DateError, IcuProvider, Locale, Weekday};
+use ars_i18n::{CalendarError, CalendarConversionError, DateError, IntlBackend, Locale, Weekday};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Default)]
 pub enum CalendarSystem {
@@ -427,7 +427,7 @@ pub fn to_zoned_date_time(
 ) -> Result<ZonedDateTime, CalendarError>;
 
 pub mod queries {
-    use ars_i18n::{CalendarDate, CalendarError, DateValue, IcuProvider, Locale, TimeZoneId};
+    use ars_i18n::{CalendarDate, CalendarError, DateValue, IntlBackend, Locale, TimeZoneId};
 
     pub fn is_same_day(a: &impl DateValue, b: &impl DateValue) -> bool;
     pub fn is_same_month(a: &impl DateValue, b: &impl DateValue) -> bool;
@@ -441,17 +441,17 @@ pub mod queries {
     pub fn end_of_month<T: DateValue>(date: &T) -> T;
     pub fn start_of_year<T: DateValue>(date: &T) -> T;
     pub fn end_of_year<T: DateValue>(date: &T) -> T;
-    pub fn start_of_week<T: DateValue>(date: &T, locale: &Locale, provider: &dyn IcuProvider) -> T;
-    pub fn end_of_week<T: DateValue>(date: &T, locale: &Locale, provider: &dyn IcuProvider) -> T;
+    pub fn start_of_week<T: DateValue>(date: &T, locale: &Locale, backend: &dyn IntlBackend) -> T;
+    pub fn end_of_week<T: DateValue>(date: &T, locale: &Locale, backend: &dyn IntlBackend) -> T;
 
-    pub fn get_day_of_week(date: &CalendarDate, locale: &Locale, provider: &dyn IcuProvider) -> u8;
-    pub fn get_weeks_in_month(date: &CalendarDate, locale: &Locale, provider: &dyn IcuProvider) -> u8;
+    pub fn get_day_of_week(date: &CalendarDate, locale: &Locale, backend: &dyn IntlBackend) -> u8;
+    pub fn get_weeks_in_month(date: &CalendarDate, locale: &Locale, backend: &dyn IntlBackend) -> u8;
     pub fn get_hours_in_day(date: &CalendarDate, time_zone: &TimeZoneId) -> Result<u8, CalendarError>;
 
     pub fn min_date<T: DateValue>(a: &T, b: &T) -> T;
     pub fn max_date<T: DateValue>(a: &T, b: &T) -> T;
-    pub fn is_weekend(date: &CalendarDate, locale: &Locale, provider: &dyn IcuProvider) -> bool;
-    pub fn is_weekday(date: &CalendarDate, locale: &Locale, provider: &dyn IcuProvider) -> bool;
+    pub fn is_weekend(date: &CalendarDate, locale: &Locale, backend: &dyn IntlBackend) -> bool;
+    pub fn is_weekday(date: &CalendarDate, locale: &Locale, backend: &dyn IntlBackend) -> bool;
 }
 
 pub mod parse {
@@ -476,7 +476,7 @@ Query semantics:
 
 - `is_same_*` compares display fields in the first argument's calendar and era. If the second argument uses a different calendar, it is converted into the first argument's calendar before comparing year, month, and day fields.
 - `is_equal_*` requires the same calendar and era and compares the exposed display fields directly. Cross-calendar projections of the same ISO day are not equal.
-- `start_of_week`, `end_of_week`, `get_weeks_in_month`, `is_weekday`, and `is_weekend` are locale-aware and therefore still require `IcuProvider`.
+- `start_of_week`, `end_of_week`, `get_weeks_in_month`, `is_weekday`, and `is_weekend` are locale-aware and therefore still require `IntlBackend`.
 - `get_day_of_week` returns `0..=6`, where `0` is the locale's first day of week from provider-backed `WeekInfo`. When the locale carries a `u-fw-*` Unicode extension, that explicit first-day override takes precedence over the locale default.
 - `get_hours_in_day` uses real zoned day-boundary math and returns `23`, `24`, or `25` when DST changes alter the local day length.
 - `is_weekend` and `is_weekday` use locale weekend metadata rather than a hard-coded Saturday/Sunday rule.

--- a/spec/testing/08-i18n-testing.md
+++ b/spec/testing/08-i18n-testing.md
@@ -1118,7 +1118,7 @@ enum Inventory {
 }
 
 impl Translate for Inventory {
-    fn translate(&self, locale: &Locale, icu: &dyn IcuProvider) -> String {
+    fn translate(&self, locale: &Locale, intl: &dyn IntlBackend) -> String {
         match locale.language().as_str() {
             "es" => match self {
                 Self::Title => "Inventario".into(),
@@ -1152,16 +1152,16 @@ impl Translate for Inventory {
 
 #[test]
 fn translate_title_per_locale() {
-    let icu = StubIcuProvider;
+    let intl = StubIntlProvider;
     assert_eq!(
         Inventory::Title.translate(
-            &Locale::parse("en").expect("en is a valid BCP-47 tag"), &icu,
+            &Locale::parse("en").expect("en is a valid BCP-47 tag"), &intl,
         ),
         "Inventory",
     );
     assert_eq!(
         Inventory::Title.translate(
-            &Locale::parse("es").expect("es is a valid BCP-47 tag"), &icu,
+            &Locale::parse("es").expect("es is a valid BCP-47 tag"), &intl,
         ),
         "Inventario",
     );
@@ -1169,16 +1169,16 @@ fn translate_title_per_locale() {
 
 #[test]
 fn translate_welcome_per_locale() {
-    let icu = StubIcuProvider;
+    let intl = StubIntlProvider;
     assert_eq!(
         Inventory::Welcome.translate(
-            &Locale::parse("en").expect("en is a valid BCP-47 tag"), &icu,
+            &Locale::parse("en").expect("en is a valid BCP-47 tag"), &intl,
         ),
         "Welcome!",
     );
     assert_eq!(
         Inventory::Welcome.translate(
-            &Locale::parse("es").expect("es is a valid BCP-47 tag"), &icu,
+            &Locale::parse("es").expect("es is a valid BCP-47 tag"), &intl,
         ),
         "¡Bienvenido!",
     );
@@ -1193,20 +1193,20 @@ Test data-carrying variants across locales with different CLDR plural rules.
 #[test]
 fn translate_item_count_english_plurals() {
     let locale = Locale::parse("en").expect("en is a valid BCP-47 tag");
-    let icu = StubIcuProvider;
-    assert_eq!(Inventory::ItemCount { count: 0 }.translate(&locale, &icu), "0 items");
-    assert_eq!(Inventory::ItemCount { count: 1 }.translate(&locale, &icu), "1 item");
-    assert_eq!(Inventory::ItemCount { count: 2 }.translate(&locale, &icu), "2 items");
-    assert_eq!(Inventory::ItemCount { count: 42 }.translate(&locale, &icu), "42 items");
+    let intl = StubIntlProvider;
+    assert_eq!(Inventory::ItemCount { count: 0 }.translate(&locale, &intl), "0 items");
+    assert_eq!(Inventory::ItemCount { count: 1 }.translate(&locale, &intl), "1 item");
+    assert_eq!(Inventory::ItemCount { count: 2 }.translate(&locale, &intl), "2 items");
+    assert_eq!(Inventory::ItemCount { count: 42 }.translate(&locale, &intl), "42 items");
 }
 
 #[test]
 fn translate_item_count_spanish_plurals() {
     let locale = Locale::parse("es").expect("es is a valid BCP-47 tag");
-    let icu = StubIcuProvider;
-    assert_eq!(Inventory::ItemCount { count: 0 }.translate(&locale, &icu), "0 elementos");
-    assert_eq!(Inventory::ItemCount { count: 1 }.translate(&locale, &icu), "1 elemento");
-    assert_eq!(Inventory::ItemCount { count: 5 }.translate(&locale, &icu), "5 elementos");
+    let intl = StubIntlProvider;
+    assert_eq!(Inventory::ItemCount { count: 0 }.translate(&locale, &intl), "0 elementos");
+    assert_eq!(Inventory::ItemCount { count: 1 }.translate(&locale, &intl), "1 elemento");
+    assert_eq!(Inventory::ItemCount { count: 5 }.translate(&locale, &intl), "5 elementos");
 }
 ```
 
@@ -1219,7 +1219,7 @@ enum PolishItems {
 }
 
 impl Translate for PolishItems {
-    fn translate(&self, locale: &Locale, _icu: &dyn IcuProvider) -> String {
+    fn translate(&self, locale: &Locale, _intl: &dyn IntlBackend) -> String {
         match locale.language().as_str() {
             "pl" => match self {
                 Self::Count { count } => {
@@ -1251,11 +1251,11 @@ impl Translate for PolishItems {
 #[test]
 fn polish_plural_categories() {
     let locale = Locale::parse("pl").expect("pl is a valid BCP-47 tag");
-    let icu = StubIcuProvider;
-    assert_eq!(PolishItems::Count { count: 1 }.translate(&locale, &icu), "1 element");
-    assert_eq!(PolishItems::Count { count: 2 }.translate(&locale, &icu), "2 elementy");
-    assert_eq!(PolishItems::Count { count: 5 }.translate(&locale, &icu), "5 elementów");
-    assert_eq!(PolishItems::Count { count: 22 }.translate(&locale, &icu), "22 elementy");
+    let intl = StubIntlProvider;
+    assert_eq!(PolishItems::Count { count: 1 }.translate(&locale, &intl), "1 element");
+    assert_eq!(PolishItems::Count { count: 2 }.translate(&locale, &intl), "2 elementy");
+    assert_eq!(PolishItems::Count { count: 5 }.translate(&locale, &intl), "5 elementów");
+    assert_eq!(PolishItems::Count { count: 22 }.translate(&locale, &intl), "22 elementy");
 }
 ```
 
@@ -1288,16 +1288,16 @@ Verify that unknown locales fall through to the English `_` arm.
 #[test]
 fn unknown_locale_falls_back_to_english() {
     let locale = Locale::parse("xx-XX").expect("xx-XX is a valid BCP-47 tag");
-    let icu = StubIcuProvider;
-    assert_eq!(Inventory::Title.translate(&locale, &icu), "Inventory");
-    assert_eq!(Inventory::Welcome.translate(&locale, &icu), "Welcome!");
-    assert_eq!(Inventory::ItemCount { count: 1 }.translate(&locale, &icu), "1 item");
+    let intl = StubIntlProvider;
+    assert_eq!(Inventory::Title.translate(&locale, &intl), "Inventory");
+    assert_eq!(Inventory::Welcome.translate(&locale, &intl), "Welcome!");
+    assert_eq!(Inventory::ItemCount { count: 1 }.translate(&locale, &intl), "1 item");
 }
 ```
 
-### 8.5 ICU Provider Threading
+### 8.5 Intl Backend Threading
 
-Verify that the `icu` parameter is correctly passed through for locale-aware formatting
+Verify that the `intl` parameter is correctly passed through for locale-aware formatting
 within `translate()`. This tests the case where `translate()` uses `NumberFormatter` or
 `DateFormatter` from the ICU provider.
 
@@ -1308,7 +1308,7 @@ enum Price {
 }
 
 impl Translate for Price {
-    fn translate(&self, locale: &Locale, icu: &dyn IcuProvider) -> String {
+    fn translate(&self, locale: &Locale, intl: &dyn IntlBackend) -> String {
         match self {
             Self::Total { amount } => {
                 let formatter = ars_i18n::NumberFormatter::new(
@@ -1330,11 +1330,11 @@ impl Translate for Price {
 #[test]
 fn translate_with_icu_number_formatting() {
     let locale = Locale::parse("en-US").expect("en-US is a valid BCP-47 tag");
-    let icu = StubIcuProvider;
-    let result = Price::Total { amount: 1234.50 }.translate(&locale, &icu);
+    let intl = StubIntlProvider;
+    let result = Price::Total { amount: 1234.50 }.translate(&locale, &intl);
     assert!(result.starts_with("Total: "), "formatted price must start with 'Total: '");
-    // The exact formatted output depends on the ICU provider; StubIcuProvider
-    // may produce simplified formatting. Production tests use Icu4xProvider.
+    // The exact formatted output depends on the active backend; StubIntlProvider
+    // may produce simplified formatting. Production tests use Icu4xBackend.
 }
 ```
 


### PR DESCRIPTION
## Summary
- finalize the `IntlBackend` trait contract by removing rollout defaults from locale-facing methods
- rename the concrete i18n backends and remaining adapter/backend-facing `icu` terminology to `intl` consistently
- add and expand i18n, adapter, wasm, and coverage tests plus spec updates to keep the implementation aligned

## Why
The backend abstraction is no longer ICU4X-only, so the old `IcuProvider` naming and default-heavy contract were misleading. This change makes the contract explicit, aligns code and spec terminology, and keeps coverage at the required thresholds after the rename.

## Validation
- `cargo xci`

Closes #546
