### PR TITLE
Add snapshot coverage for agnostic form components

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,42 @@ jobs:
       - uses: ./.github/actions/install-dioxus-desktop-deps
       - name: Unit Tests
         run: cargo xtest unit
+      - name: Install cargo-insta
+        run: cargo install cargo-insta --locked
+      - name: Snapshot Tests
+        run: cargo insta test --unreferenced=reject
+        env:
+          INSTA_UPDATE: no
+
+  snapshot-change-check:
+    name: Snapshot Change Check
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check for snapshot changes
+        id: snap-changes
+        run: |
+          SNAP_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD | grep '\.snap$' || true)
+          if [ -n "$SNAP_FILES" ]; then
+            echo "has_snaps=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Snapshot review check
+        if: steps.snap-changes.outputs.has_snaps == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if ! git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -q 'CHANGELOG'; then
+            if ! gh pr view ${{ github.event.pull_request.number }} --json labels -q '.labels[].name' | grep -q 'snapshot-reviewed'; then
+              echo "::error::PRs modifying .snap files must include a CHANGELOG entry or have the 'snapshot-reviewed' label"
+              exit 1
+            fi
+          fi
 
   i18n-browser:
     name: I18n Browser Tests

--- a/crates/ars-core/Cargo.toml
+++ b/crates/ars-core/Cargo.toml
@@ -22,6 +22,7 @@ log      = { version = "0.4", default-features = false, optional = true }
 serde    = { version = "1", default-features = false, features = ["alloc", "derive"], optional = true }
 
 [dev-dependencies]
+insta      = { version = "1", features = ["yaml"] }
 serde_json = "1"
 trybuild   = "1"
 

--- a/crates/ars-core/tests/snapshot_smoke.rs
+++ b/crates/ars-core/tests/snapshot_smoke.rs
@@ -1,0 +1,225 @@
+//! Snapshot coverage for the spec-defined `connect()` / `AttrMap` pattern.
+
+use ars_core::{
+    AriaAttr, AttrMap, ComponentPart, ConnectApi, Env, HasId, HtmlAttr, Machine, TransitionPlan,
+};
+use insta::assert_snapshot;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SnapshotState {
+    Idle,
+    Pressed,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum SnapshotEvent {
+    Toggle,
+}
+
+#[derive(Clone, Debug)]
+struct SnapshotContext {
+    disabled: bool,
+    label: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct SnapshotProps {
+    id: String,
+}
+
+impl HasId for SnapshotProps {
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    fn with_id(self, id: String) -> Self {
+        Self { id }
+    }
+
+    fn set_id(&mut self, id: String) {
+        self.id = id;
+    }
+}
+
+#[derive(ComponentPart)]
+#[scope = "snapshot-toggle"]
+enum SnapshotPart {
+    Root,
+    Indicator,
+}
+
+struct SnapshotApi<'a> {
+    state: &'a SnapshotState,
+    context: &'a SnapshotContext,
+    props: &'a SnapshotProps,
+}
+
+impl ConnectApi for SnapshotApi<'_> {
+    type Part = SnapshotPart;
+
+    fn part_attrs(&self, part: Self::Part) -> AttrMap {
+        let mut attrs = AttrMap::new();
+
+        for (attr, value) in part.data_attrs() {
+            attrs.set(attr, value);
+        }
+
+        let state_value = match self.state {
+            SnapshotState::Idle => "idle",
+            SnapshotState::Pressed => "pressed",
+        };
+
+        attrs.set(HtmlAttr::Data("ars-state"), state_value);
+
+        match part {
+            SnapshotPart::Root => {
+                attrs
+                    .set(HtmlAttr::Id, self.props.id())
+                    .set(HtmlAttr::Role, "button")
+                    .set(
+                        HtmlAttr::TabIndex,
+                        if self.context.disabled { "-1" } else { "0" },
+                    )
+                    .set(HtmlAttr::Aria(AriaAttr::Label), self.context.label.as_str())
+                    .set(
+                        HtmlAttr::Aria(AriaAttr::Pressed),
+                        match self.state {
+                            SnapshotState::Idle => "false",
+                            SnapshotState::Pressed => "true",
+                        },
+                    );
+
+                if self.context.disabled {
+                    attrs.set(HtmlAttr::Aria(AriaAttr::Disabled), "true");
+                }
+            }
+
+            SnapshotPart::Indicator => {
+                attrs
+                    .set(HtmlAttr::Id, format!("{}-indicator", self.props.id()))
+                    .set(HtmlAttr::Aria(AriaAttr::Hidden), "true");
+            }
+        }
+
+        attrs
+    }
+}
+
+struct SnapshotMachine;
+
+impl Machine for SnapshotMachine {
+    type State = SnapshotState;
+    type Event = SnapshotEvent;
+    type Context = SnapshotContext;
+    type Props = SnapshotProps;
+    type Messages = ();
+    type Api<'a> = SnapshotApi<'a>;
+
+    fn init(
+        _props: &Self::Props,
+        _env: &Env,
+        _messages: &Self::Messages,
+    ) -> (Self::State, Self::Context) {
+        (
+            SnapshotState::Idle,
+            SnapshotContext {
+                disabled: false,
+                label: String::from("Example toggle"),
+            },
+        )
+    }
+
+    fn transition(
+        state: &Self::State,
+        event: &Self::Event,
+        _context: &Self::Context,
+        _props: &Self::Props,
+    ) -> Option<TransitionPlan<Self>> {
+        match (state, event) {
+            (SnapshotState::Idle, SnapshotEvent::Toggle) => {
+                Some(TransitionPlan::to(SnapshotState::Pressed))
+            }
+
+            (SnapshotState::Pressed, SnapshotEvent::Toggle) => {
+                Some(TransitionPlan::to(SnapshotState::Idle))
+            }
+        }
+    }
+
+    fn connect<'a>(
+        state: &'a Self::State,
+        context: &'a Self::Context,
+        props: &'a Self::Props,
+        _send: &'a dyn Fn(Self::Event),
+    ) -> Self::Api<'a> {
+        SnapshotApi {
+            state,
+            context,
+            props,
+        }
+    }
+}
+
+fn snapshot_attrs(state: SnapshotState, disabled: bool, part: SnapshotPart) -> String {
+    let context = SnapshotContext {
+        disabled,
+        label: String::from("Example toggle"),
+    };
+
+    let props = SnapshotProps {
+        id: String::from("example-toggle"),
+    };
+
+    let api = SnapshotMachine::connect(
+        &state,
+        &context,
+        &props,
+        &|event: SnapshotEvent| match event {
+            SnapshotEvent::Toggle => {}
+        },
+    );
+
+    format!("{:#?}", api.part_attrs(part))
+}
+
+#[test]
+fn snapshot_root_idle_attrs() {
+    assert_snapshot!(
+        "snapshot_root_idle",
+        snapshot_attrs(SnapshotState::Idle, false, SnapshotPart::Root)
+    );
+}
+
+#[test]
+fn snapshot_root_pressed_attrs() {
+    assert_snapshot!(
+        "snapshot_root_pressed",
+        snapshot_attrs(SnapshotState::Pressed, false, SnapshotPart::Root)
+    );
+}
+
+#[test]
+fn snapshot_indicator_pressed_attrs() {
+    assert_snapshot!(
+        "snapshot_indicator_pressed",
+        snapshot_attrs(SnapshotState::Pressed, true, SnapshotPart::Indicator)
+    );
+}
+
+#[test]
+fn snapshot_fixture_machine_toggles_between_states() {
+    let next = SnapshotMachine::transition(
+        &SnapshotState::Idle,
+        &SnapshotEvent::Toggle,
+        &SnapshotContext {
+            disabled: false,
+            label: String::from("Example toggle"),
+        },
+        &SnapshotProps {
+            id: String::from("example-toggle"),
+        },
+    )
+    .expect("toggle event should produce a transition");
+
+    assert_eq!(next.target, Some(SnapshotState::Pressed));
+}

