### PR TITLE
Implement Dioxus platform services

### DIFF
--- a/crates/ars-dioxus/Cargo.toml
+++ b/crates/ars-dioxus/Cargo.toml
@@ -8,28 +8,42 @@ repository.workspace   = true
 rust-version.workspace = true
 
 [features]
-default     = ["icu4x"]
-debug       = ["dep:log", "ars-core/debug", "ars-interactions/debug", "ars-dom?/debug"]
-web         = ["dioxus/web", "dep:ars-dom", "ars-dom/web", "dep:web-sys"]
-desktop     = ["dioxus/desktop"]
+default = ["icu4x"]
+debug = ["dep:log", "ars-core/debug", "ars-interactions/debug", "ars-dom?/debug"]
+web = [
+  "dioxus/web",
+  "dep:ars-dom",
+  "ars-dom/web",
+  "dep:web-sys",
+  "dep:wasm-bindgen",
+  "dep:wasm-bindgen-futures",
+  "dep:js-sys"
+]
+desktop = ["dioxus/desktop", "dep:arboard", "dep:uuid", "dep:rfd", "dep:log"]
 desktop-dom = ["desktop", "dep:ars-dom"]
-mobile      = ["dioxus/mobile"]
-ssr         = ["dioxus/server", "dep:ars-dom", "ars-dom/ssr"]
+mobile = ["dioxus/mobile"]
+ssr = ["dioxus/server", "dep:ars-dom", "ars-dom/ssr"]
 # Pre-compiled CLDR data via ICU4X. Default backend on native targets and the
 # server-side rendering path. Use `--no-default-features --features web,ars-i18n/web-intl`
 # to swap icu4x for the browser-native Intl API on wasm32 builds.
 icu4x = ["ars-i18n/std", "ars-i18n/icu4x"]
 
 [dependencies]
-ars-a11y         = { path = "../ars-a11y" }
-ars-collections  = { path = "../ars-collections" }
-ars-components   = { path = "../ars-components" }
-ars-core         = { path = "../ars-core" }
-ars-dom          = { path = "../ars-dom", optional = true, default-features = false }
-ars-forms        = { path = "../ars-forms" }
-ars-i18n         = { path = "../ars-i18n", default-features = false }
-ars-interactions = { path = "../ars-interactions" }
-log              = { version = "0.4", default-features = false, optional = true }
+ars-a11y             = { path = "../ars-a11y" }
+ars-collections      = { path = "../ars-collections" }
+ars-components       = { path = "../ars-components" }
+ars-core             = { path = "../ars-core" }
+ars-dom              = { path = "../ars-dom", optional = true, default-features = false }
+ars-forms            = { path = "../ars-forms" }
+ars-i18n             = { path = "../ars-i18n", default-features = false }
+ars-interactions     = { path = "../ars-interactions" }
+log                  = { version = "0.4", default-features = false, optional = true }
+arboard              = { version = "3", optional = true }
+uuid                 = { version = "1", default-features = false, features = ["v4"], optional = true }
+rfd                  = { version = "0.17", optional = true }
+js-sys               = { version = "0.3", optional = true }
+wasm-bindgen         = { version = "0.2", optional = true }
+wasm-bindgen-futures = { version = "0.4", optional = true }
 
 [dependencies.dioxus]
 version          = "0.7"
@@ -41,18 +55,25 @@ features         = ["macro", "signals", "hooks", "html"]
 version = "0.3"
 optional = true
 features = [
-    "console",
-    "CssStyleDeclaration",
-    "Document",
-    "Element",
-    "Event",
-    "EventTarget",
-    "FocusEvent",
-    "HtmlElement",
-    "KeyboardEvent",
-    "MouseEvent",
-    "PointerEvent",
-    "Window"
+  "Clipboard",
+  "console",
+  "Crypto",
+  "CssStyleDeclaration",
+  "DataTransfer",
+  "Document",
+  "DomRect",
+  "DragEvent",
+  "Element",
+  "Event",
+  "EventTarget",
+  "FocusEvent",
+  "HtmlElement",
+  "KeyboardEvent",
+  "MouseEvent",
+  "Navigator",
+  "Performance",
+  "PointerEvent",
+  "Window"
 ]
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]

--- a/crates/ars-dioxus/src/attrs.rs
+++ b/crates/ars-dioxus/src/attrs.rs
@@ -832,7 +832,7 @@ mod tests {
                 Arc::new(ars_core::DefaultModalityContext::new()),
                 Arc::new(ars_i18n::StubIntlBackend),
                 Arc::new(I18nRegistries::new()),
-                Arc::new(crate::provider::NullPlatform),
+                Arc::new(crate::platform::NullPlatform),
                 StyleStrategy::Cssom,
             );
 
@@ -980,7 +980,7 @@ mod wasm_tests {
                 Arc::new(ars_core::DefaultModalityContext::new()),
                 Arc::new(ars_i18n::StubIntlBackend),
                 Arc::new(I18nRegistries::new()),
-                Arc::new(crate::provider::NullPlatform),
+                Arc::new(crate::platform::NullPlatform),
                 StyleStrategy::Cssom,
             );
 

--- a/crates/ars-dioxus/src/lib.rs
+++ b/crates/ars-dioxus/src/lib.rs
@@ -17,6 +17,7 @@ mod ephemeral;
 mod event_mapping;
 mod id;
 mod nonce;
+mod platform;
 pub mod prelude;
 mod provider;
 mod safe_listener;
@@ -41,13 +42,16 @@ pub use nonce::{
     use_nonce_css_context_provider, use_nonce_css_from_attrs, use_nonce_css_rule,
 };
 #[cfg(feature = "desktop")]
-pub use provider::DesktopPlatform;
-#[cfg(feature = "web")]
-pub use provider::WebPlatform;
+pub use platform::DesktopPlatform;
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
+pub use platform::WebPlatform;
+pub use platform::{
+    DioxusPlatform, DragData, FilePickerOptions, NullPlatform, PlatformDragEvent,
+    default_dioxus_platform, use_platform,
+};
 pub use provider::{
-    ArsContext, ArsProvider, ArsProviderProps, DioxusPlatform, DragData, FilePickerOptions,
-    NullPlatform, resolve_locale, t, use_intl_backend, use_locale, use_messages,
-    use_modality_context, use_number_formatter, use_platform, warn_missing_provider,
+    ArsContext, ArsProvider, ArsProviderProps, resolve_locale, t, use_intl_backend, use_locale,
+    use_messages, use_modality_context, use_number_formatter, warn_missing_provider,
 };
 #[cfg(feature = "web")]
 pub use safe_listener::{

--- a/crates/ars-dioxus/src/platform.rs
+++ b/crates/ars-dioxus/src/platform.rs
@@ -55,12 +55,12 @@ pub struct FilePickerOptions {
 /// - **Web (wasm32 + `feature = "web"`)**: items as `DragItem::File`
 ///   for each `DataTransfer.files()` entry; `types` populated from the
 ///   subset of default probe formats for which `data_transfer.get_data()`
-///   returns a value.
+///   returns a non-empty value.
 /// - **Desktop (`feature = "desktop"`)**: items as `DragItem::File`
 ///   for each path in wry's `DragDropEvent::Drop { paths, .. }`. Each
 ///   item carries a real `FileHandle::from_path(_)` so the drop-zone
 ///   adapter can resolve content. `types` is best-effort via the same
-///   `get_data()` probe.
+///   non-empty `get_data()` probe.
 /// - **`PlatformDragEvent::empty()`** (any target): both fields empty.
 ///
 /// `dioxus_html::DataTransfer` does not expose a `types()` accessor on
@@ -114,7 +114,11 @@ impl DragData {
 
         let mut types = DEFAULT_DRAG_TYPE_PROBES
             .iter()
-            .filter(|&format| data_transfer.get_data(format).is_some())
+            .filter(|&format| {
+                data_transfer
+                    .get_data(format)
+                    .is_some_and(|payload| !payload.is_empty())
+            })
             .map(|&format| String::from(format))
             .collect::<Vec<_>>();
 
@@ -126,22 +130,11 @@ impl DragData {
                     .content_type()
                     .unwrap_or_else(|| String::from("application/octet-stream"));
 
-                // `FileData::path()` returns `PathBuf::new()` on web (no
-                // native path available); on desktop it carries the real
-                // path forwarded from `wry::DragDropEvent::Drop { paths }`.
-                let raw_path = file.path();
-
-                let handle = if raw_path.as_os_str().is_empty() {
-                    FileHandle::opaque()
-                } else {
-                    FileHandle::from_path(raw_path)
-                };
-
                 DragItem::File {
                     name: file.name(),
                     mime_type,
                     size: file.size(),
-                    handle,
+                    handle: drag_file_handle(file.path()),
                 }
             })
             .collect::<Vec<_>>();
@@ -157,6 +150,20 @@ impl DragData {
 
         Self { items, types }
     }
+}
+
+#[cfg(all(feature = "desktop", not(target_arch = "wasm32")))]
+fn drag_file_handle(raw_path: std::path::PathBuf) -> FileHandle {
+    if raw_path.as_os_str().is_empty() {
+        FileHandle::opaque()
+    } else {
+        FileHandle::from_path(raw_path)
+    }
+}
+
+#[cfg(not(all(feature = "desktop", not(target_arch = "wasm32"))))]
+fn drag_file_handle(_raw_path: std::path::PathBuf) -> FileHandle {
+    FileHandle::opaque()
 }
 
 /// Platform-agnostic handle to a drag event.
@@ -1124,6 +1131,44 @@ mod tests {
             data.types,
             vec![String::from("text/plain"), String::from("text/html")]
         );
+    }
+
+    #[test]
+    fn drag_data_from_dioxus_drag_data_ignores_empty_probe_payloads() {
+        let native = TestNativeDataTransfer::with_data([
+            ("text/plain", ""),
+            ("text/html", "<p>hello</p>"),
+            ("text/uri-list", ""),
+            ("application/json", "{\"id\":1}"),
+        ]);
+
+        let event = DioxusDragData::new(TestDragData::new(native));
+
+        let data = DragData::from_drag_data(&event);
+
+        assert!(data.items.is_empty());
+        assert_eq!(
+            data.types,
+            vec![String::from("text/html"), String::from("application/json")]
+        );
+    }
+
+    #[test]
+    #[cfg(all(feature = "desktop", not(target_arch = "wasm32")))]
+    fn drag_file_handle_preserves_native_desktop_paths() {
+        let path = std::path::PathBuf::from("/tmp/report.json");
+
+        let handle = drag_file_handle(path.clone());
+
+        assert_eq!(handle.as_path(), Some(path.as_path()));
+    }
+
+    #[test]
+    #[cfg(not(all(feature = "desktop", not(target_arch = "wasm32"))))]
+    fn drag_file_handle_keeps_web_and_non_desktop_paths_opaque() {
+        let handle = drag_file_handle(std::path::PathBuf::from("uploads/report.json"));
+
+        assert_eq!(handle.as_path(), None);
     }
 
     #[test]

