### PR TITLE
Implement agnostic tooltip core

### DIFF
--- a/crates/ars-components/src/overlay/mod.rs
+++ b/crates/ars-components/src/overlay/mod.rs
@@ -1,4 +1,10 @@
 //! Overlay component machines.
 
+/// Shared DOM-free overlay positioning configuration.
+pub mod positioning;
+
 /// Presence machine.
 pub mod presence;
+
+/// Tooltip machine.
+pub mod tooltip;

--- a/crates/ars-components/src/overlay/positioning.rs
+++ b/crates/ars-components/src/overlay/positioning.rs
@@ -1,0 +1,222 @@
+//! DOM-free overlay positioning configuration.
+
+use alloc::vec::Vec;
+use core::fmt::{self, Display};
+
+/// Placement options for floating overlay elements relative to their anchor.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum Placement {
+    /// Bottom side, centered.
+    #[default]
+    Bottom,
+
+    /// Bottom side, start-aligned.
+    BottomStart,
+
+    /// Bottom side, end-aligned.
+    BottomEnd,
+
+    /// Top side, centered.
+    Top,
+
+    /// Top side, start-aligned.
+    TopStart,
+
+    /// Top side, end-aligned.
+    TopEnd,
+
+    /// Left side, centered.
+    Left,
+
+    /// Left side, start-aligned.
+    LeftStart,
+
+    /// Left side, end-aligned.
+    LeftEnd,
+
+    /// Right side, centered.
+    Right,
+
+    /// Right side, start-aligned.
+    RightStart,
+
+    /// Right side, end-aligned.
+    RightEnd,
+
+    /// Let the adapter positioning engine choose the side with most available space.
+    Auto,
+
+    /// Auto side selection, aligned to the start of that side.
+    AutoStart,
+
+    /// Auto side selection, aligned to the end of that side.
+    AutoEnd,
+
+    /// Logical inline-start side.
+    Start,
+
+    /// Logical inline-end side.
+    End,
+
+    /// Logical inline-start side, top-aligned.
+    StartTop,
+
+    /// Logical inline-start side, bottom-aligned.
+    StartBottom,
+
+    /// Logical inline-end side, top-aligned.
+    EndTop,
+
+    /// Logical inline-end side, bottom-aligned.
+    EndBottom,
+}
+
+impl Placement {
+    /// Returns the stable attribute token for this placement.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Bottom => "bottom",
+            Self::BottomStart => "bottom-start",
+            Self::BottomEnd => "bottom-end",
+            Self::Top => "top",
+            Self::TopStart => "top-start",
+            Self::TopEnd => "top-end",
+            Self::Left => "left",
+            Self::LeftStart => "left-start",
+            Self::LeftEnd => "left-end",
+            Self::Right => "right",
+            Self::RightStart => "right-start",
+            Self::RightEnd => "right-end",
+            Self::Auto => "auto",
+            Self::AutoStart => "auto-start",
+            Self::AutoEnd => "auto-end",
+            Self::Start => "start",
+            Self::End => "end",
+            Self::StartTop => "start-top",
+            Self::StartBottom => "start-bottom",
+            Self::EndTop => "end-top",
+            Self::EndBottom => "end-bottom",
+        }
+    }
+}
+
+impl Display for Placement {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Offset applied by the adapter positioning engine after initial placement.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct Offset {
+    /// Distance along the placement direction, away from the anchor edge.
+    pub main_axis: f64,
+
+    /// Distance perpendicular to the placement direction.
+    pub cross_axis: f64,
+}
+
+/// DOM-free options describing how an overlay should be positioned.
+#[derive(Clone, Debug, PartialEq)]
+pub struct PositioningOptions {
+    /// Desired placement relative to the trigger or anchor element.
+    pub placement: Placement,
+
+    /// Offset applied after initial placement.
+    pub offset: Offset,
+
+    /// Whether the adapter may flip to another side when the preferred side overflows.
+    pub flip: bool,
+
+    /// Whether the adapter may shift along the cross axis to stay inside the boundary.
+    pub shift: bool,
+
+    /// Minimum distance from the viewport edge when shifting.
+    pub shift_padding: f64,
+
+    /// Minimum distance from the arrow to the floating element edge.
+    pub arrow_padding: f64,
+
+    /// Whether the adapter should constrain the overlay to available space.
+    pub auto_max_size: bool,
+
+    /// Ordered fallback placements the adapter should try before the direct opposite.
+    pub fallback_placements: Vec<Placement>,
+
+    /// Whether the adapter should reposition for visual viewport changes.
+    pub keyboard_aware: bool,
+
+    /// Whether the adapter should consider all placements and choose the least-overflowing one.
+    pub auto_placement: bool,
+}
+
+impl Default for PositioningOptions {
+    fn default() -> Self {
+        Self {
+            placement: Placement::default(),
+            offset: Offset::default(),
+            flip: true,
+            shift: true,
+            shift_padding: 5.0,
+            arrow_padding: 8.0,
+            auto_max_size: true,
+            fallback_placements: Vec::new(),
+            keyboard_aware: false,
+            auto_placement: false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn placement_as_str_and_display_cover_all_variants() {
+        let cases = [
+            (Placement::Bottom, "bottom"),
+            (Placement::BottomStart, "bottom-start"),
+            (Placement::BottomEnd, "bottom-end"),
+            (Placement::Top, "top"),
+            (Placement::TopStart, "top-start"),
+            (Placement::TopEnd, "top-end"),
+            (Placement::Left, "left"),
+            (Placement::LeftStart, "left-start"),
+            (Placement::LeftEnd, "left-end"),
+            (Placement::Right, "right"),
+            (Placement::RightStart, "right-start"),
+            (Placement::RightEnd, "right-end"),
+            (Placement::Auto, "auto"),
+            (Placement::AutoStart, "auto-start"),
+            (Placement::AutoEnd, "auto-end"),
+            (Placement::Start, "start"),
+            (Placement::End, "end"),
+            (Placement::StartTop, "start-top"),
+            (Placement::StartBottom, "start-bottom"),
+            (Placement::EndTop, "end-top"),
+            (Placement::EndBottom, "end-bottom"),
+        ];
+
+        for (placement, expected) in cases {
+            assert_eq!(placement.as_str(), expected);
+            assert_eq!(placement.to_string(), expected);
+        }
+    }
+
+    #[test]
+    fn positioning_options_default_values_are_stable() {
+        let options = PositioningOptions::default();
+
+        assert_eq!(options.placement, Placement::Bottom);
+        assert_eq!(options.offset, Offset::default());
+        assert!(options.flip);
+        assert!(options.shift);
+        assert_eq!(options.shift_padding, 5.0);
+        assert_eq!(options.arrow_padding, 8.0);
+        assert!(options.auto_max_size);
+        assert!(options.fallback_placements.is_empty());
+        assert!(!options.keyboard_aware);
+        assert!(!options.auto_placement);
+    }
+}

--- a/crates/ars-components/src/overlay/snapshots/ars_components__overlay__tooltip__tests__tooltip_all_parts_closed.snap
+++ b/crates/ars-components/src/overlay/snapshots/ars_components__overlay__tooltip__tests__tooltip_all_parts_closed.snap
@@ -1,0 +1,224 @@
+---
+source: crates/ars-components/src/overlay/tooltip.rs
+expression: "snapshot_api(&service.connect(&|_| {}))"
+---
+root:
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "tooltip",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "closed",
+            ),
+        ),
+    ],
+    styles: [],
+}
+trigger:
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "tooltip",
+            ),
+        ),
+        (
+            Aria(
+                DescribedBy,
+            ),
+            String(
+                "tooltip-content-description",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "tooltip-trigger",
+            ),
+        ),
+    ],
+    styles: [],
+}
+hidden_description:
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "hidden-description",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "tooltip",
+            ),
+        ),
+        (
+            Data(
+                "ars-visually-hidden",
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "tooltip-content-description",
+            ),
+        ),
+    ],
+    styles: [],
+}
+positioner:
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "positioner",
+            ),
+        ),
+        (
+            Data(
+                "ars-placement",
+            ),
+            String(
+                "bottom",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "tooltip",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "closed",
+            ),
+        ),
+    ],
+    styles: [],
+}
+content:
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "content",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "tooltip",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "closed",
+            ),
+        ),
+        (
+            Aria(
+                Hidden,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Dir,
+            String(
+                "ltr",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "tooltip-content",
+            ),
+        ),
+    ],
+    styles: [],
+}
+arrow:
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "arrow",
+            ),
+        ),
+        (
+            Data(
+                "ars-placement",
+            ),
+            String(
+                "bottom",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "tooltip",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/overlay/snapshots/ars_components__overlay__tooltip__tests__tooltip_all_parts_open.snap
+++ b/crates/ars-components/src/overlay/snapshots/ars_components__overlay__tooltip__tests__tooltip_all_parts_open.snap
@@ -1,0 +1,224 @@
+---
+source: crates/ars-components/src/overlay/tooltip.rs
+expression: "snapshot_api(&service.connect(&|_| {}))"
+---
+root:
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "tooltip",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "open",
+            ),
+        ),
+    ],
+    styles: [],
+}
+trigger:
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "tooltip",
+            ),
+        ),
+        (
+            Aria(
+                DescribedBy,
+            ),
+            String(
+                "tooltip-content-description",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "tooltip-trigger",
+            ),
+        ),
+    ],
+    styles: [],
+}
+hidden_description:
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "hidden-description",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "tooltip",
+            ),
+        ),
+        (
+            Data(
+                "ars-visually-hidden",
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "tooltip-content-description",
+            ),
+        ),
+    ],
+    styles: [],
+}
+positioner:
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "positioner",
+            ),
+        ),
+        (
+            Data(
+                "ars-placement",
+            ),
+            String(
+                "bottom",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "tooltip",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "open",
+            ),
+        ),
+    ],
+    styles: [],
+}
+content:
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "content",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "tooltip",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "open",
+            ),
+        ),
+        (
+            Aria(
+                Hidden,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Dir,
+            String(
+                "ltr",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "tooltip-content",
+            ),
+        ),
+    ],
+    styles: [],
+}
+arrow:
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "arrow",
+            ),
+        ),
+        (
+            Data(
+                "ars-placement",
+            ),
+            String(
+                "bottom",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "tooltip",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/overlay/snapshots/ars_components__overlay__tooltip__tests__tooltip_close_pending.snap
+++ b/crates/ars-components/src/overlay/snapshots/ars_components__overlay__tooltip__tests__tooltip_close_pending.snap
@@ -1,0 +1,224 @@
+---
+source: crates/ars-components/src/overlay/tooltip.rs
+expression: "snapshot_api(&service.connect(&|_| {}))"
+---
+root:
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "tooltip",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "open",
+            ),
+        ),
+    ],
+    styles: [],
+}
+trigger:
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "tooltip",
+            ),
+        ),
+        (
+            Aria(
+                DescribedBy,
+            ),
+            String(
+                "tooltip-content-description",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "tooltip-trigger",
+            ),
+        ),
+    ],
+    styles: [],
+}
+hidden_description:
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "hidden-description",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "tooltip",
+            ),
+        ),
+        (
+            Data(
+                "ars-visually-hidden",
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "tooltip-content-description",
+            ),
+        ),
+    ],
+    styles: [],
+}
+positioner:
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "positioner",
+            ),
+        ),
+        (
+            Data(
+                "ars-placement",
+            ),
+            String(
+                "bottom",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "tooltip",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "open",
+            ),
+        ),
+    ],
+    styles: [],
+}
+content:
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "content",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "tooltip",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "open",
+            ),
+        ),
+        (
+            Aria(
+                Hidden,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Dir,
+            String(
+                "ltr",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "tooltip-content",
+            ),
+        ),
+    ],
+    styles: [],
+}
+arrow:
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "arrow",
+            ),
+        ),
+        (
+            Data(
+                "ars-placement",
+            ),
+            String(
+                "bottom",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "tooltip",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/overlay/snapshots/ars_components__overlay__tooltip__tests__tooltip_disabled.snap
+++ b/crates/ars-components/src/overlay/snapshots/ars_components__overlay__tooltip__tests__tooltip_disabled.snap
@@ -1,0 +1,240 @@
+---
+source: crates/ars-components/src/overlay/tooltip.rs
+expression: "snapshot_api(&service.connect(&|_| {}))"
+---
+root:
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-disabled",
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "tooltip",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "closed",
+            ),
+        ),
+    ],
+    styles: [],
+}
+trigger:
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "tooltip",
+            ),
+        ),
+        (
+            Aria(
+                Disabled,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Aria(
+                DescribedBy,
+            ),
+            String(
+                "tooltip-content-description",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "tooltip-trigger",
+            ),
+        ),
+    ],
+    styles: [],
+}
+hidden_description:
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "hidden-description",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "tooltip",
+            ),
+        ),
+        (
+            Data(
+                "ars-visually-hidden",
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "tooltip-content-description",
+            ),
+        ),
+    ],
+    styles: [],
+}
+positioner:
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "positioner",
+            ),
+        ),
+        (
+            Data(
+                "ars-placement",
+            ),
+            String(
+                "bottom",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "tooltip",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "closed",
+            ),
+        ),
+    ],
+    styles: [],
+}
+content:
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "content",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "tooltip",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "closed",
+            ),
+        ),
+        (
+            Aria(
+                Hidden,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Dir,
+            String(
+                "ltr",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "tooltip-content",
+            ),
+        ),
+    ],
+    styles: [],
+}
+arrow:
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "arrow",
+            ),
+        ),
+        (
+            Data(
+                "ars-placement",
+            ),
+            String(
+                "bottom",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "tooltip",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/overlay/snapshots/ars_components__overlay__tooltip__tests__tooltip_open_rtl.snap
+++ b/crates/ars-components/src/overlay/snapshots/ars_components__overlay__tooltip__tests__tooltip_open_rtl.snap
@@ -1,0 +1,224 @@
+---
+source: crates/ars-components/src/overlay/tooltip.rs
+expression: "snapshot_api(&service.connect(&|_| {}))"
+---
+root:
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "tooltip",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "open",
+            ),
+        ),
+    ],
+    styles: [],
+}
+trigger:
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "tooltip",
+            ),
+        ),
+        (
+            Aria(
+                DescribedBy,
+            ),
+            String(
+                "tooltip-content-description",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "tooltip-trigger",
+            ),
+        ),
+    ],
+    styles: [],
+}
+hidden_description:
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "hidden-description",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "tooltip",
+            ),
+        ),
+        (
+            Data(
+                "ars-visually-hidden",
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "tooltip-content-description",
+            ),
+        ),
+    ],
+    styles: [],
+}
+positioner:
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "positioner",
+            ),
+        ),
+        (
+            Data(
+                "ars-placement",
+            ),
+            String(
+                "bottom",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "tooltip",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "open",
+            ),
+        ),
+    ],
+    styles: [],
+}
+content:
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "content",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "tooltip",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "open",
+            ),
+        ),
+        (
+            Aria(
+                Hidden,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Dir,
+            String(
+                "rtl",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "tooltip-content",
+            ),
+        ),
+    ],
+    styles: [],
+}
+arrow:
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "arrow",
+            ),
+        ),
+        (
+            Data(
+                "ars-placement",
+            ),
+            String(
+                "bottom",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "tooltip",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/overlay/snapshots/ars_components__overlay__tooltip__tests__tooltip_open_with_z_index.snap
+++ b/crates/ars-components/src/overlay/snapshots/ars_components__overlay__tooltip__tests__tooltip_open_with_z_index.snap
@@ -1,0 +1,231 @@
+---
+source: crates/ars-components/src/overlay/tooltip.rs
+expression: "snapshot_api(&service.connect(&|_| {}))"
+---
+root:
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "tooltip",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "open",
+            ),
+        ),
+    ],
+    styles: [],
+}
+trigger:
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "tooltip",
+            ),
+        ),
+        (
+            Aria(
+                DescribedBy,
+            ),
+            String(
+                "tooltip-content-description",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "tooltip-trigger",
+            ),
+        ),
+    ],
+    styles: [],
+}
+hidden_description:
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "hidden-description",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "tooltip",
+            ),
+        ),
+        (
+            Data(
+                "ars-visually-hidden",
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "tooltip-content-description",
+            ),
+        ),
+    ],
+    styles: [],
+}
+positioner:
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "positioner",
+            ),
+        ),
+        (
+            Data(
+                "ars-placement",
+            ),
+            String(
+                "bottom",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "tooltip",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "open",
+            ),
+        ),
+    ],
+    styles: [
+        (
+            Custom(
+                "ars-z-index",
+            ),
+            "1300",
+        ),
+    ],
+}
+content:
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "content",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "tooltip",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "open",
+            ),
+        ),
+        (
+            Aria(
+                Hidden,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Dir,
+            String(
+                "ltr",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "tooltip-content",
+            ),
+        ),
+    ],
+    styles: [],
+}
+arrow:
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "arrow",
+            ),
+        ),
+        (
+            Data(
+                "ars-placement",
+            ),
+            String(
+                "bottom",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "tooltip",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/overlay/tooltip.rs
+++ b/crates/ars-components/src/overlay/tooltip.rs
@@ -1,0 +1,2228 @@
+//! Tooltip disclosure and attribute machine.
+
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
+use core::{
+    fmt::{self, Debug},
+    time::Duration,
+};
+
+use ars_core::{
+    AriaAttr, AttrMap, Callback, ComponentIds, ComponentMessages, ComponentPart, ConnectApi,
+    CssProperty, Direction, Env, HtmlAttr, Locale, PendingEffect, TransitionPlan, no_cleanup,
+};
+use ars_interactions::{KeyboardEventData, KeyboardKey};
+
+use super::positioning::PositioningOptions;
+
+const OPEN_DELAY_EFFECT: &str = "tooltip-open-delay";
+const CLOSE_DELAY_EFFECT: &str = "tooltip-close-delay";
+const OPEN_CHANGE_EFFECT: &str = "tooltip-open-change";
+const ALLOCATE_Z_INDEX_EFFECT: &str = "tooltip-allocate-z-index";
+const MIN_TOUCH_AUTO_HIDE: Duration = Duration::from_secs(5);
+
+/// The states of the tooltip.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum State {
+    /// The tooltip is closed.
+    #[default]
+    Closed,
+
+    /// The tooltip is waiting for its hover open delay.
+    OpenPending,
+
+    /// The tooltip is open.
+    Open,
+
+    /// The tooltip is waiting for its close delay.
+    ClosePending,
+}
+
+/// The events of the tooltip.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Event {
+    /// The pointer entered the trigger.
+    PointerEnter,
+
+    /// The pointer left the trigger.
+    PointerLeave,
+
+    /// The trigger gained keyboard focus.
+    Focus,
+
+    /// The trigger lost keyboard focus.
+    Blur,
+
+    /// The pointer entered the visible tooltip content.
+    ContentPointerEnter,
+
+    /// The pointer left the visible tooltip content.
+    ContentPointerLeave,
+
+    /// The hover open timer fired.
+    OpenTimerFired,
+
+    /// The close timer fired.
+    CloseTimerFired,
+
+    /// Escape requested tooltip dismissal.
+    CloseOnEscape,
+
+    /// Trigger activation requested tooltip dismissal.
+    CloseOnClick,
+
+    /// Page scroll requested tooltip dismissal.
+    CloseOnScroll,
+
+    /// Programmatic open requested immediate visibility.
+    Open,
+
+    /// Programmatic close requested immediate dismissal.
+    Close,
+
+    /// Controlled props synchronized the visible open state.
+    SetControlledOpen(bool),
+
+    /// Props changed without changing controlled visible state.
+    SyncProps,
+
+    /// Adapter supplied an allocated overlay z-index.
+    SetZIndex(u32),
+}
+
+/// Runtime context for Tooltip.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Context {
+    /// The resolved locale for message formatting.
+    pub locale: Locale,
+
+    /// Whether the tooltip is visibly open.
+    pub open: bool,
+
+    /// The open delay for hover-triggered tooltips.
+    pub open_delay: Duration,
+
+    /// The close delay.
+    pub close_delay: Duration,
+
+    /// Whether the tooltip ignores user interaction.
+    pub disabled: bool,
+
+    /// Text direction for tooltip content.
+    pub dir: Direction,
+
+    /// Whether the pointer is over the trigger or visible content.
+    pub hover_active: bool,
+
+    /// Whether the trigger currently has keyboard focus.
+    pub focus_active: bool,
+
+    /// Positioning options forwarded to framework adapters.
+    pub positioning: PositioningOptions,
+
+    /// The ID of the trigger element.
+    pub trigger_id: String,
+
+    /// The ID of the visible content element.
+    pub content_id: String,
+
+    /// The ID of the always-rendered hidden description element.
+    pub hidden_description_id: String,
+
+    /// Resolved messages for the tooltip.
+    pub messages: Messages,
+
+    /// Adapter-allocated z-index for the positioner.
+    pub z_index: Option<u32>,
+
+    /// Touch auto-hide timeout clamped to the accessibility minimum.
+    pub touch_auto_hide: Duration,
+}
+
+/// Immutable configuration for Tooltip.
+#[derive(Clone, Debug, PartialEq, ars_core::HasId)]
+pub struct Props {
+    /// Component instance id.
+    pub id: String,
+
+    /// Controlled open state. When `Some`, the parent owns visible open state.
+    pub open: Option<bool>,
+
+    /// Initial uncontrolled open state.
+    pub default_open: bool,
+
+    /// Delay before a hover-triggered tooltip opens.
+    pub open_delay: Duration,
+
+    /// Delay before an open tooltip closes.
+    pub close_delay: Duration,
+
+    /// Whether the tooltip ignores user interaction.
+    pub disabled: bool,
+
+    /// Positioning options forwarded to framework adapters.
+    pub positioning: PositioningOptions,
+
+    /// Whether Escape dismisses the tooltip.
+    pub close_on_escape: bool,
+
+    /// Whether trigger activation dismisses the tooltip.
+    pub close_on_click: bool,
+
+    /// Whether page scroll dismisses the tooltip.
+    pub close_on_scroll: bool,
+
+    /// Callback invoked when user interaction requests an open-state change.
+    pub on_open_change: Option<Callback<dyn Fn(bool) + Send + Sync>>,
+
+    /// Whether content is not mounted until first opened.
+    pub lazy_mount: bool,
+
+    /// Whether content is removed from the DOM after closing.
+    pub unmount_on_exit: bool,
+
+    /// Text direction for tooltip content.
+    pub dir: Direction,
+
+    /// Auto-hide timeout for touch-triggered tooltips.
+    pub touch_auto_hide: Duration,
+}
+
+impl Default for Props {
+    fn default() -> Self {
+        Self {
+            id: String::new(),
+            open: None,
+            default_open: false,
+            open_delay: Duration::from_millis(300),
+            close_delay: Duration::from_millis(300),
+            disabled: false,
+            positioning: PositioningOptions::default(),
+            close_on_escape: true,
+            close_on_click: true,
+            close_on_scroll: true,
+            on_open_change: None,
+            lazy_mount: false,
+            unmount_on_exit: false,
+            dir: Direction::Ltr,
+            touch_auto_hide: Duration::from_secs(20),
+        }
+    }
+}
+
+impl Props {
+    /// Returns Tooltip props with documented default values.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets [`id`](Self::id) to the supplied component instance id.
+    #[must_use]
+    pub fn id(mut self, id: impl Into<String>) -> Self {
+        self.id = id.into();
+        self
+    }
+
+    /// Sets [`open`](Self::open), the controlled open state.
+    #[must_use]
+    pub fn open(mut self, value: impl Into<Option<bool>>) -> Self {
+        self.open = value.into();
+        self
+    }
+
+    /// Sets [`default_open`](Self::default_open), the initial uncontrolled
+    /// open state.
+    #[must_use]
+    pub const fn default_open(mut self, value: bool) -> Self {
+        self.default_open = value;
+        self
+    }
+
+    /// Sets [`open_delay`](Self::open_delay), the hover-triggered open
+    /// delay.
+    #[must_use]
+    pub const fn open_delay(mut self, value: Duration) -> Self {
+        self.open_delay = value;
+        self
+    }
+
+    /// Sets [`close_delay`](Self::close_delay), the delay before closing
+    /// after hover or focus leaves.
+    #[must_use]
+    pub const fn close_delay(mut self, value: Duration) -> Self {
+        self.close_delay = value;
+        self
+    }
+
+    /// Sets [`disabled`](Self::disabled), whether user interaction is
+    /// ignored.
+    #[must_use]
+    pub const fn disabled(mut self, value: bool) -> Self {
+        self.disabled = value;
+        self
+    }
+
+    /// Sets [`positioning`](Self::positioning), the adapter-owned floating
+    /// placement configuration.
+    #[must_use]
+    pub fn positioning(mut self, value: PositioningOptions) -> Self {
+        self.positioning = value;
+        self
+    }
+
+    /// Sets [`close_on_escape`](Self::close_on_escape), whether Escape
+    /// dismisses the tooltip.
+    #[must_use]
+    pub const fn close_on_escape(mut self, value: bool) -> Self {
+        self.close_on_escape = value;
+        self
+    }
+
+    /// Sets [`close_on_click`](Self::close_on_click), whether trigger
+    /// activation dismisses the tooltip.
+    #[must_use]
+    pub const fn close_on_click(mut self, value: bool) -> Self {
+        self.close_on_click = value;
+        self
+    }
+
+    /// Sets [`close_on_scroll`](Self::close_on_scroll), whether page scroll
+    /// dismisses the tooltip.
+    #[must_use]
+    pub const fn close_on_scroll(mut self, value: bool) -> Self {
+        self.close_on_scroll = value;
+        self
+    }
+
+    /// Registers [`on_open_change`](Self::on_open_change), the callback
+    /// fired when user interaction requests an open-state change.
+    #[must_use]
+    pub fn on_open_change<F>(mut self, f: F) -> Self
+    where
+        F: Fn(bool) + Send + Sync + 'static,
+    {
+        self.on_open_change = Some(Callback::new(f));
+        self
+    }
+
+    /// Sets [`lazy_mount`](Self::lazy_mount), whether content is mounted
+    /// only after the tooltip first opens.
+    #[must_use]
+    pub const fn lazy_mount(mut self, value: bool) -> Self {
+        self.lazy_mount = value;
+        self
+    }
+
+    /// Sets [`unmount_on_exit`](Self::unmount_on_exit), whether content is
+    /// removed from the DOM after closing.
+    #[must_use]
+    pub const fn unmount_on_exit(mut self, value: bool) -> Self {
+        self.unmount_on_exit = value;
+        self
+    }
+
+    /// Sets [`dir`](Self::dir), the text direction for tooltip content.
+    #[must_use]
+    pub const fn dir(mut self, value: Direction) -> Self {
+        self.dir = value;
+        self
+    }
+
+    /// Sets [`touch_auto_hide`](Self::touch_auto_hide), the adapter-owned
+    /// auto-hide timeout for touch-triggered tooltips.
+    #[must_use]
+    pub const fn touch_auto_hide(mut self, value: Duration) -> Self {
+        self.touch_auto_hide = value;
+        self
+    }
+}
+
+/// Localizable Tooltip messages.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct Messages;
+
+impl ComponentMessages for Messages {}
+
+/// The Tooltip state machine.
+#[derive(Debug)]
+pub struct Machine;
+
+impl ars_core::Machine for Machine {
+    type State = State;
+    type Event = Event;
+    type Context = Context;
+    type Props = Props;
+    type Messages = Messages;
+    type Api<'a> = Api<'a>;
+
+    fn init(props: &Self::Props, env: &Env, messages: &Self::Messages) -> (State, Context) {
+        let ids = ComponentIds::from_id(&props.id);
+
+        let open = props.open.unwrap_or(props.default_open);
+
+        let content_id = ids.part("content");
+
+        let state = if open { State::Open } else { State::Closed };
+
+        (
+            state,
+            Context {
+                locale: env.locale.clone(),
+                open,
+                open_delay: props.open_delay,
+                close_delay: close_delay(props),
+                disabled: props.disabled,
+                dir: props.dir,
+                hover_active: false,
+                focus_active: false,
+                positioning: props.positioning.clone(),
+                trigger_id: ids.part("trigger"),
+                hidden_description_id: format_description_id(&content_id),
+                content_id,
+                messages: messages.clone(),
+                z_index: None,
+                touch_auto_hide: props.touch_auto_hide.max(MIN_TOUCH_AUTO_HIDE),
+            },
+        )
+    }
+
+    fn transition(
+        state: &Self::State,
+        event: &Self::Event,
+        ctx: &Self::Context,
+        props: &Self::Props,
+    ) -> Option<TransitionPlan<Self>> {
+        if ctx.disabled
+            && !matches!(
+                event,
+                Event::SetControlledOpen(_) | Event::SyncProps | Event::SetZIndex(_)
+            )
+        {
+            return None;
+        }
+
+        match (state, event) {
+            (State::Closed, Event::PointerEnter) => Some(
+                TransitionPlan::to(State::OpenPending)
+                    .apply(|ctx: &mut Context| {
+                        ctx.hover_active = true;
+                    })
+                    .with_effect(PendingEffect::named(OPEN_DELAY_EFFECT)),
+            ),
+
+            (State::Closed, Event::Focus) => Some(open_plan(props, |ctx| {
+                ctx.focus_active = true;
+            })),
+
+            (State::OpenPending, Event::OpenTimerFired) => Some(
+                open_plan(props, |ctx| {
+                    ctx.hover_active = true;
+                })
+                .cancel_effect(OPEN_DELAY_EFFECT),
+            ),
+
+            (State::OpenPending, Event::PointerEnter) => {
+                Some(TransitionPlan::context_only(|ctx: &mut Context| {
+                    ctx.hover_active = true;
+                }))
+            }
+
+            (State::OpenPending, Event::Focus) => Some(open_plan(props, |ctx| {
+                ctx.focus_active = true;
+            })),
+
+            (State::OpenPending, Event::PointerLeave) if ctx.focus_active => {
+                Some(TransitionPlan::context_only(|ctx: &mut Context| {
+                    ctx.hover_active = false;
+                }))
+            }
+
+            (State::OpenPending, Event::PointerLeave) => Some(
+                TransitionPlan::to(State::Closed)
+                    .apply(|ctx: &mut Context| {
+                        ctx.hover_active = false;
+                    })
+                    .cancel_effect(OPEN_DELAY_EFFECT),
+            ),
+
+            (State::OpenPending, Event::Blur) if ctx.hover_active => {
+                Some(TransitionPlan::context_only(|ctx: &mut Context| {
+                    ctx.focus_active = false;
+                }))
+            }
+
+            (State::OpenPending, Event::Blur) => Some(
+                TransitionPlan::to(State::Closed)
+                    .apply(|ctx: &mut Context| {
+                        ctx.focus_active = false;
+                    })
+                    .cancel_effect(OPEN_DELAY_EFFECT),
+            ),
+
+            (
+                State::OpenPending,
+                Event::CloseOnEscape | Event::CloseOnClick | Event::CloseOnScroll,
+            ) if should_close_pending(*event, props) => Some(
+                TransitionPlan::to(State::Closed)
+                    .apply(clear_activity)
+                    .cancel_effect(OPEN_DELAY_EFFECT),
+            ),
+
+            (State::Open, Event::PointerEnter | Event::ContentPointerEnter) => {
+                Some(TransitionPlan::context_only(|ctx: &mut Context| {
+                    ctx.hover_active = true;
+                }))
+            }
+
+            (State::Open, Event::Focus) => {
+                Some(TransitionPlan::context_only(|ctx: &mut Context| {
+                    ctx.focus_active = true;
+                }))
+            }
+
+            (State::Open, Event::PointerLeave | Event::ContentPointerLeave) if ctx.focus_active => {
+                Some(TransitionPlan::context_only(|ctx: &mut Context| {
+                    ctx.hover_active = false;
+                }))
+            }
+
+            (State::Open, Event::PointerLeave | Event::ContentPointerLeave) => {
+                Some(close_pending_or_closed(props, |ctx| {
+                    ctx.hover_active = false;
+                }))
+            }
+
+            (State::Open, Event::Blur) if ctx.hover_active => {
+                Some(TransitionPlan::context_only(|ctx: &mut Context| {
+                    ctx.focus_active = false;
+                }))
+            }
+
+            (State::Open, Event::Blur) => Some(close_pending_or_closed(props, |ctx| {
+                ctx.focus_active = false;
+            })),
+
+            (State::Open, Event::CloseOnEscape | Event::CloseOnClick | Event::CloseOnScroll)
+                if should_close_visible(*event, props) =>
+            {
+                Some(close_now_plan(props))
+            }
+
+            (State::ClosePending, Event::CloseTimerFired) => Some(
+                close_now_plan(props)
+                    .apply(|ctx: &mut Context| {
+                        ctx.hover_active = false;
+                        ctx.focus_active = false;
+                    })
+                    .cancel_effect(CLOSE_DELAY_EFFECT),
+            ),
+
+            (State::ClosePending, Event::PointerEnter | Event::ContentPointerEnter) => Some(
+                open_plan(props, |ctx| {
+                    ctx.hover_active = true;
+                })
+                .cancel_effect(CLOSE_DELAY_EFFECT),
+            ),
+
+            (State::ClosePending, Event::Focus) => Some(
+                open_plan(props, |ctx| {
+                    ctx.focus_active = true;
+                })
+                .cancel_effect(CLOSE_DELAY_EFFECT),
+            ),
+
+            (State::ClosePending, Event::Blur) if ctx.hover_active => {
+                Some(TransitionPlan::context_only(|ctx: &mut Context| {
+                    ctx.focus_active = false;
+                }))
+            }
+
+            (State::ClosePending, Event::PointerLeave | Event::ContentPointerLeave)
+                if ctx.focus_active =>
+            {
+                Some(TransitionPlan::context_only(|ctx: &mut Context| {
+                    ctx.hover_active = false;
+                }))
+            }
+
+            (
+                State::ClosePending,
+                Event::CloseOnEscape | Event::CloseOnClick | Event::CloseOnScroll,
+            ) if should_close_visible(*event, props) => {
+                Some(close_now_plan(props).cancel_effect(CLOSE_DELAY_EFFECT))
+            }
+
+            (State::Closed | State::OpenPending, Event::Open) => Some(open_plan(props, |_| {})),
+
+            (State::Open | State::OpenPending | State::ClosePending, Event::Close) => {
+                Some(close_now_plan(props))
+            }
+
+            (_, Event::SetControlledOpen(open)) => Some(sync_controlled_plan(*open, props)),
+
+            (_, Event::SyncProps) => Some(sync_props_plan(props)),
+
+            (_, Event::SetZIndex(z_index)) => Some(TransitionPlan::context_only({
+                let z_index = *z_index;
+                move |ctx: &mut Context| {
+                    ctx.z_index = Some(z_index);
+                }
+            })),
+
+            _ => None,
+        }
+    }
+
+    fn connect<'a>(
+        state: &'a Self::State,
+        ctx: &'a Self::Context,
+        props: &'a Self::Props,
+        send: &'a dyn Fn(Self::Event),
+    ) -> Self::Api<'a> {
+        Api {
+            state,
+            ctx,
+            props,
+            send,
+        }
+    }
+
+    fn on_props_changed(old: &Self::Props, new: &Self::Props) -> Vec<Self::Event> {
+        let mut events = Vec::new();
+
+        match (old.open, new.open) {
+            (old_open, Some(new_open)) if old_open != Some(new_open) => {
+                events.push(Event::SetControlledOpen(new_open));
+            }
+
+            _ if props_context_changed(old, new) => {
+                events.push(Event::SyncProps);
+            }
+
+            _ => {}
+        }
+
+        events
+    }
+}
+
+/// Structural parts exposed by the Tooltip connect API.
+#[derive(ComponentPart)]
+#[scope = "tooltip"]
+pub enum Part {
+    /// The root container element.
+    Root,
+
+    /// The trigger element that owns the tooltip description.
+    Trigger,
+
+    /// The always-rendered visually-hidden description.
+    HiddenDescription,
+
+    /// The adapter-owned floating positioner element.
+    Positioner,
+
+    /// The visible tooltip content element.
+    Content,
+
+    /// The optional arrow element.
+    Arrow,
+}
+
+/// Connected Tooltip API.
+pub struct Api<'a> {
+    state: &'a State,
+    ctx: &'a Context,
+    props: &'a Props,
+    send: &'a dyn Fn(Event),
+}
+
+impl Debug for Api<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Api")
+            .field("state", self.state)
+            .field("ctx", self.ctx)
+            .field("props", self.props)
+            .finish()
+    }
+}
+
+impl<'a> Api<'a> {
+    /// Returns `true` when the tooltip is visibly open.
+    #[must_use]
+    pub const fn is_open(&self) -> bool {
+        self.ctx.open
+    }
+
+    /// Returns attributes for the root element.
+    #[must_use]
+    pub fn root_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Root.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Data("ars-state"), self.state_token());
+
+        if self.ctx.disabled {
+            attrs.set(HtmlAttr::Data("ars-disabled"), "true");
+        }
+
+        attrs
+    }
+
+    /// Returns attributes for the trigger element.
+    #[must_use]
+    pub fn trigger_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Trigger.data_attrs();
+
+        attrs
+            .set(HtmlAttr::Id, &self.ctx.trigger_id)
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(
+                HtmlAttr::Aria(AriaAttr::DescribedBy),
+                &self.ctx.hidden_description_id,
+            );
+
+        if self.ctx.disabled {
+            attrs.set(HtmlAttr::Aria(AriaAttr::Disabled), "true");
+        }
+
+        attrs
+    }
+
+    /// Dispatches a trigger pointer-enter event.
+    pub fn on_trigger_pointer_enter(&self) {
+        (self.send)(Event::PointerEnter);
+    }
+
+    /// Dispatches a trigger pointer-leave event.
+    pub fn on_trigger_pointer_leave(&self) {
+        (self.send)(Event::PointerLeave);
+    }
+
+    /// Dispatches a trigger focus event.
+    pub fn on_trigger_focus(&self) {
+        (self.send)(Event::Focus);
+    }
+
+    /// Dispatches a trigger blur event.
+    pub fn on_trigger_blur(&self) {
+        (self.send)(Event::Blur);
+    }
+
+    /// Dispatches a trigger click dismissal request.
+    pub fn on_trigger_click(&self) {
+        if self.props.close_on_click {
+            (self.send)(Event::CloseOnClick);
+        }
+    }
+
+    /// Dispatches a scroll dismissal request.
+    pub fn on_scroll(&self) {
+        if self.props.close_on_scroll {
+            (self.send)(Event::CloseOnScroll);
+        }
+    }
+
+    /// Handles trigger keydown and returns whether the key was consumed.
+    #[must_use]
+    pub fn on_trigger_keydown(&self, data: &KeyboardEventData) -> bool {
+        if data.key == KeyboardKey::Escape
+            && self.props.close_on_escape
+            && matches!(
+                self.state,
+                State::OpenPending | State::Open | State::ClosePending
+            )
+        {
+            (self.send)(Event::CloseOnEscape);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Dispatches a visible-content pointer-enter event.
+    pub fn on_content_pointer_enter(&self) {
+        (self.send)(Event::ContentPointerEnter);
+    }
+
+    /// Dispatches a visible-content pointer-leave event.
+    pub fn on_content_pointer_leave(&self) {
+        (self.send)(Event::ContentPointerLeave);
+    }
+
+    /// Returns attributes for the always-rendered hidden description.
+    #[must_use]
+    pub fn hidden_description_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::HiddenDescription.data_attrs();
+
+        attrs
+            .set(HtmlAttr::Id, &self.ctx.hidden_description_id)
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Data("ars-visually-hidden"), "true");
+
+        attrs
+    }
+
+    /// Returns attributes for the adapter-owned floating positioner.
+    #[must_use]
+    pub fn positioner_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Positioner.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Data("ars-state"), self.state_token())
+            .set(
+                HtmlAttr::Data("ars-placement"),
+                self.ctx.positioning.placement.as_str(),
+            );
+
+        if let Some(z_index) = self.ctx.z_index {
+            attrs.set_style(CssProperty::Custom("ars-z-index"), z_index.to_string());
+        }
+
+        attrs
+    }
+
+    /// Returns attributes for the visible tooltip content.
+    #[must_use]
+    pub fn content_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Content.data_attrs();
+
+        attrs
+            .set(HtmlAttr::Id, &self.ctx.content_id)
+            .set(HtmlAttr::Aria(AriaAttr::Hidden), "true")
+            .set(HtmlAttr::Dir, self.ctx.dir.as_html_attr())
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Data("ars-state"), self.state_token());
+
+        attrs
+    }
+
+    /// Returns attributes for the optional arrow element.
+    #[must_use]
+    pub fn arrow_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Arrow.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(
+                HtmlAttr::Data("ars-placement"),
+                self.ctx.positioning.placement.as_str(),
+            );
+
+        attrs
+    }
+
+    const fn state_token(&self) -> &'static str {
+        if self.is_open() { "open" } else { "closed" }
+    }
+}
+
+impl ConnectApi for Api<'_> {
+    type Part = Part;
+
+    fn part_attrs(&self, part: Part) -> AttrMap {
+        match part {
+            Part::Root => self.root_attrs(),
+            Part::Trigger => self.trigger_attrs(),
+            Part::HiddenDescription => self.hidden_description_attrs(),
+            Part::Positioner => self.positioner_attrs(),
+            Part::Content => self.content_attrs(),
+            Part::Arrow => self.arrow_attrs(),
+        }
+    }
+}
+
+const fn close_delay(props: &Props) -> Duration {
+    props.close_delay
+}
+
+fn format_description_id(content_id: &str) -> String {
+    let mut id = String::from(content_id);
+
+    id.push_str("-description");
+
+    id
+}
+
+const fn clear_activity(ctx: &mut Context) {
+    ctx.hover_active = false;
+    ctx.focus_active = false;
+}
+
+const fn should_close_pending(event: Event, props: &Props) -> bool {
+    match event {
+        Event::CloseOnEscape => props.close_on_escape,
+        Event::CloseOnClick => props.close_on_click,
+        Event::CloseOnScroll => props.close_on_scroll,
+        _ => false,
+    }
+}
+
+const fn should_close_visible(event: Event, props: &Props) -> bool {
+    should_close_pending(event, props)
+}
+
+fn open_change_effect(open: bool) -> PendingEffect<Machine> {
+    PendingEffect::new(
+        OPEN_CHANGE_EFFECT,
+        move |_ctx: &Context, props: &Props, _send| {
+            if let Some(cb) = &props.on_open_change {
+                cb(open);
+            }
+
+            no_cleanup()
+        },
+    )
+}
+
+fn open_plan(
+    props: &Props,
+    apply_activity: impl FnOnce(&mut Context) + 'static,
+) -> TransitionPlan<Machine> {
+    if props.open.is_some() {
+        TransitionPlan::context_only(apply_activity).with_effect(open_change_effect(true))
+    } else {
+        TransitionPlan::to(State::Open)
+            .apply(move |ctx: &mut Context| {
+                ctx.open = true;
+                apply_activity(ctx);
+            })
+            .with_effect(open_change_effect(true))
+            .with_effect(PendingEffect::named(ALLOCATE_Z_INDEX_EFFECT))
+    }
+}
+
+fn close_pending_or_closed(
+    props: &Props,
+    apply_activity: impl FnOnce(&mut Context) + 'static,
+) -> TransitionPlan<Machine> {
+    if close_delay(props).is_zero() && props.open.is_none() {
+        close_now_plan(props).apply(apply_activity)
+    } else if props.open.is_some() {
+        TransitionPlan::context_only(apply_activity).with_effect(open_change_effect(false))
+    } else {
+        TransitionPlan::to(State::ClosePending)
+            .apply(apply_activity)
+            .with_effect(PendingEffect::named(CLOSE_DELAY_EFFECT))
+    }
+}
+
+fn close_now_plan(props: &Props) -> TransitionPlan<Machine> {
+    let plan = if props.open.is_some() {
+        TransitionPlan::context_only(clear_activity)
+    } else {
+        TransitionPlan::to(State::Closed).apply(|ctx: &mut Context| {
+            ctx.open = false;
+            clear_activity(ctx);
+        })
+    };
+
+    plan.with_effect(open_change_effect(false))
+}
+
+fn sync_controlled_plan(open: bool, props: &Props) -> TransitionPlan<Machine> {
+    let state = if open { State::Open } else { State::Closed };
+
+    let props = props.clone();
+
+    let mut plan = TransitionPlan::to(state).apply(move |ctx: &mut Context| {
+        ctx.open = open;
+
+        sync_props_context(ctx, &props);
+
+        if !open {
+            clear_activity(ctx);
+        }
+    });
+
+    if open {
+        plan = plan.with_effect(PendingEffect::named(ALLOCATE_Z_INDEX_EFFECT));
+    } else {
+        plan = plan
+            .cancel_effect(OPEN_DELAY_EFFECT)
+            .cancel_effect(CLOSE_DELAY_EFFECT);
+    }
+
+    plan
+}
+
+fn sync_props_plan(props: &Props) -> TransitionPlan<Machine> {
+    TransitionPlan::context_only({
+        let props = props.clone();
+        move |ctx: &mut Context| {
+            sync_props_context(ctx, &props);
+        }
+    })
+}
+
+fn sync_props_context(ctx: &mut Context, props: &Props) {
+    ctx.open_delay = props.open_delay;
+    ctx.close_delay = close_delay(props);
+    ctx.disabled = props.disabled;
+    ctx.dir = props.dir;
+    ctx.positioning = props.positioning.clone();
+    ctx.touch_auto_hide = props.touch_auto_hide.max(MIN_TOUCH_AUTO_HIDE);
+}
+
+fn props_context_changed(old: &Props, new: &Props) -> bool {
+    old.open_delay != new.open_delay
+        || old.close_delay != new.close_delay
+        || old.disabled != new.disabled
+        || old.dir != new.dir
+        || old.positioning != new.positioning
+        || old.touch_auto_hide != new.touch_auto_hide
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::{rc::Rc, string::ToString, sync::Arc, vec::Vec};
+    use core::{cell::RefCell, time::Duration};
+    use std::sync::Mutex;
+
+    use ars_core::{ConnectApi, Service, callback};
+    use insta::assert_snapshot;
+
+    use super::*;
+    use crate::overlay::positioning::Placement;
+
+    fn test_props() -> Props {
+        Props {
+            id: "tooltip".to_string(),
+            ..Props::default()
+        }
+    }
+
+    fn keyboard_data(key: KeyboardKey) -> KeyboardEventData {
+        KeyboardEventData {
+            key,
+            character: None,
+            code: String::new(),
+            shift_key: false,
+            ctrl_key: false,
+            alt_key: false,
+            meta_key: false,
+            repeat: false,
+            is_composing: false,
+        }
+    }
+
+    fn effect_names(result: &ars_core::SendResult<Machine>) -> Vec<&'static str> {
+        result
+            .pending_effects
+            .iter()
+            .map(|effect| effect.name)
+            .collect()
+    }
+
+    fn snapshot_api(api: &Api<'_>) -> String {
+        format!(
+            "root:\n{:#?}\ntrigger:\n{:#?}\nhidden_description:\n{:#?}\npositioner:\n{:#?}\ncontent:\n{:#?}\narrow:\n{:#?}",
+            api.root_attrs(),
+            api.trigger_attrs(),
+            api.hidden_description_attrs(),
+            api.positioner_attrs(),
+            api.content_attrs(),
+            api.arrow_attrs(),
+        )
+    }
+
+    #[test]
+    fn tooltip_props_new_returns_default_values() {
+        assert_eq!(Props::new(), Props::default());
+    }
+
+    #[test]
+    fn tooltip_props_builder_chain_applies_each_setter() {
+        let observed = Arc::new(Mutex::new(Vec::new()));
+        let observed_for_props = Arc::clone(&observed);
+        let positioning = PositioningOptions {
+            placement: Placement::RightStart,
+            ..PositioningOptions::default()
+        };
+
+        let props = Props::new()
+            .id("tooltip-builder")
+            .open(true)
+            .default_open(true)
+            .open_delay(Duration::from_millis(25))
+            .close_delay(Duration::from_millis(75))
+            .disabled(true)
+            .positioning(positioning.clone())
+            .close_on_escape(false)
+            .close_on_click(false)
+            .close_on_scroll(false)
+            .on_open_change(move |open| {
+                observed_for_props
+                    .lock()
+                    .expect("observed callback state should not be poisoned")
+                    .push(open);
+            })
+            .lazy_mount(true)
+            .unmount_on_exit(true)
+            .dir(Direction::Rtl)
+            .touch_auto_hide(Duration::from_secs(30));
+
+        assert_eq!(props.id, "tooltip-builder");
+        assert_eq!(props.open, Some(true));
+        assert!(props.default_open);
+        assert_eq!(props.open_delay, Duration::from_millis(25));
+        assert_eq!(props.close_delay, Duration::from_millis(75));
+        assert!(props.disabled);
+        assert_eq!(props.positioning, positioning);
+        assert!(!props.close_on_escape);
+        assert!(!props.close_on_click);
+        assert!(!props.close_on_scroll);
+        assert!(props.on_open_change.is_some());
+        assert!(props.lazy_mount);
+        assert!(props.unmount_on_exit);
+        assert_eq!(props.dir, Direction::Rtl);
+        assert_eq!(props.touch_auto_hide, Duration::from_secs(30));
+
+        props
+            .on_open_change
+            .as_ref()
+            .expect("builder should register callback")(false);
+
+        assert_eq!(
+            &*observed
+                .lock()
+                .expect("observed callback state should not be poisoned"),
+            &[false]
+        );
+    }
+
+    #[test]
+    fn tooltip_hover_enters_open_pending_with_open_delay_effect() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &Messages);
+
+        let result = service.send(Event::PointerEnter);
+
+        assert_eq!(service.state(), &State::OpenPending);
+        assert!(service.context().hover_active);
+        assert!(!service.context().open);
+        assert_eq!(effect_names(&result), vec![OPEN_DELAY_EFFECT]);
+    }
+
+    #[test]
+    fn tooltip_open_pending_pointer_enter_keeps_pending() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &Messages);
+
+        drop(service.send(Event::PointerEnter));
+
+        service.context_mut().hover_active = false;
+
+        let result = service.send(Event::PointerEnter);
+
+        assert_eq!(service.state(), &State::OpenPending);
+        assert!(service.context().hover_active);
+        assert!(!result.state_changed);
+    }
+
+    #[test]
+    fn tooltip_open_pending_focus_opens_immediately() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &Messages);
+
+        drop(service.send(Event::PointerEnter));
+
+        let result = service.send(Event::Focus);
+
+        assert_eq!(service.state(), &State::Open);
+        assert!(service.context().focus_active);
+        assert_eq!(
+            effect_names(&result),
+            vec![OPEN_CHANGE_EFFECT, ALLOCATE_Z_INDEX_EFFECT]
+        );
+    }
+
+    #[test]
+    fn tooltip_open_timer_opens_and_allocates_z_index() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &Messages);
+
+        drop(service.send(Event::PointerEnter));
+
+        let result = service.send(Event::OpenTimerFired);
+
+        assert_eq!(service.state(), &State::Open);
+        assert!(service.context().open);
+        assert_eq!(
+            effect_names(&result),
+            vec![OPEN_CHANGE_EFFECT, ALLOCATE_Z_INDEX_EFFECT]
+        );
+        assert_eq!(result.cancel_effects, vec![OPEN_DELAY_EFFECT]);
+    }
+
+    #[test]
+    fn tooltip_open_pending_pointer_leave_with_focus_stays_pending() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &Messages);
+
+        drop(service.send(Event::PointerEnter));
+
+        service.context_mut().focus_active = true;
+
+        let result = service.send(Event::PointerLeave);
+
+        assert_eq!(service.state(), &State::OpenPending);
+        assert!(!service.context().hover_active);
+        assert!(service.context().focus_active);
+        assert!(result.cancel_effects.is_empty());
+    }
+
+    #[test]
+    fn tooltip_open_pending_pointer_leave_without_focus_closes() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &Messages);
+
+        drop(service.send(Event::PointerEnter));
+
+        let result = service.send(Event::PointerLeave);
+
+        assert_eq!(service.state(), &State::Closed);
+        assert!(!service.context().hover_active);
+        assert_eq!(result.cancel_effects, vec![OPEN_DELAY_EFFECT]);
+    }
+
+    #[test]
+    fn tooltip_open_pending_blur_with_hover_stays_pending() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &Messages);
+
+        drop(service.send(Event::PointerEnter));
+
+        service.context_mut().focus_active = true;
+
+        let result = service.send(Event::Blur);
+
+        assert_eq!(service.state(), &State::OpenPending);
+        assert!(service.context().hover_active);
+        assert!(!service.context().focus_active);
+        assert!(result.cancel_effects.is_empty());
+    }
+
+    #[test]
+    fn tooltip_open_pending_blur_without_hover_closes() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &Messages);
+
+        drop(service.send(Event::PointerEnter));
+
+        service.context_mut().hover_active = false;
+        service.context_mut().focus_active = true;
+
+        let result = service.send(Event::Blur);
+
+        assert_eq!(service.state(), &State::Closed);
+        assert!(!service.context().focus_active);
+        assert_eq!(result.cancel_effects, vec![OPEN_DELAY_EFFECT]);
+    }
+
+    #[test]
+    fn tooltip_open_pending_dismiss_cancels_open_delay() {
+        for event in [
+            Event::CloseOnEscape,
+            Event::CloseOnClick,
+            Event::CloseOnScroll,
+        ] {
+            let mut service = Service::<Machine>::new(test_props(), &Env::default(), &Messages);
+
+            drop(service.send(Event::PointerEnter));
+
+            let result = service.send(event);
+
+            assert_eq!(service.state(), &State::Closed);
+            assert!(!service.context().hover_active);
+            assert_eq!(result.cancel_effects, vec![OPEN_DELAY_EFFECT]);
+        }
+    }
+
+    #[test]
+    fn tooltip_pointer_leave_enters_close_pending_with_close_delay_effect() {
+        let mut service = Service::<Machine>::new(
+            Props {
+                default_open: true,
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages,
+        );
+
+        let result = service.send(Event::PointerLeave);
+
+        assert_eq!(service.state(), &State::ClosePending);
+        assert!(service.context().open);
+        assert_eq!(effect_names(&result), vec![CLOSE_DELAY_EFFECT]);
+    }
+
+    #[test]
+    fn tooltip_open_pointer_enter_and_content_enter_keep_hover_active() {
+        let mut service = Service::<Machine>::new(
+            Props {
+                default_open: true,
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages,
+        );
+
+        service.context_mut().hover_active = false;
+
+        drop(service.send(Event::PointerEnter));
+
+        assert!(service.context().hover_active);
+
+        service.context_mut().hover_active = false;
+
+        drop(service.send(Event::ContentPointerEnter));
+
+        assert!(service.context().hover_active);
+    }
+
+    #[test]
+    fn tooltip_open_pointer_leave_with_focus_stays_open() {
+        let mut service = Service::<Machine>::new(
+            Props {
+                default_open: true,
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages,
+        );
+
+        drop(service.send(Event::Focus));
+
+        let result = service.send(Event::PointerLeave);
+
+        assert_eq!(service.state(), &State::Open);
+        assert!(!service.context().hover_active);
+        assert!(service.context().focus_active);
+        assert!(result.pending_effects.is_empty());
+    }
+
+    #[test]
+    fn tooltip_open_blur_with_hover_stays_open() {
+        let mut service = Service::<Machine>::new(
+            Props {
+                default_open: true,
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages,
+        );
+
+        drop(service.send(Event::PointerEnter));
+
+        service.context_mut().focus_active = true;
+
+        let result = service.send(Event::Blur);
+
+        assert_eq!(service.state(), &State::Open);
+        assert!(service.context().hover_active);
+        assert!(!service.context().focus_active);
+        assert!(result.pending_effects.is_empty());
+    }
+
+    #[test]
+    fn tooltip_zero_close_delay_closes_immediately() {
+        let mut service = Service::<Machine>::new(
+            Props {
+                default_open: true,
+                close_delay: Duration::ZERO,
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages,
+        );
+
+        let result = service.send(Event::PointerLeave);
+
+        assert_eq!(service.state(), &State::Closed);
+        assert!(!service.context().open);
+        assert_eq!(effect_names(&result), vec![OPEN_CHANGE_EFFECT]);
+    }
+
+    #[test]
+    fn tooltip_close_timer_closes() {
+        let mut service = Service::<Machine>::new(
+            Props {
+                default_open: true,
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages,
+        );
+
+        drop(service.send(Event::PointerLeave));
+
+        let result = service.send(Event::CloseTimerFired);
+
+        assert_eq!(service.state(), &State::Closed);
+        assert!(!service.context().open);
+        assert_eq!(effect_names(&result), vec![OPEN_CHANGE_EFFECT]);
+        assert_eq!(result.cancel_effects, vec![CLOSE_DELAY_EFFECT]);
+    }
+
+    #[test]
+    fn tooltip_close_pending_focus_cancels_pending_close() {
+        let mut service = Service::<Machine>::new(
+            Props {
+                default_open: true,
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages,
+        );
+
+        drop(service.send(Event::PointerLeave));
+
+        let result = service.send(Event::Focus);
+
+        assert_eq!(service.state(), &State::Open);
+        assert!(service.context().focus_active);
+        assert_eq!(result.cancel_effects, vec![CLOSE_DELAY_EFFECT]);
+    }
+
+    #[test]
+    fn tooltip_close_pending_blur_with_hover_stays_pending() {
+        let mut service = Service::<Machine>::new(
+            Props {
+                default_open: true,
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages,
+        );
+
+        drop(service.send(Event::PointerLeave));
+
+        service.context_mut().hover_active = true;
+        service.context_mut().focus_active = true;
+
+        let result = service.send(Event::Blur);
+
+        assert_eq!(service.state(), &State::ClosePending);
+        assert!(service.context().hover_active);
+        assert!(!service.context().focus_active);
+        assert!(result.pending_effects.is_empty());
+    }
+
+    #[test]
+    fn tooltip_close_pending_pointer_leave_with_focus_stays_pending() {
+        let mut service = Service::<Machine>::new(
+            Props {
+                default_open: true,
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages,
+        );
+
+        drop(service.send(Event::PointerLeave));
+
+        service.context_mut().hover_active = true;
+        service.context_mut().focus_active = true;
+
+        let result = service.send(Event::ContentPointerLeave);
+
+        assert_eq!(service.state(), &State::ClosePending);
+        assert!(!service.context().hover_active);
+        assert!(service.context().focus_active);
+        assert!(result.pending_effects.is_empty());
+    }
+
+    #[test]
+    fn tooltip_close_pending_trigger_leave_with_focus_stays_pending() {
+        let mut service = Service::<Machine>::new(
+            Props {
+                default_open: true,
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages,
+        );
+
+        drop(service.send(Event::PointerLeave));
+
+        service.context_mut().hover_active = true;
+        service.context_mut().focus_active = true;
+
+        let result = service.send(Event::PointerLeave);
+
+        assert_eq!(service.state(), &State::ClosePending);
+        assert!(!service.context().hover_active);
+        assert!(service.context().focus_active);
+        assert!(result.pending_effects.is_empty());
+    }
+
+    #[test]
+    fn tooltip_close_pending_dismiss_closes_and_cancels_delay() {
+        let mut service = Service::<Machine>::new(
+            Props {
+                default_open: true,
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages,
+        );
+
+        drop(service.send(Event::PointerLeave));
+
+        let result = service.send(Event::CloseOnEscape);
+
+        assert_eq!(service.state(), &State::Closed);
+        assert!(!service.context().open);
+        assert_eq!(result.cancel_effects, vec![CLOSE_DELAY_EFFECT]);
+    }
+
+    #[test]
+    fn tooltip_focus_opens_immediately_without_open_delay() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &Messages);
+
+        let result = service.send(Event::Focus);
+
+        assert_eq!(service.state(), &State::Open);
+        assert!(service.context().open);
+        assert!(service.context().focus_active);
+        assert_eq!(
+            effect_names(&result),
+            vec![OPEN_CHANGE_EFFECT, ALLOCATE_Z_INDEX_EFFECT]
+        );
+    }
+
+    #[test]
+    fn tooltip_blur_closes_through_close_delay() {
+        let mut service = Service::<Machine>::new(
+            Props {
+                default_open: true,
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages,
+        );
+
+        drop(service.send(Event::Focus));
+
+        let result = service.send(Event::Blur);
+
+        assert_eq!(service.state(), &State::ClosePending);
+        assert_eq!(effect_names(&result), vec![CLOSE_DELAY_EFFECT]);
+    }
+
+    #[test]
+    fn tooltip_content_pointer_enter_cancels_pending_close() {
+        let mut service = Service::<Machine>::new(
+            Props {
+                default_open: true,
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages,
+        );
+
+        drop(service.send(Event::PointerLeave));
+
+        let result = service.send(Event::ContentPointerEnter);
+
+        assert_eq!(service.state(), &State::Open);
+        assert!(service.context().hover_active);
+        assert_eq!(result.cancel_effects, vec![CLOSE_DELAY_EFFECT]);
+    }
+
+    #[test]
+    fn tooltip_escape_dismisses_when_enabled() {
+        let mut service = Service::<Machine>::new(
+            Props {
+                default_open: true,
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages,
+        );
+
+        let result = service.send(Event::CloseOnEscape);
+
+        assert_eq!(service.state(), &State::Closed);
+        assert!(!service.context().open);
+        assert_eq!(effect_names(&result), vec![OPEN_CHANGE_EFFECT]);
+    }
+
+    #[test]
+    fn tooltip_escape_ignored_when_disabled_by_prop() {
+        let mut service = Service::<Machine>::new(
+            Props {
+                default_open: true,
+                close_on_escape: false,
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages,
+        );
+
+        let result = service.send(Event::CloseOnEscape);
+
+        assert_eq!(service.state(), &State::Open);
+        assert!(result.pending_effects.is_empty());
+    }
+
+    #[test]
+    fn tooltip_click_dismiss_respects_prop() {
+        let mut service = Service::<Machine>::new(
+            Props {
+                default_open: true,
+                close_on_click: false,
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages,
+        );
+
+        drop(service.send(Event::CloseOnClick));
+
+        assert_eq!(service.state(), &State::Open);
+    }
+
+    #[test]
+    fn tooltip_scroll_dismiss_respects_prop() {
+        let mut service = Service::<Machine>::new(
+            Props {
+                default_open: true,
+                close_on_scroll: false,
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages,
+        );
+
+        drop(service.send(Event::CloseOnScroll));
+
+        assert_eq!(service.state(), &State::Open);
+    }
+
+    #[test]
+    fn tooltip_disabled_ignores_user_interaction() {
+        let mut service = Service::<Machine>::new(
+            Props {
+                disabled: true,
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages,
+        );
+
+        let result = service.send(Event::PointerEnter);
+
+        assert_eq!(service.state(), &State::Closed);
+        assert!(result.pending_effects.is_empty());
+    }
+
+    #[test]
+    fn tooltip_close_delay_does_not_clamp_for_hoverable_content() {
+        let service = Service::<Machine>::new(
+            Props {
+                close_delay: Duration::from_millis(1),
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages,
+        );
+
+        assert_eq!(service.context().close_delay, Duration::from_millis(1));
+    }
+
+    #[test]
+    fn tooltip_touch_auto_hide_clamps_to_minimum() {
+        let service = Service::<Machine>::new(
+            Props {
+                touch_auto_hide: Duration::from_millis(1),
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages,
+        );
+
+        assert_eq!(service.context().touch_auto_hide, MIN_TOUCH_AUTO_HIDE);
+    }
+
+    #[test]
+    fn tooltip_programmatic_open_and_close_skip_delays() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &Messages);
+
+        let open = service.send(Event::Open);
+
+        assert_eq!(service.state(), &State::Open);
+        assert!(service.context().open);
+        assert_eq!(
+            effect_names(&open),
+            vec![OPEN_CHANGE_EFFECT, ALLOCATE_Z_INDEX_EFFECT]
+        );
+
+        let close = service.send(Event::Close);
+
+        assert_eq!(service.state(), &State::Closed);
+        assert!(!service.context().open);
+        assert_eq!(effect_names(&close), vec![OPEN_CHANGE_EFFECT]);
+    }
+
+    #[test]
+    fn tooltip_controlled_open_request_waits_for_prop_sync() {
+        let mut service = Service::<Machine>::new(
+            Props {
+                open: Some(false),
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages,
+        );
+
+        let result = service.send(Event::Focus);
+
+        assert_eq!(service.state(), &State::Closed);
+        assert!(!service.context().open);
+        assert!(service.context().focus_active);
+        assert_eq!(effect_names(&result), vec![OPEN_CHANGE_EFFECT]);
+    }
+
+    #[test]
+    fn tooltip_controlled_close_request_waits_for_prop_sync() {
+        let mut service = Service::<Machine>::new(
+            Props {
+                open: Some(true),
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages,
+        );
+
+        drop(service.send(Event::PointerEnter));
+        drop(service.send(Event::Focus));
+
+        let result = service.send(Event::Close);
+
+        assert_eq!(service.state(), &State::Open);
+        assert!(service.context().open);
+        assert!(!service.context().hover_active);
+        assert!(!service.context().focus_active);
+        assert_eq!(effect_names(&result), vec![OPEN_CHANGE_EFFECT]);
+    }
+
+    #[test]
+    fn tooltip_controlled_pointer_leave_requests_close_without_state_change() {
+        let mut service = Service::<Machine>::new(
+            Props {
+                open: Some(true),
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages,
+        );
+
+        let result = service.send(Event::PointerLeave);
+
+        assert_eq!(service.state(), &State::Open);
+        assert!(service.context().open);
+        assert!(!service.context().hover_active);
+        assert_eq!(effect_names(&result), vec![OPEN_CHANGE_EFFECT]);
+    }
+
+    #[test]
+    fn tooltip_controlled_prop_sync_updates_state_and_context() {
+        let mut service = Service::<Machine>::new(
+            Props {
+                open: Some(false),
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages,
+        );
+
+        let result = service.set_props(Props {
+            open: Some(true),
+            ..test_props()
+        });
+
+        assert_eq!(service.state(), &State::Open);
+        assert!(service.context().open);
+        assert_eq!(effect_names(&result), vec![ALLOCATE_Z_INDEX_EFFECT]);
+    }
+
+    #[test]
+    fn tooltip_controlled_prop_sync_false_closes_and_cancels_timers() {
+        let mut service = Service::<Machine>::new(
+            Props {
+                open: Some(true),
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages,
+        );
+
+        drop(service.send(Event::PointerLeave));
+
+        let result = service.set_props(Props {
+            open: Some(false),
+            ..test_props()
+        });
+
+        assert_eq!(service.state(), &State::Closed);
+        assert!(!service.context().open);
+        assert_eq!(
+            result.cancel_effects,
+            vec![OPEN_DELAY_EFFECT, CLOSE_DELAY_EFFECT]
+        );
+    }
+
+    #[test]
+    fn tooltip_disabled_allows_prop_sync_and_z_index_feedback() {
+        let mut service = Service::<Machine>::new(
+            Props {
+                disabled: true,
+                open: Some(false),
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages,
+        );
+
+        drop(service.set_props(Props {
+            disabled: true,
+            open: Some(true),
+            ..test_props()
+        }));
+        drop(service.send(Event::SetZIndex(42)));
+
+        assert_eq!(service.state(), &State::Open);
+        assert!(service.context().open);
+        assert_eq!(service.context().z_index, Some(42));
+    }
+
+    #[test]
+    fn tooltip_props_changed_syncs_context_without_open_change() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &Messages);
+
+        let result = service.set_props(Props {
+            open_delay: Duration::from_millis(12),
+            close_delay: Duration::ZERO,
+            disabled: true,
+            dir: Direction::Rtl,
+            positioning: PositioningOptions {
+                placement: Placement::LeftEnd,
+                ..PositioningOptions::default()
+            },
+            touch_auto_hide: Duration::from_millis(1),
+            ..test_props()
+        });
+
+        assert_eq!(service.context().open_delay, Duration::from_millis(12));
+        assert_eq!(service.context().close_delay, Duration::ZERO);
+        assert!(service.context().disabled);
+        assert_eq!(service.context().dir, Direction::Rtl);
+        assert_eq!(service.context().positioning.placement, Placement::LeftEnd);
+        assert_eq!(service.context().touch_auto_hide, MIN_TOUCH_AUTO_HIDE);
+        assert!(result.pending_effects.is_empty());
+    }
+
+    #[test]
+    fn tooltip_on_props_changed_reports_each_context_backed_prop() {
+        let old = test_props();
+        let cases = [
+            Props {
+                open_delay: Duration::from_millis(12),
+                ..test_props()
+            },
+            Props {
+                close_delay: Duration::ZERO,
+                ..test_props()
+            },
+            Props {
+                disabled: true,
+                ..test_props()
+            },
+            Props {
+                dir: Direction::Rtl,
+                ..test_props()
+            },
+            Props {
+                positioning: PositioningOptions {
+                    placement: Placement::EndBottom,
+                    ..PositioningOptions::default()
+                },
+                ..test_props()
+            },
+            Props {
+                touch_auto_hide: Duration::from_millis(5_001),
+                ..test_props()
+            },
+        ];
+
+        for new in cases {
+            assert_eq!(
+                <Machine as ars_core::Machine>::on_props_changed(&old, &new),
+                vec![Event::SyncProps]
+            );
+        }
+
+        assert!(<Machine as ars_core::Machine>::on_props_changed(&old, &old).is_empty());
+    }
+
+    #[test]
+    fn tooltip_set_z_index_updates_positioner_style() {
+        let mut service = Service::<Machine>::new(
+            Props {
+                default_open: true,
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages,
+        );
+
+        drop(service.send(Event::SetZIndex(1200)));
+
+        let attrs = service.connect(&|_| {}).positioner_attrs();
+
+        assert_eq!(
+            attrs.styles(),
+            &[(CssProperty::Custom("ars-z-index"), "1200".to_string())]
+        );
+    }
+
+    #[test]
+    fn tooltip_trigger_describes_hidden_description() {
+        let service = Service::<Machine>::new(test_props(), &Env::default(), &Messages);
+
+        let api = service.connect(&|_| {});
+
+        assert_eq!(
+            api.trigger_attrs()
+                .get(&HtmlAttr::Aria(AriaAttr::DescribedBy)),
+            Some("tooltip-content-description")
+        );
+        assert_eq!(
+            api.hidden_description_attrs().get(&HtmlAttr::Id),
+            Some("tooltip-content-description")
+        );
+    }
+
+    #[test]
+    fn tooltip_content_has_accessibility_and_state_attrs() {
+        let service = Service::<Machine>::new(
+            Props {
+                default_open: true,
+                dir: Direction::Rtl,
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages,
+        );
+
+        let attrs = service.connect(&|_| {}).content_attrs();
+
+        assert_eq!(attrs.get(&HtmlAttr::Id), Some("tooltip-content"));
+        assert_eq!(attrs.get(&HtmlAttr::Role), None);
+        assert_eq!(attrs.get(&HtmlAttr::Aria(AriaAttr::Hidden)), Some("true"));
+        assert_eq!(attrs.get(&HtmlAttr::Dir), Some("rtl"));
+        assert_eq!(attrs.get(&HtmlAttr::Data("ars-state")), Some("open"));
+    }
+
+    #[test]
+    fn tooltip_positioner_has_placement_attr() {
+        let service = Service::<Machine>::new(
+            Props {
+                positioning: PositioningOptions {
+                    placement: Placement::TopStart,
+                    ..PositioningOptions::default()
+                },
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages,
+        );
+
+        let attrs = service.connect(&|_| {}).positioner_attrs();
+
+        assert_eq!(
+            attrs.get(&HtmlAttr::Data("ars-placement")),
+            Some("top-start")
+        );
+    }
+
+    #[test]
+    fn tooltip_part_attrs_match_direct_methods() {
+        let service = Service::<Machine>::new(test_props(), &Env::default(), &Messages);
+
+        let api = service.connect(&|_| {});
+
+        assert_eq!(api.part_attrs(Part::Root), api.root_attrs());
+        assert_eq!(api.part_attrs(Part::Trigger), api.trigger_attrs());
+        assert_eq!(
+            api.part_attrs(Part::HiddenDescription),
+            api.hidden_description_attrs()
+        );
+        assert_eq!(api.part_attrs(Part::Positioner), api.positioner_attrs());
+        assert_eq!(api.part_attrs(Part::Content), api.content_attrs());
+        assert_eq!(api.part_attrs(Part::Arrow), api.arrow_attrs());
+    }
+
+    #[test]
+    fn tooltip_api_debug_includes_state_context_and_props() {
+        let service = Service::<Machine>::new(test_props(), &Env::default(), &Messages);
+
+        let debug = format!("{:?}", service.connect(&|_| {}));
+
+        assert!(debug.contains("Api"));
+        assert!(debug.contains("state"));
+        assert!(debug.contains("ctx"));
+        assert!(debug.contains("props"));
+    }
+
+    #[test]
+    fn tooltip_api_event_helpers_dispatch_expected_events() {
+        let service = Service::<Machine>::new(test_props(), &Env::default(), &Messages);
+        let sent = Rc::new(RefCell::new(Vec::new()));
+        let sent_clone = Rc::clone(&sent);
+
+        let send = move |event| sent_clone.borrow_mut().push(event);
+
+        let api = service.connect(&send);
+
+        api.on_trigger_pointer_enter();
+        api.on_trigger_pointer_leave();
+        api.on_trigger_focus();
+        api.on_trigger_blur();
+        api.on_trigger_click();
+        api.on_scroll();
+        api.on_content_pointer_enter();
+        api.on_content_pointer_leave();
+
+        assert_eq!(
+            &*sent.borrow(),
+            &[
+                Event::PointerEnter,
+                Event::PointerLeave,
+                Event::Focus,
+                Event::Blur,
+                Event::CloseOnClick,
+                Event::CloseOnScroll,
+                Event::ContentPointerEnter,
+                Event::ContentPointerLeave,
+            ]
+        );
+    }
+
+    #[test]
+    fn tooltip_api_dismiss_helpers_respect_disabled_props() {
+        let service = Service::<Machine>::new(
+            Props {
+                close_on_click: false,
+                close_on_scroll: false,
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages,
+        );
+
+        let sent = Rc::new(RefCell::new(Vec::new()));
+        let sent_clone = Rc::clone(&sent);
+        let send = move |event| sent_clone.borrow_mut().push(event);
+
+        let api = service.connect(&send);
+
+        api.on_trigger_click();
+        api.on_scroll();
+
+        assert!(sent.borrow().is_empty());
+    }
+
+    #[test]
+    fn tooltip_keydown_consumes_only_handled_escape() {
+        let service = Service::<Machine>::new(
+            Props {
+                default_open: true,
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages,
+        );
+
+        let sent = Rc::new(RefCell::new(Vec::new()));
+        let sent_clone = Rc::clone(&sent);
+        let send = move |event| sent_clone.borrow_mut().push(event);
+
+        let api = service.connect(&send);
+
+        assert!(api.on_trigger_keydown(&keyboard_data(KeyboardKey::Escape)));
+        assert!(!api.on_trigger_keydown(&keyboard_data(KeyboardKey::Enter)));
+        assert_eq!(&*sent.borrow(), &[Event::CloseOnEscape]);
+    }
+
+    #[test]
+    fn tooltip_keydown_ignores_escape_when_prop_false() {
+        let service = Service::<Machine>::new(
+            Props {
+                default_open: true,
+                close_on_escape: false,
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages,
+        );
+
+        let api = service.connect(&|_| {});
+
+        assert!(!api.on_trigger_keydown(&keyboard_data(KeyboardKey::Escape)));
+    }
+
+    #[test]
+    fn tooltip_keydown_ignores_escape_when_closed() {
+        let service = Service::<Machine>::new(test_props(), &Env::default(), &Messages);
+
+        let api = service.connect(&|_| {});
+
+        assert!(!api.on_trigger_keydown(&keyboard_data(KeyboardKey::Escape)));
+    }
+
+    #[test]
+    fn tooltip_close_guard_rejects_non_close_events() {
+        assert!(!should_close_pending(Event::Open, &test_props()));
+    }
+
+    #[test]
+    fn tooltip_open_change_effect_invokes_callback_when_run() {
+        let observed = Arc::new(Mutex::new(Vec::new()));
+        let observed_clone = Arc::clone(&observed);
+        let mut service = Service::<Machine>::new(
+            Props {
+                on_open_change: Some(callback(move |open| {
+                    observed_clone
+                        .lock()
+                        .expect("observed callback state should not be poisoned")
+                        .push(open);
+                })),
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages,
+        );
+
+        let mut result = service.send(Event::Focus);
+
+        let effect = result.pending_effects.remove(0);
+        let send: ars_core::StrongSend<Event> = Arc::new(|_| {});
+
+        let cleanup = effect.run(service.context(), service.props(), send);
+
+        cleanup();
+
+        assert_eq!(
+            &*observed
+                .lock()
+                .expect("observed callback state should not be poisoned"),
+            &[true]
+        );
+    }
+
+    #[test]
+    fn snapshot_tooltip_all_parts_closed() {
+        let service = Service::<Machine>::new(test_props(), &Env::default(), &Messages);
+
+        assert_snapshot!(
+            "tooltip_all_parts_closed",
+            snapshot_api(&service.connect(&|_| {}))
+        );
+    }
+
+    #[test]
+    fn snapshot_tooltip_all_parts_open() {
+        let service = Service::<Machine>::new(
+            Props {
+                default_open: true,
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages,
+        );
+
+        assert_snapshot!(
+            "tooltip_all_parts_open",
+            snapshot_api(&service.connect(&|_| {}))
+        );
+    }
+
+    #[test]
+    fn snapshot_tooltip_open_rtl() {
+        let service = Service::<Machine>::new(
+            Props {
+                default_open: true,
+                dir: Direction::Rtl,
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages,
+        );
+
+        assert_snapshot!("tooltip_open_rtl", snapshot_api(&service.connect(&|_| {})));
+    }
+
+    #[test]
+    fn snapshot_tooltip_open_with_z_index() {
+        let mut service = Service::<Machine>::new(
+            Props {
+                default_open: true,
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages,
+        );
+
+        drop(service.send(Event::SetZIndex(1300)));
+
+        assert_snapshot!(
+            "tooltip_open_with_z_index",
+            snapshot_api(&service.connect(&|_| {}))
+        );
+    }
+
+    #[test]
+    fn snapshot_tooltip_close_pending() {
+        let mut service = Service::<Machine>::new(
+            Props {
+                default_open: true,
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages,
+        );
+
+        drop(service.send(Event::PointerLeave));
+
+        assert_snapshot!(
+            "tooltip_close_pending",
+            snapshot_api(&service.connect(&|_| {}))
+        );
+    }
+
+    #[test]
+    fn snapshot_tooltip_disabled() {
+        let service = Service::<Machine>::new(
+            Props {
+                disabled: true,
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages,
+        );
+
+        assert_snapshot!("tooltip_disabled", snapshot_api(&service.connect(&|_| {})));
+    }
+}

--- a/crates/ars-components/src/overlay/tooltip.rs
+++ b/crates/ars-components/src/overlay/tooltip.rs
@@ -749,6 +749,7 @@ impl<'a> Api<'a> {
     #[must_use]
     pub fn on_trigger_keydown(&self, data: &KeyboardEventData) -> bool {
         if data.key == KeyboardKey::Escape
+            && !self.ctx.disabled
             && self.props.close_on_escape
             && matches!(
                 self.state,
@@ -2303,6 +2304,28 @@ mod tests {
         let api = service.connect(&|_| {});
 
         assert!(!api.on_trigger_keydown(&keyboard_data(KeyboardKey::Escape)));
+    }
+
+    #[test]
+    fn tooltip_keydown_ignores_escape_when_disabled() {
+        let service = Service::<Machine>::new(
+            Props {
+                open: Some(true),
+                disabled: true,
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages,
+        );
+
+        let sent = Rc::new(RefCell::new(Vec::new()));
+        let sent_clone = Rc::clone(&sent);
+        let send = move |event| sent_clone.borrow_mut().push(event);
+
+        let api = service.connect(&send);
+
+        assert!(!api.on_trigger_keydown(&keyboard_data(KeyboardKey::Escape)));
+        assert!(sent.borrow().is_empty());
     }
 
     #[test]

--- a/crates/ars-components/src/overlay/tooltip.rs
+++ b/crates/ars-components/src/overlay/tooltip.rs
@@ -395,12 +395,7 @@ impl ars_core::Machine for Machine {
         ctx: &Self::Context,
         props: &Self::Props,
     ) -> Option<TransitionPlan<Self>> {
-        if ctx.disabled
-            && !matches!(
-                event,
-                Event::SetControlledOpen(_) | Event::SyncProps | Event::SetZIndex(_)
-            )
-        {
+        if ctx.disabled && disabled_blocks_event(*event) {
             return None;
         }
 
@@ -973,21 +968,45 @@ fn sync_props_plan(props: &Props) -> TransitionPlan<Machine> {
 }
 
 fn sync_props_context(ctx: &mut Context, props: &Props) {
+    let ids = ComponentIds::from_id(&props.id);
+    let content_id = ids.part("content");
+
     ctx.open_delay = props.open_delay;
     ctx.close_delay = close_delay(props);
     ctx.disabled = props.disabled;
     ctx.dir = props.dir;
     ctx.positioning = props.positioning.clone();
+    ctx.trigger_id = ids.part("trigger");
+    ctx.hidden_description_id = format_description_id(&content_id);
+    ctx.content_id = content_id;
     ctx.touch_auto_hide = props.touch_auto_hide.max(MIN_TOUCH_AUTO_HIDE);
 }
 
 fn props_context_changed(old: &Props, new: &Props) -> bool {
-    old.open_delay != new.open_delay
+    old.id != new.id
+        || old.open_delay != new.open_delay
         || old.close_delay != new.close_delay
         || old.disabled != new.disabled
         || old.dir != new.dir
         || old.positioning != new.positioning
         || old.touch_auto_hide != new.touch_auto_hide
+}
+
+const fn disabled_blocks_event(event: Event) -> bool {
+    matches!(
+        event,
+        Event::PointerEnter
+            | Event::PointerLeave
+            | Event::Focus
+            | Event::Blur
+            | Event::ContentPointerEnter
+            | Event::ContentPointerLeave
+            | Event::OpenTimerFired
+            | Event::Open
+            | Event::CloseOnEscape
+            | Event::CloseOnClick
+            | Event::CloseOnScroll
+    )
 }
 
 #[cfg(test)]
@@ -1628,6 +1647,67 @@ mod tests {
     }
 
     #[test]
+    fn tooltip_disabled_allows_pending_close_timer_to_finish() {
+        let mut service = Service::<Machine>::new(
+            Props {
+                default_open: true,
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages,
+        );
+
+        drop(service.send(Event::PointerLeave));
+        drop(service.set_props(Props {
+            disabled: true,
+            ..test_props()
+        }));
+
+        let result = service.send(Event::CloseTimerFired);
+
+        assert_eq!(service.state(), &State::Closed);
+        assert!(!service.context().open);
+        assert_eq!(result.cancel_effects, vec![CLOSE_DELAY_EFFECT]);
+    }
+
+    #[test]
+    fn tooltip_disabled_allows_programmatic_close() {
+        let mut service = Service::<Machine>::new(
+            Props {
+                default_open: true,
+                disabled: true,
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages,
+        );
+
+        let result = service.send(Event::Close);
+
+        assert_eq!(service.state(), &State::Closed);
+        assert!(!service.context().open);
+        assert_eq!(effect_names(&result), vec![OPEN_CHANGE_EFFECT]);
+    }
+
+    #[test]
+    fn tooltip_disabled_rejects_programmatic_open_event() {
+        let mut service = Service::<Machine>::new(
+            Props {
+                disabled: true,
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages,
+        );
+
+        let result = service.send(Event::Open);
+
+        assert_eq!(service.state(), &State::Closed);
+        assert!(!service.context().open);
+        assert!(result.pending_effects.is_empty());
+    }
+
+    #[test]
     fn tooltip_close_delay_does_not_clamp_for_hoverable_content() {
         let service = Service::<Machine>::new(
             Props {
@@ -1812,6 +1892,7 @@ mod tests {
         let mut service = Service::<Machine>::new(test_props(), &Env::default(), &Messages);
 
         let result = service.set_props(Props {
+            id: "renamed-tooltip".to_string(),
             open_delay: Duration::from_millis(12),
             close_delay: Duration::ZERO,
             disabled: true,
@@ -1824,19 +1905,61 @@ mod tests {
             ..test_props()
         });
 
+        let ids = ComponentIds::from_id("renamed-tooltip");
+        let content_id = ids.part("content");
+
         assert_eq!(service.context().open_delay, Duration::from_millis(12));
         assert_eq!(service.context().close_delay, Duration::ZERO);
         assert!(service.context().disabled);
         assert_eq!(service.context().dir, Direction::Rtl);
         assert_eq!(service.context().positioning.placement, Placement::LeftEnd);
+        assert_eq!(service.context().trigger_id, ids.part("trigger"));
+        assert_eq!(service.context().content_id, content_id);
+        assert_eq!(
+            service.context().hidden_description_id,
+            format_description_id(&service.context().content_id)
+        );
         assert_eq!(service.context().touch_auto_hide, MIN_TOUCH_AUTO_HIDE);
         assert!(result.pending_effects.is_empty());
+    }
+
+    #[test]
+    fn tooltip_id_prop_change_updates_connected_aria_ids() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &Messages);
+
+        drop(service.set_props(Props {
+            id: "renamed-tooltip".to_string(),
+            ..test_props()
+        }));
+
+        let api = service.connect(&|_| {});
+        let ids = ComponentIds::from_id("renamed-tooltip");
+        let content_id = ids.part("content");
+        let hidden_id = format_description_id(&content_id);
+
+        assert_eq!(
+            api.trigger_attrs()
+                .get(&HtmlAttr::Aria(AriaAttr::DescribedBy)),
+            Some(hidden_id.as_str())
+        );
+        assert_eq!(
+            api.hidden_description_attrs().get(&HtmlAttr::Id),
+            Some(hidden_id.as_str())
+        );
+        assert_eq!(
+            api.content_attrs().get(&HtmlAttr::Id),
+            Some(content_id.as_str())
+        );
     }
 
     #[test]
     fn tooltip_on_props_changed_reports_each_context_backed_prop() {
         let old = test_props();
         let cases = [
+            Props {
+                id: "renamed-tooltip".to_string(),
+                ..test_props()
+            },
             Props {
                 open_delay: Duration::from_millis(12),
                 ..test_props()

--- a/crates/ars-components/src/overlay/tooltip.rs
+++ b/crates/ars-components/src/overlay/tooltip.rs
@@ -412,6 +412,12 @@ impl ars_core::Machine for Machine {
                 ctx.focus_active = true;
             })),
 
+            (State::Closed, Event::Blur) => {
+                Some(TransitionPlan::context_only(|ctx: &mut Context| {
+                    ctx.focus_active = false;
+                }))
+            }
+
             (State::OpenPending, Event::OpenTimerFired) => Some(
                 open_plan(props, |ctx| {
                     ctx.hover_active = true;
@@ -425,9 +431,12 @@ impl ars_core::Machine for Machine {
                 }))
             }
 
-            (State::OpenPending, Event::Focus) => Some(open_plan(props, |ctx| {
-                ctx.focus_active = true;
-            })),
+            (State::OpenPending, Event::Focus) => Some(
+                open_plan(props, |ctx| {
+                    ctx.focus_active = true;
+                })
+                .cancel_effect(OPEN_DELAY_EFFECT),
+            ),
 
             (State::OpenPending, Event::PointerLeave) if ctx.focus_active => {
                 Some(TransitionPlan::context_only(|ctx: &mut Context| {
@@ -550,10 +559,20 @@ impl ars_core::Machine for Machine {
                 Some(close_now_plan(props).cancel_effect(CLOSE_DELAY_EFFECT))
             }
 
-            (State::Closed | State::OpenPending, Event::Open) => Some(open_plan(props, |_| {})),
+            (State::Closed, Event::Open) => Some(open_plan(props, |_| {})),
 
-            (State::Open | State::OpenPending | State::ClosePending, Event::Close) => {
-                Some(close_now_plan(props))
+            (State::OpenPending, Event::Open) => {
+                Some(open_plan(props, |_| {}).cancel_effect(OPEN_DELAY_EFFECT))
+            }
+
+            (State::Open, Event::Close) => Some(close_now_plan(props)),
+
+            (State::OpenPending, Event::Close) => {
+                Some(close_now_plan(props).cancel_effect(OPEN_DELAY_EFFECT))
+            }
+
+            (State::ClosePending, Event::Close) => {
+                Some(close_now_plan(props).cancel_effect(CLOSE_DELAY_EFFECT))
             }
 
             (_, Event::SetControlledOpen(open)) => Some(sync_controlled_plan(*open, props)),
@@ -1168,6 +1187,7 @@ mod tests {
             effect_names(&result),
             vec![OPEN_CHANGE_EFFECT, ALLOCATE_Z_INDEX_EFFECT]
         );
+        assert_eq!(result.cancel_effects, vec![OPEN_DELAY_EFFECT]);
     }
 
     #[test]
@@ -1265,6 +1285,32 @@ mod tests {
             assert!(!service.context().hover_active);
             assert_eq!(result.cancel_effects, vec![OPEN_DELAY_EFFECT]);
         }
+    }
+
+    #[test]
+    fn tooltip_open_pending_programmatic_open_cancels_open_delay() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &Messages);
+
+        drop(service.send(Event::PointerEnter));
+
+        let result = service.send(Event::Open);
+
+        assert_eq!(service.state(), &State::Open);
+        assert!(service.context().open);
+        assert_eq!(result.cancel_effects, vec![OPEN_DELAY_EFFECT]);
+    }
+
+    #[test]
+    fn tooltip_open_pending_programmatic_close_cancels_open_delay() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &Messages);
+
+        drop(service.send(Event::PointerEnter));
+
+        let result = service.send(Event::Close);
+
+        assert_eq!(service.state(), &State::Closed);
+        assert!(!service.context().open);
+        assert_eq!(result.cancel_effects, vec![OPEN_DELAY_EFFECT]);
     }
 
     #[test]
@@ -1503,6 +1549,59 @@ mod tests {
         assert_eq!(service.state(), &State::Closed);
         assert!(!service.context().open);
         assert_eq!(result.cancel_effects, vec![CLOSE_DELAY_EFFECT]);
+    }
+
+    #[test]
+    fn tooltip_close_pending_programmatic_close_cancels_delay() {
+        let mut service = Service::<Machine>::new(
+            Props {
+                default_open: true,
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages,
+        );
+
+        drop(service.send(Event::PointerLeave));
+
+        let result = service.send(Event::Close);
+
+        assert_eq!(service.state(), &State::Closed);
+        assert!(!service.context().open);
+        assert_eq!(result.cancel_effects, vec![CLOSE_DELAY_EFFECT]);
+    }
+
+    #[test]
+    fn tooltip_closed_blur_clears_stale_controlled_focus_activity() {
+        let mut service = Service::<Machine>::new(
+            Props {
+                open: Some(false),
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages,
+        );
+
+        drop(service.send(Event::Focus));
+
+        assert_eq!(service.state(), &State::Closed);
+        assert!(service.context().focus_active);
+
+        let result = service.send(Event::Blur);
+
+        assert_eq!(service.state(), &State::Closed);
+        assert!(!service.context().open);
+        assert!(!service.context().focus_active);
+        assert!(effect_names(&result).is_empty());
+        assert!(result.cancel_effects.is_empty());
+
+        drop(service.send(Event::PointerEnter));
+
+        let leave = service.send(Event::PointerLeave);
+
+        assert_eq!(service.state(), &State::Closed);
+        assert!(!service.context().hover_active);
+        assert_eq!(leave.cancel_effects, vec![OPEN_DELAY_EFFECT]);
     }
 
     #[test]

--- a/crates/ars-components/tests/proptest_state_machines/overlay.rs
+++ b/crates/ars-components/tests/proptest_state_machines/overlay.rs
@@ -1,6 +1,13 @@
-use ars_components::overlay::presence;
-use ars_core::{Env, Service};
-use proptest::prelude::*;
+use core::time::Duration;
+
+use ars_components::overlay::{
+    positioning::{Offset, Placement, PositioningOptions},
+    presence, tooltip,
+};
+use ars_core::{Direction, Env, SendResult, Service};
+use proptest::{prelude::*, test_runner::TestCaseResult};
+
+const MIN_TOUCH_AUTO_HIDE: Duration = Duration::from_secs(5);
 
 fn arb_presence_props() -> impl Strategy<Value = presence::Props> {
     (any::<bool>(), any::<bool>(), any::<bool>(), any::<bool>()).prop_map(
@@ -21,6 +28,259 @@ fn arb_presence_event() -> impl Strategy<Value = presence::Event> {
         Just(presence::Event::ContentReady),
         Just(presence::Event::AnimationEnd),
     ]
+}
+
+#[derive(Clone, Debug)]
+enum TooltipStep {
+    Send(tooltip::Event),
+    SetProps(tooltip::Props),
+}
+
+fn arb_direction() -> impl Strategy<Value = Direction> {
+    prop_oneof![Just(Direction::Ltr), Just(Direction::Rtl)]
+}
+
+fn arb_placement() -> impl Strategy<Value = Placement> {
+    prop_oneof![
+        Just(Placement::Bottom),
+        Just(Placement::BottomStart),
+        Just(Placement::BottomEnd),
+        Just(Placement::Top),
+        Just(Placement::TopStart),
+        Just(Placement::TopEnd),
+        Just(Placement::Left),
+        Just(Placement::LeftStart),
+        Just(Placement::LeftEnd),
+        Just(Placement::Right),
+        Just(Placement::RightStart),
+        Just(Placement::RightEnd),
+        Just(Placement::Auto),
+        Just(Placement::AutoStart),
+        Just(Placement::AutoEnd),
+        Just(Placement::Start),
+        Just(Placement::End),
+        Just(Placement::StartTop),
+        Just(Placement::StartBottom),
+        Just(Placement::EndTop),
+        Just(Placement::EndBottom),
+    ]
+}
+
+fn arb_duration(max_millis: u64) -> impl Strategy<Value = Duration> {
+    (0..=max_millis).prop_map(Duration::from_millis)
+}
+
+fn arb_positioning_options() -> impl Strategy<Value = PositioningOptions> {
+    (
+        arb_placement(),
+        -16.0f64..=16.0,
+        -16.0f64..=16.0,
+        any::<bool>(),
+        any::<bool>(),
+        0.0f64..=32.0,
+        0.0f64..=32.0,
+        any::<bool>(),
+        prop::collection::vec(arb_placement(), 0..4),
+        any::<bool>(),
+        any::<bool>(),
+    )
+        .prop_map(
+            |(
+                placement,
+                main_axis,
+                cross_axis,
+                flip,
+                shift,
+                shift_padding,
+                arrow_padding,
+                auto_max_size,
+                fallback_placements,
+                keyboard_aware,
+                auto_placement,
+            )| PositioningOptions {
+                placement,
+                offset: Offset {
+                    main_axis,
+                    cross_axis,
+                },
+                flip,
+                shift,
+                shift_padding,
+                arrow_padding,
+                auto_max_size,
+                fallback_placements,
+                keyboard_aware,
+                auto_placement,
+            },
+        )
+}
+
+fn arb_tooltip_props() -> impl Strategy<Value = tooltip::Props> {
+    (
+        (
+            prop::option::of(any::<bool>()),
+            any::<bool>(),
+            arb_duration(1_000),
+            arb_duration(1_000),
+            any::<bool>(),
+            arb_positioning_options(),
+            any::<bool>(),
+        ),
+        (
+            any::<bool>(),
+            any::<bool>(),
+            any::<bool>(),
+            any::<bool>(),
+            arb_direction(),
+            arb_duration(30_000),
+        ),
+    )
+        .prop_map(
+            |(
+                (
+                    open,
+                    default_open,
+                    open_delay,
+                    close_delay,
+                    disabled,
+                    positioning,
+                    close_on_escape,
+                ),
+                (
+                    close_on_click,
+                    close_on_scroll,
+                    lazy_mount,
+                    unmount_on_exit,
+                    dir,
+                    touch_auto_hide,
+                ),
+            )| tooltip::Props {
+                id: "tooltip".to_string(),
+                open,
+                default_open,
+                open_delay,
+                close_delay,
+                disabled,
+                positioning,
+                close_on_escape,
+                close_on_click,
+                close_on_scroll,
+                on_open_change: None,
+                lazy_mount,
+                unmount_on_exit,
+                dir,
+                touch_auto_hide,
+            },
+        )
+}
+
+fn arb_tooltip_event() -> impl Strategy<Value = tooltip::Event> {
+    prop_oneof![
+        Just(tooltip::Event::PointerEnter),
+        Just(tooltip::Event::PointerLeave),
+        Just(tooltip::Event::Focus),
+        Just(tooltip::Event::Blur),
+        Just(tooltip::Event::ContentPointerEnter),
+        Just(tooltip::Event::ContentPointerLeave),
+        Just(tooltip::Event::OpenTimerFired),
+        Just(tooltip::Event::CloseTimerFired),
+        Just(tooltip::Event::CloseOnEscape),
+        Just(tooltip::Event::CloseOnClick),
+        Just(tooltip::Event::CloseOnScroll),
+        Just(tooltip::Event::Open),
+        Just(tooltip::Event::Close),
+        any::<bool>().prop_map(tooltip::Event::SetControlledOpen),
+        Just(tooltip::Event::SyncProps),
+        (0..=4_000u32).prop_map(tooltip::Event::SetZIndex),
+    ]
+}
+
+fn arb_tooltip_step() -> impl Strategy<Value = TooltipStep> {
+    prop_oneof![
+        arb_tooltip_event().prop_map(TooltipStep::Send),
+        arb_tooltip_props().prop_map(TooltipStep::SetProps),
+    ]
+}
+
+const fn tooltip_event_bypasses_disabled(event: tooltip::Event) -> bool {
+    matches!(
+        event,
+        tooltip::Event::SetControlledOpen(_)
+            | tooltip::Event::SyncProps
+            | tooltip::Event::SetZIndex(_)
+    )
+}
+
+const fn tooltip_guard_rejects(event: tooltip::Event, props: &tooltip::Props) -> bool {
+    matches!(event, tooltip::Event::CloseOnEscape) && !props.close_on_escape
+        || matches!(event, tooltip::Event::CloseOnClick) && !props.close_on_click
+        || matches!(event, tooltip::Event::CloseOnScroll) && !props.close_on_scroll
+}
+
+fn assert_tooltip_state_context_invariants(service: &Service<tooltip::Machine>) -> TestCaseResult {
+    prop_assert_eq!(
+        service.context().open,
+        matches!(
+            service.state(),
+            tooltip::State::Open | tooltip::State::ClosePending
+        )
+    );
+    prop_assert!(service.context().touch_auto_hide >= MIN_TOUCH_AUTO_HIDE);
+    prop_assert_eq!(&service.context().trigger_id, "tooltip-trigger");
+    prop_assert_eq!(&service.context().content_id, "tooltip-content");
+    prop_assert_eq!(
+        &service.context().hidden_description_id,
+        "tooltip-content-description"
+    );
+
+    Ok(())
+}
+
+fn assert_tooltip_send_result_invariants(
+    service: &Service<tooltip::Machine>,
+    event: tooltip::Event,
+    result: &SendResult<tooltip::Machine>,
+    before_state: tooltip::State,
+    before_context: &tooltip::Context,
+    before_props: &tooltip::Props,
+) -> TestCaseResult {
+    if before_context.disabled && !tooltip_event_bypasses_disabled(event) {
+        prop_assert_eq!(service.state(), &before_state);
+        prop_assert_eq!(service.context(), before_context);
+        prop_assert!(result.pending_effects.is_empty());
+        prop_assert!(result.cancel_effects.is_empty());
+    }
+
+    if tooltip_guard_rejects(event, before_props) {
+        prop_assert_eq!(service.state(), &before_state);
+        prop_assert_eq!(service.context(), before_context);
+        prop_assert!(result.pending_effects.is_empty());
+        prop_assert!(result.cancel_effects.is_empty());
+    }
+
+    if before_props.open.is_some() && !matches!(event, tooltip::Event::SetControlledOpen(_)) {
+        prop_assert_eq!(service.context().open, before_context.open);
+    }
+
+    if let tooltip::Event::SetControlledOpen(open) = event {
+        prop_assert_eq!(service.context().open, open);
+        prop_assert_eq!(
+            service.state(),
+            if open {
+                &tooltip::State::Open
+            } else {
+                &tooltip::State::Closed
+            }
+        );
+    }
+
+    if let tooltip::Event::SetZIndex(z_index) = event {
+        prop_assert_eq!(service.context().z_index, Some(z_index));
+    } else {
+        prop_assert_eq!(service.context().z_index, before_context.z_index);
+    }
+
+    Ok(())
 }
 
 proptest! {
@@ -67,6 +327,56 @@ proptest! {
                     prop_assert!(service.context().unmounting);
                 }
             }
+        }
+    }
+
+    #[test]
+    #[ignore = "proptest — nightly extended-proptest job"]
+    fn proptest_tooltip_state_context_invariants_hold(
+        props in arb_tooltip_props(),
+        steps in prop::collection::vec(arb_tooltip_step(), 0..128),
+    ) {
+        let mut service = Service::<tooltip::Machine>::new(props, &Env::default(), &tooltip::Messages);
+        assert_tooltip_state_context_invariants(&service)?;
+
+        for step in steps {
+            match step {
+                TooltipStep::Send(event) => {
+                    let before_state = *service.state();
+                    let before_context = service.context().clone();
+                    let before_props = service.props().clone();
+
+                    let result = service.send(event);
+
+                    assert_tooltip_send_result_invariants(
+                        &service,
+                        event,
+                        &result,
+                        before_state,
+                        &before_context,
+                        &before_props,
+                    )?;
+                }
+
+                TooltipStep::SetProps(props) => {
+                    let before_z_index = service.context().z_index;
+                    let before_open_prop = service.props().open;
+
+                    let next_open_prop = props.open;
+
+                    drop(service.set_props(props));
+
+                    prop_assert_eq!(service.context().z_index, before_z_index);
+
+                    if before_open_prop != next_open_prop
+                        && let Some(open) = service.props().open
+                    {
+                        prop_assert_eq!(service.context().open, open);
+                    }
+                }
+            }
+
+            assert_tooltip_state_context_invariants(&service)?;
         }
     }
 }

--- a/crates/ars-components/tests/proptest_state_machines/overlay.rs
+++ b/crates/ars-components/tests/proptest_state_machines/overlay.rs
@@ -207,6 +207,8 @@ const fn tooltip_event_bypasses_disabled(event: tooltip::Event) -> bool {
         event,
         tooltip::Event::SetControlledOpen(_)
             | tooltip::Event::SyncProps
+            | tooltip::Event::CloseTimerFired
+            | tooltip::Event::Close
             | tooltip::Event::SetZIndex(_)
     )
 }

--- a/spec/components/overlay/tooltip.md
+++ b/spec/components/overlay/tooltip.md
@@ -13,7 +13,8 @@ references:
 
 # Tooltip
 
-A brief informational label appearing on hover/focus. **Not interactive** by default.
+A brief informational label appearing on hover/focus. Tooltip content is not interactive; use
+HoverCard or Popover for focusable floating content.
 
 Per WCAG 1.4.13 (Content on Hover or Focus), hover/focus-triggered content must be:
 (a) dismissible without moving pointer or focus (Escape key),
@@ -27,11 +28,12 @@ Pressing Escape while the tooltip is visible dismisses it.
 
 ```rust
 /// The states of the tooltip.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum State {
     /// The tooltip is closed.
+    #[default]
     Closed,
-    /// The tooltip is open pending.
+    /// The tooltip is waiting for its hover open delay.
     OpenPending,
     /// The tooltip is open.
     Open,
@@ -44,7 +46,7 @@ pub enum State {
 
 ```rust
 /// The events of the tooltip.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Event {
     /// The pointer enters the trigger.
     PointerEnter,
@@ -72,12 +74,20 @@ pub enum Event {
     Open,
     /// The tooltip is closed programmatically.
     Close,
+    /// Controlled props synchronized the visible open state.
+    SetControlledOpen(bool),
+    /// Props changed without changing controlled visible state.
+    SyncProps,
+    /// Adapter supplied an allocated overlay z-index.
+    SetZIndex(u32),
 }
 ```
 
 ### 1.3 Context
 
 ```rust
+use core::time::Duration;
+
 /// The context of the tooltip.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Context {
@@ -85,16 +95,13 @@ pub struct Context {
     pub locale: Locale,
     /// Whether the tooltip is open.
     pub open: bool,
-    /// The open delay in milliseconds. (default: 300ms)
-    pub open_delay_ms: u32,
-    /// The close delay in milliseconds. (default: 300ms)
-    /// (matches Ark UI convention; gives pointer time to reach interactive content)
-    pub close_delay_ms: u32,
+    /// The open delay. (default: 300ms)
+    pub open_delay: Duration,
+    /// The close delay. (default: 300ms)
+    /// Gives pointer time to reach visible tooltip content.
+    pub close_delay: Duration,
     /// Whether the tooltip is disabled.
     pub disabled: bool,
-    /// Whether the tooltip is interactive. (default: false)
-    /// Can hover tooltip content
-    pub interactive: bool,
     /// Text direction for content rendering.
     pub dir: Direction,
     /// Whether the pointer is currently over the trigger or content.
@@ -105,16 +112,25 @@ pub struct Context {
     pub positioning: PositioningOptions,
     /// The ID of the trigger element.
     pub trigger_id: String,
-    /// The ID of the content element.
+    /// The ID of the visible content element.
     pub content_id: String,
-    /// Resolved messages for accessibility labels.
+    /// The ID of the always-rendered hidden description element.
+    pub hidden_description_id: String,
+    /// Resolved messages for the tooltip.
     pub messages: Messages,
+    /// Adapter-allocated z-index for the positioner.
+    pub z_index: Option<u32>,
+    /// Touch auto-hide timeout clamped to the accessibility minimum.
+    pub touch_auto_hide: Duration,
 }
 ```
 
 ### 1.4 Props
 
 ```rust
+use core::time::Duration;
+
+use ars_core::{Callback, HasId};
 use ars_i18n::Direction;
 
 /// The props of the tooltip.
@@ -126,14 +142,12 @@ pub struct Props {
     pub open: Option<bool>,
     /// Whether the tooltip is open by default (uncontrolled). Default: false.
     pub default_open: bool,
-    /// The delay in milliseconds before the tooltip opens. Default: 300ms.
-    pub open_delay_ms: u32,
-    /// The delay in milliseconds before the tooltip closes. Default: 300ms.
-    pub close_delay_ms: u32,
+    /// The delay before the tooltip opens. Default: 300ms.
+    pub open_delay: Duration,
+    /// The delay before the tooltip closes. Default: 300ms.
+    pub close_delay: Duration,
     /// Whether the tooltip is disabled. Default: false.
     pub disabled: bool,
-    /// Whether the tooltip content is interactive (hoverable). Default: false.
-    pub interactive: bool,
     /// The positioning options for the tooltip.
     pub positioning: PositioningOptions,
     /// Whether the tooltip closes on Escape key. Default: true.
@@ -144,17 +158,17 @@ pub struct Props {
     /// Whether the tooltip closes on page scroll. Default: true.
     /// Prevents stale positioning when the trigger scrolls out of view.
     pub close_on_scroll: bool,
-    /// Callback invoked when the tooltip open state changes.
-    pub on_open_change: Option<Callback<bool>>,
+    /// Callback invoked when user interaction requests an open-state change.
+    pub on_open_change: Option<Callback<dyn Fn(bool) + Send + Sync>>,
     /// When true, tooltip content is not mounted until first opened. Default: false.
     pub lazy_mount: bool,
     /// When true, tooltip content is removed from the DOM after closing. Default: false.
     pub unmount_on_exit: bool,
     /// Text direction for tooltip content. Default: `Direction::Ltr`.
     pub dir: Direction,
-    /// Auto-hide timeout in milliseconds for touch devices. Default: 20000ms.
+    /// Auto-hide timeout for touch devices. Default: 20s.
     /// Minimum enforced: 5000ms — values below are clamped.
-    pub touch_auto_hide_ms: u32,
+    pub touch_auto_hide: Duration,
 }
 
 impl Default for Props {
@@ -163,10 +177,9 @@ impl Default for Props {
             id: String::new(),
             open: None,
             default_open: false,
-            open_delay_ms: 300,
-            close_delay_ms: 300,
+            open_delay: Duration::from_millis(300),
+            close_delay: Duration::from_millis(300),
             disabled: false,
-            interactive: false,
             positioning: PositioningOptions::default(),
             close_on_escape: true,
             close_on_click: true,
@@ -175,39 +188,84 @@ impl Default for Props {
             lazy_mount: false,
             unmount_on_exit: false,
             dir: Direction::Ltr,
-            touch_auto_hide_ms: 20000,
+            touch_auto_hide: Duration::from_secs(20),
         }
     }
 }
+
+impl Props {
+    /// Returns Tooltip props with documented default values.
+    pub fn new() -> Self { Self::default() }
+
+    /// Sets the component instance id.
+    pub fn id(mut self, id: impl Into<String>) -> Self { self.id = id.into(); self }
+    /// Sets the controlled open state.
+    pub fn open(mut self, value: impl Into<Option<bool>>) -> Self { self.open = value.into(); self }
+    /// Sets the initial uncontrolled open state.
+    pub const fn default_open(mut self, value: bool) -> Self { self.default_open = value; self }
+    /// Sets the hover-triggered open delay.
+    pub const fn open_delay(mut self, value: Duration) -> Self { self.open_delay = value; self }
+    /// Sets the close delay.
+    pub const fn close_delay(mut self, value: Duration) -> Self { self.close_delay = value; self }
+    /// Sets whether user interaction is ignored.
+    pub const fn disabled(mut self, value: bool) -> Self { self.disabled = value; self }
+    /// Sets the adapter-owned positioning configuration.
+    pub fn positioning(mut self, value: PositioningOptions) -> Self { self.positioning = value; self }
+    /// Sets whether Escape dismisses the tooltip.
+    pub const fn close_on_escape(mut self, value: bool) -> Self { self.close_on_escape = value; self }
+    /// Sets whether trigger activation dismisses the tooltip.
+    pub const fn close_on_click(mut self, value: bool) -> Self { self.close_on_click = value; self }
+    /// Sets whether page scroll dismisses the tooltip.
+    pub const fn close_on_scroll(mut self, value: bool) -> Self { self.close_on_scroll = value; self }
+    /// Registers the open-state change callback.
+    pub fn on_open_change<F>(mut self, f: F) -> Self
+    where
+        F: Fn(bool) + Send + Sync + 'static,
+    {
+        self.on_open_change = Some(Callback::new(f));
+        self
+    }
+    /// Sets whether content is mounted only after first open.
+    pub const fn lazy_mount(mut self, value: bool) -> Self { self.lazy_mount = value; self }
+    /// Sets whether content is removed from the DOM after closing.
+    pub const fn unmount_on_exit(mut self, value: bool) -> Self { self.unmount_on_exit = value; self }
+    /// Sets the text direction for tooltip content.
+    pub const fn dir(mut self, value: Direction) -> Self { self.dir = value; self }
+    /// Sets the adapter-owned touch auto-hide timeout.
+    pub const fn touch_auto_hide(mut self, value: Duration) -> Self { self.touch_auto_hide = value; self }
+}
 ```
 
-### 1.5 Interactive Tooltip Close Delay (WCAG 1.4.13 Compliance)
+### 1.5 Hoverable Visible Content (WCAG 1.4.13 Compliance)
 
-When `interactive: true`, the tooltip MUST remain visible long enough for the user to move
-their pointer from the trigger into the tooltip content. To satisfy WCAG 1.4.13 criterion (b):
+Visible tooltip content is hoverable. Entering visible content cancels a pending close and
+leaving visible content restarts the close delay. This prevents accidental dismissal while the
+pointer crosses the gap between trigger and tooltip.
 
-- **`interactive: true`**: Minimum `close_delay_ms` of **200ms** is enforced. If the user
-  sets a value below 200ms, the machine clamps it to 200ms. When the pointer leaves the
-  trigger, the close timer starts; if the pointer enters the tooltip content before the timer
-  fires, the timer is cancelled and the tooltip remains open. When the pointer leaves the
-  tooltip content, the close timer restarts.
-- **`interactive: false`** (default): `close_delay_ms` may be 0ms. The tooltip closes
-  immediately on pointer leave since the user has no reason to move into the content.
+- `close_delay` may be `Duration::ZERO`. In that case the tooltip closes immediately only when both the
+  trigger and visible content are no longer hovered and the trigger does not have focus.
+- When `close_delay` is non-zero, the close timer starts after the pointer leaves the trigger
+  or visible content. If the pointer enters the other element before the timer fires, the timer is
+  cancelled and the tooltip remains open.
 
-The init function enforces this minimum:
+Tooltip does not support buttons, links, or other focusable descendants inside content. Use
+HoverCard or Popover when the floating surface must be interactive.
 
 ```rust
-close_delay_ms: if props.interactive {
-    props.close_delay_ms.max(200)
-} else {
-    props.close_delay_ms
-},
+close_delay: props.close_delay,
 ```
 
 ### 1.6 Full Machine Implementation
 
 ```rust
-use ars_core::{TransitionPlan, PendingEffect, AttrMap};
+use ars_core::{PendingEffect, TransitionPlan};
+use core::time::Duration;
+
+const OPEN_DELAY_EFFECT: &str = "tooltip-open-delay";
+const CLOSE_DELAY_EFFECT: &str = "tooltip-close-delay";
+const OPEN_CHANGE_EFFECT: &str = "tooltip-open-change";
+const ALLOCATE_Z_INDEX_EFFECT: &str = "tooltip-allocate-z-index";
+const MIN_TOUCH_AUTO_HIDE: Duration = Duration::from_secs(5);
 
 /// The machine of the tooltip.
 pub struct Machine;
@@ -222,29 +280,25 @@ impl ars_core::Machine for Machine {
 
     fn init(props: &Self::Props, env: &Env, messages: &Self::Messages) -> (Self::State, Self::Context) {
         let ids = ComponentIds::from_id(&props.id);
-        let close_delay = if props.interactive {
-            props.close_delay_ms.max(200)
-        } else {
-            props.close_delay_ms
-        };
         let initial_open = props.open.unwrap_or(props.default_open);
         let initial_state = if initial_open { State::Open } else { State::Closed };
-        let locale = env.locale.clone();
-        let messages = messages.clone();
+        let content_id = ids.part("content");
         (initial_state, Context {
-            locale,
+            locale: env.locale.clone(),
             open: initial_open,
-            open_delay_ms: props.open_delay_ms,
-            close_delay_ms: close_delay,
+            open_delay: props.open_delay,
+            close_delay: props.close_delay,
             disabled: props.disabled,
-            interactive: props.interactive,
             dir: props.dir,
             hover_active: false,
             focus_active: false,
             positioning: props.positioning.clone(),
             trigger_id: ids.part("trigger"),
-            content_id: ids.part("content"),
-            messages,
+            hidden_description_id: format!("{content_id}-description"),
+            content_id,
+            messages: messages.clone(),
+            z_index: None,
+            touch_auto_hide: props.touch_auto_hide.max(MIN_TOUCH_AUTO_HIDE),
         })
     }
 
@@ -254,43 +308,32 @@ impl ars_core::Machine for Machine {
         ctx: &Self::Context,
         props: &Self::Props,
     ) -> Option<TransitionPlan<Self>> {
-        if ctx.disabled { return None; }
+        if ctx.disabled
+            && !matches!(
+                event,
+                Event::SetControlledOpen(_) | Event::SyncProps | Event::SetZIndex(_)
+            )
+        {
+            return None;
+        }
 
         match (state, event) {
-            // Start show delay on hover
+            // Hover opens after the configured delay.
             (State::Closed, Event::PointerEnter) => {
                 Some(TransitionPlan::to(State::OpenPending)
                     .apply(|ctx| { ctx.hover_active = true; })
-                    .with_effect(PendingEffect::new("show-delay", |ctx, _props, send| {
-                        let platform = use_platform_effects();
-                        let delay = ctx.open_delay_ms;
-                        let handle = platform.set_timeout(delay, Box::new(move || {
-                            send(Event::OpenTimerFired);
-                        }));
-                        let pc = platform.clone();
-                        Box::new(move || pc.clear_timeout(handle))
-                    })))
+                    .with_effect(PendingEffect::named(OPEN_DELAY_EFFECT)))
             }
 
-            // Start show delay on focus
+            // Keyboard focus opens immediately.
             (State::Closed, Event::Focus) => {
-                Some(TransitionPlan::to(State::OpenPending)
-                    .apply(|ctx| { ctx.focus_active = true; })
-                    .with_effect(PendingEffect::new("show-delay", |ctx, _props, send| {
-                        let platform = use_platform_effects();
-                        let delay = ctx.open_delay_ms;
-                        let handle = platform.set_timeout(delay, Box::new(move || {
-                            send(Event::OpenTimerFired);
-                        }));
-                        let pc = platform.clone();
-                        Box::new(move || pc.clear_timeout(handle))
-                    })))
+                Some(open_plan(props, |ctx| { ctx.focus_active = true; }))
             }
 
             // Timer fired -> show
             (State::OpenPending, Event::OpenTimerFired) => {
-                Some(TransitionPlan::to(State::Open)
-                    .apply(|ctx| { ctx.open = true; }))
+                Some(open_plan(props, |ctx| { ctx.hover_active = true; })
+                    .cancel_effect(OPEN_DELAY_EFFECT))
             }
 
             // Track hover/focus arriving while show delay is pending
@@ -298,7 +341,7 @@ impl ars_core::Machine for Machine {
                 Some(TransitionPlan::context_only(|ctx| { ctx.hover_active = true; }))
             }
             (State::OpenPending, Event::Focus) => {
-                Some(TransitionPlan::context_only(|ctx| { ctx.focus_active = true; }))
+                Some(open_plan(props, |ctx| { ctx.focus_active = true; }))
             }
 
             // Cancel show delay only if BOTH hover and focus are gone
@@ -320,13 +363,14 @@ impl ars_core::Machine for Machine {
             }
 
             // Escape dismisses from ShowPending
-            (State::OpenPending, Event::CloseOnEscape) => {
+            (State::OpenPending, Event::CloseOnEscape) if props.close_on_escape => {
                 Some(TransitionPlan::to(State::Closed)
-                    .apply(|ctx| { ctx.hover_active = false; ctx.focus_active = false; }))
+                    .apply(|ctx| { ctx.hover_active = false; ctx.focus_active = false; })
+                    .cancel_effect(OPEN_DELAY_EFFECT))
             }
 
             // Track additional hover/focus arriving while open
-            (State::Open, Event::PointerEnter) => {
+            (State::Open, Event::PointerEnter | Event::ContentPointerEnter) => {
                 Some(TransitionPlan::context_only(|ctx| { ctx.hover_active = true; }))
             }
             (State::Open, Event::Focus) => {
@@ -338,74 +382,47 @@ impl ars_core::Machine for Machine {
                 if ctx.focus_active {
                     // Keyboard focus still on trigger — stay visible
                     Some(TransitionPlan::context_only(|ctx| { ctx.hover_active = false; }))
-                } else if ctx.close_delay_ms == 0 {
-                    Some(TransitionPlan::to(State::Closed)
-                        .apply(|ctx| { ctx.open = false; ctx.hover_active = false; }))
+                } else if ctx.close_delay == Duration::ZERO {
+                    Some(close_now_plan(props).apply(|ctx| { ctx.hover_active = false; }))
                 } else {
                     Some(TransitionPlan::to(State::ClosePending)
                         .apply(|ctx| { ctx.hover_active = false; })
-                        .with_effect(PendingEffect::new("hide-delay", |ctx, _props, send| {
-                            let platform = use_platform_effects();
-                            let delay = ctx.close_delay_ms;
-                            let handle = platform.set_timeout(delay, Box::new(move || {
-                                send(Event::CloseTimerFired);
-                            }));
-                            let pc = platform.clone();
-                            Box::new(move || pc.clear_timeout(handle))
-                        })))
+                        .with_effect(PendingEffect::named(CLOSE_DELAY_EFFECT)))
                 }
             }
             (State::Open, Event::Blur) => {
                 if ctx.hover_active {
                     // Pointer still over trigger — stay visible
                     Some(TransitionPlan::context_only(|ctx| { ctx.focus_active = false; }))
-                } else if ctx.close_delay_ms == 0 {
-                    Some(TransitionPlan::to(State::Closed)
-                        .apply(|ctx| { ctx.open = false; ctx.focus_active = false; }))
+                } else if ctx.close_delay == Duration::ZERO {
+                    Some(close_now_plan(props).apply(|ctx| { ctx.focus_active = false; }))
                 } else {
                     Some(TransitionPlan::to(State::ClosePending)
                         .apply(|ctx| { ctx.focus_active = false; })
-                        .with_effect(PendingEffect::new("hide-delay", |ctx, _props, send| {
-                            let platform = use_platform_effects();
-                            let delay = ctx.close_delay_ms;
-                            let handle = platform.set_timeout(delay, Box::new(move || {
-                                send(Event::CloseTimerFired);
-                            }));
-                            let pc = platform.clone();
-                            Box::new(move || pc.clear_timeout(handle))
-                        })))
+                        .with_effect(PendingEffect::named(CLOSE_DELAY_EFFECT)))
                 }
             }
 
-            // Interactive tooltip: cancel hide when pointer enters content
-            (State::ClosePending, Event::ContentPointerEnter) if ctx.interactive => {
-                Some(TransitionPlan::to(State::Open)
-                    .apply(|ctx| { ctx.hover_active = true; }))
+            // Visible content is hoverable even though tooltip content is not interactive.
+            (State::ClosePending, Event::ContentPointerEnter | Event::PointerEnter) => {
+                Some(open_plan(props, |ctx| { ctx.hover_active = true; })
+                    .cancel_effect(CLOSE_DELAY_EFFECT))
             }
 
-            // Interactive tooltip: start hide delay when pointer leaves content
-            (State::Open, Event::ContentPointerLeave) if ctx.interactive => {
+            // Leaving visible content uses the same close-delay path as leaving the trigger.
+            (State::Open, Event::ContentPointerLeave) => {
                 if ctx.focus_active {
                     Some(TransitionPlan::context_only(|ctx| { ctx.hover_active = false; }))
                 } else {
                     Some(TransitionPlan::to(State::ClosePending)
                         .apply(|ctx| { ctx.hover_active = false; })
-                        .with_effect(PendingEffect::new("hide-delay", |ctx, _props, send| {
-                            let platform = use_platform_effects();
-                            let delay = ctx.close_delay_ms;
-                            let handle = platform.set_timeout(delay, Box::new(move || {
-                                send(Event::CloseTimerFired);
-                            }));
-                            let pc = platform.clone();
-                            Box::new(move || pc.clear_timeout(handle))
-                        })))
+                        .with_effect(PendingEffect::named(CLOSE_DELAY_EFFECT)))
                 }
             }
 
             // Escape dismisses from Open
-            (State::Open, Event::CloseOnEscape) => {
-                Some(TransitionPlan::to(State::Closed)
-                    .apply(|ctx| { ctx.open = false; ctx.hover_active = false; ctx.focus_active = false; }))
+            (State::Open, Event::CloseOnEscape) if props.close_on_escape => {
+                Some(close_now_plan(props))
             }
 
             // Click dismisses tooltip
@@ -423,36 +440,43 @@ impl ars_core::Machine for Machine {
             }
 
             (State::ClosePending, Event::CloseTimerFired) => {
-                Some(TransitionPlan::to(State::Closed)
-                    .apply(|ctx| { ctx.open = false; }))
+                Some(close_now_plan(props).cancel_effect(CLOSE_DELAY_EFFECT))
             }
 
-            // Re-enter before hide delay fires — cancel pending hide
-            (State::ClosePending, Event::PointerEnter) => {
-                Some(TransitionPlan::to(State::Open)
-                    .apply(|ctx| { ctx.hover_active = true; }))
-            }
+            // Re-focus before hide delay fires — cancel pending hide
             (State::ClosePending, Event::Focus) => {
-                Some(TransitionPlan::to(State::Open)
-                    .apply(|ctx| { ctx.focus_active = true; }))
+                Some(open_plan(props, |ctx| { ctx.focus_active = true; })
+                    .cancel_effect(CLOSE_DELAY_EFFECT))
             }
 
             // Escape dismisses from HidePending
-            (State::ClosePending, Event::CloseOnEscape) => {
-                Some(TransitionPlan::to(State::Closed)
-                    .apply(|ctx| { ctx.open = false; ctx.hover_active = false; ctx.focus_active = false; }))
+            (State::ClosePending, Event::CloseOnEscape) if props.close_on_escape => {
+                Some(close_now_plan(props).cancel_effect(CLOSE_DELAY_EFFECT))
             }
 
             // Programmatic open — skip delay, show immediately
             (State::Closed | State::OpenPending, Event::Open) => {
-                Some(TransitionPlan::to(State::Open)
-                    .apply(|ctx| { ctx.open = true; }))
+                Some(open_plan(props, |_| {}))
             }
 
             // Programmatic close — skip delay, hide immediately
             (State::Open | State::OpenPending | State::ClosePending, Event::Close) => {
-                Some(TransitionPlan::to(State::Closed)
-                    .apply(|ctx| { ctx.open = false; ctx.hover_active = false; ctx.focus_active = false; }))
+                Some(close_now_plan(props))
+            }
+
+            // Controlled prop synchronization owns visible open state.
+            (_, Event::SetControlledOpen(open)) => {
+                Some(sync_controlled_plan(*open, props))
+            }
+
+            // Non-open prop changes update resolved context without changing visibility.
+            (_, Event::SyncProps) => {
+                Some(sync_props_plan(props))
+            }
+
+            // Adapter-owned z-index allocation feeds back into core attrs.
+            (_, Event::SetZIndex(z)) => {
+                Some(TransitionPlan::context_only(move |ctx| { ctx.z_index = Some(*z); }))
             }
 
             _ => None,
@@ -467,7 +491,35 @@ impl ars_core::Machine for Machine {
     ) -> Self::Api<'a> {
         Api { state, ctx, props, send }
     }
+    fn on_props_changed(old: &Self::Props, new: &Self::Props) -> Vec<Self::Event> {
+        let mut events = Vec::new();
+
+        match (old.open, new.open) {
+            (old_open, Some(new_open)) if old_open != Some(new_open) => {
+                events.push(Event::SetControlledOpen(new_open));
+            }
+            _ if props_context_changed(old, new) => {
+                events.push(Event::SyncProps);
+            }
+            _ => {}
+        }
+
+        events
+    }
 }
+
+// Helper constructors:
+// - `open_plan` sets `ctx.open = true` only for uncontrolled tooltips, emits
+//   `tooltip-open-change`, and requests adapter z-index allocation via
+//   `tooltip-allocate-z-index`. Controlled open requests emit only
+//   `tooltip-open-change`; z-index is allocated when `SetControlledOpen(true)`
+//   makes the tooltip visibly open.
+// - `close_now_plan` sets `ctx.open = false` only for uncontrolled tooltips and emits
+//   `tooltip-open-change`.
+// - `sync_controlled_plan` updates visible state from `props.open` without firing
+//   `on_open_change`.
+// - `sync_props_plan` keeps resolved context fields (`disabled`, delays, `dir`,
+//   `positioning`, and `touch_auto_hide`) current when props change.
 ```
 
 ### 1.7 Connect / API
@@ -507,6 +559,9 @@ impl<'a> Api<'a> {
         attrs.set(scope_attr, scope_val);
         attrs.set(part_attr, part_val);
         attrs.set(HtmlAttr::Data("ars-state"), if self.is_open() { "open" } else { "closed" });
+        if self.ctx.disabled {
+            attrs.set(HtmlAttr::Data("ars-disabled"), "true");
+        }
         attrs
     }
 
@@ -514,10 +569,14 @@ impl<'a> Api<'a> {
     pub fn trigger_attrs(&self) -> AttrMap {
         let mut attrs = AttrMap::new();
         let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Trigger.data_attrs();
+        attrs.set(HtmlAttr::Id, &self.ctx.trigger_id);
         attrs.set(scope_attr, scope_val);
         attrs.set(part_attr, part_val);
         // Always point to the hidden description span, not just when open
-        attrs.set(HtmlAttr::Aria(AriaAttr::DescribedBy), format!("{}-description", self.ctx.content_id));
+        attrs.set(HtmlAttr::Aria(AriaAttr::DescribedBy), &self.ctx.hidden_description_id);
+        if self.ctx.disabled {
+            attrs.set(HtmlAttr::Aria(AriaAttr::Disabled), "true");
+        }
         attrs
     }
 
@@ -541,17 +600,44 @@ impl<'a> Api<'a> {
         (self.send)(Event::Blur);
     }
 
+    /// The handler for trigger activation dismissal.
+    pub fn on_trigger_click(&self) {
+        if self.props.close_on_click {
+            (self.send)(Event::CloseOnClick);
+        }
+    }
+
+    /// The handler for scroll dismissal.
+    pub fn on_scroll(&self) {
+        if self.props.close_on_scroll {
+            (self.send)(Event::CloseOnScroll);
+        }
+    }
+
     /// Returns `true` if the event was handled (Escape dismissed the tooltip).
     /// Adapters MUST call `event.stopPropagation()` when this returns `true`.
     /// This prevents Escape from closing both the Tooltip and a parent Dialog
     /// when the tooltip is open inside a dialog.
     pub fn on_trigger_keydown(&self, data: &KeyboardEventData) -> bool {
-        if data.key == KeyboardKey::Escape {
+        if data.key == KeyboardKey::Escape
+            && self.props.close_on_escape
+            && matches!(self.state, State::OpenPending | State::Open | State::ClosePending)
+        {
             (self.send)(Event::CloseOnEscape);
             true
         } else {
             false
         }
+    }
+
+    /// The handler for visible-content pointer enter.
+    pub fn on_content_pointer_enter(&self) {
+        (self.send)(Event::ContentPointerEnter);
+    }
+
+    /// The handler for visible-content pointer leave.
+    pub fn on_content_pointer_leave(&self) {
+        (self.send)(Event::ContentPointerLeave);
     }
 
     /// The attributes for the hidden description span.
@@ -561,7 +647,8 @@ impl<'a> Api<'a> {
         let [(scope_attr, scope_val), (part_attr, part_val)] = Part::HiddenDescription.data_attrs();
         attrs.set(scope_attr, scope_val);
         attrs.set(part_attr, part_val);
-        attrs.set(HtmlAttr::Id, format!("{}-description", self.ctx.content_id));
+        attrs.set(HtmlAttr::Id, &self.ctx.hidden_description_id);
+        attrs.set(HtmlAttr::Data("ars-visually-hidden"), "true");
         // Visually hidden but accessible to screen readers
         attrs
     }
@@ -572,6 +659,11 @@ impl<'a> Api<'a> {
         let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Positioner.data_attrs();
         attrs.set(scope_attr, scope_val);
         attrs.set(part_attr, part_val);
+        attrs.set(HtmlAttr::Data("ars-state"), if self.is_open() { "open" } else { "closed" });
+        attrs.set(HtmlAttr::Data("ars-placement"), self.ctx.positioning.placement.as_str());
+        if let Some(z_index) = self.ctx.z_index {
+            attrs.set_style(CssProperty::Custom("ars-z-index"), z_index.to_string());
+        }
         attrs
     }
 
@@ -582,12 +674,9 @@ impl<'a> Api<'a> {
         attrs.set(scope_attr, scope_val);
         attrs.set(part_attr, part_val);
         attrs.set(HtmlAttr::Id, &self.ctx.content_id);
-        attrs.set(HtmlAttr::Role, "tooltip");
+        attrs.set(HtmlAttr::Aria(AriaAttr::Hidden), "true");
         attrs.set(HtmlAttr::Data("ars-state"), if self.is_open() { "open" } else { "closed" });
-        attrs.set(HtmlAttr::Dir, match self.ctx.dir {
-            Direction::Ltr => "ltr",
-            Direction::Rtl => "rtl",
-        });
+        attrs.set(HtmlAttr::Dir, self.ctx.dir.as_html_attr());
         attrs
     }
 
@@ -597,6 +686,7 @@ impl<'a> Api<'a> {
         let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Arrow.data_attrs();
         attrs.set(scope_attr, scope_val);
         attrs.set(part_attr, part_val);
+        attrs.set(HtmlAttr::Data("ars-placement"), self.ctx.positioning.placement.as_str());
         attrs
     }
 }
@@ -617,6 +707,65 @@ impl ConnectApi for Api<'_> {
 }
 ```
 
+**Core/adapter boundary:** Tooltip core stores `PositioningOptions` and emits
+`data-ars-placement`; framework adapters run the `ars-dom` positioning engine and write geometry
+CSS custom properties such as `--ars-x`, `--ars-y`, and `--ars-transform-origin`. Tooltip core emits
+`tooltip-allocate-z-index` when the tooltip becomes visibly open; adapters allocate with
+`ZIndexAllocator`/`next_z_index()` and feed the value back with `Event::SetZIndex(u32)`.
+
+### 1.8 Positioning Options
+
+`ars_components::overlay::positioning` is the canonical DOM-free positioning intent model for
+agnostic overlay machines. It is pure data: no DOM references, measurement, viewport reads, or
+`ars-dom` dependency. Adapters translate these fields into the concrete DOM positioning engine.
+
+```rust
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum Placement {
+    Bottom,
+    BottomStart,
+    BottomEnd,
+    Top,
+    TopStart,
+    TopEnd,
+    Left,
+    LeftStart,
+    LeftEnd,
+    Right,
+    RightStart,
+    RightEnd,
+    Auto,
+    AutoStart,
+    AutoEnd,
+    Start,
+    End,
+    StartTop,
+    StartBottom,
+    EndTop,
+    EndBottom,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct Offset {
+    pub main_axis: f64,
+    pub cross_axis: f64,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct PositioningOptions {
+    pub placement: Placement,
+    pub offset: Offset,
+    pub flip: bool,
+    pub shift: bool,
+    pub shift_padding: f64,
+    pub arrow_padding: f64,
+    pub auto_max_size: bool,
+    pub fallback_placements: Vec<Placement>,
+    pub keyboard_aware: bool,
+    pub auto_placement: bool,
+}
+```
+
 ## 2. Anatomy
 
 ```text
@@ -625,7 +774,7 @@ Tooltip
 ├── Trigger            (required — always has aria-describedby pointing to hidden description span)
 ├── HiddenDescription  (required — visually-hidden span, always rendered, contains tooltip text)
 ├── Positioner         (required — floating positioning, visible only when open)
-├── Content            (required — role="tooltip", aria-hidden="true" — visual presentation only)
+├── Content            (required — aria-hidden="true" — visual presentation only)
 └── Arrow              (optional)
 ```
 
@@ -635,7 +784,7 @@ Tooltip
 | Trigger           | any      | `aria-describedby` pointing to HiddenDescription         |
 | HiddenDescription | `<span>` | Visually hidden, always rendered, stable ID              |
 | Positioner        | `<div>`  | `data-ars-scope="tooltip"`, `data-ars-part="positioner"` |
-| Content           | `<div>`  | `role="tooltip"`, `data-ars-state`, `dir`                |
+| Content           | `<div>`  | `aria-hidden="true"`, `data-ars-state`, `dir`            |
 | Arrow             | `<div>`  | `data-ars-scope="tooltip"`, `data-ars-part="arrow"`      |
 
 ## 3. Accessibility
@@ -644,7 +793,6 @@ Tooltip
 
 | Part              | Property           | Value                                               |
 | ----------------- | ------------------ | --------------------------------------------------- |
-| Content           | `role`             | `"tooltip"`                                         |
 | Trigger           | `aria-describedby` | HiddenDescription ID (always, not just when open)   |
 | HiddenDescription | (visually hidden)  | Contains tooltip text, always in accessibility tree |
 | Content           | `aria-hidden`      | `"true"` (visual presentation only)                 |
@@ -661,8 +809,6 @@ Tooltip
 - `Tooltip` does NOT prevent focus from moving to other elements
 - Pressing Escape while the tooltip is visible (or pending) dismisses it (WCAG 1.4.13)
 
-When `interactive: true`, a `DismissButton` SHOULD be rendered inside the tooltip content for screen reader users who cannot hover/focus away.
-
 ### 3.2 Keyboard Interaction
 
 | Key    | Action                              |
@@ -672,14 +818,15 @@ When `interactive: true`, a `DismissButton` SHOULD be rendered inside the toolti
 
 ### 3.3 Touch Device Behavior
 
-On touch devices (detected via `pointerType === "touch"`), the Tooltip adjusts its behavior:
+On touch devices (detected by adapters via pointer event metadata), adapters adjust behavior while
+keeping the core DOM-free:
 
 - Opens on tap (via `pointerenter` + `focus` from the tap)
 - Remains open until the user taps outside the trigger
-- The adapter composes `InteractOutside` (§13 in `05-interactions.md`) to detect outside taps when the tooltip is visible and the pointer type was touch
-- Auto-hides after a configurable timeout (default **20000ms**) on touch devices, since the user cannot hover to keep it open. The minimum of 20 seconds satisfies WCAG 2.2.1 (Timing Adjustable) which requires content to remain visible long enough for users to read it. The previous default of 5000ms was insufficient for users with cognitive or reading disabilities.
-- The auto-hide timeout is configurable via the `touch_auto_hide_ms: u32` prop (default: `20000`). Minimum enforced value: `5000` (values below are clamped).
-- **Screen reader pause**: When a screen reader's virtual cursor (focus) enters the tooltip's live region content, the auto-hide timer is paused. The timer resumes when screen reader focus leaves the tooltip. This ensures assistive technology users are not interrupted mid-read.
+- The adapter composes `InteractOutside` (§13 in `05-interactions.md`) to detect outside taps when the tooltip is visible and the pointer type was touch.
+- The adapter may auto-hide after the configured timeout (default **20s**) on touch devices, since the user cannot hover to keep it open. Core stores the clamped `touch_auto_hide` value and does not run timers itself.
+- The auto-hide timeout is configurable via the `touch_auto_hide: Duration` prop (default: `Duration::from_secs(20)`). Minimum enforced value: `Duration::from_secs(5)` (values below are clamped).
+- **Screen reader pause**: When an adapter implements touch auto-hide and can detect assistive-technology reading state, it must pause the timer while the description is being read. Core does not inspect DOM focus or virtual cursor state.
 - Escape key dismisses (available on iPad with keyboard)
 
 ## 4. Internationalization
@@ -704,22 +851,24 @@ impl ComponentMessages for Messages {}
 
 ### 5.1 Warmup/Cooldown Coordination
 
-When multiple tooltips exist on a page, a **tooltip provider** coordinates their open timing to provide a smoother experience. Without coordination, each tooltip enforces its full `open_delay_ms` even when the user is scanning across multiple triggers in quick succession.
+When multiple tooltips exist on a page, a **tooltip provider** coordinates their open timing to provide a smoother experience. Without coordination, each tooltip enforces its full `open_delay` even when the user is scanning across multiple triggers in quick succession.
 
 **Behavior:**
 
-- When a tooltip closes and the user moves to another tooltip trigger within the **cooldown window**, the second tooltip opens **instantly** (skipping `open_delay_ms`).
-- After the cooldown window expires without tooltip activity, the next tooltip opening uses the full `open_delay_ms` again.
+- When a tooltip closes and the user moves to another tooltip trigger within the **cooldown window**, the second tooltip opens **instantly** (skipping `open_delay`).
+- After the cooldown window expires without tooltip activity, the next tooltip opening uses the full `open_delay` again.
 
 ```rust
+use core::time::Duration;
+
 /// Global tooltip coordination state.
 /// Shared across all Tooltip instances within a TooltipProvider scope.
 pub struct TooltipGroup {
     /// Timestamp (performance.now()) of the last tooltip close event.
     pub last_close_at: Option<f64>,
-    /// Duration (ms) after closing during which the next tooltip opens instantly.
+    /// Duration after closing during which the next tooltip opens instantly.
     /// Default: 500ms.
-    pub cooldown_ms: u32,
+    pub cooldown: Duration,
     /// ID of the currently open tooltip (if any). Only one tooltip may be open at a time.
     pub active_tooltip_id: Option<String>,
 }
@@ -730,7 +879,7 @@ impl TooltipGroup {
         match self.last_close_at {
             Some(closed_at) => {
                 let elapsed = performance_now() - closed_at;
-                elapsed < self.cooldown_ms as f64
+                elapsed < self.cooldown.as_secs_f64() * 1000.0
             }
             None => false,
         }
@@ -770,10 +919,9 @@ When the Tooltip machine receives `PointerEnter` or `Focus` in the `Closed` stat
 | --------------------- | -------------------- | -------------------- | ------------------------------- | ---------------------------------- | -------------------------------------------------------------- |
 | Controlled open       | `open`               | `open`               | `open`                          | `isOpen`                           | All libraries                                                  |
 | Default open          | `default_open`       | `defaultOpen`        | `defaultOpen`                   | `defaultOpen`                      | All libraries                                                  |
-| Open delay            | `open_delay_ms`      | `openDelay`          | `delayDuration`                 | `delay`                            | All libraries; different defaults                              |
-| Close delay           | `close_delay_ms`     | `closeDelay`         | --                              | `closeDelay`                       | Ark UI/React Aria; Radix uses provider-level skipDelayDuration |
+| Open delay            | `open_delay`         | `openDelay`          | `delayDuration`                 | `delay`                            | All libraries; different defaults                              |
+| Close delay           | `close_delay`        | `closeDelay`         | --                              | `closeDelay`                       | Ark UI/React Aria; Radix uses provider-level skipDelayDuration |
 | Disabled              | `disabled`           | `disabled`           | --                              | `isDisabled`                       | All except Radix                                               |
-| Interactive           | `interactive`        | `interactive`        | `disableHoverableContent` (inv) | --                                 | Ark UI parity; Radix inverts semantics                         |
 | Close on Escape       | `close_on_escape`    | `closeOnEscape`      | (onEscapeKeyDown)               | `isKeyboardDismissDisabled`        | All libraries                                                  |
 | Close on click        | `close_on_click`     | `closeOnClick`       | --                              | --                                 | Ark UI parity                                                  |
 | Close on pointer down | --                   | `closeOnPointerDown` | --                              | --                                 | Subsumed by `close_on_click`                                   |
@@ -783,12 +931,14 @@ When the Tooltip machine receives `PointerEnter` or `Focus` in the `Closed` stat
 | Lazy mount            | `lazy_mount`         | `lazyMount`          | --                              | --                                 | Ark UI parity                                                  |
 | Unmount on exit       | `unmount_on_exit`    | `unmountOnExit`      | (forceMount inverse)            | --                                 | Ark UI parity                                                  |
 | Open change callback  | `on_open_change`     | `onOpenChange`       | `onOpenChange`                  | `onOpenChange`                     | All libraries                                                  |
-| Touch auto-hide       | `touch_auto_hide_ms` | --                   | --                              | --                                 | ars-ui addition for WCAG compliance                            |
+| Touch auto-hide       | `touch_auto_hide`    | --                   | --                              | --                                 | Adapter-owned ars-ui addition                                  |
 | `aria-label`          | (HiddenDescription)  | `aria-label`         | `aria-label`                    | --                                 | ars-ui uses always-rendered hidden span                        |
 | Skip delay duration   | (TooltipGroup)       | --                   | `skipDelayDuration`             | --                                 | Provider-level warmup/cooldown                                 |
 | Focus-only trigger    | --                   | --                   | --                              | `trigger="focus"`                  | React Aria only                                                |
 
-**Gaps:** None. React Aria's `trigger="focus"` (show only on focus, not hover) is a niche use case not needed for ars-ui's standard tooltip.
+**Intentional divergences:** Tooltip does not expose interactive content support. Interactive
+floating content belongs in HoverCard or Popover. React Aria's `trigger="focus"` (show only on
+focus, not hover) is a niche use case not needed for ars-ui's standard tooltip.
 
 ### 6.2 Anatomy
 
@@ -821,9 +971,9 @@ When the Tooltip machine receives `PointerEnter` or `Focus` in the `Closed` stat
 | ----------------------------- | ----------------------- | ------ | ----------------------------- | ------------------ |
 | Hover + focus triggers        | Yes                     | Yes    | Yes                           | Yes                |
 | Open/close delay              | Yes                     | Yes    | Yes (provider)                | Yes                |
-| Interactive content           | Yes                     | Yes    | Yes (disableHoverableContent) | --                 |
+| Interactive content           | No                      | Yes    | Yes (disableHoverableContent) | --                 |
 | WCAG 1.4.13 compliance        | Yes                     | --     | --                            | Yes                |
-| Touch device handling         | Yes                     | --     | --                            | Yes                |
+| Touch device handling         | Adapter-owned           | --     | --                            | Yes                |
 | Warmup/cooldown               | Yes (TooltipGroup)      | --     | Yes (Provider)                | Yes (built-in)     |
 | Single-open enforcement       | Yes (TooltipGroup)      | --     | --                            | Yes                |
 | Always-accessible description | Yes (HiddenDescription) | --     | --                            | --                 |
@@ -835,6 +985,6 @@ When the Tooltip machine receives `PointerEnter` or `Focus` in the `Closed` stat
 
 ### 6.5 Summary
 
-- **Overall:** Full parity.
-- **Divergences:** (1) ars-ui renders a permanently-visible `HiddenDescription` span for screen readers instead of relying on `aria-describedby` pointing to the conditionally-rendered tooltip content; this ensures touch/screen reader users always have access to tooltip text. (2) Warmup/cooldown is provided by `TooltipGroup` struct instead of a React context provider. (3) `touch_auto_hide_ms` is an ars-ui-specific addition for WCAG 2.2.1 compliance on touch devices.
+- **Overall:** Full parity for non-interactive tooltip behavior, with intentional divergence from libraries that allow interactive tooltip content.
+- **Divergences:** (1) ars-ui renders a permanently-visible `HiddenDescription` span for screen readers instead of relying on `aria-describedby` pointing to the conditionally-rendered tooltip content; this ensures touch/screen reader users always have access to tooltip text. (2) Warmup/cooldown is provided by `TooltipGroup` struct instead of a React context provider. (3) `touch_auto_hide` is an adapter-owned ars-ui-specific addition for touch devices. (4) Interactive floating content is handled by HoverCard/Popover instead of Tooltip.
 - **Recommended additions:** None.

--- a/spec/components/overlay/tooltip.md
+++ b/spec/components/overlay/tooltip.md
@@ -651,6 +651,7 @@ impl<'a> Api<'a> {
     /// when the tooltip is open inside a dialog.
     pub fn on_trigger_keydown(&self, data: &KeyboardEventData) -> bool {
         if data.key == KeyboardKey::Escape
+            && !self.ctx.disabled
             && self.props.close_on_escape
             && matches!(self.state, State::OpenPending | State::Open | State::ClosePending)
         {

--- a/spec/components/overlay/tooltip.md
+++ b/spec/components/overlay/tooltip.md
@@ -324,6 +324,9 @@ impl ars_core::Machine for Machine {
             (State::Closed, Event::Focus) => {
                 Some(open_plan(props, |ctx| { ctx.focus_active = true; }))
             }
+            (State::Closed, Event::Blur) => {
+                Some(TransitionPlan::context_only(|ctx| { ctx.focus_active = false; }))
+            }
 
             // Timer fired -> show
             (State::OpenPending, Event::OpenTimerFired) => {
@@ -336,7 +339,8 @@ impl ars_core::Machine for Machine {
                 Some(TransitionPlan::context_only(|ctx| { ctx.hover_active = true; }))
             }
             (State::OpenPending, Event::Focus) => {
-                Some(open_plan(props, |ctx| { ctx.focus_active = true; }))
+                Some(open_plan(props, |ctx| { ctx.focus_active = true; })
+                    .cancel_effect(OPEN_DELAY_EFFECT))
             }
 
             // Cancel show delay only if BOTH hover and focus are gone
@@ -345,7 +349,8 @@ impl ars_core::Machine for Machine {
                     Some(TransitionPlan::context_only(|ctx| { ctx.hover_active = false; }))
                 } else {
                     Some(TransitionPlan::to(State::Closed)
-                        .apply(|ctx| { ctx.hover_active = false; }))
+                        .apply(|ctx| { ctx.hover_active = false; })
+                        .cancel_effect(OPEN_DELAY_EFFECT))
                 }
             }
             (State::OpenPending, Event::Blur) => {
@@ -353,7 +358,8 @@ impl ars_core::Machine for Machine {
                     Some(TransitionPlan::context_only(|ctx| { ctx.focus_active = false; }))
                 } else {
                     Some(TransitionPlan::to(State::Closed)
-                        .apply(|ctx| { ctx.focus_active = false; }))
+                        .apply(|ctx| { ctx.focus_active = false; })
+                        .cancel_effect(OPEN_DELAY_EFFECT))
                 }
             }
 
@@ -421,17 +427,27 @@ impl ars_core::Machine for Machine {
             }
 
             // Click dismisses tooltip
-            (State::Open | State::OpenPending, Event::CloseOnClick) => {
+            (State::OpenPending, Event::CloseOnClick) => {
                 if !props.close_on_click { return None; }
                 Some(TransitionPlan::to(State::Closed)
-                    .apply(|ctx| { ctx.open = false; ctx.hover_active = false; ctx.focus_active = false; }))
+                    .apply(|ctx| { ctx.open = false; ctx.hover_active = false; ctx.focus_active = false; })
+                    .cancel_effect(OPEN_DELAY_EFFECT))
+            }
+            (State::Open, Event::CloseOnClick) => {
+                if !props.close_on_click { return None; }
+                Some(close_now_plan(props))
             }
 
             // Scroll dismisses tooltip
-            (State::Open | State::OpenPending, Event::CloseOnScroll) => {
+            (State::OpenPending, Event::CloseOnScroll) => {
                 if !props.close_on_scroll { return None; }
                 Some(TransitionPlan::to(State::Closed)
-                    .apply(|ctx| { ctx.open = false; ctx.hover_active = false; ctx.focus_active = false; }))
+                    .apply(|ctx| { ctx.open = false; ctx.hover_active = false; ctx.focus_active = false; })
+                    .cancel_effect(OPEN_DELAY_EFFECT))
+            }
+            (State::Open, Event::CloseOnScroll) => {
+                if !props.close_on_scroll { return None; }
+                Some(close_now_plan(props))
             }
 
             (State::ClosePending, Event::CloseTimerFired) => {
@@ -448,15 +464,30 @@ impl ars_core::Machine for Machine {
             (State::ClosePending, Event::CloseOnEscape) if props.close_on_escape => {
                 Some(close_now_plan(props).cancel_effect(CLOSE_DELAY_EFFECT))
             }
+            (State::ClosePending, Event::CloseOnClick) if props.close_on_click => {
+                Some(close_now_plan(props).cancel_effect(CLOSE_DELAY_EFFECT))
+            }
+            (State::ClosePending, Event::CloseOnScroll) if props.close_on_scroll => {
+                Some(close_now_plan(props).cancel_effect(CLOSE_DELAY_EFFECT))
+            }
 
             // Programmatic open — skip delay, show immediately
-            (State::Closed | State::OpenPending, Event::Open) => {
+            (State::Closed, Event::Open) => {
                 Some(open_plan(props, |_| {}))
+            }
+            (State::OpenPending, Event::Open) => {
+                Some(open_plan(props, |_| {}).cancel_effect(OPEN_DELAY_EFFECT))
             }
 
             // Programmatic close — skip delay, hide immediately
-            (State::Open | State::OpenPending | State::ClosePending, Event::Close) => {
+            (State::Open, Event::Close) => {
                 Some(close_now_plan(props))
+            }
+            (State::OpenPending, Event::Close) => {
+                Some(close_now_plan(props).cancel_effect(OPEN_DELAY_EFFECT))
+            }
+            (State::ClosePending, Event::Close) => {
+                Some(close_now_plan(props).cancel_effect(CLOSE_DELAY_EFFECT))
             }
 
             // Controlled prop synchronization owns visible open state.

--- a/spec/components/overlay/tooltip.md
+++ b/spec/components/overlay/tooltip.md
@@ -308,12 +308,7 @@ impl ars_core::Machine for Machine {
         ctx: &Self::Context,
         props: &Self::Props,
     ) -> Option<TransitionPlan<Self>> {
-        if ctx.disabled
-            && !matches!(
-                event,
-                Event::SetControlledOpen(_) | Event::SyncProps | Event::SetZIndex(_)
-            )
-        {
+        if ctx.disabled && disabled_blocks_event(*event) {
             return None;
         }
 
@@ -519,7 +514,12 @@ impl ars_core::Machine for Machine {
 // - `sync_controlled_plan` updates visible state from `props.open` without firing
 //   `on_open_change`.
 // - `sync_props_plan` keeps resolved context fields (`disabled`, delays, `dir`,
-//   `positioning`, and `touch_auto_hide`) current when props change.
+//   `positioning`, derived part IDs, and `touch_auto_hide`) current when props
+//   change.
+// - `disabled_blocks_event` blocks user-originated interaction, user dismissal,
+//   and explicit `Open` requests while disabled. Internal and programmatic close
+//   paths such as `CloseTimerFired` and `Close` must still complete so a
+//   disabled tooltip cannot remain stuck open.
 ```
 
 ### 1.7 Connect / API


### PR DESCRIPTION
## Summary
- add DOM-free `ars_components::overlay::tooltip` core machine and connect API
- add shared pure-data overlay positioning options
- add Tooltip snapshots, unit coverage, builder coverage, and ignored nightly proptest invariants
- sync `spec/components/overlay/tooltip.md` to the implemented contract, including `Duration` timing props

## Validation
- `CHROMEDRIVER=$HOME/.cache/ars-ui-chromedriver/chromedriver-mac-arm64/chromedriver PATH=$HOME/.cache/ars-ui-chromedriver/chromedriver-mac-arm64:$PATH cargo xci`
- `PROPTEST_CASES=512 cargo test -p ars-components --test proptest_state_machines proptest_tooltip_state_context_invariants_hold -- --ignored`
- `cargo test -p ars-components`
- `cargo clippy -p ars-components --all-targets --all-features -- -D warnings`
- `cargo insta test -p ars-components --unreferenced=reject`
- `cargo xtask spec validate`

Closes #243