### PR TITLE
[codex] Implement Dialog agnostic core

### DIFF
--- a/crates/ars-components/Cargo.toml
+++ b/crates/ars-components/Cargo.toml
@@ -13,6 +13,7 @@ std     = ["ars-core/std", "ars-forms/std", "ars-i18n/std", "ars-interactions/st
 debug   = ["dep:log", "ars-core/debug", "ars-interactions/debug"]
 
 [dependencies]
+ars-a11y         = { path = "../ars-a11y", default-features = false }
 ars-core         = { path = "../ars-core", default-features = false }
 ars-forms        = { path = "../ars-forms", default-features = false }
 ars-i18n         = { path = "../ars-i18n", default-features = false }

--- a/crates/ars-components/src/overlay/dialog.rs
+++ b/crates/ars-components/src/overlay/dialog.rs
@@ -1,0 +1,2954 @@
+//! Dialog modal/non-modal overlay machine.
+//!
+//! Owns the binary `Closed`/`Open` state, modal flag, dismissal policy, semantic
+//! IDs, ARIA/data attribute output, and the adapter-resolvable named effect
+//! intents listed in `spec/components/overlay/dialog.md` §1.11.
+//!
+//! The agnostic core never traverses the DOM, never resolves elements by ID,
+//! never attaches document listeners, and never inspects real event targets —
+//! those responsibilities belong to the framework adapter (`ars-leptos`,
+//! `ars-dioxus`). Adapters obtain live element references via `NodeRef`
+//! (Leptos) / `MountedData` (Dioxus); the ID fields in `Context` exist purely
+//! for ARIA wiring and hydration-stable `id` attributes.
+
+use alloc::{
+    string::{String, ToString as _},
+    sync::Arc,
+    vec::Vec,
+};
+use core::{
+    fmt::{self, Debug},
+    sync::atomic::{AtomicBool, Ordering},
+};
+
+use ars_a11y::FocusTarget;
+use ars_core::{
+    AriaAttr, AttrMap, Callback, ComponentIds, ComponentMessages, ComponentPart, ConnectApi, Env,
+    HtmlAttr, Locale, MessageFn, PendingEffect, TransitionPlan,
+};
+use ars_interactions::{KeyboardEventData, KeyboardKey};
+
+// ────────────────────────────────────────────────────────────────────
+// State
+// ────────────────────────────────────────────────────────────────────
+
+/// States for the [`Dialog`](self) component.
+///
+/// Dialog uses a binary lifecycle. Mount/unmount animation lifecycle is
+/// delegated to the [`Presence`](super::presence) machine and composed by the
+/// adapter — see `spec/components/overlay/dialog.md` §5.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum State {
+    /// The dialog is closed and not visible.
+    #[default]
+    Closed,
+
+    /// The dialog is open and visible.
+    Open,
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Event
+// ────────────────────────────────────────────────────────────────────
+
+/// Events accepted by the [`Dialog`](self) state machine.
+///
+/// Mount/unmount animation events (`AnimationStart` / `AnimationEnd`) are not
+/// part of this enum — animation lifecycle is owned by
+/// [`Presence`](super::presence) and composed at the adapter layer.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Event {
+    /// Open the dialog (force-open from closed).
+    Open,
+
+    /// Close the dialog (force-close from open).
+    Close,
+
+    /// Toggle the dialog open/closed.
+    Toggle,
+
+    /// User clicked the backdrop. The state machine guards on
+    /// [`Context::close_on_backdrop`] before transitioning.
+    ///
+    /// Adapters MUST invoke [`Props::on_interact_outside`] with a
+    /// [`PreventableEvent`] before sending this event, and MUST NOT send the
+    /// event when [`PreventableEvent::is_default_prevented`] returns `true`.
+    CloseOnBackdropClick,
+
+    /// User pressed the Escape key. The state machine guards on
+    /// [`Context::close_on_escape`] before transitioning.
+    ///
+    /// Adapters MUST invoke [`Props::on_escape_key_down`] with a
+    /// [`PreventableEvent`] before sending this event, and MUST NOT send the
+    /// event when [`PreventableEvent::is_default_prevented`] returns `true`.
+    CloseOnEscape,
+
+    /// A title element was rendered; sets [`Context::has_title`] so the
+    /// content `aria-labelledby` attribute is emitted.
+    RegisterTitle,
+
+    /// A description element was rendered; sets [`Context::has_description`]
+    /// so the content `aria-describedby` attribute is emitted.
+    RegisterDescription,
+
+    /// Re-apply context-backed [`Props`] fields after a prop change.
+    /// Emitted by `Machine::on_props_changed` (the `Machine` trait method
+    /// that the [`Machine`] state machine implements) when any non-`open`
+    /// field that drives [`Context`] differs between old and new props
+    /// (`modal`, `close_on_backdrop`, `close_on_escape`, `prevent_scroll`,
+    /// `restore_focus`, `initial_focus`, `final_focus`, `role`).
+    ///
+    /// The transition is context-only; it does not change [`State`] and
+    /// emits no adapter intents — the next state-flipping transition will
+    /// emit intents using the freshly-synced context.
+    SyncProps,
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Role
+// ────────────────────────────────────────────────────────────────────
+
+/// Semantic role applied to the dialog content element.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum Role {
+    /// Standard dialog (`role="dialog"`).
+    #[default]
+    Dialog,
+
+    /// Alert dialog (`role="alertdialog"`).
+    AlertDialog,
+}
+
+impl Role {
+    /// ARIA role token rendered on the content element.
+    #[must_use]
+    pub const fn as_aria_role(self) -> &'static str {
+        match self {
+            Self::Dialog => "dialog",
+            Self::AlertDialog => "alertdialog",
+        }
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────
+// PreventableEvent
+// ────────────────────────────────────────────────────────────────────
+
+/// Cancelable event passed to dismissal callbacks.
+///
+/// Used by adapters when invoking [`Props::on_escape_key_down`] /
+/// [`Props::on_interact_outside`] before dispatching
+/// [`Event::CloseOnEscape`] / [`Event::CloseOnBackdropClick`]. Consumers
+/// receive the value by clone and may call
+/// [`PreventableEvent::prevent_default`] to veto the upcoming close
+/// transition (for example, to prompt about unsaved changes). The
+/// adapter that constructed the event observes the veto via
+/// [`PreventableEvent::is_default_prevented`].
+///
+/// Internally the prevention flag is shared through
+/// [`Arc<AtomicBool>`][AtomicBool] so the value can be passed by-clone into
+/// [`Callback`] (which requires `Args: 'static`) while still propagating
+/// veto decisions back to the adapter — the same pattern used by
+/// [`DismissAttempt`](super::super::utility::dismissable::DismissAttempt).
+#[derive(Clone, Debug, Default)]
+pub struct PreventableEvent {
+    veto: Arc<AtomicBool>,
+}
+
+impl PreventableEvent {
+    /// Creates a new event with `is_default_prevented() == false`.
+    ///
+    /// ```
+    /// use ars_components::overlay::dialog::PreventableEvent;
+    ///
+    /// let event = PreventableEvent::new();
+    /// assert!(!event.is_default_prevented());
+    /// ```
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            veto: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// Marks the default behaviour as prevented. Idempotent.
+    ///
+    /// The veto flag is shared across clones — adapters typically pass a
+    /// clone into the consumer's callback and then check the original
+    /// after the callback returns.
+    ///
+    /// ```
+    /// use ars_components::overlay::dialog::PreventableEvent;
+    ///
+    /// let event = PreventableEvent::new();
+    /// let view = event.clone();
+    /// view.prevent_default();
+    /// assert!(event.is_default_prevented());
+    /// ```
+    pub fn prevent_default(&self) {
+        self.veto.store(true, Ordering::SeqCst);
+    }
+
+    /// Returns `true` if [`prevent_default`](Self::prevent_default) was
+    /// called on this event or any of its clones.
+    #[must_use]
+    pub fn is_default_prevented(&self) -> bool {
+        self.veto.load(Ordering::SeqCst)
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Context
+// ────────────────────────────────────────────────────────────────────
+
+/// Runtime context for [`Dialog`](self).
+///
+/// The IDs derived from [`Context::ids`] (via `ids.part("trigger" |
+/// "content" | "title" | "description")`) are semantic strings used for
+/// ARIA wiring and the rendered `id` attribute only. They are never used
+/// by the agnostic core or adapters as element-lookup keys; live element
+/// references are captured by the adapter via `NodeRef` / `MountedData`.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Context {
+    /// Whether the dialog is logically open.
+    pub open: bool,
+
+    /// Whether the dialog is modal (drives `aria-modal` and the
+    /// `set-background-inert` adapter intent).
+    pub modal: bool,
+
+    /// Whether backdrop clicks may close the dialog.
+    pub close_on_backdrop: bool,
+
+    /// Whether the Escape key may close the dialog.
+    pub close_on_escape: bool,
+
+    /// Whether the body should be scroll-locked while the dialog is open.
+    pub prevent_scroll: bool,
+
+    /// Whether focus should be restored to the trigger when the dialog
+    /// closes.
+    pub restore_focus: bool,
+
+    /// Initial focus target resolved by the adapter when the dialog opens.
+    pub initial_focus: Option<FocusTarget>,
+
+    /// Final focus target resolved by the adapter when the dialog closes.
+    pub final_focus: Option<FocusTarget>,
+
+    /// Semantic role applied to the content element.
+    pub role: Role,
+
+    /// Hydration-stable IDs derived from [`Props::id`]. Adapters render
+    /// each part's `id` attribute via `ids.part("trigger" | "content" |
+    /// "title" | "description")`; ARIA wiring (`aria-controls`,
+    /// `aria-labelledby`, `aria-describedby`) reads from the same
+    /// `part(...)` lookup. This matches the workspace convention used by
+    /// `form`, `field`, `fieldset`, `checkbox`, `textarea`, `text_field`,
+    /// and `date_field`.
+    pub ids: ComponentIds,
+
+    /// Whether a title was registered; controls emission of the content
+    /// `aria-labelledby` attribute.
+    pub has_title: bool,
+
+    /// Whether a description was registered; controls emission of the
+    /// content `aria-describedby` attribute.
+    pub has_description: bool,
+
+    /// Active locale used to resolve [`Messages`].
+    pub locale: Locale,
+
+    /// Localized message bundle.
+    pub messages: Messages,
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Messages
+// ────────────────────────────────────────────────────────────────────
+
+/// Localizable strings for [`Dialog`](self).
+#[derive(Clone, Debug, PartialEq)]
+pub struct Messages {
+    /// Accessible label for the close trigger button. Defaults to
+    /// `"Close dialog"`.
+    pub close_label: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
+}
+
+impl Default for Messages {
+    fn default() -> Self {
+        Self {
+            close_label: MessageFn::static_str("Close dialog"),
+        }
+    }
+}
+
+impl ComponentMessages for Messages {}
+
+// ────────────────────────────────────────────────────────────────────
+// Props
+// ────────────────────────────────────────────────────────────────────
+
+/// Immutable configuration for a [`Dialog`](self) instance.
+#[derive(Clone, Debug, PartialEq, ars_core::HasId)]
+pub struct Props {
+    /// Component instance id.
+    pub id: String,
+
+    /// Controlled open state. When `Some`, overrides
+    /// [`default_open`](Self::default_open).
+    pub open: Option<bool>,
+
+    /// Initial open state in uncontrolled mode. Default `false`.
+    pub default_open: bool,
+
+    /// Whether the dialog is modal. Default `true`.
+    pub modal: bool,
+
+    /// Whether backdrop clicks may close the dialog. Default `true`.
+    pub close_on_backdrop: bool,
+
+    /// Whether the Escape key may close the dialog. Default `true`.
+    pub close_on_escape: bool,
+
+    /// Whether to scroll-lock the body while the dialog is open.
+    /// Default `true`.
+    pub prevent_scroll: bool,
+
+    /// Whether focus is restored to the trigger when the dialog closes.
+    /// Default `true`.
+    pub restore_focus: bool,
+
+    /// Initial focus target the adapter resolves when the dialog opens.
+    pub initial_focus: Option<FocusTarget>,
+
+    /// Final focus target the adapter resolves when the dialog closes.
+    pub final_focus: Option<FocusTarget>,
+
+    /// Semantic role applied to the content element. Default
+    /// [`Role::Dialog`].
+    pub role: Role,
+
+    /// Heading level for the title (`<h{level}>`), clamped to `1..=6`.
+    /// Default `2`.
+    pub title_level: u8,
+
+    /// When `true`, dialog content is not rendered until first opened.
+    /// Default `false`.
+    pub lazy_mount: bool,
+
+    /// When `true`, dialog content is removed from the DOM on close.
+    /// Default `false`.
+    pub unmount_on_exit: bool,
+
+    /// Callback invoked after the open state changes, with the new value.
+    pub on_open_change: Option<Callback<dyn Fn(bool) + Send + Sync>>,
+
+    /// Callback invoked before [`Event::CloseOnEscape`] is dispatched. The
+    /// adapter passes a clone of the [`PreventableEvent`] it constructed; if
+    /// the consumer calls [`PreventableEvent::prevent_default`] the close is
+    /// cancelled (the veto flag is shared between clones).
+    pub on_escape_key_down: Option<Callback<dyn Fn(PreventableEvent) + Send + Sync>>,
+
+    /// Callback invoked before [`Event::CloseOnBackdropClick`] is
+    /// dispatched, on outside pointer/focus interactions. The adapter passes
+    /// a clone of the [`PreventableEvent`] it constructed; if the consumer
+    /// calls [`PreventableEvent::prevent_default`] the close is cancelled
+    /// (the veto flag is shared between clones).
+    pub on_interact_outside: Option<Callback<dyn Fn(PreventableEvent) + Send + Sync>>,
+}
+
+impl Default for Props {
+    fn default() -> Self {
+        Self {
+            id: String::new(),
+            open: None,
+            default_open: false,
+            modal: true,
+            close_on_backdrop: true,
+            close_on_escape: true,
+            prevent_scroll: true,
+            restore_focus: true,
+            initial_focus: None,
+            final_focus: None,
+            role: Role::Dialog,
+            title_level: 2,
+            lazy_mount: false,
+            unmount_on_exit: false,
+            on_open_change: None,
+            on_escape_key_down: None,
+            on_interact_outside: None,
+        }
+    }
+}
+
+impl Props {
+    /// Returns a fresh [`Props`] with every field at its [`Default`] value.
+    ///
+    /// `Props::new()` is the documented entry point for the fluent
+    /// builder. Chain setters to populate configuration without the
+    /// `..Props::default()` ceremony struct-literal construction requires:
+    ///
+    /// ```
+    /// use ars_components::overlay::dialog::{Props, Role};
+    ///
+    /// let props = Props::new()
+    ///     .id("confirm")
+    ///     .role(Role::AlertDialog)
+    ///     .modal(true)
+    ///     .close_on_backdrop(false);
+    ///
+    /// assert_eq!(props.id, "confirm");
+    /// assert_eq!(props.role, Role::AlertDialog);
+    /// assert!(props.modal);
+    /// assert!(!props.close_on_backdrop);
+    /// ```
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets [`id`](Self::id).
+    #[must_use]
+    pub fn id(mut self, id: impl Into<String>) -> Self {
+        self.id = id.into();
+        self
+    }
+
+    /// Sets [`open`](Self::open) (controlled state).
+    #[must_use]
+    pub const fn open(mut self, value: Option<bool>) -> Self {
+        self.open = value;
+        self
+    }
+
+    /// Sets [`default_open`](Self::default_open).
+    #[must_use]
+    pub const fn default_open(mut self, value: bool) -> Self {
+        self.default_open = value;
+        self
+    }
+
+    /// Sets [`modal`](Self::modal).
+    #[must_use]
+    pub const fn modal(mut self, value: bool) -> Self {
+        self.modal = value;
+        self
+    }
+
+    /// Sets [`close_on_backdrop`](Self::close_on_backdrop).
+    #[must_use]
+    pub const fn close_on_backdrop(mut self, value: bool) -> Self {
+        self.close_on_backdrop = value;
+        self
+    }
+
+    /// Sets [`close_on_escape`](Self::close_on_escape).
+    #[must_use]
+    pub const fn close_on_escape(mut self, value: bool) -> Self {
+        self.close_on_escape = value;
+        self
+    }
+
+    /// Sets [`prevent_scroll`](Self::prevent_scroll).
+    #[must_use]
+    pub const fn prevent_scroll(mut self, value: bool) -> Self {
+        self.prevent_scroll = value;
+        self
+    }
+
+    /// Sets [`restore_focus`](Self::restore_focus).
+    #[must_use]
+    pub const fn restore_focus(mut self, value: bool) -> Self {
+        self.restore_focus = value;
+        self
+    }
+
+    /// Sets [`initial_focus`](Self::initial_focus).
+    #[must_use]
+    pub const fn initial_focus(mut self, value: Option<FocusTarget>) -> Self {
+        self.initial_focus = value;
+        self
+    }
+
+    /// Sets [`final_focus`](Self::final_focus).
+    #[must_use]
+    pub const fn final_focus(mut self, value: Option<FocusTarget>) -> Self {
+        self.final_focus = value;
+        self
+    }
+
+    /// Sets [`role`](Self::role).
+    #[must_use]
+    pub const fn role(mut self, value: Role) -> Self {
+        self.role = value;
+        self
+    }
+
+    /// Sets [`title_level`](Self::title_level).
+    #[must_use]
+    pub const fn title_level(mut self, value: u8) -> Self {
+        self.title_level = value;
+        self
+    }
+
+    /// Sets [`lazy_mount`](Self::lazy_mount).
+    #[must_use]
+    pub const fn lazy_mount(mut self, value: bool) -> Self {
+        self.lazy_mount = value;
+        self
+    }
+
+    /// Sets [`unmount_on_exit`](Self::unmount_on_exit).
+    #[must_use]
+    pub const fn unmount_on_exit(mut self, value: bool) -> Self {
+        self.unmount_on_exit = value;
+        self
+    }
+
+    /// Registers [`on_open_change`](Self::on_open_change).
+    #[must_use]
+    pub fn on_open_change<F>(mut self, f: F) -> Self
+    where
+        F: Fn(bool) + Send + Sync + 'static,
+    {
+        self.on_open_change = Some(Callback::new(f));
+        self
+    }
+
+    /// Registers [`on_escape_key_down`](Self::on_escape_key_down).
+    #[must_use]
+    pub fn on_escape_key_down<F>(mut self, f: F) -> Self
+    where
+        F: Fn(PreventableEvent) + Send + Sync + 'static,
+    {
+        self.on_escape_key_down = Some(Callback::new(f));
+        self
+    }
+
+    /// Registers [`on_interact_outside`](Self::on_interact_outside).
+    #[must_use]
+    pub fn on_interact_outside<F>(mut self, f: F) -> Self
+    where
+        F: Fn(PreventableEvent) + Send + Sync + 'static,
+    {
+        self.on_interact_outside = Some(Callback::new(f));
+        self
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Part
+// ────────────────────────────────────────────────────────────────────
+
+/// Anatomy parts exposed by the [`Dialog`](self) connect API.
+#[derive(ComponentPart)]
+#[scope = "dialog"]
+pub enum Part {
+    /// The root container element.
+    Root,
+
+    /// The trigger button that opens the dialog.
+    Trigger,
+
+    /// The semi-transparent backdrop behind the content.
+    Backdrop,
+
+    /// The wrapper element that positions the content.
+    Positioner,
+
+    /// The dialog content (`role="dialog"` or `"alertdialog"`).
+    Content,
+
+    /// The optional title element used for `aria-labelledby` wiring.
+    Title,
+
+    /// The optional description element used for `aria-describedby` wiring.
+    Description,
+
+    /// The optional close trigger button rendered inside the content.
+    CloseTrigger,
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Effect names
+// ────────────────────────────────────────────────────────────────────
+
+// Effect-name values are prefixed with `dialog-` for the same reason
+// Tooltip prefixes its names with `tooltip-`: when the name string surfaces
+// in adapter logs, devtools, or shared infrastructure, the component of
+// origin is self-describing without needing to consult the `Service<M>`
+// type parameter.
+
+/// `dialog-set-background-inert` adapter intent name (see spec §1.11).
+pub const EFFECT_SET_BACKGROUND_INERT: &str = "dialog-set-background-inert";
+
+/// `dialog-remove-background-inert` adapter intent name (see spec §1.11).
+pub const EFFECT_REMOVE_BACKGROUND_INERT: &str = "dialog-remove-background-inert";
+
+/// `dialog-scroll-lock-acquire` adapter intent name (see spec §1.11).
+pub const EFFECT_SCROLL_LOCK_ACQUIRE: &str = "dialog-scroll-lock-acquire";
+
+/// `dialog-scroll-lock-release` adapter intent name (see spec §1.11).
+pub const EFFECT_SCROLL_LOCK_RELEASE: &str = "dialog-scroll-lock-release";
+
+/// `dialog-focus-initial` adapter intent name (see spec §1.11).
+pub const EFFECT_FOCUS_INITIAL: &str = "dialog-focus-initial";
+
+/// `dialog-focus-first-tabbable` adapter intent name (see spec §1.11).
+pub const EFFECT_FOCUS_FIRST_TABBABLE: &str = "dialog-focus-first-tabbable";
+
+/// `dialog-restore-focus` adapter intent name (see spec §1.11).
+pub const EFFECT_RESTORE_FOCUS: &str = "dialog-restore-focus";
+
+/// `dialog-open-change` adapter intent name (see spec §1.11).
+///
+/// Emitted on every state-flipping transition (`Closed → Open` and
+/// `Open → Closed`). The adapter resolves the intent by reading the
+/// post-transition open state from the connected [`Api`] (via
+/// [`Api::is_open`]) and invoking [`Props::on_open_change`] with that value.
+///
+/// Adapter dispatch sketch:
+///
+/// ```
+/// use ars_components::overlay::dialog::{
+///     EFFECT_OPEN_CHANGE, EFFECT_RESTORE_FOCUS, Event, Machine,
+/// };
+/// use ars_core::{Env, Service};
+///
+/// # use ars_components::overlay::dialog::{Messages, Props};
+/// #
+/// # let mut service = Service::<Machine>::new(
+/// #     Props { default_open: true, id: "dialog".into(), ..Props::default() },
+/// #     &Env::default(),
+/// #     &Messages::default(),
+/// # );
+///
+/// let result = service.send(Event::Close);
+///
+/// for effect in &result.pending_effects {
+///     match effect.name {
+///         EFFECT_OPEN_CHANGE => { /* notify consumer */ }
+///         EFFECT_RESTORE_FOCUS => { /* focus the trigger handle */ }
+///         _ => { /* ...other intents handled elsewhere... */ }
+///     }
+/// }
+/// ```
+pub const EFFECT_OPEN_CHANGE: &str = "dialog-open-change";
+
+// ────────────────────────────────────────────────────────────────────
+// Machine
+// ────────────────────────────────────────────────────────────────────
+
+/// State machine for the [`Dialog`](self) component.
+#[derive(Debug)]
+pub struct Machine;
+
+impl ars_core::Machine for Machine {
+    type State = State;
+    type Event = Event;
+    type Context = Context;
+    type Props = Props;
+    type Messages = Messages;
+    type Api<'a> = Api<'a>;
+
+    fn init(
+        props: &Self::Props,
+        env: &Env,
+        messages: &Self::Messages,
+    ) -> (Self::State, Self::Context) {
+        let open = props.open.unwrap_or(props.default_open);
+
+        let state = if open { State::Open } else { State::Closed };
+
+        let ids = ComponentIds::from_id(&props.id);
+
+        (
+            state,
+            Context {
+                open,
+                modal: props.modal,
+                close_on_backdrop: props.close_on_backdrop,
+                close_on_escape: props.close_on_escape,
+                prevent_scroll: props.prevent_scroll,
+                restore_focus: props.restore_focus,
+                initial_focus: props.initial_focus,
+                final_focus: props.final_focus,
+                role: props.role,
+                ids,
+                has_title: false,
+                has_description: false,
+                locale: env.locale.clone(),
+                messages: messages.clone(),
+            },
+        )
+    }
+
+    fn transition(
+        state: &Self::State,
+        event: &Self::Event,
+        ctx: &Self::Context,
+        props: &Self::Props,
+    ) -> Option<TransitionPlan<Self>> {
+        match (state, event) {
+            (State::Closed, Event::Open | Event::Toggle) => {
+                let mut plan = TransitionPlan::to(State::Open)
+                    .apply(|ctx: &mut Context| {
+                        ctx.open = true;
+                    })
+                    .with_effect(PendingEffect::named(EFFECT_OPEN_CHANGE))
+                    .with_effect(PendingEffect::named(EFFECT_FOCUS_INITIAL))
+                    .with_effect(PendingEffect::named(EFFECT_FOCUS_FIRST_TABBABLE));
+
+                if ctx.prevent_scroll {
+                    plan = plan.with_effect(PendingEffect::named(EFFECT_SCROLL_LOCK_ACQUIRE));
+                }
+                if ctx.modal {
+                    plan = plan.with_effect(PendingEffect::named(EFFECT_SET_BACKGROUND_INERT));
+                }
+
+                Some(plan)
+            }
+
+            (State::Open, Event::Close | Event::Toggle) => {
+                let mut plan = TransitionPlan::to(State::Closed)
+                    .apply(|ctx: &mut Context| {
+                        ctx.open = false;
+                    })
+                    .with_effect(PendingEffect::named(EFFECT_OPEN_CHANGE));
+
+                if ctx.prevent_scroll {
+                    plan = plan.with_effect(PendingEffect::named(EFFECT_SCROLL_LOCK_RELEASE));
+                }
+
+                if ctx.modal {
+                    plan = plan.with_effect(PendingEffect::named(EFFECT_REMOVE_BACKGROUND_INERT));
+                }
+
+                if ctx.restore_focus {
+                    plan = plan.with_effect(PendingEffect::named(EFFECT_RESTORE_FOCUS));
+                }
+
+                Some(plan)
+            }
+
+            (State::Open, Event::CloseOnBackdropClick) if ctx.close_on_backdrop => Some(
+                TransitionPlan::to(State::Closed)
+                    .apply(|ctx: &mut Context| {
+                        ctx.open = false;
+                    })
+                    .with_effect(PendingEffect::named(EFFECT_OPEN_CHANGE)),
+            ),
+
+            (State::Open, Event::CloseOnEscape) if ctx.close_on_escape => Some(
+                TransitionPlan::to(State::Closed)
+                    .apply(|ctx: &mut Context| {
+                        ctx.open = false;
+                    })
+                    .with_effect(PendingEffect::named(EFFECT_OPEN_CHANGE)),
+            ),
+
+            (_, Event::RegisterTitle) if !ctx.has_title => {
+                Some(TransitionPlan::context_only(|ctx: &mut Context| {
+                    ctx.has_title = true;
+                }))
+            }
+
+            (_, Event::RegisterDescription) if !ctx.has_description => {
+                Some(TransitionPlan::context_only(|ctx: &mut Context| {
+                    ctx.has_description = true;
+                }))
+            }
+
+            (_, Event::SyncProps) => {
+                // Replay context-backed prop fields. The `apply` closure
+                // captures the values by copy/move so the agnostic core
+                // does not retain `&props`.
+                let modal = props.modal;
+                let close_on_backdrop = props.close_on_backdrop;
+                let close_on_escape = props.close_on_escape;
+                let prevent_scroll = props.prevent_scroll;
+                let restore_focus = props.restore_focus;
+                let initial_focus = props.initial_focus;
+                let final_focus = props.final_focus;
+                let role = props.role;
+                Some(TransitionPlan::context_only(move |ctx: &mut Context| {
+                    ctx.modal = modal;
+                    ctx.close_on_backdrop = close_on_backdrop;
+                    ctx.close_on_escape = close_on_escape;
+                    ctx.prevent_scroll = prevent_scroll;
+                    ctx.restore_focus = restore_focus;
+                    ctx.initial_focus = initial_focus;
+                    ctx.final_focus = final_focus;
+                    ctx.role = role;
+                }))
+            }
+
+            _ => None,
+        }
+    }
+
+    fn connect<'a>(
+        state: &'a Self::State,
+        ctx: &'a Self::Context,
+        props: &'a Self::Props,
+        send: &'a dyn Fn(Self::Event),
+    ) -> Self::Api<'a> {
+        Api {
+            state,
+            ctx,
+            props,
+            send,
+        }
+    }
+
+    fn on_props_changed(old: &Self::Props, new: &Self::Props) -> Vec<Self::Event> {
+        let mut events = Vec::new();
+
+        if let (was, Some(now)) = (old.open, new.open)
+            && was != Some(now)
+        {
+            events.push(if now { Event::Open } else { Event::Close });
+        }
+
+        if context_relevant_props_changed(old, new) {
+            events.push(Event::SyncProps);
+        }
+
+        events
+    }
+}
+
+/// Returns `true` when any context-backed non-`open` prop differs between
+/// `old` and `new`. Used by [`Machine::on_props_changed`] to decide whether
+/// to emit [`Event::SyncProps`].
+fn context_relevant_props_changed(old: &Props, new: &Props) -> bool {
+    old.modal != new.modal
+        || old.close_on_backdrop != new.close_on_backdrop
+        || old.close_on_escape != new.close_on_escape
+        || old.prevent_scroll != new.prevent_scroll
+        || old.restore_focus != new.restore_focus
+        || old.initial_focus != new.initial_focus
+        || old.final_focus != new.final_focus
+        || old.role != new.role
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Api
+// ────────────────────────────────────────────────────────────────────
+
+/// Connected API surface for the [`Dialog`](self) component.
+pub struct Api<'a> {
+    state: &'a State,
+    ctx: &'a Context,
+    props: &'a Props,
+    send: &'a dyn Fn(Event),
+}
+
+impl Debug for Api<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Api")
+            .field("state", self.state)
+            .field("ctx", self.ctx)
+            .field("props", self.props)
+            .finish()
+    }
+}
+
+impl Api<'_> {
+    /// Returns `true` when the dialog is in [`State::Open`].
+    ///
+    /// ```
+    /// use ars_components::overlay::dialog::{Machine, Messages, Props};
+    /// use ars_core::{Env, Service};
+    ///
+    /// let service = Service::<Machine>::new(
+    ///     Props { default_open: true, id: "dialog".into(), ..Props::default() },
+    ///     &Env::default(),
+    ///     &Messages::default(),
+    /// );
+    ///
+    /// assert!(service.connect(&|_| {}).is_open());
+    /// ```
+    #[must_use]
+    pub const fn is_open(&self) -> bool {
+        matches!(self.state, State::Open)
+    }
+
+    /// Returns `true` when the dialog is configured as modal.
+    ///
+    /// Reads the live [`Context::modal`] flag — which is initialised from
+    /// [`Props::modal`] and re-applied by the
+    /// [`Event::SyncProps`] transition when props change at runtime.
+    /// Useful for adapters that conditionally render the
+    /// [`Part::Backdrop`] only for modal dialogs.
+    #[must_use]
+    pub const fn is_modal(&self) -> bool {
+        self.ctx.modal
+    }
+
+    /// Returns the active [`Role`] of the dialog content element.
+    ///
+    /// Reads the live [`Context::role`]. Adapters that need the role for
+    /// logging, test fixtures, or conditional behaviour read it through
+    /// this accessor; the same value drives the `role="..."` attribute on
+    /// [`Part::Content`] via [`Role::as_aria_role`].
+    #[must_use]
+    pub const fn role(&self) -> Role {
+        self.ctx.role
+    }
+
+    /// Returns the value of [`Props::lazy_mount`].
+    ///
+    /// Adapter-only hint: the agnostic core never reads this flag, but
+    /// adapters composing with [`Presence`](super::presence) need to defer
+    /// content rendering and CSS animation start until lazy content
+    /// settles. Exposed through the `Api` so adapters do not need to
+    /// thread `Props` separately.
+    #[must_use]
+    pub const fn lazy_mount(&self) -> bool {
+        self.props.lazy_mount
+    }
+
+    /// Returns the value of [`Props::unmount_on_exit`].
+    ///
+    /// Adapter-only hint: when `true`, adapters MUST remove the dialog
+    /// content from the DOM on close (after the exit animation finishes).
+    /// The agnostic core does not consume this flag.
+    #[must_use]
+    pub const fn unmount_on_exit(&self) -> bool {
+        self.props.unmount_on_exit
+    }
+
+    const fn state_token(&self) -> &'static str {
+        if self.is_open() { "open" } else { "closed" }
+    }
+
+    /// Attributes for the root element.
+    #[must_use]
+    pub fn root_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Root.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Data("ars-state"), self.state_token());
+
+        attrs
+    }
+
+    /// Attributes for the trigger button.
+    #[must_use]
+    pub fn trigger_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Trigger.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Id, self.ctx.ids.part("trigger"))
+            .set(HtmlAttr::Type, "button")
+            .set(HtmlAttr::Aria(AriaAttr::HasPopup), "dialog")
+            .set(
+                HtmlAttr::Aria(AriaAttr::Expanded),
+                if self.is_open() { "true" } else { "false" },
+            )
+            .set(
+                HtmlAttr::Aria(AriaAttr::Controls),
+                self.ctx.ids.part("content"),
+            );
+
+        attrs
+    }
+
+    /// Adapter handler: the trigger element was clicked.
+    pub fn on_trigger_click(&self) {
+        (self.send)(Event::Toggle);
+    }
+
+    /// Attributes for the backdrop element.
+    ///
+    /// `aria-hidden="true"` and `inert` are always emitted because the
+    /// backdrop is decorative. The `set-background-inert` adapter intent
+    /// (see spec §1.11) governs the *sibling* inert state, not this
+    /// element.
+    #[must_use]
+    pub fn backdrop_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Backdrop.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Data("ars-state"), self.state_token())
+            .set(HtmlAttr::Aria(AriaAttr::Hidden), "true")
+            .set(HtmlAttr::Inert, "");
+
+        attrs
+    }
+
+    /// Adapter handler: a pointer event closed the dialog from the
+    /// backdrop. Adapters MUST consult [`Props::on_interact_outside`] (with
+    /// a [`PreventableEvent`]) before calling this method.
+    pub fn on_backdrop_click(&self) {
+        (self.send)(Event::CloseOnBackdropClick);
+    }
+
+    /// Attributes for the positioner wrapper.
+    #[must_use]
+    pub fn positioner_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Positioner.data_attrs();
+
+        attrs.set(scope_attr, scope_val).set(part_attr, part_val);
+
+        attrs
+    }
+
+    /// Attributes for the content element (the dialog itself).
+    #[must_use]
+    pub fn content_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Content.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Id, self.ctx.ids.part("content"))
+            .set(HtmlAttr::Role, self.ctx.role.as_aria_role())
+            .set(HtmlAttr::Data("ars-state"), self.state_token())
+            .set(
+                HtmlAttr::TabIndex,
+                // Content is a programmatic focus target during the focus
+                // delay window; adapters override with `tabindex="0"`
+                // dynamically when needed. We render -1 by default so the
+                // content is reachable via `.focus()` but not via Tab.
+                "-1",
+            );
+
+        if self.ctx.modal {
+            attrs.set(HtmlAttr::Aria(AriaAttr::Modal), "true");
+        }
+
+        if self.ctx.has_title {
+            attrs.set(
+                HtmlAttr::Aria(AriaAttr::LabelledBy),
+                self.ctx.ids.part("title"),
+            );
+        }
+
+        if self.ctx.has_description {
+            attrs.set(
+                HtmlAttr::Aria(AriaAttr::DescribedBy),
+                self.ctx.ids.part("description"),
+            );
+        }
+        attrs
+    }
+
+    /// Adapter handler: a key was pressed on the content element. Sends
+    /// [`Event::CloseOnEscape`] when the key is Escape (after the adapter
+    /// has cleared the [`Props::on_escape_key_down`] callback).
+    pub fn on_content_keydown(&self, data: &KeyboardEventData) {
+        if data.key == KeyboardKey::Escape {
+            (self.send)(Event::CloseOnEscape);
+        }
+    }
+
+    /// Attributes for the title element.
+    ///
+    /// The `data-ars-heading-level` attribute is the clamped
+    /// [`Props::title_level`] value; adapters render `<h{level}>` accordingly.
+    #[must_use]
+    pub fn title_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Title.data_attrs();
+
+        let level = self.props.title_level.clamp(1, 6);
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Id, self.ctx.ids.part("title"))
+            .set(HtmlAttr::Data("ars-heading-level"), level.to_string());
+
+        attrs
+    }
+
+    /// Attributes for the description element.
+    #[must_use]
+    pub fn description_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Description.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Id, self.ctx.ids.part("description"));
+
+        attrs
+    }
+
+    /// Attributes for the close trigger button.
+    #[must_use]
+    pub fn close_trigger_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::CloseTrigger.data_attrs();
+
+        let label = (self.ctx.messages.close_label)(&self.ctx.locale);
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Type, "button")
+            .set(HtmlAttr::Aria(AriaAttr::Label), label);
+
+        attrs
+    }
+
+    /// Adapter handler: the close trigger was activated.
+    pub fn on_close_trigger_click(&self) {
+        (self.send)(Event::Close);
+    }
+}
+
+impl ConnectApi for Api<'_> {
+    type Part = Part;
+
+    fn part_attrs(&self, part: Part) -> AttrMap {
+        match part {
+            Part::Root => self.root_attrs(),
+            Part::Trigger => self.trigger_attrs(),
+            Part::Backdrop => self.backdrop_attrs(),
+            Part::Positioner => self.positioner_attrs(),
+            Part::Content => self.content_attrs(),
+            Part::Title => self.title_attrs(),
+            Part::Description => self.description_attrs(),
+            Part::CloseTrigger => self.close_trigger_attrs(),
+        }
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Tests
+// ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use alloc::{
+        rc::Rc,
+        string::{String, ToString},
+        vec::Vec,
+    };
+    use core::cell::RefCell;
+
+    use ars_core::{Machine as MachineTrait, MessageFn, SendResult, Service};
+    use insta::assert_snapshot;
+
+    use super::*;
+
+    // ── Test fixtures ───────────────────────────────────────────────
+
+    fn test_props() -> Props {
+        Props {
+            id: "dialog".to_string(),
+            ..Props::default()
+        }
+    }
+
+    fn keyboard_data(key: KeyboardKey) -> KeyboardEventData {
+        KeyboardEventData {
+            key,
+            character: None,
+            code: String::new(),
+            shift_key: false,
+            ctrl_key: false,
+            alt_key: false,
+            meta_key: false,
+            repeat: false,
+            is_composing: false,
+        }
+    }
+
+    fn effect_names(result: &SendResult<Machine>) -> Vec<&'static str> {
+        result
+            .pending_effects
+            .iter()
+            .map(|effect| effect.name)
+            .collect()
+    }
+
+    fn fresh_service(props: Props) -> Service<Machine> {
+        Service::<Machine>::new(props, &Env::default(), &Messages::default())
+    }
+
+    fn open_service(props: Props) -> Service<Machine> {
+        let mut props = props;
+
+        props.default_open = true;
+
+        Service::<Machine>::new(props, &Env::default(), &Messages::default())
+    }
+
+    fn snapshot_attrs(attrs: &AttrMap) -> String {
+        format!("{attrs:#?}")
+    }
+
+    // Test 1
+    #[test]
+    fn init_default_open_false_starts_closed() {
+        let service = fresh_service(test_props());
+
+        assert_eq!(service.state(), &State::Closed);
+
+        let ctx = service.context();
+
+        assert!(!ctx.open);
+        assert!(!ctx.has_title);
+        assert!(!ctx.has_description);
+        assert_eq!(ctx.ids.part("trigger"), "dialog-trigger");
+        assert_eq!(ctx.ids.part("content"), "dialog-content");
+        assert_eq!(ctx.ids.part("title"), "dialog-title");
+        assert_eq!(ctx.ids.part("description"), "dialog-description");
+    }
+
+    // Test 2
+    #[test]
+    fn init_default_open_true_starts_open() {
+        let service = fresh_service(Props {
+            default_open: true,
+            ..test_props()
+        });
+
+        assert_eq!(service.state(), &State::Open);
+        assert!(service.context().open);
+    }
+
+    // Test 3
+    #[test]
+    fn init_controlled_open_starts_open() {
+        let service = fresh_service(Props {
+            open: Some(true),
+            default_open: false,
+            ..test_props()
+        });
+
+        assert_eq!(service.state(), &State::Open);
+        assert!(service.context().open);
+    }
+
+    // Test 4
+    #[test]
+    fn init_controlled_open_overrides_default_open() {
+        let service = fresh_service(Props {
+            open: Some(false),
+            default_open: true,
+            ..test_props()
+        });
+
+        assert_eq!(service.state(), &State::Closed);
+        assert!(!service.context().open);
+    }
+
+    // Test 5
+    #[test]
+    fn init_role_alertdialog_preserved() {
+        let service = fresh_service(Props {
+            role: Role::AlertDialog,
+            ..test_props()
+        });
+
+        assert_eq!(service.context().role, Role::AlertDialog);
+    }
+
+    // Test 6
+    #[test]
+    fn init_locale_and_messages_passed_through_env() {
+        let env = Env::default();
+
+        let messages = Messages {
+            close_label: MessageFn::static_str("Cerrar"),
+        };
+
+        let service = Service::<Machine>::new(test_props(), &env, &messages);
+
+        assert_eq!(service.context().locale, env.locale);
+        assert_eq!(
+            (service.context().messages.close_label)(&service.context().locale),
+            "Cerrar"
+        );
+    }
+
+    // Test 7
+    #[test]
+    fn event_open_transitions_closed_to_open() {
+        let mut service = fresh_service(test_props());
+
+        let result = service.send(Event::Open);
+
+        assert!(result.state_changed);
+        assert_eq!(service.state(), &State::Open);
+        assert!(service.context().open);
+    }
+
+    // Test 8
+    #[test]
+    fn event_close_transitions_open_to_closed() {
+        let mut service = open_service(test_props());
+
+        let result = service.send(Event::Close);
+
+        assert!(result.state_changed);
+        assert_eq!(service.state(), &State::Closed);
+        assert!(!service.context().open);
+    }
+
+    // Test 9
+    #[test]
+    fn event_toggle_from_closed_opens() {
+        let mut service = fresh_service(test_props());
+
+        drop(service.send(Event::Toggle));
+
+        assert_eq!(service.state(), &State::Open);
+    }
+
+    // Test 10
+    #[test]
+    fn event_toggle_from_open_closes() {
+        let mut service = open_service(test_props());
+
+        drop(service.send(Event::Toggle));
+
+        assert_eq!(service.state(), &State::Closed);
+    }
+
+    // Test 11
+    #[test]
+    fn event_close_on_backdrop_click_closes_when_allowed() {
+        let mut service = open_service(Props {
+            close_on_backdrop: true,
+            ..test_props()
+        });
+
+        drop(service.send(Event::CloseOnBackdropClick));
+
+        assert_eq!(service.state(), &State::Closed);
+    }
+
+    // Test 12
+    #[test]
+    fn event_close_on_backdrop_click_no_op_when_disabled() {
+        let mut service = open_service(Props {
+            close_on_backdrop: false,
+            ..test_props()
+        });
+
+        let result = service.send(Event::CloseOnBackdropClick);
+
+        assert!(!result.state_changed);
+        assert!(!result.context_changed);
+        assert_eq!(service.state(), &State::Open);
+        assert!(service.context().open);
+    }
+
+    // Test 13
+    #[test]
+    fn event_close_on_escape_closes_when_allowed() {
+        let mut service = open_service(Props {
+            close_on_escape: true,
+            ..test_props()
+        });
+
+        drop(service.send(Event::CloseOnEscape));
+
+        assert_eq!(service.state(), &State::Closed);
+    }
+
+    // Test 14
+    #[test]
+    fn event_close_on_escape_no_op_when_disabled() {
+        let mut service = open_service(Props {
+            close_on_escape: false,
+            ..test_props()
+        });
+
+        let result = service.send(Event::CloseOnEscape);
+
+        assert!(!result.state_changed);
+        assert_eq!(service.state(), &State::Open);
+    }
+
+    // Test 15
+    #[test]
+    fn event_register_title_sets_has_title() {
+        let mut service = fresh_service(test_props());
+
+        let result = service.send(Event::RegisterTitle);
+
+        assert!(result.context_changed);
+        assert!(service.context().has_title);
+
+        // Guarded: re-sending RegisterTitle when `has_title` is already
+        // true is a no-op — no transition plan, no `context_changed` signal,
+        // no spurious re-render trigger.
+        let result_again = service.send(Event::RegisterTitle);
+
+        assert!(service.context().has_title);
+        assert!(!result_again.state_changed);
+        assert!(!result_again.context_changed);
+    }
+
+    // Test 16
+    #[test]
+    fn event_register_description_sets_has_description() {
+        let mut service = fresh_service(test_props());
+
+        let result = service.send(Event::RegisterDescription);
+
+        assert!(result.context_changed);
+        assert!(service.context().has_description);
+
+        // Guarded — see RegisterTitle.
+        let result_again = service.send(Event::RegisterDescription);
+
+        assert!(service.context().has_description);
+        assert!(!result_again.state_changed);
+        assert!(!result_again.context_changed);
+    }
+
+    // Test 17
+    #[test]
+    fn event_open_in_open_state_no_op() {
+        let mut service = open_service(test_props());
+
+        let result = service.send(Event::Open);
+
+        assert!(!result.state_changed);
+        assert_eq!(service.state(), &State::Open);
+    }
+
+    // Test 18
+    #[test]
+    fn event_close_in_closed_state_no_op() {
+        let mut service = fresh_service(test_props());
+
+        let result = service.send(Event::Close);
+
+        assert!(!result.state_changed);
+        assert_eq!(service.state(), &State::Closed);
+    }
+
+    // Test 19
+    #[test]
+    fn open_emits_scroll_lock_intent_when_prevent_scroll() {
+        let mut service = fresh_service(Props {
+            prevent_scroll: true,
+            ..test_props()
+        });
+
+        let result = service.send(Event::Open);
+
+        assert!(effect_names(&result).contains(&EFFECT_SCROLL_LOCK_ACQUIRE));
+    }
+
+    // Test 20
+    #[test]
+    fn open_skips_scroll_lock_intent_when_prevent_scroll_false() {
+        let mut service = fresh_service(Props {
+            prevent_scroll: false,
+            ..test_props()
+        });
+
+        let result = service.send(Event::Open);
+
+        assert!(!effect_names(&result).contains(&EFFECT_SCROLL_LOCK_ACQUIRE));
+    }
+
+    // Test 21
+    #[test]
+    fn open_emits_set_background_inert_intent_when_modal() {
+        let mut service = fresh_service(Props {
+            modal: true,
+            ..test_props()
+        });
+
+        let result = service.send(Event::Open);
+
+        assert!(effect_names(&result).contains(&EFFECT_SET_BACKGROUND_INERT));
+    }
+
+    // Test 22
+    #[test]
+    fn open_skips_set_background_inert_intent_when_non_modal() {
+        let mut service = fresh_service(Props {
+            modal: false,
+            ..test_props()
+        });
+
+        let result = service.send(Event::Open);
+
+        assert!(!effect_names(&result).contains(&EFFECT_SET_BACKGROUND_INERT));
+    }
+
+    // Test 23
+    #[test]
+    fn open_emits_focus_initial_intent() {
+        let mut service = fresh_service(test_props());
+
+        let result = service.send(Event::Open);
+
+        let names = effect_names(&result);
+
+        assert!(names.contains(&EFFECT_FOCUS_INITIAL));
+        assert!(names.contains(&EFFECT_FOCUS_FIRST_TABBABLE));
+    }
+
+    // Test 24
+    #[test]
+    fn close_emits_release_scroll_lock_intent_when_prevent_scroll() {
+        let mut service = open_service(Props {
+            prevent_scroll: true,
+            ..test_props()
+        });
+
+        let result = service.send(Event::Close);
+
+        assert!(effect_names(&result).contains(&EFFECT_SCROLL_LOCK_RELEASE));
+    }
+
+    // Test 25
+    #[test]
+    fn close_emits_remove_background_inert_intent_when_modal() {
+        let mut service = open_service(Props {
+            modal: true,
+            ..test_props()
+        });
+
+        let result = service.send(Event::Close);
+
+        assert!(effect_names(&result).contains(&EFFECT_REMOVE_BACKGROUND_INERT));
+    }
+
+    // Test 26
+    #[test]
+    fn close_emits_restore_focus_intent_when_restore_focus_true() {
+        let mut service = open_service(Props {
+            restore_focus: true,
+            ..test_props()
+        });
+
+        let result = service.send(Event::Close);
+
+        assert!(effect_names(&result).contains(&EFFECT_RESTORE_FOCUS));
+    }
+
+    // Test 27
+    #[test]
+    fn close_skips_restore_focus_intent_when_restore_focus_false() {
+        let mut service = open_service(Props {
+            restore_focus: false,
+            ..test_props()
+        });
+
+        let result = service.send(Event::Close);
+
+        assert!(!effect_names(&result).contains(&EFFECT_RESTORE_FOCUS));
+    }
+
+    // Test 27a — regression guard: every effect emitted by Open and Close is
+    // one of the documented payload-free named intents from spec §1.11.
+    #[test]
+    fn effects_carry_no_id_payload() {
+        const ALLOWED: &[&str] = &[
+            EFFECT_FOCUS_INITIAL,
+            EFFECT_FOCUS_FIRST_TABBABLE,
+            EFFECT_SCROLL_LOCK_ACQUIRE,
+            EFFECT_SCROLL_LOCK_RELEASE,
+            EFFECT_SET_BACKGROUND_INERT,
+            EFFECT_REMOVE_BACKGROUND_INERT,
+            EFFECT_RESTORE_FOCUS,
+            EFFECT_OPEN_CHANGE,
+        ];
+
+        let mut service = fresh_service(test_props());
+
+        let open_result = service.send(Event::Open);
+
+        for effect in &open_result.pending_effects {
+            assert!(
+                ALLOWED.contains(&effect.name),
+                "open emitted unknown effect {:?}",
+                effect.name
+            );
+            assert!(
+                effect.metadata.is_none(),
+                "open effect {:?} carries metadata payload",
+                effect.name
+            );
+        }
+
+        let close_result = service.send(Event::Close);
+
+        for effect in &close_result.pending_effects {
+            assert!(
+                ALLOWED.contains(&effect.name),
+                "close emitted unknown effect {:?}",
+                effect.name
+            );
+            assert!(
+                effect.metadata.is_none(),
+                "close effect {:?} carries metadata payload",
+                effect.name
+            );
+        }
+    }
+
+    // ── open-change adapter intent tests (Finding 1) ──────────────
+
+    #[test]
+    fn open_event_emits_open_change_intent() {
+        let mut service = fresh_service(test_props());
+
+        let result = service.send(Event::Open);
+
+        assert!(effect_names(&result).contains(&EFFECT_OPEN_CHANGE));
+    }
+
+    #[test]
+    fn close_event_emits_open_change_intent() {
+        let mut service = open_service(test_props());
+
+        let result = service.send(Event::Close);
+
+        assert!(effect_names(&result).contains(&EFFECT_OPEN_CHANGE));
+    }
+
+    #[test]
+    fn toggle_event_emits_open_change_intent_in_either_direction() {
+        let mut closed = fresh_service(test_props());
+
+        assert!(effect_names(&closed.send(Event::Toggle)).contains(&EFFECT_OPEN_CHANGE));
+
+        let mut opened = open_service(test_props());
+
+        assert!(effect_names(&opened.send(Event::Toggle)).contains(&EFFECT_OPEN_CHANGE));
+    }
+
+    #[test]
+    fn close_on_backdrop_emits_open_change_intent_when_allowed() {
+        let mut service = open_service(test_props());
+
+        let result = service.send(Event::CloseOnBackdropClick);
+
+        assert!(effect_names(&result).contains(&EFFECT_OPEN_CHANGE));
+    }
+
+    #[test]
+    fn close_on_escape_emits_open_change_intent_when_allowed() {
+        let mut service = open_service(test_props());
+
+        let result = service.send(Event::CloseOnEscape);
+
+        assert!(effect_names(&result).contains(&EFFECT_OPEN_CHANGE));
+    }
+
+    #[test]
+    fn close_on_backdrop_skips_open_change_intent_when_guarded() {
+        let mut service = open_service(Props {
+            close_on_backdrop: false,
+            ..test_props()
+        });
+
+        let result = service.send(Event::CloseOnBackdropClick);
+
+        assert!(!effect_names(&result).contains(&EFFECT_OPEN_CHANGE));
+    }
+
+    #[test]
+    fn close_on_escape_skips_open_change_intent_when_guarded() {
+        let mut service = open_service(Props {
+            close_on_escape: false,
+            ..test_props()
+        });
+
+        let result = service.send(Event::CloseOnEscape);
+
+        assert!(!effect_names(&result).contains(&EFFECT_OPEN_CHANGE));
+    }
+
+    #[test]
+    fn register_title_does_not_emit_open_change_intent() {
+        let mut service = fresh_service(test_props());
+
+        let result = service.send(Event::RegisterTitle);
+
+        assert!(!effect_names(&result).contains(&EFFECT_OPEN_CHANGE));
+    }
+
+    #[test]
+    fn register_description_does_not_emit_open_change_intent() {
+        let mut service = fresh_service(test_props());
+
+        let result = service.send(Event::RegisterDescription);
+
+        assert!(!effect_names(&result).contains(&EFFECT_OPEN_CHANGE));
+    }
+
+    #[test]
+    fn no_op_open_in_open_state_does_not_emit_open_change_intent() {
+        let mut service = open_service(test_props());
+
+        let result = service.send(Event::Open);
+
+        assert!(!effect_names(&result).contains(&EFFECT_OPEN_CHANGE));
+    }
+
+    #[test]
+    fn no_op_close_in_closed_state_does_not_emit_open_change_intent() {
+        let mut service = fresh_service(test_props());
+
+        let result = service.send(Event::Close);
+
+        assert!(!effect_names(&result).contains(&EFFECT_OPEN_CHANGE));
+    }
+
+    // ── Api event-handler dispatch tests ──────────────────────────
+
+    fn drain_to_vec(events: &Rc<RefCell<Vec<Event>>>) -> Vec<Event> {
+        events.borrow().clone()
+    }
+
+    // Test 28
+    #[test]
+    fn on_trigger_click_sends_toggle() {
+        let service = fresh_service(test_props());
+
+        let captured = Rc::new(RefCell::new(Vec::new()));
+
+        let captured_for_send = Rc::clone(&captured);
+
+        let send = move |event: Event| captured_for_send.borrow_mut().push(event);
+
+        service.connect(&send).on_trigger_click();
+
+        assert_eq!(drain_to_vec(&captured), [Event::Toggle]);
+    }
+
+    // Test 29
+    #[test]
+    fn on_backdrop_click_sends_close_on_backdrop_click() {
+        let service = open_service(test_props());
+
+        let captured = Rc::new(RefCell::new(Vec::new()));
+
+        let captured_for_send = Rc::clone(&captured);
+
+        let send = move |event: Event| captured_for_send.borrow_mut().push(event);
+
+        service.connect(&send).on_backdrop_click();
+
+        assert_eq!(drain_to_vec(&captured), [Event::CloseOnBackdropClick]);
+    }
+
+    // Test 30
+    #[test]
+    fn on_content_keydown_escape_sends_close_on_escape() {
+        let service = open_service(test_props());
+
+        let captured = Rc::new(RefCell::new(Vec::new()));
+
+        let captured_for_send = Rc::clone(&captured);
+
+        let send = move |event: Event| captured_for_send.borrow_mut().push(event);
+
+        service
+            .connect(&send)
+            .on_content_keydown(&keyboard_data(KeyboardKey::Escape));
+
+        assert_eq!(drain_to_vec(&captured), [Event::CloseOnEscape]);
+    }
+
+    // Test 31
+    #[test]
+    fn on_content_keydown_non_escape_no_op() {
+        let service = open_service(test_props());
+
+        let captured = Rc::new(RefCell::new(Vec::new()));
+
+        let captured_for_send = Rc::clone(&captured);
+
+        let send = move |event: Event| captured_for_send.borrow_mut().push(event);
+
+        let api = service.connect(&send);
+
+        api.on_content_keydown(&keyboard_data(KeyboardKey::Tab));
+        api.on_content_keydown(&keyboard_data(KeyboardKey::Enter));
+
+        assert!(drain_to_vec(&captured).is_empty());
+    }
+
+    // Test 32
+    #[test]
+    fn on_close_trigger_click_sends_close() {
+        let service = open_service(test_props());
+
+        let captured = Rc::new(RefCell::new(Vec::new()));
+
+        let captured_for_send = Rc::clone(&captured);
+
+        let send = move |event: Event| captured_for_send.borrow_mut().push(event);
+
+        service.connect(&send).on_close_trigger_click();
+
+        assert_eq!(drain_to_vec(&captured), [Event::Close]);
+    }
+
+    // Test 33
+    #[test]
+    fn is_open_returns_true_when_state_open() {
+        let service = open_service(test_props());
+
+        assert!(service.connect(&|_| {}).is_open());
+    }
+
+    // Test 34
+    #[test]
+    fn is_open_returns_false_when_state_closed() {
+        let service = fresh_service(test_props());
+
+        assert!(!service.connect(&|_| {}).is_open());
+    }
+
+    // ── PreventableEvent tests ────────────────────────────────────
+
+    // Test 35
+    #[test]
+    fn preventable_event_starts_not_prevented() {
+        let event = PreventableEvent::new();
+
+        assert!(!event.is_default_prevented());
+    }
+
+    // Test 36
+    #[test]
+    fn preventable_event_prevent_default_marks_prevented() {
+        let event = PreventableEvent::new();
+
+        event.prevent_default();
+
+        assert!(event.is_default_prevented());
+    }
+
+    // Test 37
+    #[test]
+    fn preventable_event_repeated_prevent_default_idempotent() {
+        let event = PreventableEvent::new();
+
+        event.prevent_default();
+        event.prevent_default();
+
+        assert!(event.is_default_prevented());
+
+        // Cloned views observe the shared veto.
+        let cloned = event.clone();
+
+        assert!(cloned.is_default_prevented());
+    }
+
+    // ── on_props_changed tests ────────────────────────────────────
+
+    #[test]
+    fn on_props_changed_emits_open_when_controlled_open_set_true() {
+        let old = test_props();
+
+        let new = Props {
+            open: Some(true),
+            ..test_props()
+        };
+
+        assert_eq!(Machine::on_props_changed(&old, &new), [Event::Open]);
+    }
+
+    #[test]
+    fn on_props_changed_emits_close_when_controlled_open_set_false() {
+        let old = Props {
+            open: Some(true),
+            ..test_props()
+        };
+
+        let new = Props {
+            open: Some(false),
+            ..test_props()
+        };
+
+        assert_eq!(Machine::on_props_changed(&old, &new), [Event::Close]);
+    }
+
+    #[test]
+    fn on_props_changed_emits_nothing_when_open_unchanged() {
+        let old = Props {
+            open: Some(true),
+            ..test_props()
+        };
+
+        assert!(Machine::on_props_changed(&old, &old).is_empty());
+    }
+
+    #[test]
+    fn on_props_changed_ignores_uncontrolled_to_uncontrolled() {
+        let old = test_props();
+
+        let new = Props {
+            default_open: true,
+            ..test_props()
+        };
+
+        assert!(Machine::on_props_changed(&old, &new).is_empty());
+    }
+
+    // ── Role helper ───────────────────────────────────────────────
+
+    #[test]
+    fn props_debug_redacts_callback_closures() {
+        let props = Props::new()
+            .id("dbg")
+            .on_open_change(|_| {})
+            .on_escape_key_down(|_| {})
+            .on_interact_outside(|_| {});
+
+        let rendered = format!("{props:?}");
+
+        assert!(rendered.contains("Props"));
+
+        // `Callback`'s `Debug` impl writes `Callback(..)` rather than the
+        // closure pointer, so consumers never see opaque function addresses
+        // in error messages or logs.
+        assert!(rendered.contains("Callback(..)"));
+    }
+
+    #[test]
+    fn api_debug_renders_without_send_field() {
+        let service = fresh_service(test_props());
+
+        let send: &dyn Fn(Event) = &|_| {};
+
+        let api = service.connect(&send);
+
+        let rendered = format!("{api:?}");
+
+        assert!(rendered.contains("Api"));
+
+        // The `send` closure is intentionally omitted from Debug output.
+        assert!(!rendered.contains("send:"));
+    }
+
+    #[test]
+    fn connect_api_part_attrs_match_direct_methods() {
+        use ars_core::ConnectApi as _;
+
+        let mut service = open_service(test_props());
+
+        drop(service.send(Event::RegisterTitle));
+        drop(service.send(Event::RegisterDescription));
+
+        let api = service.connect(&|_| {});
+
+        assert_eq!(api.part_attrs(Part::Root), api.root_attrs());
+        assert_eq!(api.part_attrs(Part::Trigger), api.trigger_attrs());
+        assert_eq!(api.part_attrs(Part::Backdrop), api.backdrop_attrs());
+        assert_eq!(api.part_attrs(Part::Positioner), api.positioner_attrs());
+        assert_eq!(api.part_attrs(Part::Content), api.content_attrs());
+        assert_eq!(api.part_attrs(Part::Title), api.title_attrs());
+        assert_eq!(api.part_attrs(Part::Description), api.description_attrs());
+        assert_eq!(
+            api.part_attrs(Part::CloseTrigger),
+            api.close_trigger_attrs()
+        );
+    }
+
+    #[test]
+    fn role_as_aria_role_returns_dialog_for_dialog_variant() {
+        assert_eq!(Role::Dialog.as_aria_role(), "dialog");
+    }
+
+    #[test]
+    fn role_as_aria_role_returns_alertdialog_for_alertdialog_variant() {
+        assert_eq!(Role::AlertDialog.as_aria_role(), "alertdialog");
+    }
+
+    // ── Props builder coverage ────────────────────────────────────
+
+    #[test]
+    fn props_new_returns_default() {
+        assert_eq!(Props::new(), Props::default());
+    }
+
+    #[test]
+    fn props_builder_chain_applies_each_setter() {
+        let props = Props::new()
+            .id("dialog-builder")
+            .open(Some(true))
+            .default_open(true)
+            .modal(false)
+            .close_on_backdrop(false)
+            .close_on_escape(false)
+            .prevent_scroll(false)
+            .restore_focus(false)
+            .initial_focus(Some(FocusTarget::First))
+            .final_focus(Some(FocusTarget::Last))
+            .role(Role::AlertDialog)
+            .title_level(4)
+            .lazy_mount(true)
+            .unmount_on_exit(true)
+            .on_open_change(|_| {})
+            .on_escape_key_down(|_| {})
+            .on_interact_outside(|_| {});
+
+        assert_eq!(props.id, "dialog-builder");
+        assert_eq!(props.open, Some(true));
+        assert!(props.default_open);
+        assert!(!props.modal);
+        assert!(!props.close_on_backdrop);
+        assert!(!props.close_on_escape);
+        assert!(!props.prevent_scroll);
+        assert!(!props.restore_focus);
+        assert_eq!(props.initial_focus, Some(FocusTarget::First));
+        assert_eq!(props.final_focus, Some(FocusTarget::Last));
+        assert_eq!(props.role, Role::AlertDialog);
+        assert_eq!(props.title_level, 4);
+        assert!(props.lazy_mount);
+        assert!(props.unmount_on_exit);
+        assert!(props.on_open_change.is_some());
+        assert!(props.on_escape_key_down.is_some());
+        assert!(props.on_interact_outside.is_some());
+    }
+
+    // ── Snapshot tests (38–59) ────────────────────────────────────
+
+    fn snapshot_service(props: Props) -> Service<Machine> {
+        Service::<Machine>::new(props, &Env::default(), &Messages::default())
+    }
+
+    fn snapshot_service_with_messages(props: Props, messages: &Messages) -> Service<Machine> {
+        Service::<Machine>::new(props, &Env::default(), messages)
+    }
+
+    // 38
+    #[test]
+    fn snapshot_root_closed() {
+        let service = snapshot_service(test_props());
+
+        assert_snapshot!(
+            "dialog_root_closed",
+            snapshot_attrs(&service.connect(&|_| {}).root_attrs())
+        );
+    }
+
+    // 39
+    #[test]
+    fn snapshot_root_open() {
+        let service = snapshot_service(Props {
+            default_open: true,
+            ..test_props()
+        });
+
+        assert_snapshot!(
+            "dialog_root_open",
+            snapshot_attrs(&service.connect(&|_| {}).root_attrs())
+        );
+    }
+
+    // 40
+    #[test]
+    fn snapshot_trigger_closed() {
+        let service = snapshot_service(test_props());
+
+        assert_snapshot!(
+            "dialog_trigger_closed",
+            snapshot_attrs(&service.connect(&|_| {}).trigger_attrs())
+        );
+    }
+
+    // 41
+    #[test]
+    fn snapshot_trigger_open() {
+        let service = snapshot_service(Props {
+            default_open: true,
+            ..test_props()
+        });
+
+        assert_snapshot!(
+            "dialog_trigger_open",
+            snapshot_attrs(&service.connect(&|_| {}).trigger_attrs())
+        );
+    }
+
+    // 42
+    #[test]
+    fn snapshot_backdrop_closed() {
+        let service = snapshot_service(test_props());
+
+        assert_snapshot!(
+            "dialog_backdrop_closed",
+            snapshot_attrs(&service.connect(&|_| {}).backdrop_attrs())
+        );
+    }
+
+    // 43
+    #[test]
+    fn snapshot_backdrop_open() {
+        let service = snapshot_service(Props {
+            default_open: true,
+            ..test_props()
+        });
+
+        assert_snapshot!(
+            "dialog_backdrop_open",
+            snapshot_attrs(&service.connect(&|_| {}).backdrop_attrs())
+        );
+    }
+
+    // 44
+    #[test]
+    fn snapshot_positioner() {
+        let service = snapshot_service(test_props());
+
+        assert_snapshot!(
+            "dialog_positioner",
+            snapshot_attrs(&service.connect(&|_| {}).positioner_attrs())
+        );
+    }
+
+    // 45
+    #[test]
+    fn snapshot_content_open_modal_dialog() {
+        let service = snapshot_service(Props {
+            default_open: true,
+            modal: true,
+            role: Role::Dialog,
+            ..test_props()
+        });
+
+        assert_snapshot!(
+            "dialog_content_open_modal_dialog",
+            snapshot_attrs(&service.connect(&|_| {}).content_attrs())
+        );
+    }
+
+    // 46
+    #[test]
+    fn snapshot_content_open_modal_alertdialog() {
+        let service = snapshot_service(Props {
+            default_open: true,
+            modal: true,
+            role: Role::AlertDialog,
+            ..test_props()
+        });
+
+        assert_snapshot!(
+            "dialog_content_open_modal_alertdialog",
+            snapshot_attrs(&service.connect(&|_| {}).content_attrs())
+        );
+    }
+
+    // 47
+    #[test]
+    fn snapshot_content_open_non_modal() {
+        let service = snapshot_service(Props {
+            default_open: true,
+            modal: false,
+            ..test_props()
+        });
+
+        assert_snapshot!(
+            "dialog_content_open_non_modal",
+            snapshot_attrs(&service.connect(&|_| {}).content_attrs())
+        );
+    }
+
+    // 48
+    #[test]
+    fn snapshot_content_open_with_title() {
+        let mut service = snapshot_service(Props {
+            default_open: true,
+            ..test_props()
+        });
+
+        drop(service.send(Event::RegisterTitle));
+
+        assert_snapshot!(
+            "dialog_content_open_with_title",
+            snapshot_attrs(&service.connect(&|_| {}).content_attrs())
+        );
+    }
+
+    // 49
+    #[test]
+    fn snapshot_content_open_with_description() {
+        let mut service = snapshot_service(Props {
+            default_open: true,
+            ..test_props()
+        });
+
+        drop(service.send(Event::RegisterDescription));
+
+        assert_snapshot!(
+            "dialog_content_open_with_description",
+            snapshot_attrs(&service.connect(&|_| {}).content_attrs())
+        );
+    }
+
+    // 50
+    #[test]
+    fn snapshot_content_open_with_title_and_description() {
+        let mut service = snapshot_service(Props {
+            default_open: true,
+            ..test_props()
+        });
+
+        drop(service.send(Event::RegisterTitle));
+        drop(service.send(Event::RegisterDescription));
+
+        assert_snapshot!(
+            "dialog_content_open_with_title_and_description",
+            snapshot_attrs(&service.connect(&|_| {}).content_attrs())
+        );
+    }
+
+    // 51
+    #[test]
+    fn snapshot_content_closed() {
+        let service = snapshot_service(test_props());
+
+        assert_snapshot!(
+            "dialog_content_closed",
+            snapshot_attrs(&service.connect(&|_| {}).content_attrs())
+        );
+    }
+
+    // 52
+    #[test]
+    fn snapshot_title_default_h2() {
+        let service = snapshot_service(test_props());
+
+        assert_snapshot!(
+            "dialog_title_default_h2",
+            snapshot_attrs(&service.connect(&|_| {}).title_attrs())
+        );
+    }
+
+    // 53 — title_level=1 is exercised by `title_clamped_below_one`, which
+    // verifies the clamp path produces the same `data-ars-heading-level=1`
+    // attribute. Snapshot is omitted to stay under the per-component
+    // snapshot-count cap; the assertion below proves the structural value.
+    #[test]
+    fn title_level_one_renders_data_ars_heading_level_1() {
+        let service = snapshot_service(Props {
+            title_level: 1,
+            ..test_props()
+        });
+
+        let attrs = service.connect(&|_| {}).title_attrs();
+
+        assert_eq!(attrs.get(&HtmlAttr::Data("ars-heading-level")), Some("1"));
+    }
+
+    // 54
+    #[test]
+    fn snapshot_title_clamped_above_six() {
+        let service = snapshot_service(Props {
+            title_level: 10,
+            ..test_props()
+        });
+
+        assert_snapshot!(
+            "dialog_title_clamped_above_six",
+            snapshot_attrs(&service.connect(&|_| {}).title_attrs())
+        );
+    }
+
+    // 55
+    #[test]
+    fn snapshot_title_clamped_below_one() {
+        let service = snapshot_service(Props {
+            title_level: 0,
+            ..test_props()
+        });
+
+        assert_snapshot!(
+            "dialog_title_clamped_below_one",
+            snapshot_attrs(&service.connect(&|_| {}).title_attrs())
+        );
+    }
+
+    // 56
+    #[test]
+    fn snapshot_description() {
+        let service = snapshot_service(test_props());
+
+        assert_snapshot!(
+            "dialog_description",
+            snapshot_attrs(&service.connect(&|_| {}).description_attrs())
+        );
+    }
+
+    // 57
+    #[test]
+    fn snapshot_close_trigger_default_label() {
+        let service = snapshot_service(test_props());
+
+        assert_snapshot!(
+            "dialog_close_trigger_default_label",
+            snapshot_attrs(&service.connect(&|_| {}).close_trigger_attrs())
+        );
+    }
+
+    // 58
+    #[test]
+    fn snapshot_close_trigger_custom_messages_label() {
+        let messages = Messages {
+            close_label: MessageFn::static_str("Cerrar diálogo"),
+        };
+
+        let service = snapshot_service_with_messages(test_props(), &messages);
+
+        assert_snapshot!(
+            "dialog_close_trigger_custom_messages_label",
+            snapshot_attrs(&service.connect(&|_| {}).close_trigger_attrs())
+        );
+    }
+
+    // 59 — locale-aware label resolution. The MessageFn closure inspects
+    // the active locale; we exercise BOTH branches of the same closure
+    // (shared via the `Arc<dyn Fn>` Messages clones) so the agnostic core's
+    // closure-form `MessageFn` path is fully covered. Structural
+    // verification of the close trigger AttrMap is already covered by
+    // `snapshot_close_trigger_default_label` and
+    // `snapshot_close_trigger_custom_messages_label`; this test uses
+    // direct assertions to stay under the per-component snapshot cap.
+    #[test]
+    fn close_trigger_resolves_locale_aware_label_for_both_branches() {
+        use ars_core::Locale;
+
+        let messages = Messages {
+            close_label: MessageFn::new(|locale: &Locale| {
+                if locale.to_bcp47().starts_with("es") {
+                    "Cerrar".to_string()
+                } else {
+                    "Close".to_string()
+                }
+            }),
+        };
+
+        // English / undefined locale → "Close" branch.
+        let en_service = Service::<Machine>::new(test_props(), &Env::default(), &messages);
+
+        let en_attrs = en_service.connect(&|_| {}).close_trigger_attrs();
+
+        assert_eq!(
+            en_attrs.get(&HtmlAttr::Aria(AriaAttr::Label)),
+            Some("Close")
+        );
+
+        // Spanish locale → "Cerrar" branch (same closure, different
+        // input locale → both paths now executed under coverage).
+        let es_env = Env {
+            locale: Locale::parse("es").expect("`es` is a valid BCP-47 tag"),
+            ..Env::default()
+        };
+
+        let es_service = Service::<Machine>::new(test_props(), &es_env, &messages);
+
+        let es_attrs = es_service.connect(&|_| {}).close_trigger_attrs();
+        assert_eq!(
+            es_attrs.get(&HtmlAttr::Aria(AriaAttr::Label)),
+            Some("Cerrar")
+        );
+    }
+
+    // ── Additional regression / contract tests ─────────────────────
+
+    // B — on_props_changed coverage gaps
+
+    #[test]
+    fn on_props_changed_emits_close_when_uncontrolled_to_some_false() {
+        let old = test_props();
+
+        let new = Props {
+            open: Some(false),
+            ..test_props()
+        };
+
+        assert_eq!(Machine::on_props_changed(&old, &new), [Event::Close]);
+    }
+
+    #[test]
+    fn on_props_changed_emits_nothing_when_some_true_to_none() {
+        let old = Props {
+            open: Some(true),
+            ..test_props()
+        };
+
+        let new = test_props();
+
+        assert!(Machine::on_props_changed(&old, &new).is_empty());
+    }
+
+    #[test]
+    fn on_props_changed_emits_nothing_when_some_false_to_none() {
+        let old = Props {
+            open: Some(false),
+            ..test_props()
+        };
+
+        let new = test_props();
+
+        assert!(Machine::on_props_changed(&old, &new).is_empty());
+    }
+
+    // C — PreventableEvent veto symmetry
+
+    #[test]
+    fn preventable_event_veto_set_on_clone_observable_on_original() {
+        let original = PreventableEvent::new();
+
+        let cloned = original.clone();
+
+        cloned.prevent_default();
+
+        assert!(original.is_default_prevented());
+    }
+
+    // D — Default trio
+
+    #[test]
+    fn state_default_returns_closed() {
+        assert_eq!(State::default(), State::Closed);
+    }
+
+    #[test]
+    fn role_default_returns_dialog() {
+        assert_eq!(Role::default(), Role::Dialog);
+    }
+
+    #[test]
+    fn preventable_event_default_is_not_prevented() {
+        assert!(!PreventableEvent::default().is_default_prevented());
+    }
+
+    // E — adapter-only prop accessors
+
+    #[test]
+    fn api_exposes_lazy_mount_and_unmount_on_exit_for_adapter() {
+        let service = fresh_service(Props {
+            lazy_mount: true,
+            unmount_on_exit: true,
+            ..test_props()
+        });
+
+        let api = service.connect(&|_| {});
+
+        assert!(api.lazy_mount());
+        assert!(api.unmount_on_exit());
+    }
+
+    #[test]
+    fn api_lazy_mount_and_unmount_on_exit_default_false() {
+        let service = fresh_service(test_props());
+
+        let api = service.connect(&|_| {});
+
+        assert!(!api.lazy_mount());
+        assert!(!api.unmount_on_exit());
+    }
+
+    // F — Send + Sync compile-time assertion
+
+    #[test]
+    fn preventable_event_is_send_sync() {
+        const fn assert_send_sync<T: Send + Sync>() {}
+
+        // Will fail to compile if `PreventableEvent` ever loses `Send` or
+        // `Sync` (e.g., if `Arc<AtomicBool>` is replaced with `Cell<bool>`).
+        assert_send_sync::<PreventableEvent>();
+    }
+
+    // G — controlled-mode round-trip via Service::set_props
+
+    #[test]
+    fn controlled_set_props_round_trip_flips_state_and_emits_open_change() {
+        let mut service = fresh_service(test_props());
+
+        assert_eq!(service.state(), &State::Closed);
+
+        let result = service.set_props(Props {
+            open: Some(true),
+            ..test_props()
+        });
+
+        assert!(result.state_changed);
+        assert_eq!(service.state(), &State::Open);
+        assert!(effect_names(&result).contains(&EFFECT_OPEN_CHANGE));
+
+        let result = service.set_props(Props {
+            open: Some(false),
+            ..test_props()
+        });
+
+        assert!(result.state_changed);
+        assert_eq!(service.state(), &State::Closed);
+        assert!(effect_names(&result).contains(&EFFECT_OPEN_CHANGE));
+    }
+
+    // I — on_open_change registration round-trip
+
+    // ── Effect ORDER assertions (Finding 2) ────────────────────────
+
+    #[test]
+    fn open_transition_effects_emitted_in_documented_order() {
+        // Adapter expectations: scroll-lock SHOULD acquire before focus
+        // moves so DOM measurements stabilise; open-change fires first so
+        // observers can react before background mutations land. Pin the
+        // canonical order from §1.9 for the all-flags-enabled case.
+        let mut service = fresh_service(Props {
+            modal: true,
+            prevent_scroll: true,
+            ..test_props()
+        });
+
+        let result = service.send(Event::Open);
+
+        assert_eq!(
+            effect_names(&result),
+            vec![
+                EFFECT_OPEN_CHANGE,
+                EFFECT_FOCUS_INITIAL,
+                EFFECT_FOCUS_FIRST_TABBABLE,
+                EFFECT_SCROLL_LOCK_ACQUIRE,
+                EFFECT_SET_BACKGROUND_INERT,
+            ]
+        );
+    }
+
+    #[test]
+    fn close_transition_effects_emitted_in_documented_order() {
+        let mut service = open_service(Props {
+            modal: true,
+            prevent_scroll: true,
+            restore_focus: true,
+            ..test_props()
+        });
+
+        let result = service.send(Event::Close);
+
+        assert_eq!(
+            effect_names(&result),
+            vec![
+                EFFECT_OPEN_CHANGE,
+                EFFECT_SCROLL_LOCK_RELEASE,
+                EFFECT_REMOVE_BACKGROUND_INERT,
+                EFFECT_RESTORE_FOCUS,
+            ]
+        );
+    }
+
+    // ── Multi-event sequence (Finding 3) ───────────────────────────
+
+    #[test]
+    fn open_close_open_cycle_preserves_state_machine_invariants() {
+        let mut service = fresh_service(test_props());
+
+        assert_eq!(service.state(), &State::Closed);
+        assert!(!service.context().open);
+
+        // 1. Open
+        let r1 = service.send(Event::Open);
+
+        assert!(r1.state_changed);
+        assert_eq!(service.state(), &State::Open);
+        assert!(service.context().open);
+        assert!(effect_names(&r1).contains(&EFFECT_OPEN_CHANGE));
+
+        // 2. Close via backdrop click
+        let r2 = service.send(Event::CloseOnBackdropClick);
+
+        assert!(r2.state_changed);
+        assert_eq!(service.state(), &State::Closed);
+        assert!(!service.context().open);
+        assert!(effect_names(&r2).contains(&EFFECT_OPEN_CHANGE));
+
+        // 3. Re-open via Toggle
+        let r3 = service.send(Event::Toggle);
+
+        assert!(r3.state_changed);
+        assert_eq!(service.state(), &State::Open);
+        assert!(effect_names(&r3).contains(&EFFECT_OPEN_CHANGE));
+
+        // 4. Register title and description while open — both flips happen
+        let r4 = service.send(Event::RegisterTitle);
+
+        let r5 = service.send(Event::RegisterDescription);
+
+        assert!(r4.context_changed);
+        assert!(r5.context_changed);
+        assert!(service.context().has_title);
+        assert!(service.context().has_description);
+
+        // 5. Close via Escape
+        let r6 = service.send(Event::CloseOnEscape);
+
+        assert!(r6.state_changed);
+        assert_eq!(service.state(), &State::Closed);
+
+        // has_title / has_description survive the close (they're
+        // monotonically non-decreasing across the lifecycle).
+        assert!(service.context().has_title);
+        assert!(service.context().has_description);
+    }
+
+    // ── Toggle ≡ Open/Close equivalence (Finding 4) ────────────────
+
+    #[test]
+    fn toggle_from_closed_emits_same_effects_as_open() {
+        // Two services with identical config; one driven by Open, the
+        // other by Toggle. The emitted effect names MUST match.
+        let mut by_open = fresh_service(test_props());
+        let mut by_toggle = fresh_service(test_props());
+
+        let open_effects = effect_names(&by_open.send(Event::Open));
+        let toggle_effects = effect_names(&by_toggle.send(Event::Toggle));
+
+        assert_eq!(open_effects, toggle_effects);
+        assert_eq!(by_open.state(), by_toggle.state());
+        assert_eq!(by_open.context().open, by_toggle.context().open);
+    }
+
+    #[test]
+    fn toggle_from_open_emits_same_effects_as_close() {
+        let mut by_close = open_service(test_props());
+        let mut by_toggle = open_service(test_props());
+
+        let close_effects = effect_names(&by_close.send(Event::Close));
+        let toggle_effects = effect_names(&by_toggle.send(Event::Toggle));
+
+        assert_eq!(close_effects, toggle_effects);
+        assert_eq!(by_close.state(), by_toggle.state());
+        assert_eq!(by_close.context().open, by_toggle.context().open);
+    }
+
+    // ── Catch-all `_ => None` direct assertion (Finding 5) ─────────
+
+    #[test]
+    fn transition_returns_none_for_register_title_when_already_registered() {
+        let mut ctx = Context {
+            open: false,
+            modal: true,
+            close_on_backdrop: true,
+            close_on_escape: true,
+            prevent_scroll: true,
+            restore_focus: true,
+            initial_focus: None,
+            final_focus: None,
+            role: Role::Dialog,
+            ids: ComponentIds::from_id("x"),
+            has_title: true,
+            has_description: false,
+            locale: Env::default().locale,
+            messages: Messages::default(),
+        };
+
+        let props = test_props();
+
+        let plan = Machine::transition(&State::Closed, &Event::RegisterTitle, &ctx, &props);
+
+        assert!(
+            plan.is_none(),
+            "RegisterTitle on has_title=true must route to the catch-all `_ => None` arm"
+        );
+
+        ctx.has_title = false;
+        ctx.has_description = true;
+
+        let plan = Machine::transition(&State::Closed, &Event::RegisterDescription, &ctx, &props);
+
+        assert!(
+            plan.is_none(),
+            "RegisterDescription on has_description=true must route to the catch-all"
+        );
+    }
+
+    // K — SyncProps event runtime context-backed prop sync
+
+    #[test]
+    fn event_sync_props_replays_context_backed_fields() {
+        let mut service = open_service(test_props());
+
+        // Sanity: defaults set modal=true, close_on_backdrop=true, etc.
+        assert!(service.context().modal);
+        assert!(service.context().close_on_backdrop);
+        assert!(service.context().close_on_escape);
+        assert!(service.context().prevent_scroll);
+        assert!(service.context().restore_focus);
+        assert_eq!(service.context().role, Role::Dialog);
+
+        // Replace props with non-default values for every context-backed
+        // field, then send SyncProps directly (without going through
+        // Service::set_props, which is exercised separately below).
+        *service.props_mut() = Props {
+            id: "dialog".to_string(),
+            modal: false,
+            close_on_backdrop: false,
+            close_on_escape: false,
+            prevent_scroll: false,
+            restore_focus: false,
+            initial_focus: Some(FocusTarget::First),
+            final_focus: Some(FocusTarget::Last),
+            role: Role::AlertDialog,
+            default_open: true,
+            ..Props::default()
+        };
+
+        let result = service.send(Event::SyncProps);
+
+        assert!(!result.state_changed);
+        assert!(result.context_changed);
+
+        let ctx = service.context();
+
+        assert!(!ctx.modal);
+        assert!(!ctx.close_on_backdrop);
+        assert!(!ctx.close_on_escape);
+        assert!(!ctx.prevent_scroll);
+        assert!(!ctx.restore_focus);
+        assert_eq!(ctx.initial_focus, Some(FocusTarget::First));
+        assert_eq!(ctx.final_focus, Some(FocusTarget::Last));
+        assert_eq!(ctx.role, Role::AlertDialog);
+    }
+
+    #[test]
+    fn event_sync_props_emits_no_adapter_intents() {
+        let mut service = fresh_service(test_props());
+
+        let result = service.send(Event::SyncProps);
+
+        // SyncProps is a context-only update; it MUST NOT emit any
+        // adapter intent. No focus moves, no scroll lock changes, no
+        // open-change signal.
+        assert!(result.pending_effects.is_empty());
+    }
+
+    #[test]
+    fn on_props_changed_emits_sync_props_when_modal_flips() {
+        let old = test_props();
+
+        let new = Props {
+            modal: false,
+            ..test_props()
+        };
+
+        assert_eq!(Machine::on_props_changed(&old, &new), [Event::SyncProps]);
+    }
+
+    #[test]
+    fn on_props_changed_emits_sync_props_when_role_flips() {
+        let old = test_props();
+
+        let new = Props {
+            role: Role::AlertDialog,
+            ..test_props()
+        };
+
+        assert_eq!(Machine::on_props_changed(&old, &new), [Event::SyncProps]);
+    }
+
+    #[test]
+    fn on_props_changed_emits_sync_props_when_close_policy_changes() {
+        for new in [
+            Props {
+                close_on_backdrop: false,
+                ..test_props()
+            },
+            Props {
+                close_on_escape: false,
+                ..test_props()
+            },
+            Props {
+                prevent_scroll: false,
+                ..test_props()
+            },
+            Props {
+                restore_focus: false,
+                ..test_props()
+            },
+        ] {
+            assert_eq!(
+                Machine::on_props_changed(&test_props(), &new),
+                [Event::SyncProps],
+                "expected SyncProps for prop change to {new:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn on_props_changed_emits_sync_props_when_focus_targets_change() {
+        let new = Props {
+            initial_focus: Some(FocusTarget::First),
+            final_focus: Some(FocusTarget::Last),
+            ..test_props()
+        };
+
+        assert_eq!(
+            Machine::on_props_changed(&test_props(), &new),
+            [Event::SyncProps]
+        );
+    }
+
+    #[test]
+    fn on_props_changed_emits_open_and_sync_props_together_when_both_change() {
+        let old = test_props();
+
+        let new = Props {
+            open: Some(true),
+            modal: false,
+            ..test_props()
+        };
+
+        assert_eq!(
+            Machine::on_props_changed(&old, &new),
+            [Event::Open, Event::SyncProps]
+        );
+    }
+
+    #[test]
+    fn on_props_changed_emits_nothing_when_only_id_changes() {
+        let old = test_props();
+
+        let new = Props {
+            id: "different-dialog".to_string(),
+            ..test_props()
+        };
+
+        // `id` is not a context-backed field — it only feeds
+        // `ComponentIds::from_id` at init time. Changing it is meaningless
+        // post-init and must not produce events.
+        assert!(Machine::on_props_changed(&old, &new).is_empty());
+    }
+
+    #[test]
+    fn controlled_modal_flip_via_set_props_propagates_to_context() {
+        // End-to-end: `Service::set_props` flips `modal`. The next close
+        // transition must read the freshly-synced context (`ctx.modal ==
+        // false`) and skip the `dialog-remove-background-inert` intent.
+        let mut service = open_service(test_props());
+
+        drop(service.set_props(Props {
+            default_open: true,
+            modal: false,
+            ..test_props()
+        }));
+
+        assert!(!service.context().modal);
+
+        let close_result = service.send(Event::Close);
+
+        assert!(
+            !effect_names(&close_result).contains(&EFFECT_REMOVE_BACKGROUND_INERT),
+            "non-modal dialog must not request inert removal"
+        );
+    }
+
+    // L — Api::is_modal() / Api::role() accessors
+
+    #[test]
+    fn api_is_modal_reflects_ctx_modal() {
+        let modal_service = fresh_service(Props {
+            modal: true,
+            ..test_props()
+        });
+
+        assert!(modal_service.connect(&|_| {}).is_modal());
+
+        let non_modal_service = fresh_service(Props {
+            modal: false,
+            ..test_props()
+        });
+
+        assert!(!non_modal_service.connect(&|_| {}).is_modal());
+    }
+
+    #[test]
+    fn api_role_reflects_ctx_role() {
+        let dialog_service = fresh_service(Props {
+            role: Role::Dialog,
+            ..test_props()
+        });
+
+        assert_eq!(dialog_service.connect(&|_| {}).role(), Role::Dialog);
+
+        let alertdialog_service = fresh_service(Props {
+            role: Role::AlertDialog,
+            ..test_props()
+        });
+
+        assert_eq!(
+            alertdialog_service.connect(&|_| {}).role(),
+            Role::AlertDialog
+        );
+    }
+
+    // M — backdrop_attrs invariance regression guard
+
+    #[test]
+    fn backdrop_attrs_invariant_across_modal_and_non_modal() {
+        // The backdrop is decorative when rendered. Whether the dialog is
+        // modal or non-modal, the backdrop's AttrMap output MUST be
+        // identical — adapters skip rendering the backdrop entirely for
+        // non-modal dialogs, but the agnostic-core surface stays uniform.
+        let modal = open_service(Props {
+            modal: true,
+            ..test_props()
+        });
+
+        let non_modal = open_service(Props {
+            modal: false,
+            ..test_props()
+        });
+
+        assert_eq!(
+            modal.connect(&|_| {}).backdrop_attrs(),
+            non_modal.connect(&|_| {}).backdrop_attrs()
+        );
+    }
+
+    #[test]
+    fn on_open_change_callback_registered_via_builder_is_invokable() {
+        use alloc::sync::Arc;
+        use core::sync::atomic::{AtomicBool, Ordering};
+
+        let observed = Arc::new(AtomicBool::new(false));
+
+        let observed_for_callback = Arc::clone(&observed);
+
+        let props = Props::new().id("dialog").on_open_change(move |open| {
+            observed_for_callback.store(open, Ordering::SeqCst);
+        });
+
+        // The agnostic core stores the callback in props; an adapter handling
+        // `EFFECT_OPEN_CHANGE` would invoke `props.on_open_change` with the
+        // post-transition state. We exercise that end-to-end here.
+        let cb = props
+            .on_open_change
+            .as_ref()
+            .expect("callback registered via builder");
+
+        cb(true);
+
+        assert!(observed.load(Ordering::SeqCst));
+
+        cb(false);
+
+        assert!(!observed.load(Ordering::SeqCst));
+    }
+}

--- a/crates/ars-components/src/overlay/mod.rs
+++ b/crates/ars-components/src/overlay/mod.rs
@@ -3,6 +3,9 @@
 /// Shared DOM-free overlay positioning configuration.
 pub mod positioning;
 
+/// Dialog machine.
+pub mod dialog;
+
 /// Presence machine.
 pub mod presence;
 

--- a/crates/ars-components/src/overlay/snapshots/ars_components__overlay__dialog__tests__dialog_backdrop_closed.snap
+++ b/crates/ars-components/src/overlay/snapshots/ars_components__overlay__dialog__tests__dialog_backdrop_closed.snap
@@ -1,0 +1,47 @@
+---
+source: crates/ars-components/src/overlay/dialog.rs
+expression: "snapshot_attrs(&service.connect(&|_| {}).backdrop_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "backdrop",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "dialog",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "closed",
+            ),
+        ),
+        (
+            Aria(
+                Hidden,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Inert,
+            String(
+                "",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/overlay/snapshots/ars_components__overlay__dialog__tests__dialog_backdrop_open.snap
+++ b/crates/ars-components/src/overlay/snapshots/ars_components__overlay__dialog__tests__dialog_backdrop_open.snap
@@ -1,0 +1,47 @@
+---
+source: crates/ars-components/src/overlay/dialog.rs
+expression: "snapshot_attrs(&service.connect(&|_| {}).backdrop_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "backdrop",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "dialog",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "open",
+            ),
+        ),
+        (
+            Aria(
+                Hidden,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Inert,
+            String(
+                "",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/overlay/snapshots/ars_components__overlay__dialog__tests__dialog_close_trigger_custom_messages_label.snap
+++ b/crates/ars-components/src/overlay/snapshots/ars_components__overlay__dialog__tests__dialog_close_trigger_custom_messages_label.snap
@@ -1,0 +1,39 @@
+---
+source: crates/ars-components/src/overlay/dialog.rs
+expression: "snapshot_attrs(&service.connect(&|_| {}).close_trigger_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "close-trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "dialog",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Cerrar diálogo",
+            ),
+        ),
+        (
+            Type,
+            String(
+                "button",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/overlay/snapshots/ars_components__overlay__dialog__tests__dialog_close_trigger_default_label.snap
+++ b/crates/ars-components/src/overlay/snapshots/ars_components__overlay__dialog__tests__dialog_close_trigger_default_label.snap
@@ -1,0 +1,39 @@
+---
+source: crates/ars-components/src/overlay/dialog.rs
+expression: "snapshot_attrs(&service.connect(&|_| {}).close_trigger_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "close-trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "dialog",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Close dialog",
+            ),
+        ),
+        (
+            Type,
+            String(
+                "button",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/overlay/snapshots/ars_components__overlay__dialog__tests__dialog_content_closed.snap
+++ b/crates/ars-components/src/overlay/snapshots/ars_components__overlay__dialog__tests__dialog_content_closed.snap
@@ -1,0 +1,59 @@
+---
+source: crates/ars-components/src/overlay/dialog.rs
+expression: "snapshot_attrs(&service.connect(&|_| {}).content_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "content",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "dialog",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "closed",
+            ),
+        ),
+        (
+            Aria(
+                Modal,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "dialog-content",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "dialog",
+            ),
+        ),
+        (
+            TabIndex,
+            String(
+                "-1",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/overlay/snapshots/ars_components__overlay__dialog__tests__dialog_content_open_modal_alertdialog.snap
+++ b/crates/ars-components/src/overlay/snapshots/ars_components__overlay__dialog__tests__dialog_content_open_modal_alertdialog.snap
@@ -1,0 +1,59 @@
+---
+source: crates/ars-components/src/overlay/dialog.rs
+expression: "snapshot_attrs(&service.connect(&|_| {}).content_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "content",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "dialog",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "open",
+            ),
+        ),
+        (
+            Aria(
+                Modal,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "dialog-content",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "alertdialog",
+            ),
+        ),
+        (
+            TabIndex,
+            String(
+                "-1",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/overlay/snapshots/ars_components__overlay__dialog__tests__dialog_content_open_modal_dialog.snap
+++ b/crates/ars-components/src/overlay/snapshots/ars_components__overlay__dialog__tests__dialog_content_open_modal_dialog.snap
@@ -1,0 +1,59 @@
+---
+source: crates/ars-components/src/overlay/dialog.rs
+expression: "snapshot_attrs(&service.connect(&|_| {}).content_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "content",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "dialog",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "open",
+            ),
+        ),
+        (
+            Aria(
+                Modal,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "dialog-content",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "dialog",
+            ),
+        ),
+        (
+            TabIndex,
+            String(
+                "-1",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/overlay/snapshots/ars_components__overlay__dialog__tests__dialog_content_open_non_modal.snap
+++ b/crates/ars-components/src/overlay/snapshots/ars_components__overlay__dialog__tests__dialog_content_open_non_modal.snap
@@ -1,0 +1,51 @@
+---
+source: crates/ars-components/src/overlay/dialog.rs
+expression: "snapshot_attrs(&service.connect(&|_| {}).content_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "content",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "dialog",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "open",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "dialog-content",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "dialog",
+            ),
+        ),
+        (
+            TabIndex,
+            String(
+                "-1",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/overlay/snapshots/ars_components__overlay__dialog__tests__dialog_content_open_with_description.snap
+++ b/crates/ars-components/src/overlay/snapshots/ars_components__overlay__dialog__tests__dialog_content_open_with_description.snap
@@ -1,0 +1,67 @@
+---
+source: crates/ars-components/src/overlay/dialog.rs
+expression: "snapshot_attrs(&service.connect(&|_| {}).content_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "content",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "dialog",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "open",
+            ),
+        ),
+        (
+            Aria(
+                Modal,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Aria(
+                DescribedBy,
+            ),
+            String(
+                "dialog-description",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "dialog-content",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "dialog",
+            ),
+        ),
+        (
+            TabIndex,
+            String(
+                "-1",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/overlay/snapshots/ars_components__overlay__dialog__tests__dialog_content_open_with_title.snap
+++ b/crates/ars-components/src/overlay/snapshots/ars_components__overlay__dialog__tests__dialog_content_open_with_title.snap
@@ -1,0 +1,67 @@
+---
+source: crates/ars-components/src/overlay/dialog.rs
+expression: "snapshot_attrs(&service.connect(&|_| {}).content_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "content",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "dialog",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "open",
+            ),
+        ),
+        (
+            Aria(
+                LabelledBy,
+            ),
+            String(
+                "dialog-title",
+            ),
+        ),
+        (
+            Aria(
+                Modal,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "dialog-content",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "dialog",
+            ),
+        ),
+        (
+            TabIndex,
+            String(
+                "-1",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/overlay/snapshots/ars_components__overlay__dialog__tests__dialog_content_open_with_title_and_description.snap
+++ b/crates/ars-components/src/overlay/snapshots/ars_components__overlay__dialog__tests__dialog_content_open_with_title_and_description.snap
@@ -1,0 +1,75 @@
+---
+source: crates/ars-components/src/overlay/dialog.rs
+expression: "snapshot_attrs(&service.connect(&|_| {}).content_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "content",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "dialog",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "open",
+            ),
+        ),
+        (
+            Aria(
+                LabelledBy,
+            ),
+            String(
+                "dialog-title",
+            ),
+        ),
+        (
+            Aria(
+                Modal,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Aria(
+                DescribedBy,
+            ),
+            String(
+                "dialog-description",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "dialog-content",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "dialog",
+            ),
+        ),
+        (
+            TabIndex,
+            String(
+                "-1",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/overlay/snapshots/ars_components__overlay__dialog__tests__dialog_description.snap
+++ b/crates/ars-components/src/overlay/snapshots/ars_components__overlay__dialog__tests__dialog_description.snap
@@ -1,0 +1,31 @@
+---
+source: crates/ars-components/src/overlay/dialog.rs
+expression: "snapshot_attrs(&service.connect(&|_| {}).description_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "description",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "dialog",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "dialog-description",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/overlay/snapshots/ars_components__overlay__dialog__tests__dialog_positioner.snap
+++ b/crates/ars-components/src/overlay/snapshots/ars_components__overlay__dialog__tests__dialog_positioner.snap
@@ -1,0 +1,25 @@
+---
+source: crates/ars-components/src/overlay/dialog.rs
+expression: "snapshot_attrs(&service.connect(&|_| {}).positioner_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "positioner",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "dialog",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/overlay/snapshots/ars_components__overlay__dialog__tests__dialog_root_closed.snap
+++ b/crates/ars-components/src/overlay/snapshots/ars_components__overlay__dialog__tests__dialog_root_closed.snap
@@ -1,0 +1,33 @@
+---
+source: crates/ars-components/src/overlay/dialog.rs
+expression: "snapshot_attrs(&service.connect(&|_| {}).root_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "dialog",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "closed",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/overlay/snapshots/ars_components__overlay__dialog__tests__dialog_root_open.snap
+++ b/crates/ars-components/src/overlay/snapshots/ars_components__overlay__dialog__tests__dialog_root_open.snap
@@ -1,0 +1,33 @@
+---
+source: crates/ars-components/src/overlay/dialog.rs
+expression: "snapshot_attrs(&service.connect(&|_| {}).root_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "dialog",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "open",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/overlay/snapshots/ars_components__overlay__dialog__tests__dialog_title_clamped_above_six.snap
+++ b/crates/ars-components/src/overlay/snapshots/ars_components__overlay__dialog__tests__dialog_title_clamped_above_six.snap
@@ -1,0 +1,39 @@
+---
+source: crates/ars-components/src/overlay/dialog.rs
+expression: "snapshot_attrs(&service.connect(&|_| {}).title_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-heading-level",
+            ),
+            String(
+                "6",
+            ),
+        ),
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "title",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "dialog",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "dialog-title",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/overlay/snapshots/ars_components__overlay__dialog__tests__dialog_title_clamped_below_one.snap
+++ b/crates/ars-components/src/overlay/snapshots/ars_components__overlay__dialog__tests__dialog_title_clamped_below_one.snap
@@ -1,0 +1,39 @@
+---
+source: crates/ars-components/src/overlay/dialog.rs
+expression: "snapshot_attrs(&service.connect(&|_| {}).title_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-heading-level",
+            ),
+            String(
+                "1",
+            ),
+        ),
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "title",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "dialog",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "dialog-title",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/overlay/snapshots/ars_components__overlay__dialog__tests__dialog_title_default_h2.snap
+++ b/crates/ars-components/src/overlay/snapshots/ars_components__overlay__dialog__tests__dialog_title_default_h2.snap
@@ -1,0 +1,39 @@
+---
+source: crates/ars-components/src/overlay/dialog.rs
+expression: "snapshot_attrs(&service.connect(&|_| {}).title_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-heading-level",
+            ),
+            String(
+                "2",
+            ),
+        ),
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "title",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "dialog",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "dialog-title",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/overlay/snapshots/ars_components__overlay__dialog__tests__dialog_trigger_closed.snap
+++ b/crates/ars-components/src/overlay/snapshots/ars_components__overlay__dialog__tests__dialog_trigger_closed.snap
@@ -1,0 +1,61 @@
+---
+source: crates/ars-components/src/overlay/dialog.rs
+expression: "snapshot_attrs(&service.connect(&|_| {}).trigger_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "dialog",
+            ),
+        ),
+        (
+            Aria(
+                Expanded,
+            ),
+            String(
+                "false",
+            ),
+        ),
+        (
+            Aria(
+                HasPopup,
+            ),
+            String(
+                "dialog",
+            ),
+        ),
+        (
+            Aria(
+                Controls,
+            ),
+            String(
+                "dialog-content",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "dialog-trigger",
+            ),
+        ),
+        (
+            Type,
+            String(
+                "button",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/overlay/snapshots/ars_components__overlay__dialog__tests__dialog_trigger_open.snap
+++ b/crates/ars-components/src/overlay/snapshots/ars_components__overlay__dialog__tests__dialog_trigger_open.snap
@@ -1,0 +1,61 @@
+---
+source: crates/ars-components/src/overlay/dialog.rs
+expression: "snapshot_attrs(&service.connect(&|_| {}).trigger_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "dialog",
+            ),
+        ),
+        (
+            Aria(
+                Expanded,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Aria(
+                HasPopup,
+            ),
+            String(
+                "dialog",
+            ),
+        ),
+        (
+            Aria(
+                Controls,
+            ),
+            String(
+                "dialog-content",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "dialog-trigger",
+            ),
+        ),
+        (
+            Type,
+            String(
+                "button",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/tests/proptest_state_machines/overlay.rs
+++ b/crates/ars-components/tests/proptest_state_machines/overlay.rs
@@ -1,6 +1,8 @@
 use core::time::Duration;
 
+use ars_a11y::FocusTarget;
 use ars_components::overlay::{
+    dialog,
     positioning::{Offset, Placement, PositioningOptions},
     presence, tooltip,
 };
@@ -386,6 +388,299 @@ proptest! {
             }
 
             assert_tooltip_state_context_invariants(&service)?;
+        }
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Dialog proptest
+// ────────────────────────────────────────────────────────────────────
+
+#[derive(Clone, Debug)]
+enum DialogStep {
+    Send(dialog::Event),
+    SetProps(dialog::Props),
+}
+
+const DIALOG_EFFECT_NAMES: &[&str] = &[
+    dialog::EFFECT_OPEN_CHANGE,
+    dialog::EFFECT_FOCUS_INITIAL,
+    dialog::EFFECT_FOCUS_FIRST_TABBABLE,
+    dialog::EFFECT_SCROLL_LOCK_ACQUIRE,
+    dialog::EFFECT_SCROLL_LOCK_RELEASE,
+    dialog::EFFECT_SET_BACKGROUND_INERT,
+    dialog::EFFECT_REMOVE_BACKGROUND_INERT,
+    dialog::EFFECT_RESTORE_FOCUS,
+];
+
+fn arb_focus_target() -> impl Strategy<Value = Option<FocusTarget>> {
+    prop_oneof![
+        Just(None),
+        Just(Some(FocusTarget::First)),
+        Just(Some(FocusTarget::Last)),
+        Just(Some(FocusTarget::AutofocusMarked)),
+        Just(Some(FocusTarget::PreviouslyActive)),
+    ]
+}
+
+fn arb_dialog_role() -> impl Strategy<Value = dialog::Role> {
+    prop_oneof![Just(dialog::Role::Dialog), Just(dialog::Role::AlertDialog)]
+}
+
+fn arb_dialog_props() -> impl Strategy<Value = dialog::Props> {
+    (
+        (
+            prop::option::of(any::<bool>()),
+            any::<bool>(),
+            any::<bool>(),
+            any::<bool>(),
+            any::<bool>(),
+            any::<bool>(),
+            any::<bool>(),
+            arb_focus_target(),
+        ),
+        (
+            arb_focus_target(),
+            arb_dialog_role(),
+            0_u8..=10,
+            any::<bool>(),
+            any::<bool>(),
+        ),
+    )
+        .prop_map(
+            |(
+                (
+                    open,
+                    default_open,
+                    modal,
+                    close_on_backdrop,
+                    close_on_escape,
+                    prevent_scroll,
+                    restore_focus,
+                    initial_focus,
+                ),
+                (final_focus, role, title_level, lazy_mount, unmount_on_exit),
+            )| {
+                dialog::Props::new()
+                    .id("dialog")
+                    .open(open)
+                    .default_open(default_open)
+                    .modal(modal)
+                    .close_on_backdrop(close_on_backdrop)
+                    .close_on_escape(close_on_escape)
+                    .prevent_scroll(prevent_scroll)
+                    .restore_focus(restore_focus)
+                    .initial_focus(initial_focus)
+                    .final_focus(final_focus)
+                    .role(role)
+                    .title_level(title_level)
+                    .lazy_mount(lazy_mount)
+                    .unmount_on_exit(unmount_on_exit)
+            },
+        )
+}
+
+fn arb_dialog_event() -> impl Strategy<Value = dialog::Event> {
+    prop_oneof![
+        Just(dialog::Event::Open),
+        Just(dialog::Event::Close),
+        Just(dialog::Event::Toggle),
+        Just(dialog::Event::CloseOnBackdropClick),
+        Just(dialog::Event::CloseOnEscape),
+        Just(dialog::Event::RegisterTitle),
+        Just(dialog::Event::RegisterDescription),
+        Just(dialog::Event::SyncProps),
+    ]
+}
+
+fn arb_dialog_step() -> impl Strategy<Value = DialogStep> {
+    prop_oneof![
+        arb_dialog_event().prop_map(DialogStep::Send),
+        arb_dialog_props().prop_map(DialogStep::SetProps),
+    ]
+}
+
+fn assert_dialog_state_context_invariants(service: &Service<dialog::Machine>) -> TestCaseResult {
+    // 1. State ⇔ context.open invariant.
+    prop_assert_eq!(
+        service.context().open,
+        matches!(service.state(), dialog::State::Open)
+    );
+
+    // 2. ID stability — derived from props.id at init and never mutated.
+    prop_assert_eq!(service.context().ids.part("trigger"), "dialog-trigger");
+    prop_assert_eq!(service.context().ids.part("content"), "dialog-content");
+    prop_assert_eq!(service.context().ids.part("title"), "dialog-title");
+    prop_assert_eq!(
+        service.context().ids.part("description"),
+        "dialog-description"
+    );
+
+    Ok(())
+}
+
+fn assert_dialog_send_result_invariants(
+    event: dialog::Event,
+    result: &SendResult<dialog::Machine>,
+    before_state: dialog::State,
+    before_context: &dialog::Context,
+) -> TestCaseResult {
+    // 3. Effect-name allow-list — every emitted name is one of the
+    // documented `EFFECT_*` constants.
+    for effect in &result.pending_effects {
+        prop_assert!(
+            DIALOG_EFFECT_NAMES.contains(&effect.name),
+            "unexpected effect name: {:?}",
+            effect.name
+        );
+
+        // 4. Payload-free invariant — no metadata leaks through any
+        // emitted intent (the agnostic-core contract).
+        prop_assert!(effect.metadata.is_none());
+    }
+
+    // 5. SyncProps is state-preserving: state never changes.
+    if matches!(event, dialog::Event::SyncProps) {
+        prop_assert!(!result.state_changed);
+        prop_assert!(result.pending_effects.is_empty());
+    }
+
+    // 6. Guards: CloseOnBackdropClick / CloseOnEscape MUST NOT change
+    // state when the corresponding `ctx.close_on_*` flag is false.
+    if matches!(event, dialog::Event::CloseOnBackdropClick) && !before_context.close_on_backdrop {
+        prop_assert_eq!(result.state_changed, false);
+    }
+    if matches!(event, dialog::Event::CloseOnEscape) && !before_context.close_on_escape {
+        prop_assert_eq!(result.state_changed, false);
+    }
+
+    // 7. Register{Title,Description} monotonicity: once `has_title` is
+    // true, it stays true; same for `has_description`. (Catch-all
+    // route in the state machine prevents flipping back.)
+    if matches!(
+        event,
+        dialog::Event::RegisterTitle | dialog::Event::RegisterDescription
+    ) {
+        prop_assert!(!result.state_changed);
+    }
+
+    // 8. State-flipping events emit `EFFECT_OPEN_CHANGE` exactly when
+    // the state actually changed. Conversely, no-op transitions
+    // (e.g., Open while already Open) do not emit it.
+    let emitted_open_change = result
+        .pending_effects
+        .iter()
+        .any(|e| e.name == dialog::EFFECT_OPEN_CHANGE);
+
+    let state_actually_flipped = result.state_changed;
+
+    if matches!(
+        event,
+        dialog::Event::Open
+            | dialog::Event::Close
+            | dialog::Event::Toggle
+            | dialog::Event::CloseOnBackdropClick
+            | dialog::Event::CloseOnEscape
+    ) {
+        prop_assert_eq!(emitted_open_change, state_actually_flipped);
+    } else {
+        prop_assert!(!emitted_open_change);
+    }
+
+    let _ = before_state;
+
+    Ok(())
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(
+        std::env::var("PROPTEST_CASES")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(1000)
+    ))]
+
+    #[test]
+    #[ignore = "proptest — nightly extended-proptest job"]
+    fn proptest_dialog_state_context_invariants_hold(
+        props in arb_dialog_props(),
+        steps in prop::collection::vec(arb_dialog_step(), 0..128),
+    ) {
+        let mut service = Service::<dialog::Machine>::new(
+            props,
+            &Env::default(),
+            &dialog::Messages::default(),
+        );
+
+        assert_dialog_state_context_invariants(&service)?;
+
+        // Track monotonic flags — once true, must stay true.
+        let mut had_title = service.context().has_title;
+
+        let mut had_description = service.context().has_description;
+
+        for step in steps {
+            match step {
+                DialogStep::Send(event) => {
+                    let before_state = *service.state();
+                    let before_context = service.context().clone();
+
+                    let result = service.send(event);
+
+                    assert_dialog_send_result_invariants(
+                        event,
+                        &result,
+                        before_state,
+                        &before_context,
+                    )?;
+                }
+
+                DialogStep::SetProps(props) => {
+                    let before_open_prop = service.props().open;
+                    let next_open_prop = props.open;
+
+                    drop(service.set_props(props));
+
+                    // After set_props, every context-backed prop in the
+                    // service.props() snapshot must equal the same field
+                    // in `service.context()` — proves SyncProps replayed
+                    // the incoming props.
+                    let p = service.props();
+                    let c = service.context();
+
+                    prop_assert_eq!(c.modal, p.modal);
+                    prop_assert_eq!(c.close_on_backdrop, p.close_on_backdrop);
+                    prop_assert_eq!(c.close_on_escape, p.close_on_escape);
+                    prop_assert_eq!(c.prevent_scroll, p.prevent_scroll);
+                    prop_assert_eq!(c.restore_focus, p.restore_focus);
+                    prop_assert_eq!(c.initial_focus, p.initial_focus);
+                    prop_assert_eq!(c.final_focus, p.final_focus);
+                    prop_assert_eq!(c.role, p.role);
+
+                    // Controlled-open sync: when open prop flipped to a
+                    // concrete value, state and ctx.open must match.
+                    if before_open_prop != next_open_prop
+                        && let Some(open) = service.props().open
+                    {
+                        prop_assert_eq!(service.context().open, open);
+                    }
+                }
+            }
+
+            // Monotonicity invariants enforced after each step.
+            if had_title {
+                prop_assert!(service.context().has_title);
+            }
+
+            if had_description {
+                prop_assert!(service.context().has_description);
+            }
+
+            had_title |= service.context().has_title;
+
+            had_description |= service.context().has_description;
+
+            assert_dialog_state_context_invariants(&service)?;
         }
     }
 }

