### PR TITLE
Align ArsProvider context and prop sync semantics

### DIFF
--- a/crates/ars-core/src/lib.rs
+++ b/crates/ars-core/src/lib.rs
@@ -1024,14 +1024,15 @@ impl<M: Machine> Service<M> {
     /// Updates props atomically and processes any resulting events.
     ///
     /// Calls [`Machine::on_props_changed`] with the old and new props,
-    /// enqueues any returned events, and drains the queue.
+    /// prepends any returned events ahead of already-queued user input, and
+    /// drains the queue.
     pub fn set_props(&mut self, props: M::Props) -> SendResult<M> {
         let old_props = core::mem::replace(&mut self.props, props);
 
         let events = M::on_props_changed(&old_props, &self.props);
 
-        for event in events {
-            self.event_queue.push_back(event);
+        for event in events.into_iter().rev() {
+            self.event_queue.push_front(event);
         }
 
         self.drain_queue()
@@ -1387,6 +1388,70 @@ mod tests {
     }
 
     #[test]
+    fn rejected_transition_returns_inert_send_result() {
+        #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+        enum RejectEvent {
+            Ignore,
+        }
+
+        struct RejectMachine;
+
+        impl Machine for RejectMachine {
+            type State = ToggleState;
+            type Event = RejectEvent;
+            type Context = ToggleContext;
+            type Props = ToggleProps;
+            type Messages = ();
+            type Api<'a> = ToggleApi;
+
+            fn init(
+                _props: &Self::Props,
+                _env: &Env,
+                _messages: &Self::Messages,
+            ) -> (Self::State, Self::Context) {
+                (ToggleState::Off, ToggleContext)
+            }
+
+            fn transition(
+                _state: &Self::State,
+                _event: &Self::Event,
+                _context: &Self::Context,
+                _props: &Self::Props,
+            ) -> Option<TransitionPlan<Self>> {
+                None
+            }
+
+            fn connect<'a>(
+                _state: &'a Self::State,
+                _context: &'a Self::Context,
+                _props: &'a Self::Props,
+                _send: &'a dyn Fn(Self::Event),
+            ) -> Self::Api<'a> {
+                ToggleApi
+            }
+        }
+
+        let mut service = Service::<RejectMachine>::new(
+            ToggleProps {
+                id: String::from("toggle"),
+            },
+            &Env::default(),
+            &(),
+        );
+
+        let result = service.send(RejectEvent::Ignore);
+
+        assert!(!result.state_changed);
+        assert!(!result.context_changed);
+        assert!(result.pending_effects.is_empty());
+        assert!(result.cancel_effects.is_empty());
+        assert!(!result.truncated);
+        assert_eq!(result.context_change_count, 0);
+        assert_eq!(service.state(), &ToggleState::Off);
+        assert_eq!(service.context(), &ToggleContext);
+    }
+
+    #[test]
     fn context_only_plan_does_not_change_state() {
         // Verify context_only plan reports context_changed but not state_changed.
         #[derive(Clone, Debug, PartialEq)]
@@ -1667,6 +1732,104 @@ mod tests {
 
         assert!(result.context_changed);
         assert_eq!(service.context().mode, 1);
+    }
+
+    #[test]
+    fn set_props_prepends_prop_sync_events_ahead_of_queued_user_input() {
+        struct QueueOrderMachine;
+
+        #[derive(Clone, Debug, Default, PartialEq, Eq)]
+        struct QueueOrderContext {
+            events: Vec<&'static str>,
+        }
+
+        #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+        enum QueueOrderEvent {
+            PropSync,
+            UserInput,
+        }
+
+        impl Machine for QueueOrderMachine {
+            type State = ToggleState;
+            type Event = QueueOrderEvent;
+            type Context = QueueOrderContext;
+            type Props = ToggleProps;
+            type Messages = ();
+            type Api<'a> = ToggleApi;
+
+            fn init(
+                _props: &Self::Props,
+                _env: &Env,
+                _messages: &Self::Messages,
+            ) -> (Self::State, Self::Context) {
+                (ToggleState::Off, QueueOrderContext::default())
+            }
+
+            fn transition(
+                _state: &Self::State,
+                event: &Self::Event,
+                _context: &Self::Context,
+                _props: &Self::Props,
+            ) -> Option<TransitionPlan<Self>> {
+                let label = match event {
+                    QueueOrderEvent::PropSync => "prop-sync",
+                    QueueOrderEvent::UserInput => "user-input",
+                };
+
+                Some(TransitionPlan::context_only(
+                    move |ctx: &mut QueueOrderContext| ctx.events.push(label),
+                ))
+            }
+
+            fn connect<'a>(
+                _state: &'a Self::State,
+                _context: &'a Self::Context,
+                _props: &'a Self::Props,
+                _send: &'a dyn Fn(Self::Event),
+            ) -> Self::Api<'a> {
+                ToggleApi
+            }
+
+            fn on_props_changed(old: &Self::Props, new: &Self::Props) -> Vec<Self::Event> {
+                if old.id == new.id {
+                    Vec::new()
+                } else {
+                    vec![QueueOrderEvent::PropSync]
+                }
+            }
+        }
+
+        let mut service = Service::<QueueOrderMachine>::new(
+            ToggleProps {
+                id: String::from("a"),
+            },
+            &Env::default(),
+            &(),
+        );
+        service.event_queue.push_back(QueueOrderEvent::UserInput);
+
+        let result = service.set_props(ToggleProps {
+            id: String::from("b"),
+        });
+
+        assert!(result.context_changed);
+        assert_eq!(
+            service.context().events,
+            vec!["prop-sync", "user-input"],
+            "prop sync events must be prepended so same-frame user input wins",
+        );
+
+        let unchanged = service.set_props(ToggleProps {
+            id: String::from("b"),
+        });
+
+        assert!(!unchanged.state_changed);
+        assert!(!unchanged.context_changed);
+        assert_eq!(
+            service.context().events,
+            vec!["prop-sync", "user-input"],
+            "unchanged props must not synthesize extra prop-sync work",
+        );
     }
 
     #[test]

