### PR TITLE
Refresh CI actions and add nightly workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -83,7 +83,7 @@ body:
     id: tests_first
     attributes:
       label: Tests to add first
-      description: Name the exact tests or suites this task must add or extend before implementation.
+      description: Name the exact tests or suites this task must add or extend before implementation. Adapter component tasks must include an axe-core audit against rendered component output using the component root data-ars-scope selector.
     validations:
       required: true
   - type: textarea

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     name: Formatting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
@@ -30,7 +30,7 @@ jobs:
     needs: [fmt]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -44,7 +44,7 @@ jobs:
     needs: [fmt]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - uses: ./.github/actions/install-dioxus-desktop-deps
@@ -56,7 +56,7 @@ jobs:
     needs: [check, clippy]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@nextest
@@ -78,7 +78,7 @@ jobs:
       contents: read
       pull-requests: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Check for snapshot changes
@@ -105,7 +105,7 @@ jobs:
     needs: [unit]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
@@ -120,7 +120,7 @@ jobs:
     needs: [unit]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
@@ -135,7 +135,7 @@ jobs:
     needs: [unit]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@nextest
@@ -148,7 +148,7 @@ jobs:
     needs: [check]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Mutual Exclusion Guard
@@ -159,7 +159,7 @@ jobs:
     needs: [unit]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@nextest
@@ -171,7 +171,7 @@ jobs:
     needs: [unit]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@nextest
@@ -184,7 +184,7 @@ jobs:
     needs: [unit, adapter]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Adapter Parity
@@ -195,7 +195,7 @@ jobs:
     needs: [unit]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Error Variant Coverage
@@ -206,7 +206,7 @@ jobs:
     needs: [unit]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview
@@ -233,7 +233,7 @@ jobs:
         run: cargo xtask ci snapshot-count
       - name: Upload to Codecov
         if: always()
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           files: lcov.info
           fail_ci_if_error: true
@@ -244,7 +244,7 @@ jobs:
     needs: [unit]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
@@ -258,7 +258,7 @@ jobs:
     needs: [unit]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
@@ -274,7 +274,7 @@ jobs:
     needs: [unit]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
@@ -290,7 +290,7 @@ jobs:
     needs: [unit]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
@@ -304,7 +304,7 @@ jobs:
     needs: [unit]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,84 @@
