### PR TITLE
Fix §3.2 announce spec drift and expand FocusScope wasm coverage

### DIFF
--- a/crates/ars-dom/src/focus.rs
+++ b/crates/ars-dom/src/focus.rs
@@ -1035,4 +1035,187 @@ mod wasm_tests {
 
         cleanup(&root);
     }
+
+    fn active_id() -> Option<String> {
+        document()
+            .active_element()
+            .and_then(|element| element.dyn_into::<HtmlElement>().ok())
+            .map(|element| element.id())
+            .filter(|id| !id.is_empty())
+    }
+
+    #[wasm_bindgen_test]
+    fn focus_scope_activate_auto_focuses_first_and_deactivate_restores_previous() {
+        let root = append_div(
+            body().as_ref(),
+            "scope-activate-root",
+            "position:fixed;left:-10000px;top:0;width:240px;height:120px;",
+        );
+
+        let outside = append_button(root.as_ref(), "scope-activate-outside", None, false);
+
+        let container = append_div(root.as_ref(), "scope-activate-container", "");
+
+        let inner_first = append_button(container.as_ref(), "scope-activate-first", None, false);
+        let _inner_second = append_button(container.as_ref(), "scope-activate-second", None, false);
+
+        focus_element(&outside, false);
+
+        assert_eq!(active_id(), Some(outside.id()));
+
+        let mut scope = FocusScope::new(
+            "scope-activate-container",
+            FocusScopeOptions {
+                contain: true,
+                restore_focus: true,
+                auto_focus: true,
+            },
+        );
+
+        scope.activate(FocusTarget::First);
+
+        assert!(scope.is_active());
+        assert_eq!(active_id(), Some(inner_first.id()));
+
+        scope.deactivate();
+
+        assert!(!scope.is_active());
+        assert_eq!(active_id(), Some(outside.id()));
+
+        // Double-deactivate is a no-op.
+        scope.deactivate();
+
+        assert!(!scope.is_active());
+
+        cleanup(&root);
+    }
+
+    #[wasm_bindgen_test]
+    fn focus_scope_handle_tab_key_contained_wraps_at_boundaries() {
+        let root = append_div(
+            body().as_ref(),
+            "scope-tab-wrap-root",
+            "position:fixed;left:-10000px;top:0;width:240px;height:120px;",
+        );
+
+        let container = append_div(root.as_ref(), "scope-tab-wrap-container", "");
+
+        let first = append_button(container.as_ref(), "scope-tab-wrap-first", None, false);
+        let _middle = append_button(container.as_ref(), "scope-tab-wrap-middle", None, false);
+        let last = append_button(container.as_ref(), "scope-tab-wrap-last", None, false);
+
+        let mut scope = FocusScope::new(
+            "scope-tab-wrap-container",
+            FocusScopeOptions {
+                contain: true,
+                restore_focus: false,
+                auto_focus: true,
+            },
+        );
+        scope.activate(FocusTarget::First);
+
+        assert_eq!(active_id(), Some(first.id()));
+
+        // Shift+Tab at the first tabbable wraps to the last.
+        focus_element(&first, false);
+
+        assert!(scope.handle_tab_key(true));
+        assert_eq!(active_id(), Some(last.id()));
+
+        // Tab at the last tabbable wraps to the first.
+        focus_element(&last, false);
+
+        assert!(scope.handle_tab_key(false));
+        assert_eq!(active_id(), Some(first.id()));
+
+        scope.deactivate();
+
+        cleanup(&root);
+    }
+
+    #[wasm_bindgen_test]
+    fn focus_scope_handle_tab_key_uncontained_allows_browser_default() {
+        let root = append_div(
+            body().as_ref(),
+            "scope-tab-free-root",
+            "position:fixed;left:-10000px;top:0;width:240px;height:120px;",
+        );
+
+        let container = append_div(root.as_ref(), "scope-tab-free-container", "");
+
+        let first = append_button(container.as_ref(), "scope-tab-free-first", None, false);
+        let last = append_button(container.as_ref(), "scope-tab-free-last", None, false);
+
+        let scope = FocusScope::new(
+            "scope-tab-free-container",
+            FocusScopeOptions {
+                contain: false,
+                restore_focus: false,
+                auto_focus: false,
+            },
+        );
+
+        // Uncontained scope never prevents tab navigation regardless of position.
+        focus_element(&first, false);
+
+        assert!(!scope.handle_tab_key(false));
+
+        focus_element(&last, false);
+
+        assert!(!scope.handle_tab_key(true));
+
+        cleanup(&root);
+    }
+
+    #[wasm_bindgen_test]
+    fn focus_scope_focus_first_honors_autofocus_and_previously_active_targets() {
+        let root = append_div(
+            body().as_ref(),
+            "scope-targets-root",
+            "position:fixed;left:-10000px;top:0;width:240px;height:120px;",
+        );
+
+        let container = append_div(root.as_ref(), "scope-targets-container", "");
+
+        let plain = append_button(container.as_ref(), "scope-targets-plain", None, false);
+
+        let autofocus = append_button(container.as_ref(), "scope-targets-autofocus", None, false);
+
+        autofocus
+            .set_attribute("data-ars-autofocus", "")
+            .expect("autofocus marker must set");
+
+        let scope = FocusScope::new(
+            "scope-targets-container",
+            FocusScopeOptions {
+                contain: false,
+                restore_focus: false,
+                auto_focus: false,
+            },
+        );
+
+        // AutofocusMarked prefers the marked candidate over the first tabbable.
+        scope.focus_first(FocusTarget::AutofocusMarked);
+
+        assert_eq!(active_id(), Some(autofocus.id()));
+
+        // focus_last explicitly jumps to the last tabbable.
+        scope.focus_last();
+
+        assert_eq!(active_id(), Some(autofocus.id()));
+
+        // PreviouslyActive restores a stored candidate inside the scope.
+        store_previously_active_element("scope-targets-container", FocusedElement(plain.id()));
+
+        scope.focus_first(FocusTarget::PreviouslyActive);
+
+        assert_eq!(active_id(), Some(plain.id()));
+
+        // Unknown target falls back to the first tabbable.
+        scope.focus_first(FocusTarget::First);
+
+        assert_eq!(active_id(), Some(plain.id()));
+
+        cleanup(&root);
+    }
 }