--- a/crates/ars-core/tests/snapshots/snapshot_smoke__snapshot_indicator_pressed.snap
+++ b/crates/ars-core/tests/snapshots/snapshot_smoke__snapshot_indicator_pressed.snap
@@ -1,0 +1,47 @@
+---
+source: crates/ars-core/tests/snapshot_smoke.rs
+expression: "snapshot_attrs(SnapshotState::Pressed, true, SnapshotPart::Indicator)"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "indicator",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "snapshot-toggle",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "pressed",
+            ),
+        ),
+        (
+            Aria(
+                Hidden,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "example-toggle-indicator",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-core/tests/snapshots/snapshot_smoke__snapshot_root_idle.snap
+++ b/crates/ars-core/tests/snapshots/snapshot_smoke__snapshot_root_idle.snap
@@ -1,0 +1,67 @@
+---
+source: crates/ars-core/tests/snapshot_smoke.rs
+expression: "snapshot_attrs(SnapshotState::Idle, false, SnapshotPart::Root)"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "snapshot-toggle",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "idle",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Example toggle",
+            ),
+        ),
+        (
+            Aria(
+                Pressed,
+            ),
+            String(
+                "false",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "example-toggle",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "button",
+            ),
+        ),
+        (
+            TabIndex,
+            String(
+                "0",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-core/tests/snapshots/snapshot_smoke__snapshot_root_pressed.snap
+++ b/crates/ars-core/tests/snapshots/snapshot_smoke__snapshot_root_pressed.snap
@@ -1,0 +1,67 @@
+---
+source: crates/ars-core/tests/snapshot_smoke.rs
+expression: "snapshot_attrs(SnapshotState::Pressed, false, SnapshotPart::Root)"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "snapshot-toggle",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "pressed",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Example toggle",
+            ),
+        ),
+        (
+            Aria(
+                Pressed,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "example-toggle",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "button",
+            ),
+        ),
+        (
+            TabIndex,
+            String(
+                "0",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-forms/Cargo.toml
+++ b/crates/ars-forms/Cargo.toml
@@ -26,5 +26,8 @@ version  = "0.9.1"
 optional = true
 features = ["normalization", "comments", "white-spaces", "literals"]
 
+[dev-dependencies]
+insta = { version = "1", features = ["yaml"] }
+
 [lints]
 workspace = true

--- a/crates/ars-forms/src/field/component.rs
+++ b/crates/ars-forms/src/field/component.rs
@@ -433,6 +433,7 @@ impl<'a> Api<'a> {
 #[cfg(test)]
 mod tests {
     use ars_core::{ConnectApi, Service};
+    use insta::assert_snapshot;
 
     use super::*;
 
@@ -452,6 +453,10 @@ mod tests {
 
     fn custom_error() -> Error {
         Error::custom("required", "Field is invalid")
+    }
+
+    fn snapshot_attrs(attrs: &AttrMap) -> String {
+        format!("{attrs:#?}")
     }
 
     #[test]
@@ -748,6 +753,132 @@ mod tests {
         let attrs = api.root_attrs();
 
         assert_eq!(attrs.get(&HtmlAttr::Dir), Some("rtl"));
+    }
+
+    #[test]
+    fn field_root_default_snapshot() {
+        let service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        assert_snapshot!(
+            "field_root_default",
+            snapshot_attrs(&service.connect(&|_| {}).root_attrs())
+        );
+    }
+
+    #[test]
+    fn field_root_rtl_snapshot() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        drop(service.send(Event::SetDir(Some(Direction::Rtl))));
+
+        assert_snapshot!(
+            "field_root_rtl",
+            snapshot_attrs(&service.connect(&|_| {}).root_attrs())
+        );
+    }
+
+    #[test]
+    fn field_label_default_snapshot() {
+        let service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        assert_snapshot!(
+            "field_label_default",
+            snapshot_attrs(&service.connect(&|_| {}).label_attrs())
+        );
+    }
+
+    #[test]
+    fn field_input_default_snapshot() {
+        let service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        assert_snapshot!(
+            "field_input_default",
+            snapshot_attrs(&service.connect(&|_| {}).input_attrs())
+        );
+    }
+
+    #[test]
+    fn field_input_required_snapshot() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        drop(service.send(Event::SetRequired(true)));
+
+        assert_snapshot!(
+            "field_input_required",
+            snapshot_attrs(&service.connect(&|_| {}).input_attrs())
+        );
+    }
+
+    #[test]
+    fn field_input_invalid_no_errors_snapshot() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        drop(service.send(Event::SetInvalid(true)));
+
+        assert_snapshot!(
+            "field_input_invalid_no_errors",
+            snapshot_attrs(&service.connect(&|_| {}).input_attrs())
+        );
+    }
+
+    #[test]
+    fn field_input_invalid_with_description_and_error_snapshot() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        drop(service.send(Event::SetHasDescription(true)));
+        drop(service.send(Event::SetInvalid(true)));
+        drop(service.send(Event::SetErrors(vec![custom_error()])));
+
+        assert_snapshot!(
+            "field_input_invalid_with_description_and_error",
+            snapshot_attrs(&service.connect(&|_| {}).input_attrs())
+        );
+    }
+
+    #[test]
+    fn field_input_disabled_readonly_validating_snapshot() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        drop(service.send(Event::SetDisabled(true)));
+        drop(service.send(Event::SetReadonly(true)));
+        drop(service.send(Event::SetValidating(true)));
+
+        assert_snapshot!(
+            "field_input_disabled_readonly_validating",
+            snapshot_attrs(&service.connect(&|_| {}).input_attrs())
+        );
+    }
+
+    #[test]
+    fn field_description_default_snapshot() {
+        let service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        assert_snapshot!(
+            "field_description_default",
+            snapshot_attrs(&service.connect(&|_| {}).description_attrs())
+        );
+    }
+
+    #[test]
+    fn field_error_message_hidden_snapshot() {
+        let service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        assert_snapshot!(
+            "field_error_message_hidden",
+            snapshot_attrs(&service.connect(&|_| {}).error_message_attrs())
+        );
+    }
+
+    #[test]
+    fn field_error_message_visible_snapshot() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        drop(service.send(Event::SetErrors(vec![custom_error()])));
+
+        assert_snapshot!(
+            "field_error_message_visible",
+            snapshot_attrs(&service.connect(&|_| {}).error_message_attrs())
+        );
     }
 
     #[test]