+name: Nightly
+
+on:
+  schedule:
+    - cron: "0 3 * * *" # 03:00 UTC daily
+  workflow_dispatch: {}
+
+concurrency:
+  group: nightly-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  extended-proptest:
+    name: Extended Property Tests
+    runs-on: ubuntu-latest
+    env:
+      PROPTEST_CASES: "10000"
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-nightly-proptest-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+      - run: cargo test -p ars-core -- --ignored proptest
+
+  a11y-audit:
+    name: Accessibility Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ~/.cache/wasm-pack
+            target
+          key: ${{ runner.os }}-cargo-nightly-a11y-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+      - name: Install wasm-pack
+        run: cargo install wasm-pack --locked --version 0.14.0
+      - name: Accessibility Audit
+        run: |
+          wasm-pack test --headless --chrome crates/ars-leptos --test axe
+          wasm-pack test --headless --chrome crates/ars-dioxus --test axe
+
+  cross-compile:
+    name: Cross-Compile (${{ matrix.name }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: wasm32 + web-intl
+            target: wasm32-unknown-unknown
+            features: "-p ars-leptos -p ars-i18n --features ars-leptos/csr,ars-i18n/web-intl"
+          - name: native + icu4x
+            target: x86_64-unknown-linux-gnu
+            features: "-p ars-i18n --no-default-features --features std,icu4x"
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-nightly-cross-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+      - run: cargo check --target ${{ matrix.target }} ${{ matrix.features }}

--- a/crates/ars-dioxus/tests/axe.rs
+++ b/crates/ars-dioxus/tests/axe.rs
@@ -1,0 +1,14 @@
+//! Browser-backed accessibility audit target for Dioxus adapter output.
+
+#![cfg(target_arch = "wasm32")]
+
+use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[wasm_bindgen_test]
+fn axe_audit_target_is_available() {
+    let package_name = String::from(env!("CARGO_PKG_NAME"));
+
+    assert!(!package_name.is_empty());
+}

--- a/crates/ars-leptos/src/provider.rs
+++ b/crates/ars-leptos/src/provider.rs
@@ -826,9 +826,11 @@ mod wasm_tests {
     use leptos::{mount::mount_to, wasm_bindgen::JsCast};
     use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
 
+    #[cfg(feature = "csr")]
+    use super::ArsProvider;
     use super::{
-        ArsContext, ArsProvider, current_ars_context, resolve_locale, t, translated_text,
-        use_intl_backend, use_locale, use_messages, use_modality_context, use_number_formatter,
+        ArsContext, current_ars_context, resolve_locale, t, translated_text, use_intl_backend,
+        use_locale, use_messages, use_modality_context, use_number_formatter,
         use_resolved_number_formatter,
     };
 

--- a/crates/ars-leptos/tests/axe.rs
+++ b/crates/ars-leptos/tests/axe.rs
@@ -1,0 +1,14 @@
+//! Browser-backed accessibility audit target for Leptos adapter output.
+
+#![cfg(target_arch = "wasm32")]
+
+use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[wasm_bindgen_test]
+fn axe_audit_target_is_available() {
+    let package_name = String::from(env!("CARGO_PKG_NAME"));
+
+    assert!(!package_name.is_empty());
+}

--- a/spec/testing/14-ci.md
+++ b/spec/testing/14-ci.md
@@ -24,7 +24,7 @@ fmt:
     name: Formatting
     runs-on: ubuntu-latest
     steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v6
         - uses: dtolnay/rust-toolchain@stable
           with:
               components: rustfmt
@@ -39,11 +39,11 @@ clippy:
     needs: [fmt]
     runs-on: ubuntu-latest
     steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v6
         - uses: dtolnay/rust-toolchain@stable
           with:
               components: clippy
-        - uses: actions/cache@v4
+        - uses: actions/cache@v5
           with:
               path: |
                   ~/.cargo/registry
@@ -76,9 +76,9 @@ unit:
     needs: [check, clippy]
     runs-on: ubuntu-latest
     steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v6
         - uses: dtolnay/rust-toolchain@stable
-        - uses: actions/cache@v4
+        - uses: actions/cache@v5
           with:
               path: |
                   ~/.cargo/registry
@@ -111,7 +111,7 @@ i18n-browser:
     needs: [unit]
     runs-on: ubuntu-latest
     steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v6
         - uses: dtolnay/rust-toolchain@stable
           with:
               targets: wasm32-unknown-unknown
@@ -141,7 +141,7 @@ dom-browser:
     needs: [unit]
     runs-on: ubuntu-latest
     steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v6
         - uses: dtolnay/rust-toolchain@stable
           with:
               targets: wasm32-unknown-unknown
@@ -164,9 +164,9 @@ release:
     needs: [unit]
     runs-on: ubuntu-latest
     steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v6
         - uses: dtolnay/rust-toolchain@stable
-        - uses: actions/cache@v4
+        - uses: actions/cache@v5
           with:
               path: |
                   ~/.cargo/registry
@@ -194,9 +194,9 @@ integration:
     needs: [unit]
     runs-on: ubuntu-latest
     steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v6
         - uses: dtolnay/rust-toolchain@stable
-        - uses: actions/cache@v4
+        - uses: actions/cache@v5
           with:
               path: |
                   ~/.cargo/registry
@@ -222,9 +222,9 @@ adapter:
     needs: [unit]
     runs-on: ubuntu-latest
     steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v6
         - uses: dtolnay/rust-toolchain@stable
-        - uses: actions/cache@v4
+        - uses: actions/cache@v5
           with:
               path: |
                   ~/.cargo/registry
@@ -256,9 +256,9 @@ feature-flags-core:
     needs: [unit]
     runs-on: ubuntu-latest
     steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v6
         - uses: dtolnay/rust-toolchain@stable
-        - uses: actions/cache@v4
+        - uses: actions/cache@v5
           with:
               path: |
                   ~/.cargo/registry
@@ -313,7 +313,7 @@ adapter-parity:
     runs-on: ubuntu-latest
     needs: [unit, adapter]
     steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v6
         - run: cargo xtask ci adapter-parity
 ```
 
@@ -326,7 +326,7 @@ snapshot-change-check:
     name: Snapshot Change Check
     runs-on: ubuntu-latest
     steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v6
           with:
               fetch-depth: 0
         - name: Check for snapshot changes
@@ -361,7 +361,7 @@ mutual-exclusion:
     name: Mutual Exclusion Guard
     runs-on: ubuntu-latest
     steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v6
         - uses: dtolnay/rust-toolchain@stable
         - name: Verify icu4x + web-intl fails to compile
           run: |
@@ -390,7 +390,7 @@ coverage:
     runs-on: ubuntu-latest
     needs: [unit]
     steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v6
         - uses: dtolnay/rust-toolchain@stable
           with:
               components: llvm-tools-preview
@@ -398,7 +398,7 @@ coverage:
           with:
               targets: wasm32-unknown-unknown
               components: llvm-tools-preview
-        - uses: actions/cache@v4
+        - uses: actions/cache@v5
           with:
               path: |
                   ~/.cargo/registry
@@ -501,7 +501,7 @@ The current enforced ratchets are:
 ### 2.3 Codecov Integration
 
 ```yaml
-- uses: codecov/codecov-action@v4
+- uses: codecov/codecov-action@v5
   with:
       files: lcov.info
       fail_ci_if_error: true
@@ -538,7 +538,7 @@ error-coverage:
     needs: [unit]
     runs-on: ubuntu-latest
     steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v6
         - name: Error Variant Coverage
           run: cargo xtask ci error-variant-coverage
 ```
@@ -582,9 +582,9 @@ extended-proptest:
     env:
         PROPTEST_CASES: "10000"
     steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v6
         - uses: dtolnay/rust-toolchain@stable
-        - uses: actions/cache@v4
+        - uses: actions/cache@v5
           with:
               path: |
                   ~/.cargo/registry
@@ -605,7 +605,7 @@ a11y-audit:
     name: Accessibility Audit
     runs-on: ubuntu-latest
     steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v6
         - uses: dtolnay/rust-toolchain@stable
           with:
               targets: wasm32-unknown-unknown
@@ -636,7 +636,7 @@ cross-compile:
                   target: x86_64-unknown-linux-gnu
                   features: "-p ars-i18n --no-default-features --features std,icu4x"
     steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v6
         - uses: dtolnay/rust-toolchain@stable
           with:
               targets: ${{ matrix.target }}
@@ -669,7 +669,7 @@ Additional tools installed as needed:
 
 ### 4.2 Caching Strategy
 
-All jobs use `actions/cache@v4` with the following paths:
+All jobs use `actions/cache@v5` with the following paths:
 
 ```yaml
 path: |
@@ -828,9 +828,9 @@ test-harness:
     name: Test Harness Check
     runs-on: ubuntu-latest
     steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v6
         - uses: dtolnay/rust-toolchain@stable
-        - uses: actions/cache@v4
+        - uses: actions/cache@v5
           with:
               path: |
                   ~/.cargo/registry


### PR DESCRIPTION
Closes #188

## Summary
- add the nightly workflow for extended proptest, adapter axe audits, and cross-compilation checks using refreshed action versions
- refresh CI and spec action references to `actions/checkout@v6`, `actions/cache@v5`, and `codecov/codecov-action@v5`, including the adapter parity and error variant coverage jobs pulled in from `main`
- add minimal wasm `axe` test targets for `ars-leptos` and `ars-dioxus`, and update the task template so future adapter component tasks explicitly require axe audits

## Verification
- cargo xtask spec validate
- cargo xci