### PR TITLE
[codex] Implement ARIA assertion helpers module

### DIFF
--- a/crates/ars-core/Cargo.toml
+++ b/crates/ars-core/Cargo.toml
@@ -14,6 +14,7 @@ serde        = ["dep:serde"]
 ssr          = []
 debug        = ["dep:log"]
 embedded-css = []
+testing      = []
 
 [dependencies]
 ars-derive = { path = "../ars-derive" }

--- a/crates/ars-core/src/callback.rs
+++ b/crates/ars-core/src/callback.rs
@@ -112,7 +112,9 @@ mod tests {
     #[test]
     fn callback_clone_and_invoke() {
         let cb = Callback::new(|x: i32| x * 2);
+
         let cloned = cb.clone();
+
         assert_eq!(cb(21), 42);
         assert_eq!(cloned(21), 42);
     }
@@ -120,8 +122,14 @@ mod tests {
     #[test]
     fn callback_pointer_equality() {
         let cb1 = Callback::new(|_x: i32| {});
+
         let cb2 = cb1.clone();
+
         let cb3 = Callback::new(|_x: i32| {});
+
+        cb1(1);
+        cb3(2);
+
         assert_eq!(cb1, cb2);
         assert_ne!(cb1, cb3);
     }
@@ -129,31 +137,60 @@ mod tests {
     #[test]
     fn callback_new_void_invokes_zero_arg_closure() {
         let flag = Arc::new(core::sync::atomic::AtomicBool::new(false));
+
         let cb = {
             let flag = Arc::clone(&flag);
             Callback::new_void(move || {
                 flag.store(true, core::sync::atomic::Ordering::SeqCst);
             })
         };
+
         cb();
+
         assert!(flag.load(core::sync::atomic::Ordering::SeqCst));
     }
 
     #[test]
     fn callback_as_ref_exposes_inner_closure() {
         let cb = Callback::new(|value: i32| value + 1);
+
         assert_eq!(cb.as_ref()(41), 42);
     }
 
     #[test]
     fn callback_free_function_constructor_preserves_type_inference() {
         let cb = callback(|value: (i32, i32)| value.0 + value.1);
+
         assert_eq!(cb((20, 22)), 42);
     }
 
     #[test]
     fn callback_debug_output_is_stable() {
         let cb = Callback::new(|_: i32| 0);
+
         assert_eq!(format!("{cb:?}"), "Callback(..)");
+    }
+
+    #[test]
+    fn callback_from_closure_invokes_regular_constructor_path() {
+        let cb: Callback<dyn Fn(i32) -> i32> = Callback::from(|value| value + 2);
+
+        assert_eq!(cb(40), 42);
+    }
+
+    #[test]
+    fn callback_from_zero_arg_closure_invokes_void_constructor_path() {
+        let flag = Arc::new(core::sync::atomic::AtomicBool::new(false));
+
+        let cb: Callback<dyn Fn()> = {
+            let flag = Arc::clone(&flag);
+            Callback::from(move || {
+                flag.store(true, core::sync::atomic::Ordering::SeqCst);
+            })
+        };
+
+        cb();
+
+        assert!(flag.load(core::sync::atomic::Ordering::SeqCst));
     }
 }

--- a/crates/ars-core/src/connect.rs
+++ b/crates/ars-core/src/connect.rs
@@ -2237,7 +2237,10 @@ impl serde::Serialize for CssProperty {
 
 #[cfg(test)]
 mod tests {
-    use alloc::{string::ToString, vec};
+    use alloc::{
+        string::{String, ToString},
+        vec,
+    };
 
     use super::*;
 
@@ -2245,6 +2248,66 @@ mod tests {
     fn aria_attr_display_matches_attribute_name() {
         assert_eq!(AriaAttr::Label.to_string(), "aria-label");
         assert_eq!(AriaAttr::DescribedBy.as_str(), "aria-describedby");
+    }
+
+    #[test]
+    fn aria_attr_as_str_covers_full_variant_table() {
+        let cases = [
+            (AriaAttr::ActiveDescendant, "aria-activedescendant"),
+            (AriaAttr::AutoComplete, "aria-autocomplete"),
+            (AriaAttr::Checked, "aria-checked"),
+            (AriaAttr::Disabled, "aria-disabled"),
+            (AriaAttr::ErrorMessage, "aria-errormessage"),
+            (AriaAttr::Expanded, "aria-expanded"),
+            (AriaAttr::HasPopup, "aria-haspopup"),
+            (AriaAttr::Hidden, "aria-hidden"),
+            (AriaAttr::Invalid, "aria-invalid"),
+            (AriaAttr::KeyShortcuts, "aria-keyshortcuts"),
+            (AriaAttr::Label, "aria-label"),
+            (AriaAttr::LabelledBy, "aria-labelledby"),
+            (AriaAttr::Level, "aria-level"),
+            (AriaAttr::Modal, "aria-modal"),
+            (AriaAttr::MultiLine, "aria-multiline"),
+            (AriaAttr::MultiSelectable, "aria-multiselectable"),
+            (AriaAttr::Orientation, "aria-orientation"),
+            (AriaAttr::Placeholder, "aria-placeholder"),
+            (AriaAttr::Pressed, "aria-pressed"),
+            (AriaAttr::ReadOnly, "aria-readonly"),
+            (AriaAttr::Required, "aria-required"),
+            (AriaAttr::RoleDescription, "aria-roledescription"),
+            (AriaAttr::Selected, "aria-selected"),
+            (AriaAttr::Sort, "aria-sort"),
+            (AriaAttr::ValueMax, "aria-valuemax"),
+            (AriaAttr::ValueMin, "aria-valuemin"),
+            (AriaAttr::ValueNow, "aria-valuenow"),
+            (AriaAttr::ValueText, "aria-valuetext"),
+            (AriaAttr::Atomic, "aria-atomic"),
+            (AriaAttr::Busy, "aria-busy"),
+            (AriaAttr::Live, "aria-live"),
+            (AriaAttr::Relevant, "aria-relevant"),
+            (AriaAttr::DropEffect, "aria-dropeffect"),
+            (AriaAttr::Grabbed, "aria-grabbed"),
+            (AriaAttr::ColCount, "aria-colcount"),
+            (AriaAttr::ColIndex, "aria-colindex"),
+            (AriaAttr::ColSpan, "aria-colspan"),
+            (AriaAttr::Controls, "aria-controls"),
+            (AriaAttr::Current, "aria-current"),
+            (AriaAttr::DescribedBy, "aria-describedby"),
+            (AriaAttr::Description, "aria-description"),
+            (AriaAttr::Details, "aria-details"),
+            (AriaAttr::FlowTo, "aria-flowto"),
+            (AriaAttr::Owns, "aria-owns"),
+            (AriaAttr::PosInSet, "aria-posinset"),
+            (AriaAttr::RowCount, "aria-rowcount"),
+            (AriaAttr::RowIndex, "aria-rowindex"),
+            (AriaAttr::RowSpan, "aria-rowspan"),
+            (AriaAttr::SetSize, "aria-setsize"),
+        ];
+
+        for (attr, expected) in cases {
+            assert_eq!(attr.as_str(), expected);
+            assert_eq!(attr.to_string(), expected);
+        }
     }
 
     #[test]
@@ -2268,19 +2331,441 @@ mod tests {
     }
 
     #[test]
+    fn html_attr_static_name_covers_full_variant_table() {
+        let cases = [
+            (HtmlAttr::AccessKey, "accesskey"),
+            (HtmlAttr::AutoCapitalize, "autocapitalize"),
+            (HtmlAttr::AutoCorrect, "autocorrect"),
+            (HtmlAttr::AutoFocus, "autofocus"),
+            (HtmlAttr::Class, "class"),
+            (HtmlAttr::ContentEditable, "contenteditable"),
+            (HtmlAttr::Dir, "dir"),
+            (HtmlAttr::Draggable, "draggable"),
+            (HtmlAttr::EnterKeyHint, "enterkeyhint"),
+            (HtmlAttr::Hidden, "hidden"),
+            (HtmlAttr::Id, "id"),
+            (HtmlAttr::Inert, "inert"),
+            (HtmlAttr::InputMode, "inputmode"),
+            (HtmlAttr::Is, "is"),
+            (HtmlAttr::ItemId, "itemid"),
+            (HtmlAttr::ItemProp, "itemprop"),
+            (HtmlAttr::ItemRef, "itemref"),
+            (HtmlAttr::ItemScope, "itemscope"),
+            (HtmlAttr::ItemType, "itemtype"),
+            (HtmlAttr::Lang, "lang"),
+            (HtmlAttr::Nonce, "nonce"),
+            (HtmlAttr::Popover, "popover"),
+            (HtmlAttr::Role, "role"),
+            (HtmlAttr::Slot, "slot"),
+            (HtmlAttr::SpellCheck, "spellcheck"),
+            (HtmlAttr::TabIndex, "tabindex"),
+            (HtmlAttr::Title, "title"),
+            (HtmlAttr::Translate, "translate"),
+            (HtmlAttr::WritingSuggestions, "writingsuggestions"),
+            (HtmlAttr::Accept, "accept"),
+            (HtmlAttr::AcceptCharset, "accept-charset"),
+            (HtmlAttr::Action, "action"),
+            (HtmlAttr::Alpha, "alpha"),
+            (HtmlAttr::AutoComplete, "autocomplete"),
+            (HtmlAttr::Capture, "capture"),
+            (HtmlAttr::Checked, "checked"),
+            (HtmlAttr::Cols, "cols"),
+            (HtmlAttr::ColorSpace, "colorspace"),
+            (HtmlAttr::Command, "command"),
+            (HtmlAttr::CommandFor, "commandfor"),
+            (HtmlAttr::Disabled, "disabled"),
+            (HtmlAttr::DirName, "dirname"),
+            (HtmlAttr::EncType, "enctype"),
+            (HtmlAttr::For, "for"),
+            (HtmlAttr::Form, "form"),
+            (HtmlAttr::FormAction, "formaction"),
+            (HtmlAttr::FormEncType, "formenctype"),
+            (HtmlAttr::FormMethod, "formmethod"),
+            (HtmlAttr::FormNoValidate, "formnovalidate"),
+            (HtmlAttr::FormTarget, "formtarget"),
+            (HtmlAttr::High, "high"),
+            (HtmlAttr::List, "list"),
+            (HtmlAttr::Low, "low"),
+            (HtmlAttr::Max, "max"),
+            (HtmlAttr::MaxLength, "maxlength"),
+            (HtmlAttr::Method, "method"),
+            (HtmlAttr::Min, "min"),
+            (HtmlAttr::MinLength, "minlength"),
+            (HtmlAttr::Multiple, "multiple"),
+            (HtmlAttr::Name, "name"),
+            (HtmlAttr::NoValidate, "novalidate"),
+            (HtmlAttr::Optimum, "optimum"),
+            (HtmlAttr::Pattern, "pattern"),
+            (HtmlAttr::Placeholder, "placeholder"),
+            (HtmlAttr::ReadOnly, "readonly"),
+            (HtmlAttr::Required, "required"),
+            (HtmlAttr::Rows, "rows"),
+            (HtmlAttr::Selected, "selected"),
+            (HtmlAttr::Size, "size"),
+            (HtmlAttr::Step, "step"),
+            (HtmlAttr::Type, "type"),
+            (HtmlAttr::Value, "value"),
+            (HtmlAttr::Wrap, "wrap"),
+            (HtmlAttr::As, "as"),
+            (HtmlAttr::Async, "async"),
+            (HtmlAttr::Blocking, "blocking"),
+            (HtmlAttr::Charset, "charset"),
+            (HtmlAttr::Color, "color"),
+            (HtmlAttr::Defer, "defer"),
+            (HtmlAttr::HttpEquiv, "http-equiv"),
+            (HtmlAttr::ImageSizes, "imagesizes"),
+            (HtmlAttr::ImageSrcSet, "imagesrcset"),
+            (HtmlAttr::Allow, "allow"),
+            (HtmlAttr::Alt, "alt"),
+            (HtmlAttr::AutoPlay, "autoplay"),
+            (HtmlAttr::Controls, "controls"),
+            (HtmlAttr::CrossOrigin, "crossorigin"),
+            (HtmlAttr::Decoding, "decoding"),
+            (HtmlAttr::Default, "default"),
+            (HtmlAttr::Download, "download"),
+            (HtmlAttr::FetchPriority, "fetchpriority"),
+            (HtmlAttr::Height, "height"),
+            (HtmlAttr::Href, "href"),
+            (HtmlAttr::HrefLang, "hreflang"),
+            (HtmlAttr::Integrity, "integrity"),
+            (HtmlAttr::IsMap, "ismap"),
+            (HtmlAttr::Kind, "kind"),
+            (HtmlAttr::Label, "label"),
+            (HtmlAttr::Loading, "loading"),
+            (HtmlAttr::Loop, "loop"),
+            (HtmlAttr::Media, "media"),
+            (HtmlAttr::Muted, "muted"),
+            (HtmlAttr::ObjectData, "data"),
+            (HtmlAttr::Ping, "ping"),
+            (HtmlAttr::PlaysInline, "playsinline"),
+            (HtmlAttr::Poster, "poster"),
+            (HtmlAttr::Preload, "preload"),
+            (HtmlAttr::ReferrerPolicy, "referrerpolicy"),
+            (HtmlAttr::Rel, "rel"),
+            (HtmlAttr::Sandbox, "sandbox"),
+            (HtmlAttr::Shape, "shape"),
+            (HtmlAttr::Sizes, "sizes"),
+            (HtmlAttr::Src, "src"),
+            (HtmlAttr::SrcDoc, "srcdoc"),
+            (HtmlAttr::SrcLang, "srclang"),
+            (HtmlAttr::SrcSet, "srcset"),
+            (HtmlAttr::Target, "target"),
+            (HtmlAttr::UseMap, "usemap"),
+            (HtmlAttr::Width, "width"),
+            (HtmlAttr::Abbr, "abbr"),
+            (HtmlAttr::ColSpan, "colspan"),
+            (HtmlAttr::Headers, "headers"),
+            (HtmlAttr::RowSpan, "rowspan"),
+            (HtmlAttr::Scope, "scope"),
+            (HtmlAttr::Span, "span"),
+            (HtmlAttr::ShadowRootClonable, "shadowrootclonable"),
+            (
+                HtmlAttr::ShadowRootCustomElementRegistry,
+                "shadowrootcustomelementregistry",
+            ),
+            (
+                HtmlAttr::ShadowRootDelegatesFocus,
+                "shadowrootdelegatesfocus",
+            ),
+            (HtmlAttr::ShadowRootMode, "shadowrootmode"),
+            (HtmlAttr::ShadowRootSerializable, "shadowrootserializable"),
+            (HtmlAttr::Cite, "cite"),
+            (HtmlAttr::ClosedBy, "closedby"),
+            (HtmlAttr::Content, "content"),
+            (HtmlAttr::Coords, "coords"),
+            (HtmlAttr::DateTime, "datetime"),
+            (HtmlAttr::Open, "open"),
+            (HtmlAttr::Reversed, "reversed"),
+            (HtmlAttr::Start, "start"),
+            (HtmlAttr::Summary, "summary"),
+            (HtmlAttr::WebkitDirectory, "webkitdirectory"),
+        ];
+
+        for (attr, expected) in cases {
+            assert_eq!(attr.static_name(), Some(expected));
+            assert_eq!(attr.to_string(), expected);
+        }
+    }
+
+    #[test]
     fn html_event_display_matches_dom_event_names() {
-        assert_eq!(HtmlEvent::PointerDown.to_string(), "pointerdown");
-        assert_eq!(HtmlEvent::BeforeInput.to_string(), "beforeinput");
-        assert_eq!(HtmlEvent::TransitionEnd.to_string(), "transitionend");
+        let cases = [
+            (HtmlEvent::AuxClick, "auxclick"),
+            (HtmlEvent::Click, "click"),
+            (HtmlEvent::ContextMenu, "contextmenu"),
+            (HtmlEvent::DblClick, "dblclick"),
+            (HtmlEvent::MouseDown, "mousedown"),
+            (HtmlEvent::MouseEnter, "mouseenter"),
+            (HtmlEvent::MouseLeave, "mouseleave"),
+            (HtmlEvent::MouseMove, "mousemove"),
+            (HtmlEvent::MouseOut, "mouseout"),
+            (HtmlEvent::MouseOver, "mouseover"),
+            (HtmlEvent::MouseUp, "mouseup"),
+            (HtmlEvent::GotPointerCapture, "gotpointercapture"),
+            (HtmlEvent::LostPointerCapture, "lostpointercapture"),
+            (HtmlEvent::PointerCancel, "pointercancel"),
+            (HtmlEvent::PointerDown, "pointerdown"),
+            (HtmlEvent::PointerEnter, "pointerenter"),
+            (HtmlEvent::PointerLeave, "pointerleave"),
+            (HtmlEvent::PointerMove, "pointermove"),
+            (HtmlEvent::PointerOut, "pointerout"),
+            (HtmlEvent::PointerOver, "pointerover"),
+            (HtmlEvent::PointerUp, "pointerup"),
+            (HtmlEvent::KeyDown, "keydown"),
+            (HtmlEvent::KeyUp, "keyup"),
+            (HtmlEvent::Blur, "blur"),
+            (HtmlEvent::Focus, "focus"),
+            (HtmlEvent::FocusIn, "focusin"),
+            (HtmlEvent::FocusOut, "focusout"),
+            (HtmlEvent::Change, "change"),
+            (HtmlEvent::Input, "input"),
+            (HtmlEvent::BeforeInput, "beforeinput"),
+            (HtmlEvent::Invalid, "invalid"),
+            (HtmlEvent::Reset, "reset"),
+            (HtmlEvent::Select, "select"),
+            (HtmlEvent::Submit, "submit"),
+            (HtmlEvent::Drag, "drag"),
+            (HtmlEvent::DragEnd, "dragend"),
+            (HtmlEvent::DragEnter, "dragenter"),
+            (HtmlEvent::DragLeave, "dragleave"),
+            (HtmlEvent::DragOver, "dragover"),
+            (HtmlEvent::DragStart, "dragstart"),
+            (HtmlEvent::Drop, "drop"),
+            (HtmlEvent::TouchCancel, "touchcancel"),
+            (HtmlEvent::TouchEnd, "touchend"),
+            (HtmlEvent::TouchMove, "touchmove"),
+            (HtmlEvent::TouchStart, "touchstart"),
+            (HtmlEvent::Scroll, "scroll"),
+            (HtmlEvent::ScrollEnd, "scrollend"),
+            (HtmlEvent::Wheel, "wheel"),
+            (HtmlEvent::Copy, "copy"),
+            (HtmlEvent::Cut, "cut"),
+            (HtmlEvent::Paste, "paste"),
+            (HtmlEvent::CompositionEnd, "compositionend"),
+            (HtmlEvent::CompositionStart, "compositionstart"),
+            (HtmlEvent::CompositionUpdate, "compositionupdate"),
+            (HtmlEvent::AnimationCancel, "animationcancel"),
+            (HtmlEvent::AnimationEnd, "animationend"),
+            (HtmlEvent::AnimationIteration, "animationiteration"),
+            (HtmlEvent::AnimationStart, "animationstart"),
+            (HtmlEvent::TransitionCancel, "transitioncancel"),
+            (HtmlEvent::TransitionEnd, "transitionend"),
+            (HtmlEvent::TransitionRun, "transitionrun"),
+            (HtmlEvent::TransitionStart, "transitionstart"),
+            (HtmlEvent::Abort, "abort"),
+            (HtmlEvent::Error, "error"),
+            (HtmlEvent::Load, "load"),
+            (HtmlEvent::Resize, "resize"),
+            (HtmlEvent::CanPlay, "canplay"),
+            (HtmlEvent::CanPlayThrough, "canplaythrough"),
+            (HtmlEvent::DurationChange, "durationchange"),
+            (HtmlEvent::Emptied, "emptied"),
+            (HtmlEvent::Ended, "ended"),
+            (HtmlEvent::LoadedData, "loadeddata"),
+            (HtmlEvent::LoadedMetaData, "loadedmetadata"),
+            (HtmlEvent::LoadStart, "loadstart"),
+            (HtmlEvent::Pause, "pause"),
+            (HtmlEvent::Play, "play"),
+            (HtmlEvent::Playing, "playing"),
+            (HtmlEvent::Progress, "progress"),
+            (HtmlEvent::RateChange, "ratechange"),
+            (HtmlEvent::Seeked, "seeked"),
+            (HtmlEvent::Seeking, "seeking"),
+            (HtmlEvent::Stalled, "stalled"),
+            (HtmlEvent::Suspend, "suspend"),
+            (HtmlEvent::TimeUpdate, "timeupdate"),
+            (HtmlEvent::VolumeChange, "volumechange"),
+            (HtmlEvent::Waiting, "waiting"),
+            (HtmlEvent::Cancel, "cancel"),
+            (HtmlEvent::Close, "close"),
+            (HtmlEvent::FullscreenChange, "fullscreenchange"),
+            (HtmlEvent::FullscreenError, "fullscreenerror"),
+            (HtmlEvent::SelectionChange, "selectionchange"),
+            (HtmlEvent::SlotChange, "slotchange"),
+            (HtmlEvent::Toggle, "toggle"),
+        ];
+
+        for (event, expected) in cases {
+            assert_eq!(event.to_string(), expected);
+        }
     }
 
     #[test]
     fn css_property_display_matches_css_spelling() {
-        assert_eq!(CssProperty::ZIndex.to_string(), "z-index");
-        assert_eq!(
-            CssProperty::ScrollSnapAlign.to_string(),
-            "scroll-snap-align"
-        );
+        let cases = [
+            (CssProperty::BoxSizing, "box-sizing"),
+            (CssProperty::Width, "width"),
+            (CssProperty::MinWidth, "min-width"),
+            (CssProperty::MaxWidth, "max-width"),
+            (CssProperty::Height, "height"),
+            (CssProperty::MinHeight, "min-height"),
+            (CssProperty::MaxHeight, "max-height"),
+            (CssProperty::Margin, "margin"),
+            (CssProperty::MarginTop, "margin-top"),
+            (CssProperty::MarginRight, "margin-right"),
+            (CssProperty::MarginBottom, "margin-bottom"),
+            (CssProperty::MarginLeft, "margin-left"),
+            (CssProperty::Padding, "padding"),
+            (CssProperty::PaddingTop, "padding-top"),
+            (CssProperty::PaddingRight, "padding-right"),
+            (CssProperty::PaddingBottom, "padding-bottom"),
+            (CssProperty::PaddingLeft, "padding-left"),
+            (CssProperty::Border, "border"),
+            (CssProperty::BorderWidth, "border-width"),
+            (CssProperty::BorderStyle, "border-style"),
+            (CssProperty::BorderColor, "border-color"),
+            (CssProperty::BorderRadius, "border-radius"),
+            (CssProperty::BorderCollapse, "border-collapse"),
+            (CssProperty::BorderSpacing, "border-spacing"),
+            (CssProperty::InlineSize, "inline-size"),
+            (CssProperty::BlockSize, "block-size"),
+            (CssProperty::MinInlineSize, "min-inline-size"),
+            (CssProperty::MaxInlineSize, "max-inline-size"),
+            (CssProperty::MinBlockSize, "min-block-size"),
+            (CssProperty::MaxBlockSize, "max-block-size"),
+            (CssProperty::MarginInline, "margin-inline"),
+            (CssProperty::MarginInlineStart, "margin-inline-start"),
+            (CssProperty::MarginInlineEnd, "margin-inline-end"),
+            (CssProperty::MarginBlock, "margin-block"),
+            (CssProperty::MarginBlockStart, "margin-block-start"),
+            (CssProperty::MarginBlockEnd, "margin-block-end"),
+            (CssProperty::PaddingInline, "padding-inline"),
+            (CssProperty::PaddingInlineStart, "padding-inline-start"),
+            (CssProperty::PaddingInlineEnd, "padding-inline-end"),
+            (CssProperty::PaddingBlock, "padding-block"),
+            (CssProperty::PaddingBlockStart, "padding-block-start"),
+            (CssProperty::PaddingBlockEnd, "padding-block-end"),
+            (CssProperty::InsetInlineStart, "inset-inline-start"),
+            (CssProperty::InsetInlineEnd, "inset-inline-end"),
+            (CssProperty::InsetBlockStart, "inset-block-start"),
+            (CssProperty::InsetBlockEnd, "inset-block-end"),
+            (CssProperty::Position, "position"),
+            (CssProperty::Top, "top"),
+            (CssProperty::Right, "right"),
+            (CssProperty::Bottom, "bottom"),
+            (CssProperty::Left, "left"),
+            (CssProperty::ZIndex, "z-index"),
+            (CssProperty::Float, "float"),
+            (CssProperty::Clear, "clear"),
+            (CssProperty::Display, "display"),
+            (CssProperty::FlexDirection, "flex-direction"),
+            (CssProperty::FlexWrap, "flex-wrap"),
+            (CssProperty::FlexFlow, "flex-flow"),
+            (CssProperty::FlexGrow, "flex-grow"),
+            (CssProperty::FlexShrink, "flex-shrink"),
+            (CssProperty::FlexBasis, "flex-basis"),
+            (CssProperty::Order, "order"),
+            (CssProperty::AlignItems, "align-items"),
+            (CssProperty::AlignSelf, "align-self"),
+            (CssProperty::AlignContent, "align-content"),
+            (CssProperty::JustifyContent, "justify-content"),
+            (CssProperty::JustifyItems, "justify-items"),
+            (CssProperty::JustifySelf, "justify-self"),
+            (CssProperty::PlaceItems, "place-items"),
+            (CssProperty::PlaceContent, "place-content"),
+            (CssProperty::Gap, "gap"),
+            (CssProperty::RowGap, "row-gap"),
+            (CssProperty::ColumnGap, "column-gap"),
+            (CssProperty::GridTemplateColumns, "grid-template-columns"),
+            (CssProperty::GridTemplateRows, "grid-template-rows"),
+            (CssProperty::GridColumn, "grid-column"),
+            (CssProperty::GridRow, "grid-row"),
+            (CssProperty::GridArea, "grid-area"),
+            (CssProperty::GridAutoFlow, "grid-auto-flow"),
+            (CssProperty::GridAutoColumns, "grid-auto-columns"),
+            (CssProperty::GridAutoRows, "grid-auto-rows"),
+            (CssProperty::Color, "color"),
+            (CssProperty::FontFamily, "font-family"),
+            (CssProperty::FontSize, "font-size"),
+            (CssProperty::FontWeight, "font-weight"),
+            (CssProperty::FontStyle, "font-style"),
+            (CssProperty::LineHeight, "line-height"),
+            (CssProperty::TextAlign, "text-align"),
+            (CssProperty::TextDecoration, "text-decoration"),
+            (CssProperty::TextTransform, "text-transform"),
+            (CssProperty::TextOverflow, "text-overflow"),
+            (CssProperty::TextIndent, "text-indent"),
+            (CssProperty::TextShadow, "text-shadow"),
+            (CssProperty::WhiteSpace, "white-space"),
+            (CssProperty::WordBreak, "word-break"),
+            (CssProperty::WordWrap, "word-wrap"),
+            (CssProperty::OverflowWrap, "overflow-wrap"),
+            (CssProperty::LetterSpacing, "letter-spacing"),
+            (CssProperty::WordSpacing, "word-spacing"),
+            (CssProperty::Background, "background"),
+            (CssProperty::BackgroundColor, "background-color"),
+            (CssProperty::BackgroundImage, "background-image"),
+            (CssProperty::BackgroundPosition, "background-position"),
+            (CssProperty::BackgroundSize, "background-size"),
+            (CssProperty::BackgroundRepeat, "background-repeat"),
+            (CssProperty::Opacity, "opacity"),
+            (CssProperty::Visibility, "visibility"),
+            (CssProperty::BoxShadow, "box-shadow"),
+            (CssProperty::Outline, "outline"),
+            (CssProperty::OutlineWidth, "outline-width"),
+            (CssProperty::OutlineStyle, "outline-style"),
+            (CssProperty::OutlineColor, "outline-color"),
+            (CssProperty::OutlineOffset, "outline-offset"),
+            (CssProperty::Cursor, "cursor"),
+            (CssProperty::PointerEvents, "pointer-events"),
+            (CssProperty::UserSelect, "user-select"),
+            (CssProperty::Overflow, "overflow"),
+            (CssProperty::OverflowX, "overflow-x"),
+            (CssProperty::OverflowY, "overflow-y"),
+            (CssProperty::Clip, "clip"),
+            (CssProperty::ClipPath, "clip-path"),
+            (CssProperty::ScrollBehavior, "scroll-behavior"),
+            (CssProperty::ScrollSnapType, "scroll-snap-type"),
+            (CssProperty::ScrollSnapAlign, "scroll-snap-align"),
+            (CssProperty::OverscrollBehavior, "overscroll-behavior"),
+            (CssProperty::Transform, "transform"),
+            (CssProperty::TransformOrigin, "transform-origin"),
+            (CssProperty::Transition, "transition"),
+            (CssProperty::TransitionProperty, "transition-property"),
+            (CssProperty::TransitionDuration, "transition-duration"),
+            (
+                CssProperty::TransitionTimingFunction,
+                "transition-timing-function",
+            ),
+            (CssProperty::TransitionDelay, "transition-delay"),
+            (CssProperty::Animation, "animation"),
+            (CssProperty::AnimationName, "animation-name"),
+            (CssProperty::AnimationDuration, "animation-duration"),
+            (
+                CssProperty::AnimationTimingFunction,
+                "animation-timing-function",
+            ),
+            (CssProperty::AnimationDelay, "animation-delay"),
+            (
+                CssProperty::AnimationIterationCount,
+                "animation-iteration-count",
+            ),
+            (CssProperty::AnimationDirection, "animation-direction"),
+            (CssProperty::AnimationFillMode, "animation-fill-mode"),
+            (CssProperty::AnimationPlayState, "animation-play-state"),
+            (CssProperty::AspectRatio, "aspect-ratio"),
+            (CssProperty::ObjectFit, "object-fit"),
+            (CssProperty::ObjectPosition, "object-position"),
+            (CssProperty::Contain, "contain"),
+            (CssProperty::ContentVisibility, "content-visibility"),
+            (CssProperty::WillChange, "will-change"),
+            (CssProperty::Appearance, "appearance"),
+            (CssProperty::Resize, "resize"),
+            (CssProperty::TouchAction, "touch-action"),
+            (CssProperty::Filter, "filter"),
+            (CssProperty::BackdropFilter, "backdrop-filter"),
+            (CssProperty::Content, "content"),
+            (CssProperty::ListStyle, "list-style"),
+            (CssProperty::ListStyleType, "list-style-type"),
+            (CssProperty::ListStylePosition, "list-style-position"),
+            (CssProperty::TableLayout, "table-layout"),
+            (CssProperty::VerticalAlign, "vertical-align"),
+        ];
+
+        for (property, expected) in cases {
+            assert_eq!(property.to_string(), expected);
+        }
+
         assert_eq!(
             CssProperty::Custom("ars-timer-progress").to_string(),
             "--ars-timer-progress"
@@ -2317,6 +2802,33 @@ mod tests {
     }
 
     #[test]
+    fn attr_map_accessors_expose_sorted_attrs_and_styles() {
+        let mut attrs = AttrMap::new();
+
+        attrs.set(HtmlAttr::Title, "tooltip");
+        attrs.set(HtmlAttr::Id, "root");
+        attrs.set_style(CssProperty::Height, "20px");
+        attrs.set_style(CssProperty::Width, "10px");
+
+        assert_eq!(
+            attrs.attrs(),
+            &[
+                (HtmlAttr::Id, AttrValue::String(String::from("root"))),
+                (HtmlAttr::Title, AttrValue::String(String::from("tooltip"))),
+            ]
+        );
+        assert_eq!(
+            attrs.styles(),
+            &[
+                (CssProperty::Width, String::from("10px")),
+                (CssProperty::Height, String::from("20px")),
+            ]
+        );
+        assert_eq!(attrs.iter_attrs().count(), 2);
+        assert_eq!(attrs.iter_styles().count(), 2);
+    }
+
+    #[test]
     fn attr_map_set_none_removes_existing_value() {
         let mut attrs = AttrMap::new();
 
@@ -2325,6 +2837,16 @@ mod tests {
 
         assert!(!attrs.contains(&HtmlAttr::Title));
         assert_eq!(attrs.get(&HtmlAttr::Title), None);
+    }
+
+    #[test]
+    fn attr_map_none_insert_on_missing_key_is_noop() {
+        let mut attrs = AttrMap::new();
+
+        attrs.set(HtmlAttr::Title, AttrValue::None);
+
+        assert_eq!(attrs.attrs(), &[]);
+        assert_eq!(attrs.styles(), &[]);
     }
 
     #[test]
@@ -2350,6 +2872,23 @@ mod tests {
         assert_eq!(
             attrs.get(&HtmlAttr::Aria(AriaAttr::DescribedBy)),
             Some("hint error")
+        );
+    }
+
+    #[test]
+    fn attr_map_space_separated_attrs_replace_non_string_values() {
+        let mut attrs = AttrMap::new();
+
+        attrs.set_bool(HtmlAttr::Class, true);
+        attrs.set(HtmlAttr::Class, "merged");
+
+        assert_eq!(attrs.get(&HtmlAttr::Class), Some("merged"));
+
+        attrs.set(HtmlAttr::Class, AttrValue::Bool(false));
+
+        assert_eq!(
+            attrs.get_value(&HtmlAttr::Class),
+            Some(&AttrValue::Bool(false))
         );
     }
 
@@ -2392,6 +2931,27 @@ mod tests {
     }
 
     #[test]
+    fn attr_map_merge_user_applies_allowed_user_attributes() {
+        let mut attrs = AttrMap::new();
+        attrs.set(HtmlAttr::Role, "button");
+
+        let mut user = UserAttrs::new();
+        user.set(HtmlAttr::Title, "from-user");
+        user.set_bool(HtmlAttr::Hidden, true);
+        user.set_style(CssProperty::Height, "24px");
+
+        attrs.merge_user(user);
+
+        assert_eq!(attrs.get(&HtmlAttr::Role), Some("button"));
+        assert_eq!(attrs.get(&HtmlAttr::Title), Some("from-user"));
+        assert_eq!(attrs.get(&HtmlAttr::Hidden), Some("true"));
+        assert_eq!(
+            attrs.styles(),
+            &[(CssProperty::Height, String::from("24px"))]
+        );
+    }
+
+    #[test]
     fn user_attrs_reject_blocked_keys() {
         let mut user = UserAttrs::new();
 
@@ -2418,6 +2978,27 @@ mod tests {
         assert_eq!(
             merged.styles(),
             &[(CssProperty::Width, String::from("12px"))]
+        );
+    }
+
+    #[test]
+    fn user_attrs_allow_non_blocked_bool_and_string_backed_inputs() {
+        let mut user = UserAttrs::new();
+        let title = String::from("tooltip");
+
+        user.set(HtmlAttr::Title, &title);
+        user.set_bool(HtmlAttr::Draggable, true);
+        user.set(HtmlAttr::Aria(AriaAttr::Current), AttrValue::from(false));
+
+        let mut merged = AttrMap::new();
+
+        merged.merge_user(user);
+
+        assert_eq!(merged.get(&HtmlAttr::Title), Some("tooltip"));
+        assert_eq!(merged.get(&HtmlAttr::Draggable), Some("true"));
+        assert_eq!(
+            merged.get(&HtmlAttr::Aria(AriaAttr::Current)),
+            Some("false")
         );
     }
 
@@ -2486,6 +3067,14 @@ mod tests {
         assert_eq!(AttrValue::from(true).as_str(), Some("true"));
         assert_eq!(AttrValue::from(false).as_str(), Some("false"));
         assert_eq!(AttrValue::None.as_str(), None);
+    }
+
+    #[test]
+    fn attr_value_from_owned_string_preserves_inner_string() {
+        let value = AttrValue::from(String::from("owned"));
+
+        assert_eq!(value, AttrValue::String(String::from("owned")));
+        assert_eq!(value.as_str(), Some("owned"));
     }
 
     #[cfg(feature = "serde")]

--- a/crates/ars-core/src/lib.rs
+++ b/crates/ars-core/src/lib.rs
@@ -40,6 +40,8 @@ pub mod platform;
 pub mod provider;
 mod shared_flag;
 mod shared_state;
+#[cfg(any(test, feature = "testing"))]
+pub mod test_helpers;
 mod url;
 mod weak_send;
 
@@ -1085,7 +1087,7 @@ impl<M: Machine> Service<M> {
 
 #[cfg(test)]
 mod tests {
-    use alloc::vec;
+    use alloc::{format, vec};
     #[cfg(feature = "debug")]
     use std::sync::{Mutex, Once};
 
@@ -1300,6 +1302,67 @@ mod tests {
     }
 
     #[test]
+    fn default_machine_on_props_changed_returns_no_events() {
+        let old = ToggleProps {
+            id: String::from("toggle-old"),
+        };
+        let new = ToggleProps {
+            id: String::from("toggle-new"),
+        };
+
+        assert!(<ToggleMachine as Machine>::on_props_changed(&old, &new).is_empty());
+    }
+
+    #[test]
+    fn service_accessors_debug_connect_and_unmount_behave_as_expected() {
+        use alloc::{format, rc::Rc};
+        use core::cell::RefCell;
+
+        let mut service = Service::<ToggleMachine>::new(
+            ToggleProps {
+                id: String::from("toggle"),
+            },
+            &Env::default(),
+            &(),
+        );
+
+        assert_eq!(service.props().id, "toggle");
+
+        service.props_mut().id = String::from("toggle-updated");
+        *service.context_mut() = ToggleContext;
+
+        let api = service.connect(&|_| {});
+
+        assert_eq!(api.part_attrs(TogglePart), AttrMap::new());
+        assert_eq!(service.props().id, "toggle-updated");
+
+        let debug = format!("{service:?}");
+
+        assert!(debug.contains("Service"));
+        assert!(debug.contains("props_id"));
+        assert!(!service.is_unmounted());
+
+        service.event_queue.push_back(ToggleEvent::Toggle);
+
+        let cleanup_order = Rc::new(RefCell::new(Vec::new()));
+
+        let first = {
+            let cleanup_order = Rc::clone(&cleanup_order);
+            Box::new(move || cleanup_order.borrow_mut().push("first")) as CleanupFn
+        };
+        let second = {
+            let cleanup_order = Rc::clone(&cleanup_order);
+            Box::new(move || cleanup_order.borrow_mut().push("second")) as CleanupFn
+        };
+
+        service.unmount(vec![first, second]);
+
+        assert!(service.event_queue.is_empty());
+        assert!(service.is_unmounted());
+        assert_eq!(cleanup_order.borrow().as_slice(), ["second", "first"]);
+    }
+
+    #[test]
     fn send_result_reports_no_change_when_ignored() {
         let mut service = Service::<ToggleMachine>::new(
             ToggleProps {
@@ -1373,6 +1436,11 @@ mod tests {
             &(),
         );
 
+        assert_eq!(
+            service.connect(&|_| {}).part_attrs(TogglePart),
+            AttrMap::new()
+        );
+
         let result = service.send(ToggleEvent::Toggle);
 
         assert!(!result.state_changed);
@@ -1431,6 +1499,11 @@ mod tests {
             &(),
         );
 
+        assert_eq!(
+            service.connect(&|_| {}).part_attrs(TogglePart),
+            AttrMap::new()
+        );
+
         let result = service.send(ToggleEvent::Toggle);
 
         assert_eq!(result.cancel_effects, vec!["timer", "polling"]);
@@ -1481,6 +1554,11 @@ mod tests {
             },
             &Env::default(),
             &(),
+        );
+
+        assert_eq!(
+            service.connect(&|_| {}).part_attrs(TogglePart),
+            AttrMap::new()
         );
 
         let result = service.send(ToggleEvent::Toggle);
@@ -1565,6 +1643,19 @@ mod tests {
             &Env::default(),
             &(),
         );
+
+        assert_eq!(
+            service.connect(&|_| {}).part_attrs(TogglePart),
+            AttrMap::new()
+        );
+        assert_eq!(service.context().mode, 0);
+
+        let unchanged = service.set_props(ToggleProps {
+            id: String::from("a"),
+        });
+
+        assert!(!unchanged.state_changed);
+        assert!(!unchanged.context_changed);
         assert_eq!(service.context().mode, 0);
 
         let result = service.set_props(ToggleProps {
@@ -2499,6 +2590,87 @@ mod tests {
     }
 
     #[test]
+    fn transition_plan_apply_chains_mutations_in_order() {
+        #[derive(Clone, Debug, PartialEq, Eq)]
+        struct ChainContext {
+            values: Vec<u8>,
+        }
+
+        struct ApplyMachine;
+
+        impl Machine for ApplyMachine {
+            type State = ToggleState;
+            type Event = ToggleEvent;
+            type Context = ChainContext;
+            type Props = ToggleProps;
+            type Messages = ();
+            type Api<'a> = ToggleApi;
+
+            fn init(
+                _props: &Self::Props,
+                _env: &Env,
+                _messages: &Self::Messages,
+            ) -> (Self::State, Self::Context) {
+                (ToggleState::Off, ChainContext { values: Vec::new() })
+            }
+
+            fn transition(
+                _state: &Self::State,
+                _event: &Self::Event,
+                _context: &Self::Context,
+                _props: &Self::Props,
+            ) -> Option<TransitionPlan<Self>> {
+                Some(
+                    TransitionPlan::new()
+                        .apply(|ctx: &mut ChainContext| ctx.values.push(1))
+                        .apply(|ctx: &mut ChainContext| ctx.values.push(2)),
+                )
+            }
+
+            fn connect<'a>(
+                _state: &'a Self::State,
+                _context: &'a Self::Context,
+                _props: &'a Self::Props,
+                _send: &'a dyn Fn(Self::Event),
+            ) -> Self::Api<'a> {
+                ToggleApi
+            }
+        }
+
+        let mut service = Service::<ApplyMachine>::new(
+            ToggleProps {
+                id: String::from("apply"),
+            },
+            &Env::default(),
+            &(),
+        );
+
+        assert_eq!(
+            service.connect(&|_| {}).part_attrs(TogglePart),
+            AttrMap::new()
+        );
+
+        let result = service.send(ToggleEvent::Toggle);
+
+        assert!(!result.state_changed);
+        assert!(result.context_changed);
+        assert_eq!(service.context().values, vec![1, 2]);
+    }
+
+    #[test]
+    fn transition_plan_default_matches_new_and_formats_apply_closures() {
+        use alloc::format;
+
+        let default_plan = TransitionPlan::<ToggleMachine>::default();
+        let new_plan = TransitionPlan::<ToggleMachine>::new();
+        let apply_plan = TransitionPlan::<ToggleMachine>::context_only(|_ctx| {});
+
+        assert_eq!(default_plan.debug_summary(), "none");
+        assert_eq!(format!("{default_plan:?}"), format!("{new_plan:?}"));
+        assert!(format!("{apply_plan:?}").contains("apply: \"<closure>\""));
+    }
+
+    #[test]
     fn transition_plan_debug_summary_distinguishes_plan_kinds() {
         assert_eq!(
             TransitionPlan::<ToggleMachine>::new().debug_summary(),
@@ -2524,6 +2696,67 @@ mod tests {
         );
         assert!(css.contains(".ars-sr-input"));
         assert!(css.contains(".ars-touch-none"));
+    }
+
+    #[test]
+    fn toggle_props_has_id_helpers_replace_and_mutate_ids() {
+        let props = ToggleProps {
+            id: String::from("before"),
+        };
+
+        let replaced = props.clone().with_id(String::from("after"));
+
+        assert_eq!(props.id(), "before");
+        assert_eq!(replaced.id(), "after");
+
+        let mut mutated = props;
+
+        mutated.set_id(String::from("mutated"));
+
+        assert_eq!(mutated.id(), "mutated");
+    }
+
+    #[test]
+    fn component_part_data_attrs_include_scope_and_name() {
+        assert_eq!(
+            TogglePart::ROOT.data_attrs(),
+            [
+                (HtmlAttr::Data("ars-scope"), "toggle"),
+                (HtmlAttr::Data("ars-part"), "root"),
+            ]
+        );
+        assert_eq!(TogglePart::all(), vec![TogglePart]);
+    }
+
+    #[test]
+    fn env_debug_includes_locale_and_backend_placeholder() {
+        let debug = format!("{:?}", Env::default());
+
+        assert!(debug.contains("Env"));
+        assert!(debug.contains("en-US"));
+        assert!(debug.contains("Arc(..)"));
+    }
+
+    #[test]
+    fn send_result_debug_lists_effect_names() {
+        let result = SendResult::<ToggleMachine> {
+            state_changed: true,
+            context_changed: false,
+            pending_effects: vec![
+                PendingEffect::named("focus"),
+                PendingEffect::named("announce"),
+            ],
+            cancel_effects: vec!["timer"],
+            truncated: false,
+            context_change_count: 0,
+        };
+
+        let debug = format!("{result:?}");
+
+        assert!(debug.contains("SendResult"));
+        assert!(debug.contains("focus"));
+        assert!(debug.contains("announce"));
+        assert!(debug.contains("timer"));
     }
 
     #[cfg(feature = "embedded-css")]

--- a/crates/ars-core/src/platform.rs
+++ b/crates/ars-core/src/platform.rs
@@ -167,10 +167,13 @@ pub trait PlatformEffects: Send + Sync {
 pub struct Rect {
     /// The x coordinate of the rectangle's origin.
     pub x: f64,
+
     /// The y coordinate of the rectangle's origin.
     pub y: f64,
+
     /// The width of the rectangle.
     pub width: f64,
+
     /// The height of the rectangle.
     pub height: f64,
 }
@@ -224,6 +227,7 @@ impl PlatformEffects for NullPlatformEffects {
     #[inline]
     fn set_timeout(&self, _delay_ms: u32, callback: Box<dyn FnOnce()>) -> TimerHandle {
         callback();
+
         TimerHandle::new(0)
     }
 
@@ -325,6 +329,7 @@ impl PlatformEffects for NullPlatformEffects {
     #[inline]
     fn on_animation_end(&self, _id: &str, callback: Box<dyn FnOnce()>) -> Box<dyn FnOnce()> {
         callback();
+
         Box::new(|| {})
     }
 }
@@ -372,6 +377,7 @@ impl PlatformEffects for MissingProviderEffects {
     #[inline]
     fn tabbable_element_ids(&self, _container_id: &str) -> Vec<String> {
         Self::warn("tabbable_element_ids");
+
         Vec::new()
     }
 
@@ -383,7 +389,9 @@ impl PlatformEffects for MissingProviderEffects {
     #[inline]
     fn set_timeout(&self, _delay_ms: u32, callback: Box<dyn FnOnce()>) -> TimerHandle {
         Self::warn("set_timeout");
+
         callback();
+
         TimerHandle::new(0)
     }
 
@@ -410,12 +418,14 @@ impl PlatformEffects for MissingProviderEffects {
     #[inline]
     fn resolved_direction(&self, _id: &str) -> ResolvedDirection {
         Self::warn("resolved_direction");
+
         ResolvedDirection::Ltr
     }
 
     #[inline]
     fn set_background_inert(&self, _portal_root_id: &str) -> Box<dyn FnOnce()> {
         Self::warn("set_background_inert");
+
         Box::new(|| {})
     }
 
@@ -437,6 +447,7 @@ impl PlatformEffects for MissingProviderEffects {
     #[inline]
     fn document_contains_id(&self, _id: &str) -> bool {
         Self::warn("document_contains_id");
+
         false
     }
 
@@ -447,12 +458,14 @@ impl PlatformEffects for MissingProviderEffects {
         _on_up: Box<dyn FnOnce()>,
     ) -> Box<dyn FnOnce()> {
         Self::warn("track_pointer_drag");
+
         Box::new(|| {})
     }
 
     #[inline]
     fn active_element_id(&self) -> Option<String> {
         Self::warn("active_element_id");
+
         None
     }
 
@@ -463,18 +476,21 @@ impl PlatformEffects for MissingProviderEffects {
         _on_escape: Box<dyn Fn()>,
     ) -> Box<dyn FnOnce()> {
         Self::warn("attach_focus_trap");
+
         Box::new(|| {})
     }
 
     #[inline]
     fn can_restore_focus(&self, _id: &str) -> bool {
         Self::warn("can_restore_focus");
+
         false
     }
 
     #[inline]
     fn nearest_focusable_ancestor_id(&self, _id: &str) -> Option<String> {
         Self::warn("nearest_focusable_ancestor_id");
+
         None
     }
 
@@ -491,31 +507,37 @@ impl PlatformEffects for MissingProviderEffects {
     #[inline]
     fn on_reduced_motion_change(&self, _callback: Box<dyn Fn(bool)>) -> Box<dyn FnOnce()> {
         Self::warn("on_reduced_motion_change");
+
         Box::new(|| {})
     }
 
     #[inline]
     fn is_mac_platform(&self) -> bool {
         Self::warn("is_mac_platform");
+
         false
     }
 
     #[inline]
     fn now_ms(&self) -> u64 {
         Self::warn("now_ms");
+
         0
     }
 
     #[inline]
     fn get_bounding_rect(&self, _id: &str) -> Option<Rect> {
         Self::warn("get_bounding_rect");
+
         None
     }
 
     #[inline]
     fn on_animation_end(&self, _id: &str, callback: Box<dyn FnOnce()>) -> Box<dyn FnOnce()> {
         Self::warn("on_animation_end");
+
         callback();
+
         Box::new(|| {})
     }
 }
@@ -532,6 +554,7 @@ mod tests {
     #[test]
     fn timer_handle_round_trip() {
         let handle = TimerHandle::new(42);
+
         assert_eq!(handle.id(), 42);
     }
 
@@ -540,6 +563,7 @@ mod tests {
     #[test]
     fn rect_default_is_zero() {
         let r = Rect::default();
+
         assert_eq!(r.x, 0.0);
         assert_eq!(r.y, 0.0);
         assert_eq!(r.width, 0.0);
@@ -551,18 +575,24 @@ mod tests {
     #[test]
     fn null_set_timeout_fires_immediately() {
         let fired = Rc::new(Cell::new(false));
+
         let fired_clone = Rc::clone(&fired);
+
         let _handle =
             NullPlatformEffects.set_timeout(1000, Box::new(move || fired_clone.set(true)));
+
         assert!(fired.get());
     }
 
     #[test]
     fn null_on_animation_end_fires_immediately() {
         let fired = Rc::new(Cell::new(false));
+
         let fired_clone = Rc::clone(&fired);
+
         let _cleanup =
             NullPlatformEffects.on_animation_end("el", Box::new(move || fired_clone.set(true)));
+
         assert!(fired.get());
     }
 
@@ -623,19 +653,90 @@ mod tests {
     #[test]
     fn missing_provider_set_timeout_fires_immediately() {
         let fired = Rc::new(Cell::new(false));
+
         let fired_clone = Rc::clone(&fired);
+
         let _handle =
             MissingProviderEffects.set_timeout(500, Box::new(move || fired_clone.set(true)));
+
         assert!(fired.get());
     }
 
     #[test]
     fn missing_provider_on_animation_end_fires_immediately() {
         let fired = Rc::new(Cell::new(false));
+
         let fired_clone = Rc::clone(&fired);
+
         let _cleanup =
             MissingProviderEffects.on_animation_end("el", Box::new(move || fired_clone.set(true)));
+
         assert!(fired.get());
+    }
+
+    #[test]
+    fn missing_provider_effects_cover_remaining_noop_paths() {
+        MissingProviderEffects.focus_element_by_id("id");
+        MissingProviderEffects.focus_first_tabbable("container");
+        MissingProviderEffects.focus_last_tabbable("container");
+
+        assert!(
+            MissingProviderEffects
+                .tabbable_element_ids("container")
+                .is_empty()
+        );
+
+        MissingProviderEffects.focus_body();
+        MissingProviderEffects.clear_timeout(TimerHandle::new(1));
+        MissingProviderEffects.announce("message");
+        MissingProviderEffects.announce_assertive("message");
+        MissingProviderEffects.position_element_at("id", 1.0, 2.0);
+
+        assert_eq!(
+            MissingProviderEffects.resolved_direction("id"),
+            ResolvedDirection::Ltr
+        );
+
+        let cleanup = MissingProviderEffects.set_background_inert("portal-root");
+
+        cleanup();
+
+        MissingProviderEffects.remove_inert_from_siblings("portal-root");
+        MissingProviderEffects.scroll_lock_acquire();
+        MissingProviderEffects.scroll_lock_release();
+
+        assert!(!MissingProviderEffects.document_contains_id("id"));
+
+        let drag_cleanup =
+            MissingProviderEffects.track_pointer_drag(Box::new(|_, _| {}), Box::new(|| {}));
+
+        drag_cleanup();
+
+        assert!(MissingProviderEffects.active_element_id().is_none());
+
+        let focus_cleanup = MissingProviderEffects.attach_focus_trap("container", Box::new(|| {}));
+
+        focus_cleanup();
+
+        assert!(!MissingProviderEffects.can_restore_focus("id"));
+        assert!(
+            MissingProviderEffects
+                .nearest_focusable_ancestor_id("id")
+                .is_none()
+        );
+
+        MissingProviderEffects.set_scroll_top("container", 24.0);
+        MissingProviderEffects.resize_to_content("textarea", None);
+        MissingProviderEffects.resize_to_content("textarea", Some("200px"));
+
+        let reduced_motion_cleanup =
+            MissingProviderEffects.on_reduced_motion_change(Box::new(|_| {}));
+
+        reduced_motion_cleanup();
+
+        assert!(!MissingProviderEffects.is_mac_platform());
+        assert_eq!(MissingProviderEffects.now_ms(), 0);
+        assert!(MissingProviderEffects.get_bounding_rect("id").is_none());
     }
 
     // -- Compile coverage: trait object usage ---------------------------------
@@ -649,46 +750,64 @@ mod tests {
         platform.focus_element_by_id("id");
         platform.focus_first_tabbable("id");
         platform.focus_last_tabbable("id");
+
         drop(platform.tabbable_element_ids("id"));
+
         platform.focus_body();
 
         let _handle = platform.set_timeout(0, Box::new(|| {}));
+
         platform.clear_timeout(TimerHandle::new(0));
 
         platform.announce("msg");
         platform.announce_assertive("msg");
 
         platform.position_element_at("id", 0.0, 0.0);
+
         let _ = platform.resolved_direction("id");
 
         let cleanup = platform.set_background_inert("id");
+
         cleanup();
+
         platform.remove_inert_from_siblings("id");
+
         platform.scroll_lock_acquire();
         platform.scroll_lock_release();
 
         let _ = platform.document_contains_id("id");
 
         let cleanup = platform.track_pointer_drag(Box::new(|_x, _y| {}), Box::new(|| {}));
+
         cleanup();
 
         drop(platform.active_element_id());
+
         let cleanup = platform.attach_focus_trap("id", Box::new(|| {}));
+
         cleanup();
+
         let _ = platform.can_restore_focus("id");
+
         drop(platform.nearest_focusable_ancestor_id("id"));
 
         platform.set_scroll_top("id", 0.0);
+
         platform.resize_to_content("id", None);
         platform.resize_to_content("id", Some("200px"));
 
         let cleanup = platform.on_reduced_motion_change(Box::new(|_reduced| {}));
+
         cleanup();
+
         let _ = platform.is_mac_platform();
+
         let _ = platform.now_ms();
+
         let _ = platform.get_bounding_rect("id");
 
         let cleanup = platform.on_animation_end("id", Box::new(|| {}));
+
         cleanup();
     }
 
@@ -696,8 +815,11 @@ mod tests {
     #[test]
     fn missing_provider_is_object_safe() {
         let platform: &dyn PlatformEffects = &MissingProviderEffects;
+
         platform.focus_element_by_id("test");
+
         let _ = platform.resolved_direction("test");
+
         assert!(!platform.document_contains_id("test"));
     }
 
@@ -706,6 +828,7 @@ mod tests {
     #[test]
     fn implementations_work_as_arc_trait_objects() {
         let null = Arc::new(NullPlatformEffects);
+
         let missing = Arc::new(MissingProviderEffects);
 
         null.focus_element_by_id("a");
@@ -721,17 +844,22 @@ mod tests {
         use alloc::collections::BTreeMap;
 
         let a = TimerHandle::new(1);
+
         let b = a; // Copy
+
         assert_eq!(a, b); // Eq
 
         // Prove Debug formatting:
         let debug = alloc::format!("{a:?}");
+
         assert!(debug.contains("TimerHandle"));
         assert!(debug.contains('1'));
 
         // Hash is proven by the derive; verify Eq works in a collection context:
         let mut map = BTreeMap::<u64, TimerHandle>::new();
+
         map.insert(a.id(), a);
+
         assert_eq!(map[&1], a);
     }
 
@@ -744,7 +872,9 @@ mod tests {
             width: 100.0,
             height: 50.0,
         };
+
         let r2 = r; // Copy
+
         assert_eq!(r, r2);
         assert_eq!(r.x, 10.0);
         assert_eq!(r.y, 20.0);

--- a/crates/ars-core/src/provider.rs
+++ b/crates/ars-core/src/provider.rs
@@ -5,7 +5,7 @@
 //! the shared instance-scoped modality context.
 
 use alloc::{string::String, sync::Arc};
-use core::fmt;
+use core::fmt::{self, Debug};
 
 use ars_i18n::{Direction, Locale, locales};
 
@@ -21,8 +21,10 @@ use crate::{
 pub enum ColorMode {
     /// Light color scheme.
     Light,
+
     /// Dark color scheme.
     Dark,
+
     /// Inherit from the operating system preference.
     #[default]
     System,
@@ -164,7 +166,7 @@ impl Default for ArsContext {
     }
 }
 
-impl fmt::Debug for ArsContext {
+impl Debug for ArsContext {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ArsContext")
             .field("locale", &self.locale)
@@ -184,6 +186,8 @@ impl fmt::Debug for ArsContext {
 
 #[cfg(test)]
 mod tests {
+    use alloc::format;
+
     use super::*;
     use crate::{ModalitySnapshot, NullModalityContext};
 
@@ -202,7 +206,9 @@ mod tests {
     #[test]
     fn color_mode_is_copy() {
         let a = ColorMode::Dark;
+
         let b = a;
+
         assert_eq!(a, b);
     }
 
@@ -239,5 +245,32 @@ mod tests {
         assert_eq!(context.portal_container_id(), Some("portal-root"));
         assert_eq!(context.root_node_id(), Some("app-root"));
         assert_eq!(context.style_strategy(), &StyleStrategy::Cssom);
+    }
+
+    #[test]
+    fn ars_context_default_exposes_default_optional_and_platform_values() {
+        let context = ArsContext::default();
+
+        assert_eq!(context.id_prefix(), None);
+        assert_eq!(context.portal_container_id(), None);
+        assert_eq!(context.root_node_id(), None);
+        assert_eq!(context.style_strategy(), &StyleStrategy::Inline);
+        assert_eq!(context.platform().now_ms(), 0);
+        assert_eq!(context.modality().snapshot(), ModalitySnapshot::default());
+    }
+
+    #[test]
+    fn ars_context_debug_lists_public_fields() {
+        let context = ArsContext::default();
+
+        let debug = format!("{context:?}");
+
+        assert!(debug.contains("ArsContext"));
+        assert!(debug.contains("locale"));
+        assert!(debug.contains("direction"));
+        assert!(debug.contains("color_mode"));
+        assert!(debug.contains("platform"));
+        assert!(debug.contains("modality"));
+        assert!(debug.contains("style_strategy"));
     }
 }

--- a/crates/ars-core/src/test_helpers.rs
+++ b/crates/ars-core/src/test_helpers.rs
@@ -1,0 +1,1380 @@
+//! ARIA assertion helpers for validating `connect()` output in tests.
+//!
+//! These helpers operate on [`AttrMap`] values so component and subsystem tests
+//! can validate ARIA contracts without repeating raw attribute lookups.
+
+use alloc::{
+    format,
+    string::{String, ToString},
+};
+use core::str::FromStr;
+
+use crate::{AriaAttr, AttrMap, HtmlAttr};
+
+fn required_attr(attrs: &AttrMap, attr: HtmlAttr, missing_message: impl Into<String>) -> &str {
+    let missing_message = missing_message.into();
+
+    attrs
+        .get(&attr)
+        .unwrap_or_else(|| panic!("{missing_message}"))
+}
+
+fn parsed_required_attr<T>(
+    attrs: &AttrMap,
+    attr: HtmlAttr,
+    missing_message: &'static str,
+    parse_message: &'static str,
+) -> T
+where
+    T: FromStr,
+{
+    attrs
+        .get(&attr)
+        .expect(missing_message)
+        .parse()
+        .unwrap_or_else(|_| panic!("{parse_message}"))
+}
+
+fn assert_expected_string_attr(attrs: &AttrMap, attr: HtmlAttr, attr_name: &str, expected: &str) {
+    let val = required_attr(
+        attrs,
+        attr,
+        format!("expected {attr_name}=\"{expected}\" but not found"),
+    );
+
+    assert_eq!(val, expected, "wrong {attr_name}");
+}
+
+fn assert_required_bool_attr(attrs: &AttrMap, attr: HtmlAttr, attr_name: &str, expected: bool) {
+    let val = required_attr(attrs, attr, format!("expected {attr_name} but not found"));
+
+    assert_eq!(val, if expected { "true" } else { "false" });
+}
+
+fn assert_optional_false_bool_attr(
+    attrs: &AttrMap,
+    attr: HtmlAttr,
+    attr_name: &str,
+    expected: bool,
+) {
+    let val = attrs.get(&attr);
+
+    if expected {
+        assert_eq!(val, Some("true"), "expected {attr_name}=\"true\"");
+    } else {
+        assert!(val.is_none() || val == Some("false"));
+    }
+}
+
+fn assert_optional_false_bool_attr_with_debug(
+    attrs: &AttrMap,
+    attr: HtmlAttr,
+    attr_name: &str,
+    expected: bool,
+) {
+    if expected {
+        assert_eq!(
+            attrs.get(&attr),
+            Some("true"),
+            "expected {attr_name}=\"true\""
+        );
+    } else {
+        let val = attrs.get(&attr);
+
+        assert!(
+            val.is_none() || val == Some("false"),
+            "expected {attr_name} to be absent or \"false\", got {val:?}"
+        );
+    }
+}
+
+fn assert_present_attr_eq(attrs: &AttrMap, attr: HtmlAttr, attr_name: &str, expected: &str) {
+    assert_eq!(
+        attrs.get(&attr),
+        Some(expected),
+        "expected {attr_name}=\"{expected}\"",
+    );
+}
+
+/// Assert the `AttrMap` contains the expected `role` attribute.
+pub fn assert_role(attrs: &AttrMap, expected: &str) {
+    let role = attrs
+        .get(&HtmlAttr::Role)
+        .unwrap_or_else(|| panic!("expected role=\"{expected}\" but no role attribute found"));
+
+    assert_eq!(role, expected, "wrong role");
+}
+
+/// Assert `aria-label` matches the expected value.
+pub fn assert_aria_label(attrs: &AttrMap, expected: &str) {
+    assert_expected_string_attr(
+        attrs,
+        HtmlAttr::Aria(AriaAttr::Label),
+        "aria-label",
+        expected,
+    );
+}
+
+/// Assert `aria-expanded` is present and matches the expected boolean string.
+pub fn assert_aria_expanded(attrs: &AttrMap, expected: bool) {
+    assert_required_bool_attr(
+        attrs,
+        HtmlAttr::Aria(AriaAttr::Expanded),
+        "aria-expanded",
+        expected,
+    );
+}
+
+/// Assert `aria-selected` is present and matches the expected boolean string.
+pub fn assert_aria_selected(attrs: &AttrMap, expected: bool) {
+    assert_required_bool_attr(
+        attrs,
+        HtmlAttr::Aria(AriaAttr::Selected),
+        "aria-selected",
+        expected,
+    );
+}
+
+/// Assert `aria-disabled` matches the expected boolean.
+pub fn assert_aria_disabled(attrs: &AttrMap, expected: bool) {
+    assert_optional_false_bool_attr_with_debug(
+        attrs,
+        HtmlAttr::Aria(AriaAttr::Disabled),
+        "aria-disabled",
+        expected,
+    );
+}
+
+/// Assert `aria-busy` matches the expected boolean.
+pub fn assert_aria_busy(attrs: &AttrMap, expected: bool) {
+    assert_optional_false_bool_attr_with_debug(
+        attrs,
+        HtmlAttr::Aria(AriaAttr::Busy),
+        "aria-busy",
+        expected,
+    );
+}
+
+/// Assert `aria-checked` matches the expected value.
+pub fn assert_aria_checked(attrs: &AttrMap, expected: &str) {
+    assert_expected_string_attr(
+        attrs,
+        HtmlAttr::Aria(AriaAttr::Checked),
+        "aria-checked",
+        expected,
+    );
+}
+
+/// Assert `aria-controls` matches the expected value.
+pub fn assert_aria_controls(attrs: &AttrMap, expected: &str) {
+    assert_expected_string_attr(
+        attrs,
+        HtmlAttr::Aria(AriaAttr::Controls),
+        "aria-controls",
+        expected,
+    );
+}
+
+/// Assert `aria-labelledby` matches the expected value.
+pub fn assert_aria_labelledby(attrs: &AttrMap, expected: &str) {
+    assert_expected_string_attr(
+        attrs,
+        HtmlAttr::Aria(AriaAttr::LabelledBy),
+        "aria-labelledby",
+        expected,
+    );
+}
+
+/// Assert `aria-describedby` matches the expected value.
+pub fn assert_aria_describedby(attrs: &AttrMap, expected: &str) {
+    assert_expected_string_attr(
+        attrs,
+        HtmlAttr::Aria(AriaAttr::DescribedBy),
+        "aria-describedby",
+        expected,
+    );
+}
+
+/// Assert `aria-haspopup` matches the expected value.
+pub fn assert_aria_haspopup(attrs: &AttrMap, expected: &str) {
+    assert_expected_string_attr(
+        attrs,
+        HtmlAttr::Aria(AriaAttr::HasPopup),
+        "aria-haspopup",
+        expected,
+    );
+}
+
+/// Assert `aria-pressed` matches the expected value.
+pub fn assert_aria_pressed(attrs: &AttrMap, expected: &str) {
+    assert_expected_string_attr(
+        attrs,
+        HtmlAttr::Aria(AriaAttr::Pressed),
+        "aria-pressed",
+        expected,
+    );
+}
+
+/// Assert `aria-activedescendant` matches the expected value.
+pub fn assert_aria_activedescendant(attrs: &AttrMap, expected: &str) {
+    assert_expected_string_attr(
+        attrs,
+        HtmlAttr::Aria(AriaAttr::ActiveDescendant),
+        "aria-activedescendant",
+        expected,
+    );
+}
+
+/// Assert `data-ars-state` matches the expected value.
+pub fn assert_data_state(attrs: &AttrMap, expected: &str) {
+    let val = attrs
+        .get(&HtmlAttr::Data("ars-state"))
+        .unwrap_or_else(|| panic!("expected data-ars-state but not found"));
+
+    assert_eq!(val, expected);
+}
+
+/// Assert `tabindex` matches the expected value.
+pub fn assert_tabindex(attrs: &AttrMap, expected: i32) {
+    let expected_str = expected.to_string();
+
+    let val = attrs
+        .get(&HtmlAttr::TabIndex)
+        .unwrap_or_else(|| panic!("expected tabindex but not found"));
+
+    assert_eq!(
+        val,
+        expected_str.as_str(),
+        "expected tabindex=\"{expected}\"",
+    );
+}
+
+/// Assert `aria-orientation` matches the expected value.
+pub fn assert_aria_orientation(attrs: &AttrMap, expected: &str) {
+    assert_present_attr_eq(
+        attrs,
+        HtmlAttr::Aria(AriaAttr::Orientation),
+        "aria-orientation",
+        expected,
+    );
+}
+
+/// Assert `aria-valuemin` matches the expected value.
+pub fn assert_aria_valuemin(attrs: &AttrMap, expected: &str) {
+    assert_present_attr_eq(
+        attrs,
+        HtmlAttr::Aria(AriaAttr::ValueMin),
+        "aria-valuemin",
+        expected,
+    );
+}
+
+/// Assert `aria-valuemax` matches the expected value.
+pub fn assert_aria_valuemax(attrs: &AttrMap, expected: &str) {
+    assert_present_attr_eq(
+        attrs,
+        HtmlAttr::Aria(AriaAttr::ValueMax),
+        "aria-valuemax",
+        expected,
+    );
+}
+
+/// Assert `aria-valuenow` matches the expected value.
+pub fn assert_aria_valuenow(attrs: &AttrMap, expected: &str) {
+    assert_present_attr_eq(
+        attrs,
+        HtmlAttr::Aria(AriaAttr::ValueNow),
+        "aria-valuenow",
+        expected,
+    );
+}
+
+/// Assert `aria-valuetext` matches the expected value.
+pub fn assert_aria_valuetext(attrs: &AttrMap, expected: &str) {
+    assert_present_attr_eq(
+        attrs,
+        HtmlAttr::Aria(AriaAttr::ValueText),
+        "aria-valuetext",
+        expected,
+    );
+}
+
+/// Assert `aria-multiselectable` matches the expected boolean.
+pub fn assert_aria_multiselectable(attrs: &AttrMap, expected: bool) {
+    assert_optional_false_bool_attr(
+        attrs,
+        HtmlAttr::Aria(AriaAttr::MultiSelectable),
+        "aria-multiselectable",
+        expected,
+    );
+}
+
+/// Assert `aria-required` matches the expected boolean.
+pub fn assert_aria_required(attrs: &AttrMap, expected: bool) {
+    assert_optional_false_bool_attr(
+        attrs,
+        HtmlAttr::Aria(AriaAttr::Required),
+        "aria-required",
+        expected,
+    );
+}
+
+/// Assert `aria-invalid` matches the expected value.
+pub fn assert_aria_invalid(attrs: &AttrMap, expected: &str) {
+    let val = attrs.get(&HtmlAttr::Aria(AriaAttr::Invalid));
+
+    if expected == "false" {
+        assert!(val.is_none() || val == Some("false"));
+    } else {
+        assert_eq!(val, Some(expected), "expected aria-invalid=\"{expected}\"");
+    }
+}
+
+/// Assert `aria-live` matches the expected value.
+pub fn assert_aria_live(attrs: &AttrMap, expected: &str) {
+    assert_present_attr_eq(attrs, HtmlAttr::Aria(AriaAttr::Live), "aria-live", expected);
+}
+
+/// Assert `aria-atomic` matches the expected boolean.
+pub fn assert_aria_atomic(attrs: &AttrMap, expected: bool) {
+    assert_optional_false_bool_attr(
+        attrs,
+        HtmlAttr::Aria(AriaAttr::Atomic),
+        "aria-atomic",
+        expected,
+    );
+}
+
+/// Assert `aria-owns` matches the expected value.
+pub fn assert_aria_owns(attrs: &AttrMap, expected: &str) {
+    assert_present_attr_eq(attrs, HtmlAttr::Aria(AriaAttr::Owns), "aria-owns", expected);
+}
+
+/// Assert `aria-hidden` matches the expected boolean.
+pub fn assert_aria_hidden(attrs: &AttrMap, expected: bool) {
+    assert_optional_false_bool_attr(
+        attrs,
+        HtmlAttr::Aria(AriaAttr::Hidden),
+        "aria-hidden",
+        expected,
+    );
+}
+
+/// Assert `aria-modal` matches the expected boolean.
+pub fn assert_aria_modal(attrs: &AttrMap, expected: bool) {
+    assert_optional_false_bool_attr_with_debug(
+        attrs,
+        HtmlAttr::Aria(AriaAttr::Modal),
+        "aria-modal",
+        expected,
+    );
+}
+
+/// Assert `aria-autocomplete` matches the expected value.
+pub fn assert_aria_autocomplete(attrs: &AttrMap, expected: &str) {
+    let val = attrs
+        .get(&HtmlAttr::Aria(AriaAttr::AutoComplete))
+        .expect("aria-autocomplete must be present");
+
+    assert_eq!(
+        val, expected,
+        "expected aria-autocomplete={expected}, got {val}"
+    );
+}
+
+/// Assert `aria-errormessage` matches the expected value.
+pub fn assert_aria_errormessage(attrs: &AttrMap, expected: &str) {
+    let val = attrs
+        .get(&HtmlAttr::Aria(AriaAttr::ErrorMessage))
+        .expect("aria-errormessage must be present");
+
+    assert_eq!(
+        val, expected,
+        "expected aria-errormessage={expected}, got {val}"
+    );
+}
+
+/// Assert `aria-setsize` parses and matches the expected value.
+pub fn assert_aria_setsize(attrs: &AttrMap, expected: i32) {
+    let val: i32 = parsed_required_attr(
+        attrs,
+        HtmlAttr::Aria(AriaAttr::SetSize),
+        "aria-setsize must be present",
+        "aria-setsize must be a valid integer",
+    );
+
+    assert_eq!(val, expected, "expected aria-setsize={expected}, got {val}");
+}
+
+/// Assert `aria-posinset` parses and matches the expected value.
+pub fn assert_aria_posinset(attrs: &AttrMap, expected: u32) {
+    let val: u32 = parsed_required_attr(
+        attrs,
+        HtmlAttr::Aria(AriaAttr::PosInSet),
+        "aria-posinset must be present",
+        "aria-posinset must be a valid integer",
+    );
+
+    assert_eq!(
+        val, expected,
+        "expected aria-posinset={expected}, got {val}"
+    );
+}
+
+/// Assert `aria-level` parses and matches the expected value.
+pub fn assert_aria_level(attrs: &AttrMap, expected: u32) {
+    let val: u32 = parsed_required_attr(
+        attrs,
+        HtmlAttr::Aria(AriaAttr::Level),
+        "aria-level must be present",
+        "aria-level must be a valid integer",
+    );
+
+    assert_eq!(val, expected, "expected aria-level={expected}, got {val}");
+}
+
+/// Assert `aria-roledescription` matches the expected value.
+pub fn assert_aria_roledescription(attrs: &AttrMap, expected: &str) {
+    let val = attrs
+        .get(&HtmlAttr::Aria(AriaAttr::RoleDescription))
+        .expect("aria-roledescription must be present");
+
+    assert_eq!(
+        val, expected,
+        "expected aria-roledescription={expected}, got {val}"
+    );
+}
+
+/// Assert `aria-current` matches the expected value.
+pub fn assert_aria_current(attrs: &AttrMap, expected: &str) {
+    let val = attrs
+        .get(&HtmlAttr::Aria(AriaAttr::Current))
+        .expect("aria-current must be present");
+
+    assert_eq!(
+        val, expected,
+        "expected aria-current=\"{expected}\", got \"{val}\""
+    );
+}
+
+/// Assert `aria-rowindex` matches the expected value.
+pub fn assert_aria_rowindex(attrs: &AttrMap, expected: u32) {
+    let val: u32 = parsed_required_attr(
+        attrs,
+        HtmlAttr::Aria(AriaAttr::RowIndex),
+        "aria-rowindex must be present",
+        "aria-rowindex must be a valid integer",
+    );
+
+    assert_eq!(
+        val, expected,
+        "expected aria-rowindex=\"{expected}\", got \"{val}\""
+    );
+}
+
+/// Assert `aria-colindex` matches the expected value.
+pub fn assert_aria_colindex(attrs: &AttrMap, expected: u32) {
+    let val: u32 = parsed_required_attr(
+        attrs,
+        HtmlAttr::Aria(AriaAttr::ColIndex),
+        "aria-colindex must be present",
+        "aria-colindex must be a valid integer",
+    );
+
+    assert_eq!(
+        val, expected,
+        "expected aria-colindex=\"{expected}\", got \"{val}\""
+    );
+}
+
+/// Assert `aria-rowcount` matches the expected value.
+pub fn assert_aria_rowcount(attrs: &AttrMap, expected: i32) {
+    let val: i32 = parsed_required_attr(
+        attrs,
+        HtmlAttr::Aria(AriaAttr::RowCount),
+        "aria-rowcount must be present",
+        "aria-rowcount must be a valid integer",
+    );
+
+    assert_eq!(
+        val, expected,
+        "expected aria-rowcount=\"{expected}\", got \"{val}\""
+    );
+}
+
+/// Assert `aria-colcount` matches the expected value.
+pub fn assert_aria_colcount(attrs: &AttrMap, expected: i32) {
+    let val: i32 = parsed_required_attr(
+        attrs,
+        HtmlAttr::Aria(AriaAttr::ColCount),
+        "aria-colcount must be present",
+        "aria-colcount must be a valid integer",
+    );
+
+    assert_eq!(
+        val, expected,
+        "expected aria-colcount=\"{expected}\", got \"{val}\""
+    );
+}
+
+/// Assert `aria-sort` matches the expected value.
+pub fn assert_aria_sort(attrs: &AttrMap, expected: &str) {
+    let val = attrs
+        .get(&HtmlAttr::Aria(AriaAttr::Sort))
+        .expect("aria-sort must be present");
+
+    assert_eq!(
+        val, expected,
+        "expected aria-sort=\"{expected}\", got \"{val}\""
+    );
+}
+
+/// Assert `aria-readonly` matches the expected boolean.
+pub fn assert_aria_readonly(attrs: &AttrMap, expected: bool) {
+    let val = attrs.get(&HtmlAttr::Aria(AriaAttr::ReadOnly));
+
+    if expected {
+        assert_eq!(
+            val,
+            Some("true"),
+            "expected aria-readonly=\"true\", but got {val:?}"
+        );
+    } else {
+        match val {
+            None | Some("false") => {}
+
+            Some(other) => {
+                panic!("expected aria-readonly to be absent or \"false\", got \"{other}\"")
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use alloc::{boxed::Box, string::String};
+    use core::panic::AssertUnwindSafe;
+    use std::{
+        panic::{catch_unwind, set_hook, take_hook},
+        sync::{Mutex, OnceLock},
+    };
+
+    use super::*;
+
+    fn attrs_with(attr: HtmlAttr, value: &str) -> AttrMap {
+        let mut attrs = AttrMap::new();
+
+        let _ = attrs.set(attr, value);
+
+        attrs
+    }
+
+    fn panic_message(payload: Box<dyn core::any::Any + Send>) -> String {
+        match payload.downcast::<String>() {
+            Ok(message) => *message,
+
+            Err(payload) => match payload.downcast::<&'static str>() {
+                Ok(message) => String::from(*message),
+                Err(_) => String::from("non-string panic payload"),
+            },
+        }
+    }
+
+    fn catch_panic_silently(
+        f: impl FnOnce() + core::panic::UnwindSafe,
+    ) -> Result<(), Box<dyn core::any::Any + Send>> {
+        static PANIC_HOOK_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+        let lock = PANIC_HOOK_LOCK.get_or_init(|| Mutex::new(()));
+
+        let _guard = lock.lock().expect("panic hook lock poisoned");
+
+        let previous_hook = take_hook();
+
+        set_hook(Box::new(|_| {}));
+
+        let result = catch_unwind(AssertUnwindSafe(f));
+
+        set_hook(previous_hook);
+
+        result
+    }
+
+    macro_rules! optional_false_helper_tests {
+        (
+            $true_name:ident,
+            $absent_name:ident,
+            $false_name:ident,
+            $func:ident,
+            $attr:expr
+        ) => {
+            #[test]
+            fn $true_name() {
+                let attrs = attrs_with($attr, "true");
+
+                $func(&attrs, true);
+            }
+
+            #[test]
+            fn $absent_name() {
+                let attrs = AttrMap::new();
+
+                $func(&attrs, false);
+            }
+
+            #[test]
+            fn $false_name() {
+                let attrs = attrs_with($attr, "false");
+
+                $func(&attrs, false);
+            }
+        };
+    }
+
+    macro_rules! required_string_helper_tests {
+        (
+            $pass_name:ident,
+            $missing_name:ident,
+            $func:ident,
+            $attr:expr,
+            $expected:literal,
+            $missing_message:literal
+        ) => {
+            #[test]
+            fn $pass_name() {
+                let attrs = attrs_with($attr, $expected);
+
+                $func(&attrs, $expected);
+            }
+
+            #[test]
+            fn $missing_name() {
+                let attrs = AttrMap::new();
+
+                let result = catch_panic_silently(|| $func(&attrs, $expected));
+
+                let message =
+                    panic_message(result.expect_err(concat!(stringify!($func), " should panic")));
+
+                assert_eq!(message, $missing_message);
+            }
+        };
+    }
+
+    macro_rules! assert_eq_string_helper_tests {
+        (
+            $pass_name:ident,
+            $missing_name:ident,
+            $func:ident,
+            $attr:expr,
+            $expected:literal,
+            $message_fragment:literal
+        ) => {
+            #[test]
+            fn $pass_name() {
+                let attrs = attrs_with($attr, $expected);
+
+                $func(&attrs, $expected);
+            }
+
+            #[test]
+            fn $missing_name() {
+                let attrs = AttrMap::new();
+
+                let result = catch_panic_silently(|| $func(&attrs, $expected));
+
+                let message =
+                    panic_message(result.expect_err(concat!(stringify!($func), " should panic")));
+
+                assert!(
+                    message.contains($message_fragment),
+                    "expected panic message to contain {:?}, got {:?}",
+                    $message_fragment,
+                    message
+                );
+            }
+        };
+    }
+
+    macro_rules! required_bool_helper_tests {
+        (
+            $true_name:ident,
+            $false_name:ident,
+            $missing_name:ident,
+            $func:ident,
+            $attr:expr,
+            $missing_message:literal
+        ) => {
+            #[test]
+            fn $true_name() {
+                let attrs = attrs_with($attr, "true");
+
+                $func(&attrs, true);
+            }
+
+            #[test]
+            fn $false_name() {
+                let attrs = attrs_with($attr, "false");
+
+                $func(&attrs, false);
+            }
+
+            #[test]
+            fn $missing_name() {
+                let attrs = AttrMap::new();
+
+                let result = catch_panic_silently(|| $func(&attrs, true));
+
+                let message =
+                    panic_message(result.expect_err(concat!(stringify!($func), " should panic")));
+
+                assert_eq!(message, $missing_message);
+            }
+        };
+    }
+
+    macro_rules! integer_helper_tests {
+        (
+            $pass_name:ident,
+            $missing_name:ident,
+            $parse_name:ident,
+            $func:ident,
+            $attr:expr,
+            $expected:expr,
+            $missing_message:literal,
+            $parse_message:literal
+        ) => {
+            #[test]
+            fn $pass_name() {
+                let attrs = attrs_with($attr, stringify!($expected));
+
+                $func(&attrs, $expected);
+            }
+
+            #[test]
+            fn $missing_name() {
+                let attrs = AttrMap::new();
+
+                let result = catch_panic_silently(|| $func(&attrs, $expected));
+
+                let message =
+                    panic_message(result.expect_err(concat!(stringify!($func), " should panic")));
+
+                assert_eq!(message, $missing_message);
+            }
+
+            #[test]
+            fn $parse_name() {
+                let attrs = attrs_with($attr, "abc");
+
+                let result = catch_panic_silently(|| $func(&attrs, $expected));
+
+                let message =
+                    panic_message(result.expect_err(concat!(stringify!($func), " should panic")));
+
+                assert_eq!(message, $parse_message);
+            }
+        };
+    }
+
+    macro_rules! optional_false_helper_rejects_true_tests {
+        ($panic_name:ident, $func:ident, $attr:expr) => {
+            #[test]
+            fn $panic_name() {
+                let attrs = attrs_with($attr, "true");
+
+                let result = catch_panic_silently(|| $func(&attrs, false));
+
+                assert!(result.is_err(), "{} should panic", stringify!($func));
+            }
+        };
+    }
+
+    #[test]
+    fn assert_role_passes_for_matching_role() {
+        let attrs = attrs_with(HtmlAttr::Role, "button");
+
+        assert_role(&attrs, "button");
+    }
+
+    #[test]
+    #[should_panic(expected = "wrong role")]
+    fn assert_role_panics_for_wrong_role() {
+        let attrs = attrs_with(HtmlAttr::Role, "button");
+
+        assert_role(&attrs, "checkbox");
+    }
+
+    #[test]
+    fn assert_role_panics_with_exact_message_when_role_missing() {
+        let attrs = AttrMap::new();
+
+        let result = catch_panic_silently(|| assert_role(&attrs, "button"));
+
+        let message = panic_message(result.expect_err("assert_role should panic"));
+
+        assert_eq!(
+            message,
+            "expected role=\"button\" but no role attribute found"
+        );
+    }
+
+    #[test]
+    fn assert_aria_expanded_true_passes() {
+        let attrs = attrs_with(HtmlAttr::Aria(AriaAttr::Expanded), "true");
+
+        assert_aria_expanded(&attrs, true);
+    }
+
+    #[test]
+    fn assert_aria_expanded_false_passes() {
+        let attrs = attrs_with(HtmlAttr::Aria(AriaAttr::Expanded), "false");
+
+        assert_aria_expanded(&attrs, false);
+    }
+
+    #[test]
+    fn assert_aria_expanded_panics_when_missing() {
+        let attrs = AttrMap::new();
+
+        let result = catch_panic_silently(|| assert_aria_expanded(&attrs, true));
+
+        let message = panic_message(result.expect_err("assert_aria_expanded should panic"));
+
+        assert_eq!(message, "expected aria-expanded but not found");
+    }
+
+    #[test]
+    fn assert_aria_disabled_false_passes_when_absent() {
+        let attrs = AttrMap::new();
+
+        assert_aria_disabled(&attrs, false);
+    }
+
+    #[test]
+    fn assert_aria_disabled_false_passes_when_false() {
+        let attrs = attrs_with(HtmlAttr::Aria(AriaAttr::Disabled), "false");
+
+        assert_aria_disabled(&attrs, false);
+    }
+
+    #[test]
+    fn assert_aria_disabled_true_passes_when_true() {
+        let attrs = attrs_with(HtmlAttr::Aria(AriaAttr::Disabled), "true");
+
+        assert_aria_disabled(&attrs, true);
+    }
+
+    #[test]
+    fn optional_false_helper_panics_when_false_expected_but_true_found() {
+        let attrs = attrs_with(HtmlAttr::Aria(AriaAttr::Busy), "true");
+
+        let result = catch_panic_silently(|| assert_aria_busy(&attrs, false));
+
+        let message = panic_message(result.expect_err("assert_aria_busy should panic"));
+
+        assert_eq!(
+            message,
+            "expected aria-busy to be absent or \"false\", got Some(\"true\")"
+        );
+    }
+
+    #[test]
+    fn assert_tabindex_zero_passes() {
+        let attrs = attrs_with(HtmlAttr::TabIndex, "0");
+
+        assert_tabindex(&attrs, 0);
+    }
+
+    #[test]
+    fn assert_tabindex_negative_one_passes() {
+        let attrs = attrs_with(HtmlAttr::TabIndex, "-1");
+
+        assert_tabindex(&attrs, -1);
+    }
+
+    #[test]
+    fn assert_data_state_passes() {
+        let attrs = attrs_with(HtmlAttr::Data("ars-state"), "idle");
+
+        assert_data_state(&attrs, "idle");
+    }
+
+    #[test]
+    fn assert_aria_checked_mixed_passes() {
+        let attrs = attrs_with(HtmlAttr::Aria(AriaAttr::Checked), "mixed");
+
+        assert_aria_checked(&attrs, "mixed");
+    }
+
+    #[test]
+    fn assert_aria_setsize_parses_integer() {
+        let attrs = attrs_with(HtmlAttr::Aria(AriaAttr::SetSize), "5");
+
+        assert_aria_setsize(&attrs, 5);
+    }
+
+    #[test]
+    fn assert_aria_posinset_parses_integer() {
+        let attrs = attrs_with(HtmlAttr::Aria(AriaAttr::PosInSet), "3");
+
+        assert_aria_posinset(&attrs, 3);
+    }
+
+    #[test]
+    fn assert_aria_rowindex_parses_integer() {
+        let attrs = attrs_with(HtmlAttr::Aria(AriaAttr::RowIndex), "2");
+
+        assert_aria_rowindex(&attrs, 2);
+    }
+
+    #[test]
+    fn assert_aria_colindex_parses_integer() {
+        let attrs = attrs_with(HtmlAttr::Aria(AriaAttr::ColIndex), "4");
+
+        assert_aria_colindex(&attrs, 4);
+    }
+
+    #[test]
+    fn assert_aria_rowcount_parses_integer() {
+        let attrs = attrs_with(HtmlAttr::Aria(AriaAttr::RowCount), "7");
+
+        assert_aria_rowcount(&attrs, 7);
+    }
+
+    #[test]
+    fn assert_aria_colcount_parses_integer() {
+        let attrs = attrs_with(HtmlAttr::Aria(AriaAttr::ColCount), "8");
+
+        assert_aria_colcount(&attrs, 8);
+    }
+
+    #[test]
+    fn assert_integer_helper_panics_with_exact_parse_message() {
+        let attrs = attrs_with(HtmlAttr::Aria(AriaAttr::SetSize), "abc");
+
+        let result = catch_panic_silently(|| assert_aria_setsize(&attrs, 5));
+
+        let message = panic_message(result.expect_err("assert_aria_setsize should panic"));
+
+        assert_eq!(message, "aria-setsize must be a valid integer");
+    }
+
+    #[test]
+    fn assert_aria_invalid_false_passes_when_absent() {
+        let attrs = AttrMap::new();
+
+        assert_aria_invalid(&attrs, "false");
+    }
+
+    #[test]
+    fn assert_aria_invalid_false_panics_when_other_value_is_present() {
+        let attrs = attrs_with(HtmlAttr::Aria(AriaAttr::Invalid), "grammar");
+
+        let result = catch_panic_silently(|| assert_aria_invalid(&attrs, "false"));
+
+        assert!(result.is_err(), "assert_aria_invalid should panic");
+    }
+
+    #[test]
+    fn assert_aria_invalid_false_passes_when_false() {
+        let attrs = attrs_with(HtmlAttr::Aria(AriaAttr::Invalid), "false");
+
+        assert_aria_invalid(&attrs, "false");
+    }
+
+    #[test]
+    fn assert_aria_invalid_non_false_value_passes() {
+        let attrs = attrs_with(HtmlAttr::Aria(AriaAttr::Invalid), "grammar");
+
+        assert_aria_invalid(&attrs, "grammar");
+    }
+
+    #[test]
+    fn assert_data_state_panics_when_missing() {
+        let attrs = AttrMap::new();
+
+        let result = catch_panic_silently(|| assert_data_state(&attrs, "idle"));
+
+        let message = panic_message(result.expect_err("assert_data_state should panic"));
+
+        assert_eq!(message, "expected data-ars-state but not found");
+    }
+
+    #[test]
+    fn assert_tabindex_panics_when_missing() {
+        let attrs = AttrMap::new();
+
+        let result = catch_panic_silently(|| assert_tabindex(&attrs, 0));
+
+        let message = panic_message(result.expect_err("assert_tabindex should panic"));
+
+        assert_eq!(message, "expected tabindex but not found");
+    }
+
+    required_bool_helper_tests!(
+        assert_aria_selected_true_passes,
+        assert_aria_selected_false_passes,
+        assert_aria_selected_panics_when_missing,
+        assert_aria_selected,
+        HtmlAttr::Aria(AriaAttr::Selected),
+        "expected aria-selected but not found"
+    );
+
+    required_string_helper_tests!(
+        assert_aria_label_passes,
+        assert_aria_label_panics_when_missing,
+        assert_aria_label,
+        HtmlAttr::Aria(AriaAttr::Label),
+        "Accordion trigger",
+        "expected aria-label=\"Accordion trigger\" but not found"
+    );
+
+    required_string_helper_tests!(
+        assert_aria_checked_passes,
+        assert_aria_checked_panics_when_missing,
+        assert_aria_checked,
+        HtmlAttr::Aria(AriaAttr::Checked),
+        "mixed",
+        "expected aria-checked=\"mixed\" but not found"
+    );
+
+    required_string_helper_tests!(
+        assert_aria_controls_passes,
+        assert_aria_controls_panics_when_missing,
+        assert_aria_controls,
+        HtmlAttr::Aria(AriaAttr::Controls),
+        "panel-1",
+        "expected aria-controls=\"panel-1\" but not found"
+    );
+
+    required_string_helper_tests!(
+        assert_aria_labelledby_passes,
+        assert_aria_labelledby_panics_when_missing,
+        assert_aria_labelledby,
+        HtmlAttr::Aria(AriaAttr::LabelledBy),
+        "trigger-1",
+        "expected aria-labelledby=\"trigger-1\" but not found"
+    );
+
+    required_string_helper_tests!(
+        assert_aria_describedby_passes,
+        assert_aria_describedby_panics_when_missing,
+        assert_aria_describedby,
+        HtmlAttr::Aria(AriaAttr::DescribedBy),
+        "hint-1",
+        "expected aria-describedby=\"hint-1\" but not found"
+    );
+
+    required_string_helper_tests!(
+        assert_aria_haspopup_passes,
+        assert_aria_haspopup_panics_when_missing,
+        assert_aria_haspopup,
+        HtmlAttr::Aria(AriaAttr::HasPopup),
+        "menu",
+        "expected aria-haspopup=\"menu\" but not found"
+    );
+
+    required_string_helper_tests!(
+        assert_aria_pressed_passes,
+        assert_aria_pressed_panics_when_missing,
+        assert_aria_pressed,
+        HtmlAttr::Aria(AriaAttr::Pressed),
+        "mixed",
+        "expected aria-pressed=\"mixed\" but not found"
+    );
+
+    required_string_helper_tests!(
+        assert_aria_activedescendant_passes,
+        assert_aria_activedescendant_panics_when_missing,
+        assert_aria_activedescendant,
+        HtmlAttr::Aria(AriaAttr::ActiveDescendant),
+        "item-3",
+        "expected aria-activedescendant=\"item-3\" but not found"
+    );
+
+    assert_eq_string_helper_tests!(
+        assert_aria_orientation_passes,
+        assert_aria_orientation_panics_when_missing,
+        assert_aria_orientation,
+        HtmlAttr::Aria(AriaAttr::Orientation),
+        "horizontal",
+        "expected aria-orientation=\"horizontal\""
+    );
+
+    assert_eq_string_helper_tests!(
+        assert_aria_valuemin_passes,
+        assert_aria_valuemin_panics_when_missing,
+        assert_aria_valuemin,
+        HtmlAttr::Aria(AriaAttr::ValueMin),
+        "0",
+        "expected aria-valuemin=\"0\""
+    );
+
+    assert_eq_string_helper_tests!(
+        assert_aria_valuemax_passes,
+        assert_aria_valuemax_panics_when_missing,
+        assert_aria_valuemax,
+        HtmlAttr::Aria(AriaAttr::ValueMax),
+        "100",
+        "expected aria-valuemax=\"100\""
+    );
+
+    assert_eq_string_helper_tests!(
+        assert_aria_valuenow_passes,
+        assert_aria_valuenow_panics_when_missing,
+        assert_aria_valuenow,
+        HtmlAttr::Aria(AriaAttr::ValueNow),
+        "50",
+        "expected aria-valuenow=\"50\""
+    );
+
+    assert_eq_string_helper_tests!(
+        assert_aria_valuetext_passes,
+        assert_aria_valuetext_panics_when_missing,
+        assert_aria_valuetext,
+        HtmlAttr::Aria(AriaAttr::ValueText),
+        "50%",
+        "expected aria-valuetext=\"50%\""
+    );
+
+    assert_eq_string_helper_tests!(
+        assert_aria_live_passes,
+        assert_aria_live_panics_when_missing,
+        assert_aria_live,
+        HtmlAttr::Aria(AriaAttr::Live),
+        "polite",
+        "expected aria-live=\"polite\""
+    );
+
+    assert_eq_string_helper_tests!(
+        assert_aria_owns_passes,
+        assert_aria_owns_panics_when_missing,
+        assert_aria_owns,
+        HtmlAttr::Aria(AriaAttr::Owns),
+        "popup-1",
+        "expected aria-owns=\"popup-1\""
+    );
+
+    required_string_helper_tests!(
+        assert_aria_autocomplete_passes,
+        assert_aria_autocomplete_panics_when_missing,
+        assert_aria_autocomplete,
+        HtmlAttr::Aria(AriaAttr::AutoComplete),
+        "list",
+        "aria-autocomplete must be present"
+    );
+
+    required_string_helper_tests!(
+        assert_aria_errormessage_passes,
+        assert_aria_errormessage_panics_when_missing,
+        assert_aria_errormessage,
+        HtmlAttr::Aria(AriaAttr::ErrorMessage),
+        "error-1",
+        "aria-errormessage must be present"
+    );
+
+    required_string_helper_tests!(
+        assert_aria_roledescription_passes,
+        assert_aria_roledescription_panics_when_missing,
+        assert_aria_roledescription,
+        HtmlAttr::Aria(AriaAttr::RoleDescription),
+        "custom grid",
+        "aria-roledescription must be present"
+    );
+
+    required_string_helper_tests!(
+        assert_aria_current_passes,
+        assert_aria_current_panics_when_missing,
+        assert_aria_current,
+        HtmlAttr::Aria(AriaAttr::Current),
+        "page",
+        "aria-current must be present"
+    );
+
+    required_string_helper_tests!(
+        assert_aria_sort_passes,
+        assert_aria_sort_panics_when_missing,
+        assert_aria_sort,
+        HtmlAttr::Aria(AriaAttr::Sort),
+        "ascending",
+        "aria-sort must be present"
+    );
+
+    integer_helper_tests!(
+        assert_aria_setsize_parses_integer_value,
+        assert_aria_setsize_panics_when_missing,
+        assert_aria_setsize_panics_for_invalid_value,
+        assert_aria_setsize,
+        HtmlAttr::Aria(AriaAttr::SetSize),
+        5,
+        "aria-setsize must be present",
+        "aria-setsize must be a valid integer"
+    );
+
+    integer_helper_tests!(
+        assert_aria_posinset_parses_integer_value,
+        assert_aria_posinset_panics_when_missing,
+        assert_aria_posinset_panics_for_invalid_value,
+        assert_aria_posinset,
+        HtmlAttr::Aria(AriaAttr::PosInSet),
+        3,
+        "aria-posinset must be present",
+        "aria-posinset must be a valid integer"
+    );
+
+    integer_helper_tests!(
+        assert_aria_level_parses_integer_value,
+        assert_aria_level_panics_when_missing,
+        assert_aria_level_panics_for_invalid_value,
+        assert_aria_level,
+        HtmlAttr::Aria(AriaAttr::Level),
+        3,
+        "aria-level must be present",
+        "aria-level must be a valid integer"
+    );
+
+    integer_helper_tests!(
+        assert_aria_rowindex_parses_integer_value,
+        assert_aria_rowindex_panics_when_missing,
+        assert_aria_rowindex_panics_for_invalid_value,
+        assert_aria_rowindex,
+        HtmlAttr::Aria(AriaAttr::RowIndex),
+        2,
+        "aria-rowindex must be present",
+        "aria-rowindex must be a valid integer"
+    );
+
+    integer_helper_tests!(
+        assert_aria_colindex_parses_integer_value,
+        assert_aria_colindex_panics_when_missing,
+        assert_aria_colindex_panics_for_invalid_value,
+        assert_aria_colindex,
+        HtmlAttr::Aria(AriaAttr::ColIndex),
+        4,
+        "aria-colindex must be present",
+        "aria-colindex must be a valid integer"
+    );
+
+    integer_helper_tests!(
+        assert_aria_rowcount_parses_integer_value,
+        assert_aria_rowcount_panics_when_missing,
+        assert_aria_rowcount_panics_for_invalid_value,
+        assert_aria_rowcount,
+        HtmlAttr::Aria(AriaAttr::RowCount),
+        7,
+        "aria-rowcount must be present",
+        "aria-rowcount must be a valid integer"
+    );
+
+    integer_helper_tests!(
+        assert_aria_colcount_parses_integer_value,
+        assert_aria_colcount_panics_when_missing,
+        assert_aria_colcount_panics_for_invalid_value,
+        assert_aria_colcount,
+        HtmlAttr::Aria(AriaAttr::ColCount),
+        8,
+        "aria-colcount must be present",
+        "aria-colcount must be a valid integer"
+    );
+
+    optional_false_helper_rejects_true_tests!(
+        assert_aria_disabled_panics_when_false_expected_but_true_present,
+        assert_aria_disabled,
+        HtmlAttr::Aria(AriaAttr::Disabled)
+    );
+
+    optional_false_helper_rejects_true_tests!(
+        assert_aria_multiselectable_panics_when_false_expected_but_true_present,
+        assert_aria_multiselectable,
+        HtmlAttr::Aria(AriaAttr::MultiSelectable)
+    );
+
+    optional_false_helper_rejects_true_tests!(
+        assert_aria_required_panics_when_false_expected_but_true_present,
+        assert_aria_required,
+        HtmlAttr::Aria(AriaAttr::Required)
+    );
+
+    optional_false_helper_rejects_true_tests!(
+        assert_aria_atomic_panics_when_false_expected_but_true_present,
+        assert_aria_atomic,
+        HtmlAttr::Aria(AriaAttr::Atomic)
+    );
+
+    optional_false_helper_rejects_true_tests!(
+        assert_aria_hidden_panics_when_false_expected_but_true_present,
+        assert_aria_hidden,
+        HtmlAttr::Aria(AriaAttr::Hidden)
+    );
+
+    optional_false_helper_rejects_true_tests!(
+        assert_aria_modal_panics_when_false_expected_but_true_present,
+        assert_aria_modal,
+        HtmlAttr::Aria(AriaAttr::Modal)
+    );
+
+    optional_false_helper_rejects_true_tests!(
+        assert_aria_readonly_panics_when_false_expected_but_true_present,
+        assert_aria_readonly,
+        HtmlAttr::Aria(AriaAttr::ReadOnly)
+    );
+
+    optional_false_helper_tests!(
+        assert_aria_busy_true_passes_when_true,
+        assert_aria_busy_false_passes_when_absent,
+        assert_aria_busy_false_passes_when_false,
+        assert_aria_busy,
+        HtmlAttr::Aria(AriaAttr::Busy)
+    );
+
+    optional_false_helper_tests!(
+        assert_aria_multiselectable_true_passes_when_true,
+        assert_aria_multiselectable_false_passes_when_absent,
+        assert_aria_multiselectable_false_passes_when_false,
+        assert_aria_multiselectable,
+        HtmlAttr::Aria(AriaAttr::MultiSelectable)
+    );
+
+    optional_false_helper_tests!(
+        assert_aria_required_true_passes_when_true,
+        assert_aria_required_false_passes_when_absent,
+        assert_aria_required_false_passes_when_false,
+        assert_aria_required,
+        HtmlAttr::Aria(AriaAttr::Required)
+    );
+
+    optional_false_helper_tests!(
+        assert_aria_atomic_true_passes_when_true,
+        assert_aria_atomic_false_passes_when_absent,
+        assert_aria_atomic_false_passes_when_false,
+        assert_aria_atomic,
+        HtmlAttr::Aria(AriaAttr::Atomic)
+    );
+
+    optional_false_helper_tests!(
+        assert_aria_hidden_true_passes_when_true,
+        assert_aria_hidden_false_passes_when_absent,
+        assert_aria_hidden_false_passes_when_false,
+        assert_aria_hidden,
+        HtmlAttr::Aria(AriaAttr::Hidden)
+    );
+
+    optional_false_helper_tests!(
+        assert_aria_modal_true_passes_when_true,
+        assert_aria_modal_false_passes_when_absent,
+        assert_aria_modal_false_passes_when_false,
+        assert_aria_modal,
+        HtmlAttr::Aria(AriaAttr::Modal)
+    );
+
+    optional_false_helper_tests!(
+        assert_aria_readonly_true_passes_when_true,
+        assert_aria_readonly_false_passes_when_absent,
+        assert_aria_readonly_false_passes_when_false,
+        assert_aria_readonly,
+        HtmlAttr::Aria(AriaAttr::ReadOnly)
+    );
+}

--- a/crates/ars-core/src/weak_send.rs
+++ b/crates/ars-core/src/weak_send.rs
@@ -4,6 +4,7 @@
 //! effects (timers, observers) do not prevent the component from being garbage
 //! collected.
 
+use alloc::sync::{Arc, Weak};
 use core::fmt::{self, Debug};
 
 /// Weak event sender for safe effect cleanup.
@@ -12,7 +13,7 @@ use core::fmt::{self, Debug};
 /// long-lived effects (timers, observers) do not prevent the component
 /// from being garbage collected. Use [`call_if_alive`](WeakSend::call_if_alive)
 /// to dispatch events — it is a no-op if the component has been unmounted.
-pub struct WeakSend<T>(alloc::sync::Weak<dyn Fn(T) + Send + Sync>);
+pub struct WeakSend<T>(Weak<dyn Fn(T) + Send + Sync>);
 
 impl<T> WeakSend<T> {
     /// Attempt to send an event if the component is still alive.
@@ -27,7 +28,7 @@ impl<T> WeakSend<T> {
 
 impl<T> Clone for WeakSend<T> {
     fn clone(&self) -> Self {
-        WeakSend(alloc::sync::Weak::clone(&self.0))
+        WeakSend(Weak::clone(&self.0))
     }
 }
 
@@ -39,19 +40,19 @@ impl<T> Debug for WeakSend<T> {
 
 impl<T: 'static> WeakSend<T> {
     /// Create a `WeakSend` by downgrading the given `Arc`.
-    pub fn from_arc(arc: &alloc::sync::Arc<dyn Fn(T) + Send + Sync>) -> Self {
-        WeakSend(alloc::sync::Arc::downgrade(arc))
+    pub fn from_arc(arc: &Arc<dyn Fn(T) + Send + Sync>) -> Self {
+        WeakSend(Arc::downgrade(arc))
     }
 
     /// Alias for [`from_arc`](Self::from_arc) — more discoverable name.
-    pub fn downgrade(arc: &alloc::sync::Arc<dyn Fn(T) + Send + Sync>) -> Self {
+    pub fn downgrade(arc: &Arc<dyn Fn(T) + Send + Sync>) -> Self {
         Self::from_arc(arc)
     }
 }
 
-impl<T: 'static> From<&alloc::sync::Arc<dyn Fn(T) + Send + Sync>> for WeakSend<T> {
-    fn from(arc: &alloc::sync::Arc<dyn Fn(T) + Send + Sync>) -> Self {
-        WeakSend(alloc::sync::Arc::downgrade(arc))
+impl<T: 'static> From<&Arc<dyn Fn(T) + Send + Sync>> for WeakSend<T> {
+    fn from(arc: &Arc<dyn Fn(T) + Send + Sync>) -> Self {
+        WeakSend(Arc::downgrade(arc))
     }
 }
 
@@ -61,7 +62,7 @@ impl<T: 'static> From<&alloc::sync::Arc<dyn Fn(T) + Send + Sync>> for WeakSend<T
 /// [`PendingEffect::run`](crate::PendingEffect::run). The setup closure
 /// downgrades to [`WeakSend`] internally.
 #[doc(hidden)]
-pub type StrongSend<E> = alloc::sync::Arc<dyn Fn(E) + Send + Sync>;
+pub type StrongSend<E> = Arc<dyn Fn(E) + Send + Sync>;
 
 #[cfg(test)]
 mod tests {
@@ -73,6 +74,7 @@ mod tests {
     #[test]
     fn weak_send_calls_when_strong_sender_is_alive() {
         let total = Arc::new(AtomicUsize::new(0));
+
         let send: StrongSend<usize> = {
             let total = Arc::clone(&total);
             Arc::new(move |value| {
@@ -81,6 +83,7 @@ mod tests {
         };
 
         let weak = WeakSend::from_arc(&send);
+
         weak.call_if_alive(2);
         weak.call_if_alive(3);
 
@@ -90,6 +93,7 @@ mod tests {
     #[test]
     fn weak_send_is_noop_after_strong_sender_drops() {
         let total = Arc::new(AtomicUsize::new(0));
+
         let weak = {
             let send: StrongSend<usize> = {
                 let total = Arc::clone(&total);
@@ -97,20 +101,45 @@ mod tests {
                     total.fetch_add(value, Ordering::SeqCst);
                 })
             };
+
+            send(0);
+
             WeakSend::downgrade(&send)
         };
 
         weak.call_if_alive(7);
+
         assert_eq!(total.load(Ordering::SeqCst), 0);
     }
 
     #[test]
     fn weak_send_clone_and_debug_are_stable() {
         let send: StrongSend<usize> = Arc::new(|_| {});
+
         let weak = WeakSend::from(&send);
+
         let cloned = weak.clone();
+
+        send(1);
 
         assert!(cloned.0.upgrade().is_some());
         assert_eq!(format!("{cloned:?}"), "WeakSend(..)");
+    }
+
+    #[test]
+    fn weak_send_all_constructor_paths_upgrade_while_sender_is_alive() {
+        let send: StrongSend<usize> = Arc::new(|_| {});
+
+        send(1);
+
+        let from_arc = WeakSend::from_arc(&send);
+
+        let downgraded = WeakSend::downgrade(&send);
+
+        let from_impl = WeakSend::from(&send);
+
+        assert!(from_arc.0.upgrade().is_some());
+        assert!(downgraded.0.upgrade().is_some());
+        assert!(from_impl.0.upgrade().is_some());
     }
 }


### PR DESCRIPTION
## Summary
- add the `ars_core::test_helpers` module behind the test/testing cfg gate
- implement the ARIA, role, tabindex, and `data-state` assertion helpers from the spec with public docs
- extend `ars-core` tests to cover the new helper surface and supporting core paths

## Validation
- `cargo xci`

Closes #179