### PR TITLE
Implement dismissable agnostic core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,7 +223,7 @@ jobs:
           chmod +x /tmp/llvm.sh
           sudo /tmp/llvm.sh 22
           sudo apt-get install -y clang-22 lld-22
-      - run: cargo install wasm-bindgen-cli --locked --version 0.2.118
+      - run: cargo install wasm-bindgen-cli --locked --version 0.2.120
       - name: Configure wasm coverage clang
         run: echo "WASM_COVERAGE_CLANG=/usr/bin/clang-22" >> "$GITHUB_ENV"
       - uses: ./.github/actions/install-dioxus-desktop-deps

--- a/crates/ars-components/src/utility/dismissable.rs
+++ b/crates/ars-components/src/utility/dismissable.rs
@@ -9,10 +9,11 @@
 //! The module intentionally stays free of DOM or framework types so that
 //! attribute generation can be tested with pure unit tests.
 //!
-//! **Dismiss-button wording is not part of [`Props`].** Callers resolve a
-//! localized label in their own message bundle and pass the final string to
+//! **Dismiss-button wording is not part of [`Props`].** [`Messages`] provides
+//! the shared default label bundle, but callers resolve the localized label in
+//! their adapter or overlay layer and pass the final string to
 //! [`dismiss_button_attrs`]. This keeps the shared utility focused on behavior
-//! and structure rather than owning overlay-specific wording.
+//! and structure rather than resolving i18n itself.
 
 use alloc::{string::String, sync::Arc, vec::Vec};
 use core::{
@@ -21,45 +22,11 @@ use core::{
 };
 
 use ars_core::{
-    AriaAttr, AttrMap, AttrValue, Callback, ComponentMessages, ComponentPart, HtmlAttr, MessageFn,
+    AriaAttr, AttrMap, AttrValue, Callback, ComponentMessages, ComponentPart, ConnectApi, HtmlAttr,
+    MessageFn,
 };
 use ars_i18n::Locale;
 use ars_interactions::InteractOutsideEvent;
-
-// ────────────────────────────────────────────────────────────────────
-// Messages
-// ────────────────────────────────────────────────────────────────────
-
-/// Localizable messages for the dismissable utility.
-///
-/// Adapters resolve this bundle through the standard provider stack so the
-/// visually-hidden dismiss buttons get a locale-aware `aria-label` even
-/// when the embedding overlay does not pass one explicitly. Overlay
-/// components that own their own wording (e.g. "Dismiss popover") build
-/// the label themselves and pass it directly to [`dismiss_button_attrs`]
-/// without going through this bundle.
-#[derive(Clone, Debug)]
-pub struct Messages {
-    /// Returns the localized aria-label for the visually-hidden dismiss
-    /// buttons.
-    pub dismiss_label: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
-}
-
-impl Default for Messages {
-    fn default() -> Self {
-        Self {
-            dismiss_label: MessageFn::new(|_locale: &Locale| String::from("Dismiss")),
-        }
-    }
-}
-
-impl PartialEq for Messages {
-    fn eq(&self, other: &Self) -> bool {
-        self.dismiss_label == other.dismiss_label
-    }
-}
-
-impl ComponentMessages for Messages {}
 
 // ────────────────────────────────────────────────────────────────────
 // DismissReason
@@ -163,6 +130,32 @@ impl<E: PartialEq> PartialEq for DismissAttempt<E> {
         self.event == other.event && Arc::ptr_eq(&self.veto, &other.veto)
     }
 }
+
+// ────────────────────────────────────────────────────────────────────
+// Messages
+// ────────────────────────────────────────────────────────────────────
+
+/// Localizable strings for the Dismissable structural helper.
+///
+/// The bundle intentionally contains only the generic fallback label used by
+/// adapter-owned region wrappers. Overlay components that need more specific
+/// wording should resolve their own final label and pass it to [`Api::new`] or
+/// [`dismiss_button_attrs`].
+#[derive(Clone, Debug, PartialEq)]
+pub struct Messages {
+    /// Accessible label for the visually-hidden dismiss buttons.
+    pub dismiss_label: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
+}
+
+impl Default for Messages {
+    fn default() -> Self {
+        Self {
+            dismiss_label: MessageFn::static_str("Dismiss"),
+        }
+    }
+}
+
+impl ComponentMessages for Messages {}
 
 // ────────────────────────────────────────────────────────────────────
 // Part
@@ -370,6 +363,94 @@ impl Props {
 }
 
 // ────────────────────────────────────────────────────────────────────
