### PR TITLE
Implement portal agnostic core

### DIFF
--- a/crates/ars-components/src/date_time/date_field/tests.rs
+++ b/crates/ars-components/src/date_time/date_field/tests.rs
@@ -913,10 +913,10 @@ fn month_name_typeahead_matches_locale_month_prefixes() {
 
 #[test]
 fn locale_calendar_extension_selects_calendar_when_prop_is_default() {
-    let env = Env {
-        locale: Locale::parse("th-TH-u-ca-buddhist").expect("valid locale"),
-        intl_backend: Arc::new(StubIntlBackend),
-    };
+    let env = Env::new(
+        Locale::parse("th-TH-u-ca-buddhist").expect("valid locale"),
+        Arc::new(StubIntlBackend),
+    );
 
     let service = Service::<Machine>::new(props(), &env, &Messages::default());
 
@@ -927,10 +927,10 @@ fn locale_calendar_extension_selects_calendar_when_prop_is_default() {
 fn japanese_calendar_uses_era_segment_and_ideographic_literals() {
     let service = Service::<Machine>::new(
         props().calendar(CalendarSystem::Japanese),
-        &Env {
-            locale: Locale::parse("ja-JP").expect("valid locale"),
-            intl_backend: Arc::new(StubIntlBackend),
-        },
+        &Env::new(
+            Locale::parse("ja-JP").expect("valid locale"),
+            Arc::new(StubIntlBackend),
+        ),
         &Messages::default(),
     );
 
@@ -1374,10 +1374,10 @@ fn segment_order_non_editable_kinds_stay_non_editable() {
 
 #[test]
 fn locale_order_uses_environment_locale() {
-    let env = Env {
-        locale: Locale::parse("de-DE").expect("valid locale"),
-        intl_backend: Arc::new(StubIntlBackend),
-    };
+    let env = Env::new(
+        Locale::parse("de-DE").expect("valid locale"),
+        Arc::new(StubIntlBackend),
+    );
 
     let service = Service::<Machine>::new(props(), &env, &Messages::default());
 
@@ -1421,10 +1421,10 @@ fn locale_specific_orders_and_literals_are_resolved() {
             ". ",
         ),
     ] {
-        let env = Env {
-            locale: Locale::parse(locale).expect("valid locale"),
-            intl_backend: Arc::new(StubIntlBackend),
-        };
+        let env = Env::new(
+            Locale::parse(locale).expect("valid locale"),
+            Arc::new(StubIntlBackend),
+        );
 
         let service = Service::<Machine>::new(props(), &env, &Messages::default());
 
@@ -1450,10 +1450,10 @@ fn locale_specific_orders_and_literals_are_resolved() {
 
 #[test]
 fn explicit_calendar_prop_overrides_locale_calendar_extension() {
-    let env = Env {
-        locale: Locale::parse("th-TH-u-ca-buddhist").expect("valid locale"),
-        intl_backend: Arc::new(StubIntlBackend),
-    };
+    let env = Env::new(
+        Locale::parse("th-TH-u-ca-buddhist").expect("valid locale"),
+        Arc::new(StubIntlBackend),
+    );
 
     let service = Service::<Machine>::new(
         props().calendar(CalendarSystem::Iso8601),
@@ -1801,10 +1801,10 @@ fn shared_time_segment_ranges_and_day_period_typeahead_are_supported() {
 fn japanese_era_value_text_uses_localized_era_names() {
     let mut service = Service::<Machine>::new(
         props().calendar(CalendarSystem::Japanese),
-        &Env {
-            locale: Locale::parse("ja-JP").expect("valid locale"),
-            intl_backend: Arc::new(StubIntlBackend),
-        },
+        &Env::new(
+            Locale::parse("ja-JP").expect("valid locale"),
+            Arc::new(StubIntlBackend),
+        ),
         &Messages::default(),
     );
 
@@ -1927,10 +1927,10 @@ fn date_field_explicit_aria_label_snapshots() {
 fn date_field_japanese_calendar_snapshots() {
     let service = Service::<Machine>::new(
         props().calendar(CalendarSystem::Japanese),
-        &Env {
-            locale: Locale::parse("ja-JP").expect("valid locale"),
-            intl_backend: Arc::new(StubIntlBackend),
-        },
+        &Env::new(
+            Locale::parse("ja-JP").expect("valid locale"),
+            Arc::new(StubIntlBackend),
+        ),
         &Messages::default(),
     );
 

--- a/crates/ars-components/src/layout/mod.rs
+++ b/crates/ars-components/src/layout/mod.rs
@@ -1,0 +1,4 @@
+//! Layout component machines.
+
+/// Portal component machine.
+pub mod portal;

--- a/crates/ars-components/src/layout/portal.rs
+++ b/crates/ars-components/src/layout/portal.rs
@@ -66,11 +66,14 @@ pub enum PortalTarget {
     /// The document body.
     Body,
 
-    /// An element with the given ID.
+    /// A declarative element ID target that the adapter must resolve.
     Id(String),
 
-    /// A direct element ID reference.
-    Ref(String),
+    /// An element ID target that the adapter has confirmed exists.
+    ///
+    /// This is still stable string identity, not a live DOM element or
+    /// framework handle. Adapters own native refs separately.
+    ResolvedId(String),
 }
 
 /// Immutable configuration for a Portal instance.
@@ -171,7 +174,7 @@ impl ars_core::Machine for Machine {
                 let id = id.clone();
                 Some(
                     TransitionPlan::to(State::Mounted).apply(move |ctx: &mut Context| {
-                        ctx.container = PortalTarget::Ref(id);
+                        ctx.container = PortalTarget::ResolvedId(id);
                         ctx.mounted = true;
                     }),
                 )
@@ -465,7 +468,7 @@ mod tests {
     }
 
     #[test]
-    fn container_ready_mounts_to_ref_target() {
+    fn container_ready_mounts_to_resolved_id_target() {
         let mut service = Service::<Machine>::new(
             test_props().container(PortalTarget::Id("late-root".to_string())),
             &Env::default(),
@@ -479,9 +482,27 @@ mod tests {
         assert_eq!(service.state(), &State::Mounted);
         assert_eq!(
             service.context().container,
-            PortalTarget::Ref("late-root".to_string())
+            PortalTarget::ResolvedId("late-root".to_string())
         );
         assert!(service.context().mounted);
+    }
+
+    #[test]
+    fn resolved_id_target_stays_string_identity_not_live_handle() {
+        let mut service = Service::<Machine>::new(
+            test_props().container(PortalTarget::ResolvedId("ready-root".to_string())),
+            &Env::default(),
+            &Messages,
+        );
+
+        let result = service.send(Event::ContainerReady("other-root".to_string()));
+
+        assert!(!result.state_changed);
+        assert!(!result.context_changed);
+        assert_eq!(
+            service.context().container,
+            PortalTarget::ResolvedId("ready-root".to_string())
+        );
     }
 
     #[test]
@@ -795,6 +816,40 @@ mod tests {
 
         assert_snapshot!(
             "portal_root_custom_target_mounted",
+            snapshot_attrs(&service.connect(&|_| {}).root_attrs())
+        );
+    }
+
+    #[test]
+    fn portal_root_body_target_mounted() {
+        let mut service = Service::<Machine>::new(
+            Props::new().id("body-target").container(PortalTarget::Body),
+            &Env::default(),
+            &Messages,
+        );
+
+        drop(service.send(Event::Mount));
+
+        assert_snapshot!(
+            "portal_root_body_target_mounted",
+            snapshot_attrs(&service.connect(&|_| {}).root_attrs())
+        );
+    }
+
+    #[test]
+    fn portal_root_resolved_id_target_mounted() {
+        let mut service = Service::<Machine>::new(
+            Props::new()
+                .id("resolved")
+                .container(PortalTarget::ResolvedId("ready-root".to_string())),
+            &Env::default(),
+            &Messages,
+        );
+
+        drop(service.send(Event::Mount));
+
+        assert_snapshot!(
+            "portal_root_resolved_id_target_mounted",
             snapshot_attrs(&service.connect(&|_| {}).root_attrs())
         );
     }

--- a/crates/ars-components/src/layout/portal.rs
+++ b/crates/ars-components/src/layout/portal.rs
@@ -1,0 +1,801 @@
+//! Portal mount lifecycle machine.
+//!
+//! `Portal` is a DOM-free state machine that tells framework adapters when a
+//! portal should be mounted and which target kind should receive the rendered
+//! content. Adapters own the actual DOM insertion and cleanup.
+
+use alloc::{format, string::String, vec, vec::Vec};
+use core::fmt::{self, Debug};
+
+use ars_core::{
+    AttrMap, ComponentIds, ComponentMessages, ComponentPart, ConnectApi, Env, HtmlAttr, RenderMode,
+    TransitionPlan,
+};
+
+/// The states of the portal machine.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub enum State {
+    /// The portal is unmounted.
+    #[default]
+    Unmounted,
+
+    /// The portal is mounted at its target container.
+    Mounted,
+}
+
+/// The events of the portal machine.
+#[derive(Clone, Debug, PartialEq)]
+pub enum Event {
+    /// Mount the portal after the host component mounts.
+    Mount,
+
+    /// Unmount the portal before the host component unmounts.
+    Unmount,
+
+    /// The target container became available for an ID target that may not
+    /// have existed when the portal was first mounted.
+    ContainerReady(String),
+
+    /// Synchronize the target container after props change.
+    SetContainer(PortalTarget),
+}
+
+/// Runtime context for Portal.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Context {
+    /// The resolved target container for the portal.
+    pub container: PortalTarget,
+
+    /// Whether the portal is mounted.
+    pub mounted: bool,
+
+    /// Runtime render mode resolved by the adapter.
+    pub render_mode: RenderMode,
+
+    /// Component IDs.
+    pub ids: ComponentIds,
+}
+
+/// The target container for the portal.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub enum PortalTarget {
+    /// The dedicated portal root element (`#ars-portal-root`).
+    #[default]
+    PortalRoot,
+
+    /// The document body.
+    Body,
+
+    /// An element with the given ID.
+    Id(String),
+
+    /// A direct element ID reference.
+    Ref(String),
+}
+
+/// Immutable configuration for a Portal instance.
+#[derive(Clone, Debug, Default, PartialEq, ars_core::HasId)]
+pub struct Props {
+    /// The id of the component.
+    pub id: String,
+
+    /// The target container for the portal.
+    pub container: PortalTarget,
+
+    /// Whether to render the portal inline during SSR.
+    ///
+    /// When `true`, content is rendered at the declaration site during SSR;
+    /// the client hydration layer reattaches it to the target container.
+    pub ssr_inline: bool,
+}
+
+impl Props {
+    /// Returns fresh portal props with the documented defaults.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the component instance ID.
+    #[must_use]
+    pub fn id(mut self, id: impl Into<String>) -> Self {
+        self.id = id.into();
+        self
+    }
+
+    /// Sets the portal target container.
+    #[must_use]
+    pub fn container(mut self, value: PortalTarget) -> Self {
+        self.container = value;
+        self
+    }
+
+    /// Sets whether SSR should render content inline before hydration.
+    #[must_use]
+    pub const fn ssr_inline(mut self, value: bool) -> Self {
+        self.ssr_inline = value;
+        self
+    }
+}
+
+/// Portal has no localized messages.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct Messages;
+
+impl ComponentMessages for Messages {}
+
+/// The machine for the `Portal` component.
+#[derive(Debug)]
+pub struct Machine;
+
+impl ars_core::Machine for Machine {
+    type State = State;
+    type Event = Event;
+    type Context = Context;
+    type Props = Props;
+    type Messages = Messages;
+    type Api<'a> = Api<'a>;
+
+    fn init(props: &Self::Props, env: &Env, _messages: &Self::Messages) -> (State, Context) {
+        let ctx = Context {
+            container: props.container.clone(),
+            mounted: false,
+            render_mode: env.render_mode,
+            ids: ComponentIds::from_id(&props.id),
+        };
+
+        (State::Unmounted, ctx)
+    }
+
+    fn transition(
+        state: &Self::State,
+        event: &Self::Event,
+        context: &Self::Context,
+        _props: &Self::Props,
+    ) -> Option<TransitionPlan<Self>> {
+        match (state, event) {
+            (State::Unmounted, Event::Mount) => Some(TransitionPlan::to(State::Mounted).apply(
+                |ctx: &mut Context| {
+                    ctx.mounted = true;
+                },
+            )),
+
+            (State::Mounted, Event::Unmount) => Some(TransitionPlan::to(State::Unmounted).apply(
+                |ctx: &mut Context| {
+                    ctx.mounted = false;
+                },
+            )),
+
+            (State::Unmounted, Event::ContainerReady(id)) if matches!(&context.container, PortalTarget::Id(target_id) if target_id == id) =>
+            {
+                let id = id.clone();
+                Some(
+                    TransitionPlan::to(State::Mounted).apply(move |ctx: &mut Context| {
+                        ctx.container = PortalTarget::Ref(id);
+                        ctx.mounted = true;
+                    }),
+                )
+            }
+
+            (_, Event::SetContainer(target)) => {
+                let target = target.clone();
+                Some(TransitionPlan::context_only(move |ctx: &mut Context| {
+                    ctx.container = target;
+                }))
+            }
+
+            _ => None,
+        }
+    }
+
+    fn connect<'a>(
+        state: &'a Self::State,
+        ctx: &'a Self::Context,
+        props: &'a Self::Props,
+        send: &'a dyn Fn(Self::Event),
+    ) -> Self::Api<'a> {
+        Api {
+            state,
+            ctx,
+            props,
+            send,
+        }
+    }
+
+    fn on_props_changed(old: &Self::Props, new: &Self::Props) -> Vec<Self::Event> {
+        assert_eq!(
+            old.id, new.id,
+            "Portal id cannot change after initialization"
+        );
+
+        if old.container == new.container {
+            Vec::new()
+        } else {
+            vec![Event::SetContainer(new.container.clone())]
+        }
+    }
+}
+
+/// The Portal part enum.
+#[derive(ComponentPart)]
+#[scope = "portal"]
+pub enum Part {
+    /// The portal mount point inserted at the target container.
+    Root,
+}
+
+/// Connected Portal API.
+pub struct Api<'a> {
+    state: &'a State,
+    ctx: &'a Context,
+    props: &'a Props,
+    send: &'a dyn Fn(Event),
+}
+
+impl Debug for Api<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Api")
+            .field("state", &self.state)
+            .field("ctx", &self.ctx)
+            .field("props", &self.props)
+            .finish()
+    }
+}
+
+impl Api<'_> {
+    /// Whether the portal is currently mounted.
+    #[must_use]
+    pub const fn is_mounted(&self) -> bool {
+        matches!(self.state, State::Mounted)
+    }
+
+    /// Returns the currently resolved portal target.
+    #[must_use]
+    pub const fn target(&self) -> &PortalTarget {
+        &self.ctx.container
+    }
+
+    /// Returns the runtime render mode resolved by the adapter.
+    #[must_use]
+    pub const fn render_mode(&self) -> RenderMode {
+        self.ctx.render_mode
+    }
+
+    /// Returns whether SSR should render portal content inline.
+    #[must_use]
+    pub const fn ssr_inline(&self) -> bool {
+        self.props.ssr_inline
+    }
+
+    /// Returns the stable portal owner ID used by outside-interaction helpers.
+    #[must_use]
+    pub fn owner_id(&self) -> &str {
+        self.ctx.ids.id()
+    }
+
+    /// Returns whether portal content should render inline at the declaration
+    /// site for the current runtime mode.
+    #[must_use]
+    pub const fn should_render_inline(&self) -> bool {
+        self.props.ssr_inline && self.ctx.render_mode.is_server()
+    }
+
+    /// The generated portal root element ID, usable for `aria-owns` on triggers.
+    #[must_use]
+    pub fn portal_root_id(&self) -> String {
+        format!("ars-portal-{}", self.ctx.ids.id())
+    }
+
+    /// The attributes for the portal root element.
+    #[must_use]
+    pub fn root_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Root.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Id, self.portal_root_id())
+            .set(HtmlAttr::Data("ars-portal-id"), self.ctx.ids.id())
+            .set(HtmlAttr::Data("ars-portal-owner"), self.ctx.ids.id())
+            .set(
+                HtmlAttr::Data("ars-state"),
+                if self.is_mounted() {
+                    "mounted"
+                } else {
+                    "unmounted"
+                },
+            );
+
+        attrs
+    }
+
+    /// Dispatches a mount event for the portal.
+    pub fn on_mount(&self) {
+        (self.send)(Event::Mount);
+    }
+
+    /// Dispatches an unmount event for the portal.
+    pub fn on_unmount(&self) {
+        (self.send)(Event::Unmount);
+    }
+}
+
+impl ConnectApi for Api<'_> {
+    type Part = Part;
+
+    fn part_attrs(&self, part: Part) -> AttrMap {
+        match part {
+            Part::Root => self.root_attrs(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::{
+        format,
+        rc::Rc,
+        string::{String, ToString},
+        vec::Vec,
+    };
+    use core::cell::RefCell;
+
+    use ars_core::{ConnectApi, Env, HtmlAttr, RenderMode, Service};
+    use insta::assert_snapshot;
+
+    use super::*;
+
+    fn test_props() -> Props {
+        Props::new().id("portal")
+    }
+
+    fn snapshot_attrs(attrs: &AttrMap) -> String {
+        format!("{attrs:#?}")
+    }
+
+    #[test]
+    fn props_new_returns_default_values() {
+        assert_eq!(Props::new(), Props::default());
+    }
+
+    #[test]
+    fn props_builder_chain_applies_each_setter() {
+        let props = Props::new()
+            .id("portal-1")
+            .container(PortalTarget::Id("custom-root".to_string()))
+            .ssr_inline(true);
+
+        assert_eq!(props.id, "portal-1");
+        assert_eq!(props.container, PortalTarget::Id("custom-root".to_string()));
+        assert!(props.ssr_inline);
+    }
+
+    #[test]
+    fn initializes_unmounted_with_default_portal_root() {
+        let service = Service::<Machine>::new(test_props(), &Env::default(), &Messages);
+
+        assert_eq!(service.state(), &State::Unmounted);
+        assert_eq!(service.context().container, PortalTarget::PortalRoot);
+        assert!(!service.context().mounted);
+        assert_eq!(service.context().render_mode, RenderMode::Client);
+        assert_eq!(service.context().ids.id(), "portal");
+    }
+
+    #[test]
+    fn initializes_with_adapter_render_mode() {
+        let env = Env::default().with_render_mode(RenderMode::Server);
+
+        let service = Service::<Machine>::new(test_props().ssr_inline(true), &env, &Messages);
+
+        let api = service.connect(&|_| {});
+
+        assert_eq!(service.context().render_mode, RenderMode::Server);
+        assert_eq!(api.render_mode(), RenderMode::Server);
+        assert!(api.ssr_inline());
+        assert!(api.should_render_inline());
+    }
+
+    #[test]
+    fn hydration_mode_does_not_render_inline_again() {
+        let env = Env::default().with_render_mode(RenderMode::Hydrating);
+
+        let service = Service::<Machine>::new(test_props().ssr_inline(true), &env, &Messages);
+
+        let api = service.connect(&|_| {});
+
+        assert_eq!(api.render_mode(), RenderMode::Hydrating);
+        assert!(!api.should_render_inline());
+    }
+
+    #[test]
+    fn server_mode_does_not_render_inline_when_ssr_inline_is_disabled() {
+        let env = Env::default().with_render_mode(RenderMode::Server);
+
+        let service = Service::<Machine>::new(test_props().ssr_inline(false), &env, &Messages);
+
+        let api = service.connect(&|_| {});
+
+        assert_eq!(api.render_mode(), RenderMode::Server);
+        assert!(!api.ssr_inline());
+        assert!(!api.should_render_inline());
+    }
+
+    #[test]
+    fn initializes_with_custom_target_container() {
+        let service = Service::<Machine>::new(
+            Props::new()
+                .id("portal")
+                .container(PortalTarget::Id("custom-root".to_string())),
+            &Env::default(),
+            &Messages,
+        );
+
+        assert_eq!(
+            service.context().container,
+            PortalTarget::Id("custom-root".to_string())
+        );
+        assert!(!service.context().mounted);
+    }
+
+    #[test]
+    fn mount_event_marks_content_mounted_for_adapter() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &Messages);
+
+        let result = service.send(Event::Mount);
+
+        assert!(result.state_changed);
+        assert!(result.context_changed);
+        assert_eq!(service.state(), &State::Mounted);
+        assert!(service.context().mounted);
+    }
+
+    #[test]
+    fn unmount_event_marks_content_unmounted_for_adapter_cleanup() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &Messages);
+
+        drop(service.send(Event::Mount));
+
+        let result = service.send(Event::Unmount);
+
+        assert!(result.state_changed);
+        assert!(result.context_changed);
+        assert_eq!(service.state(), &State::Unmounted);
+        assert!(!service.context().mounted);
+    }
+
+    #[test]
+    fn container_ready_mounts_to_ref_target() {
+        let mut service = Service::<Machine>::new(
+            test_props().container(PortalTarget::Id("late-root".to_string())),
+            &Env::default(),
+            &Messages,
+        );
+
+        let result = service.send(Event::ContainerReady("late-root".to_string()));
+
+        assert!(result.state_changed);
+        assert!(result.context_changed);
+        assert_eq!(service.state(), &State::Mounted);
+        assert_eq!(
+            service.context().container,
+            PortalTarget::Ref("late-root".to_string())
+        );
+        assert!(service.context().mounted);
+    }
+
+    #[test]
+    fn container_ready_ignores_unmatched_targets() {
+        let mut service = Service::<Machine>::new(
+            test_props().container(PortalTarget::Id("expected-root".to_string())),
+            &Env::default(),
+            &Messages,
+        );
+
+        let mismatched_result = service.send(Event::ContainerReady("other-root".to_string()));
+
+        assert!(!mismatched_result.state_changed);
+        assert!(!mismatched_result.context_changed);
+        assert_eq!(service.state(), &State::Unmounted);
+        assert_eq!(
+            service.context().container,
+            PortalTarget::Id("expected-root".to_string())
+        );
+
+        let mut portal_root = Service::<Machine>::new(test_props(), &Env::default(), &Messages);
+
+        let non_id_result = portal_root.send(Event::ContainerReady("late-root".to_string()));
+
+        assert!(!non_id_result.state_changed);
+        assert!(!non_id_result.context_changed);
+        assert_eq!(portal_root.context().container, PortalTarget::PortalRoot);
+    }
+
+    #[test]
+    fn invalid_transitions_are_ignored() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &Messages);
+
+        let unmount_result = service.send(Event::Unmount);
+
+        assert!(!unmount_result.state_changed);
+        assert!(!unmount_result.context_changed);
+        assert_eq!(service.state(), &State::Unmounted);
+
+        drop(service.send(Event::Mount));
+
+        let mount_result = service.send(Event::Mount);
+
+        assert!(!mount_result.state_changed);
+        assert!(!mount_result.context_changed);
+        assert_eq!(service.state(), &State::Mounted);
+
+        let ready_result = service.send(Event::ContainerReady("late-root".to_string()));
+
+        assert!(!ready_result.state_changed);
+        assert!(!ready_result.context_changed);
+        assert_eq!(service.context().container, PortalTarget::PortalRoot);
+    }
+
+    #[test]
+    fn set_props_syncs_container_without_remounting() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &Messages);
+
+        let result = service.set_props(test_props().container(PortalTarget::Body));
+
+        assert!(result.context_changed);
+        assert!(!result.state_changed);
+        assert_eq!(service.state(), &State::Unmounted);
+        assert_eq!(service.context().container, PortalTarget::Body);
+    }
+
+    #[test]
+    fn set_props_syncs_container_without_unmounting_mounted_portal() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &Messages);
+
+        drop(service.send(Event::Mount));
+
+        let result = service.set_props(test_props().container(PortalTarget::Body));
+
+        assert!(result.context_changed);
+        assert!(!result.state_changed);
+        assert_eq!(service.state(), &State::Mounted);
+        assert!(service.context().mounted);
+        assert_eq!(service.context().container, PortalTarget::Body);
+    }
+
+    #[test]
+    fn set_props_with_unchanged_container_emits_no_events() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &Messages);
+
+        let result = service.set_props(test_props());
+
+        assert!(!result.context_changed);
+        assert!(!result.state_changed);
+        assert_eq!(service.state(), &State::Unmounted);
+        assert_eq!(service.context().container, PortalTarget::PortalRoot);
+        assert_eq!(
+            <Machine as ars_core::Machine>::on_props_changed(&test_props(), &test_props()),
+            Vec::<Event>::new()
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "Portal id cannot change after initialization")]
+    fn set_props_panics_when_id_changes() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &Messages);
+
+        drop(service.set_props(Props::new().id("different")));
+    }
+
+    #[test]
+    fn api_reports_mounted_state() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &Messages);
+
+        assert!(!service.connect(&|_| {}).is_mounted());
+
+        drop(service.send(Event::Mount));
+
+        assert!(service.connect(&|_| {}).is_mounted());
+    }
+
+    #[test]
+    fn api_portal_root_id_uses_component_id() {
+        let service =
+            Service::<Machine>::new(Props::new().id("menu-1"), &Env::default(), &Messages);
+
+        assert_eq!(
+            service.connect(&|_| {}).portal_root_id(),
+            "ars-portal-menu-1"
+        );
+    }
+
+    #[test]
+    fn api_exposes_adapter_target_and_ssr_decisions() {
+        let env = Env::default().with_render_mode(RenderMode::Server);
+
+        let service = Service::<Machine>::new(
+            Props::new()
+                .id("menu-1")
+                .container(PortalTarget::Body)
+                .ssr_inline(true),
+            &env,
+            &Messages,
+        );
+
+        let api = service.connect(&|_| {});
+
+        assert_eq!(api.target(), &PortalTarget::Body);
+        assert_eq!(api.owner_id(), "menu-1");
+        assert_eq!(api.render_mode(), RenderMode::Server);
+        assert!(api.ssr_inline());
+        assert!(api.should_render_inline());
+    }
+
+    #[test]
+    fn api_debug_includes_state_context_and_props() {
+        let service = Service::<Machine>::new(
+            Props::new()
+                .id("debug-portal")
+                .container(PortalTarget::Body)
+                .ssr_inline(true),
+            &Env::default(),
+            &Messages,
+        );
+
+        let debug = format!("{:?}", service.connect(&|_| {}));
+
+        assert!(debug.starts_with("Api"));
+        assert!(debug.contains("state: Unmounted"));
+        assert!(debug.contains("container: Body"));
+        assert!(debug.contains("id: \"debug-portal\""));
+        assert!(debug.contains("ssr_inline: true"));
+    }
+
+    #[test]
+    fn api_on_mount_and_on_unmount_dispatch_events() {
+        let service = Service::<Machine>::new(test_props(), &Env::default(), &Messages);
+
+        let events = Rc::new(RefCell::new(Vec::new()));
+
+        let captured = Rc::clone(&events);
+        let send = move |event| {
+            captured.borrow_mut().push(event);
+        };
+
+        let api = service.connect(&send);
+
+        api.on_mount();
+        api.on_unmount();
+
+        assert_eq!(events.borrow().as_slice(), [Event::Mount, Event::Unmount]);
+    }
+
+    #[test]
+    fn part_attrs_match_root_attrs() {
+        let service = Service::<Machine>::new(test_props(), &Env::default(), &Messages);
+
+        let api = service.connect(&|_| {});
+
+        assert_eq!(api.part_attrs(Part::Root), api.root_attrs());
+    }
+
+    #[test]
+    fn root_attrs_do_not_emit_aria_semantics() {
+        let service = Service::<Machine>::new(test_props(), &Env::default(), &Messages);
+
+        let attrs = service.connect(&|_| {}).root_attrs();
+
+        assert!(
+            attrs
+                .attrs()
+                .iter()
+                .all(|(attr, _)| { !matches!(attr, HtmlAttr::Role | HtmlAttr::Aria(_)) })
+        );
+    }
+
+    #[test]
+    fn nested_portals_have_independent_ids_targets_and_state() {
+        let mut parent = Service::<Machine>::new(
+            Props::new()
+                .id("parent")
+                .container(PortalTarget::PortalRoot),
+            &Env::default(),
+            &Messages,
+        );
+
+        let mut child = Service::<Machine>::new(
+            Props::new()
+                .id("child")
+                .container(PortalTarget::Id("nested-root".to_string())),
+            &Env::default(),
+            &Messages,
+        );
+
+        drop(parent.send(Event::Mount));
+        drop(child.send(Event::Mount));
+
+        let parent_api = parent.connect(&|_| {});
+        let child_api = child.connect(&|_| {});
+
+        assert_eq!(parent_api.portal_root_id(), "ars-portal-parent");
+        assert_eq!(child_api.portal_root_id(), "ars-portal-child");
+        assert_eq!(parent.context().container, PortalTarget::PortalRoot);
+        assert_eq!(
+            child.context().container,
+            PortalTarget::Id("nested-root".to_string())
+        );
+        assert_eq!(
+            parent_api
+                .root_attrs()
+                .get(&HtmlAttr::Data("ars-portal-id")),
+            Some("parent")
+        );
+        assert_eq!(
+            parent_api
+                .root_attrs()
+                .get(&HtmlAttr::Data("ars-portal-owner")),
+            Some("parent")
+        );
+        assert_eq!(
+            parent_api.root_attrs().get(&HtmlAttr::Id),
+            Some("ars-portal-parent")
+        );
+        assert_eq!(
+            child_api.root_attrs().get(&HtmlAttr::Data("ars-portal-id")),
+            Some("child")
+        );
+        assert_eq!(
+            child_api
+                .root_attrs()
+                .get(&HtmlAttr::Data("ars-portal-owner")),
+            Some("child")
+        );
+
+        drop(parent.send(Event::Unmount));
+
+        assert_eq!(parent.state(), &State::Unmounted);
+        assert_eq!(child.state(), &State::Mounted);
+        assert!(!parent.context().mounted);
+        assert!(child.context().mounted);
+    }
+
+    #[test]
+    fn portal_root_unmounted() {
+        let service = Service::<Machine>::new(test_props(), &Env::default(), &Messages);
+
+        assert_snapshot!(
+            "portal_root_unmounted",
+            snapshot_attrs(&service.connect(&|_| {}).root_attrs())
+        );
+    }
+
+    #[test]
+    fn portal_root_mounted() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &Messages);
+
+        drop(service.send(Event::Mount));
+
+        assert_snapshot!(
+            "portal_root_mounted",
+            snapshot_attrs(&service.connect(&|_| {}).root_attrs())
+        );
+    }
+
+    #[test]
+    fn portal_root_custom_target_mounted() {
+        let mut service = Service::<Machine>::new(
+            Props::new()
+                .id("custom")
+                .container(PortalTarget::Id("custom-root".to_string())),
+            &Env::default(),
+            &Messages,
+        );
+
+        drop(service.send(Event::Mount));
+
+        assert_snapshot!(
+            "portal_root_custom_target_mounted",
+            snapshot_attrs(&service.connect(&|_| {}).root_attrs())
+        );
+    }
+}