--- a/crates/ars-forms/src/field/snapshots/ars_forms__field__component__tests__field_description_default.snap
+++ b/crates/ars-forms/src/field/snapshots/ars_forms__field__component__tests__field_description_default.snap
@@ -1,0 +1,31 @@
+---
+source: crates/ars-forms/src/field/component.rs
+expression: "snapshot_attrs(service.connect(&|_| {}).description_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "description",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "field",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "email-description",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-forms/src/field/snapshots/ars_forms__field__component__tests__field_error_message_hidden.snap
+++ b/crates/ars-forms/src/field/snapshots/ars_forms__field__component__tests__field_error_message_hidden.snap
@@ -1,0 +1,43 @@
+---
+source: crates/ars-forms/src/field/component.rs
+expression: "snapshot_attrs(service.connect(&|_| {}).error_message_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "error-message",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "field",
+            ),
+        ),
+        (
+            Hidden,
+            Bool(
+                true,
+            ),
+        ),
+        (
+            Id,
+            String(
+                "email-error-message",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "alert",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-forms/src/field/snapshots/ars_forms__field__component__tests__field_error_message_visible.snap
+++ b/crates/ars-forms/src/field/snapshots/ars_forms__field__component__tests__field_error_message_visible.snap
@@ -1,0 +1,37 @@
+---
+source: crates/ars-forms/src/field/component.rs
+expression: "snapshot_attrs(service.connect(&|_| {}).error_message_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "error-message",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "field",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "email-error-message",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "alert",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-forms/src/field/snapshots/ars_forms__field__component__tests__field_input_default.snap
+++ b/crates/ars-forms/src/field/snapshots/ars_forms__field__component__tests__field_input_default.snap
@@ -1,0 +1,39 @@
+---
+source: crates/ars-forms/src/field/component.rs
+expression: "snapshot_attrs(service.connect(&|_| {}).input_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "input",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "field",
+            ),
+        ),
+        (
+            Aria(
+                LabelledBy,
+            ),
+            String(
+                "email-label",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "email-input",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-forms/src/field/snapshots/ars_forms__field__component__tests__field_input_disabled_readonly_validating.snap
+++ b/crates/ars-forms/src/field/snapshots/ars_forms__field__component__tests__field_input_disabled_readonly_validating.snap
@@ -1,0 +1,63 @@
+---
+source: crates/ars-forms/src/field/component.rs
+expression: "snapshot_attrs(service.connect(&|_| {}).input_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "input",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "field",
+            ),
+        ),
+        (
+            Aria(
+                Disabled,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Aria(
+                LabelledBy,
+            ),
+            String(
+                "email-label",
+            ),
+        ),
+        (
+            Aria(
+                ReadOnly,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Aria(
+                Busy,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "email-input",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-forms/src/field/snapshots/ars_forms__field__component__tests__field_input_invalid_no_errors.snap
+++ b/crates/ars-forms/src/field/snapshots/ars_forms__field__component__tests__field_input_invalid_no_errors.snap
@@ -1,0 +1,47 @@
+---
+source: crates/ars-forms/src/field/component.rs
+expression: "snapshot_attrs(service.connect(&|_| {}).input_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "input",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "field",
+            ),
+        ),
+        (
+            Aria(
+                Invalid,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Aria(
+                LabelledBy,
+            ),
+            String(
+                "email-label",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "email-input",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-forms/src/field/snapshots/ars_forms__field__component__tests__field_input_invalid_with_description_and_error.snap
+++ b/crates/ars-forms/src/field/snapshots/ars_forms__field__component__tests__field_input_invalid_with_description_and_error.snap
@@ -1,0 +1,63 @@
+---
+source: crates/ars-forms/src/field/component.rs
+expression: "snapshot_attrs(service.connect(&|_| {}).input_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "input",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "field",
+            ),
+        ),
+        (
+            Aria(
+                ErrorMessage,
+            ),
+            String(
+                "email-error-message",
+            ),
+        ),
+        (
+            Aria(
+                Invalid,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Aria(
+                LabelledBy,
+            ),
+            String(
+                "email-label",
+            ),
+        ),
+        (
+            Aria(
+                DescribedBy,
+            ),
+            String(
+                "email-description email-error-message",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "email-input",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-forms/src/field/snapshots/ars_forms__field__component__tests__field_input_required.snap
+++ b/crates/ars-forms/src/field/snapshots/ars_forms__field__component__tests__field_input_required.snap
@@ -1,0 +1,47 @@
+---
+source: crates/ars-forms/src/field/component.rs
+expression: "snapshot_attrs(service.connect(&|_| {}).input_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "input",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "field",
+            ),
+        ),
+        (
+            Aria(
+                LabelledBy,
+            ),
+            String(
+                "email-label",
+            ),
+        ),
+        (
+            Aria(
+                Required,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "email-input",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-forms/src/field/snapshots/ars_forms__field__component__tests__field_label_default.snap
+++ b/crates/ars-forms/src/field/snapshots/ars_forms__field__component__tests__field_label_default.snap
@@ -1,0 +1,37 @@
+---
+source: crates/ars-forms/src/field/component.rs
+expression: "snapshot_attrs(service.connect(&|_| {}).label_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "label",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "field",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "email-label",
+            ),
+        ),
+        (
+            For,
+            String(
+                "email-input",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-forms/src/field/snapshots/ars_forms__field__component__tests__field_root_default.snap
+++ b/crates/ars-forms/src/field/snapshots/ars_forms__field__component__tests__field_root_default.snap
@@ -1,0 +1,31 @@
+---
+source: crates/ars-forms/src/field/component.rs
+expression: "snapshot_attrs(service.connect(&|_| {}).root_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "field",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "email",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-forms/src/field/snapshots/ars_forms__field__component__tests__field_root_rtl.snap
+++ b/crates/ars-forms/src/field/snapshots/ars_forms__field__component__tests__field_root_rtl.snap
@@ -1,0 +1,37 @@
+---
+source: crates/ars-forms/src/field/component.rs
+expression: "snapshot_attrs(service.connect(&|_| {}).root_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "field",
+            ),
+        ),
+        (
+            Dir,
+            String(
+                "rtl",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "email",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-forms/src/fieldset/component.rs
+++ b/crates/ars-forms/src/fieldset/component.rs
@@ -393,6 +393,7 @@ impl<'a> Api<'a> {
 #[cfg(test)]
 mod tests {
     use ars_core::{ConnectApi, Service};
+    use insta::assert_snapshot;
 
     use super::*;
 
@@ -412,6 +413,10 @@ mod tests {
 
     fn custom_error() -> Error {
         Error::custom("group", "Group is invalid")
+    }
+
+    fn snapshot_attrs(attrs: &AttrMap) -> String {
+        format!("{attrs:#?}")
     }
 
     #[test]
@@ -710,6 +715,117 @@ mod tests {
         let attrs = api.error_message_attrs();
 
         assert_eq!(attrs.get(&HtmlAttr::Role), Some("alert"));
+    }
+
+    #[test]
+    fn fieldset_root_default_snapshot() {
+        let service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        assert_snapshot!(
+            "fieldset_root_default",
+            snapshot_attrs(&service.connect(&|_| {}).root_attrs())
+        );
+    }
+
+    #[test]
+    fn fieldset_root_disabled_snapshot() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        drop(service.send(Event::SetDisabled(true)));
+
+        assert_snapshot!(
+            "fieldset_root_disabled",
+            snapshot_attrs(&service.connect(&|_| {}).root_attrs())
+        );
+    }
+
+    #[test]
+    fn fieldset_root_rtl_snapshot() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        drop(service.send(Event::SetDir(Some(Direction::Rtl))));
+
+        assert_snapshot!(
+            "fieldset_root_rtl",
+            snapshot_attrs(&service.connect(&|_| {}).root_attrs())
+        );
+    }
+
+    #[test]
+    fn fieldset_root_description_only_snapshot() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        drop(service.send(Event::SetHasDescription(true)));
+
+        assert_snapshot!(
+            "fieldset_root_description_only",
+            snapshot_attrs(&service.connect(&|_| {}).root_attrs())
+        );
+    }
+
+    #[test]
+    fn fieldset_root_description_and_error_snapshot() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        drop(service.send(Event::SetHasDescription(true)));
+        drop(service.send(Event::SetErrors(vec![custom_error()])));
+
+        assert_snapshot!(
+            "fieldset_root_description_and_error",
+            snapshot_attrs(&service.connect(&|_| {}).root_attrs())
+        );
+    }
+
+    #[test]
+    fn fieldset_legend_default_snapshot() {
+        let service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        assert_snapshot!(
+            "fieldset_legend_default",
+            snapshot_attrs(&service.connect(&|_| {}).legend_attrs())
+        );
+    }
+
+    #[test]
+    fn fieldset_description_default_snapshot() {
+        let service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        assert_snapshot!(
+            "fieldset_description_default",
+            snapshot_attrs(&service.connect(&|_| {}).description_attrs())
+        );
+    }
+
+    #[test]
+    fn fieldset_error_message_hidden_snapshot() {
+        let service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        assert_snapshot!(
+            "fieldset_error_message_hidden",
+            snapshot_attrs(&service.connect(&|_| {}).error_message_attrs())
+        );
+    }
+
+    #[test]
+    fn fieldset_error_message_visible_snapshot() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        drop(service.send(Event::SetErrors(vec![custom_error()])));
+
+        assert_snapshot!(
+            "fieldset_error_message_visible",
+            snapshot_attrs(&service.connect(&|_| {}).error_message_attrs())
+        );
+    }
+
+    #[test]
+    fn fieldset_content_default_snapshot() {
+        let service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        assert_snapshot!(
+            "fieldset_content_default",
+            snapshot_attrs(&service.connect(&|_| {}).content_attrs())
+        );
     }
 
     #[test]

--- a/crates/ars-forms/src/fieldset/snapshots/ars_forms__fieldset__component__tests__fieldset_content_default.snap
+++ b/crates/ars-forms/src/fieldset/snapshots/ars_forms__fieldset__component__tests__fieldset_content_default.snap
@@ -1,0 +1,25 @@
+---
+source: crates/ars-forms/src/fieldset/component.rs
+expression: "snapshot_attrs(service.connect(&|_| {}).content_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "content",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "fieldset",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-forms/src/fieldset/snapshots/ars_forms__fieldset__component__tests__fieldset_description_default.snap
+++ b/crates/ars-forms/src/fieldset/snapshots/ars_forms__fieldset__component__tests__fieldset_description_default.snap
@@ -1,0 +1,31 @@
+---
+source: crates/ars-forms/src/fieldset/component.rs
+expression: "snapshot_attrs(service.connect(&|_| {}).description_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "description",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "fieldset",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "billing-description",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-forms/src/fieldset/snapshots/ars_forms__fieldset__component__tests__fieldset_error_message_hidden.snap
+++ b/crates/ars-forms/src/fieldset/snapshots/ars_forms__fieldset__component__tests__fieldset_error_message_hidden.snap
@@ -1,0 +1,43 @@
+---
+source: crates/ars-forms/src/fieldset/component.rs
+expression: "snapshot_attrs(service.connect(&|_| {}).error_message_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "error-message",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "fieldset",
+            ),
+        ),
+        (
+            Hidden,
+            Bool(
+                true,
+            ),
+        ),
+        (
+            Id,
+            String(
+                "billing-error-message",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "alert",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-forms/src/fieldset/snapshots/ars_forms__fieldset__component__tests__fieldset_error_message_visible.snap
+++ b/crates/ars-forms/src/fieldset/snapshots/ars_forms__fieldset__component__tests__fieldset_error_message_visible.snap
@@ -1,0 +1,37 @@
+---
+source: crates/ars-forms/src/fieldset/component.rs
+expression: "snapshot_attrs(service.connect(&|_| {}).error_message_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "error-message",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "fieldset",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "billing-error-message",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "alert",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-forms/src/fieldset/snapshots/ars_forms__fieldset__component__tests__fieldset_legend_default.snap
+++ b/crates/ars-forms/src/fieldset/snapshots/ars_forms__fieldset__component__tests__fieldset_legend_default.snap
@@ -1,0 +1,31 @@
+---
+source: crates/ars-forms/src/fieldset/component.rs
+expression: "snapshot_attrs(service.connect(&|_| {}).legend_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "legend",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "fieldset",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "billing-legend",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-forms/src/fieldset/snapshots/ars_forms__fieldset__component__tests__fieldset_root_default.snap
+++ b/crates/ars-forms/src/fieldset/snapshots/ars_forms__fieldset__component__tests__fieldset_root_default.snap
@@ -1,0 +1,31 @@
+---
+source: crates/ars-forms/src/fieldset/component.rs
+expression: "snapshot_attrs(service.connect(&|_| {}).root_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "fieldset",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "billing",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-forms/src/fieldset/snapshots/ars_forms__fieldset__component__tests__fieldset_root_description_and_error.snap
+++ b/crates/ars-forms/src/fieldset/snapshots/ars_forms__fieldset__component__tests__fieldset_root_description_and_error.snap
@@ -1,0 +1,39 @@
+---
+source: crates/ars-forms/src/fieldset/component.rs
+expression: "snapshot_attrs(service.connect(&|_| {}).root_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "fieldset",
+            ),
+        ),
+        (
+            Aria(
+                DescribedBy,
+            ),
+            String(
+                "billing-description billing-error-message",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "billing",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-forms/src/fieldset/snapshots/ars_forms__fieldset__component__tests__fieldset_root_description_only.snap
+++ b/crates/ars-forms/src/fieldset/snapshots/ars_forms__fieldset__component__tests__fieldset_root_description_only.snap
@@ -1,0 +1,39 @@
+---
+source: crates/ars-forms/src/fieldset/component.rs
+expression: "snapshot_attrs(service.connect(&|_| {}).root_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "fieldset",
+            ),
+        ),
+        (
+            Aria(
+                DescribedBy,
+            ),
+            String(
+                "billing-description",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "billing",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-forms/src/fieldset/snapshots/ars_forms__fieldset__component__tests__fieldset_root_disabled.snap
+++ b/crates/ars-forms/src/fieldset/snapshots/ars_forms__fieldset__component__tests__fieldset_root_disabled.snap
@@ -1,0 +1,37 @@
+---
+source: crates/ars-forms/src/fieldset/component.rs
+expression: "snapshot_attrs(service.connect(&|_| {}).root_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "fieldset",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "billing",
+            ),
+        ),
+        (
+            Disabled,
+            Bool(
+                true,
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-forms/src/fieldset/snapshots/ars_forms__fieldset__component__tests__fieldset_root_rtl.snap
+++ b/crates/ars-forms/src/fieldset/snapshots/ars_forms__fieldset__component__tests__fieldset_root_rtl.snap
@@ -1,0 +1,37 @@
+---
+source: crates/ars-forms/src/fieldset/component.rs
+expression: "snapshot_attrs(service.connect(&|_| {}).root_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "fieldset",
+            ),
+        ),
+        (
+            Dir,
+            String(
+                "rtl",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "billing",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-forms/src/form/component.rs
+++ b/crates/ars-forms/src/form/component.rs
@@ -358,6 +358,7 @@ impl<'a> Api<'a> {
 #[cfg(test)]
 mod tests {
     use ars_core::{ConnectApi, Machine as _, Service};
+    use insta::assert_snapshot;
 
     use super::*;
 
@@ -366,6 +367,10 @@ mod tests {
             id: "checkout".to_string(),
             ..Props::default()
         }
+    }
+
+    fn snapshot_attrs(attrs: &AttrMap) -> String {
+        format!("{attrs:#?}")
     }
 
     #[test]
@@ -694,6 +699,73 @@ mod tests {
         drop(service.send(Event::Submit));
 
         assert!(service.connect(&|_| {}).is_submitting());
+    }
+
+    #[test]
+    fn form_root_idle_aria_snapshot() {
+        let service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        assert_snapshot!(
+            "form_root_idle_aria",
+            snapshot_attrs(&service.connect(&|_| {}).root_attrs())
+        );
+    }
+
+    #[test]
+    fn form_root_idle_native_snapshot() {
+        let service = Service::<Machine>::new(
+            Props {
+                validation_behavior: ValidationBehavior::Native,
+                ..test_props()
+            },
+            &Env::default(),
+            &(),
+        );
+
+        assert_snapshot!(
+            "form_root_idle_native",
+            snapshot_attrs(&service.connect(&|_| {}).root_attrs())
+        );
+    }
+
+    #[test]
+    fn form_root_submitting_snapshot() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        drop(service.send(Event::Submit));
+
+        assert_snapshot!(
+            "form_root_submitting",
+            snapshot_attrs(&service.connect(&|_| {}).root_attrs())
+        );
+    }
+
+    #[test]
+    fn form_root_action_and_role_snapshot() {
+        let service = Service::<Machine>::new(
+            Props {
+                action: Some("javascript:alert(1)".to_string()),
+                role: Some("search".to_string()),
+                ..test_props()
+            },
+            &Env::default(),
+            &(),
+        );
+
+        assert_snapshot!(
+            "form_root_action_and_role",
+            snapshot_attrs(&service.connect(&|_| {}).root_attrs())
+        );
+    }
+
+    #[test]
+    fn form_status_region_default_snapshot() {
+        let service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        assert_snapshot!(
+            "form_status_region_default",
+            snapshot_attrs(&service.connect(&|_| {}).status_region_attrs())
+        );
     }
 
     #[test]

--- a/crates/ars-forms/src/form/snapshots/ars_forms__form__component__tests__form_root_action_and_role.snap
+++ b/crates/ars-forms/src/form/snapshots/ars_forms__form__component__tests__form_root_action_and_role.snap
@@ -1,0 +1,57 @@
+---
+source: crates/ars-forms/src/form/component.rs
+expression: "snapshot_attrs(service.connect(&|_| {}).root_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "form",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "idle",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "checkout",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "search",
+            ),
+        ),
+        (
+            Action,
+            String(
+                "#",
+            ),
+        ),
+        (
+            NoValidate,
+            Bool(
+                true,
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-forms/src/form/snapshots/ars_forms__form__component__tests__form_root_idle_aria.snap
+++ b/crates/ars-forms/src/form/snapshots/ars_forms__form__component__tests__form_root_idle_aria.snap
@@ -1,0 +1,45 @@
+---
+source: crates/ars-forms/src/form/component.rs
+expression: "snapshot_attrs(service.connect(&|_| {}).root_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "form",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "idle",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "checkout",
+            ),
+        ),
+        (
+            NoValidate,
+            Bool(
+                true,
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-forms/src/form/snapshots/ars_forms__form__component__tests__form_root_idle_native.snap
+++ b/crates/ars-forms/src/form/snapshots/ars_forms__form__component__tests__form_root_idle_native.snap
@@ -1,0 +1,39 @@
+---
+source: crates/ars-forms/src/form/component.rs
+expression: "snapshot_attrs(service.connect(&|_| {}).root_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "form",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "idle",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "checkout",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-forms/src/form/snapshots/ars_forms__form__component__tests__form_root_submitting.snap
+++ b/crates/ars-forms/src/form/snapshots/ars_forms__form__component__tests__form_root_submitting.snap
@@ -1,0 +1,53 @@
+---
+source: crates/ars-forms/src/form/component.rs
+expression: "snapshot_attrs(service.connect(&|_| {}).root_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "form",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "submitting",
+            ),
+        ),
+        (
+            Aria(
+                Busy,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "checkout",
+            ),
+        ),
+        (
+            NoValidate,
+            Bool(
+                true,
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-forms/src/form/snapshots/ars_forms__form__component__tests__form_status_region_default.snap
+++ b/crates/ars-forms/src/form/snapshots/ars_forms__form__component__tests__form_status_region_default.snap
@@ -1,0 +1,47 @@
+---
+source: crates/ars-forms/src/form/component.rs
+expression: "snapshot_attrs(service.connect(&|_| {}).status_region_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "status-region",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "form",
+            ),
+        ),
+        (
+            Aria(
+                Atomic,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Aria(
+                Live,
+            ),
+            String(
+                "polite",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "status",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-forms/src/form_submit.rs
+++ b/crates/ars-forms/src/form_submit.rs
@@ -468,6 +468,7 @@ mod tests {
 
     // Import Machine trait for on_props_changed.
     use ars_core::{Machine as _, Service, StrongSend, callback};
+    use insta::assert_snapshot;
 
     use super::*;
     use crate::{
@@ -531,6 +532,10 @@ mod tests {
             ),
             schedule_microtask: callback(|_: Box<dyn FnOnce()>| {}),
         }
+    }
+
+    fn snapshot_attrs(attrs: &AttrMap) -> String {
+        format!("{attrs:#?}")
     }
 
     // --- State transition tests ---
@@ -968,6 +973,105 @@ mod tests {
 
         assert!(attrs.get(&HtmlAttr::Aria(AriaAttr::Busy)).is_none());
         assert!(attrs.get(&HtmlAttr::Disabled).is_none());
+    }
+
+    #[test]
+    fn form_submit_root_idle_snapshot() {
+        let service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        assert_snapshot!(
+            "form_submit_root_idle",
+            snapshot_attrs(&service.connect(&|_| {}).root_attrs())
+        );
+    }
+
+    #[test]
+    fn form_submit_root_validating_snapshot() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        drop(service.send(Event::Submit));
+
+        assert_snapshot!(
+            "form_submit_root_validating",
+            snapshot_attrs(&service.connect(&|_| {}).root_attrs())
+        );
+    }
+
+    #[test]
+    fn form_submit_root_validation_failed_snapshot() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        drop(service.send(Event::Submit));
+        drop(service.send(Event::ValidationFailed));
+
+        assert_snapshot!(
+            "form_submit_root_validation_failed",
+            snapshot_attrs(&service.connect(&|_| {}).root_attrs())
+        );
+    }
+
+    #[test]
+    fn form_submit_root_submitting_snapshot() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        drop(service.send(Event::Submit));
+        drop(service.send(Event::ValidationPassed));
+
+        assert_snapshot!(
+            "form_submit_root_submitting",
+            snapshot_attrs(&service.connect(&|_| {}).root_attrs())
+        );
+    }
+
+    #[test]
+    fn form_submit_root_succeeded_snapshot() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        drop(service.send(Event::Submit));
+        drop(service.send(Event::ValidationPassed));
+        drop(service.send(Event::SubmitComplete));
+
+        assert_snapshot!(
+            "form_submit_root_succeeded",
+            snapshot_attrs(&service.connect(&|_| {}).root_attrs())
+        );
+    }
+
+    #[test]
+    fn form_submit_root_failed_snapshot() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        drop(service.send(Event::Submit));
+        drop(service.send(Event::ValidationPassed));
+        drop(service.send(Event::SubmitError("server down".into())));
+
+        assert_snapshot!(
+            "form_submit_root_failed",
+            snapshot_attrs(&service.connect(&|_| {}).root_attrs())
+        );
+    }
+
+    #[test]
+    fn form_submit_button_idle_snapshot() {
+        let service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        assert_snapshot!(
+            "form_submit_button_idle",
+            snapshot_attrs(&service.connect(&|_| {}).submit_button_attrs())
+        );
+    }
+
+    #[test]
+    fn form_submit_button_submitting_snapshot() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &());
+
+        drop(service.send(Event::Submit));
+        drop(service.send(Event::ValidationPassed));
+
+        assert_snapshot!(
+            "form_submit_button_submitting",
+            snapshot_attrs(&service.connect(&|_| {}).submit_button_attrs())
+        );
     }
 
     #[test]