+// Api
+// ────────────────────────────────────────────────────────────────────
+
+/// Stateless connect API for deriving Dismissable DOM attributes.
+///
+/// The API owns the already-resolved dismiss-button label as structural
+/// adapter input, not as user-facing copy. Overlay components remain
+/// responsible for resolving the best localized phrase for their context and
+/// passing the final value here.
+pub struct Api {
+    props: Props,
+    dismiss_button_label: AttrValue,
+}
+
+impl Debug for Api {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("dismissable::Api")
+            .field("props", &self.props)
+            .field("dismiss_button_label", &self.dismiss_button_label)
+            .finish()
+    }
+}
+
+impl Api {
+    /// Creates a new Dismissable attribute API.
+    ///
+    /// `dismiss_button_label` is the final accessible label for both
+    /// visually-hidden dismiss buttons. It accepts static strings and reactive
+    /// [`AttrValue`] inputs so adapters can pass provider-resolved localized
+    /// labels without adding wording to [`Props`].
+    #[must_use]
+    pub fn new(props: Props, dismiss_button_label: impl Into<AttrValue>) -> Self {
+        Self {
+            props,
+            dismiss_button_label: dismiss_button_label.into(),
+        }
+    }
+
+    /// Returns root container attributes for the dismissable boundary.
+    ///
+    /// The root is deliberately structural: document listeners, containment
+    /// checks, and platform capability fallbacks are adapter-owned.
+    #[must_use]
+    pub fn root_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Root.data_attrs();
+
+        attrs.set(scope_attr, scope_val).set(part_attr, part_val);
+
+        if self.props.disable_outside_pointer_events {
+            attrs.set_bool(HtmlAttr::Data("ars-disable-outside-pointer-events"), true);
+        }
+
+        attrs
+    }
+
+    /// Returns attributes for either visually-hidden dismiss button.
+    #[must_use]
+    pub fn dismiss_button_attrs(&self) -> AttrMap {
+        dismiss_button_attrs(self.dismiss_button_label.clone())
+    }
+
+    /// Returns whether outside pointer events should be intercepted by the
+    /// adapter-owned document listener layer.
+    #[must_use]
+    pub const fn disable_outside_pointer_events(&self) -> bool {
+        self.props.disable_outside_pointer_events
+    }
+
+    /// Returns the DOM ids excluded from outside-interaction dismissal.
+    #[must_use]
+    pub fn exclude_ids(&self) -> &[String] {
+        &self.props.exclude_ids
+    }
+}
+
+impl ConnectApi for Api {
+    type Part = Part;
+
+    fn part_attrs(&self, part: Self::Part) -> AttrMap {
+        match part {
+            Part::Root => self.root_attrs(),
+            Part::DismissButton => self.dismiss_button_attrs(),
+        }
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────
 // dismiss_button_attrs
 // ────────────────────────────────────────────────────────────────────
 
@@ -409,39 +490,20 @@ pub fn dismiss_button_attrs(label: impl Into<AttrValue>) -> AttrMap {
 
 #[cfg(test)]
 mod tests {
-    use alloc::sync::Arc;
+    use alloc::{format, sync::Arc};
     use core::sync::atomic::{AtomicUsize, Ordering};
 
-    use ars_core::AttrValue;
+    use ars_core::{AttrValue, ConnectApi};
+    use insta::assert_snapshot;
 
     use super::*;
 
-    // ── Messages tests ─────────────────────────────────────────────
-
-    #[test]
-    fn messages_default_dismiss_label_returns_dismiss_for_any_locale() {
-        let messages = Messages::default();
-        let locale = Locale::parse("en-US").expect("en-US must parse");
-
-        assert_eq!((messages.dismiss_label)(&locale), "Dismiss");
+    fn api(props: Props) -> Api {
+        Api::new(props, "Dismiss")
     }
 
-    #[test]
-    fn messages_default_pair_compares_equal_via_arc_identity() {
-        // Two `Messages::default()` values build distinct Arc-backed
-        // closures, so `PartialEq` (which uses `Arc::ptr_eq` under the
-        // hood via `MessageFn`) should report inequality. Cloning a
-        // single instance, by contrast, shares the Arc and compares
-        // equal — this is the contract every adapter relies on when it
-        // memoizes a Messages bundle.
-        let lhs = Messages::default();
-        let rhs = Messages::default();
-
-        assert_ne!(lhs, rhs);
-
-        let cloned = lhs.clone();
-
-        assert_eq!(lhs, cloned);
+    fn snapshot_attrs(attrs: &AttrMap) -> String {
+        format!("{attrs:#?}")
     }
 
     // ── Part tests ─────────────────────────────────────────────────
@@ -727,6 +789,14 @@ mod tests {
     }
 
     #[test]
+    fn messages_default_dismiss_label_returns_dismiss() {
+        let messages = Messages::default();
+        let locale = Locale::parse("en-US").expect("en-US must parse");
+
+        assert_eq!((messages.dismiss_label)(&locale), "Dismiss");
+    }
+
+    #[test]
     fn dismiss_attempt_starts_un_prevented() {
         let attempt = DismissAttempt::new(InteractOutsideEvent::EscapeKey);
 
@@ -804,10 +874,29 @@ mod tests {
 
     #[test]
     fn props_builder_chain_applies_each_setter() {
+        let interact_calls = Arc::new(AtomicUsize::new(0));
+        let escape_calls = Arc::new(AtomicUsize::new(0));
+        let dismiss_calls = Arc::new(AtomicUsize::new(0));
+
         let props = Props::new()
-            .on_interact_outside(|_attempt: DismissAttempt<InteractOutsideEvent>| {})
-            .on_escape_key_down(|_attempt: DismissAttempt<()>| {})
-            .on_dismiss(|_reason: DismissReason| {})
+            .on_interact_outside({
+                let interact_calls = Arc::clone(&interact_calls);
+                move |_attempt: DismissAttempt<InteractOutsideEvent>| {
+                    interact_calls.fetch_add(1, Ordering::SeqCst);
+                }
+            })
+            .on_escape_key_down({
+                let escape_calls = Arc::clone(&escape_calls);
+                move |_attempt: DismissAttempt<()>| {
+                    escape_calls.fetch_add(1, Ordering::SeqCst);
+                }
+            })
+            .on_dismiss({
+                let dismiss_calls = Arc::clone(&dismiss_calls);
+                move |_reason: DismissReason| {
+                    dismiss_calls.fetch_add(1, Ordering::SeqCst);
+                }
+            })
             .disable_outside_pointer_events(true)
             .exclude_ids(["trigger", "panel"]);
 
@@ -816,6 +905,18 @@ mod tests {
         assert!(props.on_dismiss.is_some());
         assert!(props.disable_outside_pointer_events);
         assert_eq!(props.exclude_ids, vec!["trigger", "panel"]);
+
+        props.on_interact_outside.as_ref().expect("callback")(DismissAttempt::new(
+            InteractOutsideEvent::EscapeKey,
+        ));
+
+        props.on_escape_key_down.as_ref().expect("callback")(DismissAttempt::new(()));
+
+        props.on_dismiss.as_ref().expect("callback")(DismissReason::DismissButton);
+
+        assert_eq!(interact_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(escape_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(dismiss_calls.load(Ordering::SeqCst), 1);
     }
 
     #[test]
@@ -831,5 +932,129 @@ mod tests {
         props.on_dismiss.as_ref().expect("callback")(DismissReason::DismissButton);
 
         assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    // ── Api / connect tests ────────────────────────────────────────
+
+    #[test]
+    fn root_attrs_sets_scope_and_part() {
+        let attrs = api(Props::new()).root_attrs();
+
+        assert_eq!(attrs.get(&HtmlAttr::Data("ars-scope")), Some("dismissable"));
+        assert_eq!(attrs.get(&HtmlAttr::Data("ars-part")), Some("root"));
+    }
+
+    #[test]
+    fn root_attrs_omits_pointer_blocking_marker_by_default() {
+        let attrs = api(Props::new()).root_attrs();
+
+        assert_eq!(
+            attrs.get_value(&HtmlAttr::Data("ars-disable-outside-pointer-events")),
+            None
+        );
+    }
+
+    #[test]
+    fn root_attrs_sets_pointer_blocking_marker_when_enabled() {
+        let attrs = api(Props::new().disable_outside_pointer_events(true)).root_attrs();
+
+        assert_eq!(
+            attrs.get_value(&HtmlAttr::Data("ars-disable-outside-pointer-events")),
+            Some(&AttrValue::Bool(true))
+        );
+    }
+
+    #[test]
+    fn api_reports_behavioral_props() {
+        let api = api(Props::new()
+            .disable_outside_pointer_events(true)
+            .exclude_ids(["trigger", "portal"]));
+
+        assert!(api.disable_outside_pointer_events());
+        assert_eq!(api.exclude_ids(), ["trigger", "portal"]);
+    }
+
+    #[test]
+    fn api_dismiss_button_attrs_uses_constructor_label() {
+        let attrs = Api::new(Props::new(), "Close dialog").dismiss_button_attrs();
+
+        assert_eq!(
+            attrs.get(&HtmlAttr::Aria(AriaAttr::Label)),
+            Some("Close dialog")
+        );
+    }
+
+    #[test]
+    fn part_attrs_delegates_to_root_attrs() {
+        let api = api(Props::new().disable_outside_pointer_events(true));
+
+        assert_eq!(api.part_attrs(Part::Root), api.root_attrs());
+    }
+
+    #[test]
+    fn part_attrs_delegates_to_dismiss_button_attrs() {
+        let api = Api::new(Props::new(), "Close dialog");
+
+        assert_eq!(
+            api.part_attrs(Part::DismissButton),
+            api.dismiss_button_attrs()
+        );
+    }
+
+    #[test]
+    fn api_debug_includes_props_and_label() {
+        let debug = format!("{:?}", Api::new(Props::new(), "Dismiss"));
+
+        assert!(debug.contains("dismissable::Api"));
+        assert!(debug.contains("Props"));
+        assert!(debug.contains("Dismiss"));
+    }
+
+    #[test]
+    fn dismissable_root_default_snapshot() {
+        assert_snapshot!(
+            "dismissable_root_default",
+            snapshot_attrs(&api(Props::new()).root_attrs())
+        );
+    }
+
+    #[test]
+    fn dismissable_root_pointer_blocking_snapshot() {
+        assert_snapshot!(
+            "dismissable_root_pointer_blocking",
+            snapshot_attrs(&api(Props::new().disable_outside_pointer_events(true)).root_attrs())
+        );
+    }
+
+    #[test]
+    fn dismissable_dismiss_button_default_snapshot() {
+        assert_snapshot!(
+            "dismissable_dismiss_button_default",
+            snapshot_attrs(&api(Props::new()).dismiss_button_attrs())
+        );
+    }
+
+    #[test]
+    fn dismissable_dismiss_button_custom_label_snapshot() {
+        assert_snapshot!(
+            "dismissable_dismiss_button_custom_label",
+            snapshot_attrs(&Api::new(Props::new(), "Close dialog").dismiss_button_attrs())
+        );
+    }
+
+    #[test]
+    fn dismissable_part_root_snapshot() {
+        assert_snapshot!(
+            "dismissable_part_root",
+            snapshot_attrs(&api(Props::new()).part_attrs(Part::Root))
+        );
+    }
+
+    #[test]
+    fn dismissable_part_dismiss_button_snapshot() {
+        assert_snapshot!(
+            "dismissable_part_dismiss_button",
+            snapshot_attrs(&api(Props::new()).part_attrs(Part::DismissButton))
+        );
     }
 }

--- a/crates/ars-components/src/utility/snapshots/ars_components__utility__dismissable__tests__dismissable_dismiss_button_custom_label.snap
+++ b/crates/ars-components/src/utility/snapshots/ars_components__utility__dismissable__tests__dismissable_dismiss_button_custom_label.snap
@@ -1,0 +1,59 @@
+---
+source: crates/ars-components/src/utility/dismissable.rs
+expression: "snapshot_attrs(&Api::new(Props::new(), \"Close dialog\").dismiss_button_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "dismiss-button",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "dismissable",
+            ),
+        ),
+        (
+            Data(
+                "ars-visually-hidden",
+            ),
+            Bool(
+                true,
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Close dialog",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "button",
+            ),
+        ),
+        (
+            TabIndex,
+            String(
+                "0",
+            ),
+        ),
+        (
+            Type,
+            String(
+                "button",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/utility/snapshots/ars_components__utility__dismissable__tests__dismissable_dismiss_button_default.snap
+++ b/crates/ars-components/src/utility/snapshots/ars_components__utility__dismissable__tests__dismissable_dismiss_button_default.snap
@@ -1,0 +1,59 @@
+---
+source: crates/ars-components/src/utility/dismissable.rs
+expression: "snapshot_attrs(&api(Props::new()).dismiss_button_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "dismiss-button",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "dismissable",
+            ),
+        ),
+        (
+            Data(
+                "ars-visually-hidden",
+            ),
+            Bool(
+                true,
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Dismiss",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "button",
+            ),
+        ),
+        (
+            TabIndex,
+            String(
+                "0",
+            ),
+        ),
+        (
+            Type,
+            String(
+                "button",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/utility/snapshots/ars_components__utility__dismissable__tests__dismissable_part_dismiss_button.snap
+++ b/crates/ars-components/src/utility/snapshots/ars_components__utility__dismissable__tests__dismissable_part_dismiss_button.snap
@@ -1,0 +1,59 @@
+---
+source: crates/ars-components/src/utility/dismissable.rs
+expression: "snapshot_attrs(&api(Props::new()).part_attrs(Part::DismissButton))"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "dismiss-button",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "dismissable",
+            ),
+        ),
+        (
+            Data(
+                "ars-visually-hidden",
+            ),
+            Bool(
+                true,
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Dismiss",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "button",
+            ),
+        ),
+        (
+            TabIndex,
+            String(
+                "0",
+            ),
+        ),
+        (
+            Type,
+            String(
+                "button",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/utility/snapshots/ars_components__utility__dismissable__tests__dismissable_part_root.snap
+++ b/crates/ars-components/src/utility/snapshots/ars_components__utility__dismissable__tests__dismissable_part_root.snap
@@ -1,0 +1,25 @@
+---
+source: crates/ars-components/src/utility/dismissable.rs
+expression: "snapshot_attrs(&api(Props::new()).part_attrs(Part::Root))"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "dismissable",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/utility/snapshots/ars_components__utility__dismissable__tests__dismissable_root_default.snap
+++ b/crates/ars-components/src/utility/snapshots/ars_components__utility__dismissable__tests__dismissable_root_default.snap
@@ -1,0 +1,25 @@
+---
+source: crates/ars-components/src/utility/dismissable.rs
+expression: "snapshot_attrs(&api(Props::new()).root_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "dismissable",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/utility/snapshots/ars_components__utility__dismissable__tests__dismissable_root_pointer_blocking.snap
+++ b/crates/ars-components/src/utility/snapshots/ars_components__utility__dismissable__tests__dismissable_root_pointer_blocking.snap
@@ -1,0 +1,33 @@
+---
+source: crates/ars-components/src/utility/dismissable.rs
+expression: "snapshot_attrs(&api(Props::new().disable_outside_pointer_events(true)).root_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-disable-outside-pointer-events",
+            ),
+            Bool(
+                true,
+            ),
+        ),
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "dismissable",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-dioxus/src/dismissable.rs
+++ b/crates/ars-dioxus/src/dismissable.rs
@@ -8,8 +8,8 @@
 //! topmost-overlay gating without re-implementing each piece per overlay.
 //!
 //! This module re-exports the agnostic `ars_components::utility::dismissable`
-//! surface (`Props`, `Messages`, `Part`, `DismissReason`,
-//! `DismissAttempt`, `dismiss_button_attrs`) so consumers reach every
+//! surface (`Props`, `Messages`, `Part`, `DismissReason`, `DismissAttempt`,
+//! `dismiss_button_attrs`) so consumers reach every
 //! dismissable type through a single namespace —
 //! `dismissable::Props`, `dismissable::Region`, `dismissable::Handle`,
 //! `dismissable::use_dismissable`, etc.
@@ -26,8 +26,9 @@ use std::{
 };
 
 pub use ars_components::utility::dismissable::{
-    DismissAttempt, DismissReason, Messages, Part, Props, dismiss_button_attrs,
+    Api, DismissAttempt, DismissReason, Messages, Part, Props, dismiss_button_attrs,
 };
+use ars_i18n::Locale;
 use dioxus::prelude::*;
 #[cfg(feature = "web")]
 use {
@@ -395,14 +396,23 @@ pub struct RegionProps {
     #[props(optional)]
     pub inside_boundaries: Option<ReadSignal<Vec<String>>>,
 
-    /// Optional locale override — falls through to the surrounding
-    /// [`ArsProvider`](crate::ArsContext) locale when [`None`].
+    /// Explicit accessible-label override for both visually-hidden
+    /// dismiss buttons.
+    ///
+    /// When omitted, [`Region`] resolves [`Messages`] from the nearest
+    /// `ArsProvider` message registry and locale, falling back to
+    /// `"Dismiss"`. Overlay components may pass context-specific
+    /// wording such as `"Close dialog"` or `"Dismiss popover"`.
     #[props(optional)]
-    pub locale: Option<ars_i18n::Locale>,
+    pub dismiss_label: Option<String>,
 
-    /// Optional message bundle override — falls through to the
-    /// adapter's [`use_messages`] resolution chain (props →
-    /// [`I18nRegistries`] → [`Messages::default`]) when [`None`].
+    /// Explicit locale override used when resolving provider/default
+    /// [`Messages`].
+    #[props(optional, into)]
+    pub locale: Option<Signal<Locale>>,
+
+    /// Explicit message-bundle override used when `dismiss_label` is
+    /// omitted.
     #[props(optional)]
     pub messages: Option<Messages>,
 
@@ -434,8 +444,9 @@ pub fn Region(props: RegionProps) -> Element {
     let RegionProps {
         props,
         inside_boundaries,
-        locale: locale_override,
-        messages: messages_override,
+        dismiss_label,
+        locale,
+        messages,
         children,
     } = props;
 
@@ -443,21 +454,18 @@ pub fn Region(props: RegionProps) -> Element {
 
     let boundaries = inside_boundaries.unwrap_or_else(|| ReadSignal::from(boundaries_fallback));
 
-    let messages = use_messages::<Messages>(messages_override.as_ref(), locale_override.as_ref());
+    let provider_locale = resolve_locale(None);
+    let resolved_locale = locale
+        .as_ref()
+        .map_or(provider_locale, |locale| locale.read().clone());
+    let resolved_messages = use_messages(messages.as_ref(), Some(&resolved_locale));
+    let dismiss_label =
+        dismiss_label.unwrap_or_else(|| (resolved_messages.dismiss_label)(&resolved_locale));
 
-    // Both `resolve_locale` and the bundle resolution above subscribe to
-    // their reactive sources (`use_locale`, `use_context::<I18nRegistries>`)
-    // through the Dioxus runtime; deriving `dismiss_label` at the component-
-    // body level lets the rendered `aria-label` re-resolve when the
-    // surrounding `ArsProvider`'s locale or the `I18nRegistries` bundle
-    // updates at runtime. Memoizing with `use_hook` would freeze the label
-    // at first render and break runtime language switching.
-    let resolved_locale = resolve_locale(locale_override.as_ref());
-    let dismiss_label = (messages.dismiss_label)(&resolved_locale);
+    let api = Api::new(props.clone(), dismiss_label);
 
-    let dismiss_attrs = dismiss_button_attrs(dismiss_label);
-
-    let inline_attrs = attr_map_to_dioxus_inline_attrs(dismiss_attrs);
+    let root_attrs = attr_map_to_dioxus_inline_attrs(api.root_attrs());
+    let inline_attrs = attr_map_to_dioxus_inline_attrs(api.dismiss_button_attrs());
     let start_attrs = inline_attrs.clone();
     let end_attrs = inline_attrs;
 
@@ -470,6 +478,7 @@ pub fn Region(props: RegionProps) -> Element {
             onmounted: move |evt| {
                 root_ref.set(Some(evt.data()));
             },
+            ..root_attrs,
             button {
                 onclick: move |_| {
                     handle.dismiss.call(());
@@ -510,6 +519,7 @@ mod tests {
         let outer = RegionProps {
             props: Props::new().exclude_ids(["trigger"]),
             inside_boundaries: None,
+            dismiss_label: Some(String::from("Dismiss")),
             locale: None,
             messages: None,
             children: Ok(VNode::placeholder()),
@@ -530,7 +540,7 @@ mod wasm_tests {
     use std::sync::{Arc, Mutex};
 
     use ars_core::{I18nRegistries, MessageFn, MessagesRegistry};
-    use ars_i18n::{Locale, locales};
+    use ars_i18n::Locale;
     use dioxus::prelude::*;
     use wasm_bindgen::JsCast;
     use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
@@ -558,6 +568,28 @@ mod wasm_tests {
             .expect("append_child should succeed");
 
         container
+    }
+
+    fn spanish_messages() -> Arc<I18nRegistries> {
+        let mut registries = I18nRegistries::new();
+
+        registries.register(MessagesRegistry::new(Messages::default()).register(
+            "es",
+            Messages {
+                dismiss_label: MessageFn::static_str("Cerrar"),
+            },
+        ));
+
+        Arc::new(registries)
+    }
+
+    fn first_dismiss_button_label(container: &WebElementHandle) -> String {
+        container
+            .query_selector("button[data-ars-part='dismiss-button']")
+            .expect("query_selector should succeed")
+            .expect("at least one dismiss button must exist")
+            .get_attribute("aria-label")
+            .expect("dismiss button must carry an aria-label")
     }
 
     async fn animation_frame_turn() {
@@ -693,6 +725,43 @@ mod wasm_tests {
         container.remove();
     }
 
+    fn provider_label_fixture() -> Element {
+        let registries = spanish_messages();
+        let locale = use_signal(|| Locale::parse("es-MX").expect("locale should parse"));
+
+        rsx! {
+            crate::ArsProvider {
+                locale,
+                i18n_registries: registries,
+                Region { props: Props::new(),
+                    span { "content" }
+                }
+            }
+        }
+    }
+
+    #[wasm_bindgen_test]
+    async fn region_default_label_uses_provider_messages_on_wasm() {
+        let container = with_container();
+
+        let dom = VirtualDom::new(provider_label_fixture);
+
+        dioxus_web::launch::launch_virtual_dom(
+            dom,
+            dioxus_web::Config::new().rootelement(container.clone()),
+        );
+
+        flush().await;
+
+        assert_eq!(
+            first_dismiss_button_label(&container),
+            "Cerrar",
+            "Region default dismiss label must resolve through provider messages",
+        );
+
+        container.remove();
+    }
+
     #[wasm_bindgen_test]
     async fn dismiss_button_click_fires_on_dismiss_with_dismiss_button_reason_on_wasm() {
         let container = with_container();
@@ -747,51 +816,39 @@ mod wasm_tests {
     // pointerdown wasm tests at the same time.
 
     #[derive(Clone)]
-    struct LocaleFixtureProps {
-        locale: Locale,
-        messages: Messages,
+    struct LabelFixtureProps {
+        dismiss_label: String,
     }
 
-    impl PartialEq for LocaleFixtureProps {
+    impl PartialEq for LabelFixtureProps {
         fn eq(&self, other: &Self) -> bool {
-            self.locale == other.locale && self.messages == other.messages
+            self.dismiss_label == other.dismiss_label
         }
     }
 
-    #[expect(
-        clippy::needless_pass_by_value,
-        reason = "Dioxus root props are moved into the render function."
-    )]
-    fn locale_fixture(state: LocaleFixtureProps) -> Element {
+    fn label_fixture(state: LabelFixtureProps) -> Element {
+        let registries = spanish_messages();
+        let locale = use_signal(|| Locale::parse("es-MX").expect("locale should parse"));
+
         rsx! {
-            Region {
-                props: Props::new(),
-                locale: state.locale.clone(),
-                messages: state.messages.clone(),
-                span { "content" }
+            crate::ArsProvider {
+                locale,
+                i18n_registries: registries,
+                Region { props: Props::new(), dismiss_label: state.dismiss_label,
+                    span { "content" }
+                }
             }
         }
     }
 
     #[wasm_bindgen_test]
-    async fn region_locale_override_resolves_label_through_use_messages_on_wasm() {
+    async fn region_dismiss_label_prop_overrides_provider_messages_on_wasm() {
         let container = with_container();
 
-        let messages = Messages {
-            dismiss_label: MessageFn::new(|locale: &Locale| {
-                if locale.language() == "de" {
-                    String::from("Schließen")
-                } else {
-                    String::from("Dismiss")
-                }
-            }),
-        };
-
         let dom = VirtualDom::new_with_props(
-            locale_fixture,
-            LocaleFixtureProps {
-                locale: locales::de_de(),
-                messages,
+            label_fixture,
+            LabelFixtureProps {
+                dismiss_label: String::from("Close dialog"),
             },
         );
 
@@ -802,33 +859,24 @@ mod wasm_tests {
 
         flush().await;
 
-        let button = container
-            .query_selector("button[data-ars-part='dismiss-button']")
-            .expect("query_selector should succeed")
-            .expect("at least one dismiss button must exist");
-
-        let label = button
-            .get_attribute("aria-label")
-            .expect("dismiss button must carry an aria-label");
-
         assert_eq!(
-            label, "Schließen",
-            "Region locale override must flow through use_messages so dismiss_label sees the German locale",
+            first_dismiss_button_label(&container),
+            "Close dialog",
+            "Region dismiss_label prop must override provider messages",
         );
 
         container.remove();
     }
 
     #[derive(Clone)]
-    struct LocaleSwapFixtureProps {
-        initial_locale: Locale,
-        swapped_locale: Locale,
+    struct LabelSwapFixtureProps {
+        initial_label: String,
+        swapped_label: String,
     }
 
-    impl PartialEq for LocaleSwapFixtureProps {
+    impl PartialEq for LabelSwapFixtureProps {
         fn eq(&self, other: &Self) -> bool {
-            self.initial_locale == other.initial_locale
-                && self.swapped_locale == other.swapped_locale
+            self.initial_label == other.initial_label && self.swapped_label == other.swapped_label
         }
     }
 
@@ -840,55 +888,35 @@ mod wasm_tests {
         unused_qualifications,
         reason = "rsx! macro expansion adds qualified paths around onclick closure capture."
     )]
-    fn locale_swap_fixture(state: LocaleSwapFixtureProps) -> Element {
-        let mut locale_signal = use_signal(|| state.initial_locale.clone());
-        let swapped_for_handler = state.swapped_locale.clone();
-
-        // Locale-aware Messages bundle so the rendered `aria-label` differs
-        // between English and German.
-        let messages = Messages {
-            dismiss_label: MessageFn::new(|locale: &Locale| {
-                if locale.language() == "de" {
-                    String::from("Schließen")
-                } else {
-                    String::from("Dismiss")
-                }
-            }),
-        };
-
-        let mut registries = I18nRegistries::new();
-
-        registries.register::<Messages>(MessagesRegistry::new(messages));
-
-        let registries = Arc::new(registries);
+    fn label_swap_fixture(state: LabelSwapFixtureProps) -> Element {
+        let mut label_signal = use_signal(|| state.initial_label.clone());
+        let swapped_for_handler = state.swapped_label.clone();
+        let dismiss_label = label_signal();
 
         rsx! {
-            crate::ArsProvider { locale: locale_signal, i18n_registries: registries,
-                Region { props: Props::new(),
-                    span { "content" }
-                }
-                // Hidden swap-trigger button — the test clicks this to
-                // mutate the locale signal from inside the Dioxus runtime
-                // (signals can only be set from inside the runtime scope).
-                button {
-                    id: "swap-trigger",
-                    onclick: move |_| {
-                        locale_signal.set(swapped_for_handler.clone());
-                    },
-                }
+            Region { props: Props::new(), dismiss_label: Some(dismiss_label),
+                span { "content" }
+            }
+            // Hidden swap-trigger button — the test clicks this to mutate
+            // the label signal from inside the Dioxus runtime.
+            button {
+                id: "swap-trigger",
+                onclick: move |_| {
+                    label_signal.set(swapped_for_handler.clone());
+                },
             }
         }
     }
 
     #[wasm_bindgen_test]
-    async fn region_aria_label_updates_when_provider_locale_signal_changes_on_wasm() {
+    async fn region_dismiss_label_signal_updates_button_label_on_wasm() {
         let container = with_container();
 
         let dom = VirtualDom::new_with_props(
-            locale_swap_fixture,
-            LocaleSwapFixtureProps {
-                initial_locale: locales::en_us(),
-                swapped_locale: locales::de_de(),
+            label_swap_fixture,
+            LabelSwapFixtureProps {
+                initial_label: String::from("Dismiss"),
+                swapped_label: String::from("Close dialog"),
             },
         );
 
@@ -910,12 +938,11 @@ mod wasm_tests {
 
         assert_eq!(
             initial, "Dismiss",
-            "Region aria-label must reflect the initial English locale from the provider",
+            "Region aria-label must reflect the initial dismiss_label value",
         );
 
-        // Click the swap trigger to mutate the locale signal from inside
-        // the runtime. Dioxus then invalidates the Region's component
-        // scope; the `dismiss_label` re-derives in the next render and
+        // Click the swap trigger to mutate the label signal from inside
+        // the runtime. Dioxus then invalidates the component scope and
         // updates the rendered `aria-label`.
         let trigger = container
             .query_selector("#swap-trigger")
@@ -930,11 +957,11 @@ mod wasm_tests {
 
         let updated = dismiss_button
             .get_attribute("aria-label")
-            .expect("dismiss button must still carry an aria-label after locale swap");
+            .expect("dismiss button must still carry an aria-label after label change");
 
         assert_eq!(
-            updated, "Schließen",
-            "Region aria-label must re-resolve through use_messages when the provider locale signal updates at runtime",
+            updated, "Close dialog",
+            "Region aria-label must update when the dismiss_label signal changes",
         );
 
         container.remove();

--- a/crates/ars-leptos/src/attrs.rs
+++ b/crates/ars-leptos/src/attrs.rs
@@ -181,6 +181,13 @@ pub fn attr_map_to_leptos_inline_attrs(
 
 /// Applies CSS properties directly to an element via CSSOM.
 #[cfg(not(feature = "ssr"))]
+#[cfg_attr(
+    all(test, target_arch = "wasm32"),
+    expect(
+        unused_qualifications,
+        reason = "production code uses the Leptos web_sys re-export; web-sys is only a direct wasm test dependency"
+    )
+)]
 pub fn apply_styles_cssom(el: &leptos::web_sys::HtmlElement, styles: &[(CssProperty, String)]) {
     let style = el.style();
 
@@ -455,8 +462,8 @@ mod wasm_tests {
 
     wasm_bindgen_test_configure!(run_in_browser);
 
-    fn document() -> leptos::web_sys::Document {
-        leptos::web_sys::window()
+    fn document() -> web_sys::Document {
+        web_sys::window()
             .and_then(|window| window.document())
             .expect("browser document should exist")
     }
@@ -591,7 +598,7 @@ mod wasm_tests {
         let element = document()
             .create_element("div")
             .expect("create_element should succeed")
-            .dyn_into::<leptos::web_sys::HtmlElement>()
+            .dyn_into::<web_sys::HtmlElement>()
             .expect("element should cast to HtmlElement");
 
         let styles = vec![

--- a/crates/ars-leptos/src/dismissable.rs
+++ b/crates/ars-leptos/src/dismissable.rs
@@ -9,8 +9,8 @@
 //! re-implementing each piece per overlay.
 //!
 //! This module re-exports the agnostic `ars_components::utility::dismissable`
-//! surface (`Props`, `Messages`, `Part`, `DismissReason`,
-//! `DismissAttempt`, `dismiss_button_attrs`) so consumers reach every
+//! surface (`Props`, `Messages`, `Part`, `DismissReason`, `DismissAttempt`,
+//! `dismiss_button_attrs`) so consumers reach every
 //! dismissable type through a single namespace —
 //! `dismissable::Props`, `dismissable::Region`, `dismissable::Handle`,
 //! `dismissable::use_dismissable`, etc.
@@ -23,11 +23,16 @@
 //! See `spec/leptos-components/utility/dismissable.md` for the full
 //! adapter contract.
 
-use std::fmt::{self, Debug};
+use std::{
+    fmt::{self, Debug},
+    sync::Arc,
+};
 
 pub use ars_components::utility::dismissable::{
-    DismissAttempt, DismissReason, Messages, Part, Props, dismiss_button_attrs,
+    Api, DismissAttempt, DismissReason, Messages, Part, Props, dismiss_button_attrs,
 };
+use ars_core::{I18nRegistries, resolve_messages};
+use ars_i18n::Locale;
 use leptos::{callback::Callback as LeptosCallback, html, prelude::*};
 #[cfg(not(feature = "ssr"))]
 use {
@@ -42,7 +47,7 @@ use {
 use crate::{
     attrs::attr_map_to_leptos_inline_attrs,
     id::use_id,
-    provider::{resolve_locale, use_messages},
+    provider::{current_ars_context, use_locale},
 };
 
 // ────────────────────────────────────────────────────────────────────
@@ -195,6 +200,13 @@ struct DismissableState {
 }
 
 #[cfg(not(feature = "ssr"))]
+#[cfg_attr(
+    all(test, target_arch = "wasm32"),
+    expect(
+        unused_qualifications,
+        reason = "production code uses the Leptos web_sys re-export; web-sys is only a direct wasm test dependency"
+    )
+)]
 fn attach(
     state: &Rc<DismissableState>,
     root_ref: NodeRef<html::Div>,
@@ -358,58 +370,64 @@ pub fn Region(
     #[prop(optional, into)]
     inside_boundaries: Option<Signal<Vec<String>>>,
 
-    /// Optional locale override — falls through to the surrounding
-    /// `ArsProvider` locale when [`None`].
-    #[prop(optional)]
-    locale: Option<ars_i18n::Locale>,
+    /// Explicit accessible-label override for both visually-hidden
+    /// dismiss buttons.
+    ///
+    /// When omitted, [`Region`] resolves [`Messages`] from the nearest
+    /// `ArsProvider` message registry and locale, falling back to
+    /// `"Dismiss"`. Overlay components may pass context-specific
+    /// wording such as `"Close dialog"` or `"Dismiss popover"`.
+    #[prop(optional, into)]
+    dismiss_label: Option<Signal<String>>,
 
-    /// Optional message bundle override — falls through to the adapter's
-    /// [`use_messages`] resolution chain (props → `I18nRegistries` →
-    /// `Messages::default`) when [`None`].
+    /// Explicit locale override used when resolving provider/default
+    /// [`Messages`].
+    #[prop(optional, into)]
+    locale: Option<Signal<Locale>>,
+
+    /// Explicit message-bundle override used when `dismiss_label` is
+    /// omitted.
     #[prop(optional)]
     messages: Option<Messages>,
 
     /// Children rendered between the start and end dismiss buttons.
     children: Children,
 ) -> impl IntoView {
-    // Re-bind the prop-supplied overrides so the parameter values are
-    // owned locals — Leptos requires component props to be received by
-    // value, but `clippy::needless_pass_by_value` would otherwise
-    // complain that the parameters are only read via `.as_ref()`.
-    let messages_override = messages;
-    let locale_override = locale;
-
     let root_ref = NodeRef::<html::Div>::new();
 
     let boundaries = inside_boundaries.unwrap_or_else(|| Signal::stored(Vec::new()));
 
-    // Build dismiss-button attrs with a reactive `aria-label` closure so
-    // the rendered attribute updates whenever the surrounding
-    // `ArsProvider` swaps locale at runtime — or whenever the
-    // `I18nRegistries` bundle is replaced. `dismiss_button_attrs` accepts
-    // any `impl Into<AttrValue>`; passing a `Fn() -> String + Send +
-    // Sync + 'static` closure routes through the blanket
-    // `From<F> for AttrValue` impl that wraps it as
-    // `AttrValue::Reactive`. The closure subscribes to `use_locale()` via
-    // [`resolve_locale`] and to the registries via [`use_messages`] each
-    // time it runs, so tachys's reactive attribute path keeps the DOM
-    // aria-label in sync.
-    let messages_for_label = messages_override.clone();
-    let locale_for_label = locale_override.clone();
-    let dismiss_attrs = dismiss_button_attrs(move || {
-        let messages =
-            use_messages::<Messages>(messages_for_label.as_ref(), locale_for_label.as_ref());
-        (messages.dismiss_label)(&resolve_locale(locale_for_label.as_ref()))
+    let provider_locale = use_locale();
+
+    let registries = current_ars_context().map_or_else(
+        || Arc::new(I18nRegistries::new()),
+        |ctx| Arc::clone(&ctx.i18n_registries),
+    );
+
+    let dismiss_label = dismiss_label.unwrap_or_else(|| {
+        Signal::derive(move || {
+            let resolved_locale = locale
+                .as_ref()
+                .map_or_else(|| provider_locale.get(), |locale| locale.get());
+
+            let resolved_messages =
+                resolve_messages(messages.as_ref(), registries.as_ref(), &resolved_locale);
+
+            (resolved_messages.dismiss_label)(&resolved_locale)
+        })
     });
 
-    let inline_attrs = attr_map_to_leptos_inline_attrs(dismiss_attrs);
+    let api = Api::new(props.clone(), move || dismiss_label.get());
+
+    let root_attrs = attr_map_to_leptos_inline_attrs(api.root_attrs());
+    let inline_attrs = attr_map_to_leptos_inline_attrs(api.dismiss_button_attrs());
     let start_attrs = inline_attrs.clone();
     let end_attrs = inline_attrs;
 
     let handle = use_dismissable(root_ref, props, boundaries);
 
     view! {
-        <div node_ref=root_ref>
+        <div {..root_attrs} node_ref=root_ref>
             <button
                 {..start_attrs}
                 on:click=move |_| { handle.dismiss.run(()); }
@@ -539,7 +557,7 @@ mod wasm_tests {
     };
 
     use ars_core::{I18nRegistries, MessageFn, MessagesRegistry};
-    use ars_i18n::{Locale, locales};
+    use ars_i18n::Locale;
     use leptos::{mount::mount_to, prelude::*, reactive::owner::Owner};
     use wasm_bindgen::JsCast;
     use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
@@ -552,7 +570,7 @@ mod wasm_tests {
     wasm_bindgen_test_configure!(run_in_browser);
 
     fn document() -> Document {
-        leptos::web_sys::window()
+        web_sys::window()
             .and_then(|w| w.document())
             .expect("browser document should exist")
     }
@@ -572,6 +590,28 @@ mod wasm_tests {
             .expect("append_child should succeed");
 
         container
+    }
+
+    fn spanish_messages() -> Arc<I18nRegistries> {
+        let mut registries = I18nRegistries::new();
+
+        registries.register(MessagesRegistry::new(Messages::default()).register(
+            "es",
+            Messages {
+                dismiss_label: MessageFn::static_str("Cerrar"),
+            },
+        ));
+
+        Arc::new(registries)
+    }
+
+    fn first_dismiss_button_label(container: &Element) -> String {
+        container
+            .query_selector("button[data-ars-part='dismiss-button']")
+            .expect("query_selector should succeed")
+            .expect("at least one dismiss button must exist")
+            .get_attribute("aria-label")
+            .expect("dismiss button must carry an aria-label")
     }
 
     /// Tick the Leptos reactive cycle once.
@@ -666,6 +706,39 @@ mod wasm_tests {
             buttons.length(),
             2,
             "Region must render exactly two visually-hidden dismiss buttons (start + end)",
+        );
+
+        container.remove();
+    }
+
+    #[wasm_bindgen_test]
+    async fn region_default_label_uses_provider_messages_on_wasm() {
+        let owner = Owner::new();
+        owner.set();
+
+        let container = with_container();
+        let parent: HtmlElement = container.clone().unchecked_into();
+        let registries = spanish_messages();
+
+        let _handle = mount_to(parent, move || {
+            view! {
+                <crate::ArsProvider
+                    locale=Locale::parse("es-MX").expect("locale should parse")
+                    i18n_registries=Arc::clone(&registries)
+                >
+                    <Region props=Props::new()>
+                        <span>"content"</span>
+                    </Region>
+                </crate::ArsProvider>
+            }
+        });
+
+        tick().await;
+
+        assert_eq!(
+            first_dismiss_button_label(&container),
+            "Cerrar",
+            "Region default dismiss label must resolve through provider messages",
         );
 
         container.remove();
@@ -1196,91 +1269,60 @@ mod wasm_tests {
     }
 
     #[wasm_bindgen_test]
-    async fn region_locale_override_resolves_label_through_use_messages_on_wasm() {
+    async fn region_dismiss_label_prop_overrides_provider_messages_on_wasm() {
         let owner = Owner::new();
         owner.set();
 
         let container = with_container();
         let parent: HtmlElement = container.clone().unchecked_into();
+        let registries = spanish_messages();
 
         let _handle = mount_to(parent, move || {
-            let messages = Messages {
-                dismiss_label: MessageFn::new(|locale: &Locale| {
-                    if locale.language() == "de" {
-                        String::from("Schließen")
-                    } else {
-                        String::from("Dismiss")
-                    }
-                }),
-            };
-
             view! {
-                <Region
-                    props=Props::new()
-                    locale=locales::de_de()
-                    messages=messages
+                <crate::ArsProvider
+                    locale=Locale::parse("es-MX").expect("locale should parse")
+                    i18n_registries=Arc::clone(&registries)
                 >
-                    <span>"content"</span>
-                </Region>
+                    <Region
+                        props=Props::new()
+                        dismiss_label="Close dialog"
+                    >
+                        <span>"content"</span>
+                    </Region>
+                </crate::ArsProvider>
             }
         });
 
         tick().await;
 
-        let button = container
-            .query_selector("button[data-ars-part='dismiss-button']")
-            .expect("query_selector should succeed")
-            .expect("at least one dismiss button must exist");
-
-        let label = button
-            .get_attribute("aria-label")
-            .expect("dismiss button must carry an aria-label");
-
         assert_eq!(
-            label, "Schließen",
-            "Region locale override must flow through use_messages so dismiss_label sees the German locale",
+            first_dismiss_button_label(&container),
+            "Close dialog",
+            "Region dismiss_label prop must override provider messages",
         );
 
         container.remove();
     }
 
     #[wasm_bindgen_test]
-    async fn region_aria_label_updates_when_provider_locale_signal_changes_on_wasm() {
+    async fn region_dismiss_label_signal_updates_button_label_on_wasm() {
         let owner = Owner::new();
         owner.set();
 
         let container = with_container();
         let parent: HtmlElement = container.clone().unchecked_into();
 
-        // RwSignal so the test body can swap the provider's locale at runtime.
-        let locale_signal = RwSignal::new(locales::en_us());
+        let label_signal = RwSignal::new(String::from("Dismiss"));
+        let dismiss_label: Signal<String> = Signal::from(label_signal);
 
         let _handle = mount_to(parent, move || {
-            // Locale-aware Messages bundle so the rendered `aria-label`
-            // differs between English and German.
-            let messages = Messages {
-                dismiss_label: MessageFn::new(|locale: &Locale| {
-                    if locale.language() == "de" {
-                        String::from("Schließen")
-                    } else {
-                        String::from("Dismiss")
-                    }
-                }),
-            };
-
-            let mut registries = I18nRegistries::new();
-
-            registries.register::<Messages>(MessagesRegistry::new(messages));
-
             view! {
-                <crate::ArsProvider
-                    locale=locale_signal
-                    i18n_registries=Arc::new(registries)
+                <Region
+                    props=Props::new()
+                    dismiss_label=dismiss_label
                 >
-                    <Region props=Props::new()>
-                        <span>"content"</span>
-                    </Region>
-                </crate::ArsProvider>
+                    <span>"content"</span>
+                </Region>
             }
         });
 
@@ -1297,23 +1339,20 @@ mod wasm_tests {
 
         assert_eq!(
             initial, "Dismiss",
-            "Region aria-label must reflect the initial English locale from the provider",
+            "Region aria-label must reflect the initial dismiss_label signal value",
         );
 
-        // Swap the provider's locale; the `Reactive` variant's closure
-        // re-runs through tachys's `RenderEffect` and the rendered
-        // attribute updates without a remount.
-        locale_signal.set(locales::de_de());
+        label_signal.set(String::from("Close dialog"));
 
         tick().await;
 
         let updated = button
             .get_attribute("aria-label")
-            .expect("dismiss button must still carry an aria-label after locale swap");
+            .expect("dismiss button must still carry an aria-label after label change");
 
         assert_eq!(
-            updated, "Schließen",
-            "Region aria-label must re-resolve through use_messages when the provider locale signal updates at runtime",
+            updated, "Close dialog",
+            "Region aria-label must update when the dismiss_label signal changes",
         );
 
         container.remove();

--- a/crates/ars-leptos/src/provider.rs
+++ b/crates/ars-leptos/src/provider.rs
@@ -818,6 +818,8 @@ mod wasm_tests {
     #[cfg(feature = "csr")]
     use leptos::{mount::mount_to, wasm_bindgen::JsCast};
     use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+    #[cfg(feature = "csr")]
+    use web_sys::{Document, HtmlElement};
 
     #[cfg(feature = "csr")]
     use super::ArsProvider;
@@ -1246,19 +1248,19 @@ mod wasm_tests {
     }
 
     #[cfg(feature = "csr")]
-    fn document() -> leptos::web_sys::Document {
-        leptos::web_sys::window()
+    fn document() -> Document {
+        web_sys::window()
             .expect("window should exist")
             .document()
             .expect("document should exist")
     }
 
     #[cfg(feature = "csr")]
-    fn append_container() -> leptos::web_sys::HtmlElement {
+    fn append_container() -> HtmlElement {
         let container = document()
             .create_element("div")
             .expect("container creation should succeed")
-            .dyn_into::<leptos::web_sys::HtmlElement>()
+            .dyn_into::<HtmlElement>()
             .expect("container should be an HtmlElement");
 
         document()

--- a/spec/components/utility/dismissable.md
+++ b/spec/components/utility/dismissable.md
@@ -20,8 +20,10 @@ Dismissable is intentionally split into:
 - **behavior**: outside-interaction and Escape dismissal configuration
 - **structure**: a shared dismiss-button attribute helper
 
-Dismissable does **not** own user-facing wording. Callers resolve an appropriate localized label and
-pass the final string to `dismiss_button_attrs`.
+Dismissable owns the shared generic `Messages` bundle for dismiss-button fallback wording, but it
+does **not** resolve user-facing wording inside `Props` or the connect API. Callers resolve an
+appropriate localized label and pass the final string to the connect API or to
+`dismiss_button_attrs`.
 
 ## 1. API
 
@@ -63,6 +65,23 @@ impl<E> DismissAttempt<E> {
     pub fn prevent_dismiss(&self) { /* … */ }
     pub fn is_prevented(&self) -> bool { /* … */ }
 }
+
+/// Localizable strings for the Dismissable structural helper.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Messages {
+    /// Accessible label for the visually-hidden dismiss buttons.
+    pub dismiss_label: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
+}
+
+impl Default for Messages {
+    fn default() -> Self {
+        Self {
+            dismiss_label: MessageFn::static_str("Dismiss"),
+        }
+    }
+}
+
+impl ComponentMessages for Messages {}
 
 /// Props for the `Dismissable` component.
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -143,7 +162,57 @@ pub enum Part {
     DismissButton,
 }
 
-pub fn dismiss_button_attrs(label: &str) -> AttrMap {
+/// Stateless connect API for deriving Dismissable DOM attributes.
+pub struct Api {
+    props: Props,
+    dismiss_button_label: AttrValue,
+}
+
+impl Api {
+    /// Creates a new Dismissable attribute API.
+    ///
+    /// `dismiss_button_label` is the final accessible label for both visually-hidden
+    /// dismiss buttons. It accepts static strings and reactive `AttrValue` inputs so
+    /// adapters can pass provider-resolved localized labels without adding wording
+    /// to `Props`.
+    pub fn new(props: Props, dismiss_button_label: impl Into<AttrValue>) -> Self;
+
+    /// Returns root container attributes for the dismissable boundary.
+    ///
+    /// The root is structural only. Document listeners, containment checks, and
+    /// platform fallbacks remain adapter-owned.
+    pub fn root_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Root.data_attrs();
+        attrs.set(scope_attr, scope_val);
+        attrs.set(part_attr, part_val);
+        if self.props.disable_outside_pointer_events {
+            attrs.set_bool(HtmlAttr::Data("ars-disable-outside-pointer-events"), true);
+        }
+        attrs
+    }
+
+    /// Returns attributes for either visually-hidden dismiss button.
+    pub fn dismiss_button_attrs(&self) -> AttrMap {
+        dismiss_button_attrs(self.dismiss_button_label.clone())
+    }
+
+    pub fn disable_outside_pointer_events(&self) -> bool;
+    pub fn exclude_ids(&self) -> &[String];
+}
+
+impl ConnectApi for Api {
+    type Part = Part;
+
+    fn part_attrs(&self, part: Self::Part) -> AttrMap {
+        match part {
+            Part::Root => self.root_attrs(),
+            Part::DismissButton => self.dismiss_button_attrs(),
+        }
+    }
+}
+
+pub fn dismiss_button_attrs(label: impl Into<AttrValue>) -> AttrMap {
     let mut attrs = AttrMap::new();
     let [(scope_attr, scope_val), (part_attr, part_val)] = Part::DismissButton.data_attrs();
     attrs.set(scope_attr, scope_val);
@@ -159,8 +228,10 @@ pub fn dismiss_button_attrs(label: &str) -> AttrMap {
 }
 ```
 
-The helper is shared structure only. Overlay-specific message bundles own phrases such as
-`"Dismiss popover"` or `"Close dialog"`.
+The helper and connect API are shared structure only. The shared `Messages` bundle provides the
+generic `"Dismiss"` fallback for adapter-level regions. Overlay-specific message bundles may own
+more precise phrases such as `"Dismiss popover"` or `"Close dialog"`, resolve them before
+constructing the API, and pass the final string or reactive `AttrValue` into Dismissable.
 
 ## 2. Anatomy
 
@@ -173,6 +244,7 @@ Dismissable
 
 | Part            | Element    | Key attributes                                                                                  |
 | --------------- | ---------- | ----------------------------------------------------------------------------------------------- |
+| `Root`          | container  | `data-ars-scope="dismissable"`, `data-ars-part="root"`                                          |
 | `DismissButton` | `<button>` | `data-ars-scope="dismissable"`, `data-ars-part="dismiss-button"`, `aria-label`, `type="button"` |
 
 Adapters should render the element as a native `<button>` whenever possible. The helper still sets
@@ -207,6 +279,7 @@ When `disable_outside_pointer_events` is true:
 - only pointer interaction is blocked
 - keyboard navigation must remain available
 - Escape and DismissButton must continue to work
+- `Api::root_attrs()` emits `data-ars-disable-outside-pointer-events`
 
 ## 4. Behavior
 
@@ -238,8 +311,10 @@ let dismissable = dismissable::Props::new()
     .disable_outside_pointer_events(props.modal)
     .exclude_ids([trigger_id.clone()]);
 
-let dismiss_label = (messages.dismiss_label)(locale);
-let dismiss_button = dismissable::dismiss_button_attrs(&dismiss_label);
+let dismiss_label = overlay_messages.dismiss_label(locale);
+let dismissable_api = dismissable::Api::new(dismissable, &dismiss_label);
+let root = dismissable_api.root_attrs();
+let dismiss_button = dismissable_api.dismiss_button_attrs();
 ```
 
 ## 6. Library Parity
@@ -249,4 +324,4 @@ Compared against React Aria:
 - ars-ui keeps the DismissButton concept.
 - ars-ui also centralizes outside-interaction and Escape configuration in one utility surface.
 - ars-ui intentionally does not define a shared message bundle here; wording belongs to the
-  consuming overlay or application.
+  consuming overlay or application, while the final resolved label is passed into the agnostic API.

--- a/spec/dioxus-components/utility/dismissable.md
+++ b/spec/dioxus-components/utility/dismissable.md
@@ -45,13 +45,10 @@ pub struct RegionProps {
     pub props: dismissable::Props,
     #[props(optional)]
     pub inside_boundaries: Option<ReadSignal<Vec<String>>>,
-    /// Optional locale override — falls through to the surrounding
-    /// `ArsProvider` locale when [`None`].
     #[props(optional)]
-    pub locale: Option<ars_i18n::Locale>,
-    /// Optional message bundle override — falls through to the
-    /// adapter's [`use_messages`] resolution chain (props →
-    /// `I18nRegistries` → `Messages::default`) when [`None`].
+    pub dismiss_label: Option<String>,
+    #[props(optional, into)]
+    pub locale: Option<Signal<Locale>>,
     #[props(optional)]
     pub messages: Option<dismissable::Messages>,
     pub children: Element,
@@ -68,7 +65,7 @@ newtypes. Consumers can move the handle into multiple closures or pass
 it through the rsx tree without explicit clones; it stays valid until
 the owning scope unmounts.
 
-The public surface matches the full core `Props`, including `on_interact_outside`, `on_escape_key_down`, `on_dismiss`, `disable_outside_pointer_events`, `exclude_ids`, `messages`, and `locale`.
+The public surface matches the full core `Props`, including `on_interact_outside`, `on_escape_key_down`, `on_dismiss`, `disable_outside_pointer_events`, and `exclude_ids`. The agnostic core owns the shared `dismissable::Messages` fallback bundle, while the adapter-owned `Region` resolves that bundle from `ArsProvider` / `locale`, falling back to `"Dismiss"`; `dismiss_label` is an explicit final-label override.
 
 ## 3. Mapping to Core Component Contract
 
@@ -243,21 +240,33 @@ pub struct RegionProps {
     pub props: dismissable::Props,
     #[props(optional)]
     pub inside_boundaries: Option<ReadSignal<Vec<String>>>,
+    #[props(optional)]
+    pub dismiss_label: Option<String>,
+    #[props(optional, into)]
+    pub locale: Option<Signal<Locale>>,
+    #[props(optional)]
+    pub messages: Option<dismissable::Messages>,
     pub children: Element,
 }
 
 #[component]
 pub fn Region(props: RegionProps) -> Element {
-    let RegionProps { props, inside_boundaries, children } = props;
+    let RegionProps { props, inside_boundaries, dismiss_label, locale, messages, children } = props;
 
     let boundaries_fallback = use_signal(Vec::<String>::new);
     let boundaries = inside_boundaries.unwrap_or_else(|| ReadSignal::from(boundaries_fallback));
 
-    let messages = use_messages::<dismissable::Messages>(None, None);
-    let locale = use_locale();
-    let dismiss_label = use_hook(|| (messages.dismiss_label)(&locale.peek()));
+    let provider_locale = resolve_locale(None);
+    let resolved_locale = locale
+        .as_ref()
+        .map_or(provider_locale, |locale| locale.read().clone());
+    let resolved_messages = use_messages(messages.as_ref(), Some(&resolved_locale));
+    let dismiss_label =
+        dismiss_label.unwrap_or_else(|| (resolved_messages.dismiss_label)(&resolved_locale));
 
-    let attrs = dismissable::dismiss_button_attrs(&dismiss_label);
+    let api = dismissable::Api::new(props.clone(), dismiss_label);
+    let root_attrs = attr_map_to_dioxus(api.root_attrs(), &ars_core::StyleStrategy::Inline, None).attrs;
+    let attrs = api.dismiss_button_attrs();
     let start_attrs = attr_map_to_dioxus(attrs.clone(), &ars_core::StyleStrategy::Inline, None).attrs;
     let end_attrs = attr_map_to_dioxus(attrs, &ars_core::StyleStrategy::Inline, None).attrs;
 
@@ -272,6 +281,7 @@ pub fn Region(props: RegionProps) -> Element {
 
     rsx! {
         div {
+            ..root_attrs,
             onmounted: move |evt| { root_ref.set(Some(evt.data())); },
             button { onclick: move |_| { handle.dismiss.call(()); }, ..start_attrs }
             {children}

--- a/spec/leptos-components/utility/dismissable.md
+++ b/spec/leptos-components/utility/dismissable.md
@@ -43,12 +43,8 @@ pub struct Handle {
 pub fn Region(
     props: dismissable::Props,
     #[prop(optional, into)] inside_boundaries: Option<Signal<Vec<String>>>,
-    /// Optional locale override — falls through to the surrounding
-    /// `ArsProvider` locale when [`None`].
-    #[prop(optional)] locale: Option<ars_i18n::Locale>,
-    /// Optional message bundle override — falls through to the
-    /// adapter's `use_messages` resolution chain (props →
-    /// `I18nRegistries` → `Messages::default`) when [`None`].
+    #[prop(optional, into)] dismiss_label: Option<Signal<String>>,
+    #[prop(optional, into)] locale: Option<Signal<Locale>>,
     #[prop(optional)] messages: Option<dismissable::Messages>,
     children: Children,
 ) -> impl IntoView
@@ -62,7 +58,7 @@ directly. Consumers can move the handle into multiple closures or pass
 it through the view tree without explicit clones; it stays valid until
 the owning `Owner` is dropped.
 
-The public surface matches the full core `Props`, including `on_interact_outside`, `on_escape_key_down`, `on_dismiss`, `disable_outside_pointer_events`, `exclude_ids`, `messages`, and `locale`.
+The public surface matches the full core `Props`, including `on_interact_outside`, `on_escape_key_down`, `on_dismiss`, `disable_outside_pointer_events`, and `exclude_ids`. The agnostic core owns the shared `dismissable::Messages` fallback bundle, while the adapter-owned `Region` resolves that bundle from `ArsProvider` / `locale`, falling back to `"Dismiss"`; `dismiss_label` is an explicit final-label override.
 
 ## 3. Mapping to Core Component Contract
 
@@ -235,15 +231,38 @@ use leptos::{html, prelude::*, tachys::html::attribute::any_attribute::AnyAttrib
 pub fn Region(
     props: dismissable::Props,
     #[prop(optional, into)] inside_boundaries: Option<Signal<Vec<String>>>,
+    #[prop(optional, into)] dismiss_label: Option<Signal<String>>,
+    #[prop(optional, into)] locale: Option<Signal<Locale>>,
+    #[prop(optional)] messages: Option<dismissable::Messages>,
     children: Children,
 ) -> impl IntoView {
     let root_ref = NodeRef::<html::Div>::new();
     let boundaries = inside_boundaries.unwrap_or_else(|| Signal::stored(Vec::new()));
-    let messages = use_messages::<dismissable::Messages>(None, None);
-    let locale = use_locale();
-    let label = (messages.dismiss_label)(&locale.get_untracked());
 
-    let attrs = dismissable::dismiss_button_attrs(&label);
+    let provider_locale = use_locale();
+    let registries = current_ars_context()
+        .map_or_else(|| Arc::new(I18nRegistries::new()), |ctx| Arc::clone(&ctx.i18n_registries));
+    let dismiss_label = dismiss_label.unwrap_or_else(|| {
+        Signal::derive(move || {
+            let resolved_locale = locale.as_ref().map_or_else(|| provider_locale.get(), |locale| locale.get());
+            let resolved_messages =
+                resolve_messages(messages.as_ref(), registries.as_ref(), &resolved_locale);
+
+            (resolved_messages.dismiss_label)(&resolved_locale)
+        })
+    });
+
+    let api = dismissable::Api::new(props.clone(), move || dismiss_label.get());
+    let root_attrs = attr_map_to_leptos(
+        api.root_attrs(),
+        &ars_core::StyleStrategy::Inline,
+        None,
+    )
+    .attrs
+    .into_iter()
+    .map(|(name, value)| leptos::attr::custom::custom_attribute(name, value).into_any_attr())
+    .collect();
+    let attrs = api.dismiss_button_attrs();
     let leptos_attrs: Vec<AnyAttribute> = attr_map_to_leptos(
         attrs,
         &ars_core::StyleStrategy::Inline,
@@ -259,7 +278,7 @@ pub fn Region(
     let handle = dismissable::use_dismissable(root_ref, props.clone(), boundaries);
 
     view! {
-        <div node_ref=root_ref>
+        <div {..root_attrs} node_ref=root_ref>
             <button {..leptos_attrs.clone()} on:click=move |_| { handle.dismiss.run(()); } />
             {children()}
             <button {..leptos_attrs} on:click=move |_| { handle.dismiss.run(()); } />


### PR DESCRIPTION
## Summary
- add the agnostic Dismissable connect API, root and dismiss-button attrs, and snapshot coverage
- centralize `dismissable::Messages` in ars-components while keeping final label resolution in adapters
- restore provider-aware Leptos/Dioxus Region labels with explicit label overrides
- sync core and adapter specs with the implemented contract

## Validation
- `cargo xci`
- `cargo test -p ars-components dismissable`
- `cargo llvm-cov test -p ars-components --text -- dismissable`
- `wasm-pack test --headless --chrome --chromedriver target/chromedriver-147/chromedriver-mac-arm64/chromedriver crates/ars-leptos --lib --no-default-features --features csr,ars-i18n/web-intl`
- `wasm-pack test --headless --chrome --chromedriver target/chromedriver-147/chromedriver-mac-arm64/chromedriver crates/ars-dioxus --lib --no-default-features --features web,ars-i18n/web-intl`

Closes #207