--- a/crates/ars-components/src/layout/portal.rs
+++ b/crates/ars-components/src/layout/portal.rs
@@ -180,6 +180,14 @@ impl ars_core::Machine for Machine {
                 )
             }
 
+            (State::Mounted, Event::ContainerReady(id)) if matches!(&context.container, PortalTarget::Id(target_id) if target_id == id) =>
+            {
+                let id = id.clone();
+                Some(TransitionPlan::context_only(move |ctx: &mut Context| {
+                    ctx.container = PortalTarget::ResolvedId(id);
+                }))
+            }
+
             (_, Event::SetContainer(target)) => {
                 let target = target.clone();
                 Some(TransitionPlan::context_only(move |ctx: &mut Context| {
@@ -478,6 +486,28 @@ mod tests {
         let result = service.send(Event::ContainerReady("late-root".to_string()));
 
         assert!(result.state_changed);
+        assert!(result.context_changed);
+        assert_eq!(service.state(), &State::Mounted);
+        assert_eq!(
+            service.context().container,
+            PortalTarget::ResolvedId("late-root".to_string())
+        );
+        assert!(service.context().mounted);
+    }
+
+    #[test]
+    fn container_ready_resolves_target_after_mount() {
+        let mut service = Service::<Machine>::new(
+            test_props().container(PortalTarget::Id("late-root".to_string())),
+            &Env::default(),
+            &Messages,
+        );
+
+        drop(service.send(Event::Mount));
+
+        let result = service.send(Event::ContainerReady("late-root".to_string()));
+
+        assert!(!result.state_changed);
         assert!(result.context_changed);
         assert_eq!(service.state(), &State::Mounted);
         assert_eq!(

--- a/crates/ars-components/src/layout/snapshots/ars_components__layout__portal__tests__portal_root_body_target_mounted.snap
+++ b/crates/ars-components/src/layout/snapshots/ars_components__layout__portal__tests__portal_root_body_target_mounted.snap
@@ -1,0 +1,55 @@
+---
+source: crates/ars-components/src/layout/portal.rs
+expression: "snapshot_attrs(&service.connect(&|_| {}).root_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-portal-id",
+            ),
+            String(
+                "body-target",
+            ),
+        ),
+        (
+            Data(
+                "ars-portal-owner",
+            ),
+            String(
+                "body-target",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "portal",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "mounted",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "ars-portal-body-target",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/layout/snapshots/ars_components__layout__portal__tests__portal_root_custom_target_mounted.snap
+++ b/crates/ars-components/src/layout/snapshots/ars_components__layout__portal__tests__portal_root_custom_target_mounted.snap
@@ -1,0 +1,55 @@
+---
+source: crates/ars-components/src/layout/portal.rs
+expression: "snapshot_attrs(&service.connect(&|_| {}).root_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-portal-id",
+            ),
+            String(
+                "custom",
+            ),
+        ),
+        (
+            Data(
+                "ars-portal-owner",
+            ),
+            String(
+                "custom",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "portal",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "mounted",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "ars-portal-custom",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/layout/snapshots/ars_components__layout__portal__tests__portal_root_mounted.snap
+++ b/crates/ars-components/src/layout/snapshots/ars_components__layout__portal__tests__portal_root_mounted.snap
@@ -1,0 +1,55 @@
+---
+source: crates/ars-components/src/layout/portal.rs
+expression: "snapshot_attrs(&service.connect(&|_| {}).root_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-portal-id",
+            ),
+            String(
+                "portal",
+            ),
+        ),
+        (
+            Data(
+                "ars-portal-owner",
+            ),
+            String(
+                "portal",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "portal",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "mounted",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "ars-portal-portal",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/layout/snapshots/ars_components__layout__portal__tests__portal_root_resolved_id_target_mounted.snap
+++ b/crates/ars-components/src/layout/snapshots/ars_components__layout__portal__tests__portal_root_resolved_id_target_mounted.snap
@@ -1,0 +1,55 @@
+---
+source: crates/ars-components/src/layout/portal.rs
+expression: "snapshot_attrs(&service.connect(&|_| {}).root_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-portal-id",
+            ),
+            String(
+                "resolved",
+            ),
+        ),
+        (
+            Data(
+                "ars-portal-owner",
+            ),
+            String(
+                "resolved",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "portal",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "mounted",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "ars-portal-resolved",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/layout/snapshots/ars_components__layout__portal__tests__portal_root_unmounted.snap
+++ b/crates/ars-components/src/layout/snapshots/ars_components__layout__portal__tests__portal_root_unmounted.snap
@@ -1,0 +1,55 @@
+---
+source: crates/ars-components/src/layout/portal.rs
+expression: "snapshot_attrs(&service.connect(&|_| {}).root_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-portal-id",
+            ),
+            String(
+                "portal",
+            ),
+        ),
+        (
+            Data(
+                "ars-portal-owner",
+            ),
+            String(
+                "portal",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "portal",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "unmounted",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "ars-portal-portal",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/lib.rs
+++ b/crates/ars-components/src/lib.rs
@@ -17,6 +17,9 @@ pub mod input;
 /// Date and time component machines.
 pub mod date_time;
 
+/// Layout component machines.
+pub mod layout;
+
 /// Utility component machines.
 pub mod utility;
 

--- a/crates/ars-components/src/overlay/tooltip.rs
+++ b/crates/ars-components/src/overlay/tooltip.rs
@@ -122,6 +122,9 @@ pub struct Context {
     /// Positioning options forwarded to framework adapters.
     pub positioning: PositioningOptions,
 
+    /// Derived component part IDs.
+    pub ids: ComponentIds,
+
     /// The ID of the trigger element.
     pub trigger_id: String,
 
@@ -380,6 +383,7 @@ impl ars_core::Machine for Machine {
                 focus_active: false,
                 positioning: props.positioning.clone(),
                 trigger_id: ids.part("trigger"),
+                ids,
                 hidden_description_id: format_description_id(&content_id),
                 content_id,
                 messages: messages.clone(),
@@ -605,6 +609,11 @@ impl ars_core::Machine for Machine {
     }
 
     fn on_props_changed(old: &Self::Props, new: &Self::Props) -> Vec<Self::Event> {
+        assert_eq!(
+            old.id, new.id,
+            "Tooltip id cannot change after initialization"
+        );
+
         let mut events = Vec::new();
 
         match (old.open, new.open) {
@@ -696,12 +705,12 @@ impl<'a> Api<'a> {
         let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Trigger.data_attrs();
 
         attrs
-            .set(HtmlAttr::Id, &self.ctx.trigger_id)
+            .set(HtmlAttr::Id, self.ctx.ids.part("trigger"))
             .set(scope_attr, scope_val)
             .set(part_attr, part_val)
             .set(
                 HtmlAttr::Aria(AriaAttr::DescribedBy),
-                &self.ctx.hidden_description_id,
+                format_description_id(self.ctx.ids.part("content")),
             );
 
         if self.ctx.disabled {
@@ -780,7 +789,10 @@ impl<'a> Api<'a> {
         let [(scope_attr, scope_val), (part_attr, part_val)] = Part::HiddenDescription.data_attrs();
 
         attrs
-            .set(HtmlAttr::Id, &self.ctx.hidden_description_id)
+            .set(
+                HtmlAttr::Id,
+                format_description_id(self.ctx.ids.part("content")),
+            )
             .set(scope_attr, scope_val)
             .set(part_attr, part_val)
             .set(HtmlAttr::Data("ars-visually-hidden"), "true");
@@ -817,7 +829,7 @@ impl<'a> Api<'a> {
         let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Content.data_attrs();
 
         attrs
-            .set(HtmlAttr::Id, &self.ctx.content_id)
+            .set(HtmlAttr::Id, self.ctx.ids.part("content"))
             .set(HtmlAttr::Aria(AriaAttr::Hidden), "true")
             .set(HtmlAttr::Dir, self.ctx.dir.as_html_attr())
             .set(scope_attr, scope_val)
@@ -868,8 +880,8 @@ const fn close_delay(props: &Props) -> Duration {
     props.close_delay
 }
 
-fn format_description_id(content_id: &str) -> String {
-    let mut id = String::from(content_id);
+fn format_description_id(content_id: impl Into<String>) -> String {
+    let mut id = content_id.into();
 
     id.push_str("-description");
 
@@ -988,23 +1000,21 @@ fn sync_props_plan(props: &Props) -> TransitionPlan<Machine> {
 }
 
 fn sync_props_context(ctx: &mut Context, props: &Props) {
-    let ids = ComponentIds::from_id(&props.id);
-    let content_id = ids.part("content");
+    let content_id = ctx.ids.part("content");
 
     ctx.open_delay = props.open_delay;
     ctx.close_delay = close_delay(props);
     ctx.disabled = props.disabled;
     ctx.dir = props.dir;
     ctx.positioning = props.positioning.clone();
-    ctx.trigger_id = ids.part("trigger");
+    ctx.trigger_id = ctx.ids.part("trigger");
     ctx.hidden_description_id = format_description_id(&content_id);
     ctx.content_id = content_id;
     ctx.touch_auto_hide = props.touch_auto_hide.max(MIN_TOUCH_AUTO_HIDE);
 }
 
 fn props_context_changed(old: &Props, new: &Props) -> bool {
-    old.id != new.id
-        || old.open_delay != new.open_delay
+    old.open_delay != new.open_delay
         || old.close_delay != new.close_delay
         || old.disabled != new.disabled
         || old.dir != new.dir
@@ -1992,7 +2002,6 @@ mod tests {
         let mut service = Service::<Machine>::new(test_props(), &Env::default(), &Messages);
 
         let result = service.set_props(Props {
-            id: "renamed-tooltip".to_string(),
             open_delay: Duration::from_millis(12),
             close_delay: Duration::ZERO,
             disabled: true,
@@ -2005,9 +2014,10 @@ mod tests {
             ..test_props()
         });
 
-        let ids = ComponentIds::from_id("renamed-tooltip");
+        let ids = ComponentIds::from_id("tooltip");
         let content_id = ids.part("content");
 
+        assert_eq!(service.context().ids, ids);
         assert_eq!(service.context().open_delay, Duration::from_millis(12));
         assert_eq!(service.context().close_delay, Duration::ZERO);
         assert!(service.context().disabled);
@@ -2024,42 +2034,20 @@ mod tests {
     }
 
     #[test]
-    fn tooltip_id_prop_change_updates_connected_aria_ids() {
+    #[should_panic(expected = "Tooltip id cannot change after initialization")]
+    fn tooltip_set_props_panics_when_id_changes() {
         let mut service = Service::<Machine>::new(test_props(), &Env::default(), &Messages);
 
         drop(service.set_props(Props {
             id: "renamed-tooltip".to_string(),
             ..test_props()
         }));
-
-        let api = service.connect(&|_| {});
-        let ids = ComponentIds::from_id("renamed-tooltip");
-        let content_id = ids.part("content");
-        let hidden_id = format_description_id(&content_id);
-
-        assert_eq!(
-            api.trigger_attrs()
-                .get(&HtmlAttr::Aria(AriaAttr::DescribedBy)),
-            Some(hidden_id.as_str())
-        );
-        assert_eq!(
-            api.hidden_description_attrs().get(&HtmlAttr::Id),
-            Some(hidden_id.as_str())
-        );
-        assert_eq!(
-            api.content_attrs().get(&HtmlAttr::Id),
-            Some(content_id.as_str())
-        );
     }
 
     #[test]
     fn tooltip_on_props_changed_reports_each_context_backed_prop() {
         let old = test_props();
         let cases = [
-            Props {
-                id: "renamed-tooltip".to_string(),
-                ..test_props()
-            },
             Props {
                 open_delay: Duration::from_millis(12),
                 ..test_props()

--- a/crates/ars-components/tests/proptest_state_machines.rs
+++ b/crates/ars-components/tests/proptest_state_machines.rs
@@ -6,6 +6,9 @@ mod input;
 #[path = "proptest_state_machines/date_time.rs"]
 mod date_time;
 
+#[path = "proptest_state_machines/layout.rs"]
+mod layout;
+
 #[path = "proptest_state_machines/overlay.rs"]
 mod overlay;
 

--- a/crates/ars-components/tests/proptest_state_machines/layout.rs
+++ b/crates/ars-components/tests/proptest_state_machines/layout.rs
@@ -1,0 +1,175 @@
+use ars_components::layout::portal;
+use ars_core::{Env, RenderMode, SendResult, Service};
+use proptest::{prelude::*, test_runner::TestCaseResult};
+
+#[derive(Clone, Debug)]
+enum PortalStep {
+    Send(portal::Event),
+    SetProps(portal::Props),
+}
+
+fn arb_target_id() -> impl Strategy<Value = String> {
+    "[a-z][a-z0-9_-]{0,12}".prop_map(String::from)
+}
+
+fn arb_portal_target() -> impl Strategy<Value = portal::PortalTarget> {
+    prop_oneof![
+        Just(portal::PortalTarget::PortalRoot),
+        Just(portal::PortalTarget::Body),
+        arb_target_id().prop_map(portal::PortalTarget::Id),
+        arb_target_id().prop_map(portal::PortalTarget::Ref),
+    ]
+}
+
+fn arb_portal_props() -> impl Strategy<Value = portal::Props> {
+    (arb_portal_target(), any::<bool>()).prop_map(|(container, ssr_inline)| {
+        portal::Props::new()
+            .id("portal")
+            .container(container)
+            .ssr_inline(ssr_inline)
+    })
+}
+
+fn arb_portal_event() -> impl Strategy<Value = portal::Event> {
+    prop_oneof![
+        Just(portal::Event::Mount),
+        Just(portal::Event::Unmount),
+        arb_target_id().prop_map(portal::Event::ContainerReady),
+        arb_portal_target().prop_map(portal::Event::SetContainer),
+    ]
+}
+
+fn arb_portal_step() -> impl Strategy<Value = PortalStep> {
+    prop_oneof![
+        arb_portal_event().prop_map(PortalStep::Send),
+        arb_portal_props().prop_map(PortalStep::SetProps),
+    ]
+}
+
+fn assert_portal_state_context_invariants(service: &Service<portal::Machine>) -> TestCaseResult {
+    prop_assert_eq!(
+        service.context().mounted,
+        matches!(service.state(), portal::State::Mounted)
+    );
+    prop_assert_eq!(service.context().render_mode, RenderMode::Client);
+    prop_assert_eq!(service.context().ids.id(), "portal");
+
+    Ok(())
+}
+
+fn assert_portal_send_result_invariants(
+    service: &Service<portal::Machine>,
+    event: &portal::Event,
+    result: &SendResult<portal::Machine>,
+    before_state: &portal::State,
+    before_context: &portal::Context,
+) -> TestCaseResult {
+    prop_assert!(result.pending_effects.is_empty());
+    prop_assert!(result.cancel_effects.is_empty());
+
+    match event {
+        portal::Event::Mount if before_state == &portal::State::Unmounted => {
+            prop_assert_eq!(service.state(), &portal::State::Mounted);
+            prop_assert!(service.context().mounted);
+        }
+
+        portal::Event::Unmount if before_state == &portal::State::Mounted => {
+            prop_assert_eq!(service.state(), &portal::State::Unmounted);
+            prop_assert!(!service.context().mounted);
+        }
+
+        portal::Event::ContainerReady(id)
+            if before_state == &portal::State::Unmounted
+                && before_context.container == portal::PortalTarget::Id(id.clone()) =>
+        {
+            prop_assert_eq!(service.state(), &portal::State::Mounted);
+            prop_assert_eq!(
+                service.context().container.clone(),
+                portal::PortalTarget::Ref(id.clone())
+            );
+            prop_assert!(service.context().mounted);
+        }
+
+        portal::Event::SetContainer(target) => {
+            prop_assert_eq!(service.state(), before_state);
+            prop_assert_eq!(service.context().container.clone(), target.clone());
+            prop_assert_eq!(service.context().mounted, before_context.mounted);
+        }
+
+        _ => {
+            prop_assert_eq!(service.state(), before_state);
+            prop_assert_eq!(service.context(), before_context);
+        }
+    }
+
+    Ok(())
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(
+        std::env::var("PROPTEST_CASES")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(1000)
+    ))]
+
+    #[test]
+    #[ignore = "proptest — nightly extended-proptest job"]
+    fn proptest_portal_event_sequences_preserve_invariants(
+        props in arb_portal_props(),
+        steps in prop::collection::vec(arb_portal_step(), 0..128),
+    ) {
+        let mut service = Service::<portal::Machine>::new(
+            props,
+            &Env::default(),
+            &portal::Messages,
+        );
+
+        assert_portal_state_context_invariants(&service)?;
+
+        for step in steps {
+            match step {
+                PortalStep::Send(event) => {
+                    let before_state = service.state().clone();
+
+                    let before_context = service.context().clone();
+
+                    let result = service.send(event.clone());
+
+                    assert_portal_send_result_invariants(
+                        &service,
+                        &event,
+                        &result,
+                        &before_state,
+                        &before_context,
+                    )?;
+                }
+
+                PortalStep::SetProps(props) => {
+                    let before_state = service.state().clone();
+                    let before_mounted = service.context().mounted;
+                    let before_context_container = service.context().container.clone();
+                    let before_props_container = service.props().container.clone();
+
+                    let expected_container = props.container.clone();
+
+                    let result = service.set_props(props);
+
+                    prop_assert!(!result.state_changed);
+                    prop_assert_eq!(service.state(), &before_state);
+                    prop_assert_eq!(service.context().mounted, before_mounted);
+                    prop_assert_eq!(
+                        service.context().container.clone(),
+                        if before_props_container == expected_container {
+                            before_context_container
+                        } else {
+                            expected_container
+                        }
+                    );
+                }
+            }
+
+            assert_portal_state_context_invariants(&service)?;
+        }
+    }
+}

--- a/crates/ars-components/tests/proptest_state_machines/layout.rs
+++ b/crates/ars-components/tests/proptest_state_machines/layout.rs
@@ -17,7 +17,7 @@ fn arb_portal_target() -> impl Strategy<Value = portal::PortalTarget> {
         Just(portal::PortalTarget::PortalRoot),
         Just(portal::PortalTarget::Body),
         arb_target_id().prop_map(portal::PortalTarget::Id),
-        arb_target_id().prop_map(portal::PortalTarget::Ref),
+        arb_target_id().prop_map(portal::PortalTarget::ResolvedId),
     ]
 }
 
@@ -85,7 +85,7 @@ fn assert_portal_send_result_invariants(
             prop_assert_eq!(service.state(), &portal::State::Mounted);
             prop_assert_eq!(
                 service.context().container.clone(),
-                portal::PortalTarget::Ref(id.clone())
+                portal::PortalTarget::ResolvedId(id.clone())
             );
             prop_assert!(service.context().mounted);
         }

--- a/crates/ars-components/tests/proptest_state_machines/overlay.rs
+++ b/crates/ars-components/tests/proptest_state_machines/overlay.rs
@@ -228,6 +228,13 @@ fn assert_tooltip_state_context_invariants(service: &Service<tooltip::Machine>) 
         )
     );
     prop_assert!(service.context().touch_auto_hide >= MIN_TOUCH_AUTO_HIDE);
+    prop_assert_eq!(service.context().ids.id(), "tooltip");
+
+    let trigger_id = service.context().ids.part("trigger");
+    let content_id = service.context().ids.part("content");
+
+    prop_assert_eq!(&service.context().trigger_id, &trigger_id);
+    prop_assert_eq!(&service.context().content_id, &content_id);
     prop_assert_eq!(&service.context().trigger_id, "tooltip-trigger");
     prop_assert_eq!(&service.context().content_id, "tooltip-content");
     prop_assert_eq!(

--- a/crates/ars-core/src/lib.rs
+++ b/crates/ars-core/src/lib.rs
@@ -568,6 +568,34 @@ pub trait ConnectApi {
 // Env — adapter-resolved environment context
 // ────────────────────────────────────────────────────────────────────
 
+/// Runtime render mode resolved by the adapter before initializing a machine.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum RenderMode {
+    /// The component is rendering in a normal client runtime.
+    #[default]
+    Client,
+
+    /// The component is rendering HTML on the server.
+    Server,
+
+    /// The component is hydrating server-rendered HTML on the client.
+    Hydrating,
+}
+
+impl RenderMode {
+    /// Returns whether this mode is server-side rendering.
+    #[must_use]
+    pub const fn is_server(self) -> bool {
+        matches!(self, Self::Server)
+    }
+
+    /// Returns whether this mode is client hydration.
+    #[must_use]
+    pub const fn is_hydrating(self) -> bool {
+        matches!(self, Self::Hydrating)
+    }
+}
+
 /// Adapter-resolved environment context passed to [`Machine::init`].
 ///
 /// The adapter reads these values from `ArsProvider` / `ArsContext` and passes
@@ -583,6 +611,29 @@ pub struct Env {
     /// Calendar/locale data provider for date-time formatting.
     /// Defaults to [`StubIntlBackend`] (English-only, zero dependencies).
     pub intl_backend: Arc<dyn IntlBackend>,
+
+    /// Runtime render mode for server, hydration, or normal client rendering.
+    pub render_mode: RenderMode,
+}
+
+impl Env {
+    /// Creates an environment with the supplied locale and internationalization
+    /// backend in normal client render mode.
+    #[must_use]
+    pub fn new(locale: Locale, intl_backend: Arc<dyn IntlBackend>) -> Self {
+        Self {
+            locale,
+            intl_backend,
+            render_mode: RenderMode::Client,
+        }
+    }
+
+    /// Returns this environment with a different runtime render mode.
+    #[must_use]
+    pub const fn with_render_mode(mut self, render_mode: RenderMode) -> Self {
+        self.render_mode = render_mode;
+        self
+    }
 }
 
 impl Debug for Env {
@@ -590,6 +641,7 @@ impl Debug for Env {
         f.debug_struct("Env")
             .field("locale", &self.locale)
             .field("intl_backend", &"Arc(..)")
+            .field("render_mode", &self.render_mode)
             .finish()
     }
 }
@@ -599,6 +651,7 @@ impl Default for Env {
         Self {
             locale: ars_i18n::locales::en_us(),
             intl_backend: Arc::new(StubIntlBackend),
+            render_mode: RenderMode::Client,
         }
     }
 }
@@ -3040,6 +3093,21 @@ mod tests {
         assert!(debug.contains("Env"));
         assert!(debug.contains("en-US"));
         assert!(debug.contains("Arc(..)"));
+        assert!(debug.contains("Client"));
+    }
+
+    #[test]
+    fn env_render_mode_helpers_report_runtime_mode() {
+        assert!(!RenderMode::Client.is_server());
+        assert!(!RenderMode::Client.is_hydrating());
+        assert!(RenderMode::Server.is_server());
+        assert!(!RenderMode::Server.is_hydrating());
+        assert!(!RenderMode::Hydrating.is_server());
+        assert!(RenderMode::Hydrating.is_hydrating());
+
+        let env = Env::default().with_render_mode(RenderMode::Hydrating);
+
+        assert_eq!(env.render_mode, RenderMode::Hydrating);
     }
 
     #[test]

--- a/crates/ars-dioxus/src/safe_listener.rs
+++ b/crates/ars-dioxus/src/safe_listener.rs
@@ -266,10 +266,7 @@ mod wasm_tests {
     use super::{
         SafeEventListener, SafeEventListenerOptions, use_safe_event_listener,
         use_safe_event_listeners,
-        web::{
-            ListenerClosureHandle, RegisteredListener, guarded_listener_closure,
-            remove_previous_listeners,
-        },
+        web::{RegisteredListener, guarded_listener_closure, remove_previous_listeners},
     };
 
     wasm_bindgen_test_configure!(run_in_browser);

--- a/crates/ars-dioxus/src/use_machine/mod.rs
+++ b/crates/ars-dioxus/src/use_machine/mod.rs
@@ -10,7 +10,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use ars_core::{CleanupFn, Env, HasId, Machine, Service};
+use ars_core::{CleanupFn, Env, HasId, Machine, RenderMode, Service};
 use dioxus::prelude::*;
 
 use crate::{
@@ -53,6 +53,14 @@ where
     /// Used by [`derive()`](Self::derive) to track context mutations even when
     /// state remains the same.
     pub context_version: ReadSignal<u64>,
+}
+
+const fn current_render_mode() -> RenderMode {
+    if cfg!(feature = "ssr") {
+        RenderMode::Server
+    } else {
+        RenderMode::Client
+    }
 }
 
 struct MachineRuntime<M: Machine + 'static>
@@ -280,10 +288,7 @@ where
 
     let intl_backend = use_intl_backend();
 
-    let env = Env {
-        locale,
-        intl_backend,
-    };
+    let env = Env::new(locale, intl_backend).with_render_mode(current_render_mode());
 
     let messages = use_messages::<M::Messages>(None, Some(&env.locale));
 

--- a/crates/ars-dioxus/src/use_machine/mod.rs
+++ b/crates/ars-dioxus/src/use_machine/mod.rs
@@ -274,6 +274,8 @@ where
 {
     let generated_id = use_hook(|| use_id("component"));
 
+    let props_for_sync = props.clone();
+
     let props = {
         let mut props = props;
 
@@ -291,8 +293,6 @@ where
     let env = Env::new(locale, intl_backend).with_render_mode(current_render_mode());
 
     let messages = use_messages::<M::Messages>(None, Some(&env.locale));
-
-    let props_for_sync = props.clone();
 
     // Create the service once — use_signal runs its closure only on first mount.
     let service_signal = use_signal(move || Service::<M>::new(props, &env, &messages));
@@ -367,6 +367,10 @@ where
 {
     let mut prev_props = use_signal(|| None::<M::Props>);
 
+    let service_id = runtime.service.peek().props().id().to_owned();
+
+    let current_props = props_with_service_id::<M>(current_props, &service_id);
+
     let previous = prev_props.peek().clone();
 
     if previous.as_ref() != Some(&current_props) {
@@ -400,6 +404,14 @@ where
 
         prev_props.set(Some(current_props));
     }
+}
+
+fn props_with_service_id<M: Machine>(mut props: M::Props, service_id: &str) -> M::Props {
+    if props.id().is_empty() {
+        props.set_id(service_id.to_owned());
+    }
+
+    props
 }
 
 fn dispatch_event<M: Machine + 'static>(event: M::Event, mut runtime: MachineRuntime<M>)

--- a/crates/ars-dioxus/src/use_machine/test_support.rs
+++ b/crates/ars-dioxus/src/use_machine/test_support.rs
@@ -242,6 +242,11 @@ impl Machine for PropMachine {
     }
 
     fn on_props_changed(old: &Self::Props, new: &Self::Props) -> Vec<Self::Event> {
+        assert_eq!(
+            old.id, new.id,
+            "PropMachine id cannot change after initialization"
+        );
+
         let mut events = Vec::new();
 
         if old.checked != new.checked {

--- a/crates/ars-dioxus/tests/unit/use_machine.rs
+++ b/crates/ars-dioxus/tests/unit/use_machine.rs
@@ -9,6 +9,8 @@ use dioxus::dioxus_core::{NoOpMutations, ScopeId};
 use super::{test_support, test_support::*, *};
 use crate::provider::{ArsContext, NullPlatform};
 
+type PropIdSnapshot = (String, PropState, u64, u32);
+
 #[derive(Clone)]
 struct TestIntlBackend;
 
@@ -632,6 +634,133 @@ fn use_machine_with_reactive_props_syncs_external_prop_changes() {
             (PropState::On, 0, 0),
             (PropState::On, 1, 1),
         ]
+    );
+}
+
+#[test]
+fn reactive_props_sync_preserves_service_id_when_signal_props_omit_id() {
+    let snapshots = Rc::new(RefCell::new(Vec::new()));
+
+    #[expect(
+        clippy::needless_pass_by_value,
+        reason = "Dioxus root props are moved into the render function."
+    )]
+    fn app(snapshots: Rc<RefCell<Vec<PropIdSnapshot>>>) -> Element {
+        let mut props = use_signal(|| PropProps {
+            id: String::new(),
+            checked: false,
+            label: "a",
+        });
+
+        let mut phase = use_signal(|| 0u8);
+
+        let machine = use_machine_with_reactive_props::<PropMachine>(props);
+
+        snapshots.borrow_mut().push((
+            machine.service.peek().props().id().to_owned(),
+            *machine.state.peek(),
+            *machine.context_version.peek(),
+            machine.service.peek().context().sync_count,
+        ));
+
+        if phase() == 0 {
+            phase.set(1);
+
+            props.set(PropProps {
+                id: String::new(),
+                checked: true,
+                label: "a",
+            });
+        } else if phase() == 1 {
+            phase.set(2);
+
+            props.set(PropProps {
+                id: String::new(),
+                checked: true,
+                label: "b",
+            });
+        }
+
+        rsx! {
+            div {}
+        }
+    }
+
+    let mut dom = VirtualDom::new_with_props(app, Rc::clone(&snapshots));
+
+    dom.rebuild_in_place();
+    dom.mark_dirty(ScopeId::APP);
+    dom.render_immediate(&mut NoOpMutations);
+    dom.mark_dirty(ScopeId::APP);
+    dom.render_immediate(&mut NoOpMutations);
+
+    let snapshots = snapshots.borrow();
+
+    assert_eq!(snapshots.len(), 3);
+    assert!(snapshots[0].0.starts_with("component-"));
+    assert_eq!(snapshots[0].0, snapshots[1].0);
+    assert_eq!(snapshots[1].0, snapshots[2].0);
+    assert_eq!(
+        snapshots
+            .iter()
+            .map(|(_, state, version, sync_count)| (*state, *version, *sync_count))
+            .collect::<Vec<_>>()
+            .as_slice(),
+        &[
+            (PropState::Off, 0, 0),
+            (PropState::On, 0, 0),
+            (PropState::On, 1, 1),
+        ]
+    );
+}
+
+#[test]
+fn reactive_props_sync_preserves_explicit_service_id_when_next_props_omit_id() {
+    let snapshots = Rc::new(RefCell::new(Vec::new()));
+
+    #[expect(
+        clippy::needless_pass_by_value,
+        reason = "Dioxus root props are moved into the render function."
+    )]
+    fn app(snapshots: Rc<RefCell<Vec<String>>>) -> Element {
+        let mut props = use_signal(|| PropProps {
+            id: String::from("stable"),
+            checked: false,
+            label: "a",
+        });
+
+        let mut phase = use_signal(|| 0u8);
+
+        let machine = use_machine_with_reactive_props::<PropMachine>(props);
+
+        snapshots
+            .borrow_mut()
+            .push(machine.service.peek().props().id().to_owned());
+
+        if phase() == 0 {
+            phase.set(1);
+
+            props.set(PropProps {
+                id: String::new(),
+                checked: true,
+                label: "a",
+            });
+        }
+
+        rsx! {
+            div {}
+        }
+    }
+
+    let mut dom = VirtualDom::new_with_props(app, Rc::clone(&snapshots));
+
+    dom.rebuild_in_place();
+    dom.mark_dirty(ScopeId::APP);
+    dom.render_immediate(&mut NoOpMutations);
+
+    assert_eq!(
+        snapshots.borrow().as_slice(),
+        &[String::from("stable"), String::from("stable")]
     );
 }
 

--- a/crates/ars-leptos/src/use_machine/mod.rs
+++ b/crates/ars-leptos/src/use_machine/mod.rs
@@ -56,14 +56,29 @@ where
     pub context_version: ReadSignal<u64>,
 }
 
-const fn current_render_mode() -> RenderMode {
-    if cfg!(feature = "hydrate") {
+#[cfg(feature = "hydrate")]
+fn current_render_mode() -> RenderMode {
+    if cfg!(feature = "ssr") {
+        RenderMode::Server
+    } else if is_currently_hydrating() {
         RenderMode::Hydrating
-    } else if cfg!(feature = "ssr") {
+    } else {
+        RenderMode::Client
+    }
+}
+
+#[cfg(not(feature = "hydrate"))]
+const fn current_render_mode() -> RenderMode {
+    if cfg!(feature = "ssr") {
         RenderMode::Server
     } else {
         RenderMode::Client
     }
+}
+
+#[cfg(feature = "hydrate")]
+fn is_currently_hydrating() -> bool {
+    use_context::<IsHydrating>().is_some_and(|hydrating| hydrating.0)
 }
 
 // Manual Clone/Copy impls to avoid requiring M: Clone/Copy — all fields are

--- a/crates/ars-leptos/src/use_machine/mod.rs
+++ b/crates/ars-leptos/src/use_machine/mod.rs
@@ -255,7 +255,11 @@ where
     let prev_props = StoredValue::<Option<M::Props>>::new(None);
 
     let sync_effect = ImmediateEffect::new_isomorphic(move || {
-        let new_props = props_signal.get();
+        let raw_props = props_signal.get();
+
+        let service_id = service.with_value(|svc| svc.props().id().to_owned());
+
+        let new_props = props_with_service_id::<M>(raw_props, &service_id);
 
         let should_sync = prev_props.with_value(|prev| prev.as_ref() != Some(&new_props));
 
@@ -300,6 +304,14 @@ where
     on_cleanup(move || drop(sync_effect));
 
     result
+}
+
+fn props_with_service_id<M: Machine>(mut props: M::Props, service_id: &str) -> M::Props {
+    if props.id().is_empty() {
+        props.set_id(service_id.to_owned());
+    }
+
+    props
 }
 
 type EffectCleanupStore = StoredValue<HashMap<&'static str, CleanupFn>, LocalStorage>;

--- a/crates/ars-leptos/src/use_machine/mod.rs
+++ b/crates/ars-leptos/src/use_machine/mod.rs
@@ -9,7 +9,7 @@ use std::{
     fmt::{self, Debug},
 };
 
-use ars_core::{CleanupFn, Env, HasId, Machine, Service};
+use ars_core::{CleanupFn, Env, HasId, Machine, RenderMode, Service};
 use leptos::{prelude::*, reactive::owner::LocalStorage};
 #[cfg(any(all(test, target_arch = "wasm32"), not(feature = "ssr")))]
 use {ars_core::StrongSend, std::sync::Arc};
@@ -54,6 +54,16 @@ where
     /// Used by [`derive()`](Self::derive) to track context mutations even when
     /// state remains the same.
     pub context_version: ReadSignal<u64>,
+}
+
+const fn current_render_mode() -> RenderMode {
+    if cfg!(feature = "hydrate") {
+        RenderMode::Hydrating
+    } else if cfg!(feature = "ssr") {
+        RenderMode::Server
+    } else {
+        RenderMode::Client
+    }
 }
 
 // Manual Clone/Copy impls to avoid requiring M: Clone/Copy — all fields are
@@ -315,10 +325,7 @@ where
 
     let messages = use_messages::<M::Messages>(None, Some(&locale));
 
-    let env = Env {
-        locale,
-        intl_backend,
-    };
+    let env = Env::new(locale, intl_backend).with_render_mode(current_render_mode());
 
     // Create the service once — runs only on component initialization.
     let service = StoredValue::new(Service::<M>::new(props, &env, &messages));

--- a/crates/ars-leptos/src/use_machine/test_support.rs
+++ b/crates/ars-leptos/src/use_machine/test_support.rs
@@ -223,6 +223,11 @@ impl Machine for PropMachine {
     }
 
     fn on_props_changed(old: &Self::Props, new: &Self::Props) -> Vec<Self::Event> {
+        assert_eq!(
+            old.id, new.id,
+            "PropMachine id cannot change after initialization"
+        );
+
         let mut events = Vec::new();
 
         if old.checked != new.checked {

--- a/crates/ars-leptos/tests/unit/use_machine.rs
+++ b/crates/ars-leptos/tests/unit/use_machine.rs
@@ -4,7 +4,7 @@ use std::sync::Mutex;
 
 use ars_core::{
     AriaAttr, AttrMap, ComponentPart, ConnectApi, HasId, HtmlAttr, I18nRegistries, IntlBackend,
-    NullPlatformEffects, TransitionPlan,
+    NullPlatformEffects, RenderMode, TransitionPlan,
 };
 use ars_i18n::{Locale, StubIntlBackend};
 use leptos::reactive::traits::Get;
@@ -69,6 +69,44 @@ fn toggle_helper_types_and_test_backend_cover_contract_helpers() {
 }
 
 // --- Tests ---
+
+#[test]
+#[cfg(feature = "ssr")]
+fn current_render_mode_reports_server_for_ssr_builds() {
+    let owner = Owner::new();
+    owner.with(|| {
+        #[cfg(feature = "hydrate")]
+        provide_context(IsHydrating(true));
+
+        assert_eq!(current_render_mode(), RenderMode::Server);
+    });
+}
+
+#[test]
+#[cfg(not(feature = "ssr"))]
+fn current_render_mode_reports_client_without_active_hydration() {
+    let owner = Owner::new();
+    owner.with(|| {
+        assert_eq!(current_render_mode(), RenderMode::Client);
+    });
+}
+
+#[test]
+#[cfg(all(feature = "hydrate", not(feature = "ssr")))]
+fn current_render_mode_uses_hydration_context_at_runtime() {
+    let owner = Owner::new();
+    owner.with(|| {
+        provide_context(IsHydrating(true));
+
+        assert_eq!(current_render_mode(), RenderMode::Hydrating);
+    });
+
+    owner.with(|| {
+        provide_context(IsHydrating(false));
+
+        assert_eq!(current_render_mode(), RenderMode::Client);
+    });
+}
 
 #[test]
 fn use_machine_return_type_is_copy() {

--- a/crates/ars-leptos/tests/unit/use_machine.rs
+++ b/crates/ars-leptos/tests/unit/use_machine.rs
@@ -528,6 +528,76 @@ fn use_machine_with_reactive_props_syncs_state_and_context_changes() {
 }
 
 #[test]
+fn reactive_props_sync_preserves_service_id_when_signal_props_omit_id() {
+    let owner = Owner::new();
+    owner.with(|| {
+        let (props, set_props) = signal(PropProps {
+            id: String::new(),
+            checked: false,
+            label: "a",
+        });
+
+        let machine = use_machine_with_reactive_props::<PropMachine>(props.into());
+
+        let service_id = machine.service.with_value(|service| {
+            let id = service.props().id().to_owned();
+
+            assert!(id.starts_with("component-"));
+
+            id
+        });
+
+        set_props.set(PropProps {
+            id: String::new(),
+            checked: true,
+            label: "a",
+        });
+
+        assert_eq!(machine.state.get_untracked(), PropState::On);
+        assert_eq!(machine.context_version.get_untracked(), 0);
+
+        set_props.set(PropProps {
+            id: String::new(),
+            checked: true,
+            label: "b",
+        });
+
+        assert_eq!(machine.context_version.get_untracked(), 1);
+
+        machine.service.with_value(|service| {
+            assert_eq!(service.props().id(), service_id);
+            assert_eq!(service.context().sync_count, 1);
+        });
+    });
+}
+
+#[test]
+fn reactive_props_sync_preserves_explicit_service_id_when_next_props_omit_id() {
+    let owner = Owner::new();
+    owner.with(|| {
+        let (props, set_props) = signal(PropProps {
+            id: String::from("stable"),
+            checked: false,
+            label: "a",
+        });
+
+        let machine = use_machine_with_reactive_props::<PropMachine>(props.into());
+
+        set_props.set(PropProps {
+            id: String::new(),
+            checked: true,
+            label: "a",
+        });
+
+        assert_eq!(machine.state.get_untracked(), PropState::On);
+
+        machine.service.with_value(|service| {
+            assert_eq!(service.props().id(), "stable");
+        });
+    });
+}
+
+#[test]
 #[expect(
     clippy::redundant_closure_for_method_calls,
     reason = "Method pointers are not general enough for the lifetime-parameterized test API."

--- a/crates/ars-test-harness-dioxus/src/lib.rs
+++ b/crates/ars-test-harness-dioxus/src/lib.rs
@@ -782,10 +782,10 @@ mod tests {
                 container: web_sys::HtmlElement,
                 locale: Option<Locale>,
             ) -> MountedDioxusHarness<MockMachine> {
-                let env = Env {
-                    locale: locale.clone().unwrap_or_else(locales::en_us),
-                    intl_backend: Arc::new(StubIntlBackend) as Arc<dyn IntlBackend>,
-                };
+                let env = Env::new(
+                    locale.clone().unwrap_or_else(locales::en_us),
+                    Arc::new(StubIntlBackend) as Arc<dyn IntlBackend>,
+                );
 
                 let service = Rc::new(RefCell::new(Service::new(MockProps::default(), &env, &())));
 
@@ -826,10 +826,10 @@ mod tests {
                 container: web_sys::HtmlElement,
                 locale: Option<Locale>,
             ) -> MountedDioxusHarness<MockMachine> {
-                let env = Env {
-                    locale: locale.clone().unwrap_or_else(locales::en_us),
-                    intl_backend: Arc::new(StubIntlBackend) as Arc<dyn IntlBackend>,
-                };
+                let env = Env::new(
+                    locale.clone().unwrap_or_else(locales::en_us),
+                    Arc::new(StubIntlBackend) as Arc<dyn IntlBackend>,
+                );
 
                 let service = Rc::new(RefCell::new(Service::new(MockProps::default(), &env, &())));
 

--- a/crates/ars-test-harness-leptos/src/lib.rs
+++ b/crates/ars-test-harness-leptos/src/lib.rs
@@ -726,10 +726,10 @@ mod tests {
                 container: web_sys::HtmlElement,
                 locale: Option<Locale>,
             ) -> MountedLeptosHarness<MockMachine> {
-                let env = Env {
-                    locale: locale.clone().unwrap_or_else(locales::en_us),
-                    intl_backend: Arc::new(StubIntlBackend) as Arc<dyn IntlBackend>,
-                };
+                let env = Env::new(
+                    locale.clone().unwrap_or_else(locales::en_us),
+                    Arc::new(StubIntlBackend) as Arc<dyn IntlBackend>,
+                );
 
                 let service = Arc::new(Mutex::new(Service::new(MockProps::default(), &env, &())));
 
@@ -806,10 +806,10 @@ mod tests {
                 container: web_sys::HtmlElement,
                 locale: Option<Locale>,
             ) -> MountedLeptosHarness<MockMachine> {
-                let env = Env {
-                    locale: locale.clone().unwrap_or_else(locales::en_us),
-                    intl_backend: Arc::new(StubIntlBackend) as Arc<dyn IntlBackend>,
-                };
+                let env = Env::new(
+                    locale.clone().unwrap_or_else(locales::en_us),
+                    Arc::new(StubIntlBackend) as Arc<dyn IntlBackend>,
+                );
 
                 let service = Arc::new(Mutex::new(Service::new(MockProps::default(), &env, &())));
 

--- a/spec/components/date-time/date-field.md
+++ b/spec/components/date-time/date-field.md
@@ -2154,7 +2154,8 @@ mod tests {
 
     #[test]
     fn de_de_segment_order_is_day_month_year() {
-        let env = Env { locale: Locale::parse("de-DE").expect("valid locale"), ..Env::default() };
+        let mut env = Env::default();
+        env.locale = Locale::parse("de-DE").expect("valid locale");
         let svc = Service::new(Props { granularity: DateGranularity::Day, ..Props::default() }, env, Default::default());
         let kinds = svc.context().segments.iter().map(|s| s.kind).collect::<Vec<_>>();
         assert_eq!(kinds, vec![

--- a/spec/components/layout/portal.md
+++ b/spec/components/layout/portal.md
@@ -73,10 +73,13 @@ pub enum PortalTarget {
     PortalRoot,
     /// The document body.
     Body,
-    /// An element with the given ID.
+    /// A declarative element ID target that the adapter must resolve.
     Id(String),
-    /// A direct element ID reference.
-    Ref(String),
+    /// An element ID target that the adapter has confirmed exists.
+    ///
+    /// This is still stable string identity, not a live DOM element or
+    /// framework handle. Adapters own native refs separately.
+    ResolvedId(String),
 }
 
 #[derive(Clone, Debug, Default, PartialEq, HasId)]
@@ -142,7 +145,7 @@ impl ars_core::Machine for Machine {
             {
                 let id = id.clone();
                 Some(TransitionPlan::to(State::Mounted).apply(move |ctx| {
-                    ctx.container = PortalTarget::Ref(id);
+                    ctx.container = PortalTarget::ResolvedId(id);
                     ctx.mounted = true;
                 }))
             }
@@ -316,10 +319,10 @@ Focus management is the responsibility of the overlay component rendered inside 
 
 ### 5.1 Props
 
-| Feature              | ars-ui                          | Radix UI                  | Notes                                                       |
-| -------------------- | ------------------------------- | ------------------------- | ----------------------------------------------------------- |
-| Target container     | `container` (PortalTarget enum) | `container` (HTMLElement) | ars-ui has richer target system (PortalRoot, Body, Id, Ref) |
-| SSR inline rendering | `ssr_inline`                    | --                        | ars-ui addition                                             |
+| Feature              | ars-ui                          | Radix UI                  | Notes                                                              |
+| -------------------- | ------------------------------- | ------------------------- | ------------------------------------------------------------------ |
+| Target container     | `container` (PortalTarget enum) | `container` (HTMLElement) | ars-ui has richer target system (PortalRoot, Body, Id, ResolvedId) |
+| SSR inline rendering | `ssr_inline`                    | --                        | ars-ui addition                                                    |
 
 **Gaps:** None.
 
@@ -341,15 +344,15 @@ Focus management is the responsibility of the overlay component rendered inside 
 
 ### 5.4 Features
 
-| Feature                              | ars-ui core contract                                        | Adapter / DOM responsibility                                     | Radix UI |
-| ------------------------------------ | ----------------------------------------------------------- | ---------------------------------------------------------------- | -------- |
-| Render to different DOM node         | `PortalTarget` and mount state                              | Resolve target and move/render content                           | Yes      |
-| Custom target container              | `PortalTarget::Body`, `Id`, `Ref`, guarded `ContainerReady` | Locate target and report late matching IDs                       | Yes      |
-| SSR inline decision                  | `RenderMode`, `ssr_inline`, `Api::should_render_inline()`   | Set `Env::render_mode` from the framework runtime                | --       |
-| Hydration reattachment               | Stable `id`, owner marker, and render-mode introspection    | Reattach/move DOM nodes during hydration                         | --       |
-| Outside-interaction portal ownership | `data-ars-portal-owner` on `Api::root_attrs()`              | Preserve owner markers on any intermediate mount nodes           | --       |
-| Root stability                       | Stable target identity and prop-change events               | Cache invalidation, root creation, MutationObserver, and cleanup | --       |
-| Z-index layer management             | No z-index state in Portal                                  | Overlay/positioning layer owns stacking                          | --       |
+| Feature                              | ars-ui core contract                                               | Adapter / DOM responsibility                                     | Radix UI |
+| ------------------------------------ | ------------------------------------------------------------------ | ---------------------------------------------------------------- | -------- |
+| Render to different DOM node         | `PortalTarget` and mount state                                     | Resolve target and move/render content                           | Yes      |
+| Custom target container              | `PortalTarget::Body`, `Id`, `ResolvedId`, guarded `ContainerReady` | Locate target and report late matching IDs                       | Yes      |
+| SSR inline decision                  | `RenderMode`, `ssr_inline`, `Api::should_render_inline()`          | Set `Env::render_mode` from the framework runtime                | --       |
+| Hydration reattachment               | Stable `id`, owner marker, and render-mode introspection           | Reattach/move DOM nodes during hydration                         | --       |
+| Outside-interaction portal ownership | `data-ars-portal-owner` on `Api::root_attrs()`                     | Preserve owner markers on any intermediate mount nodes           | --       |
+| Root stability                       | Stable target identity and prop-change events                      | Cache invalidation, root creation, MutationObserver, and cleanup | --       |
+| Z-index layer management             | No z-index state in Portal                                         | Overlay/positioning layer owns stacking                          | --       |
 
 **Gaps:** None against Radix's portable portal surface. ars-ui intentionally
 splits the contract: `ars-components` owns state and adapter-facing metadata;
@@ -358,7 +361,7 @@ framework adapters and `ars-dom` own all DOM mutation and platform observation.
 ### 5.5 Summary
 
 - **Overall:** Full parity for the portal primitive while preserving framework-agnostic layering.
-- **Divergences:** ars-ui uses an enum-based `PortalTarget` instead of a raw DOM element reference, making the API portable across frameworks.
+- **Divergences:** ars-ui uses an enum-based `PortalTarget` instead of a raw DOM element reference, making the API portable across frameworks. Native element references stay in adapter APIs and are never stored in `ars-components`.
 - **Recommended additions:** None.
 
 ## Appendix A: SSR and Hydration Contract
@@ -393,7 +396,7 @@ Adapter and DOM invariants:
 1. `PortalTarget::PortalRoot` resolves to the shared host root managed by `ars-dom`.
 2. `PortalTarget::Body` resolves to the current document body.
 3. `PortalTarget::Id(id)` resolves by element ID. If the element is unavailable, the adapter may wait and dispatch `ContainerReady(id)` only when that exact ID appears.
-4. `PortalTarget::Ref(id)` is already resolved and must not be replaced by a different ID.
+4. `PortalTarget::ResolvedId(id)` records that the adapter has confirmed the element ID exists. It is not a native element reference and must not be replaced by a different ID.
 5. If a cached target is removed or relocated, clear the cache and resolve the target again before the next mount or move.
 
 ## Appendix C: Positioning and Stacking

--- a/spec/components/layout/portal.md
+++ b/spec/components/layout/portal.md
@@ -39,7 +39,8 @@ pub enum Event {
     Unmount,
     /// The target container became available (for `Id` targets that
     /// may not exist at `Mount` time). Carries the element ID and is honored
-    /// only when it matches the current `PortalTarget::Id`.
+    /// only when it matches the current `PortalTarget::Id`, whether the
+    /// portal is still unmounted or already mounted.
     ContainerReady(String),
     /// Synchronize the target container after props change.
     SetContainer(PortalTarget),
@@ -147,6 +148,14 @@ impl ars_core::Machine for Machine {
                 Some(TransitionPlan::to(State::Mounted).apply(move |ctx| {
                     ctx.container = PortalTarget::ResolvedId(id);
                     ctx.mounted = true;
+                }))
+            }
+            (State::Mounted, Event::ContainerReady(id))
+                if matches!(&ctx.container, PortalTarget::Id(target_id) if target_id == id) =>
+            {
+                let id = id.clone();
+                Some(TransitionPlan::context_only(move |ctx| {
+                    ctx.container = PortalTarget::ResolvedId(id);
                 }))
             }
             (_, Event::SetContainer(target)) => {

--- a/spec/components/layout/portal.md
+++ b/spec/components/layout/portal.md
@@ -38,8 +38,11 @@ pub enum Event {
     /// Unmount the portal before the host component unmounts.
     Unmount,
     /// The target container became available (for `Id` targets that
-    /// may not exist at `Mount` time). Carries the element ID.
+    /// may not exist at `Mount` time). Carries the element ID and is honored
+    /// only when it matches the current `PortalTarget::Id`.
     ContainerReady(String),
+    /// Synchronize the target container after props change.
+    SetContainer(PortalTarget),
 }
 ```
 
@@ -52,8 +55,8 @@ pub struct Context {
     pub container: PortalTarget,
     /// Whether the portal is mounted.
     pub mounted: bool,
-    /// Whether the runtime is in SSR mode.
-    pub ssr: bool,
+    /// Runtime render mode resolved by the adapter.
+    pub render_mode: RenderMode,
     /// Component IDs.
     pub ids: ComponentIds,
 }
@@ -107,11 +110,11 @@ impl ars_core::Machine for Machine {
     type Messages = Messages;
     type Api<'a> = Api<'a>;
 
-    fn init(props: &Props, _env: &Env, _messages: &Messages) -> (State, Context) {
+    fn init(props: &Props, env: &Env, _messages: &Messages) -> (State, Context) {
         let ctx = Context {
             container: props.container.clone(),
             mounted: false,
-            ssr: cfg!(feature = "ssr"),
+            render_mode: env.render_mode,
             ids: ComponentIds::from_id(&props.id),
         };
         (State::Unmounted, ctx)
@@ -134,11 +137,19 @@ impl ars_core::Machine for Machine {
                     ctx.mounted = false;
                 }))
             }
-            (State::Unmounted, Event::ContainerReady(id)) => {
+            (State::Unmounted, Event::ContainerReady(id))
+                if matches!(&ctx.container, PortalTarget::Id(target_id) if target_id == id) =>
+            {
                 let id = id.clone();
                 Some(TransitionPlan::to(State::Mounted).apply(move |ctx| {
                     ctx.container = PortalTarget::Ref(id);
                     ctx.mounted = true;
+                }))
+            }
+            (_, Event::SetContainer(target)) => {
+                let target = target.clone();
+                Some(TransitionPlan::context_only(move |ctx| {
+                    ctx.container = target;
                 }))
             }
             _ => None,
@@ -152,6 +163,19 @@ impl ars_core::Machine for Machine {
         send: &'a dyn Fn(Self::Event),
     ) -> Self::Api<'a> {
         Api { state, ctx, props, send }
+    }
+
+    fn on_props_changed(old: &Self::Props, new: &Self::Props) -> Vec<Self::Event> {
+        assert_eq!(
+            old.id, new.id,
+            "Portal id cannot change after initialization"
+        );
+
+        if old.container == new.container {
+            Vec::new()
+        } else {
+            vec![Event::SetContainer(new.container.clone())]
+        }
     }
 }
 ```
@@ -178,20 +202,50 @@ impl<'a> Api<'a> {
         *self.state == State::Mounted
     }
 
+    /// Returns the currently resolved portal target.
+    pub const fn target(&self) -> &PortalTarget {
+        &self.ctx.container
+    }
+
+    /// Returns the runtime render mode resolved by the adapter.
+    pub const fn render_mode(&self) -> RenderMode {
+        self.ctx.render_mode
+    }
+
+    /// Returns whether SSR should render portal content inline.
+    pub const fn ssr_inline(&self) -> bool {
+        self.props.ssr_inline
+    }
+
+    /// Returns the stable portal owner ID used by outside-interaction helpers.
+    pub fn owner_id(&self) -> &str {
+        self.ctx.ids.id()
+    }
+
+    /// Returns whether portal content should render inline at the declaration
+    /// site for the current runtime mode.
+    pub const fn should_render_inline(&self) -> bool {
+        self.props.ssr_inline && self.ctx.render_mode.is_server()
+    }
+
     /// The generated portal root element ID, usable for `aria-owns` on triggers.
     pub fn portal_root_id(&self) -> String {
-        format!("ars-portal-{}", self.props.id)
+        format!("ars-portal-{}", self.ctx.ids.id())
     }
 
     pub fn root_attrs(&self) -> AttrMap {
         let mut attrs = AttrMap::new();
         let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Root.data_attrs();
-        attrs.set(scope_attr, scope_val);
-        attrs.set(part_attr, part_val);
-        attrs.set(HtmlAttr::Data("ars-portal-id"), &self.props.id);
-        attrs.set(HtmlAttr::Data("ars-state"),
-            if self.is_mounted() { "mounted" } else { "unmounted" },
-        );
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Id, self.portal_root_id())
+            .set(HtmlAttr::Data("ars-portal-id"), self.ctx.ids.id())
+            .set(HtmlAttr::Data("ars-portal-owner"), self.ctx.ids.id())
+            .set(
+                HtmlAttr::Data("ars-state"),
+                if self.is_mounted() { "mounted" } else { "unmounted" },
+            );
         attrs
     }
 
@@ -214,20 +268,26 @@ impl ConnectApi for Api<'_> {
 
 ```text
 Portal
-└── Root  <div>  data-ars-scope="portal" data-ars-part="root"
-                 data-ars-portal-id="<id>" data-ars-state="unmounted|mounted"
+└── Root  <div>  id="ars-portal-<id>" data-ars-scope="portal"
+                 data-ars-part="root" data-ars-portal-id="<id>"
+                 data-ars-portal-owner="<id>" data-ars-state="unmounted|mounted"
 ```
 
-| Part | Element | Key Attributes                                              |
-| ---- | ------- | ----------------------------------------------------------- |
-| Root | `<div>` | `data-ars-portal-id`, `data-ars-state="unmounted\|mounted"` |
+| Part | Element | Key Attributes                                                                                               |
+| ---- | ------- | ------------------------------------------------------------------------------------------------------------ |
+| Root | `<div>` | `id="ars-portal-<id>"`, `data-ars-portal-id`, `data-ars-portal-owner`, `data-ars-state="unmounted\|mounted"` |
 
-Root is the mount point inserted at the portal target container.
+Root is the per-instance mount node inserted at the portal target container.
+Adapters MUST apply `Api::root_attrs()` to this owned mount node itself. They
+MUST NOT create a separate child wrapper with the same root attrs, because that
+would duplicate `id="ars-portal-<id>"`.
 
 When `PortalTarget::PortalRoot` is used, the web adapter MUST create or reuse
-the mount node through `ars_dom::ensure_portal_mount_root(props.id)`. This
-ensures the mount node ID stays stable as `ars-portal-<id>` and carries
-`data-ars-portal-owner="<id>"` for outside-interaction boundary detection.
+the per-instance mount node through
+`ars_dom::ensure_portal_mount_root(api.owner_id())`, then merge
+`Api::root_attrs()` onto that same node. The component root ID stays stable as
+`ars-portal-<id>` and carries `data-ars-portal-owner="<id>"` for
+outside-interaction boundary detection.
 
 ## 3. Accessibility
 
@@ -281,147 +341,103 @@ Focus management is the responsibility of the overlay component rendered inside 
 
 ### 5.4 Features
 
-| Feature                             | ars-ui | Radix UI |
-| ----------------------------------- | ------ | -------- |
-| Render to different DOM node        | Yes    | Yes      |
-| Custom target container             | Yes    | Yes      |
-| SSR support                         | Yes    | --       |
-| Hydration reattachment              | Yes    | --       |
-| Z-index layer management            | Yes    | --       |
-| MutationObserver for root stability | Yes    | --       |
+| Feature                              | ars-ui core contract                                        | Adapter / DOM responsibility                                     | Radix UI |
+| ------------------------------------ | ----------------------------------------------------------- | ---------------------------------------------------------------- | -------- |
+| Render to different DOM node         | `PortalTarget` and mount state                              | Resolve target and move/render content                           | Yes      |
+| Custom target container              | `PortalTarget::Body`, `Id`, `Ref`, guarded `ContainerReady` | Locate target and report late matching IDs                       | Yes      |
+| SSR inline decision                  | `RenderMode`, `ssr_inline`, `Api::should_render_inline()`   | Set `Env::render_mode` from the framework runtime                | --       |
+| Hydration reattachment               | Stable `id`, owner marker, and render-mode introspection    | Reattach/move DOM nodes during hydration                         | --       |
+| Outside-interaction portal ownership | `data-ars-portal-owner` on `Api::root_attrs()`              | Preserve owner markers on any intermediate mount nodes           | --       |
+| Root stability                       | Stable target identity and prop-change events               | Cache invalidation, root creation, MutationObserver, and cleanup | --       |
+| Z-index layer management             | No z-index state in Portal                                  | Overlay/positioning layer owns stacking                          | --       |
 
-**Gaps:** None.
+**Gaps:** None against Radix's portable portal surface. ars-ui intentionally
+splits the contract: `ars-components` owns state and adapter-facing metadata;
+framework adapters and `ars-dom` own all DOM mutation and platform observation.
 
 ### 5.5 Summary
 
-- **Overall:** Full parity. ars-ui significantly exceeds Radix UI's Portal with SSR support, hydration reattachment, z-index management, and MutationObserver-based root stability.
+- **Overall:** Full parity for the portal primitive while preserving framework-agnostic layering.
 - **Divergences:** ars-ui uses an enum-based `PortalTarget` instead of a raw DOM element reference, making the API portable across frameworks.
 - **Recommended additions:** None.
 
-## Appendix A: SSR Considerations
+## Appendix A: SSR and Hydration Contract
 
-| Scenario                | Behaviour                                                            |
-| ----------------------- | -------------------------------------------------------------------- |
-| SSR, `ssr_inline=true`  | Content rendered at declaration site; no portal in HTML.             |
-| SSR, `ssr_inline=false` | Nothing rendered; client-side JS mounts the content after hydration. |
-| Hydration               | Framework reattaches portal to the correct container.                |
-| No-JS / progressive     | Inline content is functional; portals degrade gracefully.            |
+`ars-components::layout::portal` does not inspect crate features directly.
+Framework adapters set `Env::render_mode`; Portal exposes
+`Api::should_render_inline()` as the portable decision point.
 
-### A.1 Hydration Reattachment
+| Scenario                                 | Core decision                     | Adapter behavior                                                        |
+| ---------------------------------------- | --------------------------------- | ----------------------------------------------------------------------- |
+| `RenderMode::Server`, `ssr_inline=true`  | `should_render_inline() == true`  | Render content at the declaration site with `Api::root_attrs()`.        |
+| `RenderMode::Server`, `ssr_inline=false` | `should_render_inline() == false` | Omit portal content from server HTML.                                   |
+| `RenderMode::Hydrating`                  | `should_render_inline() == false` | Reattach or move existing server-rendered nodes to the resolved target. |
+| `RenderMode::Client`                     | `should_render_inline() == false` | Mount content into the resolved target after receiving `Event::Mount`.  |
 
-```rust
-/// Called by the framework hydration layer to reattach a portal node
-/// from its inline SSR position to its runtime target.
-pub fn hydrate_portal(portal_id: &str, target: &PortalTarget) {
-    let Some(document) = web_sys::window().and_then(|w| w.document()) else {
-        log::warn!("hydrate_portal: no document available, skipping");
-        return;
-    };
+Hydration reattachment invariants:
 
-    // Escape special characters to prevent CSS selector injection.
-    let escaped_id = portal_id.replace('\\', "\\\\").replace('\'', "\\'").replace(']', "\\]");
-    let selector = format!("[data-ars-portal-id='{}']", escaped_id);
-    let node = document.query_selector(&selector).ok().flatten();
-
-    let container: Option<web_sys::Element> = match target {
-        PortalTarget::PortalRoot => get_or_create_portal_root(),
-        PortalTarget::Body => document.body().map(|b| b.into()),
-        PortalTarget::Id(id) => document.get_element_by_id(id),
-        PortalTarget::Ref(id) => document.get_element_by_id(id),
-    };
-
-    if let (Some(node), Some(container)) = (node, container) {
-        if let Some(old_parent) = node.parent_node() {
-            let _ = old_parent.remove_child(&node);
-        }
-        if let Err(e) = container.append_child(&node) {
-            log::warn!("hydrate_portal: failed to reattach portal: {:?}", e);
-        }
-    }
-}
-```
-
-Reattachment invariants:
-
-1. Remove from old location before appending to new — adapter references to the old parent are invalid after move.
-2. If duplicate `portal_id` is found, log an error and abort.
-3. Adapters MUST re-attach event listeners after hydration reattachment completes.
+1. Select the portal node by its stable `id="ars-portal-<id>"` or matching `data-ars-portal-id`.
+2. If duplicate portal nodes for the same ID are found, log an error and abort reattachment for that instance.
+3. Remove from the old location before appending to the target container.
+4. Preserve `data-ars-portal-owner="<id>"` on any moved root or intermediate mount node.
+5. Reattach framework event listeners according to the adapter runtime's hydration rules.
 
 ## Appendix B: Portal Root Stability
 
-The portal root element (`#ars-portal-root` or a custom `PortalTarget`) may be removed or relocated by application code, third-party scripts, or framework reconciliation. The adapter MUST observe the portal root for unexpected mutations.
+Portal core stores target identity and emits `SetContainer` when the container
+prop changes. DOM root creation, cache invalidation, and cleanup live in
+`ars-dom` and framework adapters.
 
-**MutationObserver Setup:**
+Adapter and DOM invariants:
 
-- Observe the portal root's **parent** with `{ childList: true, subtree: true }` to detect when the portal root itself is removed.
-- On detecting removal (the portal root is no longer in `document.body`'s subtree), **clear the cached reference** and log a warning: `"Portal root was removed from DOM; cached reference invalidated."`.
-
-**Debouncing:**
-
-- Limit to **one invalidation check per microtask** using `queueMicrotask()`. Rapid DOM mutations (e.g., framework reconciliation batches) should not trigger multiple cache clears.
-
-**SSR Hydration Edge Cases:**
-
-- During hydration, the portal root may not exist in the SSR-rendered HTML. The `get_or_create_portal_root()` function handles lazy creation, but the MutationObserver MUST NOT be attached until after hydration completes (i.e., after `hydrate_portal()` runs).
-- If the portal root is relocated (moved to a different parent) rather than removed, treat this as a removal + re-creation: clear the cache and let the next `resolve_portal_target()` call find the element in its new location.
+1. `PortalTarget::PortalRoot` resolves to the shared host root managed by `ars-dom`.
+2. `PortalTarget::Body` resolves to the current document body.
+3. `PortalTarget::Id(id)` resolves by element ID. If the element is unavailable, the adapter may wait and dispatch `ContainerReady(id)` only when that exact ID appears.
+4. `PortalTarget::Ref(id)` is already resolved and must not be replaced by a different ID.
+5. If a cached target is removed or relocated, clear the cache and resolve the target again before the next mount or move.
 
 ## Appendix C: Positioning and Stacking
 
-**Default target:** `PortalTarget::PortalRoot` renders into `#ars-portal-root`, a dedicated container appended to `document.body`.
+Portal does not own z-index, placement, or layout measurement. Overlay
+components rendered inside Portal own positioning policy and use shared
+positioning utilities for measurement and auto-update.
 
-**Custom target:** `PortalTarget::Id(String)` or `PortalTarget::Ref(String)` for rendering into a specific application-managed container (both use element IDs).
+Positioning invariants for overlays that use Portal:
 
-**Z-index layer scale:**
-
-| Layer      | Z-index range | Usage                          |
-| ---------- | ------------- | ------------------------------ |
-| `base`     | 0-99          | Normal document flow           |
-| `dropdown` | 1000-1099     | Dropdowns, select menus        |
-| `sticky`   | 1100-1199     | Sticky headers, footers        |
-| `overlay`  | 1300-1399     | Modals, dialogs                |
-| `popover`  | 1400-1499     | Popovers, tooltips             |
-| `toast`    | 1500-1599     | Toast notifications            |
-| `maximum`  | 1600+         | Topmost elements (debug tools) |
-
-- Adapters MAY expose a `z_index_base: Option<u32>` prop to override the default layer for a given portal instance.
-- **Multiple portals:** When multiple portals are mounted simultaneously, they stack in creation order with the newest on top (highest z-index within its layer). Portals created later receive a monotonically increasing z-index offset within their layer.
-- **Scroll containment:** Portal content MUST NOT cause `document.body` to scroll. Portaled overlays should use `position: fixed` (relative to viewport) or `position: absolute` (relative to the portal root) to avoid influencing body scroll dimensions.
-- **Cleanup:** The portal container element is removed from the DOM when the owning component unmounts. If the portal root has no remaining children, it MAY be left in place (to avoid re-creation cost) but MUST NOT interfere with layout.
+1. Use the resolved portal target only as the render container.
+2. Compute overlay placement relative to the trigger/anchor and viewport, not relative to the logical component tree.
+3. Preserve scroll containment by using positioning strategies that do not expand `document.body`.
+4. Keep z-index policy in overlay or layer-management components, not in Portal state.
 
 ## Appendix D: Font Loading Race Conditions
 
-Font loading can cause layout shifts that invalidate overlay positioning calculations (popovers, tooltips, dropdowns rendered via Portal). Adapters MUST account for font loading timing.
+Font loading invalidates overlay measurements, but it does not affect the
+Portal state machine. Adapters or overlay positioning utilities must trigger
+recalculation when font metrics change.
 
-**Detection:**
+Platform invariants:
 
-- Listen to `document.fonts.status` via `FontFaceSet` API. If `document.fonts.status === "loading"`, defer initial positioning calculations until `document.fonts.ready` resolves.
-- After `document.fonts.ready`, trigger a single recalculation of all active overlay positions.
-
-**Ongoing Font Loads:**
-
-- Register a `loadingdone` event listener on `document.fonts` to recalculate overlay positions when new fonts finish loading (e.g., lazy-loaded font faces triggered by newly rendered content in a portal).
-
-**CSS `font-display` Guidance:**
-
-- Recommend `font-display: swap` in documentation. With `swap`, text renders immediately in a fallback font and reflows on font load — the recalculation listener above handles the resulting layout shift.
-- `font-display: block` (invisible text until font loads) may cause overlays to position against zero-height content. The `document.fonts.ready` deferral mitigates this.
-
-**SSR Context:**
-
-- `document.fonts` is unavailable during SSR. Guard all `FontFaceSet` access with the appropriate Rust/WASM feature gate (`#[cfg(target_arch = "wasm32")]`). SSR-rendered overlays will be repositioned on hydration.
+1. On web targets with `FontFaceSet`, defer initial overlay positioning when `document.fonts.status == "loading"`.
+2. Recalculate active overlay positions once `document.fonts.ready` resolves.
+3. Recalculate on later `loadingdone` events for lazy-loaded fonts.
+4. Guard all font API access behind the appropriate web-target checks.
 
 ## Appendix E: Automatic Repositioning on Resize
 
-Popover and tooltip overlays must reposition automatically when their anchor or viewport changes size:
+Resize handling belongs to overlay positioning utilities, not Portal. For
+portaled popovers, tooltips, menus, and similar overlays:
 
-1. **`ResizeObserver` on Anchor**: Attach a `ResizeObserver` to the anchor element. On resize callback, invoke `compute_position()` to recalculate overlay placement.
-2. **`window.resize` Event**: Listen for `window` `resize` events, debounced at 100ms, to trigger repositioning. This handles browser window resizing and desktop display changes.
-3. **`visualViewport.resize` for Mobile**: On mobile devices, listen for `window.visualViewport` `resize` events to handle virtual keyboard appearance/disappearance. This event is not debounced (keyboard animations are already brief).
-4. **Adapter Contract**: The adapter must call `compute_position()` on each resize event. The core library provides the positioning algorithm; the adapter is responsible for wiring up the platform-specific resize observers and invoking the recomputation.
+1. Observe anchor size changes.
+2. Observe viewport size changes.
+3. Observe mobile visual viewport changes where available.
+4. Recompute placement through the shared positioning engine.
+5. Clean up observers when the owning overlay unmounts.
 
 ## Appendix F: iframe Boundary Handling
 
-1. Portal must detect if the target container is inside an iframe. If so, and the iframe is cross-origin, the portal falls back to rendering within the current document (logs a warning).
-2. Content portaled near iframe boundaries may be clipped — the positioning engine must account for iframe viewport bounds.
-3. Z-index stacking: portaled content inside an iframe inherits the iframe's stacking context; it cannot escape the iframe's z-index layer.
-4. Portal to `document.body` is always same-origin and safe.
+iframe behavior is a DOM target-resolution concern:
+
+1. Same-document targets are safe to resolve normally.
+2. Same-origin iframe targets may be resolved by adapter/DOM utilities that have access to that frame's document.
+3. Cross-origin iframe targets cannot be inspected or moved into; adapters must keep content in the current document and log a warning.
+4. Portaled content inside an iframe inherits that iframe's stacking and clipping boundaries.

--- a/spec/components/overlay/tooltip.md
+++ b/spec/components/overlay/tooltip.md
@@ -110,6 +110,8 @@ pub struct Context {
     pub focus_active: bool,
     /// The positioning options for the tooltip.
     pub positioning: PositioningOptions,
+    /// Derived component part IDs.
+    pub ids: ComponentIds,
     /// The ID of the trigger element.
     pub trigger_id: String,
     /// The ID of the visible content element.
@@ -293,6 +295,7 @@ impl ars_core::Machine for Machine {
             hover_active: false,
             focus_active: false,
             positioning: props.positioning.clone(),
+            ids: ids.clone(),
             trigger_id: ids.part("trigger"),
             hidden_description_id: format!("{content_id}-description"),
             content_id,
@@ -518,6 +521,11 @@ impl ars_core::Machine for Machine {
         Api { state, ctx, props, send }
     }
     fn on_props_changed(old: &Self::Props, new: &Self::Props) -> Vec<Self::Event> {
+        assert_eq!(
+            old.id, new.id,
+            "Tooltip id cannot change after initialization"
+        );
+
         let mut events = Vec::new();
 
         match (old.open, new.open) {
@@ -600,11 +608,14 @@ impl<'a> Api<'a> {
     pub fn trigger_attrs(&self) -> AttrMap {
         let mut attrs = AttrMap::new();
         let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Trigger.data_attrs();
-        attrs.set(HtmlAttr::Id, &self.ctx.trigger_id);
+        attrs.set(HtmlAttr::Id, self.ctx.ids.part("trigger"));
         attrs.set(scope_attr, scope_val);
         attrs.set(part_attr, part_val);
         // Always point to the hidden description span, not just when open
-        attrs.set(HtmlAttr::Aria(AriaAttr::DescribedBy), &self.ctx.hidden_description_id);
+        attrs.set(
+            HtmlAttr::Aria(AriaAttr::DescribedBy),
+            format!("{}-description", self.ctx.ids.part("content")),
+        );
         if self.ctx.disabled {
             attrs.set(HtmlAttr::Aria(AriaAttr::Disabled), "true");
         }
@@ -679,7 +690,10 @@ impl<'a> Api<'a> {
         let [(scope_attr, scope_val), (part_attr, part_val)] = Part::HiddenDescription.data_attrs();
         attrs.set(scope_attr, scope_val);
         attrs.set(part_attr, part_val);
-        attrs.set(HtmlAttr::Id, &self.ctx.hidden_description_id);
+        attrs.set(
+            HtmlAttr::Id,
+            format!("{}-description", self.ctx.ids.part("content")),
+        );
         attrs.set(HtmlAttr::Data("ars-visually-hidden"), "true");
         // Visually hidden but accessible to screen readers
         attrs
@@ -705,7 +719,7 @@ impl<'a> Api<'a> {
         let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Content.data_attrs();
         attrs.set(scope_attr, scope_val);
         attrs.set(part_attr, part_val);
-        attrs.set(HtmlAttr::Id, &self.ctx.content_id);
+        attrs.set(HtmlAttr::Id, self.ctx.ids.part("content"));
         attrs.set(HtmlAttr::Aria(AriaAttr::Hidden), "true");
         attrs.set(HtmlAttr::Data("ars-state"), if self.is_open() { "open" } else { "closed" });
         attrs.set(HtmlAttr::Dir, self.ctx.dir.as_html_attr());
@@ -947,26 +961,26 @@ When the Tooltip machine receives `PointerEnter` or `Focus` in the `Closed` stat
 
 ### 6.1 Props
 
-| Feature               | ars-ui               | Ark UI               | Radix UI                        | React Aria                         | Notes                                                          |
-| --------------------- | -------------------- | -------------------- | ------------------------------- | ---------------------------------- | -------------------------------------------------------------- |
-| Controlled open       | `open`               | `open`               | `open`                          | `isOpen`                           | All libraries                                                  |
-| Default open          | `default_open`       | `defaultOpen`        | `defaultOpen`                   | `defaultOpen`                      | All libraries                                                  |
-| Open delay            | `open_delay`         | `openDelay`          | `delayDuration`                 | `delay`                            | All libraries; different defaults                              |
-| Close delay           | `close_delay`        | `closeDelay`         | --                              | `closeDelay`                       | Ark UI/React Aria; Radix uses provider-level skipDelayDuration |
-| Disabled              | `disabled`           | `disabled`           | --                              | `isDisabled`                       | All except Radix                                               |
-| Close on Escape       | `close_on_escape`    | `closeOnEscape`      | (onEscapeKeyDown)               | `isKeyboardDismissDisabled`        | All libraries                                                  |
-| Close on click        | `close_on_click`     | `closeOnClick`       | --                              | --                                 | Ark UI parity                                                  |
-| Close on pointer down | --                   | `closeOnPointerDown` | --                              | --                                 | Subsumed by `close_on_click`                                   |
-| Close on scroll       | `close_on_scroll`    | `closeOnScroll`      | --                              | --                                 | Ark UI parity                                                  |
-| Positioning           | `positioning`        | `positioning`        | (side/sideOffset/align)         | `placement`/`offset`/`crossOffset` | ars-ui unified struct                                          |
-| Dir                   | `dir`                | --                   | --                              | --                                 | ars-ui addition for mixed-direction                            |
-| Lazy mount            | `lazy_mount`         | `lazyMount`          | --                              | --                                 | Ark UI parity                                                  |
-| Unmount on exit       | `unmount_on_exit`    | `unmountOnExit`      | (forceMount inverse)            | --                                 | Ark UI parity                                                  |
-| Open change callback  | `on_open_change`     | `onOpenChange`       | `onOpenChange`                  | `onOpenChange`                     | All libraries                                                  |
-| Touch auto-hide       | `touch_auto_hide`    | --                   | --                              | --                                 | Adapter-owned ars-ui addition                                  |
-| `aria-label`          | (HiddenDescription)  | `aria-label`         | `aria-label`                    | --                                 | ars-ui uses always-rendered hidden span                        |
-| Skip delay duration   | (TooltipGroup)       | --                   | `skipDelayDuration`             | --                                 | Provider-level warmup/cooldown                                 |
-| Focus-only trigger    | --                   | --                   | --                              | `trigger="focus"`                  | React Aria only                                                |
+| Feature               | ars-ui              | Ark UI               | Radix UI                | React Aria                         | Notes                                                          |
+| --------------------- | ------------------- | -------------------- | ----------------------- | ---------------------------------- | -------------------------------------------------------------- |
+| Controlled open       | `open`              | `open`               | `open`                  | `isOpen`                           | All libraries                                                  |
+| Default open          | `default_open`      | `defaultOpen`        | `defaultOpen`           | `defaultOpen`                      | All libraries                                                  |
+| Open delay            | `open_delay`        | `openDelay`          | `delayDuration`         | `delay`                            | All libraries; different defaults                              |
+| Close delay           | `close_delay`       | `closeDelay`         | --                      | `closeDelay`                       | Ark UI/React Aria; Radix uses provider-level skipDelayDuration |
+| Disabled              | `disabled`          | `disabled`           | --                      | `isDisabled`                       | All except Radix                                               |
+| Close on Escape       | `close_on_escape`   | `closeOnEscape`      | (onEscapeKeyDown)       | `isKeyboardDismissDisabled`        | All libraries                                                  |
+| Close on click        | `close_on_click`    | `closeOnClick`       | --                      | --                                 | Ark UI parity                                                  |
+| Close on pointer down | --                  | `closeOnPointerDown` | --                      | --                                 | Subsumed by `close_on_click`                                   |
+| Close on scroll       | `close_on_scroll`   | `closeOnScroll`      | --                      | --                                 | Ark UI parity                                                  |
+| Positioning           | `positioning`       | `positioning`        | (side/sideOffset/align) | `placement`/`offset`/`crossOffset` | ars-ui unified struct                                          |
+| Dir                   | `dir`               | --                   | --                      | --                                 | ars-ui addition for mixed-direction                            |
+| Lazy mount            | `lazy_mount`        | `lazyMount`          | --                      | --                                 | Ark UI parity                                                  |
+| Unmount on exit       | `unmount_on_exit`   | `unmountOnExit`      | (forceMount inverse)    | --                                 | Ark UI parity                                                  |
+| Open change callback  | `on_open_change`    | `onOpenChange`       | `onOpenChange`          | `onOpenChange`                     | All libraries                                                  |
+| Touch auto-hide       | `touch_auto_hide`   | --                   | --                      | --                                 | Adapter-owned ars-ui addition                                  |
+| `aria-label`          | (HiddenDescription) | `aria-label`         | `aria-label`            | --                                 | ars-ui uses always-rendered hidden span                        |
+| Skip delay duration   | (TooltipGroup)      | --                   | `skipDelayDuration`     | --                                 | Provider-level warmup/cooldown                                 |
+| Focus-only trigger    | --                  | --                   | --                      | `trigger="focus"`                  | React Aria only                                                |
 
 **Intentional divergences:** Tooltip does not expose interactive content support. Interactive
 floating content belongs in HoverCard or Popover. React Aria's `trigger="focus"` (show only on

--- a/spec/components/utility/form.md
+++ b/spec/components/utility/form.md
@@ -54,7 +54,7 @@ The machine context stores:
 - `server_errors`
 - `status_message`
 - `last_submit_succeeded`
-- `ids`
+- `ids: ComponentIds`
 
 ### 1.5 Props
 

--- a/spec/dioxus-components/layout/portal.md
+++ b/spec/dioxus-components/layout/portal.md
@@ -40,18 +40,20 @@ The adapter surface matches the core props. It does not add a separate adapter-o
 
 ## 4. Part Mapping
 
-| Core part / structure | Required?             | Adapter rendering target                                                                              | Ownership     | Attr source        | Notes                                                                              |
-| --------------------- | --------------------- | ----------------------------------------------------------------------------------------------------- | ------------- | ------------------ | ---------------------------------------------------------------------------------- |
-| `Root`                | required when mounted | detached `<div>` appended to the resolved host container on web, or host fallback container elsewhere | adapter-owned | `api.root_attrs()` | The root is the logical mount point, not a visual wrapper at the declaration site. |
+| Core part / structure | Required?             | Adapter rendering target                                                                              | Ownership     | Attr source        | Notes                                                                                      |
+| --------------------- | --------------------- | ----------------------------------------------------------------------------------------------------- | ------------- | ------------------ | ------------------------------------------------------------------------------------------ |
+| `Root`                | required when mounted | detached `<div>` appended to the resolved host container on web, or host fallback container elsewhere | adapter-owned | `api.root_attrs()` | The owned mount node is the Root; do not create a child wrapper with duplicate root attrs. |
 
 ## 5. Attr Merge and Ownership Rules
 
-| Target node       | Core attrs                                                        | Adapter-owned attrs                                                           | Consumer attrs                                      | Merge order                                              | Ownership notes                  |
-| ----------------- | ----------------------------------------------------------------- | ----------------------------------------------------------------------------- | --------------------------------------------------- | -------------------------------------------------------- | -------------------------------- |
-| portal mount root | `api.root_attrs()` including `data-ars-portal-id` and mount state | target ownership markers, cleanup bookkeeping, and optional boundary metadata | no direct consumer attr ownership at the mount node | core `data-ars-*` attrs and portal ownership markers win | mount root remains adapter-owned |
+| Target node       | Core attrs                                                                      | Adapter-owned attrs                                | Consumer attrs                                      | Merge order                          | Ownership notes                  |
+| ----------------- | ------------------------------------------------------------------------------- | -------------------------------------------------- | --------------------------------------------------- | ------------------------------------ | -------------------------------- |
+| portal mount root | `api.root_attrs()` including `id`, `data-ars-portal-id`, owner, and mount state | cleanup bookkeeping and optional boundary metadata | no direct consumer attr ownership at the mount node | core `id` and `data-ars-*` attrs win | mount root remains adapter-owned |
 
 - Consumer children own only the content rendered inside the portal root.
 - The adapter must not let consumer content replace or delete the documented mount node.
+- `api.root_attrs()` is applied to the owned mount node itself. It is not applied
+  to a nested wrapper under `ars_dom::ensure_portal_mount_root(api.owner_id())`.
 
 ## 6. Composition / Context Contract
 
@@ -59,16 +61,16 @@ The adapter surface matches the core props. It does not add a separate adapter-o
 
 ## 7. Prop Sync and Event Mapping
 
-| Adapter prop | Mode       | Sync trigger            | Machine event / update path                                            | Visible effect                                                                      | Notes                                             |
-| ------------ | ---------- | ----------------------- | ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------- |
-| `container`  | controlled | prop change after mount | adapter resolves target then dispatches `Mount` into the new container | moves or recreates the portal root under the new target                             | target switching must clean up the old root first |
-| `ssr_inline` | controlled | render-time only        | adapter SSR branch only                                                | renders children inline during SSR instead of an empty declaration-site placeholder | not a post-mount reactive behavior                |
+| Adapter prop | Mode       | Sync trigger            | Machine event / update path                                                   | Visible effect                                                                      | Notes                                             |
+| ------------ | ---------- | ----------------------- | ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------- |
+| `container`  | controlled | prop change after mount | core `on_props_changed` emits `SetContainer`; adapter resolves the new target | moves or recreates the portal root under the new target                             | target switching must clean up the old root first |
+| `ssr_inline` | controlled | render-time only        | `Api::should_render_inline()`                                                 | renders children inline during SSR instead of an empty declaration-site placeholder | not a post-mount reactive behavior                |
 
 | UI or lifecycle event | Preconditions                              | Machine event / callback path | Ordering notes                                       | Notes                                                                                         |
 | --------------------- | ------------------------------------------ | ----------------------------- | ---------------------------------------------------- | --------------------------------------------------------------------------------------------- |
 | component mount       | platform can supply a target container     | `Mount`                       | create root before child content is rendered into it | web uses a detached DOM root; other platforms may fall back to inline or host-native mounting |
 | component cleanup     | root currently mounted                     | `Unmount`                     | remove root after child teardown                     | cleanup is adapter-owned                                                                      |
-| late target discovery | `PortalTarget::Id` not initially available | `ContainerReady` then `Mount` | late resolution must not leak orphan roots           | web-first behavior for late DOM availability                                                  |
+| late target discovery | `PortalTarget::Id` not initially available | `ContainerReady`              | late resolution must not leak orphan roots           | core accepts only the matching ID and marks the portal mounted                                |
 
 ## 8. Registration and Cleanup Contract
 
@@ -136,7 +138,7 @@ The adapter surface matches the core props. It does not add a separate adapter-o
 ## 17. Recommended Implementation Sequence
 
 1. Initialize the core portal machine and derive the portal id.
-2. Branch SSR behavior from runtime behavior using `ssr_inline`.
+2. Branch SSR behavior from runtime behavior using `Api::should_render_inline()`.
 3. Resolve the target container and create the mount root when the host can support it.
 4. Render children into the mount root or documented fallback path.
 5. Handle target switches and cleanup without leaking roots or watchers.
@@ -196,7 +198,13 @@ pub fn Portal(props: PortalProps) -> Element {
         ssr_inline: props.ssr_inline,
         ..Default::default()
     });
-    rsx! { {props.children} }
+    let render_inline = machine.derive(|api| api.should_render_inline());
+
+    if render_inline() {
+        rsx! { {props.children} }
+    } else {
+        rsx! {}
+    }
 }
 ```
 
@@ -219,16 +227,26 @@ pub fn Portal(props: PortalProps) -> Element {
         ..Default::default()
     });
     let mut mount_root = use_signal(|| None::<HostNode>);
+    let render_inline = machine.derive(|api| api.should_render_inline());
 
     use_effect(move || {
+        if render_inline() {
+            return;
+        }
+
         if let Some(target) = resolve_portal_target(&props.container) {
-            mount_root.set(Some(ensure_portal_root(&machine, target)));
+            let owner_id = machine.with_api_snapshot(|api| api.owner_id().to_string());
+            let mount = ars_dom::ensure_portal_mount_root(&owner_id);
+            apply_attrs(&mount, machine.derive(|api| api.root_attrs()));
+            move_mount_to_target(&mount, target);
+            render_children_into_mount(&mount);
+            mount_root.set(Some(mount));
         }
     });
 
     use_drop(move || remove_portal_root(mount_root.read().clone()));
 
-    if props.ssr_inline {
+    if render_inline() {
         rsx! { {props.children} }
     } else {
         rsx! {}

--- a/spec/foundation/01-architecture.md
+++ b/spec/foundation/01-architecture.md
@@ -433,6 +433,30 @@ pub trait ConnectApi {
 /// - Non-`String` `id` field → `"HasId: `id` field must be of type String"`
 /// - Applied to enum or union → `"HasId can only be derived for structs"`
 
+/// Runtime render mode resolved by the adapter before initializing a machine.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum RenderMode {
+    /// The component is rendering in a normal client runtime.
+    #[default]
+    Client,
+    /// The component is rendering HTML on the server.
+    Server,
+    /// The component is hydrating server-rendered HTML on the client.
+    Hydrating,
+}
+
+impl RenderMode {
+    /// Returns whether this mode is server-side rendering.
+    pub const fn is_server(self) -> bool {
+        matches!(self, Self::Server)
+    }
+
+    /// Returns whether this mode is client hydration.
+    pub const fn is_hydrating(self) -> bool {
+        matches!(self, Self::Hydrating)
+    }
+}
+
 /// Adapter-resolved environment context passed to `Machine::init()`.
 ///
 /// The adapter reads these values from `ArsProvider` / `ArsContext` and passes
@@ -447,6 +471,26 @@ pub struct Env {
     /// Calendar/locale data provider for date-time formatting.
     /// Defaults to `StubIntlBackend` (English-only, zero dependencies).
     pub intl_backend: Arc<dyn IntlBackend>,
+    /// Runtime render mode for server, hydration, or normal client rendering.
+    pub render_mode: RenderMode,
+}
+
+impl Env {
+    /// Creates an environment with the supplied locale and internationalization
+    /// backend in normal client render mode.
+    pub fn new(locale: Locale, intl_backend: Arc<dyn IntlBackend>) -> Self {
+        Self {
+            locale,
+            intl_backend,
+            render_mode: RenderMode::Client,
+        }
+    }
+
+    /// Returns this environment with a different runtime render mode.
+    pub const fn with_render_mode(mut self, render_mode: RenderMode) -> Self {
+        self.render_mode = render_mode;
+        self
+    }
 }
 
 impl Default for Env {
@@ -454,6 +498,7 @@ impl Default for Env {
         Self {
             locale: Locale::parse("en-US").expect("en-US is a valid BCP-47 tag"),
             intl_backend: Arc::new(StubIntlBackend),
+            render_mode: RenderMode::Client,
         }
     }
 }

--- a/spec/foundation/04-internationalization.md
+++ b/spec/foundation/04-internationalization.md
@@ -458,7 +458,7 @@ fn use_locale() -> Locale {
 // Adapter usage — resolve env before passing to core:
 let locale = resolve_locale(adapter_props.locale.as_ref());
 let intl_backend = use_intl_backend();
-let env = Env { locale, intl_backend };
+let env = Env::new(locale, intl_backend);
 let messages = resolve_messages::<dialog::Messages>(adapter_props.messages.as_ref(), &registries, &env.locale);
 let service = Service::new(core_props, env, messages);
 ```
@@ -2250,11 +2250,11 @@ mechanism and makes the string untranslatable. The only acceptable English strin
 text at call time. This means every message invocation in a connect function passes the active
 locale. The three patterns for how locale reaches the call site are:
 
-| Component type                                                       | Locale source                                                                                                                                  | Access pattern                                |
-| -------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
-| **Stateful** (has `Machine` + `Context`)                             | Adapter constructs `Env { locale, intl_backend }`, passes to `Machine::init(props, &env, &messages)`. `init()` stores `env.locale` in Context. | `(self.ctx.messages.label)(&self.ctx.locale)` |
-| **Stateless with `Api`** (no state machine, but has an `Api` struct) | Adapter passes `&Env` to `Api::new(props, env, messages)`. Api stores `&env.locale`.                                                           | `(self.messages.label)(self.locale)`          |
-| **Standalone function** (no `Api` struct)                            | Adapter passes `locale: &Locale` directly as a function parameter.                                                                             | `(messages.label)(locale)`                    |
+| Component type                                                       | Locale source                                                                                                                                    | Access pattern                                |
+| -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------- |
+| **Stateful** (has `Machine` + `Context`)                             | Adapter constructs `Env::new(locale, intl_backend)`, passes to `Machine::init(props, &env, &messages)`. `init()` stores `env.locale` in Context. | `(self.ctx.messages.label)(&self.ctx.locale)` |
+| **Stateless with `Api`** (no state machine, but has an `Api` struct) | Adapter passes `&Env` to `Api::new(props, env, messages)`. Api stores `&env.locale`.                                                             | `(self.messages.label)(self.locale)`          |
+| **Standalone function** (no `Api` struct)                            | Adapter passes `locale: &Locale` directly as a function parameter.                                                                               | `(messages.label)(locale)`                    |
 
 For stateful components, the adapter resolves locale from `ArsProvider` context,
 places it in the `Env` struct, and passes `Env` to `Machine::init()`. The `init()`
@@ -2592,7 +2592,7 @@ let registries = use_i18n_registries();
 let messages = resolve_messages::<dialog::Messages>(
     adapter_props.messages.as_ref(), &registries, &locale,
 );
-let env = Env { locale, intl_backend };
+let env = Env::new(locale, intl_backend);
 let service = Service::new(core_props, env, messages);
 ```
 

--- a/spec/foundation/08-adapter-leptos.md
+++ b/spec/foundation/08-adapter-leptos.md
@@ -253,7 +253,7 @@ let props = {
 };
 ```
 
-**Invariant:** Once assigned at Service creation, the component ID MUST NOT change for the lifetime of the component instance. Re-renders do not regenerate IDs.
+**Invariant:** Once assigned at Service creation, the component ID MUST NOT change for the lifetime of the component instance. Re-renders do not regenerate IDs, and reactive prop synchronization must resolve later omitted `id` values to the service's current ID before calling `Service::set_props()`.
 
 ```rust
 #[cfg(feature = "hydrate")]
@@ -521,7 +521,9 @@ where
     // into `prev_props`, but skips calling `set_props()` because the machine was
     // already initialized with `initial_props`.
     let sync_effect = ImmediateEffect::new_isomorphic(move || {
-        let new_props = props_signal.get();
+        let raw_props = props_signal.get();
+        let service_id = service.with_value(|svc| svc.props().id().to_owned());
+        let new_props = props_with_service_id::<M>(raw_props, &service_id);
         let should_sync = prev_props.with_value(|prev| {
             prev.as_ref() != Some(&new_props)
         });
@@ -562,6 +564,14 @@ where
     on_cleanup(move || drop(sync_effect));
 
     result
+}
+
+fn props_with_service_id<M: Machine>(mut props: M::Props, service_id: &str) -> M::Props {
+    if props.id().is_empty() {
+        props.set_id(service_id.to_owned());
+    }
+
+    props
 }
 ```
 

--- a/spec/foundation/08-adapter-leptos.md
+++ b/spec/foundation/08-adapter-leptos.md
@@ -66,7 +66,7 @@ The central primitive. Creates a `Service<M>`, wraps it in a reactive signal, an
 ````rust
 use std::rc::Rc;
 use leptos::prelude::*;
-use ars_core::{Machine, Service, Env, Arc};
+use ars_core::{Machine, Service, Env, RenderMode, Arc};
 use ars_i18n::IntlBackend;
 
 /// Return type from `use_machine`.
@@ -256,6 +256,16 @@ let props = {
 **Invariant:** Once assigned at Service creation, the component ID MUST NOT change for the lifetime of the component instance. Re-renders do not regenerate IDs.
 
 ```rust
+const fn current_render_mode() -> RenderMode {
+    if cfg!(feature = "hydrate") {
+        RenderMode::Hydrating
+    } else if cfg!(feature = "ssr") {
+        RenderMode::Server
+    } else {
+        RenderMode::Client
+    }
+}
+
 /// Internal — creates a single Service and returns the public return type plus
 /// internal handles needed by `use_machine_with_reactive_props` to process
 /// SendResult from set_props (state_write, send_ref, effect_cleanups,
@@ -292,7 +302,7 @@ where
     let locale = resolve_locale(None);
     let intl_backend = use_intl_backend();
     let messages = use_messages::<M::Messages>(None, Some(&locale));
-    let env = Env { locale, intl_backend };
+    let env = Env::new(locale, intl_backend).with_render_mode(current_render_mode());
 
     // Create the service once — runs only on component initialization.
     // **Safety**: The `init()` function must not call `api.send()` or otherwise

--- a/spec/foundation/08-adapter-leptos.md
+++ b/spec/foundation/08-adapter-leptos.md
@@ -256,14 +256,29 @@ let props = {
 **Invariant:** Once assigned at Service creation, the component ID MUST NOT change for the lifetime of the component instance. Re-renders do not regenerate IDs.
 
 ```rust
-const fn current_render_mode() -> RenderMode {
-    if cfg!(feature = "hydrate") {
+#[cfg(feature = "hydrate")]
+fn current_render_mode() -> RenderMode {
+    if cfg!(feature = "ssr") {
+        RenderMode::Server
+    } else if is_currently_hydrating() {
         RenderMode::Hydrating
-    } else if cfg!(feature = "ssr") {
+    } else {
+        RenderMode::Client
+    }
+}
+
+#[cfg(not(feature = "hydrate"))]
+const fn current_render_mode() -> RenderMode {
+    if cfg!(feature = "ssr") {
         RenderMode::Server
     } else {
         RenderMode::Client
     }
+}
+
+#[cfg(feature = "hydrate")]
+fn is_currently_hydrating() -> bool {
+    use_context::<IsHydrating>().is_some_and(|hydrating| hydrating.0)
 }
 
 /// Internal — creates a single Service and returns the public return type plus

--- a/spec/foundation/09-adapter-dioxus.md
+++ b/spec/foundation/09-adapter-dioxus.md
@@ -59,7 +59,7 @@ ssr = ["dioxus/server", "dep:ars-dom", "ars-dom/ssr"]
 ````rust
 use std::sync::Arc;
 use dioxus::prelude::*;
-use ars_core::{Machine, Service, Env};
+use ars_core::{Machine, Service, Env, RenderMode};
 use ars_i18n::{Locale, IntlBackend, ComponentMessages, I18nRegistries};
 
 /// Return type from `use_machine`.
@@ -247,6 +247,14 @@ pub fn related_id(base: &str, suffix: &str) -> String {
 /// Resolves environment values (locale, ICU provider) and messages from
 /// `ArsProvider` context before constructing the `Service`. Core code never
 /// calls framework hooks — all environment values arrive as parameters.
+const fn current_render_mode() -> RenderMode {
+    if cfg!(feature = "ssr") {
+        RenderMode::Server
+    } else {
+        RenderMode::Client
+    }
+}
+
 fn use_machine_inner<M: Machine + 'static>(
     props: M::Props,
 ) -> (UseMachineReturn<M>, Signal<u64>)
@@ -273,7 +281,7 @@ where
     // These are adapter-only hooks — core code receives Env and Messages as parameters.
     let locale = resolve_locale(None);
     let intl_backend = use_intl_backend();
-    let env = Env { locale, intl_backend };
+    let env = Env::new(locale, intl_backend).with_render_mode(current_render_mode());
 
     // Resolve messages from adapter-level i18n hooks.
     let messages = use_messages::<M::Messages>(None, Some(&env.locale));

--- a/spec/foundation/09-adapter-dioxus.md
+++ b/spec/foundation/09-adapter-dioxus.md
@@ -264,6 +264,7 @@ where
     M::Props: Clone + PartialEq + 'static,
 {
     let generated_id = use_hook(|| format!("ars-{}", dioxus_id_counter()));
+    let props_for_sync = props.clone();
 
     // Auto-inject ID if not provided by the user.
     // Convention: all Props structs have an `id: String` field.
@@ -289,9 +290,8 @@ where
     // **Safety**: The `init()` function must not call `api.send()` or otherwise
     // produce events. It runs during component initialization and event
     // processing is not yet set up.
-    // Clone props for use_sync_props before moving into use_signal.
+    // Move normalized props into Service creation.
     // use_signal's closure runs exactly once (first mount), consuming `props`.
-    let props_for_sync = props.clone();
     let service_signal = use_signal(|| Service::<M>::new(props, env, messages));
     let context_version: Signal<u64> = use_signal(|| 0u64);
 
@@ -442,6 +442,8 @@ pub fn use_sync_props<M: Machine + 'static>(
     M::Event: Send + 'static,
 {
     let mut prev_props: Signal<Option<M::Props>> = use_signal(|| None);
+    let service_id = runtime.service.peek().props().id().to_owned();
+    let current_props = props_with_service_id::<M>(current_props, &service_id);
 
     // Run synchronously during component body — NOT in use_effect
     // Use .peek() to avoid subscribing the component to prev_props changes.
@@ -512,6 +514,14 @@ pub fn use_sync_props<M: Machine + 'static>(
         }
         *prev_props.write() = Some(current_props);
     }
+}
+
+fn props_with_service_id<M: Machine>(mut props: M::Props, service_id: &str) -> M::Props {
+    if props.id().is_empty() {
+        props.set_id(service_id.to_owned());
+    }
+
+    props
 }
 ```
 

--- a/spec/leptos-components/layout/portal.md
+++ b/spec/leptos-components/layout/portal.md
@@ -35,18 +35,20 @@ The adapter surface matches the core props. It does not add a separate adapter-o
 
 ## 4. Part Mapping
 
-| Core part / structure | Required?             | Adapter rendering target                                   | Ownership     | Attr source        | Notes                                                                             |
-| --------------------- | --------------------- | ---------------------------------------------------------- | ------------- | ------------------ | --------------------------------------------------------------------------------- |
-| `Root`                | required when mounted | detached `<div>` appended to the resolved target container | adapter-owned | `api.root_attrs()` | The root is the portal mount point, not a visual wrapper at the declaration site. |
+| Core part / structure | Required?             | Adapter rendering target                                   | Ownership     | Attr source        | Notes                                                                                      |
+| --------------------- | --------------------- | ---------------------------------------------------------- | ------------- | ------------------ | ------------------------------------------------------------------------------------------ |
+| `Root`                | required when mounted | detached `<div>` appended to the resolved target container | adapter-owned | `api.root_attrs()` | The owned mount node is the Root; do not create a child wrapper with duplicate root attrs. |
 
 ## 5. Attr Merge and Ownership Rules
 
-| Target node       | Core attrs                                                        | Adapter-owned attrs                                                                                              | Consumer attrs                                      | Merge order                                              | Ownership notes                  |
-| ----------------- | ----------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- | -------------------------------------------------------- | -------------------------------- |
-| portal mount root | `api.root_attrs()` including `data-ars-portal-id` and mount state | target ownership markers, cleanup bookkeeping, and mount-site metadata if needed for outside-interaction helpers | no direct consumer attr ownership at the mount node | core `data-ars-*` attrs and portal ownership markers win | mount root remains adapter-owned |
+| Target node       | Core attrs                                                                      | Adapter-owned attrs                                                                   | Consumer attrs                                      | Merge order                          | Ownership notes                  |
+| ----------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- | --------------------------------------------------- | ------------------------------------ | -------------------------------- |
+| portal mount root | `api.root_attrs()` including `id`, `data-ars-portal-id`, owner, and mount state | cleanup bookkeeping and mount-site metadata if needed for outside-interaction helpers | no direct consumer attr ownership at the mount node | core `id` and `data-ars-*` attrs win | mount root remains adapter-owned |
 
 - Consumer children own only the content rendered inside the portal root.
 - The adapter must not let consumer content replace or delete the documented mount node.
+- `api.root_attrs()` is applied to the owned mount node itself. It is not applied
+  to a nested wrapper under `ars_dom::ensure_portal_mount_root(api.owner_id())`.
 
 ## 6. Composition / Context Contract
 
@@ -54,16 +56,16 @@ The adapter surface matches the core props. It does not add a separate adapter-o
 
 ## 7. Prop Sync and Event Mapping
 
-| Adapter prop | Mode       | Sync trigger            | Machine event / update path                                            | Visible effect                                                                      | Notes                                             |
-| ------------ | ---------- | ----------------------- | ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------- |
-| `container`  | controlled | prop change after mount | adapter resolves target then dispatches `Mount` into the new container | moves or recreates the portal root under the new target                             | target switching must clean up the old root first |
-| `ssr_inline` | controlled | render-time only        | adapter SSR branch only                                                | renders children inline during SSR instead of an empty declaration-site placeholder | not a post-mount reactive behavior                |
+| Adapter prop | Mode       | Sync trigger            | Machine event / update path                                                   | Visible effect                                                                      | Notes                                             |
+| ------------ | ---------- | ----------------------- | ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------- |
+| `container`  | controlled | prop change after mount | core `on_props_changed` emits `SetContainer`; adapter resolves the new target | moves or recreates the portal root under the new target                             | target switching must clean up the old root first |
+| `ssr_inline` | controlled | render-time only        | `Api::should_render_inline()`                                                 | renders children inline during SSR instead of an empty declaration-site placeholder | not a post-mount reactive behavior                |
 
 | UI or lifecycle event | Preconditions                                  | Machine event / callback path | Ordering notes                                       | Notes                                                          |
 | --------------------- | ---------------------------------------------- | ----------------------------- | ---------------------------------------------------- | -------------------------------------------------------------- |
 | component mount       | browser client and target resolution available | `Mount`                       | create root before child content is rendered into it | client-only portal activation                                  |
 | component cleanup     | root currently mounted                         | `Unmount`                     | remove root after child teardown                     | cleanup is adapter-owned                                       |
-| late target discovery | `PortalTarget::Id` not initially available     | `ContainerReady` then `Mount` | late resolution must not leak orphan roots           | covers DOM nodes that appear after the portal component mounts |
+| late target discovery | `PortalTarget::Id` not initially available     | `ContainerReady`              | late resolution must not leak orphan roots           | core accepts only the matching ID and marks the portal mounted |
 
 ## 8. Registration and Cleanup Contract
 
@@ -130,7 +132,7 @@ The adapter surface matches the core props. It does not add a separate adapter-o
 ## 17. Recommended Implementation Sequence
 
 1. Initialize the core portal machine and derive the portal id.
-2. Branch SSR behavior from client behavior using `ssr_inline`.
+2. Branch SSR behavior from client behavior using `Api::should_render_inline()`.
 3. Resolve the target container and create the mount root on the client.
 4. Render children into the mount root.
 5. Handle target switches and cleanup without leaking roots or watchers.
@@ -177,17 +179,19 @@ Leptos requires a client effect to create and own the detached mount node. `Chil
 ```rust
 #[component]
 pub fn Portal(container: PortalTarget, ssr_inline: bool, children: Children) -> impl IntoView {
-    if ssr_inline && cfg!(feature = "ssr") {
-        return view! { <>{children()}</> };
-    }
-
     let machine = use_machine::<portal::Machine>(portal::Props {
         container,
         ssr_inline,
         ..Default::default()
     });
 
-    view! { <>{/* client effect owns detached mount root */}</> }
+    let render_inline = machine.derive(|api| api.should_render_inline());
+
+    view! {
+        <Show when=move || render_inline.get() fallback=move || view! { <>{/* client effect owns detached mount root */}</> }>
+            {children()}
+        </Show>
+    }
 }
 ```
 
@@ -202,19 +206,26 @@ pub fn Portal(container: PortalTarget, ssr_inline: bool, children: Children) -> 
         ..Default::default()
     });
     let mount_ref = StoredValue::new(None::<web_sys::Element>);
+    let render_inline = machine.derive(|api| api.should_render_inline());
 
     Effect::new(move |_| {
-        if !cfg!(feature = "ssr") {
-            if let Some(target) = resolve_portal_target(&container) {
-                let mount = ensure_portal_root(&machine, target);
-                mount_ref.set_value(Some(mount));
-            }
+        if render_inline.get() {
+            return;
+        }
+
+        if let Some(target) = resolve_portal_target(&container) {
+            let owner_id = machine.with_api_snapshot(|api| api.owner_id().to_string());
+            let mount = ars_dom::ensure_portal_mount_root(&owner_id);
+            apply_attrs(&mount, machine.derive(|api| api.root_attrs()));
+            move_mount_to_target(&mount, target);
+            render_children_into_mount(&mount);
+            mount_ref.set_value(Some(mount));
         }
     });
 
     on_cleanup(move || remove_portal_root(mount_ref.get_value()));
 
-    if ssr_inline && cfg!(feature = "ssr") {
+    if render_inline.get_untracked() {
         view! { <>{children()}</> }
     } else {
         view! { <></> }


### PR DESCRIPTION
## Summary
- implement the framework-agnostic Portal state machine, layout module export, root attrs, lifecycle API, and snapshots
- add unit and proptest coverage for Portal transitions, target resolution, attrs, generated ids, nested services, and invalid events
- align related core, adapter, harness, and spec contracts around render mode, effect cleanup, ComponentIds usage, and Portal target semantics

## Validation
- `cargo test -p ars-dioxus safe_listener`
- `CHROMEDRIVER=$HOME/.cache/ars-ui-chromedriver/chromedriver-mac-arm64/chromedriver PATH=$HOME/.cargo/bin:$HOME/.cache/ars-ui-chromedriver/chromedriver-mac-arm64:$PATH cargo xci`

Closes #273