### PR TITLE
Implement xtask CI enforcement checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,28 @@ jobs:
       - name: Adapter Tests
         run: cargo xtest adapter
 
+  adapter-parity:
+    name: Adapter Parity
+    needs: [unit, adapter]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Adapter Parity
+        run: cargo xtask ci adapter-parity
+
+  error-variant-coverage:
+    name: Error Variant Coverage
+    needs: [unit]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Error Variant Coverage
+        run: cargo xtask ci error-variant-coverage
+
   coverage:
     name: Coverage
     needs: [unit]
@@ -207,6 +229,8 @@ jobs:
       - uses: ./.github/actions/install-dioxus-desktop-deps
       - name: Coverage
         run: cargo xtask ci coverage
+      - name: Snapshot Count
+        run: cargo xtask ci snapshot-count
       - name: Upload to Codecov
         if: always()
         uses: codecov/codecov-action@v4

--- a/crates/ars-core/src/error.rs
+++ b/crates/ars-core/src/error.rs
@@ -1,0 +1,211 @@
+//! Standard component misuse errors.
+
+use alloc::{string::String, vec::Vec};
+use core::fmt::{self, Display};
+
+/// Standardized error type for ars-ui component API misuse.
+///
+/// Components use this error for recoverable developer-facing misuse such as
+/// missing IDs, blocked disabled interactions, invalid prop combinations, and
+/// invalid state-machine requests.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ComponentError {
+    /// A required component part ID was not provided.
+    MissingId {
+        /// Component name that rejected the props.
+        component: &'static str,
+
+        /// Component part missing an ID.
+        part: &'static str,
+    },
+
+    /// A disabled component received an event that should have been blocked.
+    DisabledGate {
+        /// Component name that rejected the event.
+        component: &'static str,
+
+        /// Event name that was sent while disabled.
+        event: String,
+    },
+
+    /// Two or more props conflict and cannot be used together.
+    InvalidPropCombination {
+        /// Component name that rejected the prop combination.
+        component: &'static str,
+
+        /// Props that conflict with each other.
+        props: Vec<&'static str>,
+
+        /// Actionable reason the combination is invalid.
+        reason: String,
+    },
+
+    /// A state machine received an event that violates its protocol.
+    InvalidStateTransition {
+        /// Component name whose state machine rejected the event.
+        component: &'static str,
+
+        /// Current state at the time of rejection.
+        current_state: String,
+
+        /// Event name that is invalid for the current state.
+        event: String,
+    },
+
+    /// A lifetime or ownership constraint was violated.
+    LifetimeViolation {
+        /// Component name that detected the lifetime violation.
+        component: &'static str,
+
+        /// Actionable reason the lifetime contract was violated.
+        reason: String,
+    },
+}
+
+impl Display for ComponentError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingId { component, part } => write!(
+                f,
+                "[ars-ui:{component}] Missing required `id` on part `{part}`. \
+                 Provide an explicit ID or use the default ID generation."
+            ),
+
+            Self::DisabledGate { component, event } => write!(
+                f,
+                "[ars-ui:{component}] Event `{event}` was sent to a disabled component. \
+                 Check `disabled` prop before dispatching."
+            ),
+
+            Self::InvalidPropCombination {
+                component,
+                props,
+                reason,
+            } => write!(
+                f,
+                "[ars-ui:{component}] Invalid prop combination {props:?}: {reason}"
+            ),
+
+            Self::InvalidStateTransition {
+                component,
+                current_state,
+                event,
+            } => write!(
+                f,
+                "[ars-ui:{component}] Cannot handle `{event}` in state `{current_state}`. \
+                 This is likely a bug in event dispatch logic."
+            ),
+
+            Self::LifetimeViolation { component, reason } => {
+                write!(f, "[ars-ui:{component}] Lifetime violation: {reason}")
+            }
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl core::error::Error for ComponentError {}
+
+#[cfg(test)]
+mod tests {
+    use alloc::{string::ToString, vec};
+
+    use super::ComponentError;
+
+    #[test]
+    fn component_error_missing_id_display_is_actionable() {
+        let error = ComponentError::MissingId {
+            component: "Dialog",
+            part: "root",
+        };
+
+        assert!(matches!(
+            error,
+            ComponentError::MissingId {
+                component: "Dialog",
+                part: "root"
+            }
+        ));
+        assert!(error.to_string().contains("[ars-ui:Dialog]"));
+        assert!(error.to_string().contains("Missing required `id`"));
+        assert!(error.to_string().contains("Provide an explicit ID"));
+    }
+
+    #[test]
+    fn component_error_disabled_gate_display_is_actionable() {
+        let error = ComponentError::DisabledGate {
+            component: "Button",
+            event: "press".to_string(),
+        };
+
+        assert!(matches!(
+            error,
+            ComponentError::DisabledGate {
+                component: "Button",
+                ..
+            }
+        ));
+        assert!(error.to_string().contains("[ars-ui:Button]"));
+        assert!(error.to_string().contains("disabled component"));
+        assert!(error.to_string().contains("Check `disabled` prop"));
+    }
+
+    #[test]
+    fn component_error_invalid_prop_combination_display_is_actionable() {
+        let error = ComponentError::InvalidPropCombination {
+            component: "Select",
+            props: vec!["open", "default_open"],
+            reason: "controlled and uncontrolled open state cannot both be set".to_string(),
+        };
+
+        assert!(matches!(
+            error,
+            ComponentError::InvalidPropCombination {
+                component: "Select",
+                ..
+            }
+        ));
+        assert!(error.to_string().contains("[ars-ui:Select]"));
+        assert!(error.to_string().contains("Invalid prop combination"));
+        assert!(error.to_string().contains("controlled and uncontrolled"));
+    }
+
+    #[test]
+    fn component_error_invalid_state_transition_display_is_actionable() {
+        let error = ComponentError::InvalidStateTransition {
+            component: "Dialog",
+            current_state: "Closed".to_string(),
+            event: "Close".to_string(),
+        };
+
+        assert!(matches!(
+            error,
+            ComponentError::InvalidStateTransition {
+                component: "Dialog",
+                ..
+            }
+        ));
+        assert!(error.to_string().contains("[ars-ui:Dialog]"));
+        assert!(error.to_string().contains("Cannot handle `Close`"));
+        assert!(error.to_string().contains("state `Closed`"));
+    }
+
+    #[test]
+    fn component_error_lifetime_violation_display_is_actionable() {
+        let error = ComponentError::LifetimeViolation {
+            component: "Tooltip",
+            reason: "service was used after unmount".to_string(),
+        };
+
+        assert!(matches!(
+            error,
+            ComponentError::LifetimeViolation {
+                component: "Tooltip",
+                ..
+            }
+        ));
+        assert!(error.to_string().contains("[ars-ui:Tooltip]"));
+        assert!(error.to_string().contains("Lifetime violation"));
+        assert!(error.to_string().contains("after unmount"));
+    }
+}

--- a/crates/ars-core/src/lib.rs
+++ b/crates/ars-core/src/lib.rs
@@ -15,6 +15,7 @@
 //! - [`PendingEffect`] — named side effect with setup closure and cleanup lifecycle
 //! - [`Callback`] — shared callback wrapper built on [`Arc`]
 //! - [`ComponentIds`] — adapter-provided base IDs expanded into stable part IDs
+//! - [`ComponentError`] — standardized recoverable component misuse errors
 //! - [`SafeUrl`] — validated URL type for URL-valued HTML attributes
 //! - [`SharedState`] — shared interior-mutable state (`Rc<RefCell>` on wasm, `Arc<Mutex>` on native)
 //! - [`WeakSend`] — weak event sender for safe effect cleanup
@@ -33,6 +34,7 @@ mod callback;
 pub mod companion_css;
 mod component_ids;
 mod connect;
+mod error;
 mod i18n_registry;
 mod message_fn;
 pub mod modality;
@@ -68,6 +70,7 @@ pub use connect::{
     AriaAttr, AttrMap, AttrMapParts, AttrValue, CssProperty, EventOptions, HtmlAttr, HtmlEvent,
     StyleStrategy, UserAttrs, data,
 };
+pub use error::ComponentError;
 pub use i18n_registry::{I18nRegistries, MessagesRegistry, resolve_messages};
 pub use message_fn::{ComponentMessages, MessageFn};
 // ── Modality ────────────────────────────────────────────────────────