--- a/crates/ars-core/src/provider.rs
+++ b/crates/ars-core/src/provider.rs
@@ -7,10 +7,11 @@
 use alloc::{string::String, sync::Arc};
 use core::fmt::{self, Debug};
 
-use ars_i18n::{Direction, Locale, locales};
+use ars_i18n::{Direction, IntlBackend, Locale, StubIntlBackend, locales};
 
 use crate::{
-    DefaultModalityContext, ModalityContext, NullPlatformEffects, PlatformEffects, StyleStrategy,
+    DefaultModalityContext, I18nRegistries, ModalityContext, NullPlatformEffects, PlatformEffects,
+    StyleStrategy,
 };
 
 /// Active color mode for theme-aware rendering.
@@ -31,6 +32,11 @@ pub enum ColorMode {
 }
 
 /// Framework-agnostic provider context shared with descendant components.
+///
+/// This is the canonical provider contract shared across adapters. Framework
+/// crates wrap these values in reactive signals, but the field set itself stays
+/// consistent so runtime-facing hooks and environment resolution follow the same
+/// semantics everywhere.
 #[derive(Clone)]
 pub struct ArsContext {
     locale: Locale,
@@ -43,6 +49,8 @@ pub struct ArsContext {
     root_node_id: Option<String>,
     platform: Arc<dyn PlatformEffects>,
     modality: Arc<dyn ModalityContext>,
+    intl_backend: Arc<dyn IntlBackend>,
+    i18n_registries: Arc<I18nRegistries>,
     style_strategy: StyleStrategy,
 }
 
@@ -64,6 +72,8 @@ impl ArsContext {
         root_node_id: Option<String>,
         platform: Arc<dyn PlatformEffects>,
         modality: Arc<dyn ModalityContext>,
+        intl_backend: Arc<dyn IntlBackend>,
+        i18n_registries: Arc<I18nRegistries>,
         style_strategy: StyleStrategy,
     ) -> Self {
         Self {
@@ -77,6 +87,8 @@ impl ArsContext {
             root_node_id,
             platform,
             modality,
+            intl_backend,
+            i18n_registries,
             style_strategy,
         }
     }
@@ -141,6 +153,18 @@ impl ArsContext {
         Arc::clone(&self.modality)
     }
 
+    /// Returns the shared ICU provider for this provider root.
+    #[must_use]
+    pub fn intl_backend(&self) -> Arc<dyn IntlBackend> {
+        Arc::clone(&self.intl_backend)
+    }
+
+    /// Returns the shared per-component message registries.
+    #[must_use]
+    pub fn i18n_registries(&self) -> Arc<I18nRegistries> {
+        Arc::clone(&self.i18n_registries)
+    }
+
     /// Returns the active style strategy.
     #[must_use]
     pub const fn style_strategy(&self) -> &StyleStrategy {
@@ -161,6 +185,8 @@ impl Default for ArsContext {
             root_node_id: None,
             platform: Arc::new(NullPlatformEffects),
             modality: Arc::new(DefaultModalityContext::new()),
+            intl_backend: Arc::new(StubIntlBackend),
+            i18n_registries: Arc::new(I18nRegistries::new()),
             style_strategy: StyleStrategy::Inline,
         }
     }
@@ -179,6 +205,8 @@ impl Debug for ArsContext {
             .field("root_node_id", &self.root_node_id)
             .field("platform", &"<dyn PlatformEffects>")
             .field("modality", &"<dyn ModalityContext>")
+            .field("intl_backend", &"<dyn IntlBackend>")
+            .field("i18n_registries", &self.i18n_registries)
             .field("style_strategy", &self.style_strategy)
             .finish()
     }
@@ -224,6 +252,14 @@ mod tests {
 
     #[test]
     fn ars_context_constructor_preserves_values() {
+        let platform: Arc<dyn PlatformEffects> = Arc::new(NullPlatformEffects);
+
+        let modality: Arc<dyn ModalityContext> = Arc::new(NullModalityContext);
+
+        let intl_backend: Arc<dyn IntlBackend> = Arc::new(StubIntlBackend);
+
+        let i18n_registries = Arc::new(I18nRegistries::new());
+
         let context = ArsContext::new(
             locales::br(),
             Direction::Ltr,
@@ -233,8 +269,10 @@ mod tests {
             Some(String::from("prefix")),
             Some(String::from("portal-root")),
             Some(String::from("app-root")),
-            Arc::new(NullPlatformEffects),
-            Arc::new(NullModalityContext),
+            Arc::clone(&platform),
+            Arc::clone(&modality),
+            Arc::clone(&intl_backend),
+            Arc::clone(&i18n_registries),
             StyleStrategy::Cssom,
         );
 
@@ -244,6 +282,10 @@ mod tests {
         assert_eq!(context.id_prefix(), Some("prefix"));
         assert_eq!(context.portal_container_id(), Some("portal-root"));
         assert_eq!(context.root_node_id(), Some("app-root"));
+        assert!(Arc::ptr_eq(&context.platform(), &platform));
+        assert!(Arc::ptr_eq(&context.modality(), &modality));
+        assert!(Arc::ptr_eq(&context.intl_backend(), &intl_backend));
+        assert!(Arc::ptr_eq(&context.i18n_registries(), &i18n_registries));
         assert_eq!(context.style_strategy(), &StyleStrategy::Cssom);
     }
 
@@ -257,6 +299,8 @@ mod tests {
         assert_eq!(context.style_strategy(), &StyleStrategy::Inline);
         assert_eq!(context.platform().now_ms(), 0);
         assert_eq!(context.modality().snapshot(), ModalitySnapshot::default());
+        let registries = context.i18n_registries();
+        assert_eq!(Arc::strong_count(&registries), 2);
     }
 
     #[test]

--- a/crates/ars-dioxus/src/attrs.rs
+++ b/crates/ars-dioxus/src/attrs.rs
@@ -580,6 +580,7 @@ mod tests {
                 None,
                 None,
                 Arc::new(NullPlatformEffects),
+                Arc::new(ars_core::DefaultModalityContext::new()),
                 Arc::new(ars_i18n::StubIntlBackend),
                 Arc::new(I18nRegistries::new()),
                 Arc::new(crate::provider::NullPlatform),

--- a/crates/ars-dioxus/src/lib.rs
+++ b/crates/ars-dioxus/src/lib.rs
@@ -33,7 +33,8 @@ pub use provider::DesktopPlatform;
 pub use provider::WebPlatform;
 pub use provider::{
     ArsContext, DioxusPlatform, DragData, FilePickerOptions, NullPlatform, t, use_intl_backend,
-    use_locale, use_messages, use_number_formatter, use_platform, warn_missing_provider,
+    use_locale, use_messages, use_modality_context, use_number_formatter, use_platform,
+    warn_missing_provider,
 };
 pub use use_machine::{UseMachineReturn, use_machine, use_machine_with_reactive_props};
 

--- a/crates/ars-dioxus/src/provider.rs
+++ b/crates/ars-dioxus/src/provider.rs
@@ -720,6 +720,26 @@ mod tests {
     }
 
     #[test]
+    fn use_modality_context_falls_back_without_provider() {
+        fn app() -> Element {
+            let first = use_modality_context();
+            let second = use_modality_context();
+
+            assert_eq!(first.snapshot(), ars_core::ModalitySnapshot::default());
+            assert_eq!(second.snapshot(), ars_core::ModalitySnapshot::default());
+            assert!(!Arc::ptr_eq(&first, &second));
+
+            rsx! {
+                div {}
+            }
+        }
+
+        let mut dom = VirtualDom::new(app);
+
+        dom.rebuild_in_place();
+    }
+
+    #[test]
     fn use_messages_reads_provider_registry_bundle() {
         fn app() -> Element {
             let mut registries = I18nRegistries::new();

--- a/crates/ars-dioxus/src/provider.rs
+++ b/crates/ars-dioxus/src/provider.rs
@@ -8,8 +8,8 @@ use std::{
 };
 
 use ars_core::{
-    ColorMode, I18nRegistries, PlatformEffects, Rect, StyleStrategy,
-    resolve_messages as core_resolve_messages,
+    ColorMode, DefaultModalityContext, I18nRegistries, ModalityContext, PlatformEffects, Rect,
+    StyleStrategy, resolve_messages as core_resolve_messages,
 };
 use ars_forms::field::FileRef;
 use ars_i18n::{
@@ -230,6 +230,9 @@ pub struct ArsContext {
     /// Platform side-effect capabilities.
     pub platform: Arc<dyn PlatformEffects>,
 
+    /// Shared input-modality state for this provider root.
+    pub modality: Arc<dyn ModalityContext>,
+
     /// ICU-backed locale data provider.
     pub intl_backend: Arc<dyn IntlBackend>,
 
@@ -255,6 +258,7 @@ impl Debug for ArsContext {
             .field("portal_container_id", &self.portal_container_id)
             .field("root_node_id", &self.root_node_id)
             .field("platform", &"Arc(..)")
+            .field("modality", &"Arc(..)")
             .field("intl_backend", &"Arc(..)")
             .field("i18n_registries", &"Arc(..)")
             .field("dioxus_platform", &"Arc(..)")
@@ -280,6 +284,7 @@ impl ArsContext {
         portal_container_id: Option<String>,
         root_node_id: Option<String>,
         platform: Arc<dyn PlatformEffects>,
+        modality: Arc<dyn ModalityContext>,
         intl_backend: Arc<dyn IntlBackend>,
         i18n_registries: Arc<I18nRegistries>,
         dioxus_platform: Arc<dyn DioxusPlatform>,
@@ -295,6 +300,7 @@ impl ArsContext {
             portal_container_id: Signal::new(portal_container_id),
             root_node_id: Signal::new(root_node_id),
             platform,
+            modality,
             intl_backend,
             i18n_registries,
             dioxus_platform,
@@ -390,6 +396,19 @@ pub fn use_intl_backend() -> Arc<dyn IntlBackend> {
     )
 }
 
+/// Resolves the shared input-modality context from provider context.
+#[must_use]
+pub fn use_modality_context() -> Arc<dyn ModalityContext> {
+    try_use_context::<ArsContext>().map_or_else(
+        || -> Arc<dyn ModalityContext> {
+            warn_missing_provider("use_modality_context");
+
+            Arc::new(DefaultModalityContext::new())
+        },
+        |ctx| -> Arc<dyn ModalityContext> { Arc::clone(&ctx.modality) },
+    )
+}
+
 /// Resolves per-component messages from override, provider registry, or defaults.
 #[must_use]
 pub fn use_messages<M: ars_core::ComponentMessages + Send + Sync + 'static>(
@@ -448,7 +467,10 @@ mod tests {
         task::{Context, Poll, Waker},
     };
 
-    use ars_core::{ColorMode, I18nRegistries, NullPlatformEffects, StyleStrategy};
+    use ars_core::{
+        ColorMode, DefaultModalityContext, I18nRegistries, ModalityContext, NullPlatformEffects,
+        StyleStrategy,
+    };
     use ars_i18n::{
         Direction, IntlBackend, Locale, NumberFormatOptions, StubIntlBackend, Translate, locales,
     };
@@ -573,6 +595,7 @@ mod tests {
             None,
             None,
             Arc::new(NullPlatformEffects),
+            Arc::new(DefaultModalityContext::new()),
             intl_backend,
             Arc::new(I18nRegistries::new()),
             Arc::new(NullPlatform),
@@ -639,6 +662,7 @@ mod tests {
                 None,
                 None,
                 Arc::new(NullPlatformEffects),
+                Arc::new(DefaultModalityContext::new()),
                 Arc::clone(&expected),
                 Arc::new(I18nRegistries::new()),
                 Arc::new(NullPlatform),
@@ -648,6 +672,42 @@ mod tests {
             use_context_provider(|| ctx);
 
             assert!(Arc::ptr_eq(&use_intl_backend(), &expected));
+
+            rsx! {
+                div {}
+            }
+        }
+
+        let mut dom = VirtualDom::new(app);
+
+        dom.rebuild_in_place();
+    }
+
+    #[test]
+    fn use_modality_context_reads_context_value() {
+        fn app() -> Element {
+            let expected: Arc<dyn ModalityContext> = Arc::new(DefaultModalityContext::new());
+
+            let ctx = ArsContext::new(
+                locales::en_us(),
+                Direction::Ltr,
+                ColorMode::System,
+                false,
+                false,
+                None,
+                None,
+                None,
+                Arc::new(NullPlatformEffects),
+                Arc::clone(&expected),
+                Arc::new(StubIntlBackend),
+                Arc::new(I18nRegistries::new()),
+                Arc::new(NullPlatform),
+                StyleStrategy::Inline,
+            );
+
+            use_context_provider(|| ctx);
+
+            assert!(Arc::ptr_eq(&use_modality_context(), &expected));
 
             rsx! {
                 div {}
@@ -683,6 +743,7 @@ mod tests {
                 None,
                 None,
                 Arc::new(NullPlatformEffects),
+                Arc::new(DefaultModalityContext::new()),
                 Arc::new(StubIntlBackend),
                 Arc::new(registries),
                 Arc::new(NullPlatform),
@@ -947,6 +1008,7 @@ mod tests {
                     None,
                     None,
                     Arc::new(NullPlatformEffects),
+                    Arc::new(DefaultModalityContext::new()),
                     Arc::new(StubIntlBackend),
                     Arc::new(I18nRegistries::new()),
                     Arc::new(NullPlatform),
@@ -1059,6 +1121,7 @@ mod tests {
                 None,
                 None,
                 Arc::new(NullPlatformEffects),
+                Arc::new(DefaultModalityContext::new()),
                 Arc::new(StubIntlBackend),
                 Arc::new(I18nRegistries::new()),
                 Arc::clone(&expected),
@@ -1231,6 +1294,7 @@ mod wasm_tests {
             None,
             None,
             Arc::new(NullPlatformEffects),
+            Arc::new(DefaultModalityContext::new()),
             intl_backend,
             Arc::new(I18nRegistries::new()),
             Arc::new(NullPlatform),

--- a/crates/ars-dioxus/src/use_machine.rs
+++ b/crates/ars-dioxus/src/use_machine.rs
@@ -1231,6 +1231,7 @@ mod tests {
             None,
             None,
             Arc::new(NullPlatformEffects),
+            Arc::new(ars_core::DefaultModalityContext::new()),
             intl_backend,
             registries,
             Arc::new(NullPlatform),

--- a/crates/ars-leptos/src/attrs.rs
+++ b/crates/ars-leptos/src/attrs.rs
@@ -283,6 +283,7 @@ mod tests {
                 None,
                 None,
                 Arc::new(NullPlatformEffects),
+                Arc::new(ars_core::DefaultModalityContext::new()),
                 Arc::new(ars_i18n::StubIntlBackend),
                 Arc::new(I18nRegistries::new()),
                 StyleStrategy::Nonce(String::from("nonce-456")),

--- a/crates/ars-leptos/src/lib.rs
+++ b/crates/ars-leptos/src/lib.rs
@@ -28,7 +28,7 @@ pub use id::reset_id_counter;
 pub use id::use_id;
 pub use provider::{
     ArsContext, provide_ars_context, resolve_locale, t, use_intl_backend, use_locale, use_messages,
-    use_number_formatter, warn_missing_provider,
+    use_modality_context, use_number_formatter, warn_missing_provider,
 };
 pub use use_machine::{UseMachineReturn, use_machine, use_machine_with_reactive_props};
 

--- a/crates/ars-leptos/src/provider.rs
+++ b/crates/ars-leptos/src/provider.rs
@@ -556,6 +556,20 @@ mod tests {
     }
 
     #[test]
+    fn use_modality_context_falls_back_without_provider() {
+        let owner = Owner::new();
+
+        owner.with(|| {
+            let first = use_modality_context();
+            let second = use_modality_context();
+
+            assert_eq!(first.snapshot(), ars_core::ModalitySnapshot::default());
+            assert_eq!(second.snapshot(), ars_core::ModalitySnapshot::default());
+            assert!(!Arc::ptr_eq(&first, &second));
+        });
+    }
+
+    #[test]
     fn use_intl_backend_falls_back_without_provider() {
         let owner = Owner::new();
 
@@ -844,7 +858,7 @@ mod wasm_tests {
             portal_container_id: Signal::stored(None),
             root_node_id: Signal::stored(None),
             platform: Arc::new(NullPlatformEffects),
-            modality: Arc::new(DefaultModalityContext::new()),
+            modality: Arc::new(ars_core::DefaultModalityContext::new()),
             intl_backend,
             i18n_registries: Arc::new(I18nRegistries::new()),
             style_strategy: StyleStrategy::Inline,

--- a/crates/ars-leptos/src/provider.rs
+++ b/crates/ars-leptos/src/provider.rs
@@ -10,8 +10,8 @@ use std::{
 };
 
 use ars_core::{
-    ColorMode, I18nRegistries, PlatformEffects, StyleStrategy,
-    resolve_messages as core_resolve_messages,
+    ColorMode, DefaultModalityContext, I18nRegistries, ModalityContext, PlatformEffects,
+    StyleStrategy, resolve_messages as core_resolve_messages,
 };
 use ars_i18n::{
     Direction, IntlBackend, Locale, NumberFormatOptions, NumberFormatter, StubIntlBackend,
@@ -49,6 +49,9 @@ pub struct ArsContext {
     /// Platform side-effect capabilities.
     pub platform: Arc<dyn PlatformEffects>,
 
+    /// Shared input-modality state for this provider root.
+    pub modality: Arc<dyn ModalityContext>,
+
     /// ICU-backed locale data provider.
     pub intl_backend: Arc<dyn IntlBackend>,
 
@@ -71,6 +74,7 @@ impl Debug for ArsContext {
             .field("portal_container_id", &self.portal_container_id)
             .field("root_node_id", &self.root_node_id)
             .field("platform", &"Arc(..)")
+            .field("modality", &"Arc(..)")
             .field("intl_backend", &"Arc(..)")
             .field("i18n_registries", &"Arc(..)")
             .field("style_strategy", &self.style_strategy)
@@ -95,6 +99,7 @@ impl ArsContext {
         portal_container_id: Option<String>,
         root_node_id: Option<String>,
         platform: Arc<dyn PlatformEffects>,
+        modality: Arc<dyn ModalityContext>,
         intl_backend: Arc<dyn IntlBackend>,
         i18n_registries: Arc<I18nRegistries>,
         style_strategy: StyleStrategy,
@@ -109,6 +114,7 @@ impl ArsContext {
             portal_container_id: Signal::stored(portal_container_id),
             root_node_id: Signal::stored(root_node_id),
             platform,
+            modality,
             intl_backend,
             i18n_registries,
             style_strategy,
@@ -166,6 +172,19 @@ pub fn use_intl_backend() -> Arc<dyn IntlBackend> {
             Arc::new(StubIntlBackend)
         },
         |ctx| -> Arc<dyn IntlBackend> { Arc::clone(&ctx.intl_backend) },
+    )
+}
+
+/// Resolves the shared input-modality context from provider context.
+#[must_use]
+pub fn use_modality_context() -> Arc<dyn ModalityContext> {
+    current_ars_context().map_or_else(
+        || -> Arc<dyn ModalityContext> {
+            warn_missing_provider("use_modality_context");
+
+            Arc::new(DefaultModalityContext::new())
+        },
+        |ctx| -> Arc<dyn ModalityContext> { Arc::clone(&ctx.modality) },
     )
 }
 
@@ -273,7 +292,10 @@ pub fn t<T: Translate + Send + Sync + 'static>(msg: T) -> impl IntoView {
 mod tests {
     use std::sync::Arc;
 
-    use ars_core::{ColorMode, I18nRegistries, NullPlatformEffects, StyleStrategy};
+    use ars_core::{
+        ColorMode, DefaultModalityContext, I18nRegistries, ModalityContext, NullPlatformEffects,
+        StyleStrategy,
+    };
     use ars_i18n::{
         Direction, IntlBackend, Locale, NumberFormatOptions, StubIntlBackend, Translate, locales,
     };
@@ -281,7 +303,8 @@ mod tests {
 
     use super::{
         ArsContext, current_ars_context, resolve_locale, t, translated_text, use_intl_backend,
-        use_locale, use_messages, use_number_formatter, use_resolved_number_formatter,
+        use_locale, use_messages, use_modality_context, use_number_formatter,
+        use_resolved_number_formatter,
     };
 
     #[derive(Clone, Debug, PartialEq)]
@@ -370,6 +393,7 @@ mod tests {
             portal_container_id: Signal::stored(None),
             root_node_id: Signal::stored(None),
             platform: Arc::new(NullPlatformEffects),
+            modality: Arc::new(DefaultModalityContext::new()),
             intl_backend,
             i18n_registries: Arc::new(I18nRegistries::new()),
             style_strategy: StyleStrategy::Inline,
@@ -389,6 +413,7 @@ mod tests {
 
             assert!(debug.contains("ArsContext"));
             assert!(debug.contains("platform: \"Arc(..)\""));
+            assert!(debug.contains("modality: \"Arc(..)\""));
             assert!(debug.contains("intl_backend: \"Arc(..)\""));
             assert!(debug.contains("i18n_registries: \"Arc(..)\""));
         });
@@ -513,6 +538,24 @@ mod tests {
     }
 
     #[test]
+    fn use_modality_context_reads_context_value() {
+        let owner = Owner::new();
+
+        owner.with(|| {
+            let expected: Arc<dyn ModalityContext> = Arc::new(DefaultModalityContext::new());
+
+            let (mut context, _) =
+                reactive_test_context(locales::en_us(), Arc::new(TestIntlBackend));
+
+            context.modality = Arc::clone(&expected);
+
+            crate::provide_ars_context(context);
+
+            assert!(Arc::ptr_eq(&use_modality_context(), &expected));
+        });
+    }
+
+    #[test]
     fn use_intl_backend_falls_back_without_provider() {
         let owner = Owner::new();
 
@@ -552,6 +595,7 @@ mod tests {
                 None,
                 None,
                 Arc::new(NullPlatformEffects),
+                Arc::new(DefaultModalityContext::new()),
                 Arc::new(StubIntlBackend),
                 Arc::new(registries),
                 StyleStrategy::Inline,
@@ -800,6 +844,7 @@ mod wasm_tests {
             portal_container_id: Signal::stored(None),
             root_node_id: Signal::stored(None),
             platform: Arc::new(NullPlatformEffects),
+            modality: Arc::new(DefaultModalityContext::new()),
             intl_backend,
             i18n_registries: Arc::new(I18nRegistries::new()),
             style_strategy: StyleStrategy::Inline,

--- a/crates/ars-leptos/src/use_machine.rs
+++ b/crates/ars-leptos/src/use_machine.rs
@@ -1156,6 +1156,7 @@ mod tests {
             None,
             None,
             Arc::new(NullPlatformEffects),
+            Arc::new(ars_core::DefaultModalityContext::new()),
             intl_backend,
             Arc::new(I18nRegistries::new()),
             ars_core::StyleStrategy::Inline,

--- a/spec/foundation/01-architecture.md
+++ b/spec/foundation/01-architecture.md
@@ -537,7 +537,7 @@ pub trait Machine: Sized + 'static {
 >
 > **Violation**: Storing `Api<'a>` beyond its scope is undefined behavior and will cause use-after-free. If persistent access to machine operations is needed, store the `send: Arc<dyn Fn(Event) + Send + Sync>` closure directly instead.
 >
-> **Ergonomic persistent access**: For cases where persistent access to machine operations is needed, store `send: Arc<dyn Fn(Event) + Send + Sync>` directly (extractable from the `Service` via `Service::send_fn()`). Do not create ad-hoc wrapper types — the adapter's `use_machine` hook already provides the ergonomic access layer.
+> **Ergonomic persistent access**: For cases where persistent access to machine operations is needed, store `send: Arc<dyn Fn(Event) + Send + Sync>` directly. Do not create ad-hoc wrapper types — the adapter's `use_machine` hook already provides the ergonomic access layer.
 
 Components SHOULD implement `fmt::Display` for their State and Event enums
 for debugging, logging, and `data-ars-state` attribute values. The architecture
@@ -4755,11 +4755,15 @@ pub enum ColorMode {
 | `platform`            | `Arc<dyn PlatformEffects>`                  | Platform capabilities for side effects. Defaults to `NullPlatformEffects`.     |
 | `modality`            | `Arc<dyn ModalityContext>`                  | Shared input-modality state for the current provider root.                     |
 | `intl_backend`        | `Arc<dyn IntlBackend>`                      | Calendar/locale data for date-time components. Defaults to `StubIntlBackend`.  |
-| `i18n_registries`     | `Rc<I18nRegistries>`                        | Per-component translation registries. Defaults to empty (English fallbacks).   |
+| `i18n_registries`     | `Arc<I18nRegistries>`                       | Per-component translation registries. Defaults to empty (English fallbacks).   |
 | `style_strategy`      | `StyleStrategy`                             | CSS style injection strategy. Defaults to `StyleStrategy::Inline`.             |
 
 Components access configuration via `ctx.locale`, `ctx.direction`, etc. Convenience
 hooks read from `ArsContext` with fallback defaults:
+
+Adapter crates publish reactive `ArsContext` wrappers that mirror this canonical
+field set and may add framework-specific extras (for example Dioxus-only
+platform services).
 
 - `use_locale()` — locale, falls back to `en-US`
 - `use_platform_effects()` — platform capabilities

--- a/spec/foundation/04-internationalization.md
+++ b/spec/foundation/04-internationalization.md
@@ -478,7 +478,7 @@ Date-time components need locale-aware calendar data (weekday names, month names
 // use_intl_backend() implementation (in adapter layer):
 fn use_intl_backend() -> Arc<dyn IntlBackend> {
     use_context::<ArsContext>()
-        .map(|ctx| ctx.intl_backend())
+        .map(|ctx| Arc::clone(&ctx.intl_backend))
         .unwrap_or_else(|| {
             warn_missing_provider("use_intl_backend");
             Arc::new(StubIntlBackend)
@@ -2592,7 +2592,7 @@ registries.register(MessagesRegistry::new(select::Messages::default())
     }));
 
 // Pass registries to ArsProvider — all descendants inherit these translations
-// ArsProvider { i18n_registries: Some(Rc::new(registries)), .. }
+// ArsProvider { i18n_registries: Some(Arc::new(registries)), .. }
 ```
 
 ### 7.4 User-Defined Translatable Text

--- a/spec/foundation/08-adapter-leptos.md
+++ b/spec/foundation/08-adapter-leptos.md
@@ -1760,7 +1760,7 @@ trait object.
 use std::sync::Arc;
 
 use ars_i18n::{Direction,IntlBackend, Locale};
-use ars_core::{ColorMode, PlatformEffects, StyleStrategy};
+use ars_core::{ColorMode, ModalityContext, PlatformEffects, StyleStrategy};
 
 /// Reactive environment context published by the Leptos ArsProvider adapter.
 #[derive(Clone)]
@@ -1774,6 +1774,7 @@ pub struct ArsContext {
     pub portal_container_id: Signal<Option<String>>,
     pub root_node_id: Signal<Option<String>>,
     pub platform: Arc<dyn PlatformEffects>,
+    pub modality: Arc<dyn ModalityContext>,
     pub intl_backend: Arc<dyn IntlBackend>,
     pub i18n_registries: Arc<I18nRegistries>,
     /// Non-reactive style strategy — set once at provider mount time.
@@ -1803,6 +1804,13 @@ The `ArsProvider` component, its props, and rendering are specified in
 The context value itself satisfies Leptos's `provide_context(T: Send + Sync + 'static)`
 contract because ars-ui standardizes on `Arc` ownership and `Send + Sync` trait
 bounds across native and wasm builds.
+This reactive wrapper mirrors the canonical `ars_core::ArsContext` provider
+surface and adds no adapter-only fields.
+
+Leptos also exposes `use_modality_context()` for provider-scoped ambient input
+modality. It clones `ctx.modality` when `ArsProvider` is present and falls back
+to `Arc::new(DefaultModalityContext::new())` with `warn_missing_provider(...)`
+diagnostics when it is not.
 
 ### 13.1 use_locale()
 

--- a/spec/foundation/09-adapter-dioxus.md
+++ b/spec/foundation/09-adapter-dioxus.md
@@ -2141,7 +2141,8 @@ includes the style strategy and the Dioxus-specific platform capabilities trait 
 ```rust
 use ars_i18n::{Direction, IntlBackend, Locale};
 use ars_core::{
-    ArsContext as CoreCtx, Arc, ColorMode, I18nRegistries, PlatformEffects, StyleStrategy,
+    ArsContext as CoreCtx, Arc, ColorMode, I18nRegistries, ModalityContext, PlatformEffects,
+    StyleStrategy,
 };
 
 /// Reactive environment context published by the Dioxus ArsProvider adapter.
@@ -2156,6 +2157,7 @@ pub struct ArsContext {
     pub portal_container_id: Signal<Option<String>>,
     pub root_node_id: Signal<Option<String>>,
     pub platform: Arc<dyn PlatformEffects>,
+    pub modality: Arc<dyn ModalityContext>,
     pub intl_backend: Arc<dyn IntlBackend>,
     pub i18n_registries: Arc<I18nRegistries>,
     pub style_strategy: StyleStrategy,
@@ -2171,13 +2173,15 @@ Although Dioxus context values only require `Clone + 'static`, ars-ui keeps the
 Dioxus-local `dioxus_platform` handle in `Arc<dyn DioxusPlatform>` so the adapter
 matches the shared `Send + Sync` ownership model used across the rest of the crate
 family.
+The shared fields above mirror the canonical `ars_core::ArsContext`; only
+`dioxus_platform` is adapter-specific.
 The Dioxus adapter resolves `platform` via feature flags: `WebPlatformEffects` (web),
 `DesktopPlatformEffects` (desktop), `NullPlatformEffects` (SSR/tests/mobile fallback).
 
 ### 16.1 use_locale()
 
 All ArsProvider fallback helpers in this section (`use_locale()`,
-`use_intl_backend()`, `t()`, and `use_platform()`) route through
+`use_intl_backend()`, `use_modality_context()`, `t()`, and `use_platform()`) route through
 `warn_missing_provider()`. That helper emits `log::warn!` only when the
 `ars-dioxus/debug` feature is enabled.
 


### PR DESCRIPTION
## Summary
- align the core `ArsContext` with the provider/i18n contract by carrying `intl_backend` and `i18n_registries`
- expose modality context through the Leptos and Dioxus adapter providers and keep the adapter specs in sync
- make `Service::set_props()` process prop-sync events ahead of queued user input and cover the ordering with tests

## Validation
- `cargo xci`

Closes #193
Closes #213
Closes #2