--- a/crates/ars-dioxus/src/platform.rs
+++ b/crates/ars-dioxus/src/platform.rs
@@ -1,0 +1,1565 @@
+//! Dioxus-specific platform abstraction (`DioxusPlatform`) and its
+//! per-target implementations.
+//!
+//! This module covers operations the framework-agnostic
+//! [`ars_core::PlatformEffects`] trait does **not** expose: file pickers,
+//! clipboard writes, drag-data extraction, bounding rects, UUID generation,
+//! and high-precision timestamps. It is the Dioxus-side analog to the
+//! browser-only surface that `ars-leptos` would otherwise inline.
+//!
+//! The trait flows into adapter components via
+//! [`ArsContext::dioxus_platform`](crate::ArsContext#structfield.dioxus_platform);
+//! components retrieve the active implementation through [`use_platform`].
+//!
+//! See `spec/foundation/09-adapter-dioxus.md` §6 for the contract.
+
+use std::{pin::Pin, rc::Rc, sync::Arc, time::Duration};
+#[cfg(feature = "desktop")]
+use std::{sync::LazyLock, time::Instant};
+
+use ars_core::Rect;
+use ars_forms::field::FileRef;
+use ars_interactions::{DragItem, FileHandle};
+use dioxus::{
+    events::{DragData as DioxusDragData, MountedData, ScrollBehavior},
+    prelude::try_use_context,
+};
+
+use crate::{ArsContext, warn_missing_provider};
+
+/// Options for opening a platform file picker.
+///
+/// Mirrors the subset of HTML `<input type="file">` configuration that the
+/// adapter exposes. Web targets ignore these options because the real file
+/// picker is hosted by the `FileUpload` component's hidden `<input>`; desktop
+/// targets translate them into `rfd` native-dialog filters.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct FilePickerOptions {
+    /// Accepted MIME types or extensions. Empty means accept any.
+    pub accept: Vec<String>,
+
+    /// Whether the user may select more than one file at once.
+    pub multiple: bool,
+}
+
+/// Adapter-local drag payload extracted from a Dioxus drag event.
+///
+/// Mirrors `spec/components/utility/drop-zone.md` §1.3. The `items`
+/// vector contains the structured drag payload (text, URI, files,
+/// etc.) when the platform exposes it; `types` carries MIME types
+/// advertised by the drag source for the formats this adapter is able
+/// to detect.
+///
+/// **What's extracted, by target:**
+///
+/// - **Web (wasm32 + `feature = "web"`)**: items as `DragItem::File`
+///   for each `DataTransfer.files()` entry; `types` populated from the
+///   subset of default probe formats for which `data_transfer.get_data()`
+///   returns a value.
+/// - **Desktop (`feature = "desktop"`)**: items as `DragItem::File`
+///   for each path in wry's `DragDropEvent::Drop { paths, .. }`. Each
+///   item carries a real `FileHandle::from_path(_)` so the drop-zone
+///   adapter can resolve content. `types` is best-effort via the same
+///   `get_data()` probe.
+/// - **`PlatformDragEvent::empty()`** (any target): both fields empty.
+///
+/// `dioxus_html::DataTransfer` does not expose a `types()` accessor on
+/// the public API (only `get_data(format)`), so the type list is built
+/// by probing a fixed set of common formats rather than enumerating
+/// the source's full advertised list. Components that need a specific
+/// format outside the default probes should call
+/// `event.data_transfer().get_data(format)` directly.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct DragData {
+    /// The dragged items.
+    ///
+    /// May be empty on `DragEnter` / `DragOver` when the browser
+    /// restricts access to item content until drop (security
+    /// restriction).
+    pub items: Vec<DragItem>,
+
+    /// MIME types advertised by the drag source for the subset of
+    /// formats the adapter probes. See the type-level docs.
+    pub types: Vec<String>,
+}
+
+/// Default best-effort formats to probe via `DataTransfer::get_data(format)`
+/// when extracting [`DragData::types`].
+///
+/// Dioxus exposes `get_data(format)` but not an enumerable `types()`
+/// API, so the adapter can only discover formats it explicitly asks
+/// about. This list is only a fallback heuristic, not an accept/reject
+/// policy. Components that care about an exact custom format should
+/// call `data_transfer.get_data(...)` directly from their event handler.
+const DEFAULT_DRAG_TYPE_PROBES: &[&str] = &[
+    "text/plain",
+    "text/html",
+    "text/uri-list",
+    "application/json",
+];
+
+impl DragData {
+    /// Builds a [`DragData`] from a Dioxus drag event.
+    ///
+    /// Works on every target Dioxus supports: web (real
+    /// `web_sys::DataTransfer`), desktop (`wry`-synthesized data
+    /// transfer carrying file paths), SSR (empty data transfer).
+    /// Items are populated from `event.data_transfer().files()` as
+    /// [`DragItem::File`] entries; `types` is populated by probing
+    /// each default probe format — including the synthetic
+    /// `"Files"` marker when files are present.
+    #[must_use]
+    pub fn from_drag_data(event: &DioxusDragData) -> Self {
+        let data_transfer = event.data_transfer();
+
+        let mut types = DEFAULT_DRAG_TYPE_PROBES
+            .iter()
+            .filter(|&format| data_transfer.get_data(format).is_some())
+            .map(|&format| String::from(format))
+            .collect::<Vec<_>>();
+
+        let items = data_transfer
+            .files()
+            .into_iter()
+            .map(|file| {
+                let mime_type = file
+                    .content_type()
+                    .unwrap_or_else(|| String::from("application/octet-stream"));
+
+                // `FileData::path()` returns `PathBuf::new()` on web (no
+                // native path available); on desktop it carries the real
+                // path forwarded from `wry::DragDropEvent::Drop { paths }`.
+                let raw_path = file.path();
+
+                let handle = if raw_path.as_os_str().is_empty() {
+                    FileHandle::opaque()
+                } else {
+                    FileHandle::from_path(raw_path)
+                };
+
+                DragItem::File {
+                    name: file.name(),
+                    mime_type,
+                    size: file.size(),
+                    handle,
+                }
+            })
+            .collect::<Vec<_>>();
+
+        // The HTML drag-and-drop spec exposes the synthetic "Files"
+        // type whenever the transfer carries one or more files. We
+        // synthesise that marker locally so the adapter behaves
+        // identically across platforms regardless of how `get_data()`
+        // is implemented.
+        if !items.is_empty() {
+            types.push(String::from("Files"));
+        }
+
+        Self { items, types }
+    }
+}
+
+/// Platform-agnostic handle to a drag event.
+///
+/// Adapter glue wraps the framework's drag event in a
+/// `PlatformDragEvent` before passing it to
+/// [`DioxusPlatform::create_drag_data`]. The wrapper holds a borrowed
+/// reference to the unified `dioxus::events::DragData` (via
+/// [`Self::from_dioxus`]) — that abstraction works identically on web
+/// (real browser event) and desktop (wry-synthesized event). On any
+/// target an "empty" wrapper is constructible (via [`Self::empty`])
+/// for tests and for components that compile against the trait but
+/// never produce real drag data.
+///
+/// `Copy` is derivable because the wrapped `Option<&T>` is `Copy`,
+/// letting callers pass the same wrapper to multiple platforms or
+/// helpers without clones.
+///
+/// This replaces an earlier `&dyn Any` parameter, which silently
+/// returned `None` if a caller passed the wrong type. With the typed
+/// constructor, the conversion happens at the call site where the
+/// type information is still in scope.
+#[derive(Clone, Copy, Debug)]
+pub struct PlatformDragEvent<'a> {
+    inner: Option<&'a DioxusDragData>,
+}
+
+impl<'a> PlatformDragEvent<'a> {
+    /// Constructs a payload-less drag event.
+    ///
+    /// Used by tests, by components that must call
+    /// [`DioxusPlatform::create_drag_data`] without a real Dioxus
+    /// event, and as the natural shape for SSR / null platforms that
+    /// do not produce drag events.
+    #[must_use]
+    pub const fn empty() -> Self {
+        Self { inner: None }
+    }
+
+    /// Wraps a Dioxus `DragData` (the platform-agnostic event payload
+    /// `dioxus_html` exposes from `ondrop` / `ondragover` handlers)
+    /// for [`DioxusPlatform::create_drag_data`].
+    #[must_use]
+    pub const fn from_dioxus(event: &'a DioxusDragData) -> Self {
+        Self { inner: Some(event) }
+    }
+
+    /// Returns the underlying [`DioxusDragData`] reference if the
+    /// wrapper was built from one, otherwise `None`.
+    #[must_use]
+    pub const fn as_dioxus(&self) -> Option<&'a DioxusDragData> {
+        self.inner
+    }
+}
+
+/// Dioxus-specific platform services not covered by core
+/// [`PlatformEffects`](ars_core::PlatformEffects).
+///
+/// Implementations cover three deployment shapes (web / desktop / null);
+/// see `WebPlatform`, `DesktopPlatform`, and [`NullPlatform`]. (`WebPlatform`
+/// and `DesktopPlatform` are only in scope under their respective feature
+/// gates, so we render them as plain code rather than intra-doc links.)
+///
+/// **Note on `Send` bounds.** The futures returned by async methods are
+/// `!Send` on WASM (where `web_sys::JsFuture` cannot cross threads). On
+/// desktop, Dioxus's runtime can run `!Send` futures on the current thread
+/// via `dioxus::spawn`, so the trait keeps a single uniform return type
+/// across platforms. Callers on desktop runtimes that require `Send` should
+/// route the future through `dioxus::spawn` or convert it themselves.
+pub trait DioxusPlatform: Send + Sync + 'static {
+    /// Focuses a mounted element through Dioxus's renderer-backed element
+    /// handle.
+    ///
+    /// This is the portable element-focus path for Dioxus renderers. Web,
+    /// desktop, and future mobile renderers expose element operations through
+    /// the [`MountedData`] value emitted by `onmounted`, not through a global
+    /// DOM ID lookup.
+    fn focus_mounted_element(
+        &self,
+        element: Rc<MountedData>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), String>>>> {
+        Box::pin(async move { element.set_focus(true).await.map_err(|err| err.to_string()) })
+    }
+
+    /// Returns the viewport-relative bounding rectangle for a mounted
+    /// element through Dioxus's renderer-backed element handle.
+    ///
+    /// Returns `None` when the renderer does not support geometry queries or
+    /// when the element is no longer mounted.
+    fn get_mounted_bounding_rect(
+        &self,
+        element: Rc<MountedData>,
+    ) -> Pin<Box<dyn Future<Output = Option<Rect>>>> {
+        Box::pin(async move { element.get_client_rect().await.ok().map(rect_from_pixels) })
+    }
+
+    /// Scrolls a mounted element into view through Dioxus's renderer-backed
+    /// element handle.
+    fn scroll_mounted_into_view(
+        &self,
+        element: Rc<MountedData>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), String>>>> {
+        Box::pin(async move {
+            element
+                .scroll_to(ScrollBehavior::Instant)
+                .await
+                .map_err(|err| err.to_string())
+        })
+    }
+
+    /// Writes text to the system clipboard. The future resolves with `Ok`
+    /// on success or an error message on failure.
+    fn set_clipboard(&self, text: &str) -> Pin<Box<dyn Future<Output = Result<(), String>>>>;
+
+    /// Opens a native file picker. The future resolves with the user's
+    /// selection, or an empty vector if the user cancelled or the platform
+    /// does not implement a picker (e.g., web defers to a hidden `<input>`).
+    fn open_file_picker(
+        &self,
+        options: FilePickerOptions,
+    ) -> Pin<Box<dyn Future<Output = Vec<FileRef>>>>;
+
+    /// Returns a monotonically non-decreasing duration since a
+    /// platform-defined start point.
+    ///
+    /// The start point is implementation-defined and intentionally opaque
+    /// (web: page-load via `performance.now()`; desktop: UNIX epoch via
+    /// `SystemTime`; null: always zero). Callers MUST use this only for
+    /// relative measurements — subtract two values from the same platform
+    /// instance to get an elapsed [`Duration`]. Comparing values across
+    /// platforms or across processes is undefined.
+    ///
+    /// Returning [`Duration`] (rather than `f64`/`u64` ms) keeps the unit
+    /// in the type and forbids accidental epoch-leak bugs.
+    fn monotonic_now(&self) -> Duration;
+
+    /// Generates a platform-scoped unique ID.
+    ///
+    /// Web returns a `UUIDv4` from `crypto.randomUUID()`; desktop returns a
+    /// `uuid::Uuid::new_v4()`; the null implementation returns a sequential
+    /// counter prefixed with `null-id-`.
+    fn new_id(&self) -> String;
+
+    /// Extracts adapter drag data from a platform-specific drag event.
+    ///
+    /// Returns `None` when the wrapper does not carry a Dioxus drag event.
+    /// Callers wrap the framework's drag event in [`PlatformDragEvent`] before
+    /// invoking this — the wrapper enforces the underlying event type at
+    /// compile time.
+    fn create_drag_data(&self, event: PlatformDragEvent<'_>) -> Option<DragData>;
+}
+
+/// No-op platform implementation used in tests, SSR, and `mobile` builds
+/// until a dedicated mobile platform is added.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct NullPlatform;
+
+impl DioxusPlatform for NullPlatform {
+    fn focus_mounted_element(
+        &self,
+        _element: Rc<MountedData>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), String>>>> {
+        Box::pin(async { Ok(()) })
+    }
+
+    fn get_mounted_bounding_rect(
+        &self,
+        _element: Rc<MountedData>,
+    ) -> Pin<Box<dyn Future<Output = Option<Rect>>>> {
+        Box::pin(async { None })
+    }
+
+    fn scroll_mounted_into_view(
+        &self,
+        _element: Rc<MountedData>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), String>>>> {
+        Box::pin(async { Ok(()) })
+    }
+
+    fn set_clipboard(&self, _text: &str) -> Pin<Box<dyn Future<Output = Result<(), String>>>> {
+        Box::pin(async { Ok(()) })
+    }
+
+    fn open_file_picker(
+        &self,
+        _options: FilePickerOptions,
+    ) -> Pin<Box<dyn Future<Output = Vec<FileRef>>>> {
+        Box::pin(async { Vec::new() })
+    }
+
+    fn monotonic_now(&self) -> Duration {
+        Duration::ZERO
+    }
+
+    fn new_id(&self) -> String {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        static COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+        format!("null-id-{}", COUNTER.fetch_add(1, Ordering::Relaxed))
+    }
+
+    fn create_drag_data(&self, _event: PlatformDragEvent<'_>) -> Option<DragData> {
+        None
+    }
+}
+
+/// Web platform implementation backed by `web_sys`.
+///
+/// Only exists on `wasm32` targets even when the `web` feature is enabled —
+/// every method invokes browser APIs that have no meaningful native
+/// fallback. On non-wasm hosts (e.g., `cargo check --features web` on a
+/// developer's Linux box, or a misconfigured production build), the type
+/// is *not in scope* and [`default_dioxus_platform`] falls through to
+/// [`NullPlatform`] instead. This keeps build tooling green without
+/// silently degrading runtime behaviour into "clipboard writes succeed but
+/// do nothing" surprises.
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
+#[derive(Clone, Copy, Debug, Default)]
+pub struct WebPlatform;
+
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
+impl DioxusPlatform for WebPlatform {
+    fn set_clipboard(&self, text: &str) -> Pin<Box<dyn Future<Output = Result<(), String>>>> {
+        let text = text.to_string();
+
+        Box::pin(async move {
+            let window = web_sys::window().ok_or_else(|| String::from("no window available"))?;
+
+            let promise = window.navigator().clipboard().write_text(&text);
+
+            wasm_bindgen_futures::JsFuture::from(promise)
+                .await
+                .map(|_| ())
+                .map_err(|err| format!("{err:?}"))
+        })
+    }
+
+    fn open_file_picker(
+        &self,
+        _options: FilePickerOptions,
+    ) -> Pin<Box<dyn Future<Output = Vec<FileRef>>>> {
+        // Web defers to the FileUpload component's hidden <input type="file">.
+        // See spec/foundation/09-adapter-dioxus.md §6.1, line 1561.
+        Box::pin(async { Vec::new() })
+    }
+
+    fn monotonic_now(&self) -> Duration {
+        let millis = web_sys::window()
+            .and_then(|window| window.performance())
+            .map(|performance| performance.now())
+            .expect("window.performance must be available on web targets");
+
+        // `performance.now()` returns a non-negative `f64` of milliseconds
+        // since page load, with sub-millisecond resolution. Convert via
+        // `from_secs_f64(millis / 1000.0)` to preserve fractional precision
+        // (`Duration::from_millis` would truncate to integer ms).
+        Duration::from_secs_f64(millis / 1000.0)
+    }
+
+    fn new_id(&self) -> String {
+        web_sys::window()
+            .map(|window| {
+                window
+                    .crypto()
+                    .expect("window.crypto must be available on web targets")
+                    .random_uuid()
+            })
+            .expect("window must be available on web targets")
+    }
+
+    fn create_drag_data(&self, event: PlatformDragEvent<'_>) -> Option<DragData> {
+        event.as_dioxus().map(DragData::from_drag_data)
+    }
+}
+
+const fn rect_from_pixels(rect: dioxus::html::geometry::PixelsRect) -> Rect {
+    Rect {
+        x: rect.origin.x,
+        y: rect.origin.y,
+        width: rect.size.width,
+        height: rect.size.height,
+    }
+}
+
+/// Desktop platform implementation backed by native crates
+/// (`arboard` for clipboard, `rfd` for file dialogs, `uuid` for IDs,
+/// `std::time::Instant` for monotonic timestamps).
+///
+/// Mounted-element focus, geometry, and scrolling use the trait's
+/// [`MountedData`]-backed defaults. Drag-data extraction uses Dioxus's unified
+/// `events::DragData` payload, which desktop synthesizes from native drag
+/// events.
+#[cfg(feature = "desktop")]
+#[derive(Clone, Copy, Debug, Default)]
+pub struct DesktopPlatform;
+
+#[cfg(feature = "desktop")]
+impl DioxusPlatform for DesktopPlatform {
+    fn set_clipboard(&self, text: &str) -> Pin<Box<dyn Future<Output = Result<(), String>>>> {
+        let text = text.to_string();
+
+        Box::pin(async move {
+            let mut clipboard = arboard::Clipboard::new().map_err(|err| err.to_string())?;
+
+            clipboard.set_text(&text).map_err(|err| err.to_string())
+        })
+    }
+
+    fn open_file_picker(
+        &self,
+        options: FilePickerOptions,
+    ) -> Pin<Box<dyn Future<Output = Vec<FileRef>>>> {
+        Box::pin(async move {
+            let mut dialog = rfd::AsyncFileDialog::new();
+
+            let extensions = file_picker_filter_extensions(&options.accept);
+
+            if !extensions.is_empty() {
+                dialog = dialog.add_filter(file_picker_filter_name(&extensions), &extensions);
+            }
+
+            let handles = if options.multiple {
+                dialog.pick_files().await.unwrap_or_default()
+            } else {
+                dialog.pick_file().await.into_iter().collect()
+            };
+
+            handles
+                .into_iter()
+                .map(|file| file_ref_from_path(file.path()))
+                .collect()
+        })
+    }
+
+    fn monotonic_now(&self) -> Duration {
+        static START: LazyLock<Instant> = LazyLock::new(Instant::now);
+
+        START.elapsed()
+    }
+
+    fn new_id(&self) -> String {
+        uuid::Uuid::new_v4().to_string()
+    }
+
+    fn create_drag_data(&self, event: PlatformDragEvent<'_>) -> Option<DragData> {
+        event.as_dioxus().map(DragData::from_drag_data)
+    }
+}
+
+#[cfg(feature = "desktop")]
+fn file_picker_filter_extensions(accept: &[String]) -> Vec<String> {
+    let mut extensions = Vec::new();
+
+    for raw in accept {
+        for token in raw
+            .split(',')
+            .map(str::trim)
+            .filter(|token| !token.is_empty())
+        {
+            for extension in accept_token_extensions(token) {
+                if !extensions.iter().any(|existing| existing == &extension) {
+                    extensions.push(extension);
+                }
+            }
+        }
+    }
+
+    extensions
+}
+
+#[cfg(feature = "desktop")]
+fn accept_token_extensions(token: &str) -> Vec<String> {
+    match token.strip_prefix('.').unwrap_or(token) {
+        "txt" => vec![String::from("txt")],
+
+        "html" | "text/html" => vec![String::from("html"), String::from("htm")],
+
+        "css" | "text/css" => vec![String::from("css")],
+
+        "csv" | "text/csv" => vec![String::from("csv")],
+
+        "json" | "application/json" => vec![String::from("json")],
+
+        "pdf" | "application/pdf" => vec![String::from("pdf")],
+
+        "png" | "image/png" => vec![String::from("png")],
+
+        "jpg" | "jpeg" | "image/jpeg" => vec![String::from("jpg"), String::from("jpeg")],
+
+        "gif" | "image/gif" => vec![String::from("gif")],
+
+        "webp" | "image/webp" => vec![String::from("webp")],
+
+        "svg" | "image/svg+xml" => vec![String::from("svg")],
+
+        "image/*" => ["png", "jpg", "jpeg", "gif", "webp", "svg", "bmp", "ico"]
+            .into_iter()
+            .map(String::from)
+            .collect(),
+
+        "mp3" | "audio/mpeg" => vec![String::from("mp3")],
+
+        "wav" | "audio/wav" => vec![String::from("wav")],
+
+        "ogg" | "audio/ogg" => vec![String::from("ogg")],
+
+        "audio/*" => ["mp3", "wav", "ogg", "flac", "aac"]
+            .into_iter()
+            .map(String::from)
+            .collect(),
+
+        "mp4" | "video/mp4" => vec![String::from("mp4")],
+
+        "webm" | "video/webm" => vec![String::from("webm")],
+
+        "mov" | "video/quicktime" => vec![String::from("mov")],
+
+        "video/*" => ["mp4", "webm", "mov", "avi", "mkv"]
+            .into_iter()
+            .map(String::from)
+            .collect(),
+
+        extension if !extension.contains('/') && !extension.contains('*') => {
+            vec![extension.to_ascii_lowercase()]
+        }
+
+        _ => Vec::new(),
+    }
+}
+
+#[cfg(feature = "desktop")]
+fn file_picker_filter_name(extensions: &[String]) -> String {
+    if extensions.is_empty() {
+        String::from("All files")
+    } else {
+        extensions
+            .iter()
+            .map(|extension| format!("*.{extension}"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+}
+
+#[cfg(feature = "desktop")]
+fn file_ref_from_path(path: &std::path::Path) -> FileRef {
+    FileRef {
+        name: path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or_default()
+            .to_owned(),
+        size: std::fs::metadata(path).map_or(0, |metadata| metadata.len()),
+        mime_type: mime_type_for_path(path),
+    }
+}
+
+#[cfg(feature = "desktop")]
+fn mime_type_for_path(path: &std::path::Path) -> String {
+    let Some(extension) = path.extension().and_then(|extension| extension.to_str()) else {
+        return String::from("application/octet-stream");
+    };
+
+    match extension.to_ascii_lowercase().as_str() {
+        "txt" => "text/plain",
+        "html" | "htm" => "text/html",
+        "css" => "text/css",
+        "csv" => "text/csv",
+        "json" => "application/json",
+        "pdf" => "application/pdf",
+        "png" => "image/png",
+        "jpg" | "jpeg" => "image/jpeg",
+        "gif" => "image/gif",
+        "webp" => "image/webp",
+        "svg" => "image/svg+xml",
+        "bmp" => "image/bmp",
+        "ico" => "image/x-icon",
+        "mp3" => "audio/mpeg",
+        "wav" => "audio/wav",
+        "ogg" => "audio/ogg",
+        "flac" => "audio/flac",
+        "aac" => "audio/aac",
+        "mp4" => "video/mp4",
+        "webm" => "video/webm",
+        "mov" => "video/quicktime",
+        "avi" => "video/x-msvideo",
+        "mkv" => "video/x-matroska",
+        _ => "application/octet-stream",
+    }
+    .to_owned()
+}
+
+/// Returns the [`DioxusPlatform`] implementation chosen by feature gating.
+///
+/// Resolution order:
+///
+/// 1. `WebPlatform` when `web` is on **and** the build target is wasm32.
+/// 2. `DesktopPlatform` when `desktop` is on (and we did not match step 1).
+/// 3. [`NullPlatform`] otherwise.
+///
+/// `web` on a non-wasm host (e.g., `cargo check --features web` from a
+/// developer's Linux box) deliberately falls through to step 2 or 3 —
+/// `WebPlatform` only exists on wasm32, so this avoids silently shipping
+/// "clipboard writes succeed but do nothing" semantics into a misconfigured
+/// production build. The `mobile` feature also currently lands at step 3.
+///
+/// `WebPlatform` and `DesktopPlatform` are rendered as plain code rather
+/// than intra-doc links because their types are cfg-gated out of scope on
+/// the docs build target.
+///
+/// This function exists alongside [`use_platform`] for callers that need a
+/// platform handle outside a Dioxus render scope (test harnesses, SSR
+/// bootstrap, benches). Inside components, prefer [`use_platform`].
+#[must_use]
+pub fn default_dioxus_platform() -> Arc<dyn DioxusPlatform> {
+    #[cfg(all(feature = "web", target_arch = "wasm32"))]
+    {
+        Arc::new(WebPlatform)
+    }
+
+    #[cfg(all(feature = "desktop", not(all(feature = "web", target_arch = "wasm32"))))]
+    {
+        Arc::new(DesktopPlatform)
+    }
+
+    #[cfg(all(
+        not(all(feature = "web", target_arch = "wasm32")),
+        not(feature = "desktop")
+    ))]
+    {
+        Arc::new(NullPlatform)
+    }
+}
+
+/// Resolves the active [`DioxusPlatform`] from the surrounding
+/// [`ArsProvider`](crate::ArsProvider) context.
+///
+/// When no [`ArsProvider`](crate::ArsProvider) is mounted, falls back to
+/// [`default_dioxus_platform`] using the resolution order
+/// **`web` → `desktop` → [`NullPlatform`]**. The `mobile` feature currently
+/// falls through to [`NullPlatform`]; when a dedicated mobile platform is
+/// added, update [`default_dioxus_platform`] with a
+/// `#[cfg(feature = "mobile")]` arm.
+#[must_use]
+pub fn use_platform() -> Arc<dyn DioxusPlatform> {
+    try_use_context::<ArsContext>().map_or_else(
+        || {
+            warn_missing_provider("use_platform");
+
+            default_dioxus_platform()
+        },
+        |ctx| Arc::clone(&ctx.dioxus_platform),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        cell::Cell,
+        collections::BTreeMap,
+        pin::Pin,
+        task::{Context, Poll, Waker},
+    };
+
+    #[cfg(feature = "desktop")]
+    use dioxus::html::SerializedFileData;
+    use dioxus::html::{
+        DataTransfer as DioxusDataTransfer, HasDataTransferData, HasDragData, HasFileData,
+        HasMouseData, InteractionElementOffset, InteractionLocation, Modifiers,
+        ModifiersInteraction, MountedError, MountedResult, NativeDataTransfer, PointerInteraction,
+        RenderedElementBacking,
+        geometry::{
+            ClientPoint, Coordinates, ElementPoint, PagePoint, PixelsRect, ScreenPoint,
+            euclid::{point2, size2},
+        },
+        input_data::{MouseButton, MouseButtonSet},
+    };
+
+    use super::*;
+
+    #[derive(Clone, Debug, Default)]
+    struct TestNativeDataTransfer {
+        data: BTreeMap<String, String>,
+        #[cfg(feature = "desktop")]
+        files: Vec<SerializedFileData>,
+    }
+
+    impl TestNativeDataTransfer {
+        fn with_data(pairs: impl IntoIterator<Item = (&'static str, &'static str)>) -> Self {
+            Self {
+                data: pairs
+                    .into_iter()
+                    .map(|(key, value)| (String::from(key), String::from(value)))
+                    .collect(),
+                #[cfg(feature = "desktop")]
+                files: Vec::new(),
+            }
+        }
+
+        #[cfg(feature = "desktop")]
+        fn with_files(files: impl IntoIterator<Item = SerializedFileData>) -> Self {
+            Self {
+                data: BTreeMap::new(),
+                files: files.into_iter().collect(),
+            }
+        }
+    }
+
+    impl NativeDataTransfer for TestNativeDataTransfer {
+        fn get_data(&self, format: &str) -> Option<String> {
+            self.data.get(format).cloned()
+        }
+
+        fn set_data(&self, _format: &str, _data: &str) -> Result<(), String> {
+            Ok(())
+        }
+
+        fn clear_data(&self, _format: Option<&str>) -> Result<(), String> {
+            Ok(())
+        }
+
+        fn effect_allowed(&self) -> String {
+            String::from("all")
+        }
+
+        fn set_effect_allowed(&self, _effect: &str) {}
+
+        fn drop_effect(&self) -> String {
+            String::from("none")
+        }
+
+        fn set_drop_effect(&self, _effect: &str) {}
+
+        fn files(&self) -> Vec<dioxus::html::FileData> {
+            #[cfg(not(feature = "desktop"))]
+            {
+                Vec::new()
+            }
+
+            #[cfg(feature = "desktop")]
+            self.files
+                .iter()
+                .cloned()
+                .map(dioxus::html::FileData::new)
+                .collect()
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    struct TestDragData {
+        transfer: TestNativeDataTransfer,
+    }
+
+    impl TestDragData {
+        fn new(transfer: TestNativeDataTransfer) -> Self {
+            Self { transfer }
+        }
+    }
+
+    impl InteractionLocation for TestDragData {
+        fn client_coordinates(&self) -> ClientPoint {
+            ClientPoint::new(0.0, 0.0)
+        }
+
+        fn screen_coordinates(&self) -> ScreenPoint {
+            ScreenPoint::new(0.0, 0.0)
+        }
+
+        fn page_coordinates(&self) -> PagePoint {
+            PagePoint::new(0.0, 0.0)
+        }
+    }
+
+    impl InteractionElementOffset for TestDragData {
+        fn coordinates(&self) -> Coordinates {
+            Coordinates::new(
+                self.screen_coordinates(),
+                self.client_coordinates(),
+                self.element_coordinates(),
+                self.page_coordinates(),
+            )
+        }
+
+        fn element_coordinates(&self) -> ElementPoint {
+            ElementPoint::new(0.0, 0.0)
+        }
+    }
+
+    impl ModifiersInteraction for TestDragData {
+        fn modifiers(&self) -> Modifiers {
+            Modifiers::empty()
+        }
+    }
+
+    impl PointerInteraction for TestDragData {
+        fn trigger_button(&self) -> Option<MouseButton> {
+            None
+        }
+
+        fn held_buttons(&self) -> MouseButtonSet {
+            MouseButtonSet::empty()
+        }
+    }
+
+    impl HasMouseData for TestDragData {
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+
+    impl HasFileData for TestDragData {
+        fn files(&self) -> Vec<dioxus::html::FileData> {
+            Vec::new()
+        }
+    }
+
+    impl HasDataTransferData for TestDragData {
+        fn data_transfer(&self) -> DioxusDataTransfer {
+            DioxusDataTransfer::new(self.transfer.clone())
+        }
+    }
+
+    impl HasDragData for TestDragData {
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    struct TestMountedBacking {
+        focused: Rc<Cell<Option<bool>>>,
+        scrolled: Rc<Cell<bool>>,
+        rect: Option<PixelsRect>,
+    }
+
+    impl TestMountedBacking {
+        fn new(rect: Option<PixelsRect>) -> Self {
+            Self {
+                focused: Rc::new(Cell::new(None)),
+                scrolled: Rc::new(Cell::new(false)),
+                rect,
+            }
+        }
+    }
+
+    impl RenderedElementBacking for TestMountedBacking {
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+
+        fn get_client_rect(&self) -> Pin<Box<dyn Future<Output = MountedResult<PixelsRect>>>> {
+            let rect = self.rect;
+
+            Box::pin(async move { rect.ok_or(MountedError::NotSupported) })
+        }
+
+        fn scroll_to(
+            &self,
+            _options: dioxus::html::ScrollToOptions,
+        ) -> Pin<Box<dyn Future<Output = MountedResult<()>>>> {
+            let scrolled = Rc::clone(&self.scrolled);
+
+            Box::pin(async move {
+                scrolled.set(true);
+                Ok(())
+            })
+        }
+
+        fn set_focus(&self, focus: bool) -> Pin<Box<dyn Future<Output = MountedResult<()>>>> {
+            let focused = Rc::clone(&self.focused);
+
+            Box::pin(async move {
+                focused.set(Some(focus));
+                Ok(())
+            })
+        }
+    }
+
+    #[derive(Clone, Copy, Debug)]
+    struct MountedDelegatingPlatform;
+
+    impl DioxusPlatform for MountedDelegatingPlatform {
+        fn set_clipboard(&self, _text: &str) -> Pin<Box<dyn Future<Output = Result<(), String>>>> {
+            Box::pin(async { Ok(()) })
+        }
+
+        fn open_file_picker(
+            &self,
+            _options: FilePickerOptions,
+        ) -> Pin<Box<dyn Future<Output = Vec<FileRef>>>> {
+            Box::pin(async { Vec::new() })
+        }
+
+        fn monotonic_now(&self) -> Duration {
+            Duration::ZERO
+        }
+
+        fn new_id(&self) -> String {
+            String::from("mounted-delegating-platform")
+        }
+
+        fn create_drag_data(&self, _event: PlatformDragEvent<'_>) -> Option<DragData> {
+            None
+        }
+    }
+
+    /// Drives a `Pin<Box<dyn Future<…>>>` to completion synchronously,
+    /// panicking if the future returns `Pending` (every `NullPlatform`
+    /// future is immediately ready).
+    fn block_on_ready<T>(mut future: Pin<Box<dyn Future<Output = T>>>) -> T {
+        let mut context = Context::from_waker(Waker::noop());
+
+        match future.as_mut().poll(&mut context) {
+            Poll::Ready(value) => value,
+            Poll::Pending => panic!("test future unexpectedly returned Pending"),
+        }
+    }
+
+    #[test]
+    fn null_platform_mounted_element_methods_are_noops() {
+        let backing =
+            TestMountedBacking::new(Some(PixelsRect::new(point2(1.0, 2.0), size2(3.0, 4.0))));
+
+        let focused = Rc::clone(&backing.focused);
+
+        let scrolled = Rc::clone(&backing.scrolled);
+
+        let element = Rc::new(MountedData::new(backing));
+
+        assert_eq!(
+            block_on_ready(NullPlatform.focus_mounted_element(Rc::clone(&element))),
+            Ok(())
+        );
+        assert!(
+            block_on_ready(NullPlatform.get_mounted_bounding_rect(Rc::clone(&element))).is_none()
+        );
+        assert_eq!(
+            block_on_ready(NullPlatform.scroll_mounted_into_view(element)),
+            Ok(())
+        );
+
+        assert_eq!(focused.get(), None);
+        assert!(!scrolled.get());
+    }
+
+    #[test]
+    fn default_mounted_element_methods_delegate_to_mounted_data() {
+        let backing =
+            TestMountedBacking::new(Some(PixelsRect::new(point2(1.0, 2.0), size2(3.0, 4.0))));
+
+        let focused = Rc::clone(&backing.focused);
+
+        let scrolled = Rc::clone(&backing.scrolled);
+
+        let element = Rc::new(MountedData::new(backing));
+
+        assert_eq!(
+            block_on_ready(MountedDelegatingPlatform.focus_mounted_element(Rc::clone(&element))),
+            Ok(())
+        );
+
+        let rect = block_on_ready(
+            MountedDelegatingPlatform.get_mounted_bounding_rect(Rc::clone(&element)),
+        )
+        .expect("mounted rect");
+
+        assert_eq!(
+            block_on_ready(MountedDelegatingPlatform.scroll_mounted_into_view(element)),
+            Ok(())
+        );
+
+        assert_eq!(focused.get(), Some(true));
+        assert!(scrolled.get());
+        assert_eq!(
+            rect,
+            Rect {
+                x: 1.0,
+                y: 2.0,
+                width: 3.0,
+                height: 4.0,
+            }
+        );
+    }
+
+    #[test]
+    fn null_platform_set_clipboard_returns_ok() {
+        assert_eq!(block_on_ready(NullPlatform.set_clipboard("text")), Ok(()));
+    }
+
+    #[test]
+    fn null_platform_open_file_picker_returns_empty() {
+        assert!(
+            block_on_ready(NullPlatform.open_file_picker(FilePickerOptions::default())).is_empty()
+        );
+    }
+
+    #[test]
+    fn null_platform_monotonic_now_is_zero() {
+        assert_eq!(NullPlatform.monotonic_now(), Duration::ZERO);
+    }
+
+    #[test]
+    fn null_platform_new_id_is_unique_and_sequential() {
+        let first = NullPlatform.new_id();
+        let second = NullPlatform.new_id();
+
+        assert!(first.starts_with("null-id-"));
+        assert!(second.starts_with("null-id-"));
+        assert_ne!(first, second);
+
+        // Suffix monotonicity: the trailing counter on `second` must be
+        // strictly greater than the one on `first`. Other tests share the
+        // global counter, so we compare relatively rather than to fixed
+        // values.
+        let suffix = |id: &str| -> usize {
+            id.strip_prefix("null-id-")
+                .and_then(|s| s.parse::<usize>().ok())
+                .expect("null-id should have numeric suffix")
+        };
+
+        assert!(suffix(&second) > suffix(&first));
+    }
+
+    #[test]
+    fn null_platform_create_drag_data_returns_none() {
+        // `NullPlatform` ignores the event entirely; an empty wrapper is
+        // the cheapest representative on a native test host.
+        assert!(
+            NullPlatform
+                .create_drag_data(PlatformDragEvent::empty())
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn file_picker_options_default_has_empty_accept_and_not_multiple() {
+        let options = FilePickerOptions::default();
+
+        assert!(options.accept.is_empty());
+        assert!(!options.multiple);
+    }
+
+    #[test]
+    fn drag_data_default_is_empty() {
+        let data = DragData::default();
+
+        assert!(data.items.is_empty());
+        assert!(data.types.is_empty());
+    }
+
+    #[test]
+    fn drag_data_from_dioxus_drag_data_extracts_known_mime_types() {
+        let native = TestNativeDataTransfer::with_data([
+            ("text/plain", "hello"),
+            ("text/html", "<p>hello</p>"),
+            ("application/x-ars-custom", "custom"),
+        ]);
+
+        let event = DioxusDragData::new(TestDragData::new(native));
+
+        let data = DragData::from_drag_data(&event);
+
+        assert!(data.items.is_empty());
+        assert_eq!(
+            data.types,
+            vec![String::from("text/plain"), String::from("text/html")]
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "desktop")]
+    fn drag_data_from_dioxus_drag_data_extracts_file_items_and_files_type() {
+        let real_path = std::path::PathBuf::from("/tmp/report.JSON");
+
+        let native = TestNativeDataTransfer::with_files([
+            SerializedFileData {
+                path: real_path.clone(),
+                size: 42,
+                last_modified: 100,
+                content_type: Some(String::from("application/json")),
+                contents: None,
+            },
+            SerializedFileData {
+                path: std::path::PathBuf::from("untitled"),
+                size: 7,
+                last_modified: 101,
+                content_type: None,
+                contents: None,
+            },
+        ]);
+
+        let event = DioxusDragData::new(TestDragData::new(native));
+
+        let data = DragData::from_drag_data(&event);
+
+        assert_eq!(data.types, vec![String::from("Files")]);
+        assert_eq!(data.items.len(), 2);
+
+        match &data.items[0] {
+            DragItem::File {
+                name,
+                mime_type,
+                size,
+                handle,
+            } => {
+                assert_eq!(name, "report.JSON");
+                assert_eq!(mime_type, "application/json");
+                assert_eq!(*size, 42);
+                assert_eq!(handle.as_path(), Some(real_path.as_path()));
+            }
+
+            other => panic!("unexpected first drag item: {other:?}"),
+        }
+
+        match &data.items[1] {
+            DragItem::File {
+                name,
+                mime_type,
+                size,
+                handle,
+            } => {
+                assert_eq!(name, "untitled");
+                assert_eq!(mime_type, "application/octet-stream");
+                assert_eq!(*size, 7);
+                assert_eq!(handle.as_path(), Some(std::path::Path::new("untitled")));
+            }
+
+            other => panic!("unexpected second drag item: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn platform_drag_event_round_trips_dioxus_drag_data() {
+        let event = DioxusDragData::new(TestDragData::new(TestNativeDataTransfer::default()));
+
+        let wrapper = PlatformDragEvent::from_dioxus(&event);
+
+        assert!(wrapper.as_dioxus().is_some());
+        assert!(PlatformDragEvent::empty().as_dioxus().is_none());
+    }
+
+    #[cfg(not(any(feature = "web", feature = "desktop")))]
+    #[test]
+    fn default_dioxus_platform_falls_back_to_null_when_no_platform_feature() {
+        let platform = default_dioxus_platform();
+
+        // Only NullPlatform reports `Duration::ZERO`; the other impls
+        // return a real clock value, so this is a precise probe.
+        assert_eq!(platform.monotonic_now(), Duration::ZERO);
+        assert!(platform.new_id().starts_with("null-id-"));
+    }
+
+    #[cfg(all(feature = "desktop", not(all(feature = "web", target_arch = "wasm32"))))]
+    #[test]
+    fn default_dioxus_platform_uses_desktop_when_web_is_unreachable() {
+        // Fires whenever desktop is on AND we can't pick web (either web
+        // is off, or we're not on wasm32). DesktopPlatform mints UUIDv4
+        // strings (36 chars with dashes); the null fallback would return
+        // a `null-id-N` instead.
+        let platform = default_dioxus_platform();
+
+        let id = platform.new_id();
+
+        assert_eq!(id.len(), 36, "expected UUIDv4 length, got {id:?}");
+        assert!(!id.starts_with("null-id-"));
+    }
+
+    #[cfg(all(feature = "web", not(feature = "desktop"), not(target_arch = "wasm32")))]
+    #[test]
+    fn default_dioxus_platform_falls_back_to_null_on_non_wasm_web_only_host() {
+        // `WebPlatform` is wasm32-only, so `--features web` on a native
+        // dev host (e.g., `cargo check --features web`) lands at the null
+        // arm. This is by design — silent web-style behaviour on a native
+        // process would mask misconfigured production builds.
+        let platform = default_dioxus_platform();
+
+        assert_eq!(platform.monotonic_now(), Duration::ZERO);
+        assert!(platform.new_id().starts_with("null-id-"));
+    }
+
+    // -- DesktopPlatform method coverage --------------------------------
+    //
+    // These tests fire on any native build of `ars-dioxus` with the
+    // `desktop` feature enabled (the workspace's `cargo xci` adapter
+    // step runs them). They lift `DesktopPlatform` from ~12% method
+    // coverage (only `new_id`, incidentally) to 100% method coverage,
+    // minus `set_clipboard`'s arboard happy path which is not safe to
+    // run in CI (it requires a display server and writes the user's
+    // real clipboard).
+
+    #[cfg(feature = "desktop")]
+    #[test]
+    fn desktop_file_picker_filter_extensions_parse_accept_tokens() {
+        let extensions = file_picker_filter_extensions(&[
+            String::from(".txt"),
+            String::from("image/png,image/jpeg"),
+            String::from("application/json"),
+            String::from("image/*"),
+        ]);
+
+        assert_eq!(
+            extensions,
+            vec![
+                String::from("txt"),
+                String::from("png"),
+                String::from("jpg"),
+                String::from("jpeg"),
+                String::from("json"),
+                String::from("gif"),
+                String::from("webp"),
+                String::from("svg"),
+                String::from("bmp"),
+                String::from("ico"),
+            ]
+        );
+        assert_eq!(
+            file_picker_filter_name(&extensions[..3]),
+            String::from("*.txt, *.png, *.jpg")
+        );
+    }
+
+    #[cfg(feature = "desktop")]
+    #[test]
+    fn desktop_file_picker_filter_extensions_cover_media_and_fallback_tokens() {
+        let extensions = file_picker_filter_extensions(&[
+            String::from("audio/*"),
+            String::from("video/mp4,video/webm,video/quicktime"),
+            String::from(".CUSTOM"),
+            String::from("application/x-unknown"),
+            String::from("*/*"),
+        ]);
+
+        assert_eq!(
+            extensions,
+            vec![
+                String::from("mp3"),
+                String::from("wav"),
+                String::from("ogg"),
+                String::from("flac"),
+                String::from("aac"),
+                String::from("mp4"),
+                String::from("webm"),
+                String::from("mov"),
+                String::from("custom"),
+            ]
+        );
+        assert_eq!(file_picker_filter_name(&[]), "All files");
+    }
+
+    #[cfg(feature = "desktop")]
+    #[test]
+    fn desktop_mime_type_for_path_covers_known_and_fallback_extensions() {
+        let cases = [
+            ("note.TXT", "text/plain"),
+            ("page.htm", "text/html"),
+            ("style.css", "text/css"),
+            ("table.csv", "text/csv"),
+            ("doc.pdf", "application/pdf"),
+            ("image.png", "image/png"),
+            ("photo.jpeg", "image/jpeg"),
+            ("anim.gif", "image/gif"),
+            ("picture.webp", "image/webp"),
+            ("icon.svg", "image/svg+xml"),
+            ("bitmap.bmp", "image/bmp"),
+            ("favicon.ico", "image/x-icon"),
+            ("song.mp3", "audio/mpeg"),
+            ("sound.wav", "audio/wav"),
+            ("voice.ogg", "audio/ogg"),
+            ("lossless.flac", "audio/flac"),
+            ("clip.aac", "audio/aac"),
+            ("movie.mp4", "video/mp4"),
+            ("movie.webm", "video/webm"),
+            ("movie.mov", "video/quicktime"),
+            ("movie.avi", "video/x-msvideo"),
+            ("movie.mkv", "video/x-matroska"),
+            ("unknown.bin", "application/octet-stream"),
+            ("no-extension", "application/octet-stream"),
+        ];
+
+        for (path, expected) in cases {
+            assert_eq!(mime_type_for_path(std::path::Path::new(path)), expected);
+        }
+    }
+
+    #[cfg(feature = "desktop")]
+    #[test]
+    fn desktop_file_ref_from_path_reads_name_size_and_mime_type() {
+        let path =
+            std::env::temp_dir().join(format!("ars-dioxus-platform-{}.json", uuid::Uuid::new_v4()));
+
+        std::fs::write(&path, br#"{"id":1}"#).expect("write temp file");
+
+        let file = file_ref_from_path(&path);
+
+        assert_eq!(
+            file.name,
+            path.file_name().unwrap().to_string_lossy().into_owned()
+        );
+        assert_eq!(file.size, 8);
+        assert_eq!(file.mime_type, "application/json");
+
+        std::fs::remove_file(path).expect("remove temp file");
+    }
+
+    #[cfg(feature = "desktop")]
+    #[test]
+    fn desktop_platform_create_drag_data_returns_none_for_empty_event() {
+        assert!(
+            DesktopPlatform
+                .create_drag_data(PlatformDragEvent::empty())
+                .is_none()
+        );
+    }
+
+    #[cfg(feature = "desktop")]
+    #[test]
+    fn desktop_platform_create_drag_data_extracts_dioxus_payload() {
+        let native = TestNativeDataTransfer::with_data([("application/json", "{\"id\":1}")]);
+
+        let event = DioxusDragData::new(TestDragData::new(native));
+
+        let data = DesktopPlatform
+            .create_drag_data(PlatformDragEvent::from_dioxus(&event))
+            .expect("desktop platform should extract Dioxus drag data");
+
+        assert!(data.items.is_empty());
+        assert_eq!(data.types, vec![String::from("application/json")]);
+    }
+
+    #[cfg(feature = "desktop")]
+    #[test]
+    fn desktop_platform_monotonic_now_is_elapsed_from_process_start() {
+        let now = DesktopPlatform.monotonic_now();
+
+        let later = DesktopPlatform.monotonic_now();
+
+        assert!(later >= now, "expected {later:?} >= {now:?}");
+    }
+
+    #[cfg(feature = "desktop")]
+    #[test]
+    fn desktop_platform_new_id_yields_unique_uuid_v4_strings() {
+        let first = DesktopPlatform.new_id();
+        let second = DesktopPlatform.new_id();
+
+        // Canonical `UUIDv4` representation is 36 characters with
+        // dashes at fixed positions and version nibble '4' at index 14.
+        for id in [&first, &second] {
+            assert_eq!(id.len(), 36, "unexpected length: {id:?}");
+            assert_eq!(id.as_bytes()[8], b'-');
+            assert_eq!(id.as_bytes()[13], b'-');
+            assert_eq!(id.as_bytes()[18], b'-');
+            assert_eq!(id.as_bytes()[23], b'-');
+            assert_eq!(id.as_bytes()[14], b'4');
+        }
+
+        // Two `Uuid::new_v4()` calls colliding has probability ~2^-122;
+        // a failure here is a real signal, not a flake.
+        assert_ne!(first, second);
+    }
+
+    /// Opt-in clipboard happy-path test.
+    ///
+    /// Default-skipped via `#[ignore]` because:
+    ///
+    /// 1. `arboard::Clipboard::new()` requires a display server
+    ///    (X11 / Wayland / macOS `WindowServer` / Windows `USER32`)
+    ///    and fails under headless CI runners.
+    /// 2. Even when it succeeds, the test would clobber the
+    ///    developer's real clipboard contents.
+    ///
+    /// Run with `cargo test -p ars-dioxus --features desktop -- --ignored`
+    /// when validating arboard integration interactively.
+    #[cfg(feature = "desktop")]
+    #[test]
+    #[ignore = "writes to the real OS clipboard; run manually with --ignored"]
+    fn desktop_platform_set_clipboard_round_trips_via_arboard() {
+        use arboard::Clipboard;
+
+        let payload = "ars-ui desktop platform clipboard probe";
+
+        let result = block_on_ready(DesktopPlatform.set_clipboard(payload));
+
+        assert!(
+            result.is_ok(),
+            "set_clipboard returned an error on a host with a display server: {result:?}",
+        );
+
+        // Round-trip: read it back through a fresh arboard handle.
+        let mut reader = Clipboard::new().expect("clipboard reader");
+
+        let actual = reader.get_text().expect("clipboard read");
+
+        assert_eq!(
+            actual, payload,
+            "clipboard round-trip lost or corrupted the payload"
+        );
+    }
+}
+
+#[cfg(all(test, feature = "web", target_arch = "wasm32"))]
+mod wasm_tests {
+    use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+
+    use super::*;
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    #[wasm_bindgen_test]
+    fn web_platform_monotonic_now_is_non_decreasing() {
+        let platform = WebPlatform;
+
+        let first = platform.monotonic_now();
+        let second = platform.monotonic_now();
+
+        assert!(second >= first, "expected {second:?} >= {first:?}");
+    }
+
+    #[wasm_bindgen_test]
+    fn web_platform_new_id_yields_uuid_shape() {
+        let id = WebPlatform.new_id();
+
+        // crypto.randomUUID returns canonical UUIDv4: 36 chars, dashes at
+        // positions 8/13/18/23, version nibble '4' at position 14.
+        assert_eq!(id.len(), 36, "unexpected length: {id:?}");
+        assert_eq!(id.as_bytes()[8], b'-');
+        assert_eq!(id.as_bytes()[13], b'-');
+        assert_eq!(id.as_bytes()[18], b'-');
+        assert_eq!(id.as_bytes()[23], b'-');
+        assert_eq!(id.as_bytes()[14], b'4');
+    }
+
+    #[wasm_bindgen_test]
+    fn web_platform_create_drag_data_returns_none_for_empty_event() {
+        // An empty wrapper carries no inner Dioxus drag event —
+        // `create_drag_data` must early-return without touching the
+        // event payload.
+        assert!(
+            WebPlatform
+                .create_drag_data(PlatformDragEvent::empty())
+                .is_none()
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn default_dioxus_platform_picks_web_on_wasm32() {
+        // Under `--features web` on wasm32 the resolution ladder must
+        // pick `WebPlatform`. Probe via `monotonic_now`: `WebPlatform`
+        // returns a non-zero `performance.now()` reading (the page is
+        // already loaded by the time the test runs); `NullPlatform`
+        // would return `Duration::ZERO`.
+        let platform = default_dioxus_platform();
+
+        assert!(
+            platform.monotonic_now() > Duration::ZERO,
+            "expected a non-zero performance.now() reading on wasm32"
+        );
+
+        // UUIDv4 length confirms `crypto.randomUUID()` was used, not
+        // the null-id counter.
+        let id = platform.new_id();
+
+        assert_eq!(id.len(), 36, "expected UUIDv4 length, got {id:?}");
+    }
+
+    #[wasm_bindgen_test]
+    fn web_platform_open_file_picker_returns_empty() {
+        use std::task::{Context, Poll, Waker};
+
+        // The web impl deliberately defers to the FileUpload component's
+        // hidden `<input>`; the trait method must resolve immediately
+        // to an empty `Vec<FileRef>` regardless of options.
+        let opts = FilePickerOptions {
+            accept: vec![String::from("image/*")],
+            multiple: true,
+        };
+
+        let pollable = WebPlatform.open_file_picker(opts);
+
+        // We can't `block_on_ready` on wasm-test (no executor); use a
+        // raw poll like the native helper does.
+        let mut pinned = pollable;
+
+        let waker = Waker::noop();
+
+        let mut cx = Context::from_waker(waker);
+
+        match pinned.as_mut().poll(&mut cx) {
+            Poll::Ready(files) => assert!(files.is_empty()),
+            Poll::Pending => panic!("open_file_picker future returned Pending on web"),
+        }
+    }
+
+    #[wasm_bindgen_test]
+    fn web_platform_new_id_is_unique_across_calls() {
+        // crypto.randomUUID is RFC 4122 random; collision probability
+        // ~2^-122 means a duplicate here is a real signal.
+        let first = WebPlatform.new_id();
+        let second = WebPlatform.new_id();
+        let third = WebPlatform.new_id();
+
+        assert_ne!(first, second);
+        assert_ne!(second, third);
+        assert_ne!(first, third);
+    }
+}

--- a/crates/ars-dioxus/src/platform.rs
+++ b/crates/ars-dioxus/src/platform.rs
@@ -538,7 +538,7 @@ fn file_picker_filter_extensions(accept: &[String]) -> Vec<String> {
 #[cfg(feature = "desktop")]
 fn accept_token_extensions(token: &str) -> Vec<String> {
     match token.strip_prefix('.').unwrap_or(token) {
-        "txt" => vec![String::from("txt")],
+        "txt" | "text/plain" => vec![String::from("txt")],
 
         "html" | "text/html" => vec![String::from("html"), String::from("htm")],
 
@@ -1321,6 +1321,14 @@ mod tests {
             file_picker_filter_name(&extensions[..3]),
             String::from("*.txt, *.png, *.jpg")
         );
+    }
+
+    #[cfg(feature = "desktop")]
+    #[test]
+    fn desktop_file_picker_filter_extensions_maps_text_plain_mime_type() {
+        let extensions = file_picker_filter_extensions(&[String::from("text/plain")]);
+
+        assert_eq!(extensions, vec![String::from("txt")]);
     }
 
     #[cfg(feature = "desktop")]

--- a/crates/ars-dioxus/src/provider.rs
+++ b/crates/ars-dioxus/src/provider.rs
@@ -1,203 +1,21 @@
 //! Reactive `ArsProvider` context helpers for the Dioxus adapter.
 
 use std::{
-    any::Any,
     fmt::{self, Debug},
-    pin::Pin,
     sync::Arc,
 };
 
 use ars_core::{
     ColorMode, DefaultModalityContext, I18nRegistries, ModalityContext, NullPlatformEffects,
-    PlatformEffects, Rect, StyleStrategy, resolve_messages as core_resolve_messages,
+    PlatformEffects, StyleStrategy, resolve_messages as core_resolve_messages,
 };
-use ars_forms::field::FileRef;
 use ars_i18n::{Direction, IntlBackend, Locale, StubIntlBackend, Translate, locales, number};
 use dioxus::prelude::*;
 
-use crate::nonce::{ArsNonceStyle, use_nonce_css_context_provider};
-
-/// Options for opening a platform file picker.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct FilePickerOptions;
-
-/// Adapter-local drag payload wrapper.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct DragData;
-
-/// Dioxus-specific platform services not covered by core [`PlatformEffects`].
-pub trait DioxusPlatform: Send + Sync + 'static {
-    /// Focus an element by its ID.
-    fn focus_element(&self, id: &str);
-
-    /// Returns the current bounding rect for an element, if available.
-    fn get_bounding_rect(&self, id: &str) -> Option<Rect>;
-
-    /// Scrolls an element into view.
-    fn scroll_into_view(&self, id: &str);
-
-    /// Writes text to the clipboard.
-    fn set_clipboard(&self, text: &str) -> Pin<Box<dyn Future<Output = Result<(), String>>>>;
-
-    /// Opens a native file picker.
-    fn open_file_picker(
-        &self,
-        options: FilePickerOptions,
-    ) -> Pin<Box<dyn Future<Output = Vec<FileRef>>>>;
-
-    /// Returns the current timestamp in milliseconds.
-    fn now_ms(&self) -> f64;
-
-    /// Generates a platform-scoped unique ID.
-    fn new_id(&self) -> String;
-
-    /// Creates drag data from a platform event, if supported.
-    fn create_drag_data(&self, event: &dyn Any) -> Option<DragData>;
-}
-
-/// Web platform implementation placeholder.
-#[cfg(feature = "web")]
-#[derive(Clone, Copy, Debug, Default)]
-pub struct WebPlatform;
-
-/// Desktop platform implementation placeholder.
-#[cfg(feature = "desktop")]
-#[derive(Clone, Copy, Debug, Default)]
-pub struct DesktopPlatform;
-
-/// No-op platform for tests and non-interactive environments.
-#[derive(Clone, Copy, Debug, Default)]
-pub struct NullPlatform;
-
-#[cfg(feature = "web")]
-impl DioxusPlatform for WebPlatform {
-    fn focus_element(&self, id: &str) {
-        NullPlatform.focus_element(id);
-    }
-
-    fn get_bounding_rect(&self, id: &str) -> Option<Rect> {
-        NullPlatform.get_bounding_rect(id)
-    }
-
-    fn scroll_into_view(&self, id: &str) {
-        NullPlatform.scroll_into_view(id);
-    }
-
-    fn set_clipboard(&self, text: &str) -> Pin<Box<dyn Future<Output = Result<(), String>>>> {
-        NullPlatform.set_clipboard(text)
-    }
-
-    fn open_file_picker(
-        &self,
-        options: FilePickerOptions,
-    ) -> Pin<Box<dyn Future<Output = Vec<FileRef>>>> {
-        NullPlatform.open_file_picker(options)
-    }
-
-    fn now_ms(&self) -> f64 {
-        NullPlatform.now_ms()
-    }
-
-    fn new_id(&self) -> String {
-        NullPlatform.new_id()
-    }
-
-    fn create_drag_data(&self, event: &dyn Any) -> Option<DragData> {
-        NullPlatform.create_drag_data(event)
-    }
-}
-
-#[cfg(feature = "desktop")]
-impl DioxusPlatform for DesktopPlatform {
-    fn focus_element(&self, id: &str) {
-        NullPlatform.focus_element(id);
-    }
-
-    fn get_bounding_rect(&self, id: &str) -> Option<Rect> {
-        NullPlatform.get_bounding_rect(id)
-    }
-
-    fn scroll_into_view(&self, id: &str) {
-        NullPlatform.scroll_into_view(id);
-    }
-
-    fn set_clipboard(&self, text: &str) -> Pin<Box<dyn Future<Output = Result<(), String>>>> {
-        NullPlatform.set_clipboard(text)
-    }
-
-    fn open_file_picker(
-        &self,
-        options: FilePickerOptions,
-    ) -> Pin<Box<dyn Future<Output = Vec<FileRef>>>> {
-        NullPlatform.open_file_picker(options)
-    }
-
-    fn now_ms(&self) -> f64 {
-        NullPlatform.now_ms()
-    }
-
-    fn new_id(&self) -> String {
-        NullPlatform.new_id()
-    }
-
-    fn create_drag_data(&self, event: &dyn Any) -> Option<DragData> {
-        NullPlatform.create_drag_data(event)
-    }
-}
-
-impl DioxusPlatform for NullPlatform {
-    fn focus_element(&self, _id: &str) {}
-
-    fn get_bounding_rect(&self, _id: &str) -> Option<Rect> {
-        None
-    }
-
-    fn scroll_into_view(&self, _id: &str) {}
-
-    fn set_clipboard(&self, _text: &str) -> Pin<Box<dyn Future<Output = Result<(), String>>>> {
-        Box::pin(async { Ok(()) })
-    }
-
-    fn open_file_picker(
-        &self,
-        _options: FilePickerOptions,
-    ) -> Pin<Box<dyn Future<Output = Vec<FileRef>>>> {
-        Box::pin(async { Vec::new() })
-    }
-
-    fn now_ms(&self) -> f64 {
-        0.0
-    }
-
-    fn new_id(&self) -> String {
-        use std::sync::atomic::{AtomicUsize, Ordering};
-
-        static COUNTER: AtomicUsize = AtomicUsize::new(0);
-
-        format!("null-id-{}", COUNTER.fetch_add(1, Ordering::Relaxed))
-    }
-
-    fn create_drag_data(&self, _event: &dyn Any) -> Option<DragData> {
-        None
-    }
-}
-
-fn default_dioxus_platform() -> Arc<dyn DioxusPlatform> {
-    #[cfg(feature = "web")]
-    {
-        Arc::new(WebPlatform)
-    }
-
-    #[cfg(all(feature = "desktop", not(feature = "web")))]
-    {
-        Arc::new(DesktopPlatform)
-    }
-
-    #[cfg(not(any(feature = "web", feature = "desktop")))]
-    {
-        Arc::new(NullPlatform)
-    }
-}
+use crate::{
+    nonce::{ArsNonceStyle, use_nonce_css_context_provider},
+    platform::{DioxusPlatform, default_dioxus_platform},
+};
 
 fn direction_from_locale(locale: &Locale) -> Direction {
     if locale.direction().is_rtl() {
@@ -645,19 +463,6 @@ pub fn use_messages<M: ars_core::ComponentMessages + Send + Sync + 'static>(
     core_resolve_messages(adapter_props_messages, registries.as_ref(), &locale)
 }
 
-/// Resolves the Dioxus-specific platform handle from provider context.
-#[must_use]
-pub fn use_platform() -> Arc<dyn DioxusPlatform> {
-    try_use_context::<ArsContext>().map_or_else(
-        || {
-            warn_missing_provider("use_platform");
-
-            default_dioxus_platform()
-        },
-        |ctx| Arc::clone(&ctx.dioxus_platform),
-    )
-}
-
 /// Resolves application-owned translatable text into a Dioxus string.
 #[must_use]
 #[expect(
@@ -692,10 +497,14 @@ mod tests {
         ColorMode, DefaultModalityContext, I18nRegistries, ModalityContext, NullPlatformEffects,
         StyleStrategy,
     };
+    use ars_forms::field::FileRef;
     use ars_i18n::{Direction, IntlBackend, Locale, StubIntlBackend, Translate, locales, number};
     use dioxus::dioxus_core::{NoOpMutations, ScopeId};
 
     use super::*;
+    use crate::platform::{
+        DragData, FilePickerOptions, NullPlatform, PlatformDragEvent, use_platform,
+    };
 
     #[derive(Clone, Debug, PartialEq, Eq)]
     enum AppText {
@@ -771,14 +580,6 @@ mod tests {
     struct TestPlatform;
 
     impl DioxusPlatform for TestPlatform {
-        fn focus_element(&self, _id: &str) {}
-
-        fn get_bounding_rect(&self, _id: &str) -> Option<Rect> {
-            None
-        }
-
-        fn scroll_into_view(&self, _id: &str) {}
-
         fn set_clipboard(&self, _text: &str) -> Pin<Box<dyn Future<Output = Result<(), String>>>> {
             Box::pin(async { Ok(()) })
         }
@@ -790,15 +591,15 @@ mod tests {
             Box::pin(async { Vec::new() })
         }
 
-        fn now_ms(&self) -> f64 {
-            1.0
+        fn monotonic_now(&self) -> std::time::Duration {
+            std::time::Duration::from_millis(1)
         }
 
         fn new_id(&self) -> String {
             String::from("test-platform-id")
         }
 
-        fn create_drag_data(&self, _event: &dyn Any) -> Option<DragData> {
+        fn create_drag_data(&self, _event: PlatformDragEvent<'_>) -> Option<DragData> {
             None
         }
     }
@@ -1368,16 +1169,16 @@ mod tests {
 
             assert!(Arc::ptr_eq(&platform, &expected));
 
-            platform.focus_element("target");
-
-            assert!(platform.get_bounding_rect("target").is_none());
-
-            platform.scroll_into_view("target");
-
             assert_eq!(block_on_ready(platform.set_clipboard("hello")), Ok(()));
-            assert!(block_on_ready(platform.open_file_picker(FilePickerOptions)).is_empty());
+            assert!(
+                block_on_ready(platform.open_file_picker(FilePickerOptions::default())).is_empty()
+            );
             assert_eq!(platform.new_id(), "test-platform-id");
-            assert!(platform.create_drag_data(&()).is_none());
+            assert!(
+                platform
+                    .create_drag_data(PlatformDragEvent::empty())
+                    .is_none()
+            );
 
             rsx! {
                 div {}
@@ -1416,17 +1217,15 @@ mod tests {
     fn null_platform_is_noop_and_returns_default_values() {
         let platform = NullPlatform;
 
-        platform.focus_element("missing");
-
-        assert!(platform.get_bounding_rect("missing").is_none());
-
-        platform.scroll_into_view("missing");
-
         assert_eq!(block_on_ready(platform.set_clipboard("text")), Ok(()));
-        assert!(block_on_ready(platform.open_file_picker(FilePickerOptions)).is_empty());
-        assert_eq!(platform.now_ms(), 0.0);
+        assert!(block_on_ready(platform.open_file_picker(FilePickerOptions::default())).is_empty());
+        assert_eq!(platform.monotonic_now(), std::time::Duration::ZERO);
         assert!(platform.new_id().starts_with("null-id-"));
-        assert!(platform.create_drag_data(&()).is_none());
+        assert!(
+            platform
+                .create_drag_data(PlatformDragEvent::empty())
+                .is_none()
+        );
     }
 
     #[test]
@@ -1512,9 +1311,7 @@ mod tests {
 #[cfg(all(test, feature = "web", target_arch = "wasm32"))]
 mod wasm_tests {
     use std::{
-        any::Any,
         cell::RefCell,
-        future::Future,
         pin::Pin,
         rc::Rc,
         sync::Arc,
@@ -1522,7 +1319,7 @@ mod wasm_tests {
     };
 
     use ars_core::{
-        ColorMode, I18nRegistries, ModalityContext, NullPlatformEffects, PlatformEffects, Rect,
+        ColorMode, I18nRegistries, ModalityContext, NullPlatformEffects, PlatformEffects,
         StyleStrategy,
     };
     use ars_forms::field::FileRef;
@@ -1534,7 +1331,13 @@ mod wasm_tests {
     use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
 
     use super::*;
-    use crate::{ArsNonceCssCtx, append_nonce_css};
+    use crate::{
+        ArsNonceCssCtx, append_nonce_css,
+        platform::{
+            DioxusPlatform, DragData, FilePickerOptions, NullPlatform, PlatformDragEvent,
+            default_dioxus_platform, use_platform,
+        },
+    };
 
     wasm_bindgen_test_configure!(run_in_browser);
 
@@ -1663,14 +1466,6 @@ mod wasm_tests {
     struct TestPlatform;
 
     impl DioxusPlatform for TestPlatform {
-        fn focus_element(&self, _id: &str) {}
-
-        fn get_bounding_rect(&self, _id: &str) -> Option<Rect> {
-            None
-        }
-
-        fn scroll_into_view(&self, _id: &str) {}
-
         fn set_clipboard(&self, _text: &str) -> Pin<Box<dyn Future<Output = Result<(), String>>>> {
             Box::pin(async { Ok(()) })
         }
@@ -1682,15 +1477,15 @@ mod wasm_tests {
             Box::pin(async { Vec::new() })
         }
 
-        fn now_ms(&self) -> f64 {
-            1.0
+        fn monotonic_now(&self) -> std::time::Duration {
+            std::time::Duration::from_millis(1)
         }
 
         fn new_id(&self) -> String {
             String::from("test-platform-id")
         }
 
-        fn create_drag_data(&self, _event: &dyn Any) -> Option<super::DragData> {
+        fn create_drag_data(&self, _event: PlatformDragEvent<'_>) -> Option<DragData> {
             None
         }
     }
@@ -1915,13 +1710,15 @@ mod wasm_tests {
     #[wasm_bindgen_test]
     fn default_dioxus_platform_uses_web_feature_path() {
         let platform = default_dioxus_platform();
+        let id = platform.new_id();
 
-        platform.focus_element("missing");
-        platform.scroll_into_view("missing");
-
-        assert!(platform.get_bounding_rect("missing").is_none());
-        assert!(platform.new_id().starts_with("null-id-"));
-        assert!(platform.create_drag_data(&()).is_none());
+        assert_eq!(id.len(), 36, "expected UUIDv4 length, got {id:?}");
+        assert!(!id.starts_with("null-id-"));
+        assert!(
+            platform
+                .create_drag_data(PlatformDragEvent::empty())
+                .is_none()
+        );
     }
 
     #[wasm_bindgen_test]
@@ -2019,9 +1816,17 @@ mod wasm_tests {
 
             let generated_id = platform.new_id();
 
-            assert!(generated_id.starts_with("null-id-"));
-            assert!(platform.get_bounding_rect("missing").is_none());
-            assert!(platform.create_drag_data(&()).is_none());
+            assert_eq!(
+                generated_id.len(),
+                36,
+                "expected UUIDv4 length, got {generated_id:?}",
+            );
+            assert!(!generated_id.starts_with("null-id-"));
+            assert!(
+                platform
+                    .create_drag_data(PlatformDragEvent::empty())
+                    .is_none()
+            );
 
             rsx! {
                 div {}
@@ -2193,14 +1998,16 @@ mod wasm_tests {
 
             assert!(Arc::ptr_eq(&platform, &expected));
 
-            platform.focus_element("target");
-            platform.scroll_into_view("target");
-
-            assert!(platform.get_bounding_rect("target").is_none());
             assert_eq!(block_on_ready(platform.set_clipboard("hello")), Ok(()));
-            assert!(block_on_ready(platform.open_file_picker(FilePickerOptions)).is_empty());
+            assert!(
+                block_on_ready(platform.open_file_picker(FilePickerOptions::default())).is_empty()
+            );
             assert_eq!(platform.new_id(), "test-platform-id");
-            assert!(platform.create_drag_data(&()).is_none());
+            assert!(
+                platform
+                    .create_drag_data(PlatformDragEvent::empty())
+                    .is_none()
+            );
 
             rsx! {
                 div {}

--- a/crates/ars-dioxus/src/safe_listener.rs
+++ b/crates/ars-dioxus/src/safe_listener.rs
@@ -266,10 +266,7 @@ mod wasm_tests {
     use super::{
         SafeEventListener, SafeEventListenerOptions, use_safe_event_listener,
         use_safe_event_listeners,
-        web::{
-            ListenerClosureHandle, RegisteredListener, guarded_listener_closure,
-            remove_previous_listeners,
-        },
+        web::{RegisteredListener, guarded_listener_closure, remove_previous_listeners},
     };
 
     wasm_bindgen_test_configure!(run_in_browser);

--- a/crates/ars-dioxus/tests/desktop_platform.rs
+++ b/crates/ars-dioxus/tests/desktop_platform.rs
@@ -1,0 +1,330 @@
+//! End-to-end Desktop test pass for the Dioxus platform abstraction.
+//!
+//! Complements the per-method native unit tests in
+//! `crates/ars-dioxus/src/platform.rs` (mod tests, gated on
+//! `feature = "desktop"`) by exercising `use_platform()` and the
+//! `ArsContext.dioxus_platform` threading through a real
+//! [`VirtualDom`] mount via [`DesktopHarness`]. The unit tests prove
+//! `DesktopPlatform`'s methods do the right thing in isolation; this
+//! file proves the trait object survives provider context, hook
+//! resolution, render cycles, and harness teardown without panicking
+//! or losing identity.
+//!
+//! Gated on `not(target_arch = "wasm32")` because `DesktopHarness`
+//! runs on the native test profile only — wasm builds exercise the
+//! same surface via `mod wasm_tests` inside `platform.rs`.
+//!
+//! Spec refs:
+//! - `spec/foundation/09-adapter-dioxus.md` §6.1 (`DioxusPlatform`)
+//! - `spec/foundation/09-adapter-dioxus.md` §6.2 (`use_platform`)
+//! - `spec/testing/15-test-harness.md` §5.4 (non-web Dioxus tier)
+
+#![cfg(all(not(target_arch = "wasm32"), feature = "desktop"))]
+
+use std::{
+    cell::RefCell,
+    rc::Rc,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use ars_core::{
+    ColorMode, DefaultModalityContext, I18nRegistries, ModalityContext, NullPlatformEffects,
+    PlatformEffects, StyleStrategy,
+};
+use ars_dioxus::{
+    ArsContext, DioxusPlatform, DragData, NullPlatform, PlatformDragEvent, use_platform,
+};
+use ars_i18n::{Direction, IntlBackend, StubIntlBackend, locales};
+use ars_test_harness_dioxus::desktop::DesktopHarness;
+use dioxus::prelude::*;
+
+/// Captures every platform method invocation a fixture makes so
+/// assertions can run after the harness has dropped. Uses sync
+/// primitives (`Arc<Mutex>`) rather than Dioxus signals because the
+/// fixture writes from inside `use_hook` and assertions read from the
+/// outer test thread after harness teardown.
+#[derive(Clone, Debug, Default)]
+struct ProbeRecorder {
+    new_ids: Arc<Mutex<Vec<String>>>,
+    last_now: Arc<Mutex<Option<Duration>>>,
+    later_now: Arc<Mutex<Option<Duration>>>,
+    drag_data_was_none: Arc<Mutex<Option<bool>>>,
+}
+
+#[derive(Clone)]
+struct FixtureProps {
+    recorder: ProbeRecorder,
+
+    /// Optional explicit platform to install on the [`ArsContext`]
+    /// before the fixture component mounts. When `None` the fixture
+    /// goes through the default-provider fallback path.
+    explicit_platform: Option<Arc<dyn DioxusPlatform>>,
+
+    /// Captured handle to the platform `use_platform()` resolved.
+    /// Populated by the fixture during render so the test thread can
+    /// verify Arc identity matches what was installed.
+    resolved_platform_slot: Rc<RefCell<Option<Arc<dyn DioxusPlatform>>>>,
+}
+
+impl PartialEq for FixtureProps {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.recorder.new_ids, &other.recorder.new_ids)
+            && Rc::ptr_eq(&self.resolved_platform_slot, &other.resolved_platform_slot)
+            && match (&self.explicit_platform, &other.explicit_platform) {
+                (Some(a), Some(b)) => Arc::ptr_eq(a, b),
+                (None, None) => true,
+                _ => false,
+            }
+    }
+}
+
+#[expect(
+    clippy::needless_pass_by_value,
+    reason = "Dioxus root props are moved into the render function."
+)]
+fn fixture(props: FixtureProps) -> Element {
+    // Provider must be installed before any consumer hook in this scope.
+    if let Some(explicit) = props.explicit_platform.clone() {
+        use_context_provider(move || build_context(explicit));
+    }
+
+    // Hooks must be called at the top level of the component — calling
+    // them from inside `use_hook(...)` triggers Dioxus's hook-list
+    // borrow check at runtime.
+    let platform = use_platform();
+
+    let recorder = props.recorder.clone();
+
+    let slot = Rc::clone(&props.resolved_platform_slot);
+
+    let captured = Arc::clone(&platform);
+
+    use_hook(move || {
+        // Stash the handle so the test can compare Arc identities.
+        *slot.borrow_mut() = Some(Arc::clone(&captured));
+
+        let drag = captured.create_drag_data(PlatformDragEvent::empty());
+
+        let id_a = captured.new_id();
+        let id_b = captured.new_id();
+
+        recorder
+            .new_ids
+            .lock()
+            .expect("new_ids mutex must not be poisoned")
+            .extend([id_a, id_b]);
+
+        *recorder
+            .last_now
+            .lock()
+            .expect("last_now mutex must not be poisoned") = Some(captured.monotonic_now());
+
+        *recorder
+            .later_now
+            .lock()
+            .expect("later_now mutex must not be poisoned") = Some(captured.monotonic_now());
+
+        *recorder
+            .drag_data_was_none
+            .lock()
+            .expect("drag mutex must not be poisoned") = Some(drag.is_none());
+    });
+
+    rsx! {
+        div { id: "desktop-platform-probe" }
+    }
+}
+
+/// Builds a minimal [`ArsContext`] carrying the supplied platform.
+/// Other context fields use the same null-effect defaults the
+/// `provider.rs` tests rely on.
+fn build_context(platform: Arc<dyn DioxusPlatform>) -> ArsContext {
+    let core_platform: Arc<dyn PlatformEffects> = Arc::new(NullPlatformEffects);
+    let modality: Arc<dyn ModalityContext> = Arc::new(DefaultModalityContext::new());
+    let intl: Arc<dyn IntlBackend> = Arc::new(StubIntlBackend);
+
+    ArsContext::new(
+        locales::en_us(),
+        Direction::Ltr,
+        ColorMode::System,
+        false,
+        false,
+        None,
+        None,
+        None,
+        core_platform,
+        modality,
+        intl,
+        Arc::new(I18nRegistries::new()),
+        platform,
+        StyleStrategy::Inline,
+    )
+}
+
+fn empty_recorder() -> ProbeRecorder {
+    ProbeRecorder::default()
+}
+
+fn make_props(
+    recorder: ProbeRecorder,
+    explicit_platform: Option<Arc<dyn DioxusPlatform>>,
+) -> FixtureProps {
+    FixtureProps {
+        recorder,
+        explicit_platform,
+        resolved_platform_slot: Rc::new(RefCell::new(None)),
+    }
+}
+
+#[test]
+fn use_platform_resolves_desktop_default_when_no_provider_is_present() {
+    // No `ArsProvider` mounted → `use_platform()` falls through
+    // [`default_dioxus_platform`] which selects `DesktopPlatform`
+    // (since `web` is not on a wasm32 target here).
+    let recorder = empty_recorder();
+
+    let props = make_props(recorder.clone(), None);
+
+    let _harness = DesktopHarness::launch_with_props(fixture, props.clone());
+
+    // The fixture must have driven every method without panicking.
+    let new_ids = recorder
+        .new_ids
+        .lock()
+        .expect("new_ids mutex must not be poisoned");
+
+    assert_eq!(new_ids.len(), 2);
+
+    // DesktopPlatform mints UUIDv4 strings, never `null-id-…`.
+    for id in new_ids.iter() {
+        assert_eq!(id.len(), 36, "expected UUIDv4 length, got {id:?}");
+        assert!(!id.starts_with("null-id-"), "got null-id from desktop path");
+    }
+
+    assert_ne!(new_ids[0], new_ids[1], "UUIDv4 collision is real signal");
+
+    // Instant-backed monotonic_now must not go backwards. The first
+    // sample can legitimately be zero because the static start point is
+    // initialized on first use.
+    let now = recorder
+        .last_now
+        .lock()
+        .expect("last_now mutex must not be poisoned")
+        .expect("fixture must record monotonic_now");
+
+    let later = recorder
+        .later_now
+        .lock()
+        .expect("later_now mutex must not be poisoned")
+        .expect("fixture must record second monotonic_now");
+
+    assert!(later >= now);
+
+    // Empty drag wrappers return their no-payload default.
+    let lock_bool = |slot: &Arc<Mutex<Option<bool>>>, label: &str| -> Option<bool> {
+        *slot
+            .lock()
+            .unwrap_or_else(|_| panic!("{label} mutex must not be poisoned"))
+    };
+
+    assert_eq!(lock_bool(&recorder.drag_data_was_none, "drag"), Some(true));
+}
+
+#[test]
+fn use_platform_returns_explicit_arc_from_ars_context_via_arc_ptr_eq() {
+    // Install a `NullPlatform` Arc explicitly; `use_platform()` must
+    // hand back the *same* Arc, proving the context lookup path
+    // doesn't accidentally allocate a fresh handle.
+    let recorder = empty_recorder();
+
+    let explicit: Arc<dyn DioxusPlatform> = Arc::new(NullPlatform);
+
+    let props = make_props(recorder.clone(), Some(Arc::clone(&explicit)));
+
+    let resolved_slot = Rc::clone(&props.resolved_platform_slot);
+
+    let _harness = DesktopHarness::launch_with_props(fixture, props);
+
+    let resolved = resolved_slot
+        .borrow()
+        .as_ref()
+        .map(Arc::clone)
+        .expect("fixture must record the resolved platform");
+
+    assert!(
+        Arc::ptr_eq(&resolved, &explicit),
+        "use_platform() must return the same Arc the provider installed",
+    );
+
+    // NullPlatform's monotonic_now is `Duration::ZERO` and new_id
+    // returns the `null-id-…` counter — distinct from
+    // DesktopPlatform's UUIDv4 output.
+    let now = recorder
+        .last_now
+        .lock()
+        .expect("last_now mutex must not be poisoned")
+        .expect("fixture must record monotonic_now");
+
+    assert_eq!(now, Duration::ZERO);
+
+    let later = recorder
+        .later_now
+        .lock()
+        .expect("later_now mutex must not be poisoned")
+        .expect("fixture must record second monotonic_now");
+
+    assert_eq!(later, Duration::ZERO);
+
+    let new_ids = recorder
+        .new_ids
+        .lock()
+        .expect("new_ids mutex must not be poisoned");
+
+    for id in new_ids.iter() {
+        assert!(id.starts_with("null-id-"), "expected null-id, got {id:?}");
+    }
+}
+
+#[test]
+fn use_platform_handle_survives_render_cycle_drop_without_panic() {
+    // Drop the harness explicitly, then access the captured Arc.
+    // `Arc<dyn DioxusPlatform>` should outlive the VirtualDom because
+    // it's reference-counted, not arena-allocated.
+    let recorder = empty_recorder();
+
+    let explicit: Arc<dyn DioxusPlatform> = Arc::new(NullPlatform);
+
+    let props = make_props(recorder, Some(Arc::clone(&explicit)));
+
+    let resolved_slot = Rc::clone(&props.resolved_platform_slot);
+
+    {
+        let _harness = DesktopHarness::launch_with_props(fixture, props);
+        // Harness drops at end of this scope.
+    }
+
+    let resolved = resolved_slot
+        .borrow()
+        .as_ref()
+        .map(Arc::clone)
+        .expect("fixture must record the resolved platform");
+
+    // After harness teardown the Arc must still be live and usable.
+    let id = resolved.new_id();
+
+    assert!(id.starts_with("null-id-"));
+    assert_eq!(resolved.monotonic_now(), Duration::ZERO);
+
+    // And it must still be the Arc we installed.
+    assert!(Arc::ptr_eq(&resolved, &explicit));
+}
+
+#[test]
+fn drag_data_default_is_equal_under_partial_eq_derive() {
+    // Pin the F1 derive cascade end-to-end on the desktop binary:
+    // `DragData` derives `PartialEq + Eq` by virtue of
+    // `ars_interactions::DragItem` deriving them. Two default
+    // instances must compare equal.
+    assert_eq!(DragData::default(), DragData::default());
+}

--- a/crates/ars-dioxus/tests/unit/use_machine.rs
+++ b/crates/ars-dioxus/tests/unit/use_machine.rs
@@ -7,7 +7,7 @@ use ars_i18n::{Direction, IntlBackend, Locale, StubIntlBackend};
 use dioxus::dioxus_core::{NoOpMutations, ScopeId};
 
 use super::{test_support, test_support::*, *};
-use crate::provider::{ArsContext, NullPlatform};
+use crate::{platform::NullPlatform, provider::ArsContext};
 
 #[derive(Clone)]
 struct TestIntlBackend;

--- a/crates/ars-dom/src/platform.rs
+++ b/crates/ars-dom/src/platform.rs
@@ -1662,7 +1662,6 @@ mod tests {
 mod wasm_tests {
     use std::{
         cell::{Cell, RefCell},
-        future::Future,
         pin::Pin,
         rc::Rc,
         task::{Context, Poll, Waker},

--- a/crates/ars-dom/src/positioning/auto_update.rs
+++ b/crates/ars-dom/src/positioning/auto_update.rs
@@ -643,7 +643,6 @@ mod host_web_tests {
 mod wasm_tests {
     use std::{
         cell::{Cell, RefCell},
-        future::Future,
         pin::Pin,
         rc::Rc,
         task::{Context, Poll, Waker},

--- a/crates/ars-interactions/src/drag_drop.rs
+++ b/crates/ars-interactions/src/drag_drop.rs
@@ -9,6 +9,8 @@ use core::{
     cell::RefCell,
     fmt::{self, Debug},
 };
+#[cfg(feature = "std")]
+use std::path::{Path, PathBuf};
 
 use ars_a11y::{AnnouncementPriority, LiveAnnouncer};
 use ars_core::{AttrMap, Callback, HtmlAttr, MessageFn};
@@ -192,7 +194,7 @@ impl KeyboardDragRegistry {
 ///
 /// Multiple representations may be present for cross-application
 /// interoperability, such as exposing both plain text and HTML.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum DragItem {
     /// Plain text content.
     Text(String),
@@ -237,13 +239,112 @@ pub enum DragItem {
     },
 }
 
-/// Opaque file-system handle resolved by `ars-dom` against browser APIs.
-#[derive(Clone, Debug)]
-pub struct FileHandle(());
+/// File-system handle attached to a [`DragItem::File`].
+///
+/// Carries either an opaque tag (web/SSR/null targets where files are
+/// resolved through a separate adapter abstraction) or a concrete native
+/// `PathBuf` (desktop / native file pickers). Equality is structural:
+/// two opaque handles are equal, and two `Path` handles are equal iff
+/// their paths match.
+///
+/// On `no_std` builds the `Path` variant is unavailable and every
+/// instance is opaque; the type still derives `PartialEq + Eq` so
+/// downstream `Vec<DragItem>` equality keeps working.
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+pub struct FileHandle {
+    inner: FileHandleInner,
+}
 
-/// Opaque directory handle resolved by `ars-dom` against browser APIs.
-#[derive(Clone, Debug)]
-pub struct DirectoryHandle(());
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+enum FileHandleInner {
+    /// Default representation for browser/SSR file references that have
+    /// no native path and are resolved via separate APIs.
+    #[default]
+    Opaque,
+
+    /// Native filesystem path captured from a desktop file picker or
+    /// drop event. Available only when the `std` feature is enabled.
+    #[cfg(feature = "std")]
+    Path(PathBuf),
+}
+
+impl FileHandle {
+    /// Returns an opaque handle. Available on every target.
+    #[must_use]
+    pub const fn opaque() -> Self {
+        Self {
+            inner: FileHandleInner::Opaque,
+        }
+    }
+
+    /// Wraps a native filesystem path (desktop / native file picker).
+    #[cfg(feature = "std")]
+    #[must_use]
+    pub const fn from_path(path: PathBuf) -> Self {
+        Self {
+            inner: FileHandleInner::Path(path),
+        }
+    }
+
+    /// Returns the native path if the handle was constructed from one,
+    /// otherwise `None`. Always returns `None` on `no_std` builds.
+    #[cfg(feature = "std")]
+    #[must_use]
+    pub fn as_path(&self) -> Option<&Path> {
+        match &self.inner {
+            FileHandleInner::Path(path) => Some(path.as_path()),
+            FileHandleInner::Opaque => None,
+        }
+    }
+}
+
+/// Directory handle attached to a [`DragItem::Directory`].
+///
+/// Mirrors [`FileHandle`] — opaque on web/SSR, native `PathBuf` on
+/// desktop. See `FileHandle` for the equality semantics.
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+pub struct DirectoryHandle {
+    inner: DirectoryHandleInner,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+enum DirectoryHandleInner {
+    #[default]
+    Opaque,
+
+    #[cfg(feature = "std")]
+    Path(PathBuf),
+}
+
+impl DirectoryHandle {
+    /// Returns an opaque directory handle.
+    #[must_use]
+    pub const fn opaque() -> Self {
+        Self {
+            inner: DirectoryHandleInner::Opaque,
+        }
+    }
+
+    /// Wraps a native filesystem path.
+    #[cfg(feature = "std")]
+    #[must_use]
+    pub const fn from_path(path: PathBuf) -> Self {
+        Self {
+            inner: DirectoryHandleInner::Path(path),
+        }
+    }
+
+    /// Returns the native path if the handle was constructed from one,
+    /// otherwise `None`. Always returns `None` on `no_std` builds.
+    #[cfg(feature = "std")]
+    #[must_use]
+    pub fn as_path(&self) -> Option<&Path> {
+        match &self.inner {
+            DirectoryHandleInner::Path(path) => Some(path.as_path()),
+            DirectoryHandleInner::Opaque => None,
+        }
+    }
+}
 
 /// Test-only helpers for constructing opaque drag payloads in downstream crates.
 #[cfg(feature = "test-support")]
@@ -263,7 +364,7 @@ pub mod test_support {
             name: name.into(),
             mime_type: mime_type.into(),
             size,
-            handle: FileHandle(()),
+            handle: FileHandle::opaque(),
         }
     }
 
@@ -272,7 +373,7 @@ pub mod test_support {
     pub fn directory_drag_item(name: impl Into<String>) -> DragItem {
         DragItem::Directory {
             name: name.into(),
-            handle: DirectoryHandle(()),
+            handle: DirectoryHandle::opaque(),
         }
     }
 }
@@ -1964,14 +2065,14 @@ mod tests {
                     name: "photo.jpg".into(),
                     mime_type: "image/jpeg".into(),
                     size: 42,
-                    handle: FileHandle(()),
+                    handle: FileHandle::opaque(),
                 },
                 DragItemKind::File,
             ),
             (
                 DragItem::Directory {
                     name: "assets".into(),
-                    handle: DirectoryHandle(()),
+                    handle: DirectoryHandle::opaque(),
                 },
                 DragItemKind::Directory,
             ),
@@ -1999,11 +2100,11 @@ mod tests {
                 name: "photo.jpg".into(),
                 mime_type: "image/jpeg".into(),
                 size: 42,
-                handle: FileHandle(()),
+                handle: FileHandle::opaque(),
             },
             DragItem::Directory {
                 name: "assets".into(),
-                handle: DirectoryHandle(()),
+                handle: DirectoryHandle::opaque(),
             },
             DragItem::Custom {
                 mime_type: "application/x-ars-demo".into(),
@@ -2966,6 +3067,50 @@ mod tests {
     }
 
     #[test]
+    fn build_drop_attrs_serializes_operation_and_indicator_variants() {
+        let cases = [
+            (
+                DropOperation::Copy,
+                DropIndicatorPosition::Before,
+                "copy",
+                "before",
+            ),
+            (
+                DropOperation::Move,
+                DropIndicatorPosition::After,
+                "move",
+                "after",
+            ),
+            (
+                DropOperation::Link,
+                DropIndicatorPosition::OnTarget,
+                "link",
+                "on",
+            ),
+            (
+                DropOperation::Cancel,
+                DropIndicatorPosition::OnTarget,
+                "none",
+                "on",
+            ),
+        ];
+
+        for (operation, position, expected_operation, expected_position) in cases {
+            let attrs = build_drop_attrs(true, Some(operation), Some(position));
+
+            assert!(attrs.contains(&HtmlAttr::Data("ars-drag-over")));
+            assert_eq!(
+                attrs.get(&HtmlAttr::Data("ars-drop-operation")),
+                Some(expected_operation)
+            );
+            assert_eq!(
+                attrs.get(&HtmlAttr::Data("ars-drop-position")),
+                Some(expected_position)
+            );
+        }
+    }
+
+    #[test]
     fn drop_result_rejects_operations_outside_accepted_list() {
         let mut result = use_drop(DropConfig {
             accepted_operations: Some(vec![DropOperation::Copy]),
@@ -3141,7 +3286,7 @@ mod tests {
                     name: "image.png".into(),
                     mime_type: "image/png".into(),
                     size: 12,
-                    handle: FileHandle(()),
+                    handle: FileHandle::opaque(),
                 }],
                 PointerType::Pen,
             )
@@ -3711,5 +3856,228 @@ mod tests {
         assert!(!result.drag_over);
         assert!(result.drop_operation.is_none());
         assert!(!result.attrs.contains(&HtmlAttr::Data("ars-drag-over")));
+    }
+
+    // -- Equality tests for the `PartialEq` / `Eq` derives ---------------
+    //
+    // `DragItem`, `FileHandle`, and `DirectoryHandle` gained `PartialEq`
+    // and `Eq` to satisfy `DragData: PartialEq + Eq` in the Dioxus
+    // adapter (`spec/components/utility/drop-zone.md` §1.3). The handles
+    // wrap either an opaque tag or a native `PathBuf`. Equality is
+    // purely structural: two opaque handles are equal, two `Path`
+    // handles compare path-by-path, and `Opaque` ≠ `Path(_)`.
+    // These tests pin the contract: same payload → equal; different
+    // variants or different payloads → not equal.
+
+    #[test]
+    fn file_handle_opaque_instances_compare_equal() {
+        // `FileHandle::opaque()` is the default constructor on every
+        // target; two opaque handles are always equal regardless of
+        // the underlying browser/SSR file each tag is paired with.
+        assert_eq!(FileHandle::opaque(), FileHandle::opaque());
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn file_handle_path_instances_compare_by_path() {
+        use std::path::PathBuf;
+
+        let a = FileHandle::from_path(PathBuf::from("/tmp/a"));
+        let same = FileHandle::from_path(PathBuf::from("/tmp/a"));
+        let other = FileHandle::from_path(PathBuf::from("/tmp/b"));
+        let opaque = FileHandle::opaque();
+
+        assert_eq!(a, same);
+        assert_ne!(a, other);
+        assert_ne!(a, opaque);
+        assert_eq!(a.as_path(), Some(std::path::Path::new("/tmp/a")));
+        assert_eq!(opaque.as_path(), None);
+    }
+
+    #[test]
+    fn directory_handle_opaque_instances_compare_equal() {
+        assert_eq!(DirectoryHandle::opaque(), DirectoryHandle::opaque());
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn directory_handle_path_instances_compare_by_path() {
+        use std::path::PathBuf;
+
+        let a = DirectoryHandle::from_path(PathBuf::from("/tmp/photos"));
+        let same = DirectoryHandle::from_path(PathBuf::from("/tmp/photos"));
+        let other = DirectoryHandle::from_path(PathBuf::from("/tmp/videos"));
+
+        assert_eq!(a, same);
+        assert_ne!(a, other);
+        assert_ne!(a, DirectoryHandle::opaque());
+        assert_eq!(a.as_path(), Some(std::path::Path::new("/tmp/photos")));
+    }
+
+    #[test]
+    fn drag_item_text_equality_compares_payload() {
+        assert_eq!(
+            DragItem::Text(String::from("hello")),
+            DragItem::Text(String::from("hello"))
+        );
+        assert_ne!(
+            DragItem::Text(String::from("hello")),
+            DragItem::Text(String::from("hello world"))
+        );
+    }
+
+    #[test]
+    fn drag_item_uri_equality_compares_payload() {
+        assert_eq!(
+            DragItem::Uri(String::from("https://example.com")),
+            DragItem::Uri(String::from("https://example.com"))
+        );
+        assert_ne!(
+            DragItem::Uri(String::from("https://example.com")),
+            DragItem::Uri(String::from("https://other.example"))
+        );
+    }
+
+    #[test]
+    fn drag_item_html_equality_compares_payload() {
+        assert_eq!(
+            DragItem::Html(String::from("<p>hi</p>")),
+            DragItem::Html(String::from("<p>hi</p>"))
+        );
+        assert_ne!(
+            DragItem::Html(String::from("<p>hi</p>")),
+            DragItem::Html(String::from("<p>bye</p>"))
+        );
+    }
+
+    #[test]
+    fn drag_item_file_equality_compares_name_mime_size() {
+        let a = DragItem::File {
+            name: String::from("photo.png"),
+            mime_type: String::from("image/png"),
+            size: 1024,
+            handle: FileHandle::opaque(),
+        };
+
+        let same = DragItem::File {
+            name: String::from("photo.png"),
+            mime_type: String::from("image/png"),
+            size: 1024,
+            handle: FileHandle::opaque(),
+        };
+
+        let other_name = DragItem::File {
+            name: String::from("other.png"),
+            mime_type: String::from("image/png"),
+            size: 1024,
+            handle: FileHandle::opaque(),
+        };
+
+        let other_mime = DragItem::File {
+            name: String::from("photo.png"),
+            mime_type: String::from("image/jpeg"),
+            size: 1024,
+            handle: FileHandle::opaque(),
+        };
+
+        let other_size = DragItem::File {
+            name: String::from("photo.png"),
+            mime_type: String::from("image/png"),
+            size: 2048,
+            handle: FileHandle::opaque(),
+        };
+
+        assert_eq!(a, same);
+        assert_ne!(a, other_name);
+        assert_ne!(a, other_mime);
+        assert_ne!(a, other_size);
+    }
+
+    #[test]
+    fn drag_item_directory_equality_compares_name() {
+        let a = DragItem::Directory {
+            name: String::from("photos"),
+            handle: DirectoryHandle::opaque(),
+        };
+
+        let same = DragItem::Directory {
+            name: String::from("photos"),
+            handle: DirectoryHandle::opaque(),
+        };
+
+        let other = DragItem::Directory {
+            name: String::from("videos"),
+            handle: DirectoryHandle::opaque(),
+        };
+
+        assert_eq!(a, same);
+        assert_ne!(a, other);
+    }
+
+    #[test]
+    fn drag_item_custom_equality_compares_mime_and_data() {
+        let a = DragItem::Custom {
+            mime_type: String::from("application/x-ars-card"),
+            data: String::from("{\"id\":1}"),
+        };
+
+        let same = DragItem::Custom {
+            mime_type: String::from("application/x-ars-card"),
+            data: String::from("{\"id\":1}"),
+        };
+
+        let other_mime = DragItem::Custom {
+            mime_type: String::from("application/x-ars-board"),
+            data: String::from("{\"id\":1}"),
+        };
+
+        let other_data = DragItem::Custom {
+            mime_type: String::from("application/x-ars-card"),
+            data: String::from("{\"id\":2}"),
+        };
+
+        assert_eq!(a, same);
+        assert_ne!(a, other_mime);
+        assert_ne!(a, other_data);
+    }
+
+    #[test]
+    fn drag_item_variants_are_distinct_even_with_identical_payload() {
+        // Text("foo") vs Uri("foo") vs Html("foo") must all be unequal
+        // — the variant tag is part of the equality, not just the
+        // payload. This is the most likely consumer pitfall.
+        let payload = String::from("foo");
+
+        let text = DragItem::Text(payload.clone());
+        let uri = DragItem::Uri(payload.clone());
+        let html = DragItem::Html(payload);
+
+        assert_ne!(text, uri);
+        assert_ne!(uri, html);
+        assert_ne!(text, html);
+    }
+
+    #[test]
+    fn drag_item_vec_equality_propagates() {
+        // `Vec<DragItem>` PartialEq is what `DragData` ultimately
+        // depends on. Pin the propagation in case the derives ever
+        // get cherry-picked by a refactor.
+        let a = vec![
+            DragItem::Text(String::from("a")),
+            DragItem::Text(String::from("b")),
+        ];
+
+        let b = vec![
+            DragItem::Text(String::from("a")),
+            DragItem::Text(String::from("b")),
+        ];
+
+        let c = vec![
+            DragItem::Text(String::from("a")),
+            DragItem::Text(String::from("z")),
+        ];
+
+        assert_eq!(a, b);
+        assert_ne!(a, c);
     }
 }

--- a/crates/ars-test-harness/src/lib.rs
+++ b/crates/ars-test-harness/src/lib.rs
@@ -2793,7 +2793,7 @@ fn is_tabbable_element(element: &web_sys::Element) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use std::{any::Any, future::Future, panic::AssertUnwindSafe, pin::Pin, str::FromStr};
+    use std::{any::Any, panic::AssertUnwindSafe, pin::Pin, str::FromStr};
     #[cfg(not(target_arch = "wasm32"))]
     use std::{
         cell::Cell,

--- a/spec/foundation/09-adapter-dioxus.md
+++ b/spec/foundation/09-adapter-dioxus.md
@@ -1464,254 +1464,473 @@ pub mod select {
 
 ### 6.1 Platform Abstraction Trait
 
+#### 6.1.1 Supporting Types
+
+`Rect` comes from `ars_core::Rect` (foundation §1, geometry primitive
+shared across adapters). `FileRef` comes from `ars_forms::field::FileRef`.
+`DragItem` and `FileHandle` come from `ars_interactions` (foundation §5,
+drag-and-drop shared payloads). The adapter does **not** redefine any of
+these — re-using them keeps domain types consistent across components.
+
 ```rust
-/// Operations that differ between web and native platforms.
+/// Options for opening a platform file picker.
 ///
-/// **Note on `Send` bounds:** The futures returned by async methods (e.g.
-/// `set_clipboard`, `open_file_picker`) are `!Send` on WASM targets. On
-/// desktop, Dioxus uses a multi-threaded runtime where futures must be `Send`.
-/// When calling these methods on desktop, use `spawn` (Dioxus `spawn` runs
-/// on the current thread for `!Send` futures) to avoid `Send` bound errors.
-pub trait DioxusPlatform: Send + Sync + 'static {
-    /// Focus an element by its ID.
-    fn focus_element(&self, id: &str);
+/// Mirrors the subset of HTML `<input type="file">` configuration the
+/// adapter exposes. Web targets ignore these options because the real
+/// picker is hosted by the FileUpload component's hidden `<input>`;
+/// desktop targets translate them into an `rfd`-style native dialog
+/// when that implementation lands.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct FilePickerOptions {
+    /// Accepted MIME types or extensions. Empty means accept any.
+    pub accept: Vec<String>,
 
-    /// Get the bounding rect of an element.
-    fn get_bounding_rect(&self, id: &str) -> Option<Rect>;
-
-    /// Scroll an element into view.
-    fn scroll_into_view(&self, id: &str);
-
-    /// Write text to the clipboard.
-    fn set_clipboard(&self, text: &str) -> Pin<Box<dyn Future<Output = Result<(), String>>>>;
-
-    /// Open a native file picker.
-    fn open_file_picker(&self, options: FilePickerOptions) -> Pin<Box<dyn Future<Output = Vec<FileRef>>>>;
-
-    /// Current timestamp in milliseconds.
-    fn now_ms(&self) -> f64;
-
-    /// Generate a UUID.
-    fn new_id(&self) -> String;
-
-    /// Create drag data from a platform-specific drag event.
-    ///
-    /// **Web:** Casts the event to `web_sys::DragEvent` and extracts
-    /// `DataTransfer` contents (files, items, types).
-    ///
-    /// **Desktop:** Extracts native file drop data from the OS event.
-    ///
-    /// Returns `None` if the event does not contain drag data.
-    fn create_drag_data(&self, event: &dyn Any) -> Option<DragData>;
+    /// Whether the user may select more than one file at once.
+    pub multiple: bool,
 }
 
-/// Web implementation using web-sys.
-#[cfg(feature = "web")]
-pub struct WebPlatform;
+/// Adapter-local drag payload extracted from a platform drag event.
+///
+/// `items` may be empty on `DragEnter`/`DragOver` if the browser
+/// restricts access to item content until drop (security restriction).
+/// `types` is always available and carries the MIME types advertised by
+/// the drag source.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct DragData {
+    pub items: Vec<DragItem>,
+    pub types: Vec<String>,
+}
 
-#[cfg(feature = "web")]
-impl DioxusPlatform for WebPlatform {
-    fn focus_element(&self, id: &str) {
-        if let Some(window) = web_sys::window() {
-            if let Some(doc) = window.document() {
-                if let Some(el) = doc.get_element_by_id(id) {
-                    let _ = el.dyn_ref::<web_sys::HtmlElement>().map(|el| el.focus().ok());
-                }
+const DEFAULT_DRAG_TYPE_PROBES: &[&str] = &[
+    "text/plain",
+    "text/html",
+    "text/uri-list",
+    "application/json",
+];
+
+impl DragData {
+    /// Builds a `DragData` from Dioxus's unified drag event payload.
+    ///
+    /// Works on every target Dioxus supports: web, desktop, and SSR.
+    /// `types` is populated by probing the known public
+    /// `DataTransfer::get_data(format)` formats; `items` is populated
+    /// from `DataTransfer::files()`.
+    pub fn from_drag_data(event: &dioxus::events::DragData) -> Self {
+        let data_transfer = event.data_transfer();
+
+        let mut types = Vec::new();
+        for format in DEFAULT_DRAG_TYPE_PROBES {
+            if data_transfer.get_data(format).is_some() {
+                types.push(String::from(*format));
             }
         }
+
+        let mut items = Vec::new();
+        for file in data_transfer.files() {
+            let mime_type = file
+                .content_type()
+                .unwrap_or_else(|| String::from("application/octet-stream"));
+            let raw_path = file.path();
+            let handle = if raw_path.as_os_str().is_empty() {
+                FileHandle::opaque()
+            } else {
+                FileHandle::from_path(raw_path)
+            };
+
+            items.push(DragItem::File {
+                name: file.name(),
+                mime_type,
+                size: file.size(),
+                handle,
+            });
+        }
+
+        if !items.is_empty() {
+            types.push(String::from("Files"));
+        }
+
+        Self { items, types }
+    }
+}
+
+/// Platform-agnostic handle to a drag event.
+///
+/// Adapter glue wraps the framework's drag event in a
+/// `PlatformDragEvent` before passing it to
+/// `DioxusPlatform::create_drag_data`. The wrapper carries a borrowed
+/// `&dioxus::events::DragData` (via `from_dioxus`), the unified event
+/// payload Dioxus exposes across web and desktop. On every target an
+/// "empty" wrapper is constructible (via `empty`) for tests and for
+/// components that compile against the trait but never produce real
+/// drag data. The typed wrapper replaces the earlier `&dyn Any`
+/// parameter so a type mismatch becomes a compile error instead of a
+/// silent `None`. `Copy` lets callers pass the same wrapper to multiple
+/// platforms or helpers without clones.
+#[derive(Clone, Copy, Debug)]
+pub struct PlatformDragEvent<'a> {
+    inner: Option<&'a dioxus::events::DragData>,
+}
+
+impl<'a> PlatformDragEvent<'a> {
+    /// Constructs a payload-less drag event. Available on every target.
+    pub const fn empty() -> Self {
+        Self { inner: None }
     }
 
-    fn get_bounding_rect(&self, id: &str) -> Option<Rect> {
-        let el = web_sys::window()?
-            .document()?
-            .get_element_by_id(id)?;
-        let rect = el.get_bounding_client_rect();
-        Some(Rect {
-            x: rect.x(),
-            y: rect.y(),
-            width: rect.width(),
-            height: rect.height(),
+    /// Wraps a Dioxus drag event for `create_drag_data`.
+    pub const fn from_dioxus(event: &'a dioxus::events::DragData) -> Self {
+        Self { inner: Some(event) }
+    }
+
+    /// Returns the underlying Dioxus drag event if the wrapper was
+    /// built from one, otherwise `None`.
+    pub const fn as_dioxus(&self) -> Option<&'a dioxus::events::DragData> {
+        self.inner
+    }
+}
+```
+
+#### 6.1.2 Trait Definition
+
+```rust
+use std::rc::Rc;
+
+use dioxus::events::{MountedData, ScrollBehavior};
+
+/// Operations that differ between web and native platforms.
+///
+/// **Note on `Send` bounds.** The futures returned by async methods
+/// (`set_clipboard`, `open_file_picker`) are `!Send` on WASM. On desktop,
+/// Dioxus's runtime can run `!Send` futures on the current thread via
+/// `dioxus::spawn`, so the trait keeps a single uniform return type
+/// across platforms. Callers on desktop runtimes that require `Send`
+/// must route the future through `dioxus::spawn` or convert it
+/// themselves.
+pub trait DioxusPlatform: Send + Sync + 'static {
+    /// Focuses a mounted element through Dioxus's renderer-backed
+    /// element handle.
+    fn focus_mounted_element(
+        &self,
+        element: Rc<MountedData>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), String>>>> {
+        Box::pin(async move {
+            element
+                .set_focus(true)
+                .await
+                .map_err(|err| err.to_string())
         })
     }
 
-    fn scroll_into_view(&self, id: &str) {
-        if let Some(window) = web_sys::window() {
-            if let Some(doc) = window.document() {
-                if let Some(el) = doc.get_element_by_id(id) {
-                    el.scroll_into_view();
-                }
-            }
-        }
+    /// Returns the viewport-relative bounding rectangle for a mounted
+    /// element through Dioxus's renderer-backed element handle.
+    fn get_mounted_bounding_rect(
+        &self,
+        element: Rc<MountedData>,
+    ) -> Pin<Box<dyn Future<Output = Option<Rect>>>> {
+        Box::pin(async move { element.get_client_rect().await.ok().map(rect_from_pixels) })
     }
 
+    /// Scrolls a mounted element into view through Dioxus's
+    /// renderer-backed element handle.
+    fn scroll_mounted_into_view(
+        &self,
+        element: Rc<MountedData>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), String>>>> {
+        Box::pin(async move {
+            element
+                .scroll_to(ScrollBehavior::Instant)
+                .await
+                .map_err(|err| err.to_string())
+        })
+    }
+
+    /// Writes text to the system clipboard.
+    fn set_clipboard(&self, text: &str) -> Pin<Box<dyn Future<Output = Result<(), String>>>>;
+
+    /// Opens a native file picker.
+    fn open_file_picker(
+        &self,
+        options: FilePickerOptions,
+    ) -> Pin<Box<dyn Future<Output = Vec<FileRef>>>>;
+
+    /// Returns a monotonically non-decreasing duration since a
+    /// platform-defined start point.
+    ///
+    /// The start point is implementation-defined and intentionally
+    /// opaque (web: page-load via `performance.now()`; desktop:
+    /// process-local `Instant` start; null: always zero). Callers MUST
+    /// use this only for relative measurements — subtract two values
+    /// from the same platform instance to get an elapsed `Duration`.
+    /// Comparing values across platforms or processes is undefined.
+    fn monotonic_now(&self) -> Duration;
+
+    /// Generates a platform-scoped unique ID.
+    ///
+    /// Web returns a UUIDv4 from `crypto.randomUUID()`; desktop returns
+    /// `uuid::Uuid::new_v4()`; the null implementation returns a
+    /// sequential counter prefixed with `null-id-`.
+    fn new_id(&self) -> String;
+
+    /// Extracts adapter drag data from a platform-specific drag event.
+    ///
+    /// Returns `None` when the wrapper does not carry a Dioxus drag
+    /// event. The typed `PlatformDragEvent` wrapper enforces the
+    /// underlying event type at compile time.
+    fn create_drag_data(&self, event: PlatformDragEvent<'_>) -> Option<DragData>;
+}
+
+const fn rect_from_pixels(rect: dioxus::html::geometry::PixelsRect) -> Rect {
+    Rect {
+        x: rect.origin.x,
+        y: rect.origin.y,
+        width: rect.size.width,
+        height: rect.size.height,
+    }
+}
+```
+
+#### 6.1.3 NullPlatform
+
+`NullPlatform` is the no-op implementation used by tests, SSR, and the
+`mobile` feature until a dedicated mobile platform lands. It is always
+in scope regardless of feature gating.
+
+```rust
+#[derive(Clone, Copy, Debug, Default)]
+pub struct NullPlatform;
+
+impl DioxusPlatform for NullPlatform {
+    fn focus_mounted_element(
+        &self,
+        _element: Rc<MountedData>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), String>>>> {
+        Box::pin(async { Ok(()) })
+    }
+
+    fn get_mounted_bounding_rect(
+        &self,
+        _element: Rc<MountedData>,
+    ) -> Pin<Box<dyn Future<Output = Option<Rect>>>> {
+        Box::pin(async { None })
+    }
+
+    fn scroll_mounted_into_view(
+        &self,
+        _element: Rc<MountedData>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), String>>>> {
+        Box::pin(async { Ok(()) })
+    }
+
+    fn set_clipboard(&self, _text: &str) -> Pin<Box<dyn Future<Output = Result<(), String>>>> {
+        Box::pin(async { Ok(()) })
+    }
+
+    fn open_file_picker(
+        &self,
+        _options: FilePickerOptions,
+    ) -> Pin<Box<dyn Future<Output = Vec<FileRef>>>> {
+        Box::pin(async { Vec::new() })
+    }
+
+    fn monotonic_now(&self) -> Duration { Duration::ZERO }
+
+    fn new_id(&self) -> String {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        static COUNTER: AtomicUsize = AtomicUsize::new(0);
+        format!("null-id-{}", COUNTER.fetch_add(1, Ordering::Relaxed))
+    }
+
+    fn create_drag_data(&self, _event: PlatformDragEvent<'_>) -> Option<DragData> { None }
+}
+```
+
+#### 6.1.4 WebPlatform (wasm32-only)
+
+`WebPlatform` exists only when both `feature = "web"` and
+`target_arch = "wasm32"` are true — every method invokes browser APIs
+that have no meaningful native fallback. On non-wasm hosts (e.g.,
+`cargo check --features web` on a developer's Linux box) the type is
+not in scope and `default_dioxus_platform()` (§6.1.6) falls through to
+`NullPlatform`. This keeps build tooling green without silently
+shipping "clipboard writes succeed but do nothing" semantics into a
+misconfigured production build.
+
+```rust
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
+#[derive(Clone, Copy, Debug, Default)]
+pub struct WebPlatform;
+
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
+impl DioxusPlatform for WebPlatform {
     fn set_clipboard(&self, text: &str) -> Pin<Box<dyn Future<Output = Result<(), String>>>> {
         let text = text.to_string();
         Box::pin(async move {
-            let window = web_sys::window().ok_or("No window")?;
-            let clipboard = window.navigator().clipboard();
-            let promise = clipboard.write_text(&text);
+            let window = web_sys::window().ok_or_else(|| String::from("no window available"))?;
+            let promise = window.navigator().clipboard().write_text(&text);
             wasm_bindgen_futures::JsFuture::from(promise)
                 .await
                 .map(|_| ())
-                .map_err(|e| format!("{:?}", e))
+                .map_err(|err| format!("{err:?}"))
         })
     }
 
-    fn open_file_picker(&self, _options: FilePickerOptions) -> Pin<Box<dyn Future<Output = Vec<FileRef>>>> {
-        Box::pin(async { vec![] }) // Uses hidden <input type="file"> in FileUpload component
+    fn open_file_picker(
+        &self,
+        _options: FilePickerOptions,
+    ) -> Pin<Box<dyn Future<Output = Vec<FileRef>>>> {
+        // Web defers to the FileUpload component's hidden <input type="file">.
+        Box::pin(async { Vec::new() })
     }
 
-    /// Returns a monotonically increasing timestamp in milliseconds.
-    /// On web: relative to page load (via `performance.now()`).
-    /// Callers MUST use this only for relative duration measurements (end - start),
-    /// NOT for absolute timestamps or cross-platform timestamp comparison.
-    fn now_ms(&self) -> f64 {
-        web_sys::window()
-            .and_then(|w| w.performance())
-            .map(|p| p.now())
-            .expect("window.performance must be available on web targets")
+    fn monotonic_now(&self) -> Duration {
+        let millis = web_sys::window()
+            .and_then(|window| window.performance())
+            .map(|performance| performance.now())
+            .expect("window.performance must be available on web targets");
+        // Convert via `from_secs_f64(millis / 1000.0)` to preserve the
+        // sub-millisecond precision `performance.now()` exposes.
+        Duration::from_secs_f64(millis / 1000.0)
     }
 
     fn new_id(&self) -> String {
-        // Use crypto.randomUUID() on web
         web_sys::window()
-            .and_then(|w| w.crypto().ok())
-            .map(|c| c.random_uuid())
-            .expect("window.crypto must be available on web targets")
+            .map(|window| {
+                window
+                    .crypto()
+                    .expect("window.crypto must be available on web targets")
+                    .random_uuid()
+            })
+            .expect("window must be available on web targets")
     }
 
-    fn create_drag_data(&self, event: &dyn Any) -> Option<DragData> {
-        use wasm_bindgen::JsCast;
-        let drag_event = event.downcast_ref::<web_sys::DragEvent>()?;
-        let data_transfer = drag_event.data_transfer()?;
-        Some(DragData::from_web_data_transfer(&data_transfer))
+    fn create_drag_data(&self, event: PlatformDragEvent<'_>) -> Option<DragData> {
+        event.as_dioxus().map(DragData::from_drag_data)
     }
 }
+```
 
-/// Desktop implementation using native OS APIs.
+#### 6.1.5 DesktopPlatform
+
+```rust
 #[cfg(feature = "desktop")]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct DesktopPlatform;
 
 #[cfg(feature = "desktop")]
 impl DioxusPlatform for DesktopPlatform {
-    fn focus_element(&self, _id: &str) {
-        // Desktop: focus is managed by the native window system
-        // For Dioxus desktop, accessibility requires different approach
-    }
-
-    fn get_bounding_rect(&self, _id: &str) -> Option<Rect> {
-        // Web-only for v1. Desktop implementation requires AccessKit layout
-        // integration to obtain element geometry from the native accessibility
-        // tree. Dioxus desktop does not yet expose layout metrics through
-        // AccessKit's node bounds. Returns None — callers must handle gracefully.
-        log::warn!("get_bounding_rect not yet implemented for desktop platform");
-        None
-    }
-
-    fn scroll_into_view(&self, _id: &str) {
-        // Web-only for v1. Desktop implementation requires AccessKit's
-        // scroll-to-visible action or a native platform equivalent.
-        // Dioxus desktop accessibility integration is evolving.
-        log::warn!("scroll_into_view not yet implemented for desktop platform");
-    }
-
     fn set_clipboard(&self, text: &str) -> Pin<Box<dyn Future<Output = Result<(), String>>>> {
         let text = text.to_string();
         Box::pin(async move {
-            // Use arboard or copypasta crate
-            use arboard::Clipboard;
-            let mut cb = Clipboard::new().map_err(|e| e.to_string())?;
-            cb.set_text(&text).map_err(|e| e.to_string())
+            let mut clipboard = arboard::Clipboard::new().map_err(|err| err.to_string())?;
+            clipboard.set_text(&text).map_err(|err| err.to_string())
         })
     }
 
-    fn open_file_picker(&self, options: FilePickerOptions) -> Pin<Box<dyn Future<Output = Vec<FileRef>>>> {
+    fn open_file_picker(
+        &self,
+        options: FilePickerOptions,
+    ) -> Pin<Box<dyn Future<Output = Vec<FileRef>>>> {
         Box::pin(async move {
-            // Web-only for v1. Desktop implementation should use the `rfd`
-            // (Rust File Dialog) crate to open native OS file picker dialogs.
-            // Mapping: options.accept → rfd file filters, options.multiple →
-            // rfd::AsyncFileDialog::pick_files vs pick_file.
-            log::warn!("open_file_picker not yet implemented for desktop platform");
-            Vec::new()
+            let mut dialog = rfd::AsyncFileDialog::new();
+            let extensions = file_picker_filter_extensions(&options.accept);
+
+            if !extensions.is_empty() {
+                dialog = dialog.add_filter(file_picker_filter_name(&extensions), &extensions);
+            }
+
+            let handles = if options.multiple {
+                dialog.pick_files().await.unwrap_or_default()
+            } else {
+                dialog.pick_file().await.into_iter().collect()
+            };
+
+            handles
+                .into_iter()
+                .map(|file| file_ref_from_path(file.path()))
+                .collect()
         })
     }
 
-    /// Returns a monotonically increasing timestamp in milliseconds.
-    /// On desktop: milliseconds since UNIX epoch (via `SystemTime::now()`).
-    /// Callers MUST use this only for relative duration measurements (end - start),
-    /// NOT for absolute timestamps or cross-platform timestamp comparison.
-    fn now_ms(&self) -> f64 {
-        use std::time::{SystemTime, UNIX_EPOCH};
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("system clock must be after UNIX_EPOCH")
-            .as_millis() as f64
+    fn monotonic_now(&self) -> Duration {
+        static START: std::sync::LazyLock<std::time::Instant> =
+            std::sync::LazyLock::new(std::time::Instant::now);
+        START.elapsed()
     }
 
     fn new_id(&self) -> String {
         uuid::Uuid::new_v4().to_string()
     }
 
-    fn create_drag_data(&self, event: &dyn Any) -> Option<DragData> {
-        // Web-only for v1. Desktop implementation requires extracting drag
-        // payload from native OS drag events (NSPasteboard on macOS,
-        // IDataObject on Windows, X11 selections on Linux). Dioxus desktop
-        // does not yet expose native drag event data to Rust components.
-        log::warn!("create_drag_data not yet implemented for desktop platform");
-        None
+    fn create_drag_data(&self, event: PlatformDragEvent<'_>) -> Option<DragData> {
+        event.as_dioxus().map(DragData::from_drag_data)
     }
 }
+```
 
-/// No-op platform for testing and non-interactive environments.
-pub struct NullPlatform;
+#### 6.1.6 default_dioxus_platform
 
-impl DioxusPlatform for NullPlatform {
-    fn focus_element(&self, _id: &str) {}
-    fn get_bounding_rect(&self, _id: &str) -> Option<Rect> { None }
-    fn scroll_into_view(&self, _id: &str) {}
-    fn set_clipboard(&self, _text: &str) -> Pin<Box<dyn Future<Output = Result<(), String>>>> {
-        Box::pin(async { Ok(()) })
-    }
-    fn open_file_picker(&self, _options: FilePickerOptions) -> Pin<Box<dyn Future<Output = Vec<FileRef>>>> {
-        Box::pin(async { vec![] })
-    }
-    fn now_ms(&self) -> f64 { 0.0 }
-    fn new_id(&self) -> String {
-        use std::sync::atomic::{AtomicUsize, Ordering};
-        static COUNTER: AtomicUsize = AtomicUsize::new(0);
-        format!("null-id-{}", COUNTER.fetch_add(1, Ordering::Relaxed))
-    }
-    fn create_drag_data(&self, _event: &dyn Any) -> Option<DragData> { None }
+`default_dioxus_platform()` returns the `DioxusPlatform` chosen by
+feature gating. It is the canonical out-of-component constructor,
+intended for test harnesses, SSR bootstrap, and benchmarks that need a
+platform handle outside a Dioxus render scope. Inside components,
+prefer `use_platform()` (§6.2).
+
+```rust
+/// Resolution order:
+///
+/// 1. `WebPlatform` when `web` is on **and** the build target is wasm32.
+/// 2. `DesktopPlatform` when `desktop` is on (and we did not match step 1).
+/// 3. `NullPlatform` otherwise.
+///
+/// `web` on a non-wasm host falls through to step 2 or 3 — `WebPlatform`
+/// only exists on wasm32. The `mobile` feature also currently lands at
+/// step 3 until a dedicated mobile platform is added.
+#[must_use]
+pub fn default_dioxus_platform() -> Arc<dyn DioxusPlatform> {
+    #[cfg(all(feature = "web", target_arch = "wasm32"))]
+    { Arc::new(WebPlatform) }
+
+    #[cfg(all(
+        feature = "desktop",
+        not(all(feature = "web", target_arch = "wasm32"))
+    ))]
+    { Arc::new(DesktopPlatform) }
+
+    #[cfg(all(
+        not(all(feature = "web", target_arch = "wasm32")),
+        not(feature = "desktop")
+    ))]
+    { Arc::new(NullPlatform) }
 }
 ```
 
 ### 6.2 Platform Hook (Dioxus-Specific)
 
-> **Note:** The `DioxusPlatform` trait object is
-> provided by `ArsProvider` (§16) via the `dioxus_platform` field on `ArsContext`.
-> The `DioxusPlatform` trait, `WebPlatform`, `DesktopPlatform`, and `NullPlatform`
-> implementations remain defined in §6.1 above. The core `PlatformEffects` trait
-> (focus, timers, scroll-lock, positioning) is also bundled into `ArsProvider`.
-> `DioxusPlatform` is a separate, Dioxus-specific abstraction for platform capabilities
-> not covered by `PlatformEffects` (file pickers, clipboard, drag data).
+> **Note:** The `DioxusPlatform` trait object is provided by `ArsProvider`
+> (§16) via the `dioxus_platform` field on `ArsContext`. The `DioxusPlatform`
+> trait, `WebPlatform`, `DesktopPlatform`, and `NullPlatform` implementations
+> remain defined in §6.1 above. The core `PlatformEffects` trait (focus,
+> timers, scroll-lock, positioning) is also bundled into `ArsProvider`.
+> `DioxusPlatform` is a separate, Dioxus-specific abstraction for platform
+> capabilities not covered by `PlatformEffects` (file pickers, clipboard,
+> drag data).
 
 ```rust
-/// Access Dioxus-specific platform services from `ArsContext`.
-/// Fallback: Web > Desktop > NullPlatform (when no `ArsProvider` is present).
-/// Note: The `mobile` feature currently falls through to `NullPlatform`.
-/// When a dedicated `MobilePlatform` is added, update this function
-/// with a `#[cfg(feature = "mobile")]` arm.
+/// Resolves the active `DioxusPlatform` from the surrounding `ArsProvider`
+/// context.
+///
+/// When no `ArsProvider` is mounted, falls back to
+/// [`default_dioxus_platform`] using the resolution order
+/// **`web` → `desktop` → `NullPlatform`**. The `mobile` feature currently
+/// falls through to `NullPlatform`; when a dedicated mobile platform is
+/// added, update [`default_dioxus_platform`] with a
+/// `#[cfg(feature = "mobile")]` arm.
 pub fn use_platform() -> Arc<dyn DioxusPlatform> {
     try_use_context::<ArsContext>()
         .map(|ctx| Arc::clone(&ctx.dioxus_platform))
         .unwrap_or_else(|| {
             warn_missing_provider("use_platform");
-            #[cfg(feature = "web")]
-            { Arc::new(WebPlatform) }
-            #[cfg(all(feature = "desktop", not(feature = "web")))]
-            { Arc::new(DesktopPlatform) }
-            #[cfg(not(any(feature = "web", feature = "desktop")))]
-            { Arc::new(NullPlatform) }
+            default_dioxus_platform()
         })
 }
 ```


### PR DESCRIPTION
## Summary

- add the Dioxus platform service layer with default web/desktop/null platform selection and provider threading
- implement desktop-backed ids, monotonic time, clipboard, file picker, drag data, and mounted element operations
- expand drag/drop and harness coverage for native drag payloads, plus sync the Dioxus adapter spec

## Validation

- `CHROMEDRIVER=$HOME/.cache/ars-ui-chromedriver/chromedriver-mac-arm64/chromedriver PATH=$HOME/.cargo/bin:$HOME/.cache/ars-ui-chromedriver/chromedriver-mac-arm64:$PATH cargo xci`

Closes: #195 