--- a/crates/ars-core/tests/component_error.rs
+++ b/crates/ars-core/tests/component_error.rs
@@ -1,0 +1,100 @@
+//! Contract tests for standardized component misuse errors.
+
+use ars_core::ComponentError;
+
+#[test]
+fn component_error_missing_id_display_is_actionable() {
+    let error = ComponentError::MissingId {
+        component: "Dialog",
+        part: "root",
+    };
+
+    assert!(matches!(
+        error,
+        ComponentError::MissingId {
+            component: "Dialog",
+            part: "root"
+        }
+    ));
+    assert!(error.to_string().contains("[ars-ui:Dialog]"));
+    assert!(error.to_string().contains("Missing required `id`"));
+    assert!(error.to_string().contains("Provide an explicit ID"));
+}
+
+#[test]
+fn component_error_disabled_gate_display_is_actionable() {
+    let error = ComponentError::DisabledGate {
+        component: "Button",
+        event: "press".to_owned(),
+    };
+
+    assert!(matches!(
+        error,
+        ComponentError::DisabledGate {
+            component: "Button",
+            ..
+        }
+    ));
+    assert!(error.to_string().contains("[ars-ui:Button]"));
+    assert!(error.to_string().contains("disabled component"));
+    assert!(error.to_string().contains("Check `disabled` prop"));
+}
+
+#[test]
+fn component_error_invalid_prop_combination_display_is_actionable() {
+    let error = ComponentError::InvalidPropCombination {
+        component: "Select",
+        props: vec!["open", "default_open"],
+        reason: "controlled and uncontrolled open state cannot both be set".to_owned(),
+    };
+
+    assert!(matches!(
+        error,
+        ComponentError::InvalidPropCombination {
+            component: "Select",
+            ..
+        }
+    ));
+    assert!(error.to_string().contains("[ars-ui:Select]"));
+    assert!(error.to_string().contains("Invalid prop combination"));
+    assert!(error.to_string().contains("controlled and uncontrolled"));
+}
+
+#[test]
+fn component_error_invalid_state_transition_display_is_actionable() {
+    let error = ComponentError::InvalidStateTransition {
+        component: "Dialog",
+        current_state: "Closed".to_owned(),
+        event: "Close".to_owned(),
+    };
+
+    assert!(matches!(
+        error,
+        ComponentError::InvalidStateTransition {
+            component: "Dialog",
+            ..
+        }
+    ));
+    assert!(error.to_string().contains("[ars-ui:Dialog]"));
+    assert!(error.to_string().contains("Cannot handle `Close`"));
+    assert!(error.to_string().contains("state `Closed`"));
+}
+
+#[test]
+fn component_error_lifetime_violation_display_is_actionable() {
+    let error = ComponentError::LifetimeViolation {
+        component: "Tooltip",
+        reason: "service was used after unmount".to_owned(),
+    };
+
+    assert!(matches!(
+        error,
+        ComponentError::LifetimeViolation {
+            component: "Tooltip",
+            ..
+        }
+    ));
+    assert!(error.to_string().contains("[ars-ui:Tooltip]"));
+    assert!(error.to_string().contains("Lifetime violation"));
+    assert!(error.to_string().contains("after unmount"));
+}

--- a/crates/ars-dom/src/focus.rs
+++ b/crates/ars-dom/src/focus.rs
@@ -735,7 +735,7 @@ fn can_restore_focus_impl(id: &str) -> bool {
     get_html_element_by_id(id).is_some_and(|element| can_restore_html_element(&element))
 }
 
-#[cfg(any(not(feature = "web"), not(target_arch = "wasm32")))]
+#[cfg(all(feature = "web", not(target_arch = "wasm32")))]
 fn can_restore_focus_impl(_id: &str) -> bool {
     false
 }
@@ -761,7 +761,7 @@ fn nearest_focusable_ancestor_id_impl(id: &str) -> Option<String> {
     None
 }
 
-#[cfg(any(not(feature = "web"), not(target_arch = "wasm32")))]
+#[cfg(all(feature = "web", not(target_arch = "wasm32")))]
 fn nearest_focusable_ancestor_id_impl(_id: &str) -> Option<String> {
     None
 }