--- a/spec/components/overlay/dialog.md
+++ b/spec/components/overlay/dialog.md
@@ -21,9 +21,10 @@ A modal or non-modal overlay that requires user interaction before returning to 
 
 ```rust
 /// States for the `Dialog` component.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum State {
     /// The dialog is closed.
+    #[default]
     Closed,
     /// The dialog is open.
     Open,
@@ -32,9 +33,15 @@ pub enum State {
 
 ### 1.2 Events
 
+The event enum contains only state-control events. Animation lifecycle
+(mount, unmount, animation start/end) is owned entirely by the
+[`Presence`](./presence.md) machine and composed at the adapter layer (see
+[§5](#5-animation-lifecycle-presence-composition)); Dialog never reacts to
+Presence events directly.
+
 ```rust
 /// Events for the `Dialog` component.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Event {
     /// Open the dialog.
     Open,
@@ -46,13 +53,18 @@ pub enum Event {
     CloseOnBackdropClick,
     /// Close the dialog on escape key.
     CloseOnEscape,
-    // NOTE: AnimationStart and AnimationEnd are NOT part of the Dialog event enum.
-    // The Presence machine (presence.md) handles animation lifecycle
-    // independently. Dialog only reacts to Presence completion via PresenceComplete.
     /// Register the title of the dialog.
     RegisterTitle,
     /// Register the description of the dialog.
     RegisterDescription,
+    /// Re-apply context-backed `Props` fields after a prop change. Emitted
+    /// from [`on_props_changed`](#19-full-machine-implementation) when any
+    /// non-`open` field that drives `Context` differs between old and new
+    /// props (`modal`, `close_on_backdrop`, `close_on_escape`,
+    /// `prevent_scroll`, `restore_focus`, `initial_focus`, `final_focus`,
+    /// `role`). The transition is context-only — no state change, no
+    /// adapter intents emitted.
+    SyncProps,
 }
 ```
 
@@ -80,14 +92,14 @@ pub struct Context {
     pub final_focus: Option<FocusTarget>,
     /// The role of the dialog.
     pub role: Role,
-    /// The ID of the trigger element.
-    pub trigger_id: String,
-    /// The ID of the content element.
-    pub content_id: String,
-    /// The ID of the title element.
-    pub title_id: String,
-    /// The ID of the description element.
-    pub description_id: String,
+    /// Hydration-stable IDs derived from `Props::id`. Adapters render
+    /// each part's `id` attribute via `ids.part("trigger" | "content" |
+    /// "title" | "description")`; ARIA wiring (`aria-controls`,
+    /// `aria-labelledby`, `aria-describedby`) reads from the same
+    /// `part(...)` lookup. This matches the workspace convention shared
+    /// with `form`, `field`, `fieldset`, `checkbox`, `textarea`,
+    /// `text_field`, and `date_field`.
+    pub ids: ComponentIds,
     /// Whether the dialog has a title.
     pub has_title: bool,
     /// Whether the dialog has a description.
@@ -99,12 +111,26 @@ pub struct Context {
 }
 
 /// The role of the dialog.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum Role {
     /// The dialog role.
+    #[default]
     Dialog,
     /// The alert dialog role.
     AlertDialog,
+}
+
+impl Role {
+    /// ARIA role token rendered on the content element. Single source of
+    /// truth for the `role="dialog"` / `role="alertdialog"` mapping; both
+    /// the agnostic `Api::content_attrs` and adapter-side test fixtures
+    /// must read the role string through this method.
+    pub const fn as_aria_role(self) -> &'static str {
+        match self {
+            Self::Dialog => "dialog",
+            Self::AlertDialog => "alertdialog",
+        }
+    }
 }
 
 // `FocusTarget` — defined in `03-accessibility.md`
