### PR TITLE
Add Dioxus and Leptos SSR hydration support

### DIFF
--- a/crates/ars-dioxus/Cargo.toml
+++ b/crates/ars-dioxus/Cargo.toml
@@ -26,6 +26,8 @@ web = [
   "dioxus/web",
   "dep:ars-dom",
   "ars-dom/web",
+  "ars-core/ssr",
+  "ars-core/serde",
   "dep:web-sys",
   "dep:wasm-bindgen",
   "dep:wasm-bindgen-futures",

--- a/crates/ars-dioxus/Cargo.toml
+++ b/crates/ars-dioxus/Cargo.toml
@@ -10,6 +10,18 @@ rust-version.workspace = true
 [features]
 default = ["icu4x"]
 debug = ["dep:log", "ars-core/debug", "ars-interactions/debug", "ars-dom?/debug"]
+desktop = ["dioxus/desktop", "dep:arboard", "dep:uuid", "dep:rfd", "dep:log"]
+desktop-dom = ["desktop", "dep:ars-dom"]
+mobile = ["dioxus/mobile"]
+ssr = [
+  "dioxus/server",
+  "dep:ars-dom",
+  "ars-dom/ssr",
+  "ars-core/ssr",
+  "ars-core/serde",
+  "dep:serde",
+  "dep:serde_json"
+]
 web = [
   "dioxus/web",
   "dep:ars-dom",
@@ -19,10 +31,6 @@ web = [
   "dep:wasm-bindgen-futures",
   "dep:js-sys"
 ]
-desktop = ["dioxus/desktop", "dep:arboard", "dep:uuid", "dep:rfd", "dep:log"]
-desktop-dom = ["desktop", "dep:ars-dom"]
-mobile = ["dioxus/mobile"]
-ssr = ["dioxus/server", "dep:ars-dom", "ars-dom/ssr"]
 # Pre-compiled CLDR data via ICU4X. Default backend on native targets and the
 # server-side rendering path. Use `--no-default-features --features web,ars-i18n/web-intl`
 # to swap icu4x for the browser-native Intl API on wasm32 builds.
@@ -44,6 +52,8 @@ rfd                  = { version = "0.17", optional = true }
 js-sys               = { version = "0.3", optional = true }
 wasm-bindgen         = { version = "0.2", optional = true }
 wasm-bindgen-futures = { version = "0.4", optional = true }
+serde                = { version = "1", default-features = false, features = ["alloc", "derive"], optional = true }
+serde_json           = { version = "1", optional = true }
 
 [dependencies.dioxus]
 version          = "0.7"
@@ -67,10 +77,13 @@ features = [
   "Event",
   "EventTarget",
   "FocusEvent",
+  "HtmlCollection",
   "HtmlElement",
   "KeyboardEvent",
   "MouseEvent",
   "Navigator",
+  "Node",
+  "NodeList",
   "Performance",
   "PointerEvent",
   "Window"

--- a/crates/ars-dioxus/src/dismissable.rs
+++ b/crates/ars-dioxus/src/dismissable.rs
@@ -43,7 +43,7 @@ use {
 
 use crate::{
     attrs::attr_map_to_dioxus_inline_attrs,
-    id::use_id,
+    id::use_stable_id,
     provider::{resolve_locale, use_messages},
 };
 
@@ -124,7 +124,9 @@ pub fn use_dismissable(
     props: Props,
     inside_boundaries: ReadSignal<Vec<String>>,
 ) -> Handle {
-    let overlay_id = use_hook(|| CopyValue::new(use_id("ars-dismissable")));
+    let stable_overlay_id = use_stable_id("dismissable");
+
+    let overlay_id = use_hook(move || CopyValue::new(stable_overlay_id));
 
     let dismiss = build_dismiss_button_callback(&props);
 
@@ -726,13 +728,11 @@ mod wasm_tests {
     }
 
     fn provider_label_fixture() -> Element {
-        let registries = spanish_messages();
+        let i18n_registries = spanish_messages();
         let locale = use_signal(|| Locale::parse("es-MX").expect("locale should parse"));
 
         rsx! {
-            crate::ArsProvider {
-                locale,
-                i18n_registries: registries,
+            crate::ArsProvider { locale, i18n_registries,
                 Region { props: Props::new(),
                     span { "content" }
                 }
@@ -827,13 +827,11 @@ mod wasm_tests {
     }
 
     fn label_fixture(state: LabelFixtureProps) -> Element {
-        let registries = spanish_messages();
+        let i18n_registries = spanish_messages();
         let locale = use_signal(|| Locale::parse("es-MX").expect("locale should parse"));
 
         rsx! {
-            crate::ArsProvider {
-                locale,
-                i18n_registries: registries,
+            crate::ArsProvider { locale, i18n_registries,
                 Region { props: Props::new(), dismiss_label: state.dismiss_label,
                     span { "content" }
                 }

--- a/crates/ars-dioxus/src/hydration.rs
+++ b/crates/ars-dioxus/src/hydration.rs
@@ -10,6 +10,8 @@ pub use ars_core::HydrationSnapshot;
 use ars_core::{HasId, Machine, Service};
 #[cfg(all(feature = "web", target_arch = "wasm32"))]
 use dioxus::prelude::{ReadableExt, WritableExt};
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
+use std::{cell::Cell, rc::Rc};
 
 /// Serializes a machine service snapshot for embedding in SSR HTML.
 ///
@@ -74,8 +76,11 @@ pub fn setup_focus_scope_hydration_safe(
     use dioxus::prelude::{use_drop, use_effect};
 
     let cleanup_scope_id = scope_id.clone();
+    let activation_active = Rc::new(Cell::new(true));
 
     use_effect({
+        let activation_active = Rc::clone(&activation_active);
+
         move || {
             let Some(document) = browser_document() else {
                 return;
@@ -84,12 +89,18 @@ pub fn setup_focus_scope_hydration_safe(
             if body_is_hydrated(&document) {
                 activate_focus_scope(&document, &scope_id, restore_target);
             } else {
-                request_hydration_activation_after_frame(scope_id.clone(), restore_target);
+                request_hydration_activation_after_frame(
+                    scope_id.clone(),
+                    restore_target,
+                    Rc::clone(&activation_active),
+                );
             }
         }
     });
 
     use_drop(move || {
+        activation_active.set(false);
+
         if let Some(document) = browser_document()
             && let Some(scope) = document.get_element_by_id(&cleanup_scope_id)
         {
@@ -140,6 +151,7 @@ fn activate_focus_scope(
 fn request_hydration_activation_after_frame(
     scope_id: String,
     restore_target: dioxus::prelude::Signal<Option<web_sys::HtmlElement>>,
+    activation_active: Rc<Cell<bool>>,
 ) {
     use wasm_bindgen::JsCast;
 
@@ -148,12 +160,18 @@ fn request_hydration_activation_after_frame(
     };
 
     let callback = wasm_bindgen::closure::Closure::once_into_js(move || {
+        if !activation_active.get() {
+            return;
+        }
+
         let Some(document) = browser_document() else {
             return;
         };
 
         if body_is_hydrated(&document) {
             activate_focus_scope(&document, &scope_id, restore_target);
+        } else {
+            request_hydration_activation_after_frame(scope_id, restore_target, activation_active);
         }
     });
 
@@ -548,7 +566,7 @@ mod wasm_tests {
     }
 
     #[wasm_bindgen_test(async)]
-    async fn setup_focus_scope_stays_inactive_when_body_remains_unhydrated_after_frame() {
+    async fn setup_focus_scope_retries_until_body_is_marked_hydrated() {
         reset_body();
 
         let container = append_html(
@@ -599,6 +617,26 @@ mod wasm_tests {
                 .and_then(|element| element.get_attribute("id"))
                 .as_deref(),
             Some("before")
+        );
+
+        document()
+            .body()
+            .expect("body should exist")
+            .set_attribute("data-ars-hydrated", "")
+            .expect("mark hydrated");
+
+        animation_frame_turn().await;
+
+        assert!(scope.has_attribute("data-ars-modal-open"));
+
+        animation_frame_turn().await;
+
+        assert_eq!(
+            document()
+                .active_element()
+                .and_then(|element| element.get_attribute("id"))
+                .as_deref(),
+            Some("target")
         );
     }
 

--- a/crates/ars-dioxus/src/hydration.rs
+++ b/crates/ars-dioxus/src/hydration.rs
@@ -7,7 +7,7 @@
 #[cfg(all(feature = "web", target_arch = "wasm32"))]
 use std::{cell::Cell, rc::Rc};
 
-#[cfg(feature = "ssr")]
+#[cfg(any(feature = "ssr", all(feature = "web", target_arch = "wasm32")))]
 pub use ars_core::HydrationSnapshot;
 #[cfg(feature = "ssr")]
 use ars_core::{HasId, Machine, Service};

--- a/crates/ars-dioxus/src/hydration.rs
+++ b/crates/ars-dioxus/src/hydration.rs
@@ -101,7 +101,12 @@ pub fn setup_focus_scope_hydration_safe(
             };
 
             if body_is_hydrated(&document) {
-                activate_focus_scope(&document, &scope_id, restore_target);
+                activate_focus_scope(
+                    &document,
+                    &scope_id,
+                    restore_target,
+                    Rc::clone(&activation_active),
+                );
             } else {
                 request_hydration_activation_after_frame(
                     scope_id.clone(),
@@ -145,6 +150,7 @@ fn activate_focus_scope(
     document: &web_sys::Document,
     scope_id: &str,
     restore_target: dioxus::prelude::Signal<Option<web_sys::HtmlElement>>,
+    activation_active: Rc<Cell<bool>>,
 ) {
     let scope: Option<web_sys::HtmlElement> = document
         .get_element_by_id(scope_id)
@@ -157,7 +163,7 @@ fn activate_focus_scope(
     remove_orphaned_inert(document);
 
     if let Some(scope) = scope {
-        request_focus_after_frame(scope, restore_target);
+        request_focus_after_frame(scope, restore_target, activation_active);
     }
 }
 
@@ -183,7 +189,7 @@ fn request_hydration_activation_after_frame(
         };
 
         if body_is_hydrated(&document) {
-            activate_focus_scope(&document, &scope_id, restore_target);
+            activate_focus_scope(&document, &scope_id, restore_target, activation_active);
         } else {
             request_hydration_activation_after_frame(scope_id, restore_target, activation_active);
         }
@@ -319,6 +325,7 @@ fn is_visible_fixed_position_target(element: &web_sys::HtmlElement) -> bool {
 fn request_focus_after_frame(
     scope: web_sys::HtmlElement,
     mut restore_target: dioxus::prelude::Signal<Option<web_sys::HtmlElement>>,
+    activation_active: Rc<Cell<bool>>,
 ) {
     use wasm_bindgen::JsCast;
 
@@ -331,6 +338,10 @@ fn request_focus_after_frame(
     };
 
     let callback = wasm_bindgen::closure::Closure::once_into_js(move || {
+        if !activation_active.get() {
+            return;
+        }
+
         let Some(target) = visible_focus_target(&scope) else {
             return;
         };
@@ -1033,8 +1044,9 @@ mod wasm_tests {
                 .expect("scope should exist")
                 .dyn_into()
                 .expect("scope should be HtmlElement");
+            let activation_active = Rc::new(Cell::new(true));
 
-            super::request_focus_after_frame(scope, restore_target);
+            super::request_focus_after_frame(scope, restore_target, activation_active);
 
             rsx! {
                 div {}
@@ -1061,6 +1073,55 @@ mod wasm_tests {
                 .and_then(|element| element.get_attribute("id"))
                 .as_deref(),
             Some("target")
+        );
+    }
+
+    #[wasm_bindgen_test(async)]
+    async fn focus_activation_skips_after_unmount_guard_is_cleared() {
+        reset_body();
+
+        let container = append_html(
+            r#"<button id="before">before</button><section id="scope"><button id="target">target</button></section>"#,
+        );
+
+        let before: HtmlElement = container
+            .query_selector("#before")
+            .expect("query should succeed")
+            .expect("before should exist")
+            .dyn_into()
+            .expect("before should be HtmlElement");
+
+        before.focus().expect("focus before");
+
+        fn app() -> Element {
+            let restore_target = use_signal(|| None::<HtmlElement>);
+
+            let scope: HtmlElement = document()
+                .get_element_by_id("scope")
+                .expect("scope should exist")
+                .dyn_into()
+                .expect("scope should be HtmlElement");
+            let activation_active = Rc::new(Cell::new(true));
+
+            super::request_focus_after_frame(scope, restore_target, Rc::clone(&activation_active));
+            activation_active.set(false);
+
+            rsx! {
+                div {}
+            }
+        }
+
+        let mut dom = VirtualDom::new(app);
+
+        dom.rebuild_in_place();
+        animation_frame_turn().await;
+
+        assert_eq!(
+            document()
+                .active_element()
+                .and_then(|element| element.get_attribute("id"))
+                .as_deref(),
+            Some("before")
         );
     }
 

--- a/crates/ars-dioxus/src/hydration.rs
+++ b/crates/ars-dioxus/src/hydration.rs
@@ -4,14 +4,15 @@
 //! contract for stateful machine hydration and provides browser-only helpers
 //! for `FocusScope` cleanup once client hydration has completed.
 
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
+use std::{cell::Cell, rc::Rc};
+
 #[cfg(feature = "ssr")]
 pub use ars_core::HydrationSnapshot;
 #[cfg(feature = "ssr")]
 use ars_core::{HasId, Machine, Service};
 #[cfg(all(feature = "web", target_arch = "wasm32"))]
 use dioxus::prelude::{ReadableExt, WritableExt};
-#[cfg(all(feature = "web", target_arch = "wasm32"))]
-use std::{cell::Cell, rc::Rc};
 
 /// Serializes a machine service snapshot for embedding in SSR HTML.
 ///

--- a/crates/ars-dioxus/src/hydration.rs
+++ b/crates/ars-dioxus/src/hydration.rs
@@ -14,6 +14,19 @@ use ars_core::{HasId, Machine, Service};
 #[cfg(all(feature = "web", target_arch = "wasm32"))]
 use dioxus::prelude::{ReadableExt, WritableExt};
 
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
+const HYDRATION_FOCUS_TARGET_SELECTOR: &str = concat!(
+    "[autofocus]:not([disabled]):not([aria-hidden='true']),",
+    "button:not([disabled]):not([aria-hidden='true']),",
+    "input:not([disabled]):not([aria-hidden='true']),",
+    "select:not([disabled]):not([aria-hidden='true']),",
+    "textarea:not([disabled]):not([aria-hidden='true']),",
+    "a[href]:not([aria-hidden='true']),",
+    "area[href]:not([aria-hidden='true']),",
+    "[tabindex]:not([disabled]):not([aria-hidden='true']),",
+    "[contenteditable]:not([contenteditable='false']):not([aria-hidden='true'])",
+);
+
 /// Serializes a machine service snapshot for embedding in SSR HTML.
 ///
 /// The returned JSON contains only the machine state and component ID. Context
@@ -227,12 +240,44 @@ fn has_open_modal_sibling(element: &web_sys::Element) -> bool {
 
 #[cfg(all(feature = "web", target_arch = "wasm32"))]
 fn visible_focus_target(scope: &web_sys::HtmlElement) -> Option<web_sys::HtmlElement> {
+    if is_focus_target_candidate(scope) && is_visible_focus_target(scope) {
+        return Some(scope.clone());
+    }
+
     scope
-        .query_selector("[autofocus], [tabindex]")
+        .query_selector(HYDRATION_FOCUS_TARGET_SELECTOR)
         .ok()
         .flatten()
         .and_then(|element| wasm_bindgen::JsCast::dyn_into(element).ok())
-        .filter(|element: &web_sys::HtmlElement| element.offset_parent().is_some())
+        .filter(is_visible_focus_target)
+}
+
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
+fn is_focus_target_candidate(element: &web_sys::Element) -> bool {
+    if element.has_attribute("disabled") {
+        return false;
+    }
+
+    if element.get_attribute("aria-hidden").as_deref() == Some("true") {
+        return false;
+    }
+
+    if element.has_attribute("autofocus") || element.has_attribute("tabindex") {
+        return true;
+    }
+
+    match element.tag_name().as_str() {
+        "BUTTON" | "INPUT" | "SELECT" | "TEXTAREA" => true,
+        "A" | "AREA" => element.has_attribute("href"),
+        _ => element
+            .get_attribute("contenteditable")
+            .is_some_and(|value| value != "false"),
+    }
+}
+
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
+fn is_visible_focus_target(element: &web_sys::HtmlElement) -> bool {
+    element.offset_parent().is_some()
 }
 
 #[cfg(all(feature = "web", target_arch = "wasm32"))]
@@ -788,12 +833,57 @@ mod wasm_tests {
         assert!(super::visible_focus_target(&scope).is_none());
     }
 
+    #[wasm_bindgen_test]
+    fn visible_focus_target_accepts_plain_button() {
+        reset_body();
+
+        let container =
+            append_html(r#"<section id="scope"><button id="target">target</button></section>"#);
+
+        let scope: HtmlElement = container
+            .query_selector("#scope")
+            .expect("query should succeed")
+            .expect("scope should exist")
+            .dyn_into()
+            .expect("scope should be HtmlElement");
+
+        assert_eq!(
+            super::visible_focus_target(&scope)
+                .and_then(|element| element.get_attribute("id"))
+                .as_deref(),
+            Some("target")
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn visible_focus_target_prefers_focusable_scope_root() {
+        reset_body();
+
+        let container = append_html(
+            r#"<section id="scope" tabindex="-1"><button id="target">target</button></section>"#,
+        );
+
+        let scope: HtmlElement = container
+            .query_selector("#scope")
+            .expect("query should succeed")
+            .expect("scope should exist")
+            .dyn_into()
+            .expect("scope should be HtmlElement");
+
+        assert_eq!(
+            super::visible_focus_target(&scope)
+                .and_then(|element| element.get_attribute("id"))
+                .as_deref(),
+            Some("scope")
+        );
+    }
+
     #[wasm_bindgen_test(async)]
     async fn focus_activation_is_deferred_until_animation_frame() {
         reset_body();
 
         let container = append_html(
-            r#"<button id="before">before</button><section id="scope"><button id="target" tabindex="0">target</button></section>"#,
+            r#"<button id="before">before</button><section id="scope"><button id="target">target</button></section>"#,
         );
 
         let before: HtmlElement = container

--- a/crates/ars-dioxus/src/hydration.rs
+++ b/crates/ars-dioxus/src/hydration.rs
@@ -1,0 +1,899 @@
+//! SSR hydration helpers for the Dioxus adapter.
+//!
+//! The adapter reuses [`ars_core::HydrationSnapshot`] as the single wire-format
+//! contract for stateful machine hydration and provides browser-only helpers
+//! for `FocusScope` cleanup once client hydration has completed.
+
+#[cfg(feature = "ssr")]
+pub use ars_core::HydrationSnapshot;
+#[cfg(feature = "ssr")]
+use ars_core::{HasId, Machine, Service};
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
+use dioxus::prelude::{ReadableExt, WritableExt};
+
+/// Serializes a machine service snapshot for embedding in SSR HTML.
+///
+/// The returned JSON contains only the machine state and component ID. Context
+/// is intentionally recomputed on the client by [`Service::new_hydrated`].
+///
+/// # Panics
+///
+/// Panics if `M::State` cannot be serialized.
+#[cfg(feature = "ssr")]
+#[must_use]
+pub fn serialize_snapshot<M: Machine>(svc: &Service<M>) -> String
+where
+    M::State: Clone + serde::Serialize,
+{
+    serde_json::to_string(&HydrationSnapshot::<M> {
+        state: svc.state().clone(),
+        id: svc.props().id().to_string(),
+    })
+    .expect("HydrationSnapshot must be serializable for SSR — ensure State implements Serialize")
+}
+
+/// Marks the document body as fully hydrated for `FocusScope` activation gates.
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
+pub fn mark_body_hydrated() {
+    let Some(document) = browser_document() else {
+        return;
+    };
+
+    let Some(body) = document.body() else {
+        return;
+    };
+
+    drop(body.set_attribute("data-ars-hydrated", ""));
+}
+
+/// Emits a debug warning when a mounted server-rendered ID differs from the client ID.
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
+pub fn warn_if_mounted_id_mismatch(element: &web_sys::Element, client_id: &str) {
+    let server_id = element.id();
+
+    if server_id.is_empty() {
+        return;
+    }
+
+    if server_id == client_id {
+        return;
+    }
+
+    #[cfg(debug_assertions)]
+    web_sys::console::warn_1(&wasm_bindgen::JsValue::from_str(
+        &hydration_id_mismatch_message(&server_id, client_id),
+    ));
+}
+
+/// Hydration-safe `FocusScope` setup for modal overlays.
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
+pub fn setup_focus_scope_hydration_safe(
+    scope_id: String,
+    restore_target: dioxus::prelude::Signal<Option<web_sys::HtmlElement>>,
+) {
+    use dioxus::prelude::{use_drop, use_effect};
+
+    let cleanup_scope_id = scope_id.clone();
+
+    use_effect({
+        move || {
+            let Some(document) = browser_document() else {
+                return;
+            };
+
+            if body_is_hydrated(&document) {
+                activate_focus_scope(&document, &scope_id, restore_target);
+            } else {
+                request_hydration_activation_after_frame(scope_id.clone(), restore_target);
+            }
+        }
+    });
+
+    use_drop(move || {
+        if let Some(document) = browser_document()
+            && let Some(scope) = document.get_element_by_id(&cleanup_scope_id)
+        {
+            drop(scope.remove_attribute("data-ars-modal-open"));
+        }
+
+        if let Some(element) = restore_target.peek().as_ref() {
+            drop(element.focus());
+        }
+    });
+}
+
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
+fn browser_document() -> Option<web_sys::Document> {
+    web_sys::window()?.document()
+}
+
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
+fn body_is_hydrated(document: &web_sys::Document) -> bool {
+    document
+        .body()
+        .and_then(|body| body.get_attribute("data-ars-hydrated"))
+        .is_some()
+}
+
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
+fn activate_focus_scope(
+    document: &web_sys::Document,
+    scope_id: &str,
+    restore_target: dioxus::prelude::Signal<Option<web_sys::HtmlElement>>,
+) {
+    let scope: Option<web_sys::HtmlElement> = document
+        .get_element_by_id(scope_id)
+        .and_then(|element| wasm_bindgen::JsCast::dyn_into(element).ok());
+
+    if let Some(scope) = scope.as_ref() {
+        drop(scope.set_attribute("data-ars-modal-open", ""));
+    }
+
+    remove_orphaned_inert(document);
+
+    if let Some(scope) = scope {
+        request_focus_after_frame(scope, restore_target);
+    }
+}
+
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
+fn request_hydration_activation_after_frame(
+    scope_id: String,
+    restore_target: dioxus::prelude::Signal<Option<web_sys::HtmlElement>>,
+) {
+    use wasm_bindgen::JsCast;
+
+    let Some(window) = web_sys::window() else {
+        return;
+    };
+
+    let callback = wasm_bindgen::closure::Closure::once_into_js(move || {
+        let Some(document) = browser_document() else {
+            return;
+        };
+
+        if body_is_hydrated(&document) {
+            activate_focus_scope(&document, &scope_id, restore_target);
+        }
+    });
+
+    drop(window.request_animation_frame(callback.unchecked_ref()));
+}
+
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
+fn remove_orphaned_inert(document: &web_sys::Document) {
+    let Ok(elements) = document.query_selector_all("[inert]") else {
+        return;
+    };
+
+    for index in 0..elements.length() {
+        let Some(node) = elements.item(index) else {
+            continue;
+        };
+
+        let Ok(element) = wasm_bindgen::JsCast::dyn_into::<web_sys::Element>(node) else {
+            continue;
+        };
+
+        if !has_open_modal_sibling(&element) {
+            drop(element.remove_attribute("inert"));
+        }
+    }
+}
+
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
+fn has_open_modal_sibling(element: &web_sys::Element) -> bool {
+    let Some(parent) = element.parent_element() else {
+        return false;
+    };
+
+    let children = parent.children();
+
+    for index in 0..children.length() {
+        let Some(child) = children.item(index) else {
+            continue;
+        };
+
+        if child.is_same_node(Some(element)) {
+            continue;
+        }
+
+        if child.has_attribute("data-ars-modal-open") {
+            return true;
+        }
+    }
+
+    false
+}
+
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
+fn visible_focus_target(scope: &web_sys::HtmlElement) -> Option<web_sys::HtmlElement> {
+    scope
+        .query_selector("[autofocus], [tabindex]")
+        .ok()
+        .flatten()
+        .and_then(|element| wasm_bindgen::JsCast::dyn_into(element).ok())
+        .filter(|element: &web_sys::HtmlElement| element.offset_parent().is_some())
+}
+
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
+fn request_focus_after_frame(
+    scope: web_sys::HtmlElement,
+    mut restore_target: dioxus::prelude::Signal<Option<web_sys::HtmlElement>>,
+) {
+    use wasm_bindgen::JsCast;
+
+    let Some(window) = web_sys::window() else {
+        return;
+    };
+
+    let Some(document) = window.document() else {
+        return;
+    };
+
+    let callback = wasm_bindgen::closure::Closure::once_into_js(move || {
+        let Some(target) = visible_focus_target(&scope) else {
+            return;
+        };
+
+        restore_target.set(
+            document
+                .active_element()
+                .and_then(|element| element.dyn_into().ok()),
+        );
+
+        drop(target.focus());
+    });
+
+    drop(window.request_animation_frame(callback.unchecked_ref()));
+}
+
+#[cfg(all(feature = "web", target_arch = "wasm32", debug_assertions))]
+fn hydration_id_mismatch_message(server_id: &str, client_id: &str) -> String {
+    format!(
+        "ars-ui hydration ID mismatch: server='{server_id}', client='{client_id}'. Component IDs may be non-deterministic across SSR/client boundaries."
+    )
+}
+
+#[cfg(all(test, feature = "ssr"))]
+mod tests {
+    use ars_core::{AttrMap, ComponentPart, ConnectApi, Env, HasId, Machine, Service};
+
+    #[cfg_attr(feature = "ssr", derive(serde::Serialize, serde::Deserialize))]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    enum TestState {
+        Off,
+    }
+
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    struct TestProps {
+        id: String,
+    }
+
+    impl HasId for TestProps {
+        fn id(&self) -> &str {
+            &self.id
+        }
+
+        fn with_id(self, id: String) -> Self {
+            Self { id }
+        }
+
+        fn set_id(&mut self, id: String) {
+            self.id = id;
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+    struct TestPart;
+
+    impl ComponentPart for TestPart {
+        const ROOT: Self = Self;
+
+        fn scope() -> &'static str {
+            "test"
+        }
+
+        fn name(&self) -> &'static str {
+            "root"
+        }
+
+        fn all() -> Vec<Self> {
+            vec![Self]
+        }
+    }
+
+    struct TestApi;
+
+    impl ConnectApi for TestApi {
+        type Part = TestPart;
+
+        fn part_attrs(&self, _part: Self::Part) -> AttrMap {
+            AttrMap::new()
+        }
+    }
+
+    struct TestMachine;
+
+    impl Machine for TestMachine {
+        type State = TestState;
+        type Event = ();
+        type Context = ();
+        type Props = TestProps;
+        type Messages = ();
+        type Api<'a> = TestApi;
+
+        fn init(
+            _props: &Self::Props,
+            _env: &Env,
+            _messages: &Self::Messages,
+        ) -> (Self::State, Self::Context) {
+            (TestState::Off, ())
+        }
+
+        fn transition(
+            _state: &Self::State,
+            _event: &Self::Event,
+            _context: &Self::Context,
+            _props: &Self::Props,
+        ) -> Option<ars_core::TransitionPlan<Self>> {
+            None
+        }
+
+        fn connect<'a>(
+            _state: &'a Self::State,
+            _context: &'a Self::Context,
+            _props: &'a Self::Props,
+            _send: &'a dyn Fn(Self::Event),
+        ) -> Self::Api<'a> {
+            TestApi
+        }
+    }
+
+    #[test]
+    fn serialize_snapshot_round_trips_state_and_id() {
+        let service = Service::<TestMachine>::new(
+            TestProps {
+                id: String::from("toggle-1"),
+            },
+            &Env::default(),
+            &(),
+        );
+
+        let json = super::serialize_snapshot(&service);
+
+        let snapshot: super::HydrationSnapshot<TestMachine> =
+            serde_json::from_str(&json).expect("snapshot should deserialize");
+
+        assert_eq!(snapshot.state, TestState::Off);
+        assert_eq!(snapshot.id, "toggle-1");
+        assert!(json.contains("\"id\":\"toggle-1\""));
+        assert!(json.contains("\"state\":\"Off\""));
+    }
+}
+
+#[cfg(all(test, feature = "web", target_arch = "wasm32"))]
+mod wasm_tests {
+    use std::{cell::Cell, rc::Rc};
+
+    use dioxus::{
+        dioxus_core::{NoOpMutations, ScopeId},
+        prelude::*,
+    };
+    use wasm_bindgen::JsCast;
+    use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+    use web_sys::HtmlElement;
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    fn document() -> web_sys::Document {
+        web_sys::window()
+            .expect("window should exist")
+            .document()
+            .expect("document should exist")
+    }
+
+    fn reset_body() {
+        let document = document();
+
+        let body = document.body().expect("body should exist");
+
+        drop(body.remove_attribute("data-ars-hydrated"));
+
+        let containers = document
+            .query_selector_all("[data-ars-hydration-test]")
+            .expect("query hydration test containers");
+
+        for index in 0..containers.length() {
+            let Some(container) = containers.item(index) else {
+                continue;
+            };
+
+            if let Some(parent) = container.parent_node() {
+                drop(parent.remove_child(&container));
+            }
+        }
+    }
+
+    fn append_html(markup: &str) -> HtmlElement {
+        let document = document();
+
+        let container: HtmlElement = document
+            .create_element("div")
+            .expect("create container")
+            .dyn_into()
+            .expect("container should be HtmlElement");
+
+        container
+            .set_attribute("data-ars-hydration-test", "")
+            .expect("mark hydration test container");
+
+        container.set_inner_html(markup);
+
+        document
+            .body()
+            .expect("body should exist")
+            .append_child(&container)
+            .expect("append container");
+
+        container
+    }
+
+    async fn animation_frame_turn() {
+        let promise = js_sys::Promise::new(&mut |resolve, _reject| {
+            let callback = wasm_bindgen::closure::Closure::once_into_js(move || {
+                drop(resolve.call0(&wasm_bindgen::JsValue::UNDEFINED));
+            });
+
+            web_sys::window()
+                .expect("window should exist")
+                .request_animation_frame(callback.unchecked_ref())
+                .expect("requestAnimationFrame should succeed");
+        });
+
+        drop(wasm_bindgen_futures::JsFuture::from(promise).await);
+    }
+
+    #[wasm_bindgen_test]
+    fn setup_focus_scope_skips_without_hydrated_body() {
+        reset_body();
+
+        append_html(
+            r#"<main inert></main><section id="scope"><button tabindex="0">focus</button></section>"#,
+        );
+
+        let ran = Rc::new(Cell::new(false));
+
+        #[expect(
+            clippy::needless_pass_by_value,
+            reason = "Dioxus root props are moved into the render function."
+        )]
+        fn app(ran: Rc<Cell<bool>>) -> Element {
+            let restore_target = use_signal(|| None::<HtmlElement>);
+
+            super::setup_focus_scope_hydration_safe(String::from("scope"), restore_target);
+
+            ran.set(true);
+
+            rsx! {
+                div {}
+            }
+        }
+
+        let mut dom = VirtualDom::new_with_props(app, Rc::clone(&ran));
+
+        dom.rebuild_in_place();
+        dom.render_immediate(&mut NoOpMutations);
+
+        assert!(ran.get());
+        assert!(
+            document()
+                .query_selector("[inert]")
+                .expect("query should succeed")
+                .is_some(),
+            "inert should remain until body is marked hydrated"
+        );
+    }
+
+    #[wasm_bindgen_test(async)]
+    async fn setup_focus_scope_activates_when_body_is_marked_hydrated_next_frame() {
+        reset_body();
+
+        append_html(r#"<main inert></main><section id="scope"></section>"#);
+
+        fn app() -> Element {
+            let restore_target = use_signal(|| None::<HtmlElement>);
+
+            super::setup_focus_scope_hydration_safe(String::from("scope"), restore_target);
+
+            rsx! {
+                div {}
+            }
+        }
+
+        let mut dom = VirtualDom::new(app);
+
+        dom.rebuild_in_place();
+        dom.render_immediate(&mut NoOpMutations);
+
+        let scope = document()
+            .get_element_by_id("scope")
+            .expect("scope should exist");
+
+        assert!(!scope.has_attribute("data-ars-modal-open"));
+        assert!(
+            document()
+                .query_selector("[inert]")
+                .expect("query should succeed")
+                .is_some(),
+            "inert should remain before the body is marked hydrated"
+        );
+
+        document()
+            .body()
+            .expect("body should exist")
+            .set_attribute("data-ars-hydrated", "")
+            .expect("mark hydrated");
+
+        animation_frame_turn().await;
+
+        assert!(scope.has_attribute("data-ars-modal-open"));
+        assert!(
+            document()
+                .query_selector("[inert]")
+                .expect("query should succeed")
+                .is_some(),
+            "inert remains while the hydrated modal scope is active"
+        );
+    }
+
+    #[wasm_bindgen_test(async)]
+    async fn setup_focus_scope_stays_inactive_when_body_remains_unhydrated_after_frame() {
+        reset_body();
+
+        let container = append_html(
+            r#"<button id="before">before</button><main inert></main><section id="scope"><button id="target" tabindex="0">target</button></section>"#,
+        );
+
+        let before: HtmlElement = container
+            .query_selector("#before")
+            .expect("query should succeed")
+            .expect("before should exist")
+            .dyn_into()
+            .expect("before should be HtmlElement");
+
+        before.focus().expect("focus before");
+
+        fn app() -> Element {
+            let restore_target = use_signal(|| None::<HtmlElement>);
+
+            super::setup_focus_scope_hydration_safe(String::from("scope"), restore_target);
+
+            rsx! {
+                div {}
+            }
+        }
+
+        let mut dom = VirtualDom::new(app);
+
+        dom.rebuild_in_place();
+        dom.render_immediate(&mut NoOpMutations);
+
+        animation_frame_turn().await;
+
+        let scope = document()
+            .get_element_by_id("scope")
+            .expect("scope should exist");
+
+        assert!(!scope.has_attribute("data-ars-modal-open"));
+        assert!(
+            document()
+                .query_selector("[inert]")
+                .expect("query should succeed")
+                .is_some(),
+            "inert should remain when hydration never completes"
+        );
+        assert_eq!(
+            document()
+                .active_element()
+                .and_then(|element| element.get_attribute("id"))
+                .as_deref(),
+            Some("before")
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn setup_focus_scope_cleans_orphaned_inert_when_hydrated_scope_is_missing() {
+        reset_body();
+
+        document()
+            .body()
+            .expect("body should exist")
+            .set_attribute("data-ars-hydrated", "")
+            .expect("mark hydrated");
+
+        append_html(r#"<main inert></main>"#);
+
+        fn app() -> Element {
+            let restore_target = use_signal(|| None::<HtmlElement>);
+
+            super::setup_focus_scope_hydration_safe(String::from("missing-scope"), restore_target);
+
+            rsx! {
+                div {}
+            }
+        }
+
+        let mut dom = VirtualDom::new(app);
+
+        dom.rebuild_in_place();
+        dom.render_immediate(&mut NoOpMutations);
+
+        assert!(
+            document()
+                .query_selector("[inert]")
+                .expect("query should succeed")
+                .is_none(),
+            "orphaned inert should be removed even when the scope is absent"
+        );
+        assert!(
+            document()
+                .query_selector("[data-ars-modal-open]")
+                .expect("query should succeed")
+                .is_none()
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn orphaned_inert_is_removed_without_open_modal_sibling() {
+        reset_body();
+
+        document()
+            .body()
+            .expect("body should exist")
+            .set_attribute("data-ars-hydrated", "")
+            .expect("mark hydrated");
+
+        append_html(r#"<main inert></main><section id="scope"></section>"#);
+
+        super::remove_orphaned_inert(&document());
+
+        assert!(
+            document()
+                .query_selector("[inert]")
+                .expect("query should succeed")
+                .is_none()
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn inert_is_retained_with_open_modal_sibling() {
+        reset_body();
+
+        append_html(r#"<main inert></main><section data-ars-modal-open></section>"#);
+
+        super::remove_orphaned_inert(&document());
+
+        assert!(
+            document()
+                .query_selector("[inert]")
+                .expect("query should succeed")
+                .is_some()
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn setup_focus_scope_marks_and_cleans_up_modal_scope() {
+        reset_body();
+
+        document()
+            .body()
+            .expect("body should exist")
+            .set_attribute("data-ars-hydrated", "")
+            .expect("mark hydrated");
+
+        append_html(r#"<main inert></main><section id="scope"></section>"#);
+
+        fn app() -> Element {
+            let restore_target = use_signal(|| None::<HtmlElement>);
+
+            super::setup_focus_scope_hydration_safe(String::from("scope"), restore_target);
+
+            rsx! {
+                div {}
+            }
+        }
+
+        let mut dom = VirtualDom::new(app);
+
+        dom.rebuild_in_place();
+        dom.render_immediate(&mut NoOpMutations);
+
+        let scope = document()
+            .get_element_by_id("scope")
+            .expect("scope should exist");
+
+        assert!(scope.has_attribute("data-ars-modal-open"));
+        assert!(
+            document()
+                .query_selector("[inert]")
+                .expect("query should succeed")
+                .is_some(),
+            "inert remains while the hydrated modal scope is active"
+        );
+
+        drop(dom);
+
+        let scope = document()
+            .get_element_by_id("scope")
+            .expect("scope should still exist");
+
+        assert!(!scope.has_attribute("data-ars-modal-open"));
+    }
+
+    #[wasm_bindgen_test]
+    fn visible_focus_target_skips_display_none_elements() {
+        reset_body();
+
+        let container = append_html(
+            r#"<section id="scope"><button tabindex="0" style="display: none">hidden</button></section>"#,
+        );
+
+        let scope: HtmlElement = container
+            .query_selector("#scope")
+            .expect("query should succeed")
+            .expect("scope should exist")
+            .dyn_into()
+            .expect("scope should be HtmlElement");
+
+        assert!(super::visible_focus_target(&scope).is_none());
+    }
+
+    #[wasm_bindgen_test(async)]
+    async fn focus_activation_is_deferred_until_animation_frame() {
+        reset_body();
+
+        let container = append_html(
+            r#"<button id="before">before</button><section id="scope"><button id="target" tabindex="0">target</button></section>"#,
+        );
+
+        let before: HtmlElement = container
+            .query_selector("#before")
+            .expect("query should succeed")
+            .expect("before should exist")
+            .dyn_into()
+            .expect("before should be HtmlElement");
+
+        before.focus().expect("focus before");
+
+        fn app() -> Element {
+            let restore_target = use_signal(|| None::<HtmlElement>);
+
+            let scope: HtmlElement = document()
+                .get_element_by_id("scope")
+                .expect("scope should exist")
+                .dyn_into()
+                .expect("scope should be HtmlElement");
+
+            super::request_focus_after_frame(scope, restore_target);
+
+            rsx! {
+                div {}
+            }
+        }
+
+        let mut dom = VirtualDom::new(app);
+
+        dom.rebuild_in_place();
+
+        assert_eq!(
+            document()
+                .active_element()
+                .and_then(|element| element.get_attribute("id"))
+                .as_deref(),
+            Some("before")
+        );
+
+        animation_frame_turn().await;
+
+        assert_eq!(
+            document()
+                .active_element()
+                .and_then(|element| element.get_attribute("id"))
+                .as_deref(),
+            Some("target")
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn use_drop_cleanup_restores_previous_focus() {
+        reset_body();
+
+        document()
+            .body()
+            .expect("body should exist")
+            .set_attribute("data-ars-hydrated", "")
+            .expect("mark hydrated");
+
+        let container = append_html(
+            r#"<button id="before">before</button><section id="scope"><button id="target" tabindex="0">target</button></section>"#,
+        );
+
+        let before: HtmlElement = container
+            .query_selector("#before")
+            .expect("query should succeed")
+            .expect("before should exist")
+            .dyn_into()
+            .expect("before should be HtmlElement");
+
+        before.focus().expect("focus before");
+
+        fn app() -> Element {
+            let mut restore_target = use_signal(|| None::<HtmlElement>);
+
+            restore_target.set(
+                document()
+                    .get_element_by_id("before")
+                    .and_then(|element| element.dyn_into().ok()),
+            );
+
+            super::setup_focus_scope_hydration_safe(String::from("scope"), restore_target);
+
+            rsx! {
+                div {}
+            }
+        }
+
+        let mut dom = VirtualDom::new(app);
+
+        dom.rebuild_in_place();
+
+        let mut mutations = NoOpMutations;
+
+        dom.mark_dirty(ScopeId::APP);
+        dom.render_immediate(&mut mutations);
+
+        drop(dom);
+
+        assert_eq!(
+            document()
+                .active_element()
+                .and_then(|element| element.get_attribute("id"))
+                .as_deref(),
+            Some("before")
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn hydration_mismatch_warning_message_matches_contract() {
+        let element = document()
+            .create_element("div")
+            .expect("create element for mismatch check");
+
+        element.set_id("ars-dialog-7");
+
+        super::warn_if_mounted_id_mismatch(&element, "ars-dialog-9");
+
+        assert_eq!(
+            super::hydration_id_mismatch_message("ars-dialog-7", "ars-dialog-9"),
+            "ars-ui hydration ID mismatch: server='ars-dialog-7', client='ars-dialog-9'. Component IDs may be non-deterministic across SSR/client boundaries."
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn hydration_mismatch_warning_helper_accepts_empty_and_matching_server_ids() {
+        let empty = document()
+            .create_element("div")
+            .expect("create empty-id element for mismatch check");
+
+        super::warn_if_mounted_id_mismatch(&empty, "ars-dialog-9");
+
+        let matching = document()
+            .create_element("div")
+            .expect("create matching-id element for mismatch check");
+
+        matching.set_id("ars-dialog-9");
+
+        super::warn_if_mounted_id_mismatch(&matching, "ars-dialog-9");
+    }
+}

--- a/crates/ars-dioxus/src/hydration.rs
+++ b/crates/ars-dioxus/src/hydration.rs
@@ -15,6 +15,9 @@ use ars_core::{HasId, Machine, Service};
 use dioxus::prelude::{ReadableExt, WritableExt};
 
 #[cfg(all(feature = "web", target_arch = "wasm32"))]
+const HYDRATION_MODAL_INERT_ATTR: &str = "data-ars-modal-inert";
+
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
 const HYDRATION_FOCUS_TARGET_SELECTOR: &str = concat!(
     "[autofocus]:not([disabled]):not([aria-hidden='true']),",
     "button:not([disabled]):not([aria-hidden='true']),",
@@ -194,7 +197,7 @@ fn request_hydration_activation_after_frame(
 
 #[cfg(all(feature = "web", target_arch = "wasm32"))]
 fn remove_orphaned_inert(document: &web_sys::Document) {
-    let Ok(elements) = document.query_selector_all("[inert]") else {
+    let Ok(elements) = document.query_selector_all("[inert][data-ars-modal-inert]") else {
         return;
     };
 
@@ -209,6 +212,7 @@ fn remove_orphaned_inert(document: &web_sys::Document) {
 
         if !has_open_modal_sibling(&element) {
             drop(element.remove_attribute("inert"));
+            drop(element.remove_attribute(HYDRATION_MODAL_INERT_ATTR));
         }
     }
 }
@@ -245,11 +249,28 @@ fn visible_focus_target(scope: &web_sys::HtmlElement) -> Option<web_sys::HtmlEle
     }
 
     scope
-        .query_selector(HYDRATION_FOCUS_TARGET_SELECTOR)
+        .query_selector_all(HYDRATION_FOCUS_TARGET_SELECTOR)
         .ok()
-        .flatten()
-        .and_then(|element| wasm_bindgen::JsCast::dyn_into(element).ok())
-        .filter(is_visible_focus_target)
+        .and_then(|elements| first_visible_focus_target(&elements))
+}
+
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
+fn first_visible_focus_target(elements: &web_sys::NodeList) -> Option<web_sys::HtmlElement> {
+    for index in 0..elements.length() {
+        let Some(node) = elements.item(index) else {
+            continue;
+        };
+
+        let Ok(element) = wasm_bindgen::JsCast::dyn_into::<web_sys::HtmlElement>(node) else {
+            continue;
+        };
+
+        if is_visible_focus_target(&element) {
+            return Some(element);
+        }
+    }
+
+    None
 }
 
 #[cfg(all(feature = "web", target_arch = "wasm32"))]
@@ -268,7 +289,9 @@ fn is_focus_target_candidate(element: &web_sys::Element) -> bool {
 
     match element.tag_name().as_str() {
         "BUTTON" | "INPUT" | "SELECT" | "TEXTAREA" => true,
+
         "A" | "AREA" => element.has_attribute("href"),
+
         _ => element
             .get_attribute("contenteditable")
             .is_some_and(|value| value != "false"),
@@ -523,7 +546,7 @@ mod wasm_tests {
         reset_body();
 
         append_html(
-            r#"<main inert></main><section id="scope"><button tabindex="0">focus</button></section>"#,
+            r#"<main inert data-ars-modal-inert></main><section id="scope"><button tabindex="0">focus</button></section>"#,
         );
 
         let ran = Rc::new(Cell::new(false));
@@ -563,7 +586,7 @@ mod wasm_tests {
     async fn setup_focus_scope_activates_when_body_is_marked_hydrated_next_frame() {
         reset_body();
 
-        append_html(r#"<main inert></main><section id="scope"></section>"#);
+        append_html(r#"<main inert data-ars-modal-inert></main><section id="scope"></section>"#);
 
         fn app() -> Element {
             let restore_target = use_signal(|| None::<HtmlElement>);
@@ -616,7 +639,7 @@ mod wasm_tests {
         reset_body();
 
         let container = append_html(
-            r#"<button id="before">before</button><main inert></main><section id="scope"><button id="target" tabindex="0">target</button></section>"#,
+            r#"<button id="before">before</button><main inert data-ars-modal-inert></main><section id="scope"><button id="target" tabindex="0">target</button></section>"#,
         );
 
         let before: HtmlElement = container
@@ -696,7 +719,7 @@ mod wasm_tests {
             .set_attribute("data-ars-hydrated", "")
             .expect("mark hydrated");
 
-        append_html(r#"<main inert></main>"#);
+        append_html(r#"<main inert data-ars-modal-inert></main>"#);
 
         fn app() -> Element {
             let restore_target = use_signal(|| None::<HtmlElement>);
@@ -738,7 +761,7 @@ mod wasm_tests {
             .set_attribute("data-ars-hydrated", "")
             .expect("mark hydrated");
 
-        append_html(r#"<main inert></main><section id="scope"></section>"#);
+        append_html(r#"<main inert data-ars-modal-inert></main><section id="scope"></section>"#);
 
         super::remove_orphaned_inert(&document());
 
@@ -748,13 +771,44 @@ mod wasm_tests {
                 .expect("query should succeed")
                 .is_none()
         );
+        assert!(
+            document()
+                .query_selector("[data-ars-modal-inert]")
+                .expect("query should succeed")
+                .is_none()
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn unowned_inert_is_not_removed_without_open_modal_sibling() {
+        reset_body();
+
+        document()
+            .body()
+            .expect("body should exist")
+            .set_attribute("data-ars-hydrated", "")
+            .expect("mark hydrated");
+
+        append_html(r#"<main inert></main><section id="scope"></section>"#);
+
+        super::remove_orphaned_inert(&document());
+
+        assert!(
+            document()
+                .query_selector("[inert]")
+                .expect("query should succeed")
+                .is_some(),
+            "author-owned inert must not be cleared by modal hydration cleanup"
+        );
     }
 
     #[wasm_bindgen_test]
     fn inert_is_retained_with_open_modal_sibling() {
         reset_body();
 
-        append_html(r#"<main inert></main><section data-ars-modal-open></section>"#);
+        append_html(
+            r#"<main inert data-ars-modal-inert></main><section data-ars-modal-open></section>"#,
+        );
 
         super::remove_orphaned_inert(&document());
 
@@ -776,7 +830,7 @@ mod wasm_tests {
             .set_attribute("data-ars-hydrated", "")
             .expect("mark hydrated");
 
-        append_html(r#"<main inert></main><section id="scope"></section>"#);
+        append_html(r#"<main inert data-ars-modal-inert></main><section id="scope"></section>"#);
 
         fn app() -> Element {
             let restore_target = use_signal(|| None::<HtmlElement>);
@@ -839,6 +893,29 @@ mod wasm_tests {
 
         let container =
             append_html(r#"<section id="scope"><button id="target">target</button></section>"#);
+
+        let scope: HtmlElement = container
+            .query_selector("#scope")
+            .expect("query should succeed")
+            .expect("scope should exist")
+            .dyn_into()
+            .expect("scope should be HtmlElement");
+
+        assert_eq!(
+            super::visible_focus_target(&scope)
+                .and_then(|element| element.get_attribute("id"))
+                .as_deref(),
+            Some("target")
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn visible_focus_target_skips_hidden_matches_until_visible_target() {
+        reset_body();
+
+        let container = append_html(
+            r#"<section id="scope"><button id="hidden" style="display: none">hidden</button><input id="target"></section>"#,
+        );
 
         let scope: HtmlElement = container
             .query_selector("#scope")

--- a/crates/ars-dioxus/src/hydration.rs
+++ b/crates/ars-dioxus/src/hydration.rs
@@ -15,9 +15,6 @@ use ars_core::{HasId, Machine, Service};
 use dioxus::prelude::{ReadableExt, WritableExt};
 
 #[cfg(all(feature = "web", target_arch = "wasm32"))]
-const HYDRATION_MODAL_INERT_ATTR: &str = "data-ars-modal-inert";
-
-#[cfg(all(feature = "web", target_arch = "wasm32"))]
 const HYDRATION_FOCUS_TARGET_SELECTOR: &str = concat!(
     "[autofocus]:not([disabled]):not([aria-hidden='true']),",
     "button:not([disabled]):not([aria-hidden='true']),",
@@ -212,7 +209,7 @@ fn remove_orphaned_inert(document: &web_sys::Document) {
 
         if !has_open_modal_sibling(&element) {
             drop(element.remove_attribute("inert"));
-            drop(element.remove_attribute(HYDRATION_MODAL_INERT_ATTR));
+            drop(element.remove_attribute(ars_dom::portal::MODAL_INERT_ATTR));
         }
     }
 }
@@ -300,7 +297,22 @@ fn is_focus_target_candidate(element: &web_sys::Element) -> bool {
 
 #[cfg(all(feature = "web", target_arch = "wasm32"))]
 fn is_visible_focus_target(element: &web_sys::HtmlElement) -> bool {
-    element.offset_parent().is_some()
+    element.offset_parent().is_some() || is_visible_fixed_position_target(element)
+}
+
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
+fn is_visible_fixed_position_target(element: &web_sys::HtmlElement) -> bool {
+    let Some(window) = web_sys::window() else {
+        return false;
+    };
+
+    let Ok(Some(style)) = window.get_computed_style(element) else {
+        return false;
+    };
+
+    style.get_property_value("position").as_deref() == Ok("fixed")
+        && style.get_property_value("display").as_deref() != Ok("none")
+        && style.get_property_value("visibility").as_deref() != Ok("hidden")
 }
 
 #[cfg(all(feature = "web", target_arch = "wasm32"))]
@@ -875,6 +887,47 @@ mod wasm_tests {
 
         let container = append_html(
             r#"<section id="scope"><button tabindex="0" style="display: none">hidden</button></section>"#,
+        );
+
+        let scope: HtmlElement = container
+            .query_selector("#scope")
+            .expect("query should succeed")
+            .expect("scope should exist")
+            .dyn_into()
+            .expect("scope should be HtmlElement");
+
+        assert!(super::visible_focus_target(&scope).is_none());
+    }
+
+    #[wasm_bindgen_test]
+    fn visible_focus_target_accepts_fixed_position_target() {
+        reset_body();
+
+        let container = append_html(
+            r#"<section id="scope"><button id="target" style="position: fixed">target</button></section>"#,
+        );
+
+        let scope: HtmlElement = container
+            .query_selector("#scope")
+            .expect("query should succeed")
+            .expect("scope should exist")
+            .dyn_into()
+            .expect("scope should be HtmlElement");
+
+        assert_eq!(
+            super::visible_focus_target(&scope)
+                .and_then(|element| element.get_attribute("id"))
+                .as_deref(),
+            Some("target")
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn visible_focus_target_rejects_hidden_fixed_position_target() {
+        reset_body();
+
+        let container = append_html(
+            r#"<section id="scope"><button id="target" style="position: fixed; visibility: hidden">target</button></section>"#,
         );
 
         let scope: HtmlElement = container

--- a/crates/ars-dioxus/src/id.rs
+++ b/crates/ars-dioxus/src/id.rs
@@ -1,7 +1,10 @@
-//! Hydration-safe deterministic ID generation.
+//! Hook-slot-stable generated ID allocation.
 //!
-//! Provides monotonic counters that produce the same ID sequence on both SSR and
-//! client when the component tree renders in the same order.
+//! Generated IDs are unique within a render pass and stable for a mounted hook
+//! slot. They are not a substitute for explicit IDs in SSR hydration paths where
+//! server and client render order may diverge.
+
+use dioxus::prelude::use_hook;
 
 // On WASM (single-threaded), use a thread-local Cell for zero-overhead counting.
 #[cfg(target_arch = "wasm32")]
@@ -22,8 +25,8 @@ mod counter {
 
     /// Resets the ID counter to zero.
     ///
-    /// Must be called at the start of each SSR request so that server-rendered IDs
-    /// match the client-side hydration sequence.
+    /// Must be called at the start of each SSR request to avoid leaking
+    /// generated ID allocations across requests.
     #[cfg(feature = "ssr")]
     pub(super) fn reset() {
         ID_COUNTER.with(|c| c.set(0));
@@ -43,24 +46,26 @@ mod counter {
 
     /// Resets the ID counter to zero.
     ///
-    /// Must be called at the start of each SSR request so that server-rendered IDs
-    /// match the client-side hydration sequence.
+    /// Must be called at the start of each SSR request to avoid leaking
+    /// generated ID allocations across requests.
     #[cfg(feature = "ssr")]
     pub(super) fn reset() {
         ID_COUNTER.store(0, Ordering::Relaxed);
     }
 }
 
-/// Generates a deterministic component ID with the given prefix.
+/// Generates a monotonic component ID with the given prefix.
 ///
 /// Returns a string of the form `"{prefix}-{counter}"`. The counter is global and
 /// monotonically increasing, ensuring uniqueness within a single render pass.
 ///
 /// # Hydration safety
 ///
-/// The counter produces identical sequences on SSR and client when the component tree
-/// renders in the same order. Call `reset_id_counter()` (available with the `ssr`
-/// feature) at the start of each SSR request to reset the sequence.
+/// The counter produces identical sequences on SSR and client only when the
+/// component tree renders in the same order. Call `reset_id_counter()`
+/// (available with the `ssr` feature) at the start of each SSR request to reset
+/// the sequence. Components that hydrate over server-rendered DOM should prefer
+/// explicit IDs.
 ///
 /// # Examples
 ///
@@ -76,10 +81,30 @@ pub fn use_id(prefix: &str) -> String {
     format!("{prefix}-{}", counter::next_id())
 }
 
+/// Generates a component ID with the adapter's stable public prefix format.
+///
+/// Returns a string of the form `"ars-{prefix}-{id}"`.
+///
+/// # Hydration safety
+///
+/// This helper uses Dioxus hook ordering so each component instance stores the
+/// counter allocation in a stable hook slot. It still delegates to the adapter's
+/// monotonic counter, which is not fully hydration-safe when SSR and client
+/// render orders diverge because of Suspense, lazy loading, or code splitting.
+/// SSR+hydration users should provide explicit component IDs until a true
+/// tree-position-based ID scheme is implemented.
+#[must_use]
+pub fn use_stable_id(prefix: &str) -> String {
+    let id = use_hook(counter::next_id);
+
+    format!("ars-{prefix}-{id}")
+}
+
 /// Resets the ID counter to zero for a new SSR request.
 ///
-/// Must be called at the start of each server-side render pass so that the generated
-/// IDs match the client-side hydration sequence exactly.
+/// Must be called at the start of each server-side render pass to avoid
+/// cross-request counter leakage. This does not make generated IDs safe when
+/// server and client render order diverge.
 #[cfg(feature = "ssr")]
 pub fn reset_id_counter() {
     counter::reset();
@@ -87,6 +112,11 @@ pub fn reset_id_counter() {
 
 #[cfg(test)]
 mod tests {
+    use dioxus::{
+        dioxus_core::{NoOpMutations, ScopeId},
+        prelude::*,
+    };
+
     use super::*;
 
     #[test]
@@ -100,6 +130,48 @@ mod tests {
         let id1 = use_id("component");
         let id2 = use_id("component");
         assert_ne!(id1, id2);
+    }
+
+    #[test]
+    fn use_stable_id_produces_ars_prefixed_ids() {
+        fn app() -> Element {
+            let id = use_stable_id("dialog");
+
+            assert!(id.starts_with("ars-dialog-"));
+
+            rsx! {
+                div {}
+            }
+        }
+
+        let mut dom = VirtualDom::new(app);
+
+        dom.rebuild_in_place();
+    }
+
+    #[test]
+    fn use_stable_id_reuses_hook_slot_across_renders() {
+        fn app() -> Element {
+            let id = use_stable_id("dialog");
+
+            let mut previous = use_signal(|| None::<String>);
+
+            if let Some(previous) = previous.peek().as_ref() {
+                assert_eq!(previous, &id);
+            } else {
+                previous.set(Some(id));
+            }
+
+            rsx! {
+                div {}
+            }
+        }
+
+        let mut dom = VirtualDom::new(app);
+
+        dom.rebuild_in_place();
+        dom.mark_dirty(ScopeId::APP);
+        dom.render_immediate(&mut NoOpMutations);
     }
 }
 
@@ -115,6 +187,7 @@ mod wasm_tests {
     fn use_id_produces_monotonic_sequence_on_wasm() {
         let id1 = use_id("component");
         let id2 = use_id("component");
+
         assert!(id1.starts_with("component-"));
         assert!(id2.starts_with("component-"));
         assert_ne!(id1, id2);

--- a/crates/ars-dioxus/src/lib.rs
+++ b/crates/ars-dioxus/src/lib.rs
@@ -8,13 +8,14 @@
 //! - [`use_machine`] — creates a reactive machine service from props
 //! - [`UseMachineReturn`] — handle for state, send, derive, and API access
 //! - [`EphemeralRef`] — borrow wrapper preventing signal storage of borrowed APIs
-//! - [`use_id`] — hydration-safe deterministic ID generation
+//! - [`use_stable_id`] — hook-slot-stable generated ID allocation
 
 mod attrs;
 mod callbacks;
 pub mod dismissable;
 mod ephemeral;
 mod event_mapping;
+mod hydration;
 mod id;
 mod nonce;
 mod platform;
@@ -34,8 +35,14 @@ pub use callbacks::{emit, emit_map};
 pub use ephemeral::EphemeralRef;
 pub use event_mapping::dioxus_key_to_keyboard_key;
 #[cfg(feature = "ssr")]
+pub use hydration::{HydrationSnapshot, serialize_snapshot};
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
+pub use hydration::{
+    mark_body_hydrated, setup_focus_scope_hydration_safe, warn_if_mounted_id_mismatch,
+};
+#[cfg(feature = "ssr")]
 pub use id::reset_id_counter;
-pub use id::use_id;
+pub use id::{use_id, use_stable_id};
 pub use nonce::{
     ArsNonceCssCtx, ArsNonceCssProvider, ArsNonceStyle, NonceCssRule, append_nonce_css,
     collect_nonce_css_from_attrs, remove_nonce_css, upsert_nonce_css,
@@ -58,6 +65,8 @@ pub use safe_listener::{
     SafeEventListener, SafeEventListenerOptions, use_safe_event_listener, use_safe_event_listeners,
 };
 pub use use_machine::{UseMachineReturn, use_machine, use_machine_with_reactive_props};
+#[cfg(feature = "ssr")]
+pub use use_machine::{use_machine_hydrated, use_machine_with_reactive_props_hydrated};
 
 /// The name of this framework adapter, used in diagnostic messages and feature gating.
 pub const ADAPTER_NAME: &str = "dioxus";

--- a/crates/ars-dioxus/src/lib.rs
+++ b/crates/ars-dioxus/src/lib.rs
@@ -34,8 +34,10 @@ pub use attrs::{
 pub use callbacks::{emit, emit_map};
 pub use ephemeral::EphemeralRef;
 pub use event_mapping::dioxus_key_to_keyboard_key;
+#[cfg(any(feature = "ssr", all(feature = "web", target_arch = "wasm32")))]
+pub use hydration::HydrationSnapshot;
 #[cfg(feature = "ssr")]
-pub use hydration::{HydrationSnapshot, serialize_snapshot};
+pub use hydration::serialize_snapshot;
 #[cfg(all(feature = "web", target_arch = "wasm32"))]
 pub use hydration::{
     mark_body_hydrated, setup_focus_scope_hydration_safe, warn_if_mounted_id_mismatch,
@@ -65,7 +67,7 @@ pub use safe_listener::{
     SafeEventListener, SafeEventListenerOptions, use_safe_event_listener, use_safe_event_listeners,
 };
 pub use use_machine::{UseMachineReturn, use_machine, use_machine_with_reactive_props};
-#[cfg(feature = "ssr")]
+#[cfg(any(feature = "ssr", all(feature = "web", target_arch = "wasm32")))]
 pub use use_machine::{use_machine_hydrated, use_machine_with_reactive_props_hydrated};
 
 /// The name of this framework adapter, used in diagnostic messages and feature gating.

--- a/crates/ars-dioxus/src/provider.rs
+++ b/crates/ars-dioxus/src/provider.rs
@@ -193,6 +193,9 @@ pub fn ArsProvider(props: ArsProviderProps) -> Element {
 
     use_nonce_css_context_provider();
 
+    #[cfg(all(feature = "web", target_arch = "wasm32"))]
+    let is_root_provider = try_use_context::<ArsContext>().is_none();
+
     let style_strategy = style_strategy.unwrap_or(StyleStrategy::Inline);
     let nonce = match &style_strategy {
         StyleStrategy::Nonce(nonce) => Some(nonce.clone()),
@@ -217,6 +220,13 @@ pub fn ArsProvider(props: ArsProviderProps) -> Element {
     });
 
     let dir = direction_for_render.read().as_html_attr();
+
+    #[cfg(all(feature = "web", target_arch = "wasm32"))]
+    use_effect(move || {
+        if is_root_provider {
+            crate::hydration::mark_body_hydrated();
+        }
+    });
 
     rsx! {
         div { dir,
@@ -2215,6 +2225,32 @@ mod wasm_tests {
         rsx! {
             ArsProvider { ProviderProbe {} }
         }
+    }
+
+    #[wasm_bindgen_test]
+    fn root_ars_provider_marks_body_hydrated_on_wasm() {
+        let document = web_sys::window()
+            .expect("window should exist")
+            .document()
+            .expect("document should exist");
+        let body = document.body().expect("body should exist");
+
+        drop(body.remove_attribute("data-ars-hydrated"));
+
+        fn app() -> Element {
+            rsx! {
+                ArsProvider {
+                    div {}
+                }
+            }
+        }
+
+        let mut dom = VirtualDom::new(app);
+
+        dom.rebuild_in_place();
+        dom.render_immediate(&mut NoOpMutations);
+
+        assert_eq!(body.get_attribute("data-ars-hydrated").as_deref(), Some(""));
     }
 
     #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/ars-dioxus/src/use_machine/mod.rs
+++ b/crates/ars-dioxus/src/use_machine/mod.rs
@@ -10,13 +10,15 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+#[cfg(feature = "ssr")]
+use ars_core::HydrationSnapshot;
 use ars_core::{CleanupFn, Env, HasId, Machine, RenderMode, Service};
 use dioxus::prelude::*;
 
 use crate::{
     ephemeral::EphemeralRef,
     provider::{resolve_locale, use_intl_backend, use_messages},
-    use_id,
+    use_stable_id,
 };
 
 /// Return type from [`use_machine`].
@@ -236,7 +238,32 @@ where
     M::Event: Send + 'static,
     M::Messages: Send + Sync + 'static,
 {
-    let (result, ..) = use_machine_inner::<M>(props);
+    let (result, ..) = use_machine_inner::<M>(props, None);
+
+    result
+}
+
+/// Creates and manages a machine service from an SSR hydration snapshot.
+///
+/// The snapshot state is installed with [`Service::new_hydrated`] so the
+/// client preserves server-rendered machine state while recomputing context
+/// from the current adapter environment.
+#[cfg(feature = "ssr")]
+pub fn use_machine_hydrated<M: Machine + 'static>(
+    props: M::Props,
+    snapshot: HydrationSnapshot<M>,
+) -> UseMachineReturn<M>
+where
+    M::State: Clone + PartialEq + 'static,
+    M::Context: Clone + 'static,
+    M::Props: Clone + PartialEq + 'static,
+    M::Event: Send + 'static,
+    M::Messages: Send + Sync + 'static,
+{
+    let (result, ..) = use_machine_inner::<M>(
+        props_with_snapshot_id::<M>(props, &snapshot),
+        Some(snapshot.state),
+    );
 
     result
 }
@@ -260,11 +287,12 @@ where
     use_machine::<M>(props_signal())
 }
 
-/// Internal implementation shared between public hooks.
-///
-/// Returns the public `UseMachineReturn` plus the internal `context_version`
-/// signal so body-level prop sync can update it during re-renders.
-fn use_machine_inner<M: Machine + 'static>(props: M::Props) -> (UseMachineReturn<M>, Signal<u64>)
+/// Creates a reactive-props machine service from an SSR hydration snapshot.
+#[cfg(feature = "ssr")]
+pub fn use_machine_with_reactive_props_hydrated<M: Machine + 'static>(
+    props_signal: Signal<M::Props>,
+    snapshot: HydrationSnapshot<M>,
+) -> UseMachineReturn<M>
 where
     M::State: Clone + PartialEq + 'static,
     M::Context: Clone + 'static,
@@ -272,7 +300,25 @@ where
     M::Event: Send + 'static,
     M::Messages: Send + Sync + 'static,
 {
-    let generated_id = use_hook(|| use_id("component"));
+    use_machine_hydrated::<M>(props_signal(), snapshot)
+}
+
+/// Internal implementation shared between public hooks.
+///
+/// Returns the public `UseMachineReturn` plus the internal `context_version`
+/// signal so body-level prop sync can update it during re-renders.
+fn use_machine_inner<M: Machine + 'static>(
+    props: M::Props,
+    hydrated_state: Option<M::State>,
+) -> (UseMachineReturn<M>, Signal<u64>)
+where
+    M::State: Clone + PartialEq + 'static,
+    M::Context: Clone + 'static,
+    M::Props: Clone + PartialEq + 'static,
+    M::Event: Send + 'static,
+    M::Messages: Send + Sync + 'static,
+{
+    let generated_id = use_stable_id("component");
 
     let props_for_sync = props.clone();
 
@@ -295,7 +341,21 @@ where
     let messages = use_messages::<M::Messages>(None, Some(&env.locale));
 
     // Create the service once — use_signal runs its closure only on first mount.
-    let service_signal = use_signal(move || Service::<M>::new(props, &env, &messages));
+    let service_signal = use_signal(move || {
+        if let Some(state) = hydrated_state {
+            #[cfg(feature = "ssr")]
+            {
+                return Service::<M>::new_hydrated(props, state, &env, &messages);
+            }
+
+            #[cfg(not(feature = "ssr"))]
+            {
+                drop(state);
+            }
+        }
+
+        Service::<M>::new(props, &env, &messages)
+    });
 
     // Create a signal tracking the current state.
     // Use .peek() to avoid subscribing the component to service_signal changes.
@@ -409,6 +469,24 @@ where
 fn props_with_service_id<M: Machine>(mut props: M::Props, service_id: &str) -> M::Props {
     if props.id().is_empty() {
         props.set_id(service_id.to_owned());
+    }
+
+    props
+}
+
+#[cfg(feature = "ssr")]
+fn props_with_snapshot_id<M: Machine>(
+    mut props: M::Props,
+    snapshot: &HydrationSnapshot<M>,
+) -> M::Props {
+    if props.id().is_empty() {
+        props.set_id(snapshot.id.clone());
+    } else {
+        debug_assert_eq!(
+            props.id(),
+            snapshot.id,
+            "HydrationSnapshot id must match Props::id"
+        );
     }
 
     props

--- a/crates/ars-dioxus/src/use_machine/mod.rs
+++ b/crates/ars-dioxus/src/use_machine/mod.rs
@@ -10,7 +10,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-#[cfg(feature = "ssr")]
+#[cfg(any(feature = "ssr", all(feature = "web", target_arch = "wasm32")))]
 use ars_core::HydrationSnapshot;
 use ars_core::{CleanupFn, Env, HasId, Machine, RenderMode, Service};
 use dioxus::prelude::*;
@@ -57,7 +57,17 @@ where
     pub context_version: ReadSignal<u64>,
 }
 
-const fn current_render_mode() -> RenderMode {
+const fn current_render_mode(_hydrated_snapshot: bool) -> RenderMode {
+    #[cfg(all(feature = "web", target_arch = "wasm32"))]
+    {
+        if _hydrated_snapshot {
+            RenderMode::Hydrating
+        } else {
+            RenderMode::Client
+        }
+    }
+
+    #[cfg(not(all(feature = "web", target_arch = "wasm32")))]
     if cfg!(feature = "ssr") {
         RenderMode::Server
     } else {
@@ -248,7 +258,7 @@ where
 /// The snapshot state is installed with [`Service::new_hydrated`] so the
 /// client preserves server-rendered machine state while recomputing context
 /// from the current adapter environment.
-#[cfg(feature = "ssr")]
+#[cfg(any(feature = "ssr", all(feature = "web", target_arch = "wasm32")))]
 pub fn use_machine_hydrated<M: Machine + 'static>(
     props: M::Props,
     snapshot: HydrationSnapshot<M>,
@@ -288,7 +298,7 @@ where
 }
 
 /// Creates a reactive-props machine service from an SSR hydration snapshot.
-#[cfg(feature = "ssr")]
+#[cfg(any(feature = "ssr", all(feature = "web", target_arch = "wasm32")))]
 pub fn use_machine_with_reactive_props_hydrated<M: Machine + 'static>(
     props_signal: Signal<M::Props>,
     snapshot: HydrationSnapshot<M>,
@@ -336,19 +346,20 @@ where
 
     let intl_backend = use_intl_backend();
 
-    let env = Env::new(locale, intl_backend).with_render_mode(current_render_mode());
+    let env = Env::new(locale, intl_backend)
+        .with_render_mode(current_render_mode(hydrated_state.is_some()));
 
     let messages = use_messages::<M::Messages>(None, Some(&env.locale));
 
     // Create the service once — use_signal runs its closure only on first mount.
     let service_signal = use_signal(move || {
         if let Some(state) = hydrated_state {
-            #[cfg(feature = "ssr")]
+            #[cfg(any(feature = "ssr", all(feature = "web", target_arch = "wasm32")))]
             {
                 return Service::<M>::new_hydrated(props, state, &env, &messages);
             }
 
-            #[cfg(not(feature = "ssr"))]
+            #[cfg(not(any(feature = "ssr", all(feature = "web", target_arch = "wasm32"))))]
             {
                 drop(state);
             }
@@ -474,7 +485,7 @@ fn props_with_service_id<M: Machine>(mut props: M::Props, service_id: &str) -> M
     props
 }
 
-#[cfg(feature = "ssr")]
+#[cfg(any(feature = "ssr", all(feature = "web", target_arch = "wasm32")))]
 fn props_with_snapshot_id<M: Machine>(
     mut props: M::Props,
     snapshot: &HydrationSnapshot<M>,

--- a/crates/ars-dioxus/src/use_machine/mod.rs
+++ b/crates/ars-dioxus/src/use_machine/mod.rs
@@ -482,7 +482,7 @@ fn props_with_snapshot_id<M: Machine>(
     if props.id().is_empty() {
         props.set_id(snapshot.id.clone());
     } else {
-        debug_assert_eq!(
+        assert_eq!(
             props.id(),
             snapshot.id,
             "HydrationSnapshot id must match Props::id"

--- a/crates/ars-dioxus/src/use_machine/test_support.rs
+++ b/crates/ars-dioxus/src/use_machine/test_support.rs
@@ -5,6 +5,7 @@ use std::sync::{Arc, Mutex};
 use ars_core::PendingEffect;
 use ars_core::{AriaAttr, AttrMap, ComponentPart, ConnectApi, Env, HasId, HtmlAttr, Machine};
 
+#[cfg_attr(feature = "ssr", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum ToggleState {
     Off,
@@ -115,6 +116,7 @@ impl Machine for ToggleMachine {
     }
 }
 
+#[cfg_attr(feature = "ssr", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum PropState {
     Off,

--- a/crates/ars-dioxus/src/use_machine/wasm_tests.rs
+++ b/crates/ars-dioxus/src/use_machine/wasm_tests.rs
@@ -80,7 +80,7 @@ fn use_machine_injects_generated_id_on_wasm() {
     dom.rebuild_in_place();
 
     assert_eq!(snapshots.borrow().len(), 1);
-    assert!(snapshots.borrow()[0].starts_with("component-"));
+    assert!(snapshots.borrow()[0].starts_with("ars-component-"));
 }
 
 #[wasm_bindgen_test]

--- a/crates/ars-dioxus/src/use_machine/wasm_tests.rs
+++ b/crates/ars-dioxus/src/use_machine/wasm_tests.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use ars_components::overlay::presence;
-use ars_core::{ConnectApi, HtmlAttr};
+use ars_core::{ConnectApi, HtmlAttr, RenderMode};
 use dioxus::dioxus_core::{NoOpMutations, ScopeId};
 use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
 
@@ -15,6 +15,12 @@ wasm_bindgen_test_configure!(run_in_browser);
 
 type PresenceDerivedSnapshot = (bool, bool, bool, Option<String>, Option<String>);
 type PresenceSnapshot = (PresenceDerivedSnapshot, presence::State);
+
+#[wasm_bindgen_test]
+fn current_render_mode_reports_client_for_web_builds() {
+    assert_eq!(current_render_mode(false), RenderMode::Client);
+    assert_eq!(current_render_mode(true), RenderMode::Hydrating);
+}
 
 #[wasm_bindgen_test]
 fn use_machine_updates_state_on_wasm() {
@@ -81,6 +87,43 @@ fn use_machine_injects_generated_id_on_wasm() {
 
     assert_eq!(snapshots.borrow().len(), 1);
     assert!(snapshots.borrow()[0].starts_with("ars-component-"));
+}
+
+#[wasm_bindgen_test]
+fn use_machine_hydrated_uses_hydrating_mode_on_wasm() {
+    let snapshots = Rc::new(RefCell::new(Vec::new()));
+
+    #[expect(
+        clippy::needless_pass_by_value,
+        reason = "Dioxus root props are moved into the render function."
+    )]
+    fn app(snapshots: Rc<RefCell<Vec<(ToggleState, String)>>>) -> Element {
+        let machine = use_machine_hydrated::<ToggleMachine>(
+            ToggleProps { id: String::new() },
+            HydrationSnapshot {
+                state: ToggleState::On,
+                id: String::from("toggle-hydrated"),
+            },
+        );
+
+        snapshots.borrow_mut().push((
+            *machine.state.peek(),
+            machine.service.peek().props().id().to_owned(),
+        ));
+
+        rsx! {
+            div {}
+        }
+    }
+
+    let mut dom = VirtualDom::new_with_props(app, Rc::clone(&snapshots));
+
+    dom.rebuild_in_place();
+
+    assert_eq!(
+        snapshots.borrow().as_slice(),
+        &[(ToggleState::On, String::from("toggle-hydrated"))]
+    );
 }
 
 #[wasm_bindgen_test]

--- a/crates/ars-dioxus/tests/unit/use_machine.rs
+++ b/crates/ars-dioxus/tests/unit/use_machine.rs
@@ -290,10 +290,10 @@ fn use_machine_hydrated_accepts_matching_explicit_props_id() {
     dom.rebuild_in_place();
 }
 
-#[cfg(all(feature = "ssr", debug_assertions))]
+#[cfg(feature = "ssr")]
 #[test]
 #[should_panic(expected = "HydrationSnapshot id must match Props::id")]
-fn props_with_snapshot_id_rejects_mismatched_explicit_props_id_in_debug() {
+fn props_with_snapshot_id_rejects_mismatched_explicit_props_id() {
     let _props = props_with_snapshot_id::<ToggleMachine>(
         ToggleProps {
             id: String::from("toggle-client"),

--- a/crates/ars-dioxus/tests/unit/use_machine.rs
+++ b/crates/ars-dioxus/tests/unit/use_machine.rs
@@ -2,6 +2,8 @@
 use std::sync::Mutex;
 use std::{cell::RefCell, rc::Rc, sync::Arc};
 
+#[cfg(feature = "ssr")]
+use ars_core::HydrationSnapshot;
 use ars_core::{HasId, I18nRegistries, MessageFn, NullPlatformEffects};
 use ars_i18n::{Direction, IntlBackend, Locale, StubIntlBackend};
 use dioxus::dioxus_core::{NoOpMutations, ScopeId};
@@ -225,6 +227,103 @@ fn use_machine_creates_service_with_initial_state() {
 
         // Context version starts at 0
         assert_eq!(*machine.context_version.peek(), 0);
+
+        rsx! {
+            div {}
+        }
+    }
+
+    let mut dom = VirtualDom::new(app);
+
+    dom.rebuild_in_place();
+}
+
+#[cfg(feature = "ssr")]
+#[test]
+fn use_machine_hydrated_preserves_snapshot_state_and_id() {
+    fn app() -> Element {
+        let machine = use_machine_hydrated::<ToggleMachine>(
+            ToggleProps { id: String::new() },
+            HydrationSnapshot {
+                state: ToggleState::On,
+                id: String::from("toggle-hydrated"),
+            },
+        );
+
+        assert_eq!(*machine.state.peek(), ToggleState::On);
+        assert_eq!(machine.service.peek().props().id(), "toggle-hydrated");
+
+        rsx! {
+            div {}
+        }
+    }
+
+    let mut dom = VirtualDom::new(app);
+
+    dom.rebuild_in_place();
+}
+
+#[cfg(feature = "ssr")]
+#[test]
+fn use_machine_hydrated_accepts_matching_explicit_props_id() {
+    fn app() -> Element {
+        let machine = use_machine_hydrated::<ToggleMachine>(
+            ToggleProps {
+                id: String::from("toggle-explicit"),
+            },
+            HydrationSnapshot {
+                state: ToggleState::On,
+                id: String::from("toggle-explicit"),
+            },
+        );
+
+        assert_eq!(*machine.state.peek(), ToggleState::On);
+        assert_eq!(machine.service.peek().props().id(), "toggle-explicit");
+
+        rsx! {
+            div {}
+        }
+    }
+
+    let mut dom = VirtualDom::new(app);
+
+    dom.rebuild_in_place();
+}
+
+#[cfg(all(feature = "ssr", debug_assertions))]
+#[test]
+#[should_panic(expected = "HydrationSnapshot id must match Props::id")]
+fn props_with_snapshot_id_rejects_mismatched_explicit_props_id_in_debug() {
+    let _props = props_with_snapshot_id::<ToggleMachine>(
+        ToggleProps {
+            id: String::from("toggle-client"),
+        },
+        &HydrationSnapshot {
+            state: ToggleState::On,
+            id: String::from("toggle-server"),
+        },
+    );
+}
+
+#[cfg(feature = "ssr")]
+#[test]
+fn reactive_props_hydrated_preserves_snapshot_state_and_id() {
+    fn app() -> Element {
+        let props = use_signal(|| ToggleProps { id: String::new() });
+
+        let machine = use_machine_with_reactive_props_hydrated::<ToggleMachine>(
+            props,
+            HydrationSnapshot {
+                state: ToggleState::On,
+                id: String::from("toggle-reactive-hydrated"),
+            },
+        );
+
+        assert_eq!(*machine.state.peek(), ToggleState::On);
+        assert_eq!(
+            machine.service.peek().props().id(),
+            "toggle-reactive-hydrated"
+        );
 
         rsx! {
             div {}
@@ -564,7 +663,7 @@ fn generated_id_stays_stable_across_rerenders() {
     let snapshots = snapshots.borrow();
 
     assert_eq!(snapshots.len(), 3);
-    assert!(snapshots[0].starts_with("component-"));
+    assert!(snapshots[0].starts_with("ars-component-"));
     assert_eq!(snapshots[0], snapshots[1]);
     assert_eq!(snapshots[1], snapshots[2]);
 }
@@ -697,7 +796,7 @@ fn reactive_props_sync_preserves_service_id_when_signal_props_omit_id() {
     let snapshots = snapshots.borrow();
 
     assert_eq!(snapshots.len(), 3);
-    assert!(snapshots[0].0.starts_with("component-"));
+    assert!(snapshots[0].0.starts_with("ars-component-"));
     assert_eq!(snapshots[0].0, snapshots[1].0);
     assert_eq!(snapshots[1].0, snapshots[2].0);
     assert_eq!(

--- a/crates/ars-dioxus/tests/unit/use_machine.rs
+++ b/crates/ars-dioxus/tests/unit/use_machine.rs
@@ -4,7 +4,7 @@ use std::{cell::RefCell, rc::Rc, sync::Arc};
 
 #[cfg(feature = "ssr")]
 use ars_core::HydrationSnapshot;
-use ars_core::{HasId, I18nRegistries, MessageFn, NullPlatformEffects};
+use ars_core::{HasId, I18nRegistries, MessageFn, NullPlatformEffects, RenderMode};
 use ars_i18n::{Direction, IntlBackend, Locale, StubIntlBackend};
 use dioxus::dioxus_core::{NoOpMutations, ScopeId};
 
@@ -12,6 +12,21 @@ use super::{test_support, test_support::*, *};
 use crate::{platform::NullPlatform, provider::ArsContext};
 
 type PropIdSnapshot = (String, PropState, u64, u32);
+
+#[test]
+fn current_render_mode_reports_server_for_ssr_builds() {
+    #[cfg(feature = "ssr")]
+    {
+        assert_eq!(current_render_mode(false), RenderMode::Server);
+        assert_eq!(current_render_mode(true), RenderMode::Server);
+    }
+
+    #[cfg(not(feature = "ssr"))]
+    {
+        assert_eq!(current_render_mode(false), RenderMode::Client);
+        assert_eq!(current_render_mode(true), RenderMode::Client);
+    }
+}
 
 #[derive(Clone)]
 struct TestIntlBackend;

--- a/crates/ars-dom/src/portal.rs
+++ b/crates/ars-dom/src/portal.rs
@@ -11,6 +11,12 @@ use std::string::String;
 /// owning overlay.
 pub const PORTAL_OWNER_ATTR: &str = "data-ars-portal-owner";
 
+/// HTML attribute marking `inert` as owned by adapter modal background handling.
+///
+/// Hydration cleanup uses this marker to remove stale SSR modal inert state
+/// without clearing author-owned `inert` regions.
+pub const MODAL_INERT_ATTR: &str = "data-ars-modal-inert";
+
 #[cfg(all(feature = "web", not(target_arch = "wasm32")))]
 use wasm_bindgen::{JsCast, JsValue};
 #[cfg(all(feature = "web", target_arch = "wasm32"))]
@@ -93,6 +99,7 @@ fn restore_action(previous: Option<&str>) -> RestoreAction {
 struct SavedSiblingAttrs {
     element: web_sys::Element,
     previous_inert: Option<String>,
+    previous_modal_inert: Option<String>,
     previous_aria_hidden: Option<String>,
 }
 
@@ -311,6 +318,7 @@ fn apply_aria_hidden(siblings: &[web_sys::Element]) -> Vec<SavedSiblingAttrs> {
             SavedSiblingAttrs {
                 element: sibling.clone(),
                 previous_inert: sibling.get_attribute("inert"),
+                previous_modal_inert: sibling.get_attribute(MODAL_INERT_ATTR),
                 previous_aria_hidden,
             }
         })
@@ -323,6 +331,9 @@ fn apply_inert(siblings: &[web_sys::Element]) {
         sibling
             .set_attribute("inert", "")
             .expect("inert assignment must succeed");
+        sibling
+            .set_attribute(MODAL_INERT_ATTR, "")
+            .expect("modal inert marker assignment must succeed");
     }
 }
 
@@ -425,6 +436,11 @@ fn install_focus_trap(
 fn restore_native_inert(saved_siblings: Vec<SavedSiblingAttrs>) {
     for saved in saved_siblings {
         restore_element_attribute(&saved.element, "inert", saved.previous_inert.as_deref());
+        restore_element_attribute(
+            &saved.element,
+            MODAL_INERT_ATTR,
+            saved.previous_modal_inert.as_deref(),
+        );
         restore_element_attribute(
             &saved.element,
             "aria-hidden",
@@ -537,6 +553,11 @@ fn remove_inert_from_siblings_impl(portal_id: &str) {
         crate::debug::warn_dom_error(
             "removing inert from portal sibling",
             child.remove_attribute("inert"),
+        );
+
+        crate::debug::warn_dom_error(
+            "removing modal inert marker from portal sibling",
+            child.remove_attribute(MODAL_INERT_ATTR),
         );
 
         crate::debug::warn_dom_error(
@@ -798,8 +819,10 @@ mod wasm_tests {
         let cleanup = set_background_inert("ars-portal-root");
 
         assert_eq!(before.get_attribute("inert").as_deref(), Some(""));
+        assert_eq!(before.get_attribute(MODAL_INERT_ATTR).as_deref(), Some(""));
         assert_eq!(before.get_attribute("aria-hidden").as_deref(), Some("true"));
         assert_eq!(after.get_attribute("inert").as_deref(), Some(""));
+        assert_eq!(after.get_attribute(MODAL_INERT_ATTR).as_deref(), Some(""));
         assert_eq!(after.get_attribute("aria-hidden").as_deref(), Some("true"));
 
         cleanup();
@@ -809,8 +832,10 @@ mod wasm_tests {
             Some("false")
         );
         assert_eq!(before.get_attribute("inert"), None);
+        assert_eq!(before.get_attribute(MODAL_INERT_ATTR), None);
         assert_eq!(after.get_attribute("aria-hidden"), None);
         assert_eq!(after.get_attribute("inert"), None);
+        assert_eq!(after.get_attribute(MODAL_INERT_ATTR), None);
 
         cleanup_node(before.as_ref());
         cleanup_node(after.as_ref());
@@ -828,6 +853,9 @@ mod wasm_tests {
         before
             .set_attribute("inert", "")
             .expect("inert assignment must succeed");
+        before
+            .set_attribute(MODAL_INERT_ATTR, "")
+            .expect("modal inert marker assignment must succeed");
 
         before
             .set_attribute("aria-hidden", "true")
@@ -838,6 +866,9 @@ mod wasm_tests {
         after
             .set_attribute("inert", "")
             .expect("inert assignment must succeed");
+        after
+            .set_attribute(MODAL_INERT_ATTR, "")
+            .expect("modal inert marker assignment must succeed");
 
         after
             .set_attribute("aria-hidden", "true")
@@ -846,8 +877,10 @@ mod wasm_tests {
         remove_inert_from_siblings("ars-portal-root");
 
         assert_eq!(before.get_attribute("inert"), None);
+        assert_eq!(before.get_attribute(MODAL_INERT_ATTR), None);
         assert_eq!(before.get_attribute("aria-hidden"), None);
         assert_eq!(after.get_attribute("inert"), None);
+        assert_eq!(after.get_attribute(MODAL_INERT_ATTR), None);
         assert_eq!(after.get_attribute("aria-hidden"), None);
 
         cleanup_node(before.as_ref());

--- a/crates/ars-leptos/Cargo.toml
+++ b/crates/ars-leptos/Cargo.toml
@@ -11,7 +11,7 @@ rust-version.workspace = true
 default = ["icu4x"]
 debug   = ["dep:log", "ars-core/debug", "ars-dom/debug", "ars-interactions/debug"]
 ssr     = ["leptos/ssr", "ars-dom/ssr", "ars-core/ssr", "ars-core/serde", "dep:serde", "dep:serde_json"]
-hydrate = ["leptos/hydrate"]
+hydrate = ["leptos/hydrate", "ars-core/ssr", "ars-core/serde"]
 csr     = ["leptos/csr"]
 # Pre-compiled CLDR data via ICU4X. Default backend on native targets and the
 # server-side rendering path. Use `--no-default-features --features csr,ars-i18n/web-intl`

--- a/crates/ars-leptos/Cargo.toml
+++ b/crates/ars-leptos/Cargo.toml
@@ -10,7 +10,7 @@ rust-version.workspace = true
 [features]
 default = ["icu4x"]
 debug   = ["dep:log", "ars-core/debug", "ars-dom/debug", "ars-interactions/debug"]
-ssr     = ["leptos/ssr", "ars-dom/ssr"]
+ssr     = ["leptos/ssr", "ars-dom/ssr", "ars-core/ssr", "ars-core/serde", "dep:serde", "dep:serde_json"]
 hydrate = ["leptos/hydrate"]
 csr     = ["leptos/csr"]
 # Pre-compiled CLDR data via ICU4X. Default backend on native targets and the
@@ -29,11 +29,15 @@ ars-i18n         = { path = "../ars-i18n", default-features = false }
 ars-interactions = { path = "../ars-interactions" }
 leptos           = { version = "0.8", default-features = false }
 log              = { version = "0.4", default-features = false, optional = true }
+serde            = { version = "1", default-features = false, features = ["alloc", "derive"], optional = true }
+serde_json       = { version = "1", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-wasm-bindgen      = "0.2"
-wasm-bindgen-test = "0.3"
-web-sys           = { version = "0.3", features = ["EventInit", "KeyboardEventInit", "PointerEventInit"] }
+js-sys               = "0.3"
+wasm-bindgen         = "0.2"
+wasm-bindgen-futures = "0.4"
+wasm-bindgen-test    = "0.3"
+web-sys              = { version = "0.3", features = ["EventInit", "KeyboardEventInit", "PointerEventInit"] }
 
 [lints]
 workspace = true

--- a/crates/ars-leptos/src/hydration.rs
+++ b/crates/ars-leptos/src/hydration.rs
@@ -1,0 +1,864 @@
+//! SSR hydration helpers for the Leptos adapter.
+//!
+//! The adapter reuses [`ars_core::HydrationSnapshot`] as the single wire-format
+//! contract for stateful machine hydration and provides browser-only helpers
+//! for `FocusScope` cleanup once client hydration has completed.
+
+#[cfg(all(feature = "hydrate", target_arch = "wasm32"))]
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
+
+#[cfg(feature = "ssr")]
+pub use ars_core::HydrationSnapshot;
+#[cfg(feature = "ssr")]
+use ars_core::{HasId, Machine, Service};
+#[cfg(all(feature = "hydrate", target_arch = "wasm32"))]
+use leptos::{
+    prelude::*,
+    reactive::owner::LocalStorage,
+    wasm_bindgen::{JsCast, JsValue, closure::Closure},
+    web_sys,
+};
+
+#[cfg(all(feature = "hydrate", target_arch = "wasm32"))]
+const HYDRATION_FOCUS_TARGET_SELECTOR: &str = concat!(
+    "[autofocus]:not([disabled]):not([aria-hidden='true']),",
+    "button:not([disabled]):not([aria-hidden='true']),",
+    "input:not([disabled]):not([aria-hidden='true']),",
+    "select:not([disabled]):not([aria-hidden='true']),",
+    "textarea:not([disabled]):not([aria-hidden='true']),",
+    "a[href]:not([aria-hidden='true']),",
+    "area[href]:not([aria-hidden='true']),",
+    "[tabindex]:not([disabled]):not([aria-hidden='true']),",
+    "[contenteditable]:not([contenteditable='false']):not([aria-hidden='true'])",
+);
+
+/// Serializes a machine service snapshot for embedding in SSR HTML.
+///
+/// The returned JSON contains only the machine state and component ID. Context
+/// is intentionally recomputed on the client by [`Service::new_hydrated`].
+///
+/// # Panics
+///
+/// Panics if `M::State` cannot be serialized.
+#[cfg(feature = "ssr")]
+#[must_use]
+pub fn serialize_snapshot<M: Machine>(svc: &Service<M>) -> String
+where
+    M::State: Clone + serde::Serialize,
+{
+    serde_json::to_string(&HydrationSnapshot::<M> {
+        state: svc.state().clone(),
+        id: svc.props().id().to_string(),
+    })
+    .expect("HydrationSnapshot must be serializable for SSR — ensure State implements Serialize")
+}
+
+/// Marks the document body as fully hydrated for `FocusScope` activation gates.
+#[cfg(all(feature = "hydrate", target_arch = "wasm32"))]
+pub fn mark_body_hydrated() {
+    let Some(document) = browser_document() else {
+        return;
+    };
+
+    let Some(body) = document.body() else {
+        return;
+    };
+
+    drop(body.set_attribute("data-ars-hydrated", ""));
+}
+
+/// Emits a debug warning when a mounted server-rendered ID differs from the client ID.
+#[cfg(all(feature = "hydrate", target_arch = "wasm32"))]
+pub fn warn_if_mounted_id_mismatch(element: &web_sys::Element, client_id: &str) {
+    let server_id = element.id();
+
+    if server_id.is_empty() {
+        return;
+    }
+
+    if server_id == client_id {
+        return;
+    }
+
+    #[cfg(debug_assertions)]
+    web_sys::console::warn_1(&JsValue::from_str(&hydration_id_mismatch_message(
+        &server_id, client_id,
+    )));
+}
+
+/// Hydration-safe `FocusScope` setup for modal overlays.
+#[cfg(all(feature = "hydrate", target_arch = "wasm32"))]
+pub fn setup_focus_scope_hydration_safe(
+    scope_id: String,
+    restore_target: StoredValue<Option<web_sys::HtmlElement>, LocalStorage>,
+) {
+    let cleanup_scope_id = scope_id.clone();
+    let activation_active = Arc::new(AtomicBool::new(true));
+
+    Effect::new({
+        let activation_active = Arc::clone(&activation_active);
+
+        move |_| {
+            let Some(document) = browser_document() else {
+                return;
+            };
+
+            if body_is_hydrated(&document) {
+                activate_focus_scope(
+                    &document,
+                    &scope_id,
+                    restore_target,
+                    Arc::clone(&activation_active),
+                );
+            } else {
+                request_hydration_activation_after_frame(
+                    scope_id.clone(),
+                    restore_target,
+                    Arc::clone(&activation_active),
+                );
+            }
+        }
+    });
+
+    on_cleanup(move || {
+        activation_active.store(false, Ordering::Relaxed);
+
+        if let Some(document) = browser_document()
+            && let Some(scope) = document.get_element_by_id(&cleanup_scope_id)
+        {
+            drop(scope.remove_attribute("data-ars-modal-open"));
+        }
+
+        restore_target.with_value(|element| {
+            if let Some(element) = element {
+                drop(element.focus());
+            }
+        });
+    });
+}
+
+#[cfg(all(feature = "hydrate", target_arch = "wasm32"))]
+fn browser_document() -> Option<web_sys::Document> {
+    web_sys::window()?.document()
+}
+
+#[cfg(all(feature = "hydrate", target_arch = "wasm32"))]
+fn body_is_hydrated(document: &web_sys::Document) -> bool {
+    document
+        .body()
+        .and_then(|body| body.get_attribute("data-ars-hydrated"))
+        .is_some()
+}
+
+#[cfg(all(feature = "hydrate", target_arch = "wasm32"))]
+fn activate_focus_scope(
+    document: &web_sys::Document,
+    scope_id: &str,
+    restore_target: StoredValue<Option<web_sys::HtmlElement>, LocalStorage>,
+    activation_active: Arc<AtomicBool>,
+) {
+    let scope: Option<web_sys::HtmlElement> = document
+        .get_element_by_id(scope_id)
+        .and_then(|element| element.dyn_into().ok());
+
+    if let Some(scope) = scope.as_ref() {
+        drop(scope.set_attribute("data-ars-modal-open", ""));
+    }
+
+    remove_orphaned_inert(document);
+
+    if let Some(scope) = scope {
+        request_focus_after_frame(scope, restore_target, activation_active);
+    }
+}
+
+#[cfg(all(feature = "hydrate", target_arch = "wasm32"))]
+fn request_hydration_activation_after_frame(
+    scope_id: String,
+    restore_target: StoredValue<Option<web_sys::HtmlElement>, LocalStorage>,
+    activation_active: Arc<AtomicBool>,
+) {
+    let Some(window) = web_sys::window() else {
+        return;
+    };
+
+    let callback = Closure::once_into_js(move || {
+        if !activation_active.load(Ordering::Relaxed) {
+            return;
+        }
+
+        let Some(document) = browser_document() else {
+            return;
+        };
+
+        if body_is_hydrated(&document) {
+            activate_focus_scope(&document, &scope_id, restore_target, activation_active);
+        } else {
+            request_hydration_activation_after_frame(scope_id, restore_target, activation_active);
+        }
+    });
+
+    drop(window.request_animation_frame(callback.unchecked_ref()));
+}
+
+#[cfg(all(feature = "hydrate", target_arch = "wasm32"))]
+fn remove_orphaned_inert(document: &web_sys::Document) {
+    let Ok(elements) = document.query_selector_all("[inert][data-ars-modal-inert]") else {
+        return;
+    };
+
+    for index in 0..elements.length() {
+        let Some(node) = elements.item(index) else {
+            continue;
+        };
+
+        let Ok(element) = node.dyn_into::<web_sys::Element>() else {
+            continue;
+        };
+
+        if !has_open_modal_sibling(&element) {
+            drop(element.remove_attribute("inert"));
+            drop(element.remove_attribute(ars_dom::portal::MODAL_INERT_ATTR));
+        }
+    }
+}
+
+#[cfg(all(feature = "hydrate", target_arch = "wasm32"))]
+fn has_open_modal_sibling(element: &web_sys::Element) -> bool {
+    let Some(parent) = element.parent_element() else {
+        return false;
+    };
+
+    let children = parent.children();
+
+    for index in 0..children.length() {
+        let Some(child) = children.item(index) else {
+            continue;
+        };
+
+        if child.is_same_node(Some(element)) {
+            continue;
+        }
+
+        if child.has_attribute("data-ars-modal-open") {
+            return true;
+        }
+    }
+
+    false
+}
+
+#[cfg(all(feature = "hydrate", target_arch = "wasm32"))]
+fn visible_focus_target(scope: &web_sys::HtmlElement) -> Option<web_sys::HtmlElement> {
+    if is_focus_target_candidate(scope) && is_visible_focus_target(scope) {
+        return Some(scope.clone());
+    }
+
+    scope
+        .query_selector_all(HYDRATION_FOCUS_TARGET_SELECTOR)
+        .ok()
+        .and_then(|elements| first_visible_focus_target(&elements))
+}
+
+#[cfg(all(feature = "hydrate", target_arch = "wasm32"))]
+fn first_visible_focus_target(elements: &web_sys::NodeList) -> Option<web_sys::HtmlElement> {
+    for index in 0..elements.length() {
+        let Some(node) = elements.item(index) else {
+            continue;
+        };
+
+        let Ok(element) = node.dyn_into::<web_sys::HtmlElement>() else {
+            continue;
+        };
+
+        if is_visible_focus_target(&element) {
+            return Some(element);
+        }
+    }
+
+    None
+}
+
+#[cfg(all(feature = "hydrate", target_arch = "wasm32"))]
+fn is_focus_target_candidate(element: &web_sys::Element) -> bool {
+    if element.has_attribute("disabled") {
+        return false;
+    }
+
+    if element.get_attribute("aria-hidden").as_deref() == Some("true") {
+        return false;
+    }
+
+    if element.has_attribute("autofocus") || element.has_attribute("tabindex") {
+        return true;
+    }
+
+    match element.tag_name().as_str() {
+        "BUTTON" | "INPUT" | "SELECT" | "TEXTAREA" => true,
+        "A" | "AREA" => element.has_attribute("href"),
+        _ => element
+            .get_attribute("contenteditable")
+            .is_some_and(|value| value != "false"),
+    }
+}
+
+#[cfg(all(feature = "hydrate", target_arch = "wasm32"))]
+fn is_visible_focus_target(element: &web_sys::HtmlElement) -> bool {
+    element.offset_parent().is_some() || is_visible_fixed_position_target(element)
+}
+
+#[cfg(all(feature = "hydrate", target_arch = "wasm32"))]
+fn is_visible_fixed_position_target(element: &web_sys::HtmlElement) -> bool {
+    let Some(window) = web_sys::window() else {
+        return false;
+    };
+
+    let Ok(Some(style)) = window.get_computed_style(element) else {
+        return false;
+    };
+
+    style.get_property_value("position").as_deref() == Ok("fixed")
+        && style.get_property_value("display").as_deref() != Ok("none")
+        && style.get_property_value("visibility").as_deref() != Ok("hidden")
+}
+
+#[cfg(all(feature = "hydrate", target_arch = "wasm32"))]
+fn request_focus_after_frame(
+    scope: web_sys::HtmlElement,
+    restore_target: StoredValue<Option<web_sys::HtmlElement>, LocalStorage>,
+    activation_active: Arc<AtomicBool>,
+) {
+    let Some(window) = web_sys::window() else {
+        return;
+    };
+
+    let Some(document) = window.document() else {
+        return;
+    };
+
+    let callback = Closure::once_into_js(move || {
+        if !activation_active.load(Ordering::Relaxed) {
+            return;
+        }
+
+        let Some(target) = visible_focus_target(&scope) else {
+            return;
+        };
+
+        restore_target.set_value(
+            document
+                .active_element()
+                .and_then(|element| element.dyn_into().ok()),
+        );
+
+        drop(target.focus());
+    });
+
+    drop(window.request_animation_frame(callback.unchecked_ref()));
+}
+
+#[cfg(all(feature = "hydrate", target_arch = "wasm32", debug_assertions))]
+fn hydration_id_mismatch_message(server_id: &str, client_id: &str) -> String {
+    format!(
+        "ars-ui hydration ID mismatch: server='{server_id}', client='{client_id}'. Component IDs may be non-deterministic across SSR/client boundaries."
+    )
+}
+
+#[cfg(all(test, feature = "ssr"))]
+mod tests {
+    use ars_core::{AttrMap, ComponentPart, ConnectApi, Env, HasId, Machine, Service};
+
+    #[cfg_attr(feature = "ssr", derive(serde::Serialize, serde::Deserialize))]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    enum TestState {
+        Off,
+    }
+
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    struct TestProps {
+        id: String,
+    }
+
+    impl HasId for TestProps {
+        fn id(&self) -> &str {
+            &self.id
+        }
+
+        fn with_id(self, id: String) -> Self {
+            Self { id }
+        }
+
+        fn set_id(&mut self, id: String) {
+            self.id = id;
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+    struct TestPart;
+
+    impl ComponentPart for TestPart {
+        const ROOT: Self = Self;
+
+        fn scope() -> &'static str {
+            "test"
+        }
+
+        fn name(&self) -> &'static str {
+            "root"
+        }
+
+        fn all() -> Vec<Self> {
+            vec![Self]
+        }
+    }
+
+    struct TestApi;
+
+    impl ConnectApi for TestApi {
+        type Part = TestPart;
+
+        fn part_attrs(&self, _part: Self::Part) -> AttrMap {
+            AttrMap::new()
+        }
+    }
+
+    struct TestMachine;
+
+    impl Machine for TestMachine {
+        type State = TestState;
+        type Event = ();
+        type Context = ();
+        type Props = TestProps;
+        type Messages = ();
+        type Api<'a> = TestApi;
+
+        fn init(
+            _props: &Self::Props,
+            _env: &Env,
+            _messages: &Self::Messages,
+        ) -> (Self::State, Self::Context) {
+            (TestState::Off, ())
+        }
+
+        fn transition(
+            _state: &Self::State,
+            _event: &Self::Event,
+            _context: &Self::Context,
+            _props: &Self::Props,
+        ) -> Option<ars_core::TransitionPlan<Self>> {
+            None
+        }
+
+        fn connect<'a>(
+            _state: &'a Self::State,
+            _context: &'a Self::Context,
+            _props: &'a Self::Props,
+            _send: &'a dyn Fn(Self::Event),
+        ) -> Self::Api<'a> {
+            TestApi
+        }
+    }
+
+    #[test]
+    fn serialize_snapshot_round_trips_state_and_id() {
+        let service = Service::<TestMachine>::new(
+            TestProps {
+                id: String::from("toggle-1"),
+            },
+            &Env::default(),
+            &(),
+        );
+
+        let json = super::serialize_snapshot(&service);
+
+        let snapshot: super::HydrationSnapshot<TestMachine> =
+            serde_json::from_str(&json).expect("snapshot should deserialize");
+
+        assert_eq!(snapshot.state, TestState::Off);
+        assert_eq!(snapshot.id, "toggle-1");
+        assert!(json.contains("\"id\":\"toggle-1\""));
+        assert!(json.contains("\"state\":\"Off\""));
+    }
+}
+
+#[cfg(all(test, feature = "hydrate", target_arch = "wasm32"))]
+mod wasm_tests {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    };
+
+    use leptos::{
+        prelude::*,
+        reactive::owner::LocalStorage,
+        wasm_bindgen::{self, JsCast},
+        web_sys,
+    };
+    use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    fn document() -> web_sys::Document {
+        web_sys::window()
+            .expect("window should exist")
+            .document()
+            .expect("document should exist")
+    }
+
+    fn reset_body() {
+        let document = document();
+        let body = document.body().expect("body should exist");
+
+        drop(body.remove_attribute("data-ars-hydrated"));
+
+        let containers = document
+            .query_selector_all("[data-ars-hydration-test]")
+            .expect("query hydration test containers");
+
+        for index in 0..containers.length() {
+            let Some(container) = containers.item(index) else {
+                continue;
+            };
+
+            if let Some(parent) = container.parent_node() {
+                drop(parent.remove_child(&container));
+            }
+        }
+    }
+
+    fn append_html(markup: &str) -> web_sys::HtmlElement {
+        let document = document();
+        let container: web_sys::HtmlElement = document
+            .create_element("div")
+            .expect("create container")
+            .dyn_into()
+            .expect("container should be HtmlElement");
+
+        container
+            .set_attribute("data-ars-hydration-test", "")
+            .expect("mark hydration test container");
+        container.set_inner_html(markup);
+
+        document
+            .body()
+            .expect("body should exist")
+            .append_child(&container)
+            .expect("append container");
+
+        container
+    }
+
+    async fn animation_frame_turn() {
+        let promise = js_sys::Promise::new(&mut |resolve, _reject| {
+            let callback = wasm_bindgen::closure::Closure::once_into_js(move || {
+                drop(resolve.call0(&wasm_bindgen::JsValue::UNDEFINED));
+            });
+
+            web_sys::window()
+                .expect("window should exist")
+                .request_animation_frame(callback.unchecked_ref())
+                .expect("requestAnimationFrame should schedule");
+        });
+
+        wasm_bindgen_futures::JsFuture::from(promise)
+            .await
+            .expect("animation frame promise should resolve");
+    }
+
+    fn restore_target() -> StoredValue<Option<web_sys::HtmlElement>, LocalStorage> {
+        StoredValue::new_local(None)
+    }
+
+    #[wasm_bindgen_test]
+    fn mark_body_hydrated_sets_marker() {
+        reset_body();
+
+        super::mark_body_hydrated();
+
+        assert_eq!(
+            document()
+                .body()
+                .expect("body should exist")
+                .get_attribute("data-ars-hydrated")
+                .as_deref(),
+            Some("")
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn orphaned_inert_is_removed_without_open_modal_sibling() {
+        reset_body();
+
+        let container = append_html(r#"<main id="page" inert data-ars-modal-inert=""></main>"#);
+        let document = document();
+
+        super::remove_orphaned_inert(&document);
+
+        let page = container
+            .query_selector("#page")
+            .expect("query should succeed")
+            .expect("page should exist");
+
+        assert_eq!(page.get_attribute("inert"), None);
+        assert_eq!(page.get_attribute(ars_dom::portal::MODAL_INERT_ATTR), None);
+    }
+
+    #[wasm_bindgen_test]
+    fn unowned_inert_is_not_removed_without_open_modal_sibling() {
+        reset_body();
+
+        let container = append_html(r#"<main id="page" inert></main>"#);
+        let document = document();
+
+        super::remove_orphaned_inert(&document);
+
+        let page = container
+            .query_selector("#page")
+            .expect("query should succeed")
+            .expect("page should exist");
+
+        assert_eq!(page.get_attribute("inert").as_deref(), Some(""));
+    }
+
+    #[wasm_bindgen_test]
+    fn inert_is_retained_with_open_modal_sibling() {
+        reset_body();
+
+        let container = append_html(
+            r#"<main id="page" inert data-ars-modal-inert=""></main><section id="scope" data-ars-modal-open=""></section>"#,
+        );
+        let document = document();
+
+        super::remove_orphaned_inert(&document);
+
+        let page = container
+            .query_selector("#page")
+            .expect("query should succeed")
+            .expect("page should exist");
+
+        assert_eq!(page.get_attribute("inert").as_deref(), Some(""));
+        assert_eq!(
+            page.get_attribute(ars_dom::portal::MODAL_INERT_ATTR)
+                .as_deref(),
+            Some("")
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn visible_focus_target_skips_hidden_matches_until_visible_target() {
+        reset_body();
+
+        let container = append_html(
+            r#"<section id="scope"><button id="hidden" style="display: none">hidden</button><input id="target"></section>"#,
+        );
+        let scope: web_sys::HtmlElement = container
+            .query_selector("#scope")
+            .expect("query should succeed")
+            .expect("scope should exist")
+            .dyn_into()
+            .expect("scope should be HtmlElement");
+
+        assert_eq!(
+            super::visible_focus_target(&scope)
+                .and_then(|element| element.get_attribute("id"))
+                .as_deref(),
+            Some("target")
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn visible_focus_target_accepts_fixed_position_target() {
+        reset_body();
+
+        let container = append_html(
+            r#"<section id="scope"><button id="target" style="position: fixed">target</button></section>"#,
+        );
+        let scope: web_sys::HtmlElement = container
+            .query_selector("#scope")
+            .expect("query should succeed")
+            .expect("scope should exist")
+            .dyn_into()
+            .expect("scope should be HtmlElement");
+
+        assert_eq!(
+            super::visible_focus_target(&scope)
+                .and_then(|element| element.get_attribute("id"))
+                .as_deref(),
+            Some("target")
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn visible_focus_target_rejects_hidden_fixed_position_target() {
+        reset_body();
+
+        let container = append_html(
+            r#"<section id="scope"><button id="target" style="position: fixed; visibility: hidden">target</button></section>"#,
+        );
+        let scope: web_sys::HtmlElement = container
+            .query_selector("#scope")
+            .expect("query should succeed")
+            .expect("scope should exist")
+            .dyn_into()
+            .expect("scope should be HtmlElement");
+
+        assert!(super::visible_focus_target(&scope).is_none());
+    }
+
+    #[wasm_bindgen_test]
+    fn visible_focus_target_prefers_focusable_scope_root() {
+        reset_body();
+
+        let container = append_html(
+            r#"<section id="scope" tabindex="-1"><button id="target">target</button></section>"#,
+        );
+        let scope: web_sys::HtmlElement = container
+            .query_selector("#scope")
+            .expect("query should succeed")
+            .expect("scope should exist")
+            .dyn_into()
+            .expect("scope should be HtmlElement");
+
+        assert_eq!(
+            super::visible_focus_target(&scope)
+                .and_then(|element| element.get_attribute("id"))
+                .as_deref(),
+            Some("scope")
+        );
+    }
+
+    #[wasm_bindgen_test(async)]
+    async fn focus_activation_is_deferred_until_animation_frame() {
+        reset_body();
+
+        let container = append_html(
+            r#"<button id="before">before</button><section id="scope"><button id="target">target</button></section>"#,
+        );
+        let before: web_sys::HtmlElement = container
+            .query_selector("#before")
+            .expect("query should succeed")
+            .expect("before should exist")
+            .dyn_into()
+            .expect("before should be HtmlElement");
+        let scope: web_sys::HtmlElement = container
+            .query_selector("#scope")
+            .expect("query should succeed")
+            .expect("scope should exist")
+            .dyn_into()
+            .expect("scope should be HtmlElement");
+
+        before.focus().expect("focus before");
+
+        super::request_focus_after_frame(scope, restore_target(), Arc::new(AtomicBool::new(true)));
+
+        assert_eq!(
+            document()
+                .active_element()
+                .and_then(|element| element.get_attribute("id"))
+                .as_deref(),
+            Some("before")
+        );
+
+        animation_frame_turn().await;
+
+        assert_eq!(
+            document()
+                .active_element()
+                .and_then(|element| element.get_attribute("id"))
+                .as_deref(),
+            Some("target")
+        );
+    }
+
+    #[wasm_bindgen_test(async)]
+    async fn focus_activation_skips_after_unmount_guard_is_cleared() {
+        reset_body();
+
+        let container = append_html(
+            r#"<button id="before">before</button><section id="scope"><button id="target">target</button></section>"#,
+        );
+        let before: web_sys::HtmlElement = container
+            .query_selector("#before")
+            .expect("query should succeed")
+            .expect("before should exist")
+            .dyn_into()
+            .expect("before should be HtmlElement");
+        let scope: web_sys::HtmlElement = container
+            .query_selector("#scope")
+            .expect("query should succeed")
+            .expect("scope should exist")
+            .dyn_into()
+            .expect("scope should be HtmlElement");
+        let active = Arc::new(AtomicBool::new(true));
+
+        before.focus().expect("focus before");
+
+        super::request_focus_after_frame(scope, restore_target(), Arc::clone(&active));
+        active.store(false, Ordering::Relaxed);
+        animation_frame_turn().await;
+
+        assert_eq!(
+            document()
+                .active_element()
+                .and_then(|element| element.get_attribute("id"))
+                .as_deref(),
+            Some("before")
+        );
+    }
+
+    #[wasm_bindgen_test(async)]
+    async fn setup_focus_scope_retries_until_body_is_marked_hydrated() {
+        reset_body();
+
+        let container = append_html(
+            r#"<button id="before">before</button><section id="scope"><button id="target">target</button></section>"#,
+        );
+        let before: web_sys::HtmlElement = container
+            .query_selector("#before")
+            .expect("query should succeed")
+            .expect("before should exist")
+            .dyn_into()
+            .expect("before should be HtmlElement");
+
+        before.focus().expect("focus before");
+
+        let owner = Owner::new();
+        owner.with(|| {
+            super::setup_focus_scope_hydration_safe(String::from("scope"), restore_target());
+        });
+
+        leptos::task::tick().await;
+        animation_frame_turn().await;
+
+        assert_eq!(
+            document()
+                .active_element()
+                .and_then(|element| element.get_attribute("id"))
+                .as_deref(),
+            Some("before")
+        );
+
+        super::mark_body_hydrated();
+        animation_frame_turn().await;
+        animation_frame_turn().await;
+
+        assert_eq!(
+            document()
+                .active_element()
+                .and_then(|element| element.get_attribute("id"))
+                .as_deref(),
+            Some("target")
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn hydration_mismatch_warning_message_matches_contract() {
+        assert_eq!(
+            super::hydration_id_mismatch_message("ars-dialog-7", "ars-dialog-9"),
+            "ars-ui hydration ID mismatch: server='ars-dialog-7', client='ars-dialog-9'. Component IDs may be non-deterministic across SSR/client boundaries."
+        );
+    }
+}

--- a/crates/ars-leptos/src/hydration.rs
+++ b/crates/ars-leptos/src/hydration.rs
@@ -10,7 +10,7 @@ use std::sync::{
     atomic::{AtomicBool, Ordering},
 };
 
-#[cfg(feature = "ssr")]
+#[cfg(any(feature = "ssr", all(feature = "hydrate", target_arch = "wasm32")))]
 pub use ars_core::HydrationSnapshot;
 #[cfg(feature = "ssr")]
 use ars_core::{HasId, Machine, Service};

--- a/crates/ars-leptos/src/lib.rs
+++ b/crates/ars-leptos/src/lib.rs
@@ -16,6 +16,7 @@ mod controlled;
 pub mod dismissable;
 mod ephemeral;
 mod event_mapping;
+mod hydration;
 mod id;
 mod nonce;
 pub mod prelude;
@@ -36,6 +37,12 @@ pub use controlled::use_controlled_prop;
 pub use ephemeral::EphemeralRef;
 pub use event_mapping::leptos_key_to_keyboard_key;
 #[cfg(feature = "ssr")]
+pub use hydration::{HydrationSnapshot, serialize_snapshot};
+#[cfg(all(feature = "hydrate", target_arch = "wasm32"))]
+pub use hydration::{
+    mark_body_hydrated, setup_focus_scope_hydration_safe, warn_if_mounted_id_mismatch,
+};
+#[cfg(feature = "ssr")]
 pub use id::reset_id_counter;
 pub use id::use_id;
 pub use nonce::{
@@ -51,6 +58,8 @@ pub use safe_listener::{
     SafeEventListener, SafeEventListenerOptions, use_safe_event_listener, use_safe_event_listeners,
 };
 pub use use_machine::{UseMachineReturn, use_machine, use_machine_with_reactive_props};
+#[cfg(feature = "ssr")]
+pub use use_machine::{use_machine_hydrated, use_machine_with_reactive_props_hydrated};
 
 /// The name of this framework adapter, used in diagnostic messages and feature gating.
 pub const ADAPTER_NAME: &str = "leptos";

--- a/crates/ars-leptos/src/lib.rs
+++ b/crates/ars-leptos/src/lib.rs
@@ -36,8 +36,10 @@ pub use callbacks::{emit, emit_map};
 pub use controlled::use_controlled_prop;
 pub use ephemeral::EphemeralRef;
 pub use event_mapping::leptos_key_to_keyboard_key;
+#[cfg(any(feature = "ssr", all(feature = "hydrate", target_arch = "wasm32")))]
+pub use hydration::HydrationSnapshot;
 #[cfg(feature = "ssr")]
-pub use hydration::{HydrationSnapshot, serialize_snapshot};
+pub use hydration::serialize_snapshot;
 #[cfg(all(feature = "hydrate", target_arch = "wasm32"))]
 pub use hydration::{
     mark_body_hydrated, setup_focus_scope_hydration_safe, warn_if_mounted_id_mismatch,
@@ -58,7 +60,7 @@ pub use safe_listener::{
     SafeEventListener, SafeEventListenerOptions, use_safe_event_listener, use_safe_event_listeners,
 };
 pub use use_machine::{UseMachineReturn, use_machine, use_machine_with_reactive_props};
-#[cfg(feature = "ssr")]
+#[cfg(any(feature = "ssr", all(feature = "hydrate", target_arch = "wasm32")))]
 pub use use_machine::{use_machine_hydrated, use_machine_with_reactive_props_hydrated};
 
 /// The name of this framework adapter, used in diagnostic messages and feature gating.

--- a/crates/ars-leptos/src/provider.rs
+++ b/crates/ars-leptos/src/provider.rs
@@ -131,6 +131,27 @@ pub(crate) fn current_ars_context() -> Option<ArsContext> {
     use_context::<ArsContext>()
 }
 
+#[cfg(all(feature = "hydrate", target_arch = "wasm32"))]
+#[derive(Clone, Copy)]
+struct ArsProviderRootMarker;
+
+#[cfg(all(feature = "hydrate", target_arch = "wasm32"))]
+fn is_root_ars_provider() -> bool {
+    use_context::<ArsProviderRootMarker>().is_none()
+}
+
+#[cfg(all(feature = "hydrate", target_arch = "wasm32"))]
+fn provide_ars_provider_root_marker() {
+    provide_context(ArsProviderRootMarker);
+}
+
+#[cfg(all(feature = "hydrate", target_arch = "wasm32"))]
+fn mark_body_hydrated_for_provider(is_root_provider: bool) {
+    if is_root_provider {
+        crate::hydration::mark_body_hydrated();
+    }
+}
+
 /// Publishes [`ArsContext`] into Leptos context.
 pub fn provide_ars_context(context: ArsContext) {
     provide_context(context);
@@ -190,7 +211,15 @@ pub fn ArsProvider(
     };
 
     #[cfg(all(feature = "hydrate", target_arch = "wasm32"))]
-    Effect::new(|_| crate::hydration::mark_body_hydrated());
+    let is_root_provider = is_root_ars_provider();
+
+    #[cfg(all(feature = "hydrate", target_arch = "wasm32"))]
+    provide_ars_provider_root_marker();
+
+    #[cfg(all(feature = "hydrate", target_arch = "wasm32"))]
+    Effect::new(move |_| {
+        mark_body_hydrated_for_provider(is_root_provider);
+    });
 
     use_nonce_css_context_provider();
 
@@ -832,8 +861,10 @@ mod wasm_tests {
     };
     use ars_i18n::{Direction, IntlBackend, Locale, StubIntlBackend, Translate, locales, number};
     use leptos::prelude::*;
+    #[cfg(any(feature = "csr", feature = "hydrate"))]
+    use leptos::web_sys;
     #[cfg(feature = "csr")]
-    use leptos::{mount::mount_to, wasm_bindgen::JsCast, web_sys};
+    use leptos::{mount::mount_to, wasm_bindgen::JsCast};
     use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
 
     #[cfg(feature = "csr")]
@@ -1264,12 +1295,54 @@ mod wasm_tests {
         });
     }
 
-    #[cfg(feature = "csr")]
+    #[cfg(any(feature = "csr", feature = "hydrate"))]
     fn document() -> web_sys::Document {
         web_sys::window()
             .expect("window should exist")
             .document()
             .expect("document should exist")
+    }
+
+    #[cfg(feature = "hydrate")]
+    fn body() -> web_sys::HtmlElement {
+        document().body().expect("body should exist")
+    }
+
+    #[cfg(feature = "hydrate")]
+    #[wasm_bindgen_test]
+    fn nested_provider_marker_does_not_mark_body_hydrated_on_wasm() {
+        let owner = Owner::new();
+
+        owner.with(|| {
+            let body = body();
+
+            drop(body.remove_attribute("data-ars-hydrated"));
+            super::provide_ars_provider_root_marker();
+
+            assert!(!super::is_root_ars_provider());
+
+            super::mark_body_hydrated_for_provider(super::is_root_ars_provider());
+
+            assert_eq!(body.get_attribute("data-ars-hydrated"), None);
+        });
+    }
+
+    #[cfg(feature = "hydrate")]
+    #[wasm_bindgen_test]
+    fn root_provider_marker_marks_body_hydrated_on_wasm() {
+        let owner = Owner::new();
+
+        owner.with(|| {
+            let body = body();
+
+            drop(body.remove_attribute("data-ars-hydrated"));
+
+            assert!(super::is_root_ars_provider());
+
+            super::mark_body_hydrated_for_provider(super::is_root_ars_provider());
+
+            assert_eq!(body.get_attribute("data-ars-hydrated").as_deref(), Some(""));
+        });
     }
 
     #[cfg(feature = "csr")]

--- a/crates/ars-leptos/src/provider.rs
+++ b/crates/ars-leptos/src/provider.rs
@@ -189,6 +189,9 @@ pub fn ArsProvider(
         StyleStrategy::Inline | StyleStrategy::Cssom => None,
     };
 
+    #[cfg(all(feature = "hydrate", target_arch = "wasm32"))]
+    Effect::new(|_| crate::hydration::mark_body_hydrated());
+
     use_nonce_css_context_provider();
 
     provide_ars_context(ArsContext {

--- a/crates/ars-leptos/src/use_machine/mod.rs
+++ b/crates/ars-leptos/src/use_machine/mod.rs
@@ -419,9 +419,10 @@ where
 {
     let props = {
         let mut props = props;
+        let generated_id = use_id("component");
 
         if props.id().is_empty() {
-            props.set_id(use_id("component"));
+            props.set_id(generated_id);
         }
 
         props

--- a/crates/ars-leptos/src/use_machine/mod.rs
+++ b/crates/ars-leptos/src/use_machine/mod.rs
@@ -9,6 +9,8 @@ use std::{
     fmt::{self, Debug},
 };
 
+#[cfg(feature = "ssr")]
+use ars_core::HydrationSnapshot;
 use ars_core::{CleanupFn, Env, HasId, Machine, RenderMode, Service};
 use leptos::{prelude::*, reactive::owner::LocalStorage};
 #[cfg(any(all(test, target_arch = "wasm32"), not(feature = "ssr")))]
@@ -225,7 +227,32 @@ where
     M::Event: Send + Sync + 'static,
     M::Messages: Send + Sync + 'static,
 {
-    let (result, ..) = use_machine_inner::<M>(props);
+    let (result, ..) = use_machine_inner::<M>(props, None);
+
+    result
+}
+
+/// Creates and manages a machine service from an SSR hydration snapshot.
+///
+/// The snapshot state is installed with [`Service::new_hydrated`] so the
+/// client preserves server-rendered machine state while recomputing context
+/// from the current adapter environment.
+#[cfg(feature = "ssr")]
+pub fn use_machine_hydrated<M: Machine + 'static>(
+    props: M::Props,
+    snapshot: HydrationSnapshot<M>,
+) -> UseMachineReturn<M>
+where
+    M::State: Clone + PartialEq + Send + Sync + 'static,
+    M::Context: Clone + Send + Sync + 'static,
+    M::Props: Clone + PartialEq + Send + Sync + 'static,
+    M::Event: Send + Sync + 'static,
+    M::Messages: Send + Sync + 'static,
+{
+    let (result, ..) = use_machine_inner::<M>(
+        props_with_snapshot_id::<M>(props, &snapshot),
+        Some(snapshot.state),
+    );
 
     result
 }
@@ -247,8 +274,41 @@ where
 {
     let initial_props = props_signal.get();
 
+    use_machine_with_reactive_props_inner::<M>(props_signal, initial_props, None)
+}
+
+/// Creates a reactive-props machine service from an SSR hydration snapshot.
+#[cfg(feature = "ssr")]
+pub fn use_machine_with_reactive_props_hydrated<M: Machine + 'static>(
+    props_signal: Signal<M::Props>,
+    snapshot: HydrationSnapshot<M>,
+) -> UseMachineReturn<M>
+where
+    M::State: Clone + PartialEq + Send + Sync + 'static,
+    M::Context: Clone + Send + Sync + 'static,
+    M::Props: Clone + PartialEq + Send + Sync + 'static,
+    M::Event: Send + Sync + 'static,
+    M::Messages: Send + Sync + 'static,
+{
+    let initial_props = props_with_snapshot_id::<M>(props_signal.get(), &snapshot);
+
+    use_machine_with_reactive_props_inner::<M>(props_signal, initial_props, Some(snapshot.state))
+}
+
+fn use_machine_with_reactive_props_inner<M: Machine + 'static>(
+    props_signal: Signal<M::Props>,
+    initial_props: M::Props,
+    hydrated_state: Option<M::State>,
+) -> UseMachineReturn<M>
+where
+    M::State: Clone + PartialEq + Send + Sync + 'static,
+    M::Context: Clone + Send + Sync + 'static,
+    M::Props: Clone + PartialEq + Send + Sync + 'static,
+    M::Event: Send + Sync + 'static,
+    M::Messages: Send + Sync + 'static,
+{
     let (result, context_version_write, state_write, send_ref, effect_cleanups) =
-        use_machine_inner::<M>(initial_props);
+        use_machine_inner::<M>(initial_props, hydrated_state);
 
     let service = result.service;
 
@@ -314,6 +374,24 @@ fn props_with_service_id<M: Machine>(mut props: M::Props, service_id: &str) -> M
     props
 }
 
+#[cfg(feature = "ssr")]
+fn props_with_snapshot_id<M: Machine>(
+    mut props: M::Props,
+    snapshot: &HydrationSnapshot<M>,
+) -> M::Props {
+    if props.id().is_empty() {
+        props.set_id(snapshot.id.clone());
+    } else {
+        assert_eq!(
+            props.id(),
+            snapshot.id,
+            "HydrationSnapshot id must match Props::id"
+        );
+    }
+
+    props
+}
+
 type EffectCleanupStore = StoredValue<HashMap<&'static str, CleanupFn>, LocalStorage>;
 type SendCallbackRef<M> = StoredValue<Option<Callback<<M as Machine>::Event>>>;
 type UseMachineInnerParts<M> = (
@@ -328,7 +406,10 @@ type UseMachineInnerParts<M> = (
 ///
 /// Returns the public `UseMachineReturn` plus internal write handles needed by
 /// `use_machine_with_reactive_props` for syncing external prop changes.
-fn use_machine_inner<M: Machine + 'static>(props: M::Props) -> UseMachineInnerParts<M>
+fn use_machine_inner<M: Machine + 'static>(
+    props: M::Props,
+    hydrated_state: Option<M::State>,
+) -> UseMachineInnerParts<M>
 where
     M::State: Clone + PartialEq + Send + Sync + 'static,
     M::Context: Clone + Send + Sync + 'static,
@@ -355,7 +436,20 @@ where
     let env = Env::new(locale, intl_backend).with_render_mode(current_render_mode());
 
     // Create the service once — runs only on component initialization.
-    let service = StoredValue::new(Service::<M>::new(props, &env, &messages));
+    let service = StoredValue::new(if let Some(state) = hydrated_state {
+        #[cfg(feature = "ssr")]
+        {
+            Service::<M>::new_hydrated(props, state, &env, &messages)
+        }
+
+        #[cfg(not(feature = "ssr"))]
+        {
+            drop(state);
+            Service::<M>::new(props, &env, &messages)
+        }
+    } else {
+        Service::<M>::new(props, &env, &messages)
+    });
 
     // Create a signal tracking the current state.
     let initial_state = service.with_value(|s| s.state().clone());

--- a/crates/ars-leptos/src/use_machine/mod.rs
+++ b/crates/ars-leptos/src/use_machine/mod.rs
@@ -9,7 +9,7 @@ use std::{
     fmt::{self, Debug},
 };
 
-#[cfg(feature = "ssr")]
+#[cfg(any(feature = "ssr", all(feature = "hydrate", target_arch = "wasm32")))]
 use ars_core::HydrationSnapshot;
 use ars_core::{CleanupFn, Env, HasId, Machine, RenderMode, Service};
 use leptos::{prelude::*, reactive::owner::LocalStorage};
@@ -59,10 +59,10 @@ where
 }
 
 #[cfg(feature = "hydrate")]
-fn current_render_mode() -> RenderMode {
-    if cfg!(feature = "ssr") {
+fn current_render_mode(hydrated_snapshot: bool) -> RenderMode {
+    if cfg!(all(feature = "ssr", not(target_arch = "wasm32"))) {
         RenderMode::Server
-    } else if is_currently_hydrating() {
+    } else if hydrated_snapshot || is_currently_hydrating() {
         RenderMode::Hydrating
     } else {
         RenderMode::Client
@@ -70,7 +70,7 @@ fn current_render_mode() -> RenderMode {
 }
 
 #[cfg(not(feature = "hydrate"))]
-const fn current_render_mode() -> RenderMode {
+const fn current_render_mode(_hydrated_snapshot: bool) -> RenderMode {
     if cfg!(feature = "ssr") {
         RenderMode::Server
     } else {
@@ -237,7 +237,7 @@ where
 /// The snapshot state is installed with [`Service::new_hydrated`] so the
 /// client preserves server-rendered machine state while recomputing context
 /// from the current adapter environment.
-#[cfg(feature = "ssr")]
+#[cfg(any(feature = "ssr", all(feature = "hydrate", target_arch = "wasm32")))]
 pub fn use_machine_hydrated<M: Machine + 'static>(
     props: M::Props,
     snapshot: HydrationSnapshot<M>,
@@ -278,7 +278,7 @@ where
 }
 
 /// Creates a reactive-props machine service from an SSR hydration snapshot.
-#[cfg(feature = "ssr")]
+#[cfg(any(feature = "ssr", all(feature = "hydrate", target_arch = "wasm32")))]
 pub fn use_machine_with_reactive_props_hydrated<M: Machine + 'static>(
     props_signal: Signal<M::Props>,
     snapshot: HydrationSnapshot<M>,
@@ -374,7 +374,7 @@ fn props_with_service_id<M: Machine>(mut props: M::Props, service_id: &str) -> M
     props
 }
 
-#[cfg(feature = "ssr")]
+#[cfg(any(feature = "ssr", all(feature = "hydrate", target_arch = "wasm32")))]
 fn props_with_snapshot_id<M: Machine>(
     mut props: M::Props,
     snapshot: &HydrationSnapshot<M>,
@@ -433,16 +433,17 @@ where
 
     let messages = use_messages::<M::Messages>(None, Some(&locale));
 
-    let env = Env::new(locale, intl_backend).with_render_mode(current_render_mode());
+    let env = Env::new(locale, intl_backend)
+        .with_render_mode(current_render_mode(hydrated_state.is_some()));
 
     // Create the service once — runs only on component initialization.
     let service = StoredValue::new(if let Some(state) = hydrated_state {
-        #[cfg(feature = "ssr")]
+        #[cfg(any(feature = "ssr", all(feature = "hydrate", target_arch = "wasm32")))]
         {
             Service::<M>::new_hydrated(props, state, &env, &messages)
         }
 
-        #[cfg(not(feature = "ssr"))]
+        #[cfg(not(any(feature = "ssr", all(feature = "hydrate", target_arch = "wasm32"))))]
         {
             drop(state);
             Service::<M>::new(props, &env, &messages)

--- a/crates/ars-leptos/src/use_machine/wasm_tests.rs
+++ b/crates/ars-leptos/src/use_machine/wasm_tests.rs
@@ -1,13 +1,19 @@
 use std::sync::{Arc, Mutex};
 
 use ars_components::overlay::presence;
-use ars_core::{ConnectApi, HtmlAttr};
+use ars_core::{ConnectApi, HtmlAttr, RenderMode};
 use leptos::reactive::traits::GetUntracked;
 use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
 
 use super::{test_support::*, *};
 
 wasm_bindgen_test_configure!(run_in_browser);
+
+#[wasm_bindgen_test]
+fn current_render_mode_reports_client_or_hydrating_on_wasm() {
+    assert_eq!(current_render_mode(false), RenderMode::Client);
+    assert_eq!(current_render_mode(true), RenderMode::Hydrating);
+}
 
 #[wasm_bindgen_test]
 fn callback_to_strong_send_uses_wasm_send_handle() {
@@ -49,6 +55,25 @@ fn use_machine_updates_state_on_wasm() {
         machine.send.run(ToggleEvent::Toggle);
 
         assert_eq!(machine.state.get_untracked(), ToggleState::On);
+    });
+}
+
+#[wasm_bindgen_test]
+fn use_machine_hydrated_preserves_snapshot_on_wasm() {
+    let owner = Owner::new();
+    owner.with(|| {
+        let machine = use_machine_hydrated::<ToggleMachine>(
+            ToggleProps { id: String::new() },
+            HydrationSnapshot {
+                state: ToggleState::On,
+                id: String::from("toggle-hydrated"),
+            },
+        );
+
+        assert_eq!(machine.state.get_untracked(), ToggleState::On);
+        machine.service.with_value(|service| {
+            assert_eq!(service.props().id(), "toggle-hydrated");
+        });
     });
 }
 

--- a/crates/ars-leptos/src/use_machine/wasm_tests.rs
+++ b/crates/ars-leptos/src/use_machine/wasm_tests.rs
@@ -12,7 +12,12 @@ wasm_bindgen_test_configure!(run_in_browser);
 #[wasm_bindgen_test]
 fn current_render_mode_reports_client_or_hydrating_on_wasm() {
     assert_eq!(current_render_mode(false), RenderMode::Client);
+
+    #[cfg(feature = "hydrate")]
     assert_eq!(current_render_mode(true), RenderMode::Hydrating);
+
+    #[cfg(not(feature = "hydrate"))]
+    assert_eq!(current_render_mode(true), RenderMode::Client);
 }
 
 #[wasm_bindgen_test]
@@ -59,6 +64,7 @@ fn use_machine_updates_state_on_wasm() {
 }
 
 #[wasm_bindgen_test]
+#[cfg(feature = "hydrate")]
 fn use_machine_hydrated_preserves_snapshot_on_wasm() {
     let owner = Owner::new();
     owner.with(|| {

--- a/crates/ars-leptos/tests/unit/use_machine.rs
+++ b/crates/ars-leptos/tests/unit/use_machine.rs
@@ -488,6 +488,94 @@ fn use_machine_injects_generated_id_when_props_id_is_empty() {
     });
 }
 
+#[cfg(feature = "ssr")]
+#[test]
+fn use_machine_hydrated_preserves_snapshot_state_and_id() {
+    let owner = Owner::new();
+    owner.with(|| {
+        let machine = use_machine_hydrated::<ToggleMachine>(
+            ToggleProps { id: String::new() },
+            HydrationSnapshot::<ToggleMachine> {
+                state: ToggleState::On,
+                id: String::from("toggle-hydrated"),
+            },
+        );
+
+        assert_eq!(machine.state.get_untracked(), ToggleState::On);
+        machine.service.with_value(|service| {
+            assert_eq!(service.state(), &ToggleState::On);
+            assert_eq!(service.props().id(), "toggle-hydrated");
+        });
+    });
+}
+
+#[cfg(feature = "ssr")]
+#[test]
+#[should_panic(expected = "HydrationSnapshot id must match Props::id")]
+fn use_machine_hydrated_rejects_mismatched_explicit_props_id() {
+    let owner = Owner::new();
+    owner.with(|| {
+        let _machine = use_machine_hydrated::<ToggleMachine>(
+            ToggleProps {
+                id: String::from("client-id"),
+            },
+            HydrationSnapshot::<ToggleMachine> {
+                state: ToggleState::On,
+                id: String::from("server-id"),
+            },
+        );
+    });
+}
+
+#[cfg(feature = "ssr")]
+#[test]
+fn use_machine_with_reactive_props_hydrated_keeps_syncing_props() {
+    let owner = Owner::new();
+    owner.with(|| {
+        let (props, set_props) = signal(PropProps {
+            id: String::new(),
+            checked: false,
+            label: "a",
+        });
+
+        let machine = use_machine_with_reactive_props_hydrated::<PropMachine>(
+            props.into(),
+            HydrationSnapshot::<PropMachine> {
+                state: PropState::On,
+                id: String::from("prop-hydrated"),
+            },
+        );
+
+        assert_eq!(machine.state.get_untracked(), PropState::On);
+        machine.service.with_value(|service| {
+            assert_eq!(service.props().id(), "prop-hydrated");
+        });
+
+        set_props.set(PropProps {
+            id: String::new(),
+            checked: true,
+            label: "b",
+        });
+
+        assert_eq!(machine.state.get_untracked(), PropState::On);
+        assert_eq!(machine.context_version.get_untracked(), 1);
+
+        set_props.set(PropProps {
+            id: String::new(),
+            checked: false,
+            label: "b",
+        });
+
+        assert_eq!(machine.state.get_untracked(), PropState::Off);
+        assert_eq!(machine.context_version.get_untracked(), 1);
+
+        machine.service.with_value(|service| {
+            assert_eq!(service.props().id(), "prop-hydrated");
+            assert_eq!(service.context().sync_count, 1);
+        });
+    });
+}
+
 #[test]
 fn use_machine_with_reactive_props_syncs_state_and_context_changes() {
     let owner = Owner::new();

--- a/crates/ars-leptos/tests/unit/use_machine.rs
+++ b/crates/ars-leptos/tests/unit/use_machine.rs
@@ -78,7 +78,8 @@ fn current_render_mode_reports_server_for_ssr_builds() {
         #[cfg(feature = "hydrate")]
         provide_context(IsHydrating(true));
 
-        assert_eq!(current_render_mode(), RenderMode::Server);
+        assert_eq!(current_render_mode(false), RenderMode::Server);
+        assert_eq!(current_render_mode(true), RenderMode::Server);
     });
 }
 
@@ -87,7 +88,13 @@ fn current_render_mode_reports_server_for_ssr_builds() {
 fn current_render_mode_reports_client_without_active_hydration() {
     let owner = Owner::new();
     owner.with(|| {
-        assert_eq!(current_render_mode(), RenderMode::Client);
+        assert_eq!(current_render_mode(false), RenderMode::Client);
+
+        #[cfg(feature = "hydrate")]
+        assert_eq!(current_render_mode(true), RenderMode::Hydrating);
+
+        #[cfg(not(feature = "hydrate"))]
+        assert_eq!(current_render_mode(true), RenderMode::Client);
     });
 }
 
@@ -98,13 +105,14 @@ fn current_render_mode_uses_hydration_context_at_runtime() {
     owner.with(|| {
         provide_context(IsHydrating(true));
 
-        assert_eq!(current_render_mode(), RenderMode::Hydrating);
+        assert_eq!(current_render_mode(false), RenderMode::Hydrating);
     });
 
     owner.with(|| {
         provide_context(IsHydrating(false));
 
-        assert_eq!(current_render_mode(), RenderMode::Client);
+        assert_eq!(current_render_mode(false), RenderMode::Client);
+        assert_eq!(current_render_mode(true), RenderMode::Hydrating);
     });
 }
 

--- a/crates/ars-leptos/tests/unit/use_machine.rs
+++ b/crates/ars-leptos/tests/unit/use_machine.rs
@@ -519,6 +519,33 @@ fn use_machine_hydrated_preserves_snapshot_state_and_id() {
 
 #[cfg(feature = "ssr")]
 #[test]
+fn use_machine_hydrated_consumes_generated_id_slot() {
+    crate::reset_id_counter();
+
+    let owner = Owner::new();
+    owner.with(|| {
+        let hydrated = use_machine_hydrated::<ToggleMachine>(
+            ToggleProps { id: String::new() },
+            HydrationSnapshot::<ToggleMachine> {
+                state: ToggleState::On,
+                id: String::from("toggle-hydrated"),
+            },
+        );
+
+        let generated = use_machine::<ToggleMachine>(ToggleProps { id: String::new() });
+
+        hydrated.service.with_value(|service| {
+            assert_eq!(service.props().id(), "toggle-hydrated");
+        });
+
+        generated.service.with_value(|service| {
+            assert_eq!(service.props().id(), "component-1");
+        });
+    });
+}
+
+#[cfg(feature = "ssr")]
+#[test]
 #[should_panic(expected = "HydrationSnapshot id must match Props::id")]
 fn use_machine_hydrated_rejects_mismatched_explicit_props_id() {
     let owner = Owner::new();

--- a/spec/foundation/08-adapter-leptos.md
+++ b/spec/foundation/08-adapter-leptos.md
@@ -34,11 +34,13 @@ ars-forms = { workspace = true }
 ars-dom = { workspace = true }
 leptos = "0.8"
 log = { version = "0.4", default-features = false, optional = true }
+serde = { version = "1", default-features = false, features = ["alloc", "derive"], optional = true }
+serde_json = { version = "1", optional = true }
 
 [features]
 default = []
 debug = ["dep:log", "ars-core/debug", "ars-dom/debug", "ars-interactions/debug"]
-ssr = ["leptos/ssr", "ars-dom/ssr"]
+ssr = ["leptos/ssr", "ars-dom/ssr", "ars-core/ssr", "ars-core/serde", "dep:serde", "dep:serde_json"]
 hydrate = ["leptos/hydrate"]
 csr = ["leptos/csr"]
 ```
@@ -619,99 +621,143 @@ During server-side rendering, effects are not executed. The `use_machine` hook g
 
 **Solution.** The following rules govern FocusScope behavior across the SSR-to-hydration boundary:
 
-1. **Emit valid focus targets during SSR.** Server-rendered modal overlays MUST include at least one focusable element in the HTML output. Use `<button autofocus>` or an element with `tabindex="-1"` so that the hydration effect has a valid target.
+1. **Emit valid focus targets during SSR.** Server-rendered modal overlays MUST include at least one focusable element in the HTML output. A naturally focusable control such as a `button` or `input`, an element with `autofocus`, or a focusable scope root with `tabindex="-1"` gives the hydration effect a valid target.
 
-2. **Scan for orphaned `inert` on hydration.** A post-hydration effect queries all elements with `[inert]` and removes the attribute from any element that is not currently a sibling of an open modal. This prevents "frozen" regions left over from SSR. Cleanup of the modal-open marker uses `on_cleanup`.
+2. **Scan for orphaned adapter-owned `inert` on hydration.** A post-hydration effect queries elements with both `[inert]` and `data-ars-modal-inert` and removes both attributes from any marked element that is not currently a sibling of an open modal. This prevents "frozen" regions left over from SSR without clearing author-owned inert regions used for unrelated loading or interaction locks. Cleanup of the modal-open marker uses `on_cleanup`.
 
-3. **Validate focus target existence and visibility.** Before calling `.focus()`, the FocusScope checks that the target element exists and is visible by verifying `element.offset_parent().is_some()`. Elements that are `display: none` or detached return `None` and are skipped.
+3. **Validate focus target existence and visibility.** Before calling `.focus()`, the FocusScope checks the focusable scope root first, then scans all descendants matching the hydration focus selector until it finds a visible target. It accepts elements with an `offsetParent` and visible `position: fixed` elements whose `offsetParent` is `null`, while rejecting `display: none`, `visibility: hidden`, and detached targets.
 
-4. **Gate focus trap activation on hydration completion.** The root provider sets a `data-ars-hydrated` attribute on the document body once hydration is complete. Nested providers MUST NOT repeatedly mark the body; the marker represents the root hydration boundary. FocusScope defers trap activation until this attribute is present, preventing premature focus movement during partial hydration. If the marker is absent when the effect first runs, FocusScope schedules one `request_animation_frame` retry before giving up.
+4. **Gate focus trap activation on hydration completion.** The root provider sets a `data-ars-hydrated` attribute on the document body once hydration is complete. Nested providers MUST NOT repeatedly mark the body; the marker represents the root hydration boundary. FocusScope defers trap activation until this attribute is present, preventing premature focus movement during partial hydration. If the marker is absent when the effect first runs, FocusScope retries through `request_animation_frame` until the marker appears or the scope unmounts.
 
-5. **Use `request_animation_frame` for DOM settlement.** After hydration, focus trap activation is wrapped in a `request_animation_frame` callback to ensure the DOM has fully settled before the trap is engaged.
+5. **Use `request_animation_frame` for DOM settlement.** After hydration, focus trap activation is wrapped in a `request_animation_frame` callback to ensure the DOM has fully settled before the trap is engaged. The deferred focus callback MUST share the cleanup/mounted guard so it no-ops after unmount.
 
 ```rust
-use leptos::prelude::*;
-use wasm_bindgen::JsCast;
+use leptos::{prelude::*, reactive::owner::LocalStorage};
+use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
+use wasm_bindgen::{JsCast, closure::Closure};
 
 /// Hydration-safe FocusScope setup for modal overlays.
 /// Called by FocusScope or Dialog component code after hydration is confirmed.
 fn setup_focus_scope_hydration_safe(
-    scope_ref: NodeRef<html::Div>,
-    restore_target: StoredValue<Option<web_sys::HtmlElement>>,
+    scope_id: String,
+    restore_target: StoredValue<Option<web_sys::HtmlElement>, LocalStorage>,
 ) {
-    // Step 1: Clean up orphaned inert attributes left by SSR.
-    #[cfg(not(feature = "ssr"))]
-    Effect::new(move |_| {
-        let document = document();
+    let cleanup_scope_id = scope_id.clone();
+    let activation_active = Arc::new(AtomicBool::new(true));
 
-        // Gate on hydration completion, with one frame of tolerance for the
-        // root provider marker to settle.
-        let body = document.body().expect("document.body");
-        if body.get_attribute("data-ars-hydrated").is_none() {
-            request_animation_frame(move || {
-                let body = document.body().expect("document.body");
-                if body.get_attribute("data-ars-hydrated").is_some() {
-                    activate_focus_scope(&document, scope_ref, restore_target);
-                }
-            });
-        } else {
-            activate_focus_scope(&document, scope_ref, restore_target);
+    Effect::new({
+        let activation_active = Arc::clone(&activation_active);
+
+        move |_| {
+            let Some(document) = web_sys::window().and_then(|window| window.document()) else {
+                return;
+            };
+
+            if body_is_hydrated(&document) {
+                activate_focus_scope(
+                    &document,
+                    &scope_id,
+                    restore_target,
+                    Arc::clone(&activation_active),
+                );
+            } else {
+                request_hydration_activation_after_frame(
+                    scope_id.clone(),
+                    restore_target,
+                    Arc::clone(&activation_active),
+                );
+            }
         }
     });
 
     on_cleanup(move || {
-        if let Some(scope_el) = scope_ref.get() {
-            let scope_el: web_sys::HtmlElement = scope_el.into();
-            scope_el.remove_attribute("data-ars-modal-open").ok();
+        activation_active.store(false, Ordering::Relaxed);
+
+        if let Some(document) = web_sys::window().and_then(|window| window.document()) {
+            if let Some(scope_el) = document.get_element_by_id(&cleanup_scope_id) {
+                scope_el.remove_attribute("data-ars-modal-open").ok();
+            }
         }
 
-        if let Some(el) = restore_target.get_value().as_ref() {
-            el.focus().ok();
+        restore_target.with_value(|target| {
+            if let Some(el) = target {
+                el.focus().ok();
+            }
+        });
+    });
+}
+
+fn request_hydration_activation_after_frame(
+    scope_id: String,
+    restore_target: StoredValue<Option<web_sys::HtmlElement>, LocalStorage>,
+    activation_active: Arc<AtomicBool>,
+) {
+    let cb = Closure::once_into_js(move || {
+        if !activation_active.load(Ordering::Relaxed) {
+            return;
+        }
+
+        let Some(document) = web_sys::window().and_then(|window| window.document()) else {
+            return;
+        };
+
+        if body_is_hydrated(&document) {
+            activate_focus_scope(&document, &scope_id, restore_target, activation_active);
+        } else {
+            request_hydration_activation_after_frame(scope_id, restore_target, activation_active);
         }
     });
+
+    web_sys::window()
+        .expect("window must exist")
+        .request_animation_frame(cb.unchecked_ref())
+        .ok();
+}
+
+fn body_is_hydrated(document: &web_sys::Document) -> bool {
+    document
+        .body()
+        .and_then(|body| body.get_attribute("data-ars-hydrated"))
+        .is_some()
 }
 
 fn activate_focus_scope(
     document: &web_sys::Document,
-    scope_ref: NodeRef<html::Div>,
-    restore_target: StoredValue<Option<web_sys::HtmlElement>>,
+    scope_id: &str,
+    restore_target: StoredValue<Option<web_sys::HtmlElement>, LocalStorage>,
+    activation_active: Arc<AtomicBool>,
 ) {
-    let scope_el = scope_ref.get().map(|node| {
-        let scope_el: web_sys::HtmlElement = node.into();
-        scope_el.set_attribute("data-ars-modal-open", "").ok();
-        scope_el
-    });
+    let scope_el = document
+        .get_element_by_id(scope_id)
+        .and_then(|el| el.dyn_into::<web_sys::HtmlElement>().ok());
 
-    // Remove orphaned inert attributes. An inert element is retained while
-    // it remains a sibling of the hydrated modal scope.
+    if let Some(scope_el) = scope_el.as_ref() {
+        scope_el.set_attribute("data-ars-modal-open", "").ok();
+    }
+
+    // Remove adapter-owned orphaned inert attributes. An inert element is retained
+    // while it remains a sibling of the hydrated modal scope.
     let inert_elements = document
-        .query_selector_all("[inert]")
+        .query_selector_all("[inert][data-ars-modal-inert]")
         .expect("querySelectorAll");
     for i in 0..inert_elements.length() {
         if let Some(el) = inert_elements.item(i) {
             let html_el: web_sys::Element = el.unchecked_into();
-            // Only remove if no open modal is a sibling.
             if !has_open_modal_sibling(&html_el) {
                 html_el.remove_attribute("inert").ok();
+                html_el.remove_attribute(ars_dom::portal::MODAL_INERT_ATTR).ok();
             }
         }
     }
 
-    // Step 2: Activate focus trap after DOM settles.
     if let Some(scope_el) = scope_el {
         let document = document.clone();
-        request_animation_frame(move || {
-            // Validate target exists and is visible.
-            let target = scope_el
-                .query_selector("[autofocus], [tabindex]")
-                .ok()
-                .flatten()
-                .and_then(|el| el.dyn_into::<web_sys::HtmlElement>().ok())
-                .filter(|el| el.offset_parent().is_some());
+        let cb = Closure::once_into_js(move || {
+            if !activation_active.load(Ordering::Relaxed) {
+                return;
+            }
 
-            if let Some(el) = target {
-                // Save the currently focused element BEFORE moving focus,
-                // so it can be restored when the scope is deactivated.
+            if let Some(el) = visible_focus_target(&scope_el) {
                 restore_target.set_value(
                     document
                         .active_element()
@@ -720,8 +766,92 @@ fn activate_focus_scope(
                 el.focus().ok();
             }
         });
+
+        web_sys::window()
+            .expect("window must exist")
+            .request_animation_frame(cb.unchecked_ref())
+            .ok();
     }
 }
+
+fn visible_focus_target(scope: &web_sys::HtmlElement) -> Option<web_sys::HtmlElement> {
+    if is_focus_target_candidate(scope) && is_visible_focus_target(scope) {
+        return Some(scope.clone());
+    }
+
+    scope
+        .query_selector_all(HYDRATION_FOCUS_TARGET_SELECTOR)
+        .ok()
+        .and_then(|elements| {
+            for index in 0..elements.length() {
+                let Some(node) = elements.item(index) else {
+                    continue;
+                };
+
+                let Ok(element) = node.dyn_into::<web_sys::HtmlElement>() else {
+                    continue;
+                };
+
+                if is_visible_focus_target(&element) {
+                    return Some(element);
+                }
+            }
+
+            None
+        })
+}
+
+fn is_visible_focus_target(element: &web_sys::HtmlElement) -> bool {
+    element.offset_parent().is_some() || is_visible_fixed_position_target(element)
+}
+
+fn is_visible_fixed_position_target(element: &web_sys::HtmlElement) -> bool {
+    let Some(window) = web_sys::window() else {
+        return false;
+    };
+
+    let Ok(Some(style)) = window.get_computed_style(element) else {
+        return false;
+    };
+
+    style.get_property_value("position").as_deref() == Ok("fixed")
+        && style.get_property_value("display").as_deref() != Ok("none")
+        && style.get_property_value("visibility").as_deref() != Ok("hidden")
+}
+
+fn is_focus_target_candidate(element: &web_sys::Element) -> bool {
+    if element.has_attribute("disabled") {
+        return false;
+    }
+
+    if element.get_attribute("aria-hidden").as_deref() == Some("true") {
+        return false;
+    }
+
+    if element.has_attribute("autofocus") || element.has_attribute("tabindex") {
+        return true;
+    }
+
+    match element.tag_name().as_str() {
+        "BUTTON" | "INPUT" | "SELECT" | "TEXTAREA" => true,
+        "A" | "AREA" => element.has_attribute("href"),
+        _ => element
+            .get_attribute("contenteditable")
+            .is_some_and(|value| value != "false"),
+    }
+}
+
+const HYDRATION_FOCUS_TARGET_SELECTOR: &str = concat!(
+    "[autofocus]:not([disabled]):not([aria-hidden='true']),",
+    "button:not([disabled]):not([aria-hidden='true']),",
+    "input:not([disabled]):not([aria-hidden='true']),",
+    "select:not([disabled]):not([aria-hidden='true']),",
+    "textarea:not([disabled]):not([aria-hidden='true']),",
+    "a[href]:not([aria-hidden='true']),",
+    "area[href]:not([aria-hidden='true']),",
+    "[tabindex]:not([disabled]):not([aria-hidden='true']),",
+    "[contenteditable]:not([contenteditable='false']):not([aria-hidden='true'])",
+);
 
 fn has_open_modal_sibling(element: &web_sys::Element) -> bool {
     let Some(parent) = element.parent_element() else {
@@ -1667,7 +1797,9 @@ server and client halves of a hydration round-trip from disagreeing on
 field layout.
 
 ```rust
-use ars_core::{HydrationSnapshot, Machine, Service};
+#[cfg(feature = "ssr")]
+pub use ars_core::HydrationSnapshot;
+use ars_core::{HasId, Machine, Service};
 
 // In SSR mode: embed a snapshot in HTML via a script tag.
 #[cfg(feature = "ssr")]
@@ -1684,7 +1816,8 @@ where
 }
 
 // In hydration mode: read the snapshot and initialize the machine from it
-// via `Service::new_hydrated(props, snapshot.state, &env, &messages)`.
+// via `use_machine_hydrated(props, snapshot)`, which internally calls
+// `Service::new_hydrated(props, snapshot.state, &env, &messages)`.
 // This ensures the machine starts in the same state the server rendered.
 ```
 

--- a/spec/foundation/08-adapter-leptos.md
+++ b/spec/foundation/08-adapter-leptos.md
@@ -232,21 +232,22 @@ This eliminates the use-after-free class of bugs where `Api<'a>` outlives the `S
 
 > **Note:** `EphemeralRef` / `with_api_ephemeral()` is for imperative, non-reactive API access (e.g., inside event handlers). For reactive derived values, use `machine.derive(|api| ...)` which returns a `Memo<T>`. These are complementary patterns: derive() for render-time reads, EphemeralRef for event-time reads.
 
-### 3.2 Hydration-Safe Component IDs
+### 3.2 Component IDs and Hydration
 
-The Leptos adapter MUST use `use_id()` (a global monotonic counter) for all component IDs to ensure SSR/hydration consistency. The counter produces the same sequence on server and client when the component tree renders in the same order. The ID resolution order is:
+The Leptos adapter MUST prefer explicit component IDs for hydrated SSR paths.
+Generated adapter IDs are unique within a render pass and stable only when the
+server and client render the same hook sequence. The ID resolution order is:
 
 1. **`props.id` takes priority** — If the consumer provides an explicit `id` prop, use it as-is. The consumer is responsible for ensuring uniqueness and hydration stability.
-2. **`use_id()` fallback** — If `props.id` is empty, the adapter calls `use_id("component")` to generate a hydration-safe ID. The global `ID_COUNTER` produces deterministic IDs as long as SSR and client render components in the same tree order. `reset_id_counter()` must be called at the start of each SSR request.
+2. **`use_id()` fallback** — If `props.id` is empty, the adapter calls `use_id("component")` to generate a fallback ID. The global `ID_COUNTER` produces deterministic IDs only when SSR and client render components in the same tree order. `reset_id_counter()` must be called at the start of each SSR request to avoid cross-request leakage, but it does not make generated IDs safe when render order diverges.
 
 ```rust
 // In use_machine_inner():
 let props = {
     let mut p = props;
     if p.id().is_empty() {
-        // use_id() returns a deterministic ID that matches between SSR and hydration.
-        // This is critical: non-deterministic IDs (e.g., random UUIDs) cause hydration
-        // mismatches, breaking ARIA linkage (label-for, describedby, etc.).
+        // Generated fallback IDs are stable only when SSR and hydration render
+        // the same hook path. Hydrated components should prefer explicit IDs.
         p.set_id(use_id("component"));
     }
     p
@@ -620,20 +621,20 @@ During server-side rendering, effects are not executed. The `use_machine` hook g
 
 1. **Emit valid focus targets during SSR.** Server-rendered modal overlays MUST include at least one focusable element in the HTML output. Use `<button autofocus>` or an element with `tabindex="-1"` so that the hydration effect has a valid target.
 
-2. **Scan for orphaned `inert` on hydration.** A post-hydration effect queries all elements with `[inert]` and removes the attribute from any element that is not currently a sibling of an open modal. This prevents "frozen" regions left over from SSR.
+2. **Scan for orphaned `inert` on hydration.** A post-hydration effect queries all elements with `[inert]` and removes the attribute from any element that is not currently a sibling of an open modal. This prevents "frozen" regions left over from SSR. Cleanup of the modal-open marker uses `on_cleanup`.
 
 3. **Validate focus target existence and visibility.** Before calling `.focus()`, the FocusScope checks that the target element exists and is visible by verifying `element.offset_parent().is_some()`. Elements that are `display: none` or detached return `None` and are skipped.
 
-4. **Gate focus trap activation on hydration completion.** The adapter sets a `data-ars-hydrated` attribute on the document body once hydration is complete. FocusScope defers trap activation until this attribute is present, preventing premature focus movement during partial hydration.
+4. **Gate focus trap activation on hydration completion.** The root provider sets a `data-ars-hydrated` attribute on the document body once hydration is complete. Nested providers MUST NOT repeatedly mark the body; the marker represents the root hydration boundary. FocusScope defers trap activation until this attribute is present, preventing premature focus movement during partial hydration. If the marker is absent when the effect first runs, FocusScope schedules one `request_animation_frame` retry before giving up.
 
 5. **Use `request_animation_frame` for DOM settlement.** After hydration, focus trap activation is wrapped in a `request_animation_frame` callback to ensure the DOM has fully settled before the trap is engaged.
 
 ```rust
 use leptos::prelude::*;
-use web_sys::wasm_bindgen::JsCast;
+use wasm_bindgen::JsCast;
 
 /// Hydration-safe FocusScope setup for modal overlays.
-/// Called from `use_machine` effect setup after hydration is confirmed.
+/// Called by FocusScope or Dialog component code after hydration is confirmed.
 fn setup_focus_scope_hydration_safe(
     scope_ref: NodeRef<html::Div>,
     restore_target: StoredValue<Option<web_sys::HtmlElement>>,
@@ -643,56 +644,106 @@ fn setup_focus_scope_hydration_safe(
     Effect::new(move |_| {
         let document = document();
 
-        // Gate on hydration completion.
+        // Gate on hydration completion, with one frame of tolerance for the
+        // root provider marker to settle.
         let body = document.body().expect("document.body");
         if body.get_attribute("data-ars-hydrated").is_none() {
-            return;
-        }
-
-        // Remove orphaned inert attributes.
-        let inert_elements = document
-            .query_selector_all("[inert]")
-            .expect("querySelectorAll");
-        for i in 0..inert_elements.length() {
-            if let Some(el) = inert_elements.item(i) {
-                let html_el: web_sys::HtmlElement = el.unchecked_into();
-                // Only remove if no open modal is a sibling.
-                if document
-                    .query_selector("[data-ars-modal-open]")
-                    .ok()
-                    .flatten()
-                    .is_none()
-                {
-                    html_el.remove_attribute("inert").ok();
-                }
-            }
-        }
-
-        // Step 2: Activate focus trap after DOM settles.
-        if let Some(scope_el) = scope_ref.get() {
-            let scope_el: web_sys::HtmlElement = scope_el.into();
             request_animation_frame(move || {
-                // Validate target exists and is visible.
-                let target = scope_el
-                    .query_selector("[autofocus], [tabindex]")
-                    .ok()
-                    .flatten()
-                    .and_then(|el| el.dyn_into::<web_sys::HtmlElement>().ok())
-                    .filter(|el| el.offset_parent().is_some());
-
-                if let Some(el) = target {
-                    // Save the currently focused element BEFORE moving focus,
-                    // so it can be restored when the scope is deactivated.
-                    restore_target.set_value(
-                        document
-                            .active_element()
-                            .and_then(|ae| ae.dyn_into().ok()),
-                    );
-                    el.focus().ok();
+                let body = document.body().expect("document.body");
+                if body.get_attribute("data-ars-hydrated").is_some() {
+                    activate_focus_scope(&document, scope_ref, restore_target);
                 }
             });
+        } else {
+            activate_focus_scope(&document, scope_ref, restore_target);
         }
     });
+
+    on_cleanup(move || {
+        if let Some(scope_el) = scope_ref.get() {
+            let scope_el: web_sys::HtmlElement = scope_el.into();
+            scope_el.remove_attribute("data-ars-modal-open").ok();
+        }
+
+        if let Some(el) = restore_target.get_value().as_ref() {
+            el.focus().ok();
+        }
+    });
+}
+
+fn activate_focus_scope(
+    document: &web_sys::Document,
+    scope_ref: NodeRef<html::Div>,
+    restore_target: StoredValue<Option<web_sys::HtmlElement>>,
+) {
+    let scope_el = scope_ref.get().map(|node| {
+        let scope_el: web_sys::HtmlElement = node.into();
+        scope_el.set_attribute("data-ars-modal-open", "").ok();
+        scope_el
+    });
+
+    // Remove orphaned inert attributes. An inert element is retained while
+    // it remains a sibling of the hydrated modal scope.
+    let inert_elements = document
+        .query_selector_all("[inert]")
+        .expect("querySelectorAll");
+    for i in 0..inert_elements.length() {
+        if let Some(el) = inert_elements.item(i) {
+            let html_el: web_sys::Element = el.unchecked_into();
+            // Only remove if no open modal is a sibling.
+            if !has_open_modal_sibling(&html_el) {
+                html_el.remove_attribute("inert").ok();
+            }
+        }
+    }
+
+    // Step 2: Activate focus trap after DOM settles.
+    if let Some(scope_el) = scope_el {
+        let document = document.clone();
+        request_animation_frame(move || {
+            // Validate target exists and is visible.
+            let target = scope_el
+                .query_selector("[autofocus], [tabindex]")
+                .ok()
+                .flatten()
+                .and_then(|el| el.dyn_into::<web_sys::HtmlElement>().ok())
+                .filter(|el| el.offset_parent().is_some());
+
+            if let Some(el) = target {
+                // Save the currently focused element BEFORE moving focus,
+                // so it can be restored when the scope is deactivated.
+                restore_target.set_value(
+                    document
+                        .active_element()
+                        .and_then(|ae| ae.dyn_into().ok()),
+                );
+                el.focus().ok();
+            }
+        });
+    }
+}
+
+fn has_open_modal_sibling(element: &web_sys::Element) -> bool {
+    let Some(parent) = element.parent_element() else {
+        return false;
+    };
+
+    let children = parent.children();
+    for index in 0..children.length() {
+        let Some(child) = children.item(index) else {
+            continue;
+        };
+
+        if child.is_same_node(Some(element)) {
+            continue;
+        }
+
+        if child.has_attribute("data-ars-modal-open") {
+            return true;
+        }
+    }
+
+    false
 }
 ```
 
@@ -1623,7 +1674,7 @@ use ars_core::{HydrationSnapshot, Machine, Service};
 fn serialize_snapshot<M>(svc: &Service<M>) -> String
 where
     M: Machine,
-    M::State: serde::Serialize,
+    M::State: Clone + serde::Serialize,
 {
     serde_json::to_string(&HydrationSnapshot::<M> {
         state: svc.state().clone(),

--- a/spec/foundation/08-adapter-leptos.md
+++ b/spec/foundation/08-adapter-leptos.md
@@ -41,7 +41,7 @@ serde_json = { version = "1", optional = true }
 default = []
 debug = ["dep:log", "ars-core/debug", "ars-dom/debug", "ars-interactions/debug"]
 ssr = ["leptos/ssr", "ars-dom/ssr", "ars-core/ssr", "ars-core/serde", "dep:serde", "dep:serde_json"]
-hydrate = ["leptos/hydrate"]
+hydrate = ["leptos/hydrate", "ars-core/ssr", "ars-core/serde"]
 csr = ["leptos/csr"]
 ```
 
@@ -260,10 +260,10 @@ let props = {
 
 ```rust
 #[cfg(feature = "hydrate")]
-fn current_render_mode() -> RenderMode {
-    if cfg!(feature = "ssr") {
+fn current_render_mode(hydrated_snapshot: bool) -> RenderMode {
+    if cfg!(all(feature = "ssr", not(target_arch = "wasm32"))) {
         RenderMode::Server
-    } else if is_currently_hydrating() {
+    } else if hydrated_snapshot || is_currently_hydrating() {
         RenderMode::Hydrating
     } else {
         RenderMode::Client
@@ -271,7 +271,7 @@ fn current_render_mode() -> RenderMode {
 }
 
 #[cfg(not(feature = "hydrate"))]
-const fn current_render_mode() -> RenderMode {
+const fn current_render_mode(_hydrated_snapshot: bool) -> RenderMode {
     if cfg!(feature = "ssr") {
         RenderMode::Server
     } else {
@@ -320,7 +320,8 @@ where
     let locale = resolve_locale(None);
     let intl_backend = use_intl_backend();
     let messages = use_messages::<M::Messages>(None, Some(&locale));
-    let env = Env::new(locale, intl_backend).with_render_mode(current_render_mode());
+    let env = Env::new(locale, intl_backend)
+        .with_render_mode(current_render_mode(hydrated_state.is_some()));
 
     // Create the service once — runs only on component initialization.
     // **Safety**: The `init()` function must not call `api.send()` or otherwise
@@ -1797,7 +1798,7 @@ server and client halves of a hydration round-trip from disagreeing on
 field layout.
 
 ```rust
-#[cfg(feature = "ssr")]
+#[cfg(any(feature = "ssr", all(feature = "hydrate", target_arch = "wasm32")))]
 pub use ars_core::HydrationSnapshot;
 use ars_core::{HasId, Machine, Service};
 

--- a/spec/foundation/09-adapter-dioxus.md
+++ b/spec/foundation/09-adapter-dioxus.md
@@ -257,13 +257,14 @@ const fn current_render_mode() -> RenderMode {
 
 fn use_machine_inner<M: Machine + 'static>(
     props: M::Props,
+    hydrated_state: Option<M::State>,
 ) -> (UseMachineReturn<M>, Signal<u64>)
 where
     M::State: Clone + PartialEq + 'static,
     M::Context: Clone + 'static,
     M::Props: Clone + PartialEq + 'static,
 {
-    let generated_id = use_hook(|| format!("ars-{}", dioxus_id_counter()));
+    let generated_id = use_stable_id("component");
     let props_for_sync = props.clone();
 
     // Auto-inject ID if not provided by the user.
@@ -271,8 +272,6 @@ where
     let props = {
         let mut p = props;
         if p.id().is_empty() {
-            // Same counter as use_stable_id() — inlined here since use_machine_inner
-            // has no prefix context. Component-level code should use use_stable_id().
             p.set_id(generated_id);
         }
         p
@@ -287,12 +286,25 @@ where
     // Resolve messages from adapter-level i18n hooks.
     let messages = use_messages::<M::Messages>(None, Some(&env.locale));
 
+    // `use_machine_hydrated()` passes `Some(snapshot.state)` so client hydration
+    // preserves the server-rendered state while recomputing context from the
+    // current adapter environment.
     // **Safety**: The `init()` function must not call `api.send()` or otherwise
     // produce events. It runs during component initialization and event
     // processing is not yet set up.
     // Move normalized props into Service creation.
     // use_signal's closure runs exactly once (first mount), consuming `props`.
-    let service_signal = use_signal(|| Service::<M>::new(props, env, messages));
+    let service_signal = use_signal(move || {
+        if let Some(state) = hydrated_state {
+            #[cfg(feature = "ssr")]
+            {
+                return Service::new_hydrated(props, state, &env, &messages);
+            }
+        }
+
+        Service::new(props, &env, &messages)
+    });
+
     let context_version: Signal<u64> = use_signal(|| 0u64);
 
     // Create state_signal BEFORE use_sync_props to ensure it exists if sync triggers re-render.
@@ -3097,13 +3109,22 @@ pub fn emit_map<T, U: 'static>(handler: Option<&EventHandler<U>>, value: T, f: i
 
 ---
 
-### 19.2 Hydration-Safe ID Generation
+### 19.2 Generated IDs and Hydration
 
-The `dioxus_id_counter()` function (thread-local on WASM, `AtomicU64` on native) is **NOT hydration-safe**. During SSR, the server increments the counter in rendering order; on hydration, the client may increment differently due to lazy loading, code splitting, or Suspense boundaries. This causes ARIA attribute mismatches (`aria-labelledby`, `aria-describedby`, `aria-controls` pointing to wrong elements).
+The `dioxus_id_counter()` function (thread-local on WASM, `AtomicU64` on
+native) is **NOT hydration-safe**. During SSR, the server increments the counter
+in rendering order; on hydration, the client may increment differently due to
+lazy loading, code splitting, or Suspense boundaries. This causes ARIA attribute
+mismatches (`aria-labelledby`, `aria-describedby`, `aria-controls` pointing to
+wrong elements).
 
 **Requirements:**
 
-1. **Deterministic ID scheme**: Replace `dioxus_id_counter()` with a deterministic ID generation strategy tied to the component tree position, analogous to React's `useId()`. The ID must be identical on server and client for the same component instance.
+1. **Explicit IDs for SSR + hydration**: Components rendered through SSR and
+   hydrated on the client MUST receive explicit `id` props from application code
+   or from a higher-level component API that can serialize and restore the same
+   value. Generated IDs are only a fallback for client-only rendering and for
+   non-hydrated SSR output.
 
 2. **SSR counter reset**: When the `dioxus/server` feature is active, the ID counter MUST be reset at the start of each SSR request to prevent cross-request counter leakage:
 
@@ -3118,23 +3139,43 @@ The `dioxus_id_counter()` function (thread-local on WASM, `AtomicU64` on native)
     }
     ```
 
-3. **Hydration mismatch detection**: In debug builds, the client SHOULD compare server-rendered IDs (extracted from the hydrated DOM) with client-generated IDs. On mismatch, emit a console warning:
+   Resetting the counter prevents request-to-request leakage, but it does not
+   make generated IDs safe if server and client render different hook paths.
+
+3. **Hydration mismatch detection**: In debug builds, the client SHOULD compare
+   the mounted DOM element's server-rendered `id` with the client ID it is about
+   to use. On mismatch, emit a console warning:
    `"ars-ui hydration ID mismatch: server='ars-dialog-7', client='ars-dialog-9'. Component IDs may be non-deterministic across SSR/client boundaries."`
 
-4. **Recommended implementation**: Use Dioxus's built-in hook ordering (which is stable across SSR/hydration) combined with a component-path prefix:
+4. **Generated fallback implementation**: `use_stable_id()` must use Dioxus hook
+   storage so the generated value is stable for the lifetime of a mounted
+   component and does not change across re-renders:
 
 ```rust
 fn use_stable_id(prefix: &str) -> String {
-    // Hook ordering is deterministic in Dioxus — same component
-    // at same tree position gets same hook slot on server and client.
+    // Hook storage keeps the generated suffix stable across re-renders, but
+    // the suffix still comes from the adapter counter and is not hydration-safe.
     let id = use_hook(|| dioxus_id_counter());
     format!("ars-{prefix}-{id}")
+}
+
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
+fn warn_if_mounted_id_mismatch(element: &web_sys::Element, client_id: &str) {
+    let server_id = element.id();
+    if server_id.is_empty() || server_id == client_id {
+        return;
+    }
+
+    #[cfg(debug_assertions)]
+    web_sys::console::warn_1(&wasm_bindgen::JsValue::from_str(&format!(
+        "ars-ui hydration ID mismatch: server='{server_id}', client='{client_id}'. Component IDs may be non-deterministic across SSR/client boundaries."
+    )));
 }
 ```
 
 > **Warning:** `use_stable_id` currently delegates to `dioxus_id_counter()`, which is NOT
 > hydration-safe. SSR+hydration users MUST provide explicit `id` props on all components
-> until a deterministic tree-position-based ID scheme is implemented.
+> unless the component restores the exact server ID from a hydration snapshot.
 
 ---
 
@@ -3148,20 +3189,20 @@ fn use_stable_id(prefix: &str) -> String {
 
 1. **Emit valid focus targets during SSR.** Server-rendered modal overlays MUST include at least one focusable element in the HTML output. Use a `button` with `autofocus` or an element with `tabindex="-1"` so that the hydration effect has a valid target.
 
-2. **Scan for orphaned `inert` on hydration.** A post-hydration `use_effect` queries all elements with `[inert]` and removes the attribute from any element that is not currently a sibling of an open modal. This prevents "frozen" regions left over from SSR. Cleanup of these attributes uses `use_drop` (Dioxus equivalent of Leptos `on_cleanup`).
+2. **Scan for orphaned `inert` on hydration.** A post-hydration `use_effect` queries all elements with `[inert]` and removes the attribute from any element that is not currently a sibling of an open modal. This prevents "frozen" regions left over from SSR. Cleanup of the modal-open marker uses `use_drop` (Dioxus equivalent of Leptos `on_cleanup`).
 
 3. **Validate focus target existence and visibility.** Before calling `.focus()`, the FocusScope checks that the target element exists and is visible by verifying `element.offset_parent().is_some()`. Elements that are `display: none` or detached return `None` and are skipped.
 
-4. **Gate focus trap activation on hydration completion.** The adapter sets a `data-ars-hydrated` attribute on the document body once hydration is complete. FocusScope defers trap activation until this attribute is present, preventing premature focus movement during partial hydration. In Dioxus, this check is wrapped in a `use_effect` (which only runs on the client), rather than a `#[cfg(not(feature = "ssr"))]` gated `Effect::new` as in the Leptos adapter.
+4. **Gate focus trap activation on hydration completion.** The root `ArsProvider` sets a `data-ars-hydrated` attribute on the document body once hydration is complete. Nested providers MUST NOT repeatedly mark the body; the marker represents the root hydration boundary. FocusScope defers trap activation until this attribute is present, preventing premature focus movement during partial hydration. If the marker is absent when the effect first runs, FocusScope schedules one `request_animation_frame` retry before giving up. In Dioxus, this check is wrapped in a `use_effect` (which only runs on the client), rather than a `#[cfg(not(feature = "ssr"))]` gated `Effect::new` as in the Leptos adapter.
 
 5. **Use `request_animation_frame` for DOM settlement.** After hydration, focus trap activation is wrapped in a `request_animation_frame` callback to ensure the DOM has fully settled before the trap is engaged.
 
 ```rust
 use dioxus::prelude::*;
-use web_sys::wasm_bindgen::JsCast;
+use wasm_bindgen::JsCast;
 
 /// Hydration-safe FocusScope setup for modal overlays.
-/// Called from `use_machine` effect setup after hydration is confirmed.
+/// Called by FocusScope or Dialog component code after hydration is confirmed.
 ///
 /// Dioxus adapter differences from Leptos:
 /// - `use_effect` instead of `#[cfg(not(feature = "ssr"))]` gated `Effect::new`
@@ -3172,6 +3213,8 @@ fn setup_focus_scope_hydration_safe(
     scope_id: String,
     mut restore_target: Signal<Option<web_sys::HtmlElement>>,
 ) {
+    let cleanup_scope_id = scope_id.clone();
+
     // Step 1: Clean up orphaned inert attributes left by SSR.
     // use_effect only runs on the client, so no #[cfg(not(feature = "ssr"))] needed.
     use_effect(move || {
@@ -3180,73 +3223,118 @@ fn setup_focus_scope_hydration_safe(
             .document()
             .expect("document");
 
-        // Gate on hydration completion.
+        // Gate on hydration completion, with one frame of tolerance for the
+        // root provider marker to settle.
         let body = document.body().expect("document.body");
         if body.get_attribute("data-ars-hydrated").is_none() {
-            return;
-        }
-
-        // Remove orphaned inert attributes.
-        let inert_elements = document
-            .query_selector_all("[inert]")
-            .expect("querySelectorAll");
-        for i in 0..inert_elements.length() {
-            if let Some(el) = inert_elements.item(i) {
-                let html_el: web_sys::HtmlElement = el.unchecked_into();
-                // Only remove if no open modal is a sibling.
-                if document
-                    .query_selector("[data-ars-modal-open]")
-                    .ok()
-                    .flatten()
-                    .is_none()
-                {
-                    html_el.remove_attribute("inert").ok();
-                }
-            }
-        }
-
-        // Step 2: Activate focus trap after DOM settles.
-        let scope_el = document
-            .get_element_by_id(&scope_id)
-            .and_then(|el| el.dyn_into::<web_sys::HtmlElement>().ok());
-
-        if let Some(scope_el) = scope_el {
-            // Use request_animation_frame to wait for DOM settlement.
-            let document_clone = document.clone();
-            let cb = wasm_bindgen::closure::Closure::once_into_js(move || {
-                // Validate target exists and is visible.
-                let target = scope_el
-                    .query_selector("[autofocus], [tabindex]")
-                    .ok()
-                    .flatten()
-                    .and_then(|el| el.dyn_into::<web_sys::HtmlElement>().ok())
-                    .filter(|el| el.offset_parent().is_some());
-
-                if let Some(el) = target {
-                    // Save the currently focused element BEFORE moving focus,
-                    // so it can be restored when the scope is deactivated.
-                    restore_target.set(
-                        document_clone
-                            .active_element()
-                            .and_then(|ae| ae.dyn_into().ok()),
-                    );
-                    el.focus().ok();
+            let scope_id = scope_id.clone();
+            let document = document.clone();
+            request_animation_frame(move || {
+                let body = document.body().expect("document.body");
+                if body.get_attribute("data-ars-hydrated").is_some() {
+                    activate_focus_scope(&document, &scope_id, restore_target);
                 }
             });
-            web_sys::window()
-                .expect("window must exist")
-                .request_animation_frame(cb.as_ref().unchecked_ref())
-                .ok();
+        } else {
+            activate_focus_scope(&document, &scope_id, restore_target);
         }
     });
 
     // Step 3: Clean up on unmount using use_drop (Dioxus equivalent of on_cleanup).
     use_drop(move || {
+        if let Some(document) = web_sys::window().and_then(|window| window.document()) {
+            if let Some(scope_el) = document.get_element_by_id(&cleanup_scope_id) {
+                scope_el.remove_attribute("data-ars-modal-open").ok();
+            }
+        }
+
         // Restore focus to the previously focused element when scope deactivates.
         if let Some(el) = restore_target.peek().as_ref() {
             el.focus().ok();
         }
     });
+}
+
+fn activate_focus_scope(
+    document: &web_sys::Document,
+    scope_id: &str,
+    restore_target: Signal<Option<web_sys::HtmlElement>>,
+) {
+    let scope_el = document
+        .get_element_by_id(scope_id)
+        .and_then(|el| el.dyn_into::<web_sys::HtmlElement>().ok());
+
+    if let Some(scope_el) = scope_el.as_ref() {
+        scope_el.set_attribute("data-ars-modal-open", "").ok();
+    }
+
+    // Remove orphaned inert attributes. An inert element is retained while
+    // it remains a sibling of the hydrated modal scope.
+    let inert_elements = document
+        .query_selector_all("[inert]")
+        .expect("querySelectorAll");
+    for i in 0..inert_elements.length() {
+        if let Some(el) = inert_elements.item(i) {
+            let html_el: web_sys::Element = el.unchecked_into();
+            // Only remove if no open modal is a sibling.
+            if !has_open_modal_sibling(&html_el) {
+                html_el.remove_attribute("inert").ok();
+            }
+        }
+    }
+
+    // Step 2: Activate focus trap after DOM settles.
+    if let Some(scope_el) = scope_el {
+        // Use request_animation_frame to wait for DOM settlement.
+        let document_clone = document.clone();
+        let cb = wasm_bindgen::closure::Closure::once_into_js(move || {
+            // Validate target exists and is visible.
+            let target = scope_el
+                .query_selector("[autofocus], [tabindex]")
+                .ok()
+                .flatten()
+                .and_then(|el| el.dyn_into::<web_sys::HtmlElement>().ok())
+                .filter(|el| el.offset_parent().is_some());
+
+            if let Some(el) = target {
+                // Save the currently focused element BEFORE moving focus,
+                // so it can be restored when the scope is deactivated.
+                restore_target.set(
+                    document_clone
+                        .active_element()
+                        .and_then(|ae| ae.dyn_into().ok()),
+                );
+                el.focus().ok();
+            }
+        });
+        web_sys::window()
+            .expect("window must exist")
+            .request_animation_frame(cb.as_ref().unchecked_ref())
+            .ok();
+    }
+}
+
+fn has_open_modal_sibling(element: &web_sys::Element) -> bool {
+    let Some(parent) = element.parent_element() else {
+        return false;
+    };
+
+    let children = parent.children();
+    for index in 0..children.length() {
+        let Some(child) = children.item(index) else {
+            continue;
+        };
+
+        if child.is_same_node(Some(element)) {
+            continue;
+        }
+
+        if child.has_attribute("data-ars-modal-open") {
+            return true;
+        }
+    }
+
+    false
 }
 ```
 
@@ -3260,21 +3348,64 @@ halves of a round-trip must agree on the wire format, so a single source
 of truth lives in the foundation crate.
 
 ```rust
-use ars_core::{HydrationSnapshot, Machine, Service};
+use ars_core::{HasId, HydrationSnapshot, Machine, Service};
+use dioxus::prelude::*;
 
 /// In SSR mode: embed a snapshot as a JSON script tag.
-/// In hydration mode: read the snapshot and initialize the machine via
-/// `Service::new_hydrated(props, snapshot.state, &env, &messages)`.
 #[cfg(feature = "ssr")]
 fn serialize_snapshot<M: Machine>(svc: &Service<M>) -> String
 where
-    M::State: serde::Serialize,
+    M::State: Clone + serde::Serialize,
 {
     serde_json::to_string(&HydrationSnapshot::<M> {
         state: svc.state().clone(),
         id: svc.props().id().to_string(),
     })
     .expect("HydrationSnapshot must be serializable for SSR — ensure State implements Serialize")
+}
+
+/// In hydration mode: read the snapshot and initialize the machine via
+/// `Service::new_hydrated(props, snapshot.state, &env, &messages)`.
+#[cfg(feature = "ssr")]
+fn use_machine_hydrated<M: Machine + 'static>(
+    props: M::Props,
+    snapshot: HydrationSnapshot<M>,
+) -> UseMachineReturn<M>
+where
+    M::State: Clone + PartialEq + 'static,
+    M::Context: Clone + 'static,
+    M::Props: Clone + PartialEq + 'static,
+    M::Event: Send + 'static,
+    M::Messages: Send + Sync + 'static,
+{
+    let props = if props.id().is_empty() {
+        props.with_id(snapshot.id.clone())
+    } else {
+        debug_assert_eq!(
+            props.id(),
+            snapshot.id,
+            "HydrationSnapshot id must match Props::id"
+        );
+        props
+    };
+
+    let (result, ..) = use_machine_inner::<M>(props, Some(snapshot.state));
+    result
+}
+
+#[cfg(feature = "ssr")]
+fn use_machine_with_reactive_props_hydrated<M: Machine + 'static>(
+    props_signal: Signal<M::Props>,
+    snapshot: HydrationSnapshot<M>,
+) -> UseMachineReturn<M>
+where
+    M::State: Clone + PartialEq + 'static,
+    M::Context: Clone + 'static,
+    M::Props: Clone + PartialEq + 'static,
+    M::Event: Send + 'static,
+    M::Messages: Send + Sync + 'static,
+{
+    use_machine_hydrated::<M>(props_signal(), snapshot)
 }
 ```
 

--- a/spec/foundation/09-adapter-dioxus.md
+++ b/spec/foundation/09-adapter-dioxus.md
@@ -3191,7 +3191,7 @@ fn warn_if_mounted_id_mismatch(element: &web_sys::Element, client_id: &str) {
 
 2. **Scan for orphaned adapter-owned `inert` on hydration.** A post-hydration `use_effect` queries elements with both `[inert]` and `data-ars-modal-inert` and removes both attributes from any marked element that is not currently a sibling of an open modal. This prevents "frozen" regions left over from SSR without clearing author-owned inert regions used for unrelated loading or interaction locks. Cleanup of the modal-open marker uses `use_drop` (Dioxus equivalent of Leptos `on_cleanup`).
 
-3. **Validate focus target existence and visibility.** Before calling `.focus()`, the FocusScope checks the focusable scope root first, then scans all descendants matching the hydration focus selector until it finds a visible target. It verifies `element.offset_parent().is_some()` before focusing. Elements that are `display: none` or detached return `None` and are skipped rather than aborting the scan.
+3. **Validate focus target existence and visibility.** Before calling `.focus()`, the FocusScope checks the focusable scope root first, then scans all descendants matching the hydration focus selector until it finds a visible target. It accepts elements with an `offsetParent` and visible `position: fixed` elements whose `offsetParent` is `null`, while rejecting `display: none`, `visibility: hidden`, and detached targets.
 
 4. **Gate focus trap activation on hydration completion.** The root `ArsProvider` sets a `data-ars-hydrated` attribute on the document body once hydration is complete. Nested providers MUST NOT repeatedly mark the body; the marker represents the root hydration boundary. FocusScope defers trap activation until this attribute is present, preventing premature focus movement during partial hydration. If the marker is absent when the effect first runs, FocusScope retries through `request_animation_frame` until the marker appears or the scope unmounts. In Dioxus, this check is wrapped in a `use_effect` (which only runs on the client), rather than a `#[cfg(not(feature = "ssr"))]` gated `Effect::new` as in the Leptos adapter.
 
@@ -3201,8 +3201,6 @@ fn warn_if_mounted_id_mismatch(element: &web_sys::Element, client_id: &str) {
 use dioxus::prelude::*;
 use std::{cell::Cell, rc::Rc};
 use wasm_bindgen::JsCast;
-
-const HYDRATION_MODAL_INERT_ATTR: &str = "data-ars-modal-inert";
 
 const HYDRATION_FOCUS_TARGET_SELECTOR: &str = concat!(
     "[autofocus]:not([disabled]):not([aria-hidden='true']),",
@@ -3326,7 +3324,7 @@ fn activate_focus_scope(
             // Only remove if no open modal is a sibling.
             if !has_open_modal_sibling(&html_el) {
                 html_el.remove_attribute("inert").ok();
-                html_el.remove_attribute(HYDRATION_MODAL_INERT_ATTR).ok();
+                html_el.remove_attribute(ars_dom::portal::MODAL_INERT_ATTR).ok();
             }
         }
     }
@@ -3409,7 +3407,21 @@ fn is_focus_target_candidate(element: &web_sys::Element) -> bool {
 }
 
 fn is_visible_focus_target(element: &web_sys::HtmlElement) -> bool {
-    element.offset_parent().is_some()
+    element.offset_parent().is_some() || is_visible_fixed_position_target(element)
+}
+
+fn is_visible_fixed_position_target(element: &web_sys::HtmlElement) -> bool {
+    let Some(window) = web_sys::window() else {
+        return false;
+    };
+
+    let Ok(Some(style)) = window.get_computed_style(element) else {
+        return false;
+    };
+
+    style.get_property_value("position").as_deref() == Ok("fixed")
+        && style.get_property_value("display").as_deref() != Ok("none")
+        && style.get_property_value("visibility").as_deref() != Ok("hidden")
 }
 
 fn has_open_modal_sibling(element: &web_sys::Element) -> bool {

--- a/spec/foundation/09-adapter-dioxus.md
+++ b/spec/foundation/09-adapter-dioxus.md
@@ -3189,9 +3189,9 @@ fn warn_if_mounted_id_mismatch(element: &web_sys::Element, client_id: &str) {
 
 1. **Emit valid focus targets during SSR.** Server-rendered modal overlays MUST include at least one focusable element in the HTML output. A naturally focusable control such as a `button` or `input`, an element with `autofocus`, or a focusable scope root with `tabindex="-1"` gives the hydration effect a valid target.
 
-2. **Scan for orphaned `inert` on hydration.** A post-hydration `use_effect` queries all elements with `[inert]` and removes the attribute from any element that is not currently a sibling of an open modal. This prevents "frozen" regions left over from SSR. Cleanup of the modal-open marker uses `use_drop` (Dioxus equivalent of Leptos `on_cleanup`).
+2. **Scan for orphaned adapter-owned `inert` on hydration.** A post-hydration `use_effect` queries elements with both `[inert]` and `data-ars-modal-inert` and removes both attributes from any marked element that is not currently a sibling of an open modal. This prevents "frozen" regions left over from SSR without clearing author-owned inert regions used for unrelated loading or interaction locks. Cleanup of the modal-open marker uses `use_drop` (Dioxus equivalent of Leptos `on_cleanup`).
 
-3. **Validate focus target existence and visibility.** Before calling `.focus()`, the FocusScope checks the focusable scope root first, then scans descendants matching the hydration focus selector. It verifies `element.offset_parent().is_some()` before focusing. Elements that are `display: none` or detached return `None` and are skipped.
+3. **Validate focus target existence and visibility.** Before calling `.focus()`, the FocusScope checks the focusable scope root first, then scans all descendants matching the hydration focus selector until it finds a visible target. It verifies `element.offset_parent().is_some()` before focusing. Elements that are `display: none` or detached return `None` and are skipped rather than aborting the scan.
 
 4. **Gate focus trap activation on hydration completion.** The root `ArsProvider` sets a `data-ars-hydrated` attribute on the document body once hydration is complete. Nested providers MUST NOT repeatedly mark the body; the marker represents the root hydration boundary. FocusScope defers trap activation until this attribute is present, preventing premature focus movement during partial hydration. If the marker is absent when the effect first runs, FocusScope retries through `request_animation_frame` until the marker appears or the scope unmounts. In Dioxus, this check is wrapped in a `use_effect` (which only runs on the client), rather than a `#[cfg(not(feature = "ssr"))]` gated `Effect::new` as in the Leptos adapter.
 
@@ -3201,6 +3201,8 @@ fn warn_if_mounted_id_mismatch(element: &web_sys::Element, client_id: &str) {
 use dioxus::prelude::*;
 use std::{cell::Cell, rc::Rc};
 use wasm_bindgen::JsCast;
+
+const HYDRATION_MODAL_INERT_ATTR: &str = "data-ars-modal-inert";
 
 const HYDRATION_FOCUS_TARGET_SELECTOR: &str = concat!(
     "[autofocus]:not([disabled]):not([aria-hidden='true']),",
@@ -3229,7 +3231,7 @@ fn setup_focus_scope_hydration_safe(
     let cleanup_scope_id = scope_id.clone();
     let activation_active = Rc::new(Cell::new(true));
 
-    // Step 1: Clean up orphaned inert attributes left by SSR.
+    // Step 1: Clean up adapter-owned orphaned inert attributes left by SSR.
     // use_effect only runs on the client, so no #[cfg(not(feature = "ssr"))] needed.
     use_effect({
         let activation_active = Rc::clone(&activation_active);
@@ -3313,10 +3315,10 @@ fn activate_focus_scope(
         scope_el.set_attribute("data-ars-modal-open", "").ok();
     }
 
-    // Remove orphaned inert attributes. An inert element is retained while
-    // it remains a sibling of the hydrated modal scope.
+    // Remove adapter-owned orphaned inert attributes. An inert element is retained
+    // while it remains a sibling of the hydrated modal scope.
     let inert_elements = document
-        .query_selector_all("[inert]")
+        .query_selector_all("[inert][data-ars-modal-inert]")
         .expect("querySelectorAll");
     for i in 0..inert_elements.length() {
         if let Some(el) = inert_elements.item(i) {
@@ -3324,6 +3326,7 @@ fn activate_focus_scope(
             // Only remove if no open modal is a sibling.
             if !has_open_modal_sibling(&html_el) {
                 html_el.remove_attribute("inert").ok();
+                html_el.remove_attribute(HYDRATION_MODAL_INERT_ATTR).ok();
             }
         }
     }
@@ -3360,11 +3363,27 @@ fn visible_focus_target(scope: &web_sys::HtmlElement) -> Option<web_sys::HtmlEle
     }
 
     scope
-        .query_selector(HYDRATION_FOCUS_TARGET_SELECTOR)
+        .query_selector_all(HYDRATION_FOCUS_TARGET_SELECTOR)
         .ok()
-        .flatten()
-        .and_then(|element| element.dyn_into().ok())
-        .filter(is_visible_focus_target)
+        .and_then(|elements| first_visible_focus_target(&elements))
+}
+
+fn first_visible_focus_target(elements: &web_sys::NodeList) -> Option<web_sys::HtmlElement> {
+    for index in 0..elements.length() {
+        let Some(node) = elements.item(index) else {
+            continue;
+        };
+
+        let Ok(element) = node.dyn_into::<web_sys::HtmlElement>() else {
+            continue;
+        };
+
+        if is_visible_focus_target(&element) {
+            return Some(element);
+        }
+    }
+
+    None
 }
 
 fn is_focus_target_candidate(element: &web_sys::Element) -> bool {

--- a/spec/foundation/09-adapter-dioxus.md
+++ b/spec/foundation/09-adapter-dioxus.md
@@ -45,11 +45,11 @@ log = { version = "0.4", default-features = false, optional = true }
 [features]
 default = []
 debug = ["dep:log", "ars-core/debug", "ars-interactions/debug", "ars-dom?/debug"]
-web = ["dioxus/web", "dep:ars-dom", "ars-dom/web"]
+web = ["dioxus/web", "dep:ars-dom", "ars-dom/web", "ars-core/ssr", "ars-core/serde"]
 desktop = ["dioxus/desktop"]
 desktop-dom = ["desktop", "dep:ars-dom"]
 mobile = ["dioxus/mobile"]  # Currently resolves to NullPlatform; MobilePlatform pending
-ssr = ["dioxus/server", "dep:ars-dom", "ars-dom/ssr"]
+ssr = ["dioxus/server", "dep:ars-dom", "ars-dom/ssr", "ars-core/ssr", "ars-core/serde", "dep:serde", "dep:serde_json"]
 ```
 
 ---
@@ -247,7 +247,17 @@ pub fn related_id(base: &str, suffix: &str) -> String {
 /// Resolves environment values (locale, ICU provider) and messages from
 /// `ArsProvider` context before constructing the `Service`. Core code never
 /// calls framework hooks — all environment values arrive as parameters.
-const fn current_render_mode() -> RenderMode {
+const fn current_render_mode(hydrated_snapshot: bool) -> RenderMode {
+    #[cfg(all(feature = "web", target_arch = "wasm32"))]
+    {
+        if hydrated_snapshot {
+            RenderMode::Hydrating
+        } else {
+            RenderMode::Client
+        }
+    }
+
+    #[cfg(not(all(feature = "web", target_arch = "wasm32")))]
     if cfg!(feature = "ssr") {
         RenderMode::Server
     } else {
@@ -281,7 +291,8 @@ where
     // These are adapter-only hooks — core code receives Env and Messages as parameters.
     let locale = resolve_locale(None);
     let intl_backend = use_intl_backend();
-    let env = Env::new(locale, intl_backend).with_render_mode(current_render_mode());
+    let env = Env::new(locale, intl_backend)
+        .with_render_mode(current_render_mode(hydrated_state.is_some()));
 
     // Resolve messages from adapter-level i18n hooks.
     let messages = use_messages::<M::Messages>(None, Some(&env.locale));
@@ -296,7 +307,7 @@ where
     // use_signal's closure runs exactly once (first mount), consuming `props`.
     let service_signal = use_signal(move || {
         if let Some(state) = hydrated_state {
-            #[cfg(feature = "ssr")]
+            #[cfg(any(feature = "ssr", all(feature = "web", target_arch = "wasm32")))]
             {
                 return Service::new_hydrated(props, state, &env, &messages);
             }
@@ -3485,8 +3496,11 @@ where
 }
 
 /// In hydration mode: read the snapshot and initialize the machine via
-/// `Service::new_hydrated(props, snapshot.state, &env, &messages)`.
-#[cfg(feature = "ssr")]
+/// `Service::new_hydrated(props, snapshot.state, &env, &messages)`. The client
+/// hydration hook is available in browser builds without enabling the adapter's
+/// server runtime feature, because `web + ssr` would pull server-only Dioxus
+/// dependencies into `wasm32`.
+#[cfg(any(feature = "ssr", all(feature = "web", target_arch = "wasm32")))]
 fn use_machine_hydrated<M: Machine + 'static>(
     props: M::Props,
     snapshot: HydrationSnapshot<M>,
@@ -3501,7 +3515,7 @@ where
     let props = if props.id().is_empty() {
         props.with_id(snapshot.id.clone())
     } else {
-        debug_assert_eq!(
+        assert_eq!(
             props.id(),
             snapshot.id,
             "HydrationSnapshot id must match Props::id"
@@ -3513,7 +3527,7 @@ where
     result
 }
 
-#[cfg(feature = "ssr")]
+#[cfg(any(feature = "ssr", all(feature = "web", target_arch = "wasm32")))]
 fn use_machine_with_reactive_props_hydrated<M: Machine + 'static>(
     props_signal: Signal<M::Props>,
     snapshot: HydrationSnapshot<M>,

--- a/spec/foundation/09-adapter-dioxus.md
+++ b/spec/foundation/09-adapter-dioxus.md
@@ -3249,7 +3249,12 @@ fn setup_focus_scope_hydration_safe(
                     Rc::clone(&activation_active),
                 );
             } else {
-                activate_focus_scope(&document, &scope_id, restore_target);
+                activate_focus_scope(
+                    &document,
+                    &scope_id,
+                    restore_target,
+                    Rc::clone(&activation_active),
+                );
             }
         }
     });
@@ -3288,7 +3293,7 @@ fn request_hydration_activation_after_frame(
 
         let body = document.body().expect("document.body");
         if body.get_attribute("data-ars-hydrated").is_some() {
-            activate_focus_scope(&document, &scope_id, restore_target);
+            activate_focus_scope(&document, &scope_id, restore_target, activation_active);
         } else {
             request_hydration_activation_after_frame(scope_id, restore_target, activation_active);
         }
@@ -3304,6 +3309,7 @@ fn activate_focus_scope(
     document: &web_sys::Document,
     scope_id: &str,
     restore_target: Signal<Option<web_sys::HtmlElement>>,
+    activation_active: Rc<Cell<bool>>,
 ) {
     let scope_el = document
         .get_element_by_id(scope_id)
@@ -3334,6 +3340,10 @@ fn activate_focus_scope(
         // Use request_animation_frame to wait for DOM settlement.
         let document_clone = document.clone();
         let cb = wasm_bindgen::closure::Closure::once_into_js(move || {
+            if !activation_active.get() {
+                return;
+            }
+
             // Validate target exists and is visible.
             let target = visible_focus_target(&scope_el);
 

--- a/spec/foundation/09-adapter-dioxus.md
+++ b/spec/foundation/09-adapter-dioxus.md
@@ -3187,19 +3187,32 @@ fn warn_if_mounted_id_mismatch(element: &web_sys::Element, client_id: &str) {
 
 **Solution.** The following rules govern FocusScope behavior across the SSR-to-hydration boundary:
 
-1. **Emit valid focus targets during SSR.** Server-rendered modal overlays MUST include at least one focusable element in the HTML output. Use a `button` with `autofocus` or an element with `tabindex="-1"` so that the hydration effect has a valid target.
+1. **Emit valid focus targets during SSR.** Server-rendered modal overlays MUST include at least one focusable element in the HTML output. A naturally focusable control such as a `button` or `input`, an element with `autofocus`, or a focusable scope root with `tabindex="-1"` gives the hydration effect a valid target.
 
 2. **Scan for orphaned `inert` on hydration.** A post-hydration `use_effect` queries all elements with `[inert]` and removes the attribute from any element that is not currently a sibling of an open modal. This prevents "frozen" regions left over from SSR. Cleanup of the modal-open marker uses `use_drop` (Dioxus equivalent of Leptos `on_cleanup`).
 
-3. **Validate focus target existence and visibility.** Before calling `.focus()`, the FocusScope checks that the target element exists and is visible by verifying `element.offset_parent().is_some()`. Elements that are `display: none` or detached return `None` and are skipped.
+3. **Validate focus target existence and visibility.** Before calling `.focus()`, the FocusScope checks the focusable scope root first, then scans descendants matching the hydration focus selector. It verifies `element.offset_parent().is_some()` before focusing. Elements that are `display: none` or detached return `None` and are skipped.
 
-4. **Gate focus trap activation on hydration completion.** The root `ArsProvider` sets a `data-ars-hydrated` attribute on the document body once hydration is complete. Nested providers MUST NOT repeatedly mark the body; the marker represents the root hydration boundary. FocusScope defers trap activation until this attribute is present, preventing premature focus movement during partial hydration. If the marker is absent when the effect first runs, FocusScope schedules one `request_animation_frame` retry before giving up. In Dioxus, this check is wrapped in a `use_effect` (which only runs on the client), rather than a `#[cfg(not(feature = "ssr"))]` gated `Effect::new` as in the Leptos adapter.
+4. **Gate focus trap activation on hydration completion.** The root `ArsProvider` sets a `data-ars-hydrated` attribute on the document body once hydration is complete. Nested providers MUST NOT repeatedly mark the body; the marker represents the root hydration boundary. FocusScope defers trap activation until this attribute is present, preventing premature focus movement during partial hydration. If the marker is absent when the effect first runs, FocusScope retries through `request_animation_frame` until the marker appears or the scope unmounts. In Dioxus, this check is wrapped in a `use_effect` (which only runs on the client), rather than a `#[cfg(not(feature = "ssr"))]` gated `Effect::new` as in the Leptos adapter.
 
 5. **Use `request_animation_frame` for DOM settlement.** After hydration, focus trap activation is wrapped in a `request_animation_frame` callback to ensure the DOM has fully settled before the trap is engaged.
 
 ```rust
 use dioxus::prelude::*;
+use std::{cell::Cell, rc::Rc};
 use wasm_bindgen::JsCast;
+
+const HYDRATION_FOCUS_TARGET_SELECTOR: &str = concat!(
+    "[autofocus]:not([disabled]):not([aria-hidden='true']),",
+    "button:not([disabled]):not([aria-hidden='true']),",
+    "input:not([disabled]):not([aria-hidden='true']),",
+    "select:not([disabled]):not([aria-hidden='true']),",
+    "textarea:not([disabled]):not([aria-hidden='true']),",
+    "a[href]:not([aria-hidden='true']),",
+    "area[href]:not([aria-hidden='true']),",
+    "[tabindex]:not([disabled]):not([aria-hidden='true']),",
+    "[contenteditable]:not([contenteditable='false']):not([aria-hidden='true'])",
+);
 
 /// Hydration-safe FocusScope setup for modal overlays.
 /// Called by FocusScope or Dialog component code after hydration is confirmed.
@@ -3211,37 +3224,40 @@ use wasm_bindgen::JsCast;
 /// - Focus operations go through platform abstraction where available
 fn setup_focus_scope_hydration_safe(
     scope_id: String,
-    mut restore_target: Signal<Option<web_sys::HtmlElement>>,
+    restore_target: Signal<Option<web_sys::HtmlElement>>,
 ) {
     let cleanup_scope_id = scope_id.clone();
+    let activation_active = Rc::new(Cell::new(true));
 
     // Step 1: Clean up orphaned inert attributes left by SSR.
     // use_effect only runs on the client, so no #[cfg(not(feature = "ssr"))] needed.
-    use_effect(move || {
-        let document = web_sys::window()
-            .expect("window")
-            .document()
-            .expect("document");
+    use_effect({
+        let activation_active = Rc::clone(&activation_active);
 
-        // Gate on hydration completion, with one frame of tolerance for the
-        // root provider marker to settle.
-        let body = document.body().expect("document.body");
-        if body.get_attribute("data-ars-hydrated").is_none() {
-            let scope_id = scope_id.clone();
-            let document = document.clone();
-            request_animation_frame(move || {
-                let body = document.body().expect("document.body");
-                if body.get_attribute("data-ars-hydrated").is_some() {
-                    activate_focus_scope(&document, &scope_id, restore_target);
-                }
-            });
-        } else {
-            activate_focus_scope(&document, &scope_id, restore_target);
+        move || {
+            let document = web_sys::window()
+                .expect("window")
+                .document()
+                .expect("document");
+
+            // Gate on hydration completion, retrying until the root provider marker settles.
+            let body = document.body().expect("document.body");
+            if body.get_attribute("data-ars-hydrated").is_none() {
+                request_hydration_activation_after_frame(
+                    scope_id.clone(),
+                    restore_target,
+                    Rc::clone(&activation_active),
+                );
+            } else {
+                activate_focus_scope(&document, &scope_id, restore_target);
+            }
         }
     });
 
     // Step 3: Clean up on unmount using use_drop (Dioxus equivalent of on_cleanup).
     use_drop(move || {
+        activation_active.set(false);
+
         if let Some(document) = web_sys::window().and_then(|window| window.document()) {
             if let Some(scope_el) = document.get_element_by_id(&cleanup_scope_id) {
                 scope_el.remove_attribute("data-ars-modal-open").ok();
@@ -3253,6 +3269,35 @@ fn setup_focus_scope_hydration_safe(
             el.focus().ok();
         }
     });
+}
+
+fn request_hydration_activation_after_frame(
+    scope_id: String,
+    restore_target: Signal<Option<web_sys::HtmlElement>>,
+    activation_active: Rc<Cell<bool>>,
+) {
+    let cb = wasm_bindgen::closure::Closure::once_into_js(move || {
+        if !activation_active.get() {
+            return;
+        }
+
+        let document = web_sys::window()
+            .expect("window")
+            .document()
+            .expect("document");
+
+        let body = document.body().expect("document.body");
+        if body.get_attribute("data-ars-hydrated").is_some() {
+            activate_focus_scope(&document, &scope_id, restore_target);
+        } else {
+            request_hydration_activation_after_frame(scope_id, restore_target, activation_active);
+        }
+    });
+
+    web_sys::window()
+        .expect("window must exist")
+        .request_animation_frame(cb.unchecked_ref())
+        .ok();
 }
 
 fn activate_focus_scope(
@@ -3289,12 +3334,7 @@ fn activate_focus_scope(
         let document_clone = document.clone();
         let cb = wasm_bindgen::closure::Closure::once_into_js(move || {
             // Validate target exists and is visible.
-            let target = scope_el
-                .query_selector("[autofocus], [tabindex]")
-                .ok()
-                .flatten()
-                .and_then(|el| el.dyn_into::<web_sys::HtmlElement>().ok())
-                .filter(|el| el.offset_parent().is_some());
+            let target = visible_focus_target(&scope_el);
 
             if let Some(el) = target {
                 // Save the currently focused element BEFORE moving focus,
@@ -3309,9 +3349,48 @@ fn activate_focus_scope(
         });
         web_sys::window()
             .expect("window must exist")
-            .request_animation_frame(cb.as_ref().unchecked_ref())
+            .request_animation_frame(cb.unchecked_ref())
             .ok();
     }
+}
+
+fn visible_focus_target(scope: &web_sys::HtmlElement) -> Option<web_sys::HtmlElement> {
+    if is_focus_target_candidate(scope) && is_visible_focus_target(scope) {
+        return Some(scope.clone());
+    }
+
+    scope
+        .query_selector(HYDRATION_FOCUS_TARGET_SELECTOR)
+        .ok()
+        .flatten()
+        .and_then(|element| element.dyn_into().ok())
+        .filter(is_visible_focus_target)
+}
+
+fn is_focus_target_candidate(element: &web_sys::Element) -> bool {
+    if element.has_attribute("disabled") {
+        return false;
+    }
+
+    if element.get_attribute("aria-hidden").as_deref() == Some("true") {
+        return false;
+    }
+
+    if element.has_attribute("autofocus") || element.has_attribute("tabindex") {
+        return true;
+    }
+
+    match element.tag_name().as_str() {
+        "BUTTON" | "INPUT" | "SELECT" | "TEXTAREA" => true,
+        "A" | "AREA" => element.has_attribute("href"),
+        _ => element
+            .get_attribute("contenteditable")
+            .is_some_and(|value| value != "false"),
+    }
+}
+
+fn is_visible_focus_target(element: &web_sys::HtmlElement) -> bool {
+    element.offset_parent().is_some()
 }
 
 fn has_open_modal_sibling(element: &web_sys::Element) -> bool {

--- a/spec/foundation/11-dom-utilities.md
+++ b/spec/foundation/11-dom-utilities.md
@@ -2615,15 +2615,19 @@ pub fn ensure_portal_mount_root(owner_id: &str) -> web_sys::Element {
     mount
 }
 
-/// Set `inert` and `aria-hidden="true"` on all siblings of the portal root.
-/// Returns a cleanup function that removes the attributes.
+/// Attribute marking `inert` as owned by adapter modal background handling.
+pub const MODAL_INERT_ATTR: &str = "data-ars-modal-inert";
+
+/// Set `inert`, `data-ars-modal-inert`, and `aria-hidden="true"` on all
+/// siblings of the portal root. Returns a cleanup function that restores the
+/// previous attributes.
 pub fn set_background_inert(portal_root_id: &str) -> Box<dyn FnOnce()> {
     let document = web_sys::window().expect("window exists in browser context")
         .document().expect("document exists");
     let body = document.body().expect("document has body");
     let portal_root = document.get_element_by_id(portal_root_id);
     let children = body.children();
-    let mut restored: Vec<(web_sys::Element, Option<String>, Option<String>)> = Vec::new();
+    let mut restored: Vec<(web_sys::Element, Option<String>, Option<String>, Option<String>)> = Vec::new();
 
     for i in 0..children.length() {
         if let Some(child) = children.item(i) {
@@ -2635,20 +2639,26 @@ pub fn set_background_inert(portal_root_id: &str) -> Box<dyn FnOnce()> {
             }
             // Save original attribute values for cleanup
             let prev_inert = child.get_attribute("inert");
+            let prev_modal_inert = child.get_attribute(MODAL_INERT_ATTR);
             let prev_aria_hidden = child.get_attribute("aria-hidden");
 
             child.set_attribute("inert", "").expect("set inert attribute");
+            child.set_attribute(MODAL_INERT_ATTR, "").expect("set modal inert marker");
             child.set_attribute("aria-hidden", "true").expect("set aria-hidden attribute");
-            restored.push((child, prev_inert, prev_aria_hidden));
+            restored.push((child, prev_inert, prev_modal_inert, prev_aria_hidden));
         }
     }
 
     // Return cleanup function
     Box::new(move || {
-        for (el, prev_inert, prev_aria_hidden) in restored {
+        for (el, prev_inert, prev_modal_inert, prev_aria_hidden) in restored {
             match prev_inert {
                 Some(v) => el.set_attribute("inert", &v).expect("restore inert attribute"),
                 None => el.remove_attribute("inert").expect("remove inert attribute"),
+            }
+            match prev_modal_inert {
+                Some(v) => el.set_attribute(MODAL_INERT_ATTR, &v).expect("restore modal inert marker"),
+                None => el.remove_attribute(MODAL_INERT_ATTR).expect("remove modal inert marker"),
             }
             match prev_aria_hidden {
                 Some(v) => el.set_attribute("aria-hidden", &v).expect("restore aria-hidden attribute"),

--- a/spec/testing/07-ssr-hydration.md
+++ b/spec/testing/07-ssr-hydration.md
@@ -136,10 +136,13 @@ Any component that branches on runtime information (viewport size, user agent, e
 
 ## 4. Hydration ID Consistency Test
 
-Components that generate IDs (via `ComponentIds`, `HasId`, or hydration-safe ID
-generation) MUST verify that SSR and hydration produce identical
-IDs. A mismatch causes Leptos/Dioxus hydration errors and broken ARIA
-references (`aria-labelledby`, `aria-controls`, etc.).
+Components that participate in SSR hydration MUST verify that every DOM ID and
+ARIA ID reference used during hydration comes from an explicit prop or from a
+serialized hydration snapshot. Generated adapter counters are not a hydration
+contract: they are acceptable for client-only rendering and non-hydrated SSR
+output, but they can diverge when server and client render different hook paths.
+A mismatch causes Leptos/Dioxus hydration errors and broken ARIA references
+(`aria-labelledby`, `aria-controls`, etc.).
 
 ```rust
 #[test]
@@ -150,7 +153,7 @@ fn hydration_ids_match_between_ssr_and_client() {
         ..Default::default()
     };
 
-    // Step 1: Render with Service::new — extract all generated IDs.
+    // Step 1: Render with Service::new — extract all explicit and derived IDs.
     // SSR vs hydration mode is determined by the adapter (Leptos/Dioxus) wrapping,
     // not by the Service constructor. The Service API is the same in both modes.
     let ssr_svc = Service::<dialog::Machine>::new(props.clone());
@@ -163,18 +166,7 @@ fn hydration_ids_match_between_ssr_and_client() {
         ssr_api.backdrop_attrs(),
     ]);
 
-    // Reset ID counter to simulate the SSR→client boundary
-    // (server and client both start from 0)
-    // Reset the adapter's ID counter before each SSR test.
-    // Each adapter has its own counter — there is no shared ars_core counter.
-    // Leptos: ars_leptos::reset_id_counter() (see foundation 08 §15)
-    // Dioxus: ars_dioxus::reset_id_counter() (see foundation 09 §15)
-    #[cfg(feature = "leptos")]
-    ars_leptos::reset_id_counter();
-    #[cfg(feature = "dioxus")]
-    ars_dioxus::reset_id_counter();
-
-    // Step 2: Render again with same props — IDs must match.
+    // Step 2: Render again with the same explicit IDs — IDs must match.
     // In a real app, step 1 runs on the server and step 2 runs on the client.
     // Both use Service::new with the same props; the adapter controls which
     // rendering path (SSR string output vs hydration DOM attachment) is used.
@@ -220,9 +212,14 @@ fn extract_all_ids(attr_maps: &[AttrMap]) -> BTreeSet<String> {
 }
 ```
 
-> **Cross-reference:** This test pattern validates the hydration-safe ID
-> generation work. See `01-architecture.md` for
-> the `ComponentIds` contract.
+Generated fallback IDs should be covered separately by adapter-local tests that
+prove uniqueness and hook-slot stability. They MUST NOT be treated as sufficient
+proof that an SSR hydration path is stable unless the component restores the
+exact server ID from a hydration snapshot.
+
+> **Cross-reference:** This test pattern validates explicit and snapshot-restored
+> hydration ID contracts. See `01-architecture.md` for the `ComponentIds`
+> contract.
 
 ---
 


### PR DESCRIPTION
## Summary
- add `ars-dioxus` SSR snapshot serialization and web hydration helpers
- wire hydrated `use_machine` paths, stable IDs, and provider body hydration marking
- extend the same SSR hydration contract to `ars-leptos`, including snapshot serialization, hydrated machine hooks, provider marking, and browser FocusScope guards
- sync adapter/SSR hydration specs and expand native plus wasm coverage

## Validation
- `CHROMEDRIVER=$HOME/.cache/ars-ui-chromedriver/chromedriver-mac-arm64/chromedriver PATH=$HOME/.cargo/bin:$HOME/.cache/ars-ui-chromedriver/chromedriver-mac-arm64:$PATH cargo xtask ci coverage`
- `CHROMEDRIVER=$HOME/.cache/ars-ui-chromedriver/chromedriver-mac-arm64/chromedriver PATH=$HOME/.cargo/bin:$HOME/.cache/ars-ui-chromedriver/chromedriver-mac-arm64:$PATH cargo xtask ci snapshot-count error-variant-coverage feature-matrix mutual-exclusion`
- `cargo clippy -p ars-dioxus --all-targets --features ssr -- -D warnings`
- `cargo clippy -p ars-dioxus --all-targets --features web -- -D warnings`
- `CHROMEDRIVER=$HOME/.cache/ars-ui-chromedriver/chromedriver-mac-arm64/chromedriver PATH=$HOME/.cache/ars-ui-chromedriver/chromedriver-mac-arm64:$PATH wasm-pack test --headless --chrome crates/ars-dioxus --features web`
- `cargo test -p ars-leptos --features ssr hydration`
- `cargo test -p ars-leptos --features ssr use_machine_hydrated`
- `cargo test -p ars-leptos --features ssr use_machine_with_reactive_props_hydrated`
- `cargo clippy -p ars-leptos --all-targets --features ssr -- -D warnings`
- `cargo clippy -p ars-leptos --all-targets --features hydrate --target wasm32-unknown-unknown -- -D warnings`
- `CHROMEDRIVER=$HOME/.cache/ars-ui-chromedriver/chromedriver-mac-arm64/chromedriver PATH=$HOME/.cargo/bin:$HOME/.cache/ars-ui-chromedriver/chromedriver-mac-arm64:$PATH wasm-pack test --headless --chrome crates/ars-leptos --features hydrate`
- `cargo xtask spec validate`
- `cargo xtask ci feature-matrix-leptos`

Closes #196
Closes #628