--- a/crates/ars-test-harness/src/lib.rs
+++ b/crates/ars-test-harness/src/lib.rs
@@ -2798,8 +2798,7 @@ mod tests {
     use std::{
         cell::Cell,
         rc::Rc,
-        sync::Arc,
-        task::{Context, Poll, Wake, Waker},
+        task::{Context, Poll, Waker},
     };
 
     use ars_core::{AttrValue, Env, HasId, HtmlAttr};
@@ -3073,20 +3072,12 @@ mod tests {
     }
 
     #[cfg(not(target_arch = "wasm32"))]
-    struct NoopWake;
-
-    #[cfg(not(target_arch = "wasm32"))]
-    impl Wake for NoopWake {
-        fn wake(self: Arc<Self>) {}
-    }
-
-    #[cfg(not(target_arch = "wasm32"))]
     fn run_ready<F: Future>(future: F) -> F::Output {
-        let waker = Waker::from(Arc::new(NoopWake));
+        let waker = Waker::noop();
 
         let mut future = std::pin::pin!(future);
 
-        let mut context = Context::from_waker(&waker);
+        let mut context = Context::from_waker(waker);
 
         match future.as_mut().poll(&mut context) {
             Poll::Ready(output) => output,
@@ -3416,10 +3407,9 @@ mod tests {
 
         assert!(pending_message.contains("Poll::Pending"));
 
-        let waker = Waker::from(Arc::new(NoopWake));
+        let waker = Waker::noop();
 
         waker.wake_by_ref();
-        waker.wake();
 
         assert!(format!("{:?}", MockClipboard {}).contains("MockClipboard"));
     }

--- a/spec/testing/13-policies.md
+++ b/spec/testing/13-policies.md
@@ -323,7 +323,10 @@ For each component (e.g., Checkbox, Select, Dialog):
 
 > See [14-ci.md](./14-ci.md) §6.1 for the lint specification — it must match this per-component granularity.
 
-Any component with zero integration tests in either adapter is a policy violation.
+Any component with integration tests in one adapter and zero integration tests
+in the other adapter is a policy violation. Components with zero integration
+tests in both adapters are reported as not-yet-implemented by the CI lint until
+adapter-level component coverage starts for that component.
 
 > CI enforcement: see [14-ci.md](14-ci.md#16-adapter-parity-enforcement).
 

--- a/spec/testing/13-policies.md
+++ b/spec/testing/13-policies.md
@@ -308,7 +308,7 @@ CI matrix entry: `cargo test -p ars-dom --features ssr`
 
 ### 2.4 Adapter Parity Enforcement Matrix
 
-Test parity between the Leptos and Dioxus adapters MUST be maintained to prevent one adapter from falling behind in coverage.
+Test-count parity between the Leptos and Dioxus adapters MUST be maintained to prevent one adapter from falling behind in coverage.
 
 **Per-Component Test Count Parity**:
 
@@ -319,37 +319,13 @@ For each component (e.g., Checkbox, Select, Dialog):
   |ars-leptos tests - ars-dioxus tests| <= 2  (tolerance for adapter-specific edge cases)
 ```
 
-`check_adapter_parity.sh` compares test counts per component (not total), with tolerance of |count_leptos - count_dioxus| <= 2 per component.
+`cargo xtask lint adapter-parity` compares test counts per component (not total), with tolerance of |count_leptos - count_dioxus| <= 2 per component.
 
-> See [14-ci.md](./14-ci.md) §6.1 for the script specification — it must match this per-component granularity.
+> See [14-ci.md](./14-ci.md) §6.1 for the lint specification — it must match this per-component granularity.
 
 Any component with zero integration tests in either adapter is a policy violation.
 
 > CI enforcement: see [14-ci.md](14-ci.md#16-adapter-parity-enforcement).
-
-**Snapshot Equivalence**: Both adapters MUST produce identical `AttrMap` snapshots for the same `Context` and `Props` combination:
-
-```rust
-#[test]
-fn attr_map_parity_checkbox() {
-    let props = CheckboxProps::default();
-    let leptos_attrs = ars_leptos::render_attrs::<Checkbox>(&props);
-    let dioxus_attrs = ars_dioxus::render_attrs::<Checkbox>(&props);
-    assert_eq!(leptos_attrs, dioxus_attrs, "AttrMap mismatch for Checkbox");
-}
-```
-
-This test MUST exist for every component and cover at least: default props, disabled state, and one interactive state (e.g., checked, open, selected).
-
-> **Scope:** Adapter parity for `render_attrs` output is enforced only for the `web` target
-> (both adapters rendering to browser DOM). SSR output and Dioxus Desktop are excluded from
-> snapshot equivalence checks, as they may legitimately differ (Leptos SSR adds hydration
-> markers, Dioxus Desktop has no DOM).
->
-> `render_attrs` is defined in each adapter crate: `ars_leptos::render_attrs()` and
-> `ars_dioxus::render_attrs()`. These functions convert an `AttrMap` to framework-specific
-> attribute representations. See [08-adapter-leptos.md](../foundation/08-adapter-leptos.md)
-> and [09-adapter-dioxus.md](../foundation/09-adapter-dioxus.md) for definitions.
 
 ---
 
@@ -365,16 +341,21 @@ This test MUST exist for every component and cover at least: default props, disa
 - **Warning threshold:** When total snapshot count exceeds 500, a CI warning is emitted.
 - **Per-component limit:** No single component should have more than 20 snapshot files. Components exceeding this should consolidate state variants.
 - **Quarterly audit:** Review snapshot growth each quarter. Prune snapshots for removed or significantly refactored components.
-- **New component budget:** Each new component starts with a budget of 3 snapshots per state variant × number of anatomy parts.
+- **Review budget guideline:** Each new component starts review with a snapshot plan of 3 snapshots per state variant × number of anatomy parts.
+- **CI floor:** Each component implementation file (`component.rs`) with more than two `State` variants must have at least 3 snapshots per state variant.
 
-Each component is budgeted a maximum of **20 snapshots**. The budget formula is:
+Each component is budgeted a maximum of **20 snapshots**. The review guideline formula is:
 
 `budget = min(3 × state_variants × anatomy_parts, 20)`
 
-Components exceeding 20 snapshots require explicit justification in PR review.
+Components exceeding 20 snapshots fail the snapshot-count lint and should
+consolidate state variants before merge.
 
-**Enforcement:** The `check_snapshot_count.py` script verifies per-component snapshot counts
-using a flat cap of 20. The script counts `*.snap` files per component directory.
+**Enforcement:** `cargo xtask lint snapshot-count` verifies per-component snapshot counts
+using the implementation-derived state-variant floor and a flat cap of 20. The lint
+counts `*.snap` files per component directory. The anatomy-part multiplier is a
+review guideline because anatomy parts are specified in component specs rather than
+implementation files.
 
 > **CI enforcement:** The snapshot count linting job in [14-ci.md section 2.4](14-ci.md#24-snapshot-count-linting) enforces both minimum (>= 3 per component variant) and maximum (<= 20 per component) bounds.
 
@@ -429,9 +410,7 @@ and those operational floors may temporarily lag the long-term targets below.
 
 > CI enforcement: see [14-ci.md](14-ci.md#2-coverage-pipeline).
 
-**Snapshot count enforcement**: Every component with more than two `State` variants MUST have
-at least 3 snapshot tests per variant. Components with fewer are flagged for review. The lint
-runs via `scripts/check_snapshot_count.py` and parses `*.snap` files in the test directory.
+**Snapshot count enforcement**: Every component implementation file (`component.rs`) with more than two `State` variants MUST have at least 3 snapshot tests per variant. Components with fewer fail the snapshot-count lint. The lint runs via `cargo xtask lint snapshot-count` and parses `*.snap` files in the test directory.
 
 > CI integration: see [14-ci.md](14-ci.md#24-snapshot-count-linting).
 

--- a/spec/testing/14-ci.md
+++ b/spec/testing/14-ci.md
@@ -304,21 +304,17 @@ That aggregate run prints:
 
 ### 1.7 Adapter Parity Enforcement
 
-The parity script validates per-component test counts and snapshot equivalence
-between the Leptos and Dioxus adapters. See [13-policies.md](13-policies.md) for
-the parity rules.
+The xtask parity lint validates per-component test counts between the Leptos and
+Dioxus adapters. See [13-policies.md](13-policies.md) for the parity rules.
 
 ```yaml
 adapter-parity:
     name: Adapter Parity
     runs-on: ubuntu-latest
-    needs: [core-tests, adapter-tests]
+    needs: [unit, adapter]
     steps:
         - uses: actions/checkout@v4
-        - run: bash scripts/check_adapter_parity.sh
-          env:
-              LEPTOS_TEST_DIR: crates/ars-leptos/tests
-              DIOXUS_TEST_DIR: crates/ars-dioxus/tests
+        - run: cargo xtask ci adapter-parity
 ```
 
 ### 1.7 Snapshot Change Check
@@ -520,12 +516,15 @@ Codecov is configured to:
 
 ### 2.4 Snapshot Count Linting
 
-The snapshot count lint verifies every component with more than two `State`
-variants has at least 3 snapshot tests per variant. See
+The snapshot count lint verifies every component implementation file
+(`component.rs`) with more than two `State` variants has at least 3 snapshot
+tests per variant. See
 [13-policies.md](13-policies.md#31-snapshot-count-budgeting) for the policy.
+The CI entrypoint scans the workspace `crates/` tree so component snapshots in
+subsystem crates are included.
 
 ```yaml
-- run: python3 scripts/check_snapshot_count.py --snapshots-dir crates/ars-core/tests/snapshots --min-per-variant 3 --max-per-component 20
+- run: cargo xtask ci snapshot-count
 ```
 
 ### 2.5 Error Variant Coverage
@@ -536,19 +535,15 @@ runs in the PR pipeline (not post-merge) to catch gaps before code lands.
 ```yaml
 error-coverage:
     name: Error Variant Coverage
-    needs: [core-tests]
+    needs: [unit]
     runs-on: ubuntu-latest
     steps:
         - uses: actions/checkout@v4
         - name: Error Variant Coverage
-          run: |
-              python3 scripts/check_error_variant_coverage.py \
-                --source-glob "crates/ars-core/src/**/*.rs" \
-                --test-glob "crates/ars-core/tests/**/*.rs" \
-                --enum-name "ComponentError"
+          run: cargo xtask ci error-variant-coverage
 ```
 
-#### 2.5.1 `scripts/check_error_variant_coverage.py`
+#### 2.5.1 `cargo xtask lint error-variant-coverage`
 
 **Purpose:** Verifies every `ComponentError` enum variant has at least one test exercising it.
 
@@ -792,20 +787,21 @@ coverage collection.
 | `cargo xtask coverage check`              | Ad-hoc single-crate coverage check for local development      | Developer               |
 | `cargo xtask coverage wasm`               | Generate experimental browser-test lcov for one wasm package  | Coverage pipeline       |
 | `cargo xtask coverage merge`              | Merge native and wasm lcov without double-counting records    | Coverage pipeline       |
-| `scripts/check_snapshot_count.py`         | Verify snapshot count per component state meets minimum       | Coverage pipeline       |
-| `scripts/check_adapter_parity.sh`         | Compare test counts and snapshot equivalence across adapters  | PR pipeline             |
-| `scripts/check_error_variant_coverage.py` | Verify every `ComponentError` variant has test coverage       | PR pipeline             |
+| `cargo xtask lint snapshot-count`         | Verify snapshot count per component state meets minimum       | Coverage pipeline       |
+| `cargo xtask lint adapter-parity`         | Compare per-component test counts across adapters             | PR pipeline             |
+| `cargo xtask lint error-variant-coverage` | Verify every `ComponentError` variant has test coverage       | PR pipeline             |
 
 All tools exit non-zero on failure, causing the CI job to fail.
 
-### 6.1 `scripts/check_adapter_parity.sh`
+### 6.1 `cargo xtask lint adapter-parity`
 
 **Purpose:** Verifies Leptos and Dioxus adapters have equivalent test coverage on a per-component basis.
 
 **Inputs:**
 
-- `LEPTOS_TEST_DIR`: Path to ars-leptos test directory (default: `crates/ars-leptos/tests`)
-- `DIOXUS_TEST_DIR`: Path to ars-dioxus test directory (default: `crates/ars-dioxus/tests`)
+- `--leptos-test-dir`: Path to ars-leptos test directory (default: `crates/ars-leptos/tests`)
+- `--dioxus-test-dir`: Path to ars-dioxus test directory (default: `crates/ars-dioxus/tests`)
+- `--tolerance`: Allowed per-component count delta (default: `2`)
 
 **Logic:**
 
@@ -814,64 +810,10 @@ All tools exit non-zero on failure, causing the CI job to fail.
 3. Compare per-component: `|leptos_count - dioxus_count| <= 2` (tolerance for adapter-specific edge cases)
 4. Flag any component with zero tests in either adapter as a violation
 
-**Reference implementation:**
-
-```bash
-#!/bin/bash
-# Adapter Parity Check — per-component comparison
-# Matches policy in 13-policies.md: per-component tolerance of |delta| <= 2
-
-LEPTOS_DIR="${LEPTOS_TEST_DIR:-crates/ars-leptos/tests}"
-DIOXUS_DIR="${DIOXUS_TEST_DIR:-crates/ars-dioxus/tests}"
-TOLERANCE=2
-FAILED=0
-
-# Extract component name from test filename.
-# Convention: test_{component}_{scenario}.rs where component may have underscores.
-# Use known component list for reliable extraction.
-KNOWN_COMPONENTS="accordion action_group alert_dialog angle_slider as_child aspect_ratio autocomplete avatar badge breadcrumbs button calendar carousel center checkbox checkbox_group client_only clipboard collapsible color_area color_field color_picker color_slider color_swatch color_swatch_picker color_wheel combobox context_menu contextual_help date_field date_picker date_range_field date_range_picker date_time_picker dialog dismissable download_trigger drawer drop_zone editable environment_provider field fieldset file_trigger file_upload floating_panel focus_ring focus_scope form frame grid grid_list group heading highlight hover_card image_cropper keyboard landmark link listbox live_region marquee menu menu_bar meter number_input pagination password_input pin_input popover portal presence progress qr_code radio_group range_calendar range_slider rating_group scroll_area search_input segment_group select separator signature_pad skeleton slider splitter stack stat steps swap switch table tabs tag_group tags_input text_field textarea time_field timer toast toggle toggle_button toggle_group toolbar tooltip tour tree_view visually_hidden z_index_allocator"
-# Generated from spec/manifest.toml — regenerate with:
-# rg '^\[components\.[^]]+\]$' spec/manifest.toml | sed -E 's/^\[components\.([^]]+)\]$/\1/' | tr '-' '_' | paste -sd' ' -
-
-extract_component() {
-    local file="$1"
-    local stem=$(basename "$file" .rs | sed 's/^test_//')
-    for comp in $KNOWN_COMPONENTS; do
-        if echo "$stem" | grep -q "^${comp}_\|^${comp}$"; then
-            echo "$comp"
-            return
-        fi
-    done
-    echo "$stem" | sed 's/_[^_]*$//'  # fallback: strip last segment
-}
-
-COMPONENTS=$(for f in $(find "$LEPTOS_DIR" "$DIOXUS_DIR" -name "test_*.rs"); do
-    extract_component "$f"
-done | sort -u)
-
-echo "Component           | Leptos | Dioxus | Delta | Status"
-echo "--------------------|--------|--------|-------|-------"
-
-for COMPONENT in $COMPONENTS; do
-    LEPTOS_COUNT=$(grep -c "#\[.*test\]" "$LEPTOS_DIR"/test_${COMPONENT}*.rs 2>/dev/null || echo 0)
-    DIOXUS_COUNT=$(grep -c "#\[.*test\]" "$DIOXUS_DIR"/test_${COMPONENT}*.rs 2>/dev/null || echo 0)
-    DELTA=$((LEPTOS_COUNT - DIOXUS_COUNT))
-    ABS_DELTA=${DELTA#-}
-
-    if [ "$ABS_DELTA" -gt "$TOLERANCE" ]; then
-        STATUS="FAIL"
-        FAILED=1
-    elif [ "$LEPTOS_COUNT" -eq 0 ] && [ "$DIOXUS_COUNT" -eq 0 ]; then
-        STATUS="SKIP"
-    else
-        STATUS="OK"
-    fi
-
-    printf "%-19s | %6d | %6d | %5d | %s\n" "$COMPONENT" "$LEPTOS_COUNT" "$DIOXUS_COUNT" "$DELTA" "$STATUS"
-done
-
-exit $FAILED
-```
+The Rust implementation derives known component names from `spec/manifest.toml`
+and treats components with no test files in either adapter as not yet
+implemented. Once either adapter has tests for a component, both adapters must
+have nonzero tests and the per-component delta must remain within tolerance.
 
 **Exit codes:** 0 = parity OK, 1 = parity violation
 

--- a/xtask/src/ci/mod.rs
+++ b/xtask/src/ci/mod.rs
@@ -13,7 +13,7 @@ use std::{
     process,
 };
 
-use crate::{coverage, i18n, test};
+use crate::{coverage, i18n, lint, test};
 
 const MUTUAL_EXCLUSION_GUARD: &str = "features `icu4x` and `web-intl` are mutually exclusive";
 
@@ -52,8 +52,17 @@ pub enum Step {
     /// Adapter harness tests (Leptos + Dioxus).
     Adapter,
 
+    /// Compare per-component test counts between adapters.
+    AdapterParity,
+
     /// Generate coverage and check per-crate thresholds.
     Coverage,
+
+    /// Enforce per-component snapshot-count policy.
+    SnapshotCount,
+
+    /// Verify every `ComponentError` variant appears in tests.
+    ErrorVariantCoverage,
 
     /// Meta-step: run all five feature-matrix groups.
     FeatureMatrix,
@@ -91,7 +100,10 @@ const PIPELINE_ORDER: &[Step] = &[
     Step::Release,
     Step::Integration,
     Step::Adapter,
+    Step::AdapterParity,
     Step::Coverage,
+    Step::SnapshotCount,
+    Step::ErrorVariantCoverage,
     Step::FeatureMatrixCore,
     Step::FeatureMatrixI18n,
     Step::FeatureMatrixSubsystems,
@@ -129,6 +141,9 @@ pub enum Error {
 
     /// Coverage threshold check failed.
     Coverage(coverage::Error),
+
+    /// Repository lint check failed.
+    Lint(lint::Error),
 }
 
 impl Display for Error {
@@ -158,6 +173,8 @@ impl Display for Error {
             Self::Io(e) => write!(f, "IO error: {e}"),
 
             Self::Coverage(e) => write!(f, "{e}"),
+
+            Self::Lint(e) => write!(f, "{e}"),
         }
     }
 }
@@ -249,7 +266,13 @@ fn run_step(step: Step, message_format: Option<&str>) -> Result<(), Error> {
 
         Step::Adapter => run_adapter(),
 
+        Step::AdapterParity => run_adapter_parity(),
+
         Step::Coverage => run_coverage(),
+
+        Step::SnapshotCount => run_snapshot_count(),
+
+        Step::ErrorVariantCoverage => run_error_variant_coverage(),
 
         Step::FeatureMatrix => {
             unreachable!("FeatureMatrix is expanded by resolve_steps")
@@ -425,6 +448,51 @@ fn run_integration() -> Result<(), Error> {
 
 fn run_adapter() -> Result<(), Error> {
     run_test_stage(Step::Adapter, test::Stage::Adapter)
+}
+
+fn run_adapter_parity() -> Result<(), Error> {
+    match lint::check_adapter_parity(&lint::AdapterParityOptions {
+        leptos_test_dir: PathBuf::from("crates/ars-leptos/tests"),
+        dioxus_test_dir: PathBuf::from("crates/ars-dioxus/tests"),
+        tolerance: 2,
+    }) {
+        Ok(output) => {
+            eprint!("{output}");
+            Ok(())
+        }
+
+        Err(error) => Err(Error::Lint(error)),
+    }
+}
+
+fn run_snapshot_count() -> Result<(), Error> {
+    match lint::check_snapshot_count(&lint::SnapshotCountOptions {
+        snapshots_dir: PathBuf::from("crates"),
+        min_per_variant: 3,
+        max_per_component: 20,
+    }) {
+        Ok(output) => {
+            eprint!("{output}");
+            Ok(())
+        }
+
+        Err(error) => Err(Error::Lint(error)),
+    }
+}
+
+fn run_error_variant_coverage() -> Result<(), Error> {
+    match lint::check_error_variant_coverage(&lint::ErrorVariantCoverageOptions {
+        source_glob: "crates/ars-core/src/**/*.rs".to_owned(),
+        test_glob: "crates/ars-core/tests/**/*.rs".to_owned(),
+        enum_name: "ComponentError".to_owned(),
+    }) {
+        Ok(output) => {
+            eprint!("{output}");
+            Ok(())
+        }
+
+        Err(error) => Err(Error::Lint(error)),
+    }
 }
 
 fn run_mutual_exclusion() -> Result<(), Error> {
@@ -696,7 +764,10 @@ const fn step_name(step: Step) -> &'static str {
         Step::Release => "release",
         Step::Integration => "integration",
         Step::Adapter => "adapter",
+        Step::AdapterParity => "adapter-parity",
         Step::Coverage => "coverage",
+        Step::SnapshotCount => "snapshot-count",
+        Step::ErrorVariantCoverage => "error-variant-coverage",
         Step::FeatureMatrix => "feature-matrix",
         Step::FeatureMatrixCore => "feature-matrix-core",
         Step::FeatureMatrixI18n => "feature-matrix-i18n",
@@ -822,7 +893,10 @@ mod tests {
             Step::Release,
             Step::Integration,
             Step::Adapter,
+            Step::AdapterParity,
             Step::Coverage,
+            Step::SnapshotCount,
+            Step::ErrorVariantCoverage,
             Step::FeatureMatrix,
             Step::FeatureMatrixCore,
             Step::FeatureMatrixI18n,

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod ci;
 pub mod coverage;
 pub(crate) mod i18n;
+pub mod lint;
 pub mod manifest;
 #[cfg(feature = "mcp")]
 pub mod mcp;

--- a/xtask/src/lint.rs
+++ b/xtask/src/lint.rs
@@ -131,13 +131,8 @@ pub fn check_adapter_parity(options: &AdapterParityOptions) -> Result<String, Er
     let leptos_counts = adapter_test_counts(&options.leptos_test_dir, &components)?;
     let dioxus_counts = adapter_test_counts(&options.dioxus_test_dir, &components)?;
 
-    let mut all_components = BTreeSet::new();
-
-    all_components.extend(leptos_counts.keys().cloned());
-    all_components.extend(dioxus_counts.keys().cloned());
-
     let (mut output, failures) = adapter_parity_report(
-        &all_components,
+        &components,
         &leptos_counts,
         &dioxus_counts,
         options.tolerance,
@@ -175,7 +170,9 @@ fn adapter_parity_report(
 
         let delta = leptos.abs_diff(dioxus);
 
-        let status = if leptos == 0 || dioxus == 0 {
+        let status = if leptos == 0 && dioxus == 0 {
+            "SKIP"
+        } else if leptos == 0 || dioxus == 0 {
             failures.push(format!(
                 "{component}: both adapters must have tests, leptos={leptos}, dioxus={dioxus}"
             ));
@@ -881,6 +878,17 @@ mod tests {
 
         assert_eq!(failures.len(), 1);
         assert!(failures[0].contains("both adapters must have tests"));
+    }
+
+    #[test]
+    fn adapter_parity_reports_manifest_components_with_no_tests_as_skipped() {
+        let components = BTreeSet::from(["button".to_owned()]);
+
+        let (output, failures) =
+            adapter_parity_report(&components, &BTreeMap::new(), &BTreeMap::new(), 2);
+
+        assert!(failures.is_empty());
+        assert!(output.contains("button | 0 | 0 | 0 | SKIP"));
     }
 
     #[test]

--- a/xtask/src/lint.rs
+++ b/xtask/src/lint.rs
@@ -1,0 +1,1062 @@
+//! CI lint checks for repository-level testing policy.
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt::{self, Display, Write as _},
+    fs, io,
+    path::{Path, PathBuf},
+};
+
+use regex::Regex;
+
+use crate::manifest;
+
+/// Options for adapter parity linting.
+#[derive(Debug, Clone)]
+pub struct AdapterParityOptions {
+    /// Directory containing Leptos adapter tests.
+    pub leptos_test_dir: PathBuf,
+
+    /// Directory containing Dioxus adapter tests.
+    pub dioxus_test_dir: PathBuf,
+
+    /// Maximum allowed per-component test-count delta.
+    pub tolerance: usize,
+}
+
+/// Options for snapshot-count linting.
+#[derive(Debug, Clone)]
+pub struct SnapshotCountOptions {
+    /// Directory tree containing `.snap` files.
+    pub snapshots_dir: PathBuf,
+
+    /// Minimum snapshot count per detected state variant.
+    pub min_per_variant: usize,
+
+    /// Maximum snapshot count per component before failure.
+    pub max_per_component: usize,
+}
+
+/// Options for error-variant coverage linting.
+#[derive(Debug, Clone)]
+pub struct ErrorVariantCoverageOptions {
+    /// Glob selecting Rust source files containing the enum.
+    pub source_glob: String,
+
+    /// Glob selecting Rust test files to inspect.
+    pub test_glob: String,
+
+    /// Enum name whose variants must be exercised.
+    pub enum_name: String,
+}
+
+/// Errors from lint checks.
+#[derive(Debug)]
+pub enum Error {
+    /// IO error reading repository files.
+    Io(io::Error),
+
+    /// Regex compilation error.
+    Regex(regex::Error),
+
+    /// Spec manifest operation failed.
+    Manifest(manifest::Error),
+
+    /// The requested enum was not found in any matched source file.
+    EnumNotFound {
+        /// Enum name requested by the caller.
+        enum_name: String,
+    },
+
+    /// One or more lint checks failed.
+    Failed {
+        /// Human-readable failure report.
+        summary: String,
+    },
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(error) => write!(f, "IO error: {error}"),
+            Self::Regex(error) => write!(f, "regex error: {error}"),
+            Self::Manifest(error) => write!(f, "{error}"),
+            Self::EnumNotFound { enum_name } => {
+                write!(
+                    f,
+                    "enum `{enum_name}` was not found in matched source files"
+                )
+            }
+            Self::Failed { summary } => write!(f, "{summary}"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl From<io::Error> for Error {
+    fn from(error: io::Error) -> Self {
+        Self::Io(error)
+    }
+}
+
+impl From<regex::Error> for Error {
+    fn from(error: regex::Error) -> Self {
+        Self::Regex(error)
+    }
+}
+
+impl From<manifest::Error> for Error {
+    fn from(error: manifest::Error) -> Self {
+        Self::Manifest(error)
+    }
+}
+
+/// Run the adapter parity lint.
+///
+/// # Errors
+///
+/// Returns [`Error::Failed`] when implemented components diverge beyond the
+/// configured tolerance.
+pub fn check_adapter_parity(options: &AdapterParityOptions) -> Result<String, Error> {
+    let root = manifest::SpecRoot::discover(&std::env::current_dir()?)?;
+
+    let components = root
+        .manifest
+        .components
+        .keys()
+        .map(|name| name.replace('-', "_"))
+        .collect::<BTreeSet<_>>();
+
+    let leptos_counts = adapter_test_counts(&options.leptos_test_dir, &components)?;
+    let dioxus_counts = adapter_test_counts(&options.dioxus_test_dir, &components)?;
+
+    let mut all_components = BTreeSet::new();
+
+    all_components.extend(leptos_counts.keys().cloned());
+    all_components.extend(dioxus_counts.keys().cloned());
+
+    let (mut output, failures) = adapter_parity_report(
+        &all_components,
+        &leptos_counts,
+        &dioxus_counts,
+        options.tolerance,
+    );
+
+    if failures.is_empty() {
+        Ok(output)
+    } else {
+        output.push_str("\nAdapter parity violations:\n");
+
+        for failure in &failures {
+            writeln!(output, "- {failure}").expect("write to string");
+        }
+
+        Err(Error::Failed { summary: output })
+    }
+}
+
+fn adapter_parity_report(
+    components: &BTreeSet<String>,
+    leptos_counts: &BTreeMap<String, usize>,
+    dioxus_counts: &BTreeMap<String, usize>,
+    tolerance: usize,
+) -> (String, Vec<String>) {
+    let mut output = String::from("Component | Leptos | Dioxus | Delta | Status\n");
+
+    output.push_str("----------|--------|--------|-------|-------\n");
+
+    let mut failures = Vec::new();
+
+    for component in components {
+        let leptos = leptos_counts.get(component).copied().unwrap_or(0);
+
+        let dioxus = dioxus_counts.get(component).copied().unwrap_or(0);
+
+        let delta = leptos.abs_diff(dioxus);
+
+        let status = if leptos == 0 || dioxus == 0 {
+            failures.push(format!(
+                "{component}: both adapters must have tests, leptos={leptos}, dioxus={dioxus}"
+            ));
+            "FAIL"
+        } else if delta > tolerance {
+            failures.push(format!(
+                "{component}: leptos={leptos}, dioxus={dioxus}, delta={delta}, tolerance={tolerance}"
+            ));
+            "FAIL"
+        } else {
+            "OK"
+        };
+
+        writeln!(
+            output,
+            "{component} | {leptos} | {dioxus} | {delta} | {status}"
+        )
+        .expect("write to string");
+    }
+
+    (output, failures)
+}
+
+/// Run the snapshot count lint.
+///
+/// # Errors
+///
+/// Returns [`Error::Failed`] when detected stateful components have fewer than
+/// the required snapshot count.
+pub fn check_snapshot_count(options: &SnapshotCountOptions) -> Result<String, Error> {
+    let snapshots = collect_files(&options.snapshots_dir, |path| {
+        path.extension()
+            .is_some_and(|extension| extension == "snap")
+    })?;
+
+    let total_snapshots = snapshots.len();
+
+    let mut counts = BTreeMap::<String, usize>::new();
+
+    for snapshot in snapshots {
+        if let Some(component) = infer_snapshot_component(&snapshot) {
+            *counts.entry(component).or_insert(0) += 1;
+        }
+    }
+
+    let state_variants = detect_state_variants(&workspace_root_for(&options.snapshots_dir))?;
+    let mut output = String::from("Component | Snapshots | State variants | Required | Status\n");
+
+    output.push_str("----------|-----------|----------------|----------|-------\n");
+
+    let mut components = BTreeSet::new();
+
+    components.extend(counts.keys().cloned());
+    components.extend(
+        state_variants
+            .iter()
+            .filter_map(|(component, variants)| (*variants > 2).then_some(component.clone())),
+    );
+
+    let mut failures = Vec::new();
+    let mut warnings = Vec::new();
+
+    if total_snapshots > 500 {
+        warnings.push(format!(
+            "total snapshots={total_snapshots}, warning threshold=500"
+        ));
+    }
+
+    for component in components {
+        let count = counts.get(&component).copied().unwrap_or(0);
+
+        let variants = state_variants.get(&component).copied().unwrap_or(0);
+
+        let required = if variants > 2 {
+            variants * options.min_per_variant
+        } else {
+            0
+        };
+
+        let mut status = "OK";
+
+        if required > 0 && count < required {
+            failures.push(format!(
+                "{component}: snapshots={count}, state_variants={variants}, required={required}"
+            ));
+
+            status = "FAIL";
+        }
+
+        if count > options.max_per_component {
+            failures.push(format!(
+                "{component}: snapshots={count}, max={}",
+                options.max_per_component
+            ));
+
+            status = "FAIL";
+        }
+
+        writeln!(
+            output,
+            "{component} | {count} | {variants} | {required} | {status}"
+        )
+        .expect("write to string");
+    }
+
+    if !warnings.is_empty() {
+        output.push_str("\nSnapshot count warnings:\n");
+
+        for warning in &warnings {
+            writeln!(output, "- {warning}").expect("write to string");
+        }
+    }
+
+    if failures.is_empty() {
+        Ok(output)
+    } else {
+        output.push_str("\nSnapshot count violations:\n");
+
+        for failure in &failures {
+            writeln!(output, "- {failure}").expect("write to string");
+        }
+
+        Err(Error::Failed { summary: output })
+    }
+}
+
+/// Run the error-variant coverage lint.
+///
+/// # Errors
+///
+/// Returns [`Error::Failed`] when one or more enum variants do not appear in a
+/// test function body.
+pub fn check_error_variant_coverage(
+    options: &ErrorVariantCoverageOptions,
+) -> Result<String, Error> {
+    let source_files = files_matching_glob(&options.source_glob)?;
+
+    let test_files = files_matching_glob(&options.test_glob)?;
+
+    let variants = parse_enum_variants(&source_files, &options.enum_name)?;
+
+    let test_bodies = parse_test_bodies(&test_files)?;
+
+    let mut uncovered = Vec::new();
+
+    for variant in &variants {
+        if !test_bodies.iter().any(|body| body.contains(variant)) {
+            uncovered.push(variant.clone());
+        }
+    }
+
+    let mut output = format!(
+        "Error variant coverage for `{}`: {} variants, {} test functions\n",
+        options.enum_name,
+        variants.len(),
+        test_bodies.len()
+    );
+
+    if uncovered.is_empty() {
+        output.push_str("All variants are covered.\n");
+
+        Ok(output)
+    } else {
+        output.push_str("Uncovered variants:\n");
+
+        for variant in &uncovered {
+            writeln!(output, "- {variant}").expect("write to string");
+        }
+
+        Err(Error::Failed { summary: output })
+    }
+}
+
+fn adapter_test_counts(
+    dir: &Path,
+    known_components: &BTreeSet<String>,
+) -> Result<BTreeMap<String, usize>, Error> {
+    if !dir.exists() {
+        return Ok(BTreeMap::new());
+    }
+
+    let test_attr = Regex::new(r"#\[\s*(?:wasm_bindgen_)?test\s*\]")?;
+
+    let files = collect_files(dir, |path| {
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.starts_with("test_") && name.ends_with(".rs"))
+    })?;
+
+    let mut counts = BTreeMap::new();
+
+    for file in files {
+        let Some(component) = extract_component_from_test_file(&file, known_components) else {
+            continue;
+        };
+
+        let content = fs::read_to_string(&file)?;
+
+        let count = test_attr.find_iter(&content).count();
+
+        *counts.entry(component).or_insert(0) += count;
+    }
+
+    Ok(counts)
+}
+
+fn extract_component_from_test_file(
+    path: &Path,
+    known_components: &BTreeSet<String>,
+) -> Option<String> {
+    let stem = path.file_stem()?.to_str()?.strip_prefix("test_")?;
+    known_components
+        .iter()
+        .filter(|component| {
+            stem == component.as_str() || stem.starts_with(&format!("{component}_"))
+        })
+        .max_by_key(|component| component.len())
+        .cloned()
+        .or_else(|| {
+            stem.rsplit_once('_')
+                .map(|(component, _)| component.to_owned())
+        })
+}
+
+fn infer_snapshot_component(path: &Path) -> Option<String> {
+    for ancestor in path.ancestors() {
+        if ancestor.file_name().and_then(|name| name.to_str()) == Some("snapshots")
+            && let Some(parent) = ancestor.parent()
+            && let Some(component) = parent.file_name().and_then(|name| name.to_str())
+            && component != "tests"
+            && component != "src"
+        {
+            return Some(component.replace('-', "_"));
+        }
+    }
+
+    let stem = path.file_stem()?.to_str()?;
+
+    let compact = stem.split("__").collect::<Vec<_>>();
+
+    if compact
+        .first()
+        .is_some_and(|crate_name| crate_name.starts_with("ars_"))
+        && let Some(component) = compact.get(1)
+    {
+        return Some((*component).replace('-', "_"));
+    }
+
+    compact
+        .windows(2)
+        .find_map(|parts| (parts[1] == "component").then(|| parts[0].replace('-', "_")))
+        .or_else(|| stem.split("__").next().map(|name| name.replace('-', "_")))
+}
+
+fn detect_state_variants(root: &Path) -> Result<BTreeMap<String, usize>, Error> {
+    let enum_start = Regex::new(r"(?m)^\s*(?:pub(?:\([^)]*\))?\s+)?enum\s+State\s*\{")?;
+
+    let variant = Regex::new(r"^\s*([A-Z][A-Za-z0-9_]*)\s*(?:[{(,]|$)")?;
+
+    let files = collect_files(root, |path| {
+        path.extension().is_some_and(|extension| extension == "rs")
+            && path.file_name().is_some_and(|name| name == "component.rs")
+            && path
+                .components()
+                .any(|component| component.as_os_str() == "src")
+            && !path
+                .components()
+                .any(|component| component.as_os_str() == "target")
+    })?;
+
+    let mut variants = BTreeMap::new();
+
+    for file in files {
+        let content = fs::read_to_string(&file)?;
+
+        if enum_start.find(&content).is_none() {
+            continue;
+        }
+
+        let Some(component) = infer_source_component(&file) else {
+            continue;
+        };
+
+        let count = parse_state_variant_count(&content, &variant);
+
+        if count > 0 {
+            variants
+                .entry(component)
+                .and_modify(|existing: &mut usize| *existing = (*existing).max(count))
+                .or_insert(count);
+        }
+    }
+
+    Ok(variants)
+}
+
+fn parse_state_variant_count(content: &str, variant: &Regex) -> usize {
+    let Some(start) = content.find("enum State") else {
+        return 0;
+    };
+
+    let Some(open_offset) = content[start..].find('{') else {
+        return 0;
+    };
+
+    let body_start = start + open_offset + 1;
+
+    let mut depth = 1usize;
+
+    let mut end = body_start;
+
+    for (offset, ch) in content[body_start..].char_indices() {
+        match ch {
+            '{' => depth += 1,
+
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    end = body_start + offset;
+                    break;
+                }
+            }
+
+            _ => {}
+        }
+    }
+
+    content[body_start..end]
+        .lines()
+        .filter(|line| variant.is_match(line.trim()))
+        .count()
+}
+
+fn infer_source_component(path: &Path) -> Option<String> {
+    let mut parts = path.components().peekable();
+
+    while let Some(part) = parts.next() {
+        if part.as_os_str() == "src" {
+            return parts
+                .next()
+                .and_then(|component| {
+                    let path = Path::new(component.as_os_str());
+
+                    if path.extension().is_some_and(|extension| extension == "rs") {
+                        path.file_stem()
+                    } else {
+                        path.file_name()
+                    }
+                    .and_then(|name| name.to_str())
+                    .map(str::to_owned)
+                })
+                .or_else(|| {
+                    path.parent()
+                        .and_then(Path::file_name)
+                        .and_then(|name| name.to_str())
+                        .map(str::to_owned)
+                });
+        }
+    }
+
+    None
+}
+
+fn workspace_root_for(path: &Path) -> PathBuf {
+    let mut root = PathBuf::new();
+
+    for component in path.components() {
+        if component.as_os_str() == "crates" {
+            return if root.as_os_str().is_empty() {
+                PathBuf::from(".")
+            } else {
+                root
+            };
+        }
+
+        root.push(component.as_os_str());
+    }
+
+    PathBuf::from(".")
+}
+
+fn parse_enum_variants(files: &[PathBuf], enum_name: &str) -> Result<Vec<String>, Error> {
+    let enum_start = Regex::new(&format!(
+        r"(?m)^\s*(?:pub(?:\([^)]*\))?\s+)?enum\s+{}\s*\{{",
+        regex::escape(enum_name)
+    ))?;
+
+    let variant = Regex::new(r"^\s+(\w+)\s*[{(,]")?;
+
+    let mut parsed = BTreeSet::new();
+
+    let mut found = false;
+
+    for file in files {
+        let content = fs::read_to_string(file)?;
+
+        let Some(start_match) = enum_start.find(&content) else {
+            continue;
+        };
+
+        found = true;
+
+        let body_start = start_match.end();
+
+        let mut depth = 1usize;
+
+        let mut body_end = body_start;
+
+        for (offset, ch) in content[body_start..].char_indices() {
+            match ch {
+                '{' => depth += 1,
+
+                '}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        body_end = body_start + offset;
+                        break;
+                    }
+                }
+
+                _ => {}
+            }
+        }
+
+        for line in content[body_start..body_end].lines() {
+            if let Some(captures) = variant.captures(line) {
+                parsed.insert(captures[1].to_owned());
+            }
+        }
+    }
+
+    if !found {
+        return Err(Error::EnumNotFound {
+            enum_name: enum_name.to_owned(),
+        });
+    }
+
+    Ok(parsed.into_iter().collect())
+}
+
+fn parse_test_bodies(files: &[PathBuf]) -> Result<Vec<String>, Error> {
+    let test_attr = Regex::new(r"#\[\s*test\s*\]")?;
+
+    let fn_start = Regex::new(r"fn\s+\w+\s*\([^)]*\)\s*\{")?;
+
+    let mut bodies = Vec::new();
+
+    for file in files {
+        let content = fs::read_to_string(file)?;
+
+        for attr_match in test_attr.find_iter(&content) {
+            let Some(fn_match) = fn_start.find(&content[attr_match.end()..]) else {
+                continue;
+            };
+
+            let body_start = attr_match.end() + fn_match.end();
+
+            if let Some(body) = balanced_body(&content[body_start..]) {
+                bodies.push(body.to_owned());
+            }
+        }
+    }
+
+    Ok(bodies)
+}
+
+fn balanced_body(content: &str) -> Option<&str> {
+    let mut depth = 1usize;
+
+    for (offset, ch) in content.char_indices() {
+        match ch {
+            '{' => depth += 1,
+
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(&content[..offset]);
+                }
+            }
+
+            _ => {}
+        }
+    }
+
+    None
+}
+
+fn files_matching_glob(pattern: &str) -> Result<Vec<PathBuf>, Error> {
+    let regex = Regex::new(&format!("^{}$", glob_to_regex(pattern)))?;
+
+    let root = glob_root(pattern);
+
+    collect_files(&root, |path| {
+        let normalized = normalize_path(path);
+
+        regex.is_match(&normalized)
+    })
+}
+
+fn glob_root(pattern: &str) -> PathBuf {
+    let wildcard = pattern
+        .char_indices()
+        .find(|(_, ch)| matches!(ch, '*' | '?' | '['))
+        .map_or(pattern.len(), |(idx, _)| idx);
+
+    let prefix = &pattern[..wildcard];
+
+    let root = prefix.rsplit_once('/').map_or(".", |(root, _)| root);
+
+    if root.is_empty() {
+        PathBuf::from(".")
+    } else {
+        PathBuf::from(root)
+    }
+}
+
+fn glob_to_regex(pattern: &str) -> String {
+    let mut out = String::new();
+
+    let mut chars = pattern.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        match ch {
+            '*' if chars.peek() == Some(&'*') => {
+                chars.next();
+
+                if chars.peek() == Some(&'/') {
+                    chars.next();
+
+                    out.push_str("(?:.*/)?");
+                } else {
+                    out.push_str(".*");
+                }
+            }
+
+            '*' => out.push_str("[^/]*"),
+
+            '?' => out.push_str("[^/]"),
+
+            '/' => out.push('/'),
+
+            other => out.push_str(&regex::escape(&other.to_string())),
+        }
+    }
+
+    out
+}
+
+fn collect_files(
+    root: &Path,
+    mut include: impl FnMut(&Path) -> bool,
+) -> Result<Vec<PathBuf>, Error> {
+    let mut files = Vec::new();
+
+    if !root.exists() {
+        return Ok(files);
+    }
+
+    collect_files_inner(root, &mut include, &mut files)?;
+
+    files.sort();
+
+    Ok(files)
+}
+
+fn collect_files_inner(
+    root: &Path,
+    include: &mut impl FnMut(&Path) -> bool,
+    files: &mut Vec<PathBuf>,
+) -> Result<(), Error> {
+    for entry in fs::read_dir(root)? {
+        let entry = entry?;
+
+        let path = entry.path();
+
+        if path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| matches!(name, "target" | ".git"))
+        {
+            continue;
+        }
+
+        if path.is_dir() {
+            collect_files_inner(&path, include, files)?;
+        } else if include(&path) {
+            files.push(path);
+        }
+    }
+
+    Ok(())
+}
+
+fn normalize_path(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        fs,
+        path::{Path, PathBuf},
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    use super::*;
+
+    fn temp_dir(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock before epoch")
+            .as_nanos();
+
+        let path = std::env::temp_dir().join(format!("ars-ui-lint-{name}-{nanos}"));
+
+        fs::create_dir_all(&path).expect("create temp dir");
+
+        path
+    }
+
+    fn write(path: &Path, content: &str) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("create parent dir");
+        }
+
+        fs::write(path, content).expect("write file");
+    }
+
+    #[test]
+    fn adapter_parity_counts_equal_tests() {
+        let root = temp_dir("adapter-pass");
+
+        let leptos = root.join("leptos");
+        let dioxus = root.join("dioxus");
+
+        write(
+            &leptos.join("test_button_basic.rs"),
+            "#[test]\nfn one() {}\n#[wasm_bindgen_test]\nfn two() {}\n",
+        );
+
+        write(
+            &dioxus.join("test_button_basic.rs"),
+            "#[test]\nfn one() {}\n#[wasm_bindgen_test]\nfn two() {}\n",
+        );
+
+        let components = BTreeSet::from(["button".to_owned()]);
+
+        let leptos_counts = adapter_test_counts(&leptos, &components).expect("leptos counts");
+        let dioxus_counts = adapter_test_counts(&dioxus, &components).expect("dioxus counts");
+
+        assert_eq!(leptos_counts["button"], 2);
+        assert_eq!(dioxus_counts["button"], 2);
+
+        drop(fs::remove_dir_all(root));
+    }
+
+    #[test]
+    fn adapter_parity_handles_missing_test_directories() {
+        let root = temp_dir("adapter-missing");
+
+        let counts =
+            adapter_test_counts(&root.join("missing"), &BTreeSet::new()).expect("missing counts");
+
+        assert!(counts.is_empty());
+
+        drop(fs::remove_dir_all(root));
+    }
+
+    #[test]
+    fn adapter_parity_reports_divergent_counts() {
+        let root = temp_dir("adapter-fail");
+
+        let leptos = root.join("leptos");
+        let dioxus = root.join("dioxus");
+
+        write(
+            &leptos.join("test_dialog_basic.rs"),
+            "#[test]\nfn one() {}\n#[test]\nfn two() {}\n#[test]\nfn three() {}\n",
+        );
+        write(&dioxus.join("test_dialog_basic.rs"), "");
+
+        let components = BTreeSet::from(["dialog".to_owned()]);
+
+        let leptos_counts = adapter_test_counts(&leptos, &components).expect("leptos counts");
+        let dioxus_counts = adapter_test_counts(&dioxus, &components).expect("dioxus counts");
+
+        assert!(leptos_counts["dialog"].abs_diff(dioxus_counts["dialog"]) > 2);
+
+        drop(fs::remove_dir_all(root));
+    }
+
+    #[test]
+    fn adapter_parity_reports_one_sided_zero_counts() {
+        let components = BTreeSet::from(["dialog".to_owned()]);
+
+        let leptos_counts = BTreeMap::from([("dialog".to_owned(), 1)]);
+        let dioxus_counts = BTreeMap::new();
+
+        let (_output, failures) =
+            adapter_parity_report(&components, &leptos_counts, &dioxus_counts, 2);
+
+        assert_eq!(failures.len(), 1);
+        assert!(failures[0].contains("both adapters must have tests"));
+    }
+
+    #[test]
+    fn snapshot_count_passes_when_budget_is_met() {
+        let root = temp_dir("snapshot-pass");
+
+        for idx in 0..9 {
+            write(
+                &root.join(format!(
+                    "crates/demo/src/widget/snapshots/widget_{idx}.snap"
+                )),
+                "snapshot",
+            );
+        }
+
+        write(
+            &root.join("crates/demo/src/widget/component.rs"),
+            "pub enum State {\n    Idle,\n    Open,\n    Closed,\n}\n",
+        );
+
+        let state_variants = detect_state_variants(&root).expect("state variants");
+
+        assert_eq!(state_variants["widget"], 3);
+
+        drop(fs::remove_dir_all(root));
+    }
+
+    #[test]
+    fn snapshot_count_detects_undercovered_component() {
+        let root = temp_dir("snapshot-fail");
+
+        for idx in 0..2 {
+            write(
+                &root.join(format!("crates/demo/src/field/snapshots/field_{idx}.snap")),
+                "snapshot",
+            );
+        }
+
+        write(
+            &root.join("crates/demo/src/field/component.rs"),
+            "pub enum State {\n    Idle,\n    Valid,\n    Invalid,\n}\n",
+        );
+
+        let options = SnapshotCountOptions {
+            snapshots_dir: root.join("crates/demo/src/field/snapshots"),
+            min_per_variant: 3,
+            max_per_component: 20,
+        };
+
+        let result = check_snapshot_count(&options);
+
+        assert!(matches!(result, Err(Error::Failed { .. })));
+
+        drop(fs::remove_dir_all(root));
+    }
+
+    #[test]
+    fn snapshot_count_detects_stateful_component_with_zero_snapshots() {
+        let root = temp_dir("snapshot-zero");
+
+        write(
+            &root.join("crates/demo/src/menu/component.rs"),
+            "pub enum State {\n    Closed,\n    Open,\n    Highlighted,\n}\n",
+        );
+
+        let options = SnapshotCountOptions {
+            snapshots_dir: root.join("crates"),
+            min_per_variant: 3,
+            max_per_component: 20,
+        };
+
+        let result = check_snapshot_count(&options);
+
+        assert!(matches!(result, Err(Error::Failed { .. })));
+
+        drop(fs::remove_dir_all(root));
+    }
+
+    #[test]
+    fn snapshot_count_fails_for_maximum() {
+        let root = temp_dir("snapshot-max");
+
+        for idx in 0..3 {
+            write(
+                &root.join(format!(
+                    "crates/demo/src/button/snapshots/button_{idx}.snap"
+                )),
+                "snapshot",
+            );
+        }
+
+        let options = SnapshotCountOptions {
+            snapshots_dir: root.join("crates/demo/src/button/snapshots"),
+            min_per_variant: 3,
+            max_per_component: 2,
+        };
+
+        let result = check_snapshot_count(&options);
+
+        assert!(matches!(result, Err(Error::Failed { .. })));
+
+        drop(fs::remove_dir_all(root));
+    }
+
+    #[test]
+    fn snapshot_count_warns_when_total_exceeds_threshold() {
+        let root = temp_dir("snapshot-total");
+
+        for idx in 0..501 {
+            write(
+                &root.join(format!(
+                    "crates/demo/src/button/snapshots/button_{idx}.snap"
+                )),
+                "snapshot",
+            );
+        }
+
+        let options = SnapshotCountOptions {
+            snapshots_dir: root.join("crates/demo/src/button/snapshots"),
+            min_per_variant: 3,
+            max_per_component: 600,
+        };
+
+        let output = check_snapshot_count(&options).expect("warning should not fail");
+
+        assert!(output.contains("Snapshot count warnings"));
+        assert!(output.contains("total snapshots=501"));
+
+        drop(fs::remove_dir_all(root));
+    }
+
+    #[test]
+    fn error_variant_coverage_passes_when_all_variants_are_covered() {
+        let root = temp_dir("error-pass");
+
+        write(
+            &root.join("src/error.rs"),
+            "pub enum ComponentError {\n    MissingId,\n    DisabledGate { event: String },\n    InvalidStateTransition(String),\n}\n",
+        );
+        write(
+            &root.join("tests/error.rs"),
+            "#[test]\nfn covers() {\n    let _ = ComponentError::MissingId;\n    let _ = ComponentError::DisabledGate { event: String::new() };\n    let _ = ComponentError::InvalidStateTransition(String::new());\n}\n",
+        );
+
+        let options = ErrorVariantCoverageOptions {
+            source_glob: format!("{}/src/**/*.rs", normalize_path(&root)),
+            test_glob: format!("{}/tests/**/*.rs", normalize_path(&root)),
+            enum_name: "ComponentError".to_owned(),
+        };
+
+        check_error_variant_coverage(&options).expect("all variants covered");
+
+        drop(fs::remove_dir_all(root));
+    }
+
+    #[test]
+    fn error_variant_coverage_reports_uncovered_variants() {
+        let root = temp_dir("error-fail");
+
+        write(
+            &root.join("src/error.rs"),
+            "pub enum ComponentError {\n    MissingId,\n    DisabledGate { event: String },\n}\n",
+        );
+        write(
+            &root.join("tests/error.rs"),
+            "#[test]\nfn covers() {\n    let _ = ComponentError::MissingId;\n}\n",
+        );
+
+        let options = ErrorVariantCoverageOptions {
+            source_glob: format!("{}/src/**/*.rs", normalize_path(&root)),
+            test_glob: format!("{}/tests/**/*.rs", normalize_path(&root)),
+            enum_name: "ComponentError".to_owned(),
+        };
+
+        let result = check_error_variant_coverage(&options);
+
+        assert!(matches!(result, Err(Error::Failed { .. })));
+
+        drop(fs::remove_dir_all(root));
+    }
+}

--- a/xtask/src/lint.rs
+++ b/xtask/src/lint.rs
@@ -213,15 +213,17 @@ pub fn check_snapshot_count(options: &SnapshotCountOptions) -> Result<String, Er
 
     let total_snapshots = snapshots.len();
 
+    let state_variants = detect_state_variants(&workspace_root_for(&options.snapshots_dir))?;
     let mut counts = BTreeMap::<String, usize>::new();
 
     for snapshot in snapshots {
-        if let Some(component) = infer_snapshot_component(&snapshot) {
+        if let Some(component) = infer_snapshot_component(&snapshot)
+            && state_variants.contains_key(&component)
+        {
             *counts.entry(component).or_insert(0) += 1;
         }
     }
 
-    let state_variants = detect_state_variants(&workspace_root_for(&options.snapshots_dir))?;
     let mut output = String::from("Component | Snapshots | State variants | Required | Status\n");
 
     output.push_str("----------|-----------|----------------|----------|-------\n");
@@ -970,6 +972,11 @@ mod tests {
             );
         }
 
+        write(
+            &root.join("crates/demo/src/button/component.rs"),
+            "pub enum State {\n    Idle,\n}\n",
+        );
+
         let options = SnapshotCountOptions {
             snapshots_dir: root.join("crates/demo/src/button/snapshots"),
             min_per_variant: 3,
@@ -979,6 +986,32 @@ mod tests {
         let result = check_snapshot_count(&options);
 
         assert!(matches!(result, Err(Error::Failed { .. })));
+
+        drop(fs::remove_dir_all(root));
+    }
+
+    #[test]
+    fn snapshot_count_ignores_non_component_snapshot_suites() {
+        let root = temp_dir("snapshot-non-component");
+
+        for idx in 0..3 {
+            write(
+                &root.join(format!(
+                    "crates/ars-core/tests/snapshots/snapshot_smoke__{idx}.snap"
+                )),
+                "snapshot",
+            );
+        }
+
+        let options = SnapshotCountOptions {
+            snapshots_dir: root.join("crates"),
+            min_per_variant: 3,
+            max_per_component: 2,
+        };
+
+        let output = check_snapshot_count(&options).expect("non-component snapshots are ignored");
+
+        assert!(!output.contains("snapshot_smoke"));
 
         drop(fs::remove_dir_all(root));
     }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -3,7 +3,7 @@
 use std::{env, path::PathBuf, process, sync};
 
 use clap::{Parser, Subcommand};
-use xtask::{ci, coverage, manifest, mcp, spec, test};
+use xtask::{ci, coverage, lint, manifest, mcp, spec, test};
 
 /// ars-ui workspace task runner.
 #[derive(Parser)]
@@ -54,6 +54,12 @@ enum Command {
     Coverage {
         #[command(subcommand)]
         cmd: CoverageCommand,
+    },
+
+    /// Repository testing policy lints.
+    Lint {
+        #[command(subcommand)]
+        cmd: LintCommand,
     },
 
     /// Run workspace tests through cargo-nextest.
@@ -123,6 +129,54 @@ enum CoverageCommand {
         /// Path to lcov.info file.
         #[arg(long)]
         file: PathBuf,
+    },
+}
+
+#[derive(Subcommand)]
+enum LintCommand {
+    /// Compare per-component adapter test counts.
+    AdapterParity {
+        /// Directory containing Leptos adapter tests.
+        #[arg(long, default_value = "crates/ars-leptos/tests")]
+        leptos_test_dir: PathBuf,
+
+        /// Directory containing Dioxus adapter tests.
+        #[arg(long, default_value = "crates/ars-dioxus/tests")]
+        dioxus_test_dir: PathBuf,
+
+        /// Maximum allowed per-component count delta.
+        #[arg(long, default_value_t = 2)]
+        tolerance: usize,
+    },
+
+    /// Enforce per-component snapshot count budgets.
+    SnapshotCount {
+        /// Directory tree containing `.snap` files.
+        #[arg(long, default_value = "crates")]
+        snapshots_dir: PathBuf,
+
+        /// Minimum snapshot count per detected state variant.
+        #[arg(long, default_value_t = 3)]
+        min_per_variant: usize,
+
+        /// Maximum snapshots per component before failure.
+        #[arg(long, default_value_t = 20)]
+        max_per_component: usize,
+    },
+
+    /// Verify each error enum variant appears in a test function.
+    ErrorVariantCoverage {
+        /// Glob selecting Rust source files containing the enum.
+        #[arg(long, default_value = "crates/ars-core/src/**/*.rs")]
+        source_glob: String,
+
+        /// Glob selecting Rust test files to inspect.
+        #[arg(long, default_value = "crates/ars-core/tests/**/*.rs")]
+        test_glob: String,
+
+        /// Enum name whose variants must be exercised.
+        #[arg(long, default_value = "ComponentError")]
+        enum_name: String,
     },
 }
 
@@ -331,6 +385,50 @@ fn main() {
                     coverage::check_all(&file, &coverage::default_thresholds())
                 }
             };
+
+            match result {
+                Ok(output) => print!("{output}"),
+                Err(e) => {
+                    eprintln!("{e}");
+                    process::exit(1);
+                }
+            }
+        }
+
+        // ── Lint ──────────────────────────────────────────────────────
+        Command::Lint { cmd } => {
+            let result = match cmd {
+                LintCommand::AdapterParity {
+                    leptos_test_dir,
+                    dioxus_test_dir,
+                    tolerance,
+                } => lint::check_adapter_parity(&lint::AdapterParityOptions {
+                    leptos_test_dir,
+                    dioxus_test_dir,
+                    tolerance,
+                }),
+
+                LintCommand::SnapshotCount {
+                    snapshots_dir,
+                    min_per_variant,
+                    max_per_component,
+                } => lint::check_snapshot_count(&lint::SnapshotCountOptions {
+                    snapshots_dir,
+                    min_per_variant,
+                    max_per_component,
+                }),
+
+                LintCommand::ErrorVariantCoverage {
+                    source_glob,
+                    test_glob,
+                    enum_name,
+                } => lint::check_error_variant_coverage(&lint::ErrorVariantCoverageOptions {
+                    source_glob,
+                    test_glob,
+                    enum_name,
+                }),
+            };
+
             match result {
                 Ok(output) => print!("{output}"),
                 Err(e) => {


### PR DESCRIPTION
Closes #184
Closes #185
Closes #186

## Summary
- add Rust xtask lint commands and CI entrypoints for adapter parity, snapshot count, and error variant coverage
- wire the new enforcement steps into GitHub Actions and the default cargo xci order
- add ars_core::ComponentError with coverage tests and sync testing specs away from script names
- clean up native warning paths so the published branch is warning-clean under the local CI gate

## Verification
- cargo xci