--- a/crates/ars-forms/src/snapshots/ars_forms__form_submit__tests__form_submit_button_idle.snap
+++ b/crates/ars-forms/src/snapshots/ars_forms__form_submit__tests__form_submit_button_idle.snap
@@ -1,0 +1,25 @@
+---
+source: crates/ars-forms/src/form_submit.rs
+expression: "snapshot_attrs(service.connect(&|_| {}).submit_button_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "submit-button",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "form-submit",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-forms/src/snapshots/ars_forms__form_submit__tests__form_submit_button_submitting.snap
+++ b/crates/ars-forms/src/snapshots/ars_forms__form_submit__tests__form_submit_button_submitting.snap
@@ -1,0 +1,47 @@
+---
+source: crates/ars-forms/src/form_submit.rs
+expression: "snapshot_attrs(service.connect(&|_| {}).submit_button_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "submit-button",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "form-submit",
+            ),
+        ),
+        (
+            Aria(
+                Disabled,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Aria(
+                Busy,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Disabled,
+            Bool(
+                true,
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-forms/src/snapshots/ars_forms__form_submit__tests__form_submit_root_failed.snap
+++ b/crates/ars-forms/src/snapshots/ars_forms__form_submit__tests__form_submit_root_failed.snap
@@ -1,0 +1,39 @@
+---
+source: crates/ars-forms/src/form_submit.rs
+expression: "snapshot_attrs(service.connect(&|_| {}).root_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "form-submit",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "failed",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "test-form",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-forms/src/snapshots/ars_forms__form_submit__tests__form_submit_root_idle.snap
+++ b/crates/ars-forms/src/snapshots/ars_forms__form_submit__tests__form_submit_root_idle.snap
@@ -1,0 +1,39 @@
+---
+source: crates/ars-forms/src/form_submit.rs
+expression: "snapshot_attrs(service.connect(&|_| {}).root_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "form-submit",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "idle",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "test-form",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-forms/src/snapshots/ars_forms__form_submit__tests__form_submit_root_submitting.snap
+++ b/crates/ars-forms/src/snapshots/ars_forms__form_submit__tests__form_submit_root_submitting.snap
@@ -1,0 +1,39 @@
+---
+source: crates/ars-forms/src/form_submit.rs
+expression: "snapshot_attrs(service.connect(&|_| {}).root_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "form-submit",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "submitting",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "test-form",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-forms/src/snapshots/ars_forms__form_submit__tests__form_submit_root_succeeded.snap
+++ b/crates/ars-forms/src/snapshots/ars_forms__form_submit__tests__form_submit_root_succeeded.snap
@@ -1,0 +1,39 @@
+---
+source: crates/ars-forms/src/form_submit.rs
+expression: "snapshot_attrs(service.connect(&|_| {}).root_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "form-submit",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "succeeded",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "test-form",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-forms/src/snapshots/ars_forms__form_submit__tests__form_submit_root_validating.snap
+++ b/crates/ars-forms/src/snapshots/ars_forms__form_submit__tests__form_submit_root_validating.snap
@@ -1,0 +1,39 @@
+---
+source: crates/ars-forms/src/form_submit.rs
+expression: "snapshot_attrs(service.connect(&|_| {}).root_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "form-submit",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "validating",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "test-form",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-forms/src/snapshots/ars_forms__form_submit__tests__form_submit_root_validation_failed.snap
+++ b/crates/ars-forms/src/snapshots/ars_forms__form_submit__tests__form_submit_root_validation_failed.snap
@@ -1,0 +1,39 @@
+---
+source: crates/ars-forms/src/form_submit.rs
+expression: "snapshot_attrs(service.connect(&|_| {}).root_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "form-submit",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "validation-failed",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "test-form",
+            ),
+        ),
+    ],
+    styles: [],
+}


### PR DESCRIPTION
Closes #180

## Summary
- add `insta` snapshot infrastructure to `ars-core` and `ars-forms`
- add a real `ars-core` `connect()` / `AttrMap` snapshot fixture and commit generated snapshots
- add exhaustive snapshot coverage for the implemented agnostic form machines and enforce snapshot checks in CI

## Verification
- `cargo xci`