--- a/crates/ars-dom/src/focus.rs
+++ b/crates/ars-dom/src/focus.rs
@@ -1146,7 +1146,7 @@ mod wasm_tests {
         let first = append_button(container.as_ref(), "scope-tab-free-first", None, false);
         let last = append_button(container.as_ref(), "scope-tab-free-last", None, false);
 
-        let scope = FocusScope::new(
+        let mut scope = FocusScope::new(
             "scope-tab-free-container",
             FocusScopeOptions {
                 contain: false,
@@ -1155,7 +1155,15 @@ mod wasm_tests {
             },
         );
 
-        // Uncontained scope never prevents tab navigation regardless of position.
+        // Inactive scope short-circuits; verify first, then flip `active`
+        // so the remaining assertions exercise the
+        // `active && !contain` arm of `resolve_tab_navigation`.
+        focus_element(&first, false);
+        assert!(!scope.handle_tab_key(false));
+        scope.activate(FocusTarget::First);
+        assert!(scope.is_active());
+
+        // Active but uncontained scope still allows browser default navigation.
         focus_element(&first, false);
 
         assert!(!scope.handle_tab_key(false));

--- a/spec/foundation/03-accessibility.md
+++ b/spec/foundation/03-accessibility.md
@@ -2538,8 +2538,11 @@ pub struct Announcement {
 ///
 /// The adapter mounts a `LiveAnnouncerProvider` that wraps the application tree
 /// and provides `Rc<RefCell<LiveAnnouncer>>` via the framework's context system.
-/// Components access it indirectly through `ars_dom::announce()` and
-/// `ars_dom::announce_assertive()` — they never hold a direct reference.
+/// Components access it indirectly through the `PlatformEffects::announce()` and
+/// `PlatformEffects::announce_assertive()` trait methods defined in
+/// `01-architecture.md` §2.2.7 — they never hold a direct reference. The web
+/// implementation (`WebPlatformEffects` in `ars-dom`) bridges those trait calls
+/// onto this `LiveAnnouncer` instance.
 ///
 /// This ensures announcements are coordinated, deduplicated, and testable
 /// (tests can provide a mock announcer or skip the provider for no-op behavior).

--- a/spec/foundation/11-dom-utilities.md
+++ b/spec/foundation/11-dom-utilities.md
@@ -1453,41 +1453,6 @@ pub fn focus_element_by_id(id: &str) {
     }
 }
 
-/// Announce a message to screen readers with polite priority.
-///
-/// Resolves the `LiveAnnouncer` from the adapter's framework context internally.
-/// No-op during SSR or when no `LiveAnnouncerProvider` is in the component tree.
-///
-/// This is the primary announcement API used by component effects (e.g., announcing
-/// a new month after calendar navigation, announcing sort state changes in tables).
-/// Components call `ars_dom::announce(&msg)` — they never manage the `LiveAnnouncer`
-/// instance directly.
-pub fn announce(message: &str) {
-    if let Some(announcer) = use_announcer() {
-        announcer.borrow_mut().announce(message);
-    }
-}
-
-/// Announce a message with assertive priority (interrupts current screen reader speech).
-/// Use sparingly — unexpected interruptions degrade UX significantly.
-pub fn announce_assertive(message: &str) {
-    if let Some(announcer) = use_announcer() {
-        announcer.borrow_mut().announce_assertive(message);
-    }
-}
-
-/// Adapter-provided context resolution for the LiveAnnouncer.
-/// Each framework adapter implements this via its own context system:
-///   - Leptos: `use_context::<Rc<RefCell<LiveAnnouncer>>>()`
-///   - Dioxus: `try_consume_context::<Rc<RefCell<LiveAnnouncer>>>()`
-/// Returns `None` if no `LiveAnnouncerProvider` is mounted (SSR, tests without provider).
-fn use_announcer() -> Option<Rc<RefCell<LiveAnnouncer>>> {
-    // Adapter-specific implementation.
-    // The adapter's root component (or ArsProvider) mounts a
-    // LiveAnnouncerProvider that provides Rc<RefCell<LiveAnnouncer>> via context.
-    use_context::<Rc<RefCell<LiveAnnouncer>>>()
-}
-
 /// Focus the first tabbable element inside a container identified by ID.
 /// Used by modal dialogs to move focus into the dialog content on open.
 /// No-op if the container is not found or contains no tabbable elements.
@@ -1553,6 +1518,8 @@ pub fn remove_inert_from_siblings(portal_id: &str) {
     }
 }
 ```
+
+> **Screen-reader announcements:** `ars-dom` does not expose free functions `announce()` / `announce_assertive()`. The canonical call site is the `PlatformEffects` trait in `ars-core` (see `01-architecture.md` §2.2.7) — components invoke `platform_effects.announce(&msg)` / `.announce_assertive(&msg)` resolved from the adapter's `ArsProvider` context. On web targets, `WebPlatformEffects` implements the trait by delegating to the shared `LiveAnnouncer` defined in `03-accessibility.md` §5.1. The only announcer surface owned by `ars-dom` is the live-region DOM bootstrap `ensure_dom()` in `ars-dom/src/announcer.rs`, which creates the two hidden `aria-live` containers (`#ars-live-polite`, `#ars-live-assertive`) the `LiveAnnouncer` writes into.
 
 ### 3.3 FocusScope Implementation
 


### PR DESCRIPTION
## Summary

- Rewrites `spec/foundation/11-dom-utilities.md` §3.2 and `03-accessibility.md` §5.1 to remove the claim that `ars_dom::announce()` / `ars_dom::announce_assertive()` exist as free functions. The canonical surface is `PlatformEffects::announce()` on the trait defined in `01-architecture.md` §2.2.7; the web implementation (`WebPlatformEffects`, tracked in Epic #2) bridges those calls onto the shared `LiveAnnouncer` in `ars-a11y`. `ars-dom` owns only the live-region DOM bootstrap (`ensure_dom()` in `crates/ars-dom/src/announcer.rs`).
- Adds four `#[wasm_bindgen_test]` cases for `FocusScope` in `crates/ars-dom/src/focus.rs`: activate + deactivate round-trip with previous-focus restore, Tab/Shift+Tab wrap in a contained scope, uncontained scope allowing browser default, and `focus_first` target resolution (AutofocusMarked, PreviouslyActive, First) plus `focus_last`. Previously only the selector query had wasm coverage.

## Coverage impact

| | Before | After |
|---|---|---|
| `focus.rs` line coverage | 76.0% | **92.1%** |
| `ars-dom` merged (native + wasm) line | 95.2% | **96.4%** |
| `ars-dom` merged branch | 69.7% | 68.0%[^1] |
| Wasm tests | 95 | **99** |

[^1]: Branch count dropped a bit because the new tests expose previously-unexercised conditional arms; both metrics stay well above the enforced 85%/50% floor in `xtask/src/coverage.rs`.

## Epic #6 status

Every sub-issue (#18, #66, #67, #115, #112, #113, #114, #39, #74, #40, #68, #88, #69, #72, #85, #176) is merged and maps to the corresponding section of `spec/foundation/11-dom-utilities.md`. §11 (URL sanitization) correctly lives in `ars-core` per the spec's own delegation note. No missing implementation work — only the §3.2 doc drift blocked closure.

## Test plan

- [x] `cargo xtask spec validate` — 336 files pass.
- [x] `cargo xci` — all 16 steps pass (2,784 native + 99 wasm tests, 0 failures).
- [x] `cargo xtask coverage wasm --package ars-dom` + merge + `check-all` — 96.4% line / 68.0% branch, `PASS`.
- [x] Remote CI green.

Closes #6