@@ -118,18 +144,28 @@ pub enum Role {
 /// to let consumers intercept and cancel the default close behavior.
 ///
 /// Example: preventing close when there are unsaved changes.
-#[derive(Clone, Debug)]
+///
+/// The veto flag is shared through `Arc<AtomicBool>` so the value can be
+/// passed by-clone into [`Callback`], which requires `Args: 'static` and
+/// therefore cannot accept `&mut PreventableEvent`. The same shared-veto
+/// pattern is used by [`DismissAttempt`](../utility/dismissable.md).
+#[derive(Clone, Debug, Default)]
 pub struct PreventableEvent {
-    /// Whether the default behavior has been prevented.
-    prevented: bool,
+    veto: Arc<AtomicBool>,
 }
 
 impl PreventableEvent {
-    pub fn new() -> Self { Self { prevented: false } }
-    /// Prevent the default behavior (e.g., prevent dialog from closing).
-    pub fn prevent_default(&mut self) { self.prevented = true; }
-    /// Whether `prevent_default()` was called.
-    pub fn is_default_prevented(&self) -> bool { self.prevented }
+    pub fn new() -> Self {
+        Self { veto: Arc::new(AtomicBool::new(false)) }
+    }
+    /// Prevent the default behavior (e.g., prevent dialog from closing). Idempotent.
+    pub fn prevent_default(&self) {
+        self.veto.store(true, Ordering::SeqCst);
+    }
+    /// Whether `prevent_default()` was called on this event or any of its clones.
+    pub fn is_default_prevented(&self) -> bool {
+        self.veto.load(Ordering::SeqCst)
+    }
 }
 
 /// The props of the dialog.
@@ -170,13 +206,17 @@ pub struct Props {
     /// Fires after the transition with the new open state value.
     pub on_open_change: Option<Callback<bool>>,
     /// Callback invoked when Escape is pressed while the dialog is open.
-    /// Call `event.prevent_default()` to prevent the dialog from closing.
-    /// Fires before the close transition — if prevented, the transition is cancelled.
-    pub on_escape_key_down: Option<Callback<PreventableEvent>>,
+    /// The adapter passes a clone of the [`PreventableEvent`] it constructed;
+    /// the consumer may call `event.prevent_default()` to prevent the dialog
+    /// from closing (the veto flag is shared between clones). Fires before
+    /// the close transition — if prevented, the transition is cancelled.
+    pub on_escape_key_down: Option<Callback<dyn Fn(PreventableEvent) + Send + Sync>>,
     /// Callback invoked when a pointer down or focus event occurs outside the dialog content.
-    /// Call `event.prevent_default()` to prevent the dialog from closing.
-    /// Fires before the close transition — if prevented, the transition is cancelled.
-    pub on_interact_outside: Option<Callback<PreventableEvent>>,
+    /// The adapter passes a clone of the [`PreventableEvent`] it constructed;
+    /// the consumer may call `event.prevent_default()` to prevent the dialog
+    /// from closing (the veto flag is shared between clones). Fires before
+    /// the close transition — if prevented, the transition is cancelled.
+    pub on_interact_outside: Option<Callback<dyn Fn(PreventableEvent) + Send + Sync>>,
 }
 
 impl Default for Props {
@@ -203,6 +243,23 @@ impl Default for Props {
     }
 }
 ```
+
+`Props` also exposes a fluent builder following the workspace convention
+established by [`Presence`](./presence.md) and [`Tooltip`](./tooltip.md):
+`Props::new()` returns the default value, and a chained setter exists for
+each field (`.id(...)`, `.open(...)`, `.modal(...)`, `.on_open_change(...)`,
+…). The builder is purely ergonomic — it carries no semantics beyond
+mutating the returned `Props`.
+
+> **Adapter-only props.** `lazy_mount` and `unmount_on_exit` are _adapter
+> hints_: they configure how the framework adapter composes with
+> [`Presence`](./presence.md) (deferred content rendering and
+> unmount-after-exit-animation respectively) and **do not affect the
+> agnostic state machine**. `transition()` does not read either flag, and
+> they are not reflected in any [§1.11](#111-adapter-intent-contract)
+> intent. Adapters access them via `Api::lazy_mount()` /
+> `Api::unmount_on_exit()` (or directly via `props`) when wiring the
+> Presence composition described in [§5](#5-animation-lifecycle-presence-composition).
 
 ### 1.5 Scroll Lock Restoration Edge Cases
 
@@ -323,7 +380,12 @@ pub fn dialog_stack_pop(dialog_id: &str) {
 3. **Clean slate on empty**: When the last dialog closes and the stack is empty, ALL `inert` attributes set by the dialog system are cleared. No elements remain inert.
 4. **Stack ordering**: Dialogs are always pushed/popped in LIFO order. If a non-topmost dialog closes (unusual but possible via programmatic close), it is removed from its position and inert is recalculated for the current top.
 
-**Dialog Open/Close Integration**: The dialog state machine's `Open` and `Close` transitions MUST call `dialog_stack_push()` and `dialog_stack_pop()` respectively as part of their `PendingEffect` setup/cleanup.
+**Dialog Open/Close Integration**: The agnostic state machine emits the
+`dialog-set-background-inert` and `dialog-remove-background-inert` intents (see
+[§1.11](#111-adapter-intent-contract)). When the adapter receives those intents it MUST
+call `dialog_stack_push()` / `dialog_stack_pop()`, passing identifiers it owns
+internally — the dialog stack is an adapter-internal data structure. The agnostic core
+itself never references the stack.
 
 #### 1.7.2 Escape Key Behavior in Nested Overlays
 
@@ -345,7 +407,14 @@ When multiple dialogs are stacked, Escape key handling MUST route to the topmost
 
 **Rapid Escape deduplication**: No special deduplication logic is needed for rapid repeated Escape presses. This is naturally handled by the state machine: the first Escape transitions the topmost dialog from `Open → Closing` (or directly to `Closed` if animations are skipped). A second Escape arriving while the dialog is in `Closing` or `Closed` state is a no-op — the state machine has no valid transition for `Event::Escape` in those states, so it is silently ignored.
 
-**Pop timing guarantee**: `dialog_stack_pop()` is executed as a `PendingEffect` during the close transition. Because effects run synchronously before the next event is processed, the stack is updated (and the previously-second dialog becomes topmost) before any subsequent Escape `keydown` event can be handled. This ensures that the second Escape press — if it arrives after the first dialog's close effect runs — correctly targets the next dialog in the stack, not the already-closing one.
+**Pop timing guarantee**: The adapter calls `dialog_stack_pop()` while handling the
+`dialog-remove-background-inert` adapter intent (see
+[§1.11](#111-adapter-intent-contract)) during the close transition. Because adapter
+effect handlers run synchronously before the next event is processed, the stack is
+updated (and the previously-second dialog becomes topmost) before any subsequent
+Escape `keydown` event can be handled. This ensures that the second Escape press — if
+it arrives after the first dialog's close intent runs — correctly targets the next
+dialog in the stack, not the already-closing one.
 
 #### 1.7.4 Focus Restoration Safety for Nested Dialogs
 
@@ -394,7 +463,13 @@ When using lazy content loading, content MUST be fully rendered before the enter
 
 #### 1.8.2 Focus Escape During Animation
 
-`FocusScope` MUST NOT activate until the enter animation has started (after `animationstart` fires). During any animation delay, set `tabindex="-1"` on the container to prevent focus escape to background elements.
+`FocusScope` MUST NOT activate until the enter animation has started (after
+`animationstart` fires). The Content part already carries a static
+`tabindex="-1"` (see [§1.10 `content_attrs`](#110-connect--api)), so during
+the animation delay the adapter simply moves focus to the Content handle —
+no dynamic tabindex toggling is required. The `tabindex="-1"` makes Content
+programmatically focusable (`.focus()` works) without making it a Tab stop,
+which is the correct steady-state behaviour for a `<div role="dialog">`.
 
 #### 1.8.3 FocusScope Activation Lifecycle
 
@@ -407,13 +482,19 @@ The following sequence governs FocusScope activation for dialog overlays:
 
 ### 1.9 Full Machine Implementation
 
-````rust
-use ars_core::{TransitionPlan, PendingEffect, Bindable, AttrMap};
+The agnostic core emits **payload-free named effects** only. Adapters subscribe to these
+names and resolve element targets through their captured framework handles
+(`NodeRef<T>` in Leptos, `MountedData` / `Signal<Option<MountedData>>` in Dioxus) — never
+through ID lookup. See [§1.11 Adapter intent contract](#111-adapter-intent-contract) for
+the per-name contract.
+
+```rust
+use ars_core::{ComponentIds, Env, Machine as MachineTrait, PendingEffect, TransitionPlan};
 
 /// The machine for the `Dialog` component.
 pub struct Machine;
 
-impl ars_core::Machine for Machine {
+impl MachineTrait for Machine {
     type State = State;
     type Event = Event;
     type Context = Context;
@@ -421,31 +502,33 @@ impl ars_core::Machine for Machine {
     type Messages = Messages;
     type Api<'a> = Api<'a>;
 
-    fn init(props: &Self::Props, env: &Env, messages: &Self::Messages) -> (Self::State, Self::Context) {
+    fn init(
+        props: &Self::Props,
+        env: &Env,
+        messages: &Self::Messages,
+    ) -> (Self::State, Self::Context) {
         let open = props.open.unwrap_or(props.default_open);
         let state = if open { State::Open } else { State::Closed };
         let ids = ComponentIds::from_id(&props.id);
-        let locale = env.locale.clone();
-        let messages = messages.clone();
-        (state, Context {
-            open,
-            modal: props.modal,
-            close_on_backdrop: props.close_on_backdrop,
-            close_on_escape: props.close_on_escape,
-            prevent_scroll: props.prevent_scroll,
-            restore_focus: props.restore_focus,
-            initial_focus: props.initial_focus.clone(),
-            final_focus: props.final_focus.clone(),
-            role: props.role.clone(),
-            trigger_id: ids.part("trigger"),
-            content_id: ids.part("content"),
-            title_id: ids.part("title"),
-            description_id: ids.part("description"),
-            has_title: false,
-            has_description: false,
-            locale,
-            messages,
-        })
+        (
+            state,
+            Context {
+                open,
+                modal: props.modal,
+                close_on_backdrop: props.close_on_backdrop,
+                close_on_escape: props.close_on_escape,
+                prevent_scroll: props.prevent_scroll,
+                restore_focus: props.restore_focus,
+                initial_focus: props.initial_focus,
+                final_focus: props.final_focus,
+                role: props.role,
+                ids,
+                has_title: false,
+                has_description: false,
+                locale: env.locale.clone(),
+                messages: messages.clone(),
+            },
+        )
     }
 
     fn transition(
@@ -456,117 +539,86 @@ impl ars_core::Machine for Machine {
     ) -> Option<TransitionPlan<Self>> {
         match (state, event) {
             (State::Closed, Event::Open | Event::Toggle) => {
-                Some(TransitionPlan::to(State::Open)
-                    .apply(|ctx| { ctx.open = true; })
-                    .with_effect(PendingEffect::new("prevent-scroll", |ctx, props, _send| {
-                        if props.prevent_scroll {
-                            // Scroll lock implementation:
-                            // 1. Set `overflow: hidden; position: fixed; width: 100vw` on document element.
-                            // 2. Measure `window.scrollY` before locking and restore after unlocking.
-                            // 3. Nested scrollable containers inside the dialog MUST remain scrollable.
-                            // 4. When multiple modals stack, only the topmost modal controls the scroll lock.
-                            let restore = prevent_body_scroll();
-                            Box::new(restore)
-                        } else {
-                            no_cleanup()
-                        }
-                    }))
-                    .with_effect(PendingEffect::new("focus-management", |ctx, props, _send| {
-                        let initial = props.initial_focus.clone();
-                        let content_id = ctx.content_id.clone();
-                        focus_initial(&content_id, initial.as_ref());
-                        let trigger_id = ctx.trigger_id.clone();
-                        let restore = props.restore_focus;
-                        let final_focus = props.final_focus.clone();
-                        Box::new(move || {
-                            if restore {
-                                focus_final(&trigger_id, final_focus.as_ref());
-                            }
-                        })
-                    }))
-                    .with_effect(PendingEffect::new("set_background_inert", |_ctx, _props, _send| {
-                        let platform = use_platform_effects();
-                        let cleanup = platform.set_background_inert("ars-portal-root");
-                        cleanup
-                    }))
-                    // The cleanup returned by `set_background_inert()` is stored by the
-                    // adapter's PendingEffect lifecycle and runs automatically when this
-                    // effect is replaced or the dialog leaves `Open`. That cleanup is the
-                    // authoritative teardown path for native inert and polyfill state.
-                    // ── Adapter-level static dialog stack specification ──
-                    //
-                    // Maintain a static `DIALOG_STACK: Vec<DialogId>` at the adapter level.
-                    //
-                    // On Open: push dialog ID onto stack. Apply `inert` attribute only to
-                    //          siblings of the current top dialog.
-                    //
-                    // On Close: pop dialog ID from stack. If stack is non-empty, re-apply
-                    //           `inert` to siblings of the new top. If stack is empty, remove
-                    //           all `inert` attributes.
-                    //
-                    // This ensures closing an inner dialog does not accidentally remove
-                    // `inert` from the outer dialog's background.
-                    //
-                    // ```rust
-                    // static DIALOG_STACK: Mutex<Vec<DialogId>> = Mutex::new(Vec::new());
-                    // ```
-                    .with_effect(PendingEffect::new("focus-first-tabbable", |ctx, _props, _send| {
-                        let platform = use_platform_effects();
-                        let content_id = ctx.ids.part("content");
-                        platform.focus_first_tabbable(&content_id);
-                        no_cleanup()
-                    })))
+                let mut plan = TransitionPlan::to(State::Open)
+                    .apply(|ctx| {
+                        ctx.open = true;
+                    })
+                    .with_effect(PendingEffect::named(EFFECT_OPEN_CHANGE))
+                    .with_effect(PendingEffect::named(EFFECT_FOCUS_INITIAL))
+                    .with_effect(PendingEffect::named(EFFECT_FOCUS_FIRST_TABBABLE));
+                if ctx.prevent_scroll {
+                    plan = plan.with_effect(PendingEffect::named(EFFECT_SCROLL_LOCK_ACQUIRE));
+                }
+                if ctx.modal {
+                    plan = plan.with_effect(PendingEffect::named(EFFECT_SET_BACKGROUND_INERT));
+                }
+                Some(plan)
             }
             (State::Open, Event::Close | Event::Toggle) => {
-                Some(TransitionPlan::to(State::Closed)
-                    .apply(|ctx| { ctx.open = false; })
-                    .with_effect(PendingEffect::new("release-scroll-lock", |_ctx, props, _send| {
-                        let platform = use_platform_effects();
-                        if props.prevent_scroll {
-                            platform.scroll_lock_release();
-                        }
-                        no_cleanup()
-                    }))
-                    .with_effect(PendingEffect::new("remove-background-inert", |ctx, _props, _send| {
-                        let platform = use_platform_effects();
-                        // Best-effort direct clearing used for stack recalculation and
-                        // defensive close flows. This does not replace the stored cleanup
-                        // from `set_background_inert()`.
-                        platform.remove_inert_from_siblings(&ctx.ids.part("portal"));
-                        no_cleanup()
-                    }))
-                    .with_effect(PendingEffect::new("restore-focus", |ctx, _props, _send| {
-                        let platform = use_platform_effects();
-                        if platform.document_contains_id(&ctx.trigger_id) {
-                            platform.focus_element_by_id(&ctx.trigger_id);
-                        } else {
-                            // Trigger removed from DOM — fall back to body
-                            platform.focus_body();
-                        }
-                        no_cleanup()
-                    })))
+                let mut plan = TransitionPlan::to(State::Closed)
+                    .apply(|ctx| {
+                        ctx.open = false;
+                    })
+                    .with_effect(PendingEffect::named(EFFECT_OPEN_CHANGE));
+                if ctx.prevent_scroll {
+                    plan = plan.with_effect(PendingEffect::named(EFFECT_SCROLL_LOCK_RELEASE));
+                }
+                if ctx.modal {
+                    plan = plan.with_effect(PendingEffect::named(EFFECT_REMOVE_BACKGROUND_INERT));
+                }
+                if ctx.restore_focus {
+                    plan = plan.with_effect(PendingEffect::named(EFFECT_RESTORE_FOCUS));
+                }
+                Some(plan)
             }
-            (State::Open, Event::CloseOnBackdropClick) => {
-                if ctx.close_on_backdrop {
-                    Some(TransitionPlan::to(State::Closed)
-                        .apply(|ctx| { ctx.open = false; }))
-                } else { None }
-            }
-            (State::Open, Event::CloseOnEscape) => {
-                if ctx.close_on_escape {
-                    Some(TransitionPlan::to(State::Closed)
-                        .apply(|ctx| { ctx.open = false; }))
-                } else { None }
-            }
-            // Register title/description for aria-labelledby/describedby wiring
-            (_, Event::RegisterTitle) => {
-                Some(TransitionPlan::context_only(|ctx| {
+            (State::Open, Event::CloseOnBackdropClick) if ctx.close_on_backdrop => Some(
+                TransitionPlan::to(State::Closed)
+                    .apply(|ctx| {
+                        ctx.open = false;
+                    })
+                    .with_effect(PendingEffect::named(EFFECT_OPEN_CHANGE)),
+            ),
+            (State::Open, Event::CloseOnEscape) if ctx.close_on_escape => Some(
+                TransitionPlan::to(State::Closed)
+                    .apply(|ctx| {
+                        ctx.open = false;
+                    })
+                    .with_effect(PendingEffect::named(EFFECT_OPEN_CHANGE)),
+            ),
+            // Register title/description for aria-labelledby/describedby wiring.
+            // Guarded — re-sending after the flag is set is a no-op so the
+            // Service does not signal `context_changed = true` spuriously.
+            (_, Event::RegisterTitle) if !ctx.has_title => Some(
+                TransitionPlan::context_only(|ctx| {
                     ctx.has_title = true;
-                }))
-            }
-            (_, Event::RegisterDescription) => {
-                Some(TransitionPlan::context_only(|ctx| {
+                }),
+            ),
+            (_, Event::RegisterDescription) if !ctx.has_description => Some(
+                TransitionPlan::context_only(|ctx| {
                     ctx.has_description = true;
+                }),
+            ),
+            // Replay context-backed prop fields after a runtime prop
+            // change. Captured by-copy/by-move so the agnostic core does
+            // not retain a reference to `props` past the apply closure.
+            (_, Event::SyncProps) => {
+                let modal = props.modal;
+                let close_on_backdrop = props.close_on_backdrop;
+                let close_on_escape = props.close_on_escape;
+                let prevent_scroll = props.prevent_scroll;
+                let restore_focus = props.restore_focus;
+                let initial_focus = props.initial_focus;
+                let final_focus = props.final_focus;
+                let role = props.role;
+                Some(TransitionPlan::context_only(move |ctx| {
+                    ctx.modal = modal;
+                    ctx.close_on_backdrop = close_on_backdrop;
+                    ctx.close_on_escape = close_on_escape;
+                    ctx.prevent_scroll = prevent_scroll;
+                    ctx.restore_focus = restore_focus;
+                    ctx.initial_focus = initial_focus;
+                    ctx.final_focus = final_focus;
+                    ctx.role = role;
                 }))
             }
             _ => None,
@@ -581,8 +633,54 @@ impl ars_core::Machine for Machine {
     ) -> Self::Api<'a> {
         Api { state, ctx, props, send }
     }
+
+    fn on_props_changed(old: &Self::Props, new: &Self::Props) -> Vec<Self::Event> {
+        // Two independent sync axes:
+        //
+        // 1. **Controlled-mode `open` sync** — when a parent component
+        //    flips `props.open` between `Some(true)` ↔ `Some(false)` (or
+        //    transitions from uncontrolled to controlled), emit `Open` /
+        //    `Close` so the state machine reconciles. The dispatched event
+        //    runs `transition`, which emits `EFFECT_OPEN_CHANGE` (§1.11).
+        //    Because the consumer initiated the change, the adapter MUST
+        //    suppress the resulting `on_open_change` callback to avoid an
+        //    echo loop. Adapters typically track the source of the event
+        //    in their own dispatch layer.
+        //
+        // 2. **Context-backed prop sync** — when any non-`open` field that
+        //    drives `Context` changes (`modal`, `close_on_backdrop`,
+        //    `close_on_escape`, `prevent_scroll`, `restore_focus`,
+        //    `initial_focus`, `final_focus`, `role`), emit `SyncProps`.
+        //    The corresponding transition replays those props into
+        //    `Context` so subsequent state-flipping transitions emit
+        //    intents using the freshly-synced configuration.
+        //
+        // Both events may be emitted from a single `set_props` call; the
+        // Service queues them in order and drains them sequentially.
+        let mut events = Vec::new();
+        if let (was, Some(now)) = (old.open, new.open)
+            && was != Some(now)
+        {
+            events.push(if now { Event::Open } else { Event::Close });
+        }
+        if context_relevant_props_changed(old, new) {
+            events.push(Event::SyncProps);
+        }
+        events
+    }
 }
-````
+
+fn context_relevant_props_changed(old: &Props, new: &Props) -> bool {
+    old.modal != new.modal
+        || old.close_on_backdrop != new.close_on_backdrop
+        || old.close_on_escape != new.close_on_escape
+        || old.prevent_scroll != new.prevent_scroll
+        || old.restore_focus != new.restore_focus
+        || old.initial_focus != new.initial_focus
+        || old.final_focus != new.final_focus
+        || old.role != new.role
+}
+```
 
 > **Preventable event callbacks.** The `on_escape_key_down` and `on_interact_outside` callbacks are invoked by the adapter layer BEFORE sending the corresponding event to the state machine. If the consumer calls `prevent_default()`, the adapter MUST NOT send the event — the dialog stays open. This pattern keeps the state machine pure (no side-effect callbacks in `transition()`) while giving consumers veto power over dismissal.
 >
@@ -603,16 +701,43 @@ impl ars_core::Machine for Machine {
 > fn on_keydown(event: &KeyboardEvent, props: &Props, send: &dyn Fn(Event)) {
 >     if event.key() == "Escape" && props.close_on_escape {
 >         if let Some(ref callback) = props.on_escape_key_down {
->             let mut preventable = PreventableEvent::new();
->             callback.call(&mut preventable);
+>             let preventable = PreventableEvent::new();
+>             callback.call(preventable.clone());
 >             if preventable.is_default_prevented() { return; }
 >         }
 >         send(Event::CloseOnEscape);
 >     }
 > }
+>
+> // Adapter pseudocode for backdrop-click handling — symmetric flow:
+> fn on_backdrop_pointer_down(props: &Props, send: &dyn Fn(Event)) {
+>     if !props.close_on_backdrop { return; }
+>     if let Some(ref callback) = props.on_interact_outside {
+>         let preventable = PreventableEvent::new();
+>         callback.call(preventable.clone());
+>         if preventable.is_default_prevented() { return; }
+>     }
+>     send(Event::CloseOnBackdropClick);
+> }
 > ```
 
 ### 1.10 Connect / API
+
+> **Element handle contract.** IDs derived from `Context::ids` (via
+> `ids.part("trigger" | "content" | "title" | "description")`) are semantic strings used
+> solely for ARIA wiring (`aria-labelledby`, `aria-describedby`, `aria-controls`) and the
+> `id` attribute on each rendered part for hydration stability. They are **never** used
+> as element-lookup keys — the agnostic core never calls `getElementById` or any
+> equivalent platform helper. Adapters obtain live element references through framework
+> primitives:
+>
+> - **Leptos** — `NodeRef<T>` captured at the render site for each anatomy part.
+> - **Dioxus** — `MountedData` (typically held inside a `Signal<Option<MountedData>>`)
+>   captured via the `onmounted` event for each anatomy part.
+>
+> When an effect intent fires (see [§1.11](#111-adapter-intent-contract)), the adapter
+> resolves the target element through the captured handle for that part, never by
+> looking up the ID.
 
 ```rust
 #[derive(ComponentPart)]
@@ -629,6 +754,10 @@ pub enum Part {
 }
 
 /// The API for the `Dialog` component.
+///
+/// `Api` implements `Debug` (omitting the non-`Debug` `send` callback
+/// field) for ergonomic logging in tests and dev tools. The `Debug`
+/// impl renders the borrowed `state`, `ctx`, and `props` only.
 pub struct Api<'a> {
     /// The current state of the dialog.
     state: &'a State,
@@ -655,15 +784,21 @@ impl<'a> Api<'a> {
     }
 
     /// The attributes for the trigger element.
+    ///
+    /// `type="button"` is emitted unconditionally. HTML `<button>` defaults
+    /// to `type="submit"` inside a `<form>`, which would submit the form on
+    /// click; pinning the type to `"button"` is the correct defensive
+    /// default for a dialog trigger.
     pub fn trigger_attrs(&self) -> AttrMap {
         let mut attrs = AttrMap::new();
         let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Trigger.data_attrs();
         attrs.set(scope_attr, scope_val);
         attrs.set(part_attr, part_val);
-        attrs.set(HtmlAttr::Id, &self.ctx.trigger_id);
+        attrs.set(HtmlAttr::Id, self.ctx.ids.part("trigger"));
+        attrs.set(HtmlAttr::Type, "button");
         attrs.set(HtmlAttr::Aria(AriaAttr::HasPopup), "dialog");
         attrs.set(HtmlAttr::Aria(AriaAttr::Expanded), if self.is_open() { "true" } else { "false" });
-        attrs.set(HtmlAttr::Aria(AriaAttr::Controls), &self.ctx.content_id);
+        attrs.set(HtmlAttr::Aria(AriaAttr::Controls), self.ctx.ids.part("content"));
         attrs
     }
 
@@ -675,7 +810,8 @@ impl<'a> Api<'a> {
     /// The attributes for the backdrop element.
     // NOTE: `aria-hidden="true"` and `inert` on the backdrop are always correct
     // (it is decorative). Feature detection for `inert` applies to the
-    // `set_background_inert` effect on sibling elements, not to this backdrop element.
+    // `dialog-set-background-inert` adapter intent on sibling elements, not to
+    // this backdrop element.
     pub fn backdrop_attrs(&self) -> AttrMap {
         let mut attrs = AttrMap::new();
         let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Backdrop.data_attrs();
@@ -702,23 +838,30 @@ impl<'a> Api<'a> {
     }
 
     /// The attributes for the content element.
+    ///
+    /// `tabindex="-1"` is emitted statically: a `<div role="dialog">` is
+    /// otherwise not focusable, but the adapter must be able to call
+    /// `.focus()` on the content during the entry animation
+    /// ([§1.8.2](#182-focus-escape-during-animation)) and during the
+    /// focus-restoration fallback chain
+    /// ([§3.3.1](#331-focus-restoration-fallback-chain)). `tabindex="-1"`
+    /// makes the element programmatically focusable while keeping it out of
+    /// the Tab order.
     pub fn content_attrs(&self) -> AttrMap {
         let mut attrs = AttrMap::new();
         let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Content.data_attrs();
         attrs.set(scope_attr, scope_val);
         attrs.set(part_attr, part_val);
-        attrs.set(HtmlAttr::Id, &self.ctx.content_id);
-        attrs.set(HtmlAttr::Role, match self.ctx.role {
-            Role::Dialog => "dialog",
-            Role::AlertDialog => "alertdialog",
-        });
+        attrs.set(HtmlAttr::Id, self.ctx.ids.part("content"));
+        attrs.set(HtmlAttr::Role, self.ctx.role.as_aria_role());
         attrs.set(HtmlAttr::Data("ars-state"), if self.is_open() { "open" } else { "closed" });
+        attrs.set(HtmlAttr::TabIndex, "-1");
         if self.ctx.modal { attrs.set(HtmlAttr::Aria(AriaAttr::Modal), "true"); }
         if self.ctx.has_title {
-            attrs.set(HtmlAttr::Aria(AriaAttr::LabelledBy), &self.ctx.title_id);
+            attrs.set(HtmlAttr::Aria(AriaAttr::LabelledBy), self.ctx.ids.part("title"));
         }
         if self.ctx.has_description {
-            attrs.set(HtmlAttr::Aria(AriaAttr::DescribedBy), &self.ctx.description_id);
+            attrs.set(HtmlAttr::Aria(AriaAttr::DescribedBy), self.ctx.ids.part("description"));
         }
         attrs
     }
@@ -736,7 +879,7 @@ impl<'a> Api<'a> {
         let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Title.data_attrs();
         attrs.set(scope_attr, scope_val);
         attrs.set(part_attr, part_val);
-        attrs.set(HtmlAttr::Id, &self.ctx.title_id);
+        attrs.set(HtmlAttr::Id, self.ctx.ids.part("title"));
         // The adapter renders the Title as <h{level}> using this value.
         // Clamped to valid heading levels 1..=6.
         let level = self.props.title_level.clamp(1, 6);
@@ -750,16 +893,21 @@ impl<'a> Api<'a> {
         let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Description.data_attrs();
         attrs.set(scope_attr, scope_val);
         attrs.set(part_attr, part_val);
-        attrs.set(HtmlAttr::Id, &self.ctx.description_id);
+        attrs.set(HtmlAttr::Id, self.ctx.ids.part("description"));
         attrs
     }
 
     /// The attributes for the close trigger element.
+    ///
+    /// `type="button"` is emitted for the same reason as
+    /// [`trigger_attrs`](#1-state-machine): close triggers rendered inside a
+    /// surrounding `<form>` must not submit it on click.
     pub fn close_trigger_attrs(&self) -> AttrMap {
         let mut attrs = AttrMap::new();
         let [(scope_attr, scope_val), (part_attr, part_val)] = Part::CloseTrigger.data_attrs();
         attrs.set(scope_attr, scope_val);
         attrs.set(part_attr, part_val);
+        attrs.set(HtmlAttr::Type, "button");
         attrs.set(HtmlAttr::Aria(AriaAttr::Label), (self.ctx.messages.close_label)(&self.ctx.locale));
         attrs
     }
@@ -788,6 +936,59 @@ impl ConnectApi for Api<'_> {
 }
 ```
 
+### 1.11 Adapter intent contract
+
+The agnostic [`Machine`](#19-full-machine-implementation) emits each named effect below
+without any payload. Adapters subscribe to these names via `SendResult::pending_effects`
+and resolve target elements through their captured framework handles (see
+[§1.10 Element handle contract](#110-connect--api)). Cross-references in this section
+to [§1.5](#15-scroll-lock-restoration-edge-cases), [§1.6](#16-inert-attribute-polyfill),
+[§1.7](#17-nested-dialogs), and [§3.3.1](#331-focus-restoration-fallback-chain) describe
+the adapter-side behaviour required for each intent — those sections are non-normative
+for the agnostic core.
+
+All emission predicates below read from `ctx` (the runtime context), not
+`props` directly. `ctx` is initialised from `props` at `init()` time and
+remains the authoritative configuration source visible to `transition`.
+
+All effect-name values are prefixed with `dialog-` for the same reason
+[`Tooltip`](./tooltip.md) prefixes its names with `tooltip-`: when the
+literal surfaces in adapter logs or devtools the component of origin is
+self-describing without consulting the `Service<M>` type parameter.
+
+| Effect name                      | When emitted                                           | Adapter obligation                                                                                                                                                                                                         |
+| -------------------------------- | ------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dialog-open-change`             | Every state-flipping transition (any `Closed ↔ Open`). | Read `api.is_open()` after the transition runs and invoke `props.on_open_change` with that value if it is `Some`. See the echo-loop note in [§1.9 `on_props_changed`](#19-full-machine-implementation).                    |
+| `dialog-scroll-lock-acquire`     | `Closed → Open` and `ctx.prevent_scroll == true`.      | Acquire body-scroll lock following [§1.5](#15-scroll-lock-restoration-edge-cases); only the outermost dialog in the stack actually applies the lock.                                                                       |
+| `dialog-scroll-lock-release`     | `Open → Closed` and `ctx.prevent_scroll == true`.      | Release the lock acquired above. Outermost-only ownership applies.                                                                                                                                                         |
+| `dialog-set-background-inert`    | `Closed → Open` and `ctx.modal == true`.               | Apply `inert` to portal-root siblings, falling back to the polyfill described in [§1.6](#16-inert-attribute-polyfill). Push the dialog onto the dialog stack ([§1.7.1](#171-dialogstack-global-nested-dialog-management)). |
+| `dialog-remove-background-inert` | `Open → Closed` and `ctx.modal == true`.               | Run the cleanup stored at acquire time and pop the dialog stack. Re-apply `inert` for the new top of the stack if non-empty.                                                                                               |
+| `dialog-focus-initial`           | `Closed → Open`.                                       | Resolve `props.initial_focus` against the captured content handle and move focus accordingly. If `initial_focus` is `None`, the adapter's default is to leave focus to the next intent (`dialog-focus-first-tabbable`).    |
+| `dialog-focus-first-tabbable`    | `Closed → Open`.                                       | If no element gained focus from `dialog-focus-initial`, focus the first tabbable descendant of the captured content handle. The adapter never resolves the content element by ID.                                          |
+| `dialog-restore-focus`           | `Open → Closed` and `ctx.restore_focus == true`.       | Use the captured trigger handle's connectedness check to focus it; otherwise walk the [§3.3.1](#331-focus-restoration-fallback-chain) fallback chain, ending at `<body>`.                                                  |
+
+The canonical resolution keys are exported by the implementation as
+`pub const &str` so adapters match by const, not by literal string.
+Literal-string matching is an anti-pattern: a typo silently produces a
+no-op handler.
+
+```rust
+// Re-exported from `ars_components::overlay::dialog`.
+pub const EFFECT_OPEN_CHANGE: &str             = "dialog-open-change";
+pub const EFFECT_SCROLL_LOCK_ACQUIRE: &str     = "dialog-scroll-lock-acquire";
+pub const EFFECT_SCROLL_LOCK_RELEASE: &str     = "dialog-scroll-lock-release";
+pub const EFFECT_SET_BACKGROUND_INERT: &str    = "dialog-set-background-inert";
+pub const EFFECT_REMOVE_BACKGROUND_INERT: &str = "dialog-remove-background-inert";
+pub const EFFECT_FOCUS_INITIAL: &str           = "dialog-focus-initial";
+pub const EFFECT_FOCUS_FIRST_TABBABLE: &str    = "dialog-focus-first-tabbable";
+pub const EFFECT_RESTORE_FOCUS: &str           = "dialog-restore-focus";
+```
+
+Adapters MAY subscribe to additional names of their own (e.g. animation
+coordination) but MUST NOT reinterpret the names above. The agnostic core
+never emits any effect that carries an ID payload, a closure body, or a
+`WeakSend` reference; effect names are the entire contract.
+
 ## 2. Anatomy
 
 ```text
@@ -802,36 +1003,40 @@ Dialog
 └── CloseTrigger     (optional — button inside dialog to close it)
 ```
 
-| Part         | Element    | Key Attributes                                                       |
-| ------------ | ---------- | -------------------------------------------------------------------- |
-| Root         | `<div>`    | `data-ars-scope="dialog"`, `data-ars-part="root"`, `data-ars-state`  |
-| Trigger      | `<button>` | `aria-haspopup="dialog"`, `aria-expanded`, `aria-controls`           |
-| Backdrop     | `<div>`    | `aria-hidden="true"`, `inert`, `data-ars-state`                      |
-| Positioner   | `<div>`    | `data-ars-scope="dialog"`, `data-ars-part="positioner"`              |
-| Content      | `<div>`    | `role="dialog"`, `aria-modal`, `aria-labelledby`, `aria-describedby` |
-| Title        | `<h2>`     | `data-ars-heading-level`                                             |
-| Description  | `<p>`      | `id` for `aria-describedby` wiring                                   |
-| CloseTrigger | `<button>` | `aria-label` from Messages                                           |
+| Part         | Element    | Key Attributes                                                                        |
+| ------------ | ---------- | ------------------------------------------------------------------------------------- |
+| Root         | `<div>`    | `data-ars-scope="dialog"`, `data-ars-part="root"`, `data-ars-state`                   |
+| Trigger      | `<button>` | `type="button"`, `aria-haspopup="dialog"`, `aria-expanded`, `aria-controls`           |
+| Backdrop     | `<div>`    | `aria-hidden="true"`, `inert`, `data-ars-state`                                       |
+| Positioner   | `<div>`    | `data-ars-scope="dialog"`, `data-ars-part="positioner"`                               |
+| Content      | `<div>`    | `role="dialog"`, `tabindex="-1"`, `aria-modal`, `aria-labelledby`, `aria-describedby` |
+| Title        | `<h2>`     | `data-ars-heading-level`                                                              |
+| Description  | `<p>`      | `id` for `aria-describedby` wiring                                                    |
+| CloseTrigger | `<button>` | `type="button"`, `aria-label` from Messages                                           |
 
 ## 3. Accessibility
 
 ### 3.1 ARIA Roles, States, and Properties
 
-| Part     | Role / Property    | Value                                              |
-| -------- | ------------------ | -------------------------------------------------- |
-| Content  | `role`             | `"dialog"` or `"alertdialog"`                      |
-| Content  | `aria-modal`       | `"true"` when modal                                |
-| Content  | `aria-labelledby`  | Title part ID (when title is rendered)             |
-| Content  | `aria-describedby` | Description part ID (when description is rendered) |
-| Trigger  | `aria-haspopup`    | `"dialog"`                                         |
-| Trigger  | `aria-expanded`    | `"true"` / `"false"`                               |
-| Trigger  | `aria-controls`    | Content part ID                                    |
-| Backdrop | `aria-hidden`      | `"true"` (decorative)                              |
-| Backdrop | `inert`            | Always present (decorative, non-interactive)       |
+| Part         | Role / Property    | Value                                               |
+| ------------ | ------------------ | --------------------------------------------------- |
+| Content      | `role`             | `"dialog"` or `"alertdialog"`                       |
+| Content      | `tabindex`         | `"-1"` (programmatically focusable, not a Tab stop) |
+| Content      | `aria-modal`       | `"true"` when modal                                 |
+| Content      | `aria-labelledby`  | Title part ID (when title is rendered)              |
+| Content      | `aria-describedby` | Description part ID (when description is rendered)  |
+| Trigger      | `type`             | `"button"` (defensive default; see §1.10)           |
+| Trigger      | `aria-haspopup`    | `"dialog"`                                          |
+| Trigger      | `aria-expanded`    | `"true"` / `"false"`                                |
+| Trigger      | `aria-controls`    | Content part ID                                     |
+| Backdrop     | `aria-hidden`      | `"true"` (decorative)                               |
+| Backdrop     | `inert`            | Always present (decorative, non-interactive)        |
+| CloseTrigger | `type`             | `"button"` (defensive default; see §1.10)           |
+| CloseTrigger | `aria-label`       | from `Messages.close_label`                         |
 
-- `inert` on background content: When a modal dialog is open, all DOM siblings of the portal root MUST have the `inert` attribute set. The `inert` attribute prevents all keyboard, pointer, and assistive technology interaction with background content. This is the modern replacement for `aria-hidden="true"` on siblings. The `set_background_inert` effect handles this via `platform.set_background_inert("ars-portal-root")`.
+- `inert` on background content: When a modal dialog is open, all DOM siblings of the portal root MUST have the `inert` attribute set. The `inert` attribute prevents all keyboard, pointer, and assistive technology interaction with background content. This is the modern replacement for `aria-hidden="true"` on siblings. The agnostic core emits the `dialog-set-background-inert` intent (see [§1.11](#111-adapter-intent-contract)); the adapter applies `inert` to the captured portal-root handle's siblings.
 - `aria-hidden="true"` is set as fallback for older browsers that do not support `inert` (Safari < 15.5, Firefox < 112). The adapter should feature-detect `inert` support and use `aria-hidden="true"` only as a fallback.
-- Both attributes are removed when dialog closes (handled by the effect cleanup function).
+- Both attributes are removed when the dialog closes — the adapter runs the cleanup it stored when handling `dialog-set-background-inert`, triggered by the agnostic core's `dialog-remove-background-inert` intent.
 
 ### 3.2 Keyboard Interaction
 
@@ -850,36 +1055,51 @@ Dialog
 
 #### 3.3.1 Focus Restoration Fallback Chain
 
-When the dialog closes with `restore_focus: true`, the original trigger element may have been removed from the DOM, disabled, or moved to a different container while the dialog was open. The adapter MUST use the following fallback chain:
+When the dialog closes with `restore_focus: true`, the trigger element captured by the
+adapter at render time may have been disconnected, disabled, or relocated while the
+dialog was open. The adapter handles the agnostic core's `dialog-restore-focus` intent (see
+[§1.11](#111-adapter-intent-contract)) using the following fallback chain. **All steps
+operate on the framework handle the adapter captured for each part — `NodeRef<T>` in
+Leptos, `MountedData` in Dioxus — never via ID lookup.**
 
-1. **Original trigger** — if it still exists in the DOM and is focusable (`!disabled`, `offsetParent !== null`).
-2. **Nearest focusable ancestor** — walk up from the trigger's last known position (`parentElement`) until a focusable element is found.
+1. **Captured trigger handle** — if the handle's element is connected to the document
+   (`isConnected` / `parentElement.is_some()`) and is focusable (`!disabled`,
+   `offsetParent !== null`).
+2. **Nearest focusable ancestor** — walk from the trigger handle's last known parent
+   (held by the adapter through the captured node reference) until a focusable element
+   is found.
 3. **`<body>`** — last resort if no focusable element is found in the ancestor chain.
 
-If focus restoration falls through to step 2 or 3, the adapter emits a `focus_restored_failed` event on the dialog's root element with `detail: { intended_target: trigger_id, actual_target: focused_element_id }`. This allows application code to handle edge cases (e.g., re-rendering the trigger or announcing an explanation to screen readers).
+If focus restoration falls through to step 2 or 3, the adapter emits a
+`focus_restored_failed` event on the dialog's root handle with
+`detail: { intended_target: <trigger handle>, actual_target: <focused handle> }`. This
+allows application code to handle edge cases (e.g., re-rendering the trigger or
+announcing an explanation to screen readers). The detail values are framework handles
+or DOM `Element`s captured by the adapter — not `id` strings.
 
 ```rust
-// In the adapter's close effect:
-fn restore_focus_with_fallback(trigger_id: &str) {
-    let doc = document();
-    // Step 1: Try original trigger
-    if let Some(el) = doc.get_element_by_id(trigger_id) {
-        if is_focusable(&el) {
-            el.focus().ok();
+// In the Leptos adapter's `restore-focus` handler — illustrative only.
+// `trigger_ref: NodeRef<HtmlButtonElement>` is captured at trigger render time and
+// passed into the adapter's effect-handling layer. The agnostic core never sees it.
+fn restore_focus_with_fallback(trigger_ref: NodeRef<HtmlButtonElement>) {
+    // Step 1: Try the captured trigger handle.
+    if let Some(el) = trigger_ref.get() {
+        if el.is_connected() && is_focusable(&el) {
+            let _ = el.focus();
+            return;
+        }
+        // Step 2: Walk ancestors of the captured handle.
+        if let Some(focusable) = find_nearest_focusable_ancestor(&el) {
+            let _ = focusable.focus();
+            emit_focus_restored_failed(&el, &focusable);
             return;
         }
     }
-    // Step 2: Walk ancestors from trigger's last known parent
-    if let Some(parent) = last_known_parent_of(trigger_id) {
-        if let Some(focusable) = find_nearest_focusable_ancestor(&parent) {
-            focusable.focus();
-            emit_focus_restored_failed(trigger_id, &focusable);
-            return;
-        }
+    // Step 3: Body fallback.
+    if let Some(body) = document().body() {
+        let _ = body.focus();
+        emit_focus_restored_failed_body(&body);
     }
-    // Step 3: Body fallback
-    doc.body().focus();
-    emit_focus_restored_failed(trigger_id, &doc.body());
 }
 ```
 
@@ -916,10 +1136,11 @@ cursor escape — `inert` elements are excluded from the accessibility tree enti
 
 Implementation requirements:
 
-1. **Mandate `inert` on all siblings** of the modal dialog's portal root via
-   `set_background_inert()`. This MUST be applied before the dialog receives focus.
-   The `inert` attribute prevents ALL interaction (keyboard, pointer, and assistive
-   technology) with background content.
+1. **Mandate `inert` on all siblings** of the modal dialog's portal root via the
+   `dialog-set-background-inert` adapter intent (see
+   [§1.11](#111-adapter-intent-contract)). This MUST be applied before the dialog
+   receives focus. The `inert` attribute prevents ALL interaction (keyboard, pointer,
+   and assistive technology) with background content.
 2. **Consider native `<dialog>` element**: The native `<dialog>` element with `showModal()`
    provides browser-native focus trapping that includes virtual cursor containment on
    browsers that support it (Chrome 37+, Firefox 98+, Safari 15.4+). When the adapter
@@ -946,7 +1167,7 @@ Implementation requirements:
 
 ```rust
 /// The messages of the dialog.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Messages {
     /// Close trigger label (default: "Close dialog")
     pub close_label: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,


### PR DESCRIPTION
## Summary
- add the framework-agnostic Dialog machine/connect API in `ars-components`
- add Dialog snapshots and proptest state-machine coverage
- sync the Dialog spec around agnostic adapter intents and focus/dismissal responsibilities

## Validation
- `git rebase origin/main --autostash`
- `CHROMEDRIVER=$HOME/.cache/ars-ui-chromedriver/chromedriver-mac-arm64/chromedriver PATH=$HOME/.cache/ars-ui-chromedriver/chromedriver-mac-arm64:$PATH cargo xci` ran through the initial phases, then stopped at coverage because that PATH shadowed `wasm-bindgen-test-runner` 0.2.120 with an older runner.
- `CHROMEDRIVER=$HOME/.cache/ars-ui-chromedriver/chromedriver-mac-arm64/chromedriver PATH=$HOME/.cargo/bin:$HOME/.cache/ars-ui-chromedriver/chromedriver-mac-arm64:$PATH cargo xtask ci coverage snapshot-count error-variant-coverage feature-matrix mutual-exclusion`

Closes #253