### PR TITLE
[codex] Implement task 200 utility z-index core

### DIFF
--- a/crates/ars-components/src/data_display/skeleton.rs
+++ b/crates/ars-components/src/data_display/skeleton.rs
@@ -3,7 +3,7 @@
 //! `Skeleton` is a stateless, framework-agnostic attribute mapper for loading
 //! placeholder shapes.
 
-use alloc::string::String;
+use alloc::string::{String, ToString as _};
 use core::{
     fmt::{self, Debug},
     num::NonZero,
@@ -427,6 +427,7 @@ mod tests {
         for (variant, expected, animated) in cases {
             assert_eq!(variant.as_str(), expected);
             assert_eq!(variant.is_animated(), animated);
+
             let attrs = api(Props::new().variant(variant)).root_attrs();
 
             assert_eq!(attrs.get(&HtmlAttr::Data("ars-variant")), Some(expected));
@@ -443,6 +444,7 @@ mod tests {
 
         for (shape, expected) in cases {
             assert_eq!(shape.as_str(), expected);
+
             let attrs = api(Props::new().shape(shape)).root_attrs();
 
             assert_eq!(attrs.get(&HtmlAttr::Data("ars-shape")), Some(expected));

--- a/crates/ars-components/src/date_time/date_field/mod.rs
+++ b/crates/ars-components/src/date_time/date_field/mod.rs
@@ -9,6 +9,7 @@ mod segment;
 mod tests;
 
 use alloc::{
+    boxed::Box,
     format,
     string::{String, ToString},
     sync::Arc,

--- a/crates/ars-components/src/utility/button.rs
+++ b/crates/ars-components/src/utility/button.rs
@@ -4,7 +4,10 @@
 //! adapters own DOM event normalization and native handler deduplication;
 //! this module owns typed props, state transitions, and `AttrMap` output.
 
-use alloc::{string::String, vec::Vec};
+use alloc::{
+    string::{String, ToString as _},
+    vec::Vec,
+};
 use core::fmt::{self, Debug, Display};
 
 use ars_core::{
@@ -680,6 +683,7 @@ impl ars_core::Machine for Machine {
             (State::Pressed, Event::Blur) => {
                 Some(TransitionPlan::to(State::Idle).apply(|ctx: &mut Context| {
                     ctx.pressed = false;
+
                     clear_focus(ctx);
                 }))
             }
@@ -714,6 +718,7 @@ impl ars_core::Machine for Machine {
                 Some(TransitionPlan::to(State::Idle).apply(|ctx: &mut Context| {
                     ctx.disabled = true;
                     ctx.pressed = false;
+
                     clear_focus(ctx);
                 }))
             }
@@ -722,6 +727,7 @@ impl ars_core::Machine for Machine {
                 Some(TransitionPlan::context_only(|ctx: &mut Context| {
                     ctx.disabled = true;
                     ctx.pressed = false;
+
                     clear_focus(ctx);
                 }))
             }

--- a/crates/ars-components/src/utility/client_only.rs
+++ b/crates/ars-components/src/utility/client_only.rs
@@ -1,0 +1,67 @@
+//! Logical props for client-only rendering boundaries.
+//!
+//! `ClientOnly` renders no wrapper and has no agnostic connect API. Framework
+//! adapters own the actual SSR and hydration gating behavior; this module only
+//! defines the shared props shape.
+
+/// Props for the `ClientOnly` logical boundary.
+///
+/// `Fallback` is the framework-specific view or element type rendered during
+/// SSR and the initial hydration pass. When [`fallback`](Self::fallback) is
+/// `None`, adapters render no fallback content.
+#[derive(Clone, Debug, Default)]
+pub struct Props<Fallback = ()> {
+    /// Optional fallback content rendered before the client-only children mount.
+    pub fallback: Option<Fallback>,
+}
+
+impl<Fallback> Props<Fallback> {
+    /// Create `ClientOnly` props with no fallback content.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self { fallback: None }
+    }
+
+    /// Set the fallback content rendered during SSR and initial hydration.
+    #[must_use]
+    pub fn fallback(mut self, fallback: Fallback) -> Self {
+        self.fallback = Some(fallback);
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn props_default_has_no_fallback() {
+        let props = Props::<&str>::default();
+
+        assert_eq!(props.fallback, None);
+    }
+
+    #[test]
+    fn props_new_has_no_fallback() {
+        let props = Props::<&str>::new();
+
+        assert_eq!(props.fallback, None);
+    }
+
+    #[test]
+    fn fallback_builder_sets_fallback_content() {
+        let props = Props::new().fallback("Loading");
+
+        assert_eq!(props.fallback, Some("Loading"));
+    }
+
+    #[test]
+    fn props_clone_debug_cover_generic_fallback() {
+        let props = Props::new().fallback(String::from("Loading"));
+
+        let cloned = props.clone();
+
+        assert_eq!(props.fallback, cloned.fallback);
+        assert!(format!("{props:?}").contains("Loading"));
+    }
+}

--- a/crates/ars-components/src/utility/mod.rs
+++ b/crates/ars-components/src/utility/mod.rs
@@ -6,6 +6,9 @@ pub mod as_child;
 /// Button component machine.
 pub mod button;
 
+/// `ClientOnly` logical boundary props.
+pub mod client_only;
+
 /// Dismissable helpers.
 pub mod dismissable;
 
@@ -26,3 +29,6 @@ pub mod separator;
 
 /// `VisuallyHidden` component (stateless attribute mapper).
 pub mod visually_hidden;
+
+/// `ZIndexAllocator` context provider contract.
+pub mod z_index_allocator;

--- a/crates/ars-components/src/utility/z_index_allocator.rs
+++ b/crates/ars-components/src/utility/z_index_allocator.rs
@@ -1,0 +1,210 @@
+//! Context contract for z-index allocation providers.
+//!
+//! `ZIndexAllocator` is a logical utility: adapters create a provider-scoped
+//! context so descendant overlays can claim monotonically increasing stacking
+//! layers without sharing a process-global allocator. The agnostic component
+//! owns no DOM element and therefore exposes no `Part`, `Api`, `ConnectApi`, or
+//! `AttrMap` output.
+
+use ars_core::SharedState;
+pub use ars_core::{
+    Z_INDEX_BASE, Z_INDEX_CEILING, ZIndexAllocator, ZIndexClaim, next_z_index, reset_z_index,
+};
+
+/// Framework-agnostic z-index provider context.
+///
+/// Adapters publish this type through framework context. Descendant overlays
+/// claim z-index values from the contained allocator and release those claims
+/// during teardown.
+#[derive(Clone, Debug, Default)]
+pub struct Context {
+    /// Allocator used by descendant overlay components.
+    allocator: SharedState<ZIndexAllocator>,
+}
+
+impl Context {
+    /// Create an empty z-index provider context.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            allocator: SharedState::new(ZIndexAllocator::new()),
+        }
+    }
+
+    /// Allocate and track the next z-index value.
+    #[must_use]
+    pub fn allocate(&self) -> u32 {
+        self.allocator.with(ZIndexAllocator::allocate)
+    }
+
+    /// Allocate and track the next z-index as an identity-safe claim handle.
+    #[must_use]
+    pub fn allocate_claim(&self) -> ZIndexClaim {
+        self.allocator.with(ZIndexAllocator::allocate_claim)
+    }
+
+    /// Release a previously allocated z-index value.
+    pub fn release(&self, z: u32) {
+        self.allocator.with(|allocator| allocator.release(z));
+    }
+
+    /// Release a previously allocated z-index claim.
+    pub fn release_claim(&self, claim: ZIndexClaim) {
+        self.allocator
+            .with(|allocator| allocator.release_claim(claim));
+    }
+
+    /// Clear tracked allocations and reset the provider-scoped z-index counter.
+    pub fn reset(&self) {
+        self.allocator.with(ZIndexAllocator::reset);
+    }
+}
+
+/// Props for the `ZIndexAllocator` provider boundary.
+///
+/// The provider has no configurable agnostic options today. Adapter components
+/// use this zero-sized type to preserve the utility component shape while
+/// publishing [`Context`] through framework context.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Props;
+
+impl Props {
+    /// Create default `ZIndexAllocator` provider props.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn props_default_is_empty() {
+        let props: Props = default_value();
+
+        assert_eq!(props, Props);
+    }
+
+    #[test]
+    fn props_new_matches_default() {
+        assert_eq!(Props::new(), Props);
+    }
+
+    #[test]
+    fn module_reexports_allocator_context_type() {
+        reset_z_index(Z_INDEX_BASE);
+
+        let allocator = ZIndexAllocator::new();
+
+        assert_eq!(allocator.allocate(), Z_INDEX_BASE);
+    }
+
+    #[test]
+    fn context_allocates_from_provider_scope() {
+        reset_z_index(Z_INDEX_BASE);
+
+        let context = Context::new();
+
+        assert_eq!(context.allocate(), Z_INDEX_BASE);
+        assert_eq!(next_z_index(), Z_INDEX_BASE);
+    }
+
+    #[test]
+    fn context_release_claim_does_not_reuse_values() {
+        reset_z_index(Z_INDEX_BASE);
+
+        let context = Context::new();
+
+        let claim = context.allocate_claim();
+
+        context.release_claim(claim);
+
+        assert_eq!(context.allocate(), Z_INDEX_BASE + 1);
+    }
+
+    #[test]
+    fn context_release_value_delegates_to_shared_allocator() {
+        reset_z_index(Z_INDEX_BASE);
+
+        let context = Context::new();
+        let cloned = context.clone();
+
+        let z = context.allocate();
+        let _other = context.allocate();
+
+        cloned.release(z);
+
+        assert_eq!(context.allocate(), Z_INDEX_BASE + 2);
+    }
+
+    #[test]
+    fn context_reset_clears_tracked_and_resets_provider_scope() {
+        reset_z_index(Z_INDEX_BASE);
+
+        let context = Context::new();
+        let cloned = context.clone();
+
+        let stale = context.allocate_claim();
+        let _other = context.allocate_claim();
+
+        cloned.reset();
+        context.release_claim(stale);
+
+        assert_eq!(context.allocate(), Z_INDEX_BASE);
+    }
+
+    #[test]
+    fn context_clone_shares_allocator_scope() {
+        reset_z_index(Z_INDEX_BASE);
+
+        let context = Context::new();
+        let cloned = context.clone();
+
+        assert_eq!(context.allocate(), Z_INDEX_BASE);
+        assert_eq!(cloned.allocate(), Z_INDEX_BASE + 1);
+    }
+
+    #[test]
+    fn context_clone_release_claim_shares_allocator_scope() {
+        reset_z_index(Z_INDEX_BASE);
+
+        let context = Context::new();
+        let cloned = context.clone();
+
+        let claim = context.allocate_claim();
+        let _other = context.allocate_claim();
+
+        cloned.release_claim(claim);
+
+        assert_eq!(context.allocate(), Z_INDEX_BASE + 2);
+    }
+
+    #[test]
+    fn allocator_integration_is_independent_from_global_counter() {
+        reset_z_index(Z_INDEX_BASE);
+
+        let allocator = ZIndexAllocator::new();
+
+        assert_eq!(next_z_index(), Z_INDEX_BASE);
+        assert_eq!(allocator.allocate(), Z_INDEX_BASE);
+        assert_eq!(next_z_index(), Z_INDEX_BASE + 1);
+    }
+
+    #[test]
+    fn allocator_release_does_not_reuse_values() {
+        reset_z_index(Z_INDEX_BASE);
+
+        let allocator = ZIndexAllocator::new();
+        let z = allocator.allocate();
+
+        allocator.release(z);
+
+        assert_eq!(allocator.allocate(), Z_INDEX_BASE + 1);
+    }
+
+    fn default_value<T: Default>() -> T {
+        T::default()
+    }
+}

--- a/crates/ars-core/src/lib.rs
+++ b/crates/ars-core/src/lib.rs
@@ -45,6 +45,7 @@ mod shared_flag;
 mod shared_state;
 mod url;
 mod weak_send;
+pub mod z_index;
 
 /// Hidden re-exports used by proc macros to stay hygienic without forcing
 /// downstream crates to import `alloc`.
@@ -89,6 +90,9 @@ pub use shared_flag::SharedFlag;
 pub use shared_state::SharedState;
 pub use url::{SafeUrl, UnsafeUrlError, is_safe_url, sanitize_url};
 pub use weak_send::{StrongSend, WeakSend};
+pub use z_index::{
+    Z_INDEX_BASE, Z_INDEX_CEILING, ZIndexAllocator, ZIndexClaim, next_z_index, reset_z_index,
+};
 
 // ════════════════════════════════════════════════════════════════════
 // Inline types — kept in lib.rs because the derive macros expand to

--- a/crates/ars-core/src/z_index.rs
+++ b/crates/ars-core/src/z_index.rs
@@ -1,0 +1,596 @@
+//! Pure z-index allocation for layered component surfaces.
+//!
+//! The allocator provides DOM-free scoped stacking counters used by overlay
+//! adapters. `ars-dom` re-exports this module's public allocation API so
+//! existing DOM-facing call sites keep the same paths.
+
+use alloc::vec::Vec;
+use core::cell::{Cell, RefCell};
+#[cfg(not(feature = "std"))]
+use core::sync::atomic::{AtomicU32, Ordering};
+
+/// Starting value for z-index allocation.
+///
+/// Application content should stay below this value; generated overlay layers
+/// start here and move upward monotonically.
+pub const Z_INDEX_BASE: u32 = 1000;
+
+/// Maximum z-index value before the counter wraps back to [`Z_INDEX_BASE`].
+///
+/// This prevents overflow on very long-running applications that allocate many
+/// transient overlay layers.
+pub const Z_INDEX_CEILING: u32 = u32::MAX - 1000;
+
+#[cfg(feature = "std")]
+thread_local! {
+    /// Per-thread monotonic z-index counter.
+    static NEXT_Z_INDEX: Cell<u32> = const { Cell::new(Z_INDEX_BASE) };
+}
+
+#[cfg(not(feature = "std"))]
+static NEXT_Z_INDEX: AtomicU32 = AtomicU32::new(Z_INDEX_BASE);
+
+/// Allocate the next z-index from the compatibility global counter.
+///
+/// Each call returns a monotonically increasing value starting at
+/// [`Z_INDEX_BASE`]. Values are never reused, even after a value is released
+/// through [`ZIndexAllocator::release`].
+///
+/// # Overflow protection
+///
+/// When the counter reaches [`Z_INDEX_CEILING`], it returns [`Z_INDEX_BASE`]
+/// for that allocation and stores [`Z_INDEX_BASE`] + 1 for the next allocation.
+#[must_use]
+pub fn next_z_index() -> u32 {
+    next_z_index_impl()
+}
+
+#[cfg(feature = "std")]
+fn next_z_index_impl() -> u32 {
+    NEXT_Z_INDEX.with(|z| {
+        let value = z.get();
+
+        if value >= Z_INDEX_CEILING {
+            warn_z_index_wrap();
+
+            z.set(Z_INDEX_BASE + 1);
+
+            Z_INDEX_BASE
+        } else {
+            z.set(value + 1);
+
+            value
+        }
+    })
+}
+
+#[cfg(not(feature = "std"))]
+fn next_z_index_impl() -> u32 {
+    loop {
+        let value = NEXT_Z_INDEX.load(Ordering::Relaxed);
+
+        let (returned, next) = if value >= Z_INDEX_CEILING {
+            warn_z_index_wrap();
+
+            (Z_INDEX_BASE, Z_INDEX_BASE + 1)
+        } else {
+            (value, value + 1)
+        };
+
+        if NEXT_Z_INDEX
+            .compare_exchange(value, next, Ordering::Relaxed, Ordering::Relaxed)
+            .is_ok()
+        {
+            return returned;
+        }
+    }
+}
+
+#[cfg(feature = "debug")]
+fn warn_z_index_wrap() {
+    log::warn!(
+        "[ars-core] z-index counter reached ceiling ({Z_INDEX_CEILING}), \
+         resetting to base ({Z_INDEX_BASE})"
+    );
+}
+
+#[cfg(not(feature = "debug"))]
+const fn warn_z_index_wrap() {}
+
+/// Reset the compatibility global z-index counter to the supplied base value.
+///
+/// This is intended for deterministic tests and application-level teardown.
+/// Provider-scoped overlay flows should allocate and release through
+/// [`ZIndexAllocator`] rather than resetting the compatibility global counter.
+pub fn reset_z_index(base: u32) {
+    reset_z_index_impl(base);
+}
+
+#[cfg(feature = "std")]
+fn reset_z_index_impl(base: u32) {
+    NEXT_Z_INDEX.with(|z| z.set(base));
+}
+
+#[cfg(not(feature = "std"))]
+fn reset_z_index_impl(base: u32) {
+    NEXT_Z_INDEX.store(base, Ordering::Relaxed);
+}
+
+/// Handle for an allocated z-index claim.
+///
+/// The [`value`](Self::value) is the CSS z-index to apply. The private identity
+/// is used by [`ZIndexAllocator::release_claim`] so cleanup can target one
+/// allocation even if a value is duplicated after a counter reset or wrap.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct ZIndexClaim {
+    /// CSS z-index value assigned to the claim.
+    value: u32,
+
+    /// Allocator-local identity for release bookkeeping.
+    id: u64,
+}
+
+impl ZIndexClaim {
+    /// Return the CSS z-index value for this claim.
+    #[must_use]
+    pub const fn value(self) -> u32 {
+        self.value
+    }
+}
+
+/// Structured z-index allocator with explicit lifecycle tracking.
+///
+/// The allocator owns a scoped z-index counter and records claims that have
+/// been allocated. Releasing a claim removes it from the tracked set but does
+/// not make it available for reuse; the scoped counter only moves forward.
+#[derive(Debug)]
+pub struct ZIndexAllocator {
+    /// Scoped monotonic z-index counter for this allocator instance.
+    next_z_index: Cell<u32>,
+
+    /// Claims currently tracked by this allocator instance.
+    allocated: RefCell<Vec<ZIndexClaim>>,
+
+    /// Allocator-local claim id source.
+    next_claim_id: Cell<u64>,
+}
+
+impl ZIndexAllocator {
+    /// Create a new allocator with no tracked allocations.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            next_z_index: Cell::new(Z_INDEX_BASE),
+            allocated: RefCell::new(Vec::new()),
+            next_claim_id: Cell::new(0),
+        }
+    }
+
+    /// Allocate and track the next z-index value.
+    ///
+    /// Values start at [`Z_INDEX_BASE`] and increase monotonically until the
+    /// overflow ceiling is reached.
+    #[must_use]
+    pub fn allocate(&self) -> u32 {
+        self.allocate_claim().value()
+    }
+
+    /// Allocate and track the next z-index as an identity-safe claim handle.
+    ///
+    /// Prefer this API for lifecycle-managed overlays. The returned
+    /// [`ZIndexClaim`] can be released with [`Self::release_claim`] without
+    /// relying on value matching.
+    #[must_use]
+    pub fn allocate_claim(&self) -> ZIndexClaim {
+        let claim = ZIndexClaim {
+            value: self.next_z_index(),
+            id: self.next_claim_id.get(),
+        };
+
+        self.next_claim_id.set(claim.id.wrapping_add(1));
+
+        self.allocated.borrow_mut().push(claim);
+
+        claim
+    }
+
+    /// Release a previously allocated z-index value.
+    ///
+    /// Unknown values and already released values are ignored. This
+    /// compatibility API releases the first tracked claim with the supplied
+    /// value. Prefer [`Self::release_claim`] when the caller owns a claim
+    /// handle.
+    pub fn release(&self, z: u32) {
+        let mut allocated = self.allocated.borrow_mut();
+
+        if let Some(index) = allocated.iter().position(|claim| claim.value == z) {
+            allocated.remove(index);
+        }
+    }
+
+    /// Release a previously allocated z-index claim.
+    ///
+    /// Unknown claims and already released claims are ignored. Released values
+    /// are not reused by future allocations.
+    pub fn release_claim(&self, claim: ZIndexClaim) {
+        let mut allocated = self.allocated.borrow_mut();
+
+        if let Some(index) = allocated.iter().position(|tracked| *tracked == claim) {
+            allocated.remove(index);
+        }
+    }
+
+    /// Clear tracked allocations and reset the provider-scoped counter to
+    /// [`Z_INDEX_BASE`].
+    ///
+    /// Allocator-local claim identity is not reset. That prevents stale
+    /// [`ZIndexClaim`] handles from matching new claims after a reset.
+    pub fn reset(&self) {
+        self.allocated.borrow_mut().clear();
+
+        self.next_z_index.set(Z_INDEX_BASE);
+    }
+}
+
+impl ZIndexAllocator {
+    /// Allocate the next z-index from this allocator's scoped counter.
+    fn next_z_index(&self) -> u32 {
+        let value = self.next_z_index.get();
+
+        if value >= Z_INDEX_CEILING {
+            warn_z_index_wrap();
+
+            self.next_z_index.set(Z_INDEX_BASE + 1);
+
+            Z_INDEX_BASE
+        } else {
+            self.next_z_index.set(value + 1);
+
+            value
+        }
+    }
+}
+
+impl Default for ZIndexAllocator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::format;
+    use core::sync::atomic::{AtomicBool, Ordering};
+
+    use super::*;
+
+    static TEST_SERIAL: AtomicBool = AtomicBool::new(false);
+
+    struct SerialGuard;
+
+    impl Drop for SerialGuard {
+        fn drop(&mut self) {
+            TEST_SERIAL.store(false, Ordering::Release);
+        }
+    }
+
+    fn serial_reset() -> SerialGuard {
+        while TEST_SERIAL
+            .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .is_err()
+        {
+            core::hint::spin_loop();
+        }
+
+        reset_z_index(Z_INDEX_BASE);
+
+        SerialGuard
+    }
+
+    impl ZIndexAllocator {
+        fn tracked_count(&self) -> usize {
+            self.allocated.borrow().len()
+        }
+
+        fn set_next_z_index(&self, value: u32) {
+            self.next_z_index.set(value);
+        }
+    }
+
+    #[test]
+    fn next_z_index_starts_at_base() {
+        let _guard = serial_reset();
+
+        assert_eq!(next_z_index(), 1000);
+    }
+
+    #[test]
+    fn next_z_index_is_monotonically_increasing() {
+        let _guard = serial_reset();
+
+        let z1 = next_z_index();
+        let z2 = next_z_index();
+        let z3 = next_z_index();
+
+        assert_eq!(z1, 1000);
+        assert_eq!(z2, 1001);
+        assert_eq!(z3, 1002);
+        assert!(z3 > z2);
+        assert!(z2 > z1);
+    }
+
+    #[test]
+    fn next_z_index_wraps_at_ceiling() {
+        let _guard = serial_reset();
+
+        reset_z_index(Z_INDEX_CEILING);
+
+        assert_eq!(
+            next_z_index(),
+            Z_INDEX_BASE,
+            "ceiling hit should return Z_INDEX_BASE"
+        );
+    }
+
+    #[test]
+    fn next_z_index_resumes_after_wrap() {
+        let _guard = serial_reset();
+
+        reset_z_index(Z_INDEX_CEILING);
+
+        let _ = next_z_index();
+
+        assert_eq!(
+            next_z_index(),
+            Z_INDEX_BASE + 1,
+            "post-wrap should resume from Z_INDEX_BASE + 1"
+        );
+    }
+
+    #[test]
+    fn next_z_index_one_below_ceiling_then_wraps() {
+        let _guard = serial_reset();
+
+        reset_z_index(Z_INDEX_CEILING - 1);
+
+        assert_eq!(next_z_index(), Z_INDEX_CEILING - 1);
+        assert_eq!(next_z_index(), Z_INDEX_BASE);
+    }
+
+    #[test]
+    fn reset_z_index_changes_next_value() {
+        let _guard = serial_reset();
+
+        reset_z_index(5000);
+
+        assert_eq!(next_z_index(), 5000);
+        assert_eq!(next_z_index(), 5001);
+    }
+
+    #[test]
+    fn reset_z_index_to_base_restores_default() {
+        let _guard = serial_reset();
+
+        let _ = next_z_index();
+        let _ = next_z_index();
+
+        reset_z_index(Z_INDEX_BASE);
+
+        assert_eq!(next_z_index(), 1000);
+    }
+
+    #[test]
+    fn allocator_allocate_returns_increasing_values() {
+        let _guard = serial_reset();
+
+        let allocator = ZIndexAllocator::new();
+
+        assert_eq!(allocator.allocate(), 1000);
+        assert_eq!(allocator.allocate(), 1001);
+        assert_eq!(allocator.allocate(), 1002);
+    }
+
+    #[test]
+    fn allocator_allocate_wraps_at_ceiling() {
+        let _guard = serial_reset();
+
+        let allocator = ZIndexAllocator::new();
+
+        allocator.set_next_z_index(Z_INDEX_CEILING);
+
+        assert_eq!(allocator.allocate(), Z_INDEX_BASE);
+        assert_eq!(allocator.allocate(), Z_INDEX_BASE + 1);
+        assert_eq!(allocator.tracked_count(), 2);
+    }
+
+    #[test]
+    fn allocator_allocate_is_scoped_independent_from_global_counter() {
+        let _guard = serial_reset();
+
+        reset_z_index(5000);
+
+        let allocator = ZIndexAllocator::new();
+
+        assert_eq!(next_z_index(), 5000);
+        assert_eq!(allocator.allocate(), Z_INDEX_BASE);
+        assert_eq!(next_z_index(), 5001);
+        assert_eq!(allocator.allocate(), Z_INDEX_BASE + 1);
+    }
+
+    #[test]
+    fn allocator_release_removes_from_tracked() {
+        let _guard = serial_reset();
+
+        let allocator = ZIndexAllocator::new();
+
+        let z1 = allocator.allocate();
+        let _z2 = allocator.allocate();
+
+        assert_eq!(allocator.tracked_count(), 2);
+
+        allocator.release(z1);
+
+        assert_eq!(allocator.tracked_count(), 1);
+    }
+
+    #[test]
+    fn allocator_allocate_claim_returns_claim_value() {
+        let _guard = serial_reset();
+
+        let allocator = ZIndexAllocator::new();
+
+        let claim = allocator.allocate_claim();
+
+        assert_eq!(claim.value(), Z_INDEX_BASE);
+        assert_eq!(allocator.tracked_count(), 1);
+    }
+
+    #[test]
+    fn allocator_release_claim_removes_exact_claim() {
+        let _guard = serial_reset();
+
+        let allocator = ZIndexAllocator::new();
+
+        let claim = allocator.allocate_claim();
+        let _other = allocator.allocate_claim();
+
+        allocator.release_claim(claim);
+
+        assert_eq!(allocator.tracked_count(), 1);
+    }
+
+    #[test]
+    fn allocator_release_claim_does_not_remove_same_value_with_different_identity() {
+        let _guard = serial_reset();
+
+        let allocator = ZIndexAllocator::new();
+
+        let stale = allocator.allocate_claim();
+
+        allocator.reset();
+
+        let current = allocator.allocate_claim();
+
+        assert_eq!(stale.value(), current.value());
+
+        allocator.release_claim(stale);
+
+        assert_eq!(allocator.tracked_count(), 1);
+    }
+
+    #[test]
+    fn allocator_release_value_removes_one_matching_claim() {
+        let _guard = serial_reset();
+
+        let allocator = ZIndexAllocator::new();
+
+        let first = allocator.allocate_claim();
+
+        allocator.set_next_z_index(Z_INDEX_BASE);
+
+        let second = allocator.allocate_claim();
+
+        assert_eq!(first.value(), second.value());
+
+        allocator.release(first.value());
+
+        assert_eq!(allocator.tracked_count(), 1);
+    }
+
+    #[test]
+    fn allocator_release_unknown_is_noop() {
+        let _guard = serial_reset();
+
+        let allocator = ZIndexAllocator::new();
+
+        allocator.release(9999);
+
+        assert_eq!(allocator.tracked_count(), 0);
+    }
+
+    #[test]
+    fn allocator_release_does_not_affect_counter() {
+        let _guard = serial_reset();
+
+        let allocator = ZIndexAllocator::new();
+
+        let z1 = allocator.allocate();
+
+        allocator.release(z1);
+
+        assert_eq!(allocator.allocate(), 1001);
+    }
+
+    #[test]
+    fn allocator_double_release_is_noop() {
+        let _guard = serial_reset();
+
+        let allocator = ZIndexAllocator::new();
+
+        let z1 = allocator.allocate();
+        let _z2 = allocator.allocate();
+
+        assert_eq!(allocator.tracked_count(), 2);
+
+        allocator.release(z1);
+
+        assert_eq!(allocator.tracked_count(), 1);
+
+        allocator.release(z1);
+
+        assert_eq!(allocator.tracked_count(), 1);
+    }
+
+    #[test]
+    fn allocator_release_after_reset_is_noop() {
+        let _guard = serial_reset();
+
+        let allocator = ZIndexAllocator::new();
+
+        let z1 = allocator.allocate();
+
+        allocator.reset();
+
+        assert_eq!(allocator.tracked_count(), 0);
+
+        allocator.release(z1);
+
+        assert_eq!(allocator.tracked_count(), 0);
+    }
+
+    #[test]
+    fn allocator_reset_clears_tracked_and_resets_counter() {
+        let _guard = serial_reset();
+
+        let allocator = ZIndexAllocator::new();
+
+        let _ = allocator.allocate();
+        let _ = allocator.allocate();
+
+        assert_eq!(allocator.tracked_count(), 2);
+
+        allocator.reset();
+
+        assert_eq!(allocator.tracked_count(), 0);
+        assert_eq!(allocator.allocate(), 1000);
+    }
+
+    #[test]
+    fn allocator_default_is_empty() {
+        let _guard = serial_reset();
+
+        assert_eq!(ZIndexAllocator::default().tracked_count(), 0);
+    }
+
+    #[test]
+    fn allocator_debug_format() {
+        let _guard = serial_reset();
+
+        let debug = format!("{:?}", ZIndexAllocator::new());
+
+        assert!(
+            debug.contains("ZIndexAllocator"),
+            "Debug output should contain the type name"
+        );
+    }
+}

--- a/crates/ars-dom/src/lib.rs
+++ b/crates/ars-dom/src/lib.rs
@@ -95,7 +95,10 @@ pub use scroll_lock::{
 };
 #[cfg(all(feature = "web", target_arch = "wasm32"))]
 pub use scroll_lock::{needs_ios_workaround, scrollbar_width};
-pub use z_index::{ZIndexAllocator, next_z_index, reset_z_index, supports_top_layer};
+pub use z_index::{
+    Z_INDEX_BASE, Z_INDEX_CEILING, ZIndexAllocator, ZIndexClaim, next_z_index, reset_z_index,
+    supports_top_layer,
+};
 
 #[cfg(all(test, feature = "ssr"))]
 mod ssr_smoke_tests {

--- a/crates/ars-dom/src/z_index.rs
+++ b/crates/ars-dom/src/z_index.rs
@@ -1,236 +1,27 @@
-//! Z-index allocator for overlay stacking order.
+//! DOM-facing z-index helpers for overlay stacking order.
 //!
-//! Overlay components (Dialog, Popover, Menu, Tooltip, etc.) need predictable
-//! stacking. When multiple overlays are open simultaneously — or nested (e.g., a
-//! Dialog containing a Menu) — each overlay must render above the previous one.
-//!
-//! This module provides:
-//!
-//! - **[`next_z_index()`]**: A thread-local monotonic counter that returns the
-//!   next z-index value starting at 1000. Values are never reused.
-//! - **[`reset_z_index()`]**: Resets the counter for tests or application teardown.
-//! - **[`ZIndexAllocator`]**: A structured wrapper with explicit lifecycle
-//!   control (allocate / release / reset) for overlay managers.
+//! Pure allocation lives in [`ars_core::z_index`]. This module preserves the
+//! historical `ars_dom::z_index` paths for adapters while keeping DOM-specific
+//! feature detection, such as CSS top-layer support, in `ars-dom`.
 
-use std::cell::{Cell, RefCell};
+pub use ars_core::z_index::{
+    Z_INDEX_BASE, Z_INDEX_CEILING, ZIndexAllocator, ZIndexClaim, next_z_index, reset_z_index,
+};
 
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-/// Starting value for z-index allocation. Application content uses 0–999;
-/// the allocator exclusively manages values from 1000 upward.
-const Z_INDEX_BASE: u32 = 1000;
-
-/// Maximum z-index value before the counter wraps back to [`Z_INDEX_BASE`].
-/// Prevents overflow on very long-running SPAs with many overlay open/close
-/// cycles (e.g., tooltips, popovers across thousands of interactions).
-const Z_INDEX_CEILING: u32 = u32::MAX - 1000;
-
-// ---------------------------------------------------------------------------
-// Thread-local counter
-// ---------------------------------------------------------------------------
-
-thread_local! {
-    /// Per-thread monotonic z-index counter. Starts at [`Z_INDEX_BASE`] (1000).
-    /// Single-threaded per thread: consistent with the library's `Rc`-based,
-    /// WASM-first design. On native targets, each thread gets its own counter.
-    static NEXT_Z_INDEX: Cell<u32> = const { Cell::new(Z_INDEX_BASE) };
-}
-
-// ---------------------------------------------------------------------------
-// Free functions
-// ---------------------------------------------------------------------------
-
-/// Allocate the next z-index for an overlay.
-///
-/// Each call returns a monotonically increasing value starting at 1000.
-/// The counter is thread-local: each thread maintains its own sequence.
-/// Values are never reused — gaps from released overlays are expected
-/// and harmless.
-///
-/// # Overflow protection
-///
-/// When the counter reaches `Z_INDEX_CEILING` (`u32::MAX - 1000`), it
-/// resets to `Z_INDEX_BASE` (1000). Existing overlays at high z-index values
-/// still render above normal content; new overlays start a fresh sequence.
-///
-/// # Examples
-///
-/// ```
-/// use ars_dom::z_index::{next_z_index, reset_z_index};
-///
-/// reset_z_index(1000);
-/// let z1 = next_z_index(); // 1000
-/// let z2 = next_z_index(); // 1001
-/// assert!(z2 > z1);
-/// ```
-#[must_use]
-pub fn next_z_index() -> u32 {
-    NEXT_Z_INDEX.with(|z| {
-        let val = z.get();
-
-        if val >= Z_INDEX_CEILING {
-            // Returning Z_INDEX_BASE here and storing BASE + 1 keeps the
-            // sequence monotonic from the caller's perspective after wrap:
-            // this call receives the fresh base and the next call advances.
-            // Reset to base — existing overlays at high z-indexes will still
-            // render above normal content; new overlays start fresh.
-            #[cfg(feature = "debug")]
-            log::warn!(
-                "[ars-dom] z-index counter reached ceiling ({Z_INDEX_CEILING}), \
-                 resetting to base ({Z_INDEX_BASE})"
-            );
-
-            z.set(Z_INDEX_BASE + 1);
-
-            Z_INDEX_BASE
-        } else {
-            z.set(val + 1);
-
-            val
-        }
-    })
-}
-
-/// Reset the z-index counter to a given base value.
-///
-/// Intended for use in tests to ensure deterministic z-index values,
-/// and for application-level teardown (e.g., full-page navigation in an SPA).
-///
-/// # Examples
-///
-/// ```
-/// use ars_dom::z_index::{next_z_index, reset_z_index};
-///
-/// reset_z_index(1000);
-/// assert_eq!(next_z_index(), 1000);
-/// assert_eq!(next_z_index(), 1001);
-/// ```
-pub fn reset_z_index(base: u32) {
-    NEXT_Z_INDEX.with(|z| z.set(base));
-}
-
-// ---------------------------------------------------------------------------
-// ZIndexAllocator
-// ---------------------------------------------------------------------------
-
-/// Structured z-index allocator for managing overlay stacking with explicit
-/// lifecycle control.
-///
-/// Wraps the thread-local [`next_z_index()`] counter and tracks allocated
-/// values for bookkeeping. Released values are removed from the tracked set
-/// but never reassigned — the counter only moves forward.
-///
-/// # Usage
-///
-/// ```
-/// use ars_dom::z_index::{ZIndexAllocator, reset_z_index};
-///
-/// reset_z_index(1000);
-///
-/// let allocator = ZIndexAllocator::new();
-///
-/// let z1 = allocator.allocate(); // 1000
-/// let z2 = allocator.allocate(); // 1001
-///
-/// allocator.release(z1);         // removes from tracking, does not reuse
-///
-/// let z3 = allocator.allocate(); // 1002 (not 1000)
-/// ```
-#[derive(Debug)]
-pub struct ZIndexAllocator {
-    /// Tracked z-index values for lifecycle management. Enables future
-    /// compaction strategies when all values in a range are released.
-    allocated: RefCell<Vec<u32>>,
-}
-
-impl ZIndexAllocator {
-    /// Create a new allocator with no tracked allocations.
-    ///
-    /// Uses the global thread-local counter starting at 1000.
-    #[must_use]
-    pub fn new() -> Self {
-        Self {
-            allocated: RefCell::new(Vec::new()),
-        }
-    }
-
-    /// Allocate the next z-index value.
-    ///
-    /// Delegates to the thread-local [`next_z_index()`] counter and records
-    /// the value for later release. Returns a monotonically increasing `u32`
-    /// starting at 1000. Values are never reused — gaps from released
-    /// overlays are expected and harmless.
-    #[must_use]
-    pub fn allocate(&self) -> u32 {
-        let z = next_z_index();
-
-        self.allocated.borrow_mut().push(z);
-
-        z
-    }
-
-    /// Release a previously allocated z-index.
-    ///
-    /// Removes the value from the tracked set. Does **not** make the value
-    /// available for reuse — the counter only moves forward. Releasing a
-    /// value that was never allocated is a no-op.
-    pub fn release(&self, z: u32) {
-        self.allocated.borrow_mut().retain(|&v| v != z);
-    }
-
-    /// Reset the allocator: clear all tracked allocations and reset the
-    /// thread-local counter to the base value (1000).
-    ///
-    /// Intended for tests and application-level teardown (e.g., full-page
-    /// navigation in an SPA).
-    pub fn reset(&self) {
-        self.allocated.borrow_mut().clear();
-
-        reset_z_index(Z_INDEX_BASE);
-    }
-}
-
-impl Default for ZIndexAllocator {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Top-layer detection
-// ---------------------------------------------------------------------------
-
-/// Check whether the browser supports the CSS top-layer (native `<dialog>` or
-/// Popover API).
+/// Check whether the browser supports the CSS top-layer.
 ///
 /// Detected once per thread and cached. When top-layer is supported, overlay
 /// components can skip z-index allocation and rely on the browser's native
-/// stacking. Returns `false` in non-browser environments (SSR, native desktop,
-/// tests).
+/// stacking. Returns `false` in non-browser environments.
 ///
 /// # Spec reference
 ///
 /// `spec/foundation/11-dom-utilities.md` §6.5 — CSS `top-layer` Note.
-///
-/// # Examples
-///
-/// ```
-/// use ars_dom::z_index::supports_top_layer;
-///
-/// // In non-browser test environment, always returns false.
-/// assert!(!supports_top_layer());
-/// ```
 #[must_use]
 pub fn supports_top_layer() -> bool {
     supports_top_layer_impl()
 }
 
-/// Web implementation: creates a temporary `<dialog>` element and checks for
-/// the `showModal` method via `js_sys::Reflect::has`. The result is cached in a
-/// thread-local `Cell<Option<bool>>` so the feature probe runs at most once per
-/// thread.
 #[cfg(all(feature = "web", target_arch = "wasm32"))]
 fn supports_top_layer_impl() -> bool {
     use std::cell::Cell;
@@ -240,14 +31,16 @@ fn supports_top_layer_impl() -> bool {
     }
 
     CACHED.with(|c| {
-        if let Some(v) = c.get() {
-            return v;
+        if let Some(value) = c.get() {
+            return value;
         }
 
         let supported = web_sys::window()
-            .and_then(|w| w.document())
-            .and_then(|d| d.create_element("dialog").ok())
-            .is_some_and(|el| js_sys::Reflect::has(&el, &"showModal".into()).unwrap_or(false));
+            .and_then(|window| window.document())
+            .and_then(|document| document.create_element("dialog").ok())
+            .is_some_and(|element| {
+                js_sys::Reflect::has(&element, &"showModal".into()).unwrap_or(false)
+            });
 
         c.set(Some(supported));
 
@@ -255,367 +48,53 @@ fn supports_top_layer_impl() -> bool {
     })
 }
 
-/// Non-web fallback: top-layer is a browser-only concept.
 #[cfg(not(all(feature = "web", target_arch = "wasm32")))]
 const fn supports_top_layer_impl() -> bool {
     false
 }
 
-// ---------------------------------------------------------------------------
-// Test helpers
-// ---------------------------------------------------------------------------
-
-/// Reset the thread-local z-index counter to [`Z_INDEX_BASE`].
-/// Called by [`tests::serial_reset()`] before each test.
-#[cfg(test)]
-fn reset_global_state() {
-    NEXT_Z_INDEX.with(|z| z.set(Z_INDEX_BASE));
-}
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
-
 #[cfg(test)]
 mod tests {
     use std::sync::{Mutex, MutexGuard};
 
-    use super::*;
+    use super::{Z_INDEX_BASE, ZIndexAllocator, next_z_index, reset_z_index, supports_top_layer};
 
-    /// Serializes z-index tests so they don't run in parallel.
-    ///
-    /// Although `thread_local!` is per-thread, the Rust test runner may reuse
-    /// threads across tests. Each test calls [`serial_reset()`] which acquires
-    /// this lock and zeroes global state before the test body runs. The
-    /// returned guard holds the lock for the test's lifetime.
     static TEST_SERIAL: Mutex<()> = Mutex::new(());
 
-    /// Acquire the serialization lock and reset global state.
-    ///
-    /// Returns a [`MutexGuard`] that keeps the lock held until dropped
-    /// (end of the calling test). This ensures no two z-index tests
-    /// touch the thread-local counter concurrently.
     fn serial_reset() -> MutexGuard<'static, ()> {
         let guard = TEST_SERIAL
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
 
-        reset_global_state();
+        reset_z_index(Z_INDEX_BASE);
 
         guard
     }
 
-    // -- Test helper for inspecting tracked allocations ----------------------
-
-    impl ZIndexAllocator {
-        /// Returns the number of currently tracked allocations (test-only).
-        fn tracked_count(&self) -> usize {
-            self.allocated.borrow().len()
-        }
-    }
-
-    // == A. Thread-local monotonic counter ===================================
-
     #[test]
-    fn next_z_index_starts_at_base() {
-        let _g = serial_reset();
+    fn ars_dom_allocator_uses_provider_scoped_counter() {
+        let _guard = serial_reset();
 
+        let allocator = ZIndexAllocator::new();
+
+        assert_eq!(allocator.allocate(), 1000);
+        assert_eq!(allocator.allocate(), 1001);
         assert_eq!(next_z_index(), 1000);
     }
-
-    #[test]
-    fn next_z_index_is_monotonically_increasing() {
-        let _g = serial_reset();
-
-        let z1 = next_z_index();
-        let z2 = next_z_index();
-        let z3 = next_z_index();
-
-        assert_eq!(z1, 1000);
-        assert_eq!(z2, 1001);
-        assert_eq!(z3, 1002);
-        assert!(z3 > z2);
-        assert!(z2 > z1);
-    }
-
-    #[test]
-    fn next_z_index_wraps_at_ceiling() {
-        let _g = serial_reset();
-
-        reset_z_index(Z_INDEX_CEILING);
-
-        let z = next_z_index();
-
-        assert_eq!(z, Z_INDEX_BASE, "ceiling hit should return Z_INDEX_BASE");
-    }
-
-    #[test]
-    fn next_z_index_resumes_after_wrap() {
-        let _g = serial_reset();
-
-        reset_z_index(Z_INDEX_CEILING);
-
-        let _ = next_z_index(); // triggers wrap, returns Z_INDEX_BASE
-
-        let z = next_z_index();
-
-        assert_eq!(
-            z,
-            Z_INDEX_BASE + 1,
-            "post-wrap should resume from Z_INDEX_BASE + 1"
-        );
-    }
-
-    #[test]
-    fn next_z_index_one_below_ceiling_then_wraps() {
-        let _g = serial_reset();
-
-        reset_z_index(Z_INDEX_CEILING - 1);
-
-        let z1 = next_z_index();
-
-        assert_eq!(z1, Z_INDEX_CEILING - 1, "one below ceiling is still normal");
-
-        let z2 = next_z_index();
-
-        assert_eq!(z2, Z_INDEX_BASE, "next call hits ceiling and wraps");
-    }
-
-    // == B. Configurable base ================================================
-
-    #[test]
-    fn reset_z_index_changes_next_value() {
-        let _g = serial_reset();
-
-        reset_z_index(5000);
-
-        assert_eq!(next_z_index(), 5000);
-        assert_eq!(next_z_index(), 5001);
-    }
-
-    #[test]
-    fn reset_z_index_to_base_restores_default() {
-        let _g = serial_reset();
-
-        // Move counter forward
-        let _ = next_z_index(); // 1000
-        let _ = next_z_index(); // 1001
-
-        // Reset back to base
-        reset_z_index(Z_INDEX_BASE);
-
-        assert_eq!(next_z_index(), 1000);
-    }
-
-    // == C. ZIndexAllocator::allocate() ======================================
-
-    #[test]
-    fn allocator_allocate_returns_increasing_values() {
-        let _g = serial_reset();
-
-        let alloc = ZIndexAllocator::new();
-
-        let z1 = alloc.allocate();
-        let z2 = alloc.allocate();
-        let z3 = alloc.allocate();
-
-        assert_eq!(z1, 1000);
-        assert_eq!(z2, 1001);
-        assert_eq!(z3, 1002);
-    }
-
-    #[test]
-    fn allocator_allocate_wraps_at_ceiling() {
-        let _g = serial_reset();
-
-        reset_z_index(Z_INDEX_CEILING);
-
-        let alloc = ZIndexAllocator::new();
-
-        let z1 = alloc.allocate();
-
-        assert_eq!(z1, Z_INDEX_BASE, "allocator must wrap at ceiling");
-
-        let z2 = alloc.allocate();
-
-        assert_eq!(z2, Z_INDEX_BASE + 1, "allocator must resume after wrap");
-        assert_eq!(alloc.tracked_count(), 2);
-    }
-
-    #[test]
-    fn allocator_allocate_delegates_to_thread_local() {
-        let _g = serial_reset();
-
-        let alloc = ZIndexAllocator::new();
-
-        // Interleave bare next_z_index() with allocator
-        let z1 = next_z_index(); // 1000 (bare)
-        let z2 = alloc.allocate(); // 1001 (allocator)
-        let z3 = next_z_index(); // 1002 (bare)
-        let z4 = alloc.allocate(); // 1003 (allocator)
-
-        assert_eq!(z1, 1000);
-        assert_eq!(z2, 1001);
-        assert_eq!(z3, 1002);
-        assert_eq!(z4, 1003);
-    }
-
-    // == D. ZIndexAllocator::release() =======================================
-
-    #[test]
-    fn allocator_release_removes_from_tracked() {
-        let _g = serial_reset();
-
-        let alloc = ZIndexAllocator::new();
-
-        let z1 = alloc.allocate();
-        let _z2 = alloc.allocate();
-
-        assert_eq!(alloc.tracked_count(), 2);
-
-        alloc.release(z1);
-
-        assert_eq!(alloc.tracked_count(), 1);
-    }
-
-    #[test]
-    fn allocator_release_unknown_is_noop() {
-        let _g = serial_reset();
-
-        let alloc = ZIndexAllocator::new();
-
-        // Release a value that was never allocated — should not panic.
-        alloc.release(9999);
-
-        assert_eq!(alloc.tracked_count(), 0);
-    }
-
-    #[test]
-    fn allocator_release_does_not_affect_counter() {
-        let _g = serial_reset();
-
-        let alloc = ZIndexAllocator::new();
-
-        let z1 = alloc.allocate(); // 1000
-
-        alloc.release(z1);
-
-        let z2 = alloc.allocate(); // 1001, NOT 1000 (values never reused)
-
-        assert_eq!(z2, 1001);
-    }
-
-    #[test]
-    fn allocator_double_release_is_noop() {
-        let _g = serial_reset();
-
-        let alloc = ZIndexAllocator::new();
-
-        let z1 = alloc.allocate();
-        let _z2 = alloc.allocate();
-
-        assert_eq!(alloc.tracked_count(), 2);
-
-        alloc.release(z1);
-
-        assert_eq!(alloc.tracked_count(), 1);
-
-        // Second release of same value — already removed, no panic.
-        alloc.release(z1);
-
-        assert_eq!(
-            alloc.tracked_count(),
-            1,
-            "second release must not remove other entries"
-        );
-    }
-
-    #[test]
-    fn allocator_release_after_reset_is_noop() {
-        let _g = serial_reset();
-
-        let alloc = ZIndexAllocator::new();
-
-        let z1 = alloc.allocate();
-
-        alloc.reset();
-
-        assert_eq!(alloc.tracked_count(), 0);
-
-        // Release a value that was cleared by reset — should not panic.
-        alloc.release(z1);
-
-        assert_eq!(alloc.tracked_count(), 0);
-    }
-
-    // == E. ZIndexAllocator::reset() =========================================
-
-    #[test]
-    fn allocator_reset_clears_tracked_and_resets_counter() {
-        let _g = serial_reset();
-
-        let alloc = ZIndexAllocator::new();
-
-        let _ = alloc.allocate(); // 1000
-        let _ = alloc.allocate(); // 1001
-
-        assert_eq!(alloc.tracked_count(), 2);
-
-        alloc.reset();
-
-        assert_eq!(alloc.tracked_count(), 0);
-
-        // Counter should be back at base
-        assert_eq!(alloc.allocate(), 1000);
-    }
-
-    // == F. Trait implementations ============================================
-
-    #[test]
-    fn allocator_default_is_empty() {
-        let _g = serial_reset();
-
-        let alloc = ZIndexAllocator::default();
-
-        assert_eq!(alloc.tracked_count(), 0);
-    }
-
-    #[test]
-    fn allocator_debug_format() {
-        let _g = serial_reset();
-
-        let alloc = ZIndexAllocator::new();
-
-        let debug = format!("{alloc:?}");
-
-        assert!(
-            debug.contains("ZIndexAllocator"),
-            "Debug output should contain the type name"
-        );
-    }
-
-    // == G. supports_top_layer() ============================================
 
     #[test]
     fn supports_top_layer_returns_false_in_test_environment() {
-        // Native test runner (not wasm32) has no browser — always false.
         assert!(!supports_top_layer());
     }
 
     #[test]
     fn supports_top_layer_is_idempotent() {
-        // Multiple calls must return the same value (tests caching contract).
         let first = supports_top_layer();
-
         let second = supports_top_layer();
 
         assert_eq!(first, second);
     }
 }
-
-// ---------------------------------------------------------------------------
-// WASM browser tests
-// ---------------------------------------------------------------------------
 
 #[cfg(all(test, feature = "web", target_arch = "wasm32"))]
 mod wasm_tests {
@@ -625,20 +104,14 @@ mod wasm_tests {
 
     wasm_bindgen_test_configure!(run_in_browser);
 
-    // == supports_top_layer() in a real browser =============================
-
     #[wasm_bindgen_test]
     fn supports_top_layer_returns_true_in_modern_browser() {
-        // Modern headless browsers (Chrome, Firefox) support <dialog>.showModal()
-        // and therefore the CSS top-layer. The function must detect this.
         assert!(supports_top_layer());
     }
 
     #[wasm_bindgen_test]
     fn supports_top_layer_caches_across_calls() {
-        // Exercises the Cell<Option<bool>> cache-hit path inside the web impl.
         let first = supports_top_layer();
-
         let second = supports_top_layer();
 
         assert_eq!(first, second);

--- a/crates/ars-dom/tests/z_index_compat.rs
+++ b/crates/ars-dom/tests/z_index_compat.rs
@@ -1,0 +1,36 @@
+//! Compatibility tests for DOM-facing z-index re-exports.
+
+use std::sync::{Mutex, MutexGuard};
+
+static TEST_SERIAL: Mutex<()> = Mutex::new(());
+
+fn serial_reset() -> MutexGuard<'static, ()> {
+    let guard = TEST_SERIAL
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+    ars_dom::reset_z_index(ars_dom::Z_INDEX_BASE);
+
+    guard
+}
+
+#[test]
+fn z_index_ars_dom_and_ars_core_free_functions_interleave_on_same_sequence() {
+    let _guard = serial_reset();
+
+    assert_eq!(ars_dom::next_z_index(), ars_dom::Z_INDEX_BASE);
+    assert_eq!(ars_core::next_z_index(), ars_dom::Z_INDEX_BASE + 1);
+    assert_eq!(ars_dom::next_z_index(), ars_dom::Z_INDEX_BASE + 2);
+}
+
+#[test]
+fn z_index_ars_dom_allocator_is_provider_scoped() {
+    let _guard = serial_reset();
+
+    let allocator = ars_dom::ZIndexAllocator::new();
+
+    assert_eq!(ars_dom::next_z_index(), ars_dom::Z_INDEX_BASE);
+    assert_eq!(allocator.allocate(), ars_dom::Z_INDEX_BASE);
+    assert_eq!(ars_core::next_z_index(), ars_dom::Z_INDEX_BASE + 1);
+    assert_eq!(allocator.allocate(), ars_dom::Z_INDEX_BASE + 1);
+}

--- a/spec/components/utility/client-only.md
+++ b/spec/components/utility/client-only.md
@@ -19,17 +19,32 @@ references:
 
 ```rust
 /// Props for the `ClientOnly` component.
-#[derive(Clone, Debug)]
-pub struct Props {
+#[derive(Clone, Debug, Default)]
+pub struct Props<Fallback = ()> {
     /// Optional fallback content rendered during SSR.
     /// When None, nothing is rendered on the server.
-    pub fallback: Option</* framework-specific view/element type */>,
+    pub fallback: Option<Fallback>,
+}
+
+impl<Fallback> Props<Fallback> {
+    /// Create `ClientOnly` props with no fallback content.
+    pub const fn new() -> Self {
+        Self { fallback: None }
+    }
+
+    /// Set the fallback content rendered during SSR and initial hydration.
+    pub fn fallback(mut self, fallback: Fallback) -> Self {
+        self.fallback = Some(fallback);
+        self
+    }
 }
 ```
 
+`Fallback` is the framework-specific view or element type. The agnostic core does not name Leptos or Dioxus view types directly, and it does not require `Fallback: PartialEq + Eq`; adapter view types are often closure-backed or virtual-node-backed values where equality is not meaningful.
+
 ### 1.2 Connect / API
 
-`ClientOnly` is a logical wrapper — it has no `Part` enum, no `ConnectApi`, and no `AttrMap` output. The adapter implements the SSR/hydration gating logic directly (see §5).
+`ClientOnly` is a logical wrapper — it has no `Part` enum, no `ConnectApi`, and no `AttrMap` output. The adapter implements the SSR/hydration gating logic directly (see §5). Snapshot tests for `connect()` / `Api` `AttrMap` output are not applicable because this utility has no agnostic connect API.
 
 ## 2. Anatomy
 
@@ -107,7 +122,7 @@ fn ClientOnly(fallback: Option<Element>, children: Element) -> Element {
 - **Client-side**: Renders children on the first client-side render cycle (after hydration completes). The `mounted` signal flips to `true` inside a `Effect::new` / `use_effect`, which runs after the initial hydration pass.
 - **No waterfall**: `ClientOnly` does NOT delay rendering of surrounding content. Sibling and parent components render normally on the server and hydrate normally on the client. Only the ClientOnly subtree itself is deferred to the client — the rest of the page is unaffected.
 - **Hydration mismatch avoidance**: Because the server renders nothing (or the fallback) and the client initially renders the same thing before the effect flips `mounted`, there is no mismatch between server HTML and initial client HTML.
-- **`fallback` prop**: `fallback: Option<ChildrenFn>` provides optional server-side placeholder content. Use this for skeleton loaders, placeholder text, or `aria-busy="true"` containers that give users visual feedback while the client-only content loads. When `None`, the server output is empty.
+- **`fallback` prop**: agnostic `Props<Fallback>` stores `fallback: Option<Fallback>`. Leptos maps `Fallback` to `ChildrenFn`; Dioxus maps it to `Element`. Use this for skeleton loaders, placeholder text, or `aria-busy="true"` containers that give users visual feedback while the client-only content loads. When `None`, the server output is empty.
 - **Use cases**: `localStorage`, `window.matchMedia`, `navigator`, Canvas/WebGL, third-party browser scripts — any API that does not exist during SSR.
 
 ## 8. Library Parity

--- a/spec/components/utility/z-index-allocator.md
+++ b/spec/components/utility/z-index-allocator.md
@@ -10,61 +10,164 @@ references: {}
 
 # ZIndexAllocator
 
-ZIndexAllocator provides z-index allocation services to descendant overlay components via context. It delegates to the canonical `next_z_index()` thread-local counter defined in `spec/foundation/11-dom-utilities.md` §6.2 and `spec/shared/z-index-stacking.md`.
+ZIndexAllocator provides provider-scoped z-index allocation services to descendant overlay components via context. Its agnostic `Context` wraps `ars_core::ZIndexAllocator`; the legacy `next_z_index()` free function remains available from `ars-core` and `ars-dom` for compatibility, but provider-backed overlays should allocate through context. See `spec/foundation/11-dom-utilities.md` §6.2 and `spec/shared/z-index-stacking.md`.
 
 ## 1. API
 
-`ZIndexAllocator` is a context-only provider — it has no `Part` enum, no `ConnectApi`, and no `AttrMap` output. Adapters create a `ZIndexAllocator` in a top-level provider and expose it via framework context.
+`ZIndexAllocator` is a context-only provider — it has no `Part` enum, no `ConnectApi`, and no `AttrMap` output. Adapters create a `z_index_allocator::Context` in a top-level provider and expose it via framework context. Snapshot tests for `connect()` / `Api` `AttrMap` output are not applicable because this utility has no agnostic connect API.
 
-### 1.1 ZIndexAllocator
+### 1.1 Props
 
 ```rust
-pub struct ZIndexAllocator {
-    allocated: RefCell<Vec<u32>>,
-}
+/// Props for the `ZIndexAllocator` provider boundary.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Props;
 
-impl ZIndexAllocator {
-    /// Create a new allocator. Uses the global thread-local base (1000).
-    pub fn new() -> Self {
-        Self {
-            allocated: RefCell::new(Vec::new()),
-        }
-    }
-
-    /// Allocate the next z-index value.
-    ///
-    /// Returns a monotonically increasing `u32` starting at `Z_INDEX_BASE` (1000).
-    /// Values are never reused — gaps from released values are expected.
-    ///
-    /// # Overflow Protection
-    /// When the counter reaches `Z_INDEX_CEILING` (`u32::MAX - 1000`), the
-    /// allocator resets to `Z_INDEX_BASE` and emits a `cfg(debug_assertions)`
-    /// warning. In practice, overflow requires billions of allocations.
-    pub fn allocate(&self) -> u32 {
-        let z = next_z_index(); // ars_dom thread-local counter
-        self.allocated.borrow_mut().push(z);
-        z
-    }
-
-    /// Release a previously allocated z-index.
-    ///
-    /// Removes the value from the tracked set. Does NOT make the value
-    /// available for reuse — the counter only moves forward.
-    pub fn release(&self, z: u32) {
-        self.allocated.borrow_mut().retain(|&v| v != z);
-    }
-
-    /// Reset all tracked allocations.
-    ///
-    /// Used for testing. Also resets the global counter via `reset_z_index(Z_INDEX_BASE)`.
-    pub fn reset(&self) {
-        self.allocated.borrow_mut().clear();
-        reset_z_index(Z_INDEX_BASE);
+impl Props {
+    /// Create default `ZIndexAllocator` provider props.
+    pub const fn new() -> Self {
+        Self
     }
 }
 ```
 
-### 1.2 Constants
+The provider has no configurable agnostic options today. Framework adapters use this zero-sized type to preserve the utility component shape while publishing [`Context`] through framework context.
+
+### 1.2 Context
+
+```rust
+pub use ars_core::{
+    SharedState, Z_INDEX_BASE, Z_INDEX_CEILING, ZIndexAllocator, ZIndexClaim, next_z_index,
+    reset_z_index,
+};
+
+/// Framework-agnostic z-index provider context.
+#[derive(Clone, Debug, Default)]
+pub struct Context {
+    allocator: SharedState<ZIndexAllocator>,
+}
+
+impl Context {
+    /// Create an empty z-index provider context.
+    pub fn new() -> Self {
+        Self {
+            allocator: SharedState::new(ZIndexAllocator::new()),
+        }
+    }
+
+    /// Allocate and track the next z-index value.
+    pub fn allocate(&self) -> u32 {
+        self.allocator.with(ZIndexAllocator::allocate)
+    }
+
+    /// Allocate and track the next z-index as an identity-safe claim handle.
+    pub fn allocate_claim(&self) -> ZIndexClaim {
+        self.allocator.with(ZIndexAllocator::allocate_claim)
+    }
+
+    /// Release a previously allocated z-index value.
+    pub fn release(&self, z: u32) {
+        self.allocator.with(|allocator| allocator.release(z));
+    }
+
+    /// Release a previously allocated z-index claim.
+    pub fn release_claim(&self, claim: ZIndexClaim) {
+        self.allocator.with(|allocator| allocator.release_claim(claim));
+    }
+
+    /// Clear tracked allocations and reset the provider-scoped z-index counter.
+    pub fn reset(&self) {
+        self.allocator.with(ZIndexAllocator::reset);
+    }
+}
+```
+
+`Context` is the type adapters publish through framework context. It wraps the canonical `ars_core::ZIndexAllocator` in `SharedState` so cloned context values keep one allocator scope even when framework context APIs clone provider payloads.
+
+### 1.3 ZIndexAllocator Core Contract
+
+```rust
+use core::cell::{Cell, RefCell};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct ZIndexClaim {
+    value: u32,
+    id: u64,
+}
+
+impl ZIndexClaim {
+    /// Return the CSS z-index value for this claim.
+    pub const fn value(self) -> u32 {
+        self.value
+    }
+}
+
+#[derive(Debug)]
+pub struct ZIndexAllocator {
+    next_z_index: Cell<u32>,
+    allocated: RefCell<Vec<ZIndexClaim>>,
+    next_claim_id: Cell<u64>,
+}
+
+impl ZIndexAllocator {
+    /// Create a new allocator with no tracked allocations.
+    pub const fn new() -> Self {
+        Self {
+            next_z_index: Cell::new(Z_INDEX_BASE),
+            allocated: RefCell::new(Vec::new()),
+            next_claim_id: Cell::new(0),
+        }
+    }
+
+    /// Allocate the next z-index value.
+    pub fn allocate(&self) -> u32 {
+        self.allocate_claim().value()
+    }
+
+    /// Allocate the next z-index as an identity-safe claim handle.
+    pub fn allocate_claim(&self) -> ZIndexClaim {
+        let claim = ZIndexClaim {
+            value: self.next_z_index(),
+            id: self.next_claim_id.get(),
+        };
+
+        self.next_claim_id.set(claim.id.wrapping_add(1));
+        self.allocated.borrow_mut().push(claim);
+
+        claim
+    }
+
+    /// Release a previously allocated z-index.
+    pub fn release(&self, z: u32) {
+        let mut allocated = self.allocated.borrow_mut();
+
+        if let Some(index) = allocated.iter().position(|claim| claim.value == z) {
+            allocated.remove(index);
+        }
+    }
+
+    /// Release a previously allocated z-index claim.
+    pub fn release_claim(&self, claim: ZIndexClaim) {
+        let mut allocated = self.allocated.borrow_mut();
+
+        if let Some(index) = allocated.iter().position(|tracked| *tracked == claim) {
+            allocated.remove(index);
+        }
+    }
+
+    /// Reset all tracked allocations.
+    pub fn reset(&self) {
+        self.allocated.borrow_mut().clear();
+        self.next_z_index.set(Z_INDEX_BASE);
+    }
+}
+```
+
+`allocate_claim()` / `release_claim()` are the preferred lifecycle API because they release by allocator-local identity. `allocate()` / `release(u32)` remain available for compatibility and simple integrations; value-based release removes the first tracked claim with that value and ignores unknown values. Released values are never reused. `reset()` clears tracked claims and resets the provider-scoped counter but does not reset allocator-local claim identity, preventing stale handles from matching new claims after reset.
+
+`ars-dom` re-exports `ZIndexAllocator`, `ZIndexClaim`, `next_z_index()`, and `reset_z_index()` for adapter compatibility, but it does not own allocation behavior.
+
+### 1.4 Constants
 
 | Constant          | Value             | Description                           |
 | ----------------- | ----------------- | ------------------------------------- |
@@ -89,15 +192,16 @@ ZIndexAllocator has no ARIA semantics. It is a context-only provider invisible t
 ## 4. Usage
 
 ```rust
-// Adapter creates the allocator in a top-level provider
-let allocator = ZIndexAllocator::new();
+// Adapter creates the context in a top-level provider
+let context = z_index_allocator::Context::new();
 
 // Overlay components request z-index values
-let z = allocator.allocate();
+let claim = context.allocate_claim();
+let z = claim.value();
 // Use z for the overlay's container style
 
 // On overlay unmount
-allocator.release(z);
+context.release_claim(claim);
 ```
 
 See `spec/shared/z-index-stacking.md` for the full stacking context model and `spec/foundation/11-dom-utilities.md` §6 for the z-index management architecture.

--- a/spec/dioxus-components/overlay/tooltip.md
+++ b/spec/dioxus-components/overlay/tooltip.md
@@ -146,7 +146,7 @@ struct Context {
 
 `Group` coordination: `Tooltip` reads `try_use_context::<GroupContext>()` when present. If warm, it skips `OpenPending` and transitions directly to `Open`. On open, it records itself as active and closes any previously active tooltip. On close, it records `last_close_at` for warmup tracking.
 
-Portal rendering: Positioner, Content, and Arrow render into the portal root obtained from `try_use_context::<ArsContext>()`. Z-index is allocated from `try_use_context::<ZIndexAllocator>()`.
+Portal rendering: Positioner, Content, and Arrow render into the portal root obtained from `try_use_context::<ArsContext>()`. Z-index is allocated from `try_use_context::<z_index_allocator::Context>()`.
 
 ## 7. Prop Sync and Event Mapping
 

--- a/spec/dioxus-components/utility/z-index-allocator.md
+++ b/spec/dioxus-components/utility/z-index-allocator.md
@@ -44,7 +44,7 @@ pub fn ZIndexAllocatorProvider(props: ZIndexAllocatorProviderProps) -> Element
 
 ## 6. Composition / Context Contract
 
-Publish allocator context with `use_context_provider`. Optional consumers use `try_use_context::<ZIndexAllocator>()`.
+Publish allocator context with `use_context_provider`. Optional consumers use `try_use_context::<z_index_allocator::Context>()`.
 
 ## 7. Prop Sync and Event Mapping
 
@@ -86,10 +86,10 @@ Allocator behavior is mostly provider-internal. If allocator options are configu
 
 ## 12. Failure and Degradation Rules
 
-| Condition                                                   | Policy          | Notes                                                           |
-| ----------------------------------------------------------- | --------------- | --------------------------------------------------------------- |
-| claimant releases an unknown or already-released allocation | warn and ignore | Preserve allocator integrity while surfacing the misuse.        |
-| provider absent where a claimant expects allocation context | fail fast       | Claimants require the allocator contract to allocate correctly. |
+| Condition                                                   | Policy                                  | Notes                                                                                                  |
+| ----------------------------------------------------------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| claimant releases an unknown or already-released allocation | ignore in core; adapters may debug-warn | Core release is idempotent; adapter diagnostics may surface misuse when provider context is available. |
+| provider absent where a claimant expects allocation context | fail fast                               | Claimants require the allocator contract to allocate correctly.                                        |
 
 ## 13. Identity and Key Policy
 
@@ -167,7 +167,7 @@ pub struct ZIndexAllocatorProviderSketchProps {
 
 #[component]
 pub fn ZIndexAllocatorProvider(props: ZIndexAllocatorProviderSketchProps) -> Element {
-    use_context_provider(|| z_index_allocator::ZIndexAllocator::new());
+    use_context_provider(|| z_index_allocator::Context::new());
     rsx! { {props.children} }
 }
 ```

--- a/spec/foundation/11-dom-utilities.md
+++ b/spec/foundation/11-dom-utilities.md
@@ -2361,117 +2361,79 @@ Overlay components need predictable stacking. When multiple overlays are open si
 
 ### 6.2 Strategy
 
-````rust
-// ars-dom/src/z_index.rs
+```rust
+// ars-core/src/z_index.rs
 
-use std::cell::{Cell, RefCell};
+use core::cell::{Cell, RefCell};
 
-thread_local! {
-    /// Base z-index value. Set high enough to sit above typical application content.
-    /// Consumer stylesheets should avoid z-index values at or above this base.
-    static NEXT_Z_INDEX: Cell<u32> = Cell::new(1000);
+pub const Z_INDEX_BASE: u32 = 1000;
+pub const Z_INDEX_CEILING: u32 = u32::MAX - 1000;
+
+/// Allocate the next z-index from the compatibility global counter.
+///
+/// In `std` builds the counter is thread-local. In `no_std` builds the same
+/// free function uses an atomic fallback so the pure core crate keeps compiling
+/// without `std`; that fallback preserves monotonic allocation but is not a
+/// browser runtime context boundary.
+pub fn next_z_index() -> u32;
+
+/// Reset the compatibility global z-index counter to the supplied base value.
+pub fn reset_z_index(base: u32);
+
+/// Handle for an allocated z-index claim.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct ZIndexClaim {
+    value: u32,
+    id: u64,
 }
 
-/// Allocate the next z-index for an overlay.
-/// Each call returns a monotonically increasing value.
-/// Single-threaded: consistent with the library's `Rc`-based, WASM-first design.
-///
-/// # Example
-///
-/// ```rust
-/// let z = next_z_index(); // 1000
-/// let z2 = next_z_index(); // 1001
-/// assert!(z2 > z);
-/// ```
-/// Z-index overflow threshold. If the counter exceeds this, it resets to the
-/// base value. This prevents wrap-around to 0 on very long-running SPAs that
-/// open many overlays (e.g., tooltips, popovers over thousands of interactions).
-const Z_INDEX_BASE: u32 = 1000;
-const Z_INDEX_CEILING: u32 = u32::MAX - 1000;
-
-pub fn next_z_index() -> u32 {
-    NEXT_Z_INDEX.with(|z| {
-        let val = z.get();
-        if val >= Z_INDEX_CEILING {
-            // Return the fresh base now, but store BASE + 1 so the following
-            // allocation continues from the new sequence without repeating BASE.
-            // Reset to base — existing overlays at high z-indexes will still
-            // render above normal content; new overlays start fresh.
-            #[cfg(feature = "debug")]
-            log::warn!(
-                "[ars-dom] z-index counter reached ceiling ({Z_INDEX_CEILING}), \
-                 resetting to base ({Z_INDEX_BASE})"
-            );
-            z.set(Z_INDEX_BASE + 1);
-            Z_INDEX_BASE
-        } else {
-            z.set(val + 1);
-            val
-        }
-    })
-}
-
-/// Reset the z-index counter to a given base value.
-/// Intended for use in tests to ensure deterministic z-index values.
-///
-/// # Example
-///
-/// ```rust
-/// reset_z_index(1000);
-/// assert_eq!(next_z_index(), 1000);
-/// assert_eq!(next_z_index(), 1001);
-/// ```
-pub fn reset_z_index(base: u32) {
-    NEXT_Z_INDEX.with(|z| z.set(base));
+impl ZIndexClaim {
+    pub const fn value(self) -> u32;
 }
 
 /// Structured z-index allocator for managing overlay stacking with explicit
-/// lifecycle control. Wraps the thread-local counter and adds release tracking
-/// to enable future compaction strategies.
+/// lifecycle control.
+#[derive(Debug)]
 pub struct ZIndexAllocator {
-    allocated: RefCell<Vec<u32>>,
+    next_z_index: Cell<u32>,
+    allocated: RefCell<Vec<ZIndexClaim>>,
+    next_claim_id: Cell<u64>,
 }
 
 impl ZIndexAllocator {
-    pub fn new() -> Self {
-        Self {
-            allocated: RefCell::new(Vec::new()),
-        }
-    }
+    pub const fn new() -> Self;
 
-    /// Allocate the next z-index. Delegates to the thread-local counter
-    /// and records the value for later release/compaction.
-    pub fn allocate(&self) -> u32 {
-        let z = next_z_index();
-        self.allocated.borrow_mut().push(z);
-        z
-    }
+    /// Allocate and track the next z-index value.
+    pub fn allocate(&self) -> u32;
 
-    /// Release a previously allocated z-index. Removes it from the tracked
-    /// set. After release, the value will not be reused — new allocations
-    /// always increment. Release enables future compaction: when all values
-    /// in a range are released, the allocator can reclaim that range.
-    pub fn release(&self, z: u32) {
-        self.allocated.borrow_mut().retain(|&v| v != z);
-    }
+    /// Allocate and track the next z-index as an identity-safe claim handle.
+    pub fn allocate_claim(&self) -> ZIndexClaim;
 
-    /// Reset the allocator: clear all tracked allocations and reset the
-    /// thread-local counter to the base value. Intended for tests and
-    /// application-level teardown (e.g., full-page navigation in an SPA).
-    pub fn reset(&self) {
-        self.allocated.borrow_mut().clear();
-        reset_z_index(Z_INDEX_BASE);
-    }
+    /// Release the first tracked claim with this value. Unknown values are ignored.
+    pub fn release(&self, z: u32);
+
+    /// Release one exact claim handle. Unknown claims are ignored.
+    pub fn release_claim(&self, claim: ZIndexClaim);
+
+    /// Clear tracked allocations and reset the provider-scoped counter to `Z_INDEX_BASE`.
+    pub fn reset(&self);
 }
-````
+```
+
+When the counter reaches `Z_INDEX_CEILING`, allocation returns `Z_INDEX_BASE` for that call and stores `Z_INDEX_BASE + 1` for the next allocation. This prevents integer overflow while keeping the new sequence monotonic after wrap.
+
+`ZIndexAllocator` owns a provider-scoped counter. `allocate_claim()` / `release_claim()` are the preferred lifecycle API because release targets an allocator-local claim identity. `allocate()` / `release(u32)` remain available for compatibility and simple integrations; value-based release removes the first tracked claim with that value and ignores unknown values. Released values are never reused. `reset()` clears tracked claims and resets the provider-scoped counter, but allocator-local claim identity continues to move forward so stale handles cannot release newly allocated claims after reset.
+
+`ars-dom::z_index` re-exports `ZIndexAllocator`, `ZIndexClaim`, `next_z_index()`, `reset_z_index()`, `Z_INDEX_BASE`, and `Z_INDEX_CEILING` from `ars-core` so adapter code can keep DOM-facing imports. The free functions are compatibility global-counter APIs; provider-backed overlays should use `z_index_allocator::Context`. Browser capability detection such as `supports_top_layer()` remains owned by `ars-dom`.
 
 ### 6.3 Usage Pattern
 
-Each overlay component calls `next_z_index()` when it opens (mounts into the DOM). Components with both a backdrop and content element allocate two consecutive z-index values: one for the backdrop (lower) and one for the content (higher). The returned value is applied as an inline style on the overlay's positioner or root element:
+Each overlay component allocates from the nearest `z_index_allocator::Context` when it opens (mounts into the DOM). Components with both a backdrop and content element allocate two consecutive z-index values: one for the backdrop (lower) and one for the content (higher). The returned value is applied as an inline style on the overlay's positioner or root element:
 
 ```rust
-// Inside a Popover's connect function:
-let z = next_z_index();
+// Inside a Popover adapter hook:
+let claim = z_index_context.allocate_claim();
+let z = claim.value();
 positioner_attrs.set_style(CssProperty::ZIndex, z.to_string());
 ```
 
@@ -2483,7 +2445,7 @@ This guarantees that overlays stack in opening order:
 
 When an overlay closes and later reopens, it receives a new (higher) z-index. This avoids stale z-index conflicts when overlays open and close in unpredictable order.
 
-> **Z-index management.** The monotonic counter (`next_z_index()`) always increments; values are
+> **Z-index management.** The provider-scoped monotonic counter always increments; values are
 > never reused or compacted. When an overlay closes and reopens, it receives a new, higher value.
 > Gaps in the sequence (e.g., [1000, 1002, 1005]) are expected and harmless — they do not cause
 > stacking inversions because the opening order is preserved by the counter. The `ZIndexAllocator`
@@ -2498,9 +2460,9 @@ When an overlay closes and later reopens, it receives a new (higher) z-index. Th
 | 0–999 | User/application content. The library MUST NOT allocate in this range. |
 | 1000+ | Overlay components managed by `ZIndexAllocator`.                       |
 
-**Cross-adapter consistency:** All adapters (Leptos, Dioxus) share the same thread-local `NEXT_Z_INDEX` counter via `ars-dom`. This ensures that overlays opened by different adapter instances on the same page stack correctly.
+**Cross-adapter consistency:** Adapters (Leptos, Dioxus) must publish the same `z_index_allocator::Context` type and consume it from the nearest provider. Overlays under the same provider share one scoped sequence. Separate providers intentionally create separate scopes; applications that need all overlays on a page to share one sequence should place one allocator provider above all layered surfaces.
 
-**Nested overlay ordering:** Nested overlays (e.g., a Menu inside a Dialog) increment from the parent's z-index. The `next_z_index()` function handles this automatically since calls are sequential — the child always receives a higher value than the parent.
+**Nested overlay ordering:** Nested overlays (e.g., a Menu inside a Dialog) increment from the parent's provider scope. Sequential context allocations ensure the child receives a higher value than the parent when both consume the same provider.
 
 **Portal z-index independence:** Overlays rendered through portals (appended to `document.body`) are outside their parent's stacking context. Their z-index is absolute, not relative to the parent component's stacking context. This is by design — portal-based overlays must stack above all non-overlay content regardless of where the trigger component lives in the DOM tree.
 

--- a/spec/leptos-components/overlay/tooltip.md
+++ b/spec/leptos-components/overlay/tooltip.md
@@ -118,7 +118,7 @@ struct Context {
 
 `Group` coordination: `Tooltip` reads `use_context::<GroupContext>()` when present. If warm, it skips `OpenPending` and transitions directly to `Open`. On open, it records itself as active and closes any previously active tooltip. On close, it records `last_close_at` for warmup tracking.
 
-Portal rendering: Positioner, Content, and Arrow render into the portal root obtained from `use_context::<ArsContext>()`. Z-index is allocated from `use_context::<ZIndexAllocator>()`.
+Portal rendering: Positioner, Content, and Arrow render into the portal root obtained from `use_context::<ArsContext>()`. Z-index is allocated from `use_context::<z_index_allocator::Context>()`.
 
 ## 7. Prop Sync and Event Mapping
 

--- a/spec/leptos-components/utility/z-index-allocator.md
+++ b/spec/leptos-components/utility/z-index-allocator.md
@@ -38,7 +38,7 @@ This spec maps the core [`ZIndexAllocator`](../../components/utility/z-index-all
 
 ## 6. Composition / Context Contract
 
-Publish allocator context with `provide_context`. Optional consumers use `use_context::<ZIndexAllocator>()`.
+Publish allocator context with `provide_context`. Optional consumers use `use_context::<z_index_allocator::Context>()`.
 
 ## 7. Prop Sync and Event Mapping
 
@@ -80,10 +80,10 @@ Allocator behavior is mostly provider-internal. If allocator options are configu
 
 ## 12. Failure and Degradation Rules
 
-| Condition                                                   | Policy          | Notes                                                           |
-| ----------------------------------------------------------- | --------------- | --------------------------------------------------------------- |
-| claimant releases an unknown or already-released allocation | warn and ignore | Preserve allocator integrity while surfacing the misuse.        |
-| provider absent where a claimant expects allocation context | fail fast       | Claimants require the allocator contract to allocate correctly. |
+| Condition                                                   | Policy                                  | Notes                                                                                                  |
+| ----------------------------------------------------------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| claimant releases an unknown or already-released allocation | ignore in core; adapters may debug-warn | Core release is idempotent; adapter diagnostics may surface misuse when provider context is available. |
+| provider absent where a claimant expects allocation context | fail fast                               | Claimants require the allocator contract to allocate correctly.                                        |
 
 ## 13. Identity and Key Policy
 
@@ -156,7 +156,7 @@ Leptos owner cleanup may be used by descendants to release values.
 ```rust
 #[component]
 pub fn ZIndexAllocatorProvider(children: Children) -> impl IntoView {
-    provide_context(z_index_allocator::ZIndexAllocator::new());
+    provide_context(z_index_allocator::Context::new());
     view! { <>{children()}</> }
 }
 ```

--- a/spec/shared/z-index-stacking.md
+++ b/spec/shared/z-index-stacking.md
@@ -2,18 +2,16 @@
 
 Shared z-index allocation strategy for overlay components.
 
-All overlay components render into `ars-portal-root` and MUST use a coordinated z-index allocation strategy to prevent stacking context collisions. The canonical allocator is the `next_z_index()` free function from the `ars-dom` crate (see `11-dom-utilities.md` §6 Z-Index Management for the full specification), which returns monotonically increasing values starting at 1000. Separately, the `ZIndexAllocator` component (see `components/utility/z-index-allocator.md`) is a framework-level wrapper that injects the allocator into the adapter context, making `next_z_index()` available to adapter hooks via context propagation:
+All overlay components render into `ars-portal-root` and MUST use a coordinated z-index allocation strategy to prevent stacking context collisions. The canonical runtime allocator is `z_index_allocator::Context`, provided by the `ZIndexAllocator` component (see `components/utility/z-index-allocator.md`) and backed by `ars_core::ZIndexAllocator`. The compatibility `next_z_index()` free function remains available from `ars-core` and `ars-dom`, but provider-backed overlays should allocate through context so the allocation scope is explicit:
 
 ```rust
-/// Canonical z-index allocator: returns the next sequential z-index.
-/// Each call returns a value one higher than the previous (1000, 1001, 1002, ...).
-/// This ensures overlays opened later always stack above earlier ones.
-/// See `11-dom-utilities.md` §6 Z-Index Management for the full specification.
-/// Implementation uses `thread_local! { static NEXT_Z_INDEX: Cell<u32> = Cell::new(1000); }`
-/// Free function — no `&self`.
-/// Overflow protection: values are clamped at `Z_INDEX_CEILING` (see `11-dom-utilities.md` §6.2).
-pub fn next_z_index() -> u32 { /* monotonic counter starting at 1000 */ }
+let claim = z_index_context.allocate_claim();
+let z = claim.value();
 ```
+
+Provider scope is the runtime stacking contract for browser and adapter builds: overlays under the same provider observe one ordered sequence. The compatibility free function uses a `std` thread-local counter in ordinary builds and a `no_std` atomic fallback so `ars-core --no-default-features` keeps compiling and testing pure code; that fallback preserves monotonic allocation for the compatibility API but is not a browser context boundary.
+
+Adapters SHOULD allocate `ZIndexClaim` handles through `z_index_allocator::Context::allocate_claim()` and release them through `release_claim()` during cleanup. Value-only `allocate()` / `release(u32)` remain available for compatibility, but claim handles avoid accidental cleanup of a different allocation when values repeat after test resets or overflow wrapping.
 
 **Stacking context warning**: If an overlay's content element has CSS properties that create a new stacking context (`opacity < 1`, `transform`, `filter`, `will-change`), nested overlays may be trapped in the parent's stacking context regardless of z-index. The adapter SHOULD emit a console warning at development time when these properties are detected on overlay content elements.
 
@@ -21,10 +19,10 @@ pub fn next_z_index() -> u32 { /* monotonic counter starting at 1000 */ }
 
 ```text
 ars-portal-root
-├── DialogBackdrop   (z-index: next_z_index() → 1000)   ← sibling, not parent
-├── DialogContent    (z-index: next_z_index() → 1001)
-├── NestedBackdrop   (z-index: next_z_index() → 1002)
-└── NestedContent    (z-index: next_z_index() → 1003)
+├── DialogBackdrop   (z-index: context.allocate_claim() → 1000)   ← sibling, not parent
+├── DialogContent    (z-index: context.allocate_claim() → 1001)
+├── NestedBackdrop   (z-index: context.allocate_claim() → 1002)
+└── NestedContent    (z-index: context.allocate_claim() → 1003)
 ```
 
 ## 1. Overlay Positioning Considerations


### PR DESCRIPTION
## Summary
- Move the pure z-index allocator contract into `ars-core` and keep `ars-dom` compatibility re-exports.
- Add `ars-components` utility modules for `z_index_allocator` and `client_only`.
- Switch allocator runtime use to provider-scoped context/claims and sync related specs.

## Validation
- `cargo test -p ars-core z_index`
- `cargo test -p ars-dom z_index`
- `cargo test -p ars-components utility::z_index_allocator`
- `cargo test -p ars-components utility::client_only`
- `cargo check -p ars-core --no-default-features`
- `cargo check -p ars-components --no-default-features`
- `cargo insta test --unreferenced=reject`
- `cargo xtask spec validate`
- `CHROMEDRIVER=$HOME/.cache/ars-ui-chromedriver/chromedriver-mac-arm64/chromedriver PATH=$HOME/.cargo/bin:$HOME/.cache/ars-ui-chromedriver/chromedriver-mac-arm64:$PATH cargo xci coverage snapshot-count error-variant-coverage feature-matrix-core feature-matrix-i18n feature-matrix-subsystems feature-matrix-leptos feature-matrix-dioxus mutual-exclusion`
- `CHROMEDRIVER=$HOME/.cache/ars-ui-chromedriver/chromedriver-mac-arm64/chromedriver PATH=$HOME/.cache/ars-ui-chromedriver/chromedriver-mac-arm64:$PATH cargo xci` passed through fmt/check/clippy/unit/i18n-browser/dom-browser/release/integration/adapter/adapter-parity before coverage preflight exposed stale cached wasm-bindgen PATH ordering; the tail was rerun with `~/.cargo/bin` first as listed above.

Closes #200