### PR TITLE
fix: slim Dioxus harness wasm coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,7 @@ jobs:
     name: Coverage
     needs: [unit]
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -248,6 +249,16 @@ jobs:
       - uses: ./.github/actions/install-dioxus-desktop-deps
       - name: Coverage
         run: cargo xtask ci coverage
+      - name: Upload coverage diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-diagnostics
+          path: |
+            lcov.info
+            target/coverage/*.lcov
+            target/wasm-coverage/**/profraw/*.profraw
+          if-no-files-found: ignore
       - name: Snapshot Count
         run: cargo xtask ci snapshot-count
       - name: Upload to Codecov

--- a/crates/ars-test-harness-dioxus/Cargo.toml
+++ b/crates/ars-test-harness-dioxus/Cargo.toml
@@ -7,9 +7,13 @@ description.workspace  = true
 repository.workspace   = true
 rust-version.workspace = true
 
+[features]
+default = ["icu4x"]
+icu4x   = ["ars-dioxus/icu4x"]
+
 [dependencies]
 ars-core             = { path = "../ars-core" }
-ars-dioxus           = { path = "../ars-dioxus", features = ["web"] }
+ars-dioxus           = { path = "../ars-dioxus", default-features = false, features = ["web"] }
 ars-i18n             = { path = "../ars-i18n", default-features = false }
 ars-test-harness     = { path = "../ars-test-harness" }
 dioxus-web           = "0.7.6"

--- a/spec/testing/14-ci.md
+++ b/spec/testing/14-ci.md
@@ -437,7 +437,7 @@ coverage:
     - `ars-leptos` with `--features csr`
     - `ars-dioxus` with `--features web`
     - `ars-test-harness-leptos`
-    - `ars-test-harness-dioxus`
+    - `ars-test-harness-dioxus` with `--no-default-features --features ars-i18n/web-intl`
 3. Merge the native and wasm lcov tracefiles with `cargo xtask coverage merge`
    so duplicate file records are unioned instead of double-counted.
 
@@ -481,23 +481,23 @@ merge currently adds browser-only `web`/`wasm32` code for `ars-dom`.
 
 The current enforced ratchets are:
 
-| Crate                   | Enforced Line Minimum | Enforced Branch Minimum | Notes                                                              |
-| ----------------------- | --------------------- | ----------------------- | ------------------------------------------------------------------ |
-| ars-core                | 75%                   | 70%                     | Ratcheted from current merged coverage                             |
-| ars-a11y                | 80%                   | 70%                     | Ratcheted from current merged coverage                             |
-| ars-collections         | 95%                   | 90%                     | Ratcheted from current merged coverage                             |
-| ars-components          | 90%                   | 90%                     | Ratcheted from current merged coverage for core component machines |
-| ars-dom                 | 85%                   | 50%                     | Includes merged browser-only `web` / `wasm32` coverage             |
-| ars-forms               | 90%                   | 75%                     | Ratcheted from current merged coverage                             |
-| ars-i18n                | 95%                   | 65%                     | Ratcheted from current merged coverage                             |
-| ars-interactions        | 98%                   | 90%                     | Ratcheted from current merged coverage                             |
-| ars-leptos              | 78%                   | 55%                     | Includes merged browser-only `csr` / `wasm32` coverage             |
-| ars-dioxus              | 79%                   | 70%                     | Includes merged browser-only `web` / `wasm32` coverage             |
+| Crate                   | Enforced Line Minimum | Enforced Branch Minimum | Notes                                                                  |
+| ----------------------- | --------------------- | ----------------------- | ---------------------------------------------------------------------- |
+| ars-core                | 75%                   | 70%                     | Ratcheted from current merged coverage                                 |
+| ars-a11y                | 80%                   | 70%                     | Ratcheted from current merged coverage                                 |
+| ars-collections         | 95%                   | 90%                     | Ratcheted from current merged coverage                                 |
+| ars-components          | 90%                   | 90%                     | Ratcheted from current merged coverage for core component machines     |
+| ars-dom                 | 85%                   | 50%                     | Includes merged browser-only `web` / `wasm32` coverage                 |
+| ars-forms               | 90%                   | 75%                     | Ratcheted from current merged coverage                                 |
+| ars-i18n                | 95%                   | 65%                     | Ratcheted from current merged coverage                                 |
+| ars-interactions        | 98%                   | 90%                     | Ratcheted from current merged coverage                                 |
+| ars-leptos              | 78%                   | 55%                     | Includes merged browser-only `csr` / `wasm32` coverage                 |
+| ars-dioxus              | 79%                   | 70%                     | Includes merged browser-only `web` / `wasm32` coverage                 |
 | ars-test-harness        | 99%                   | 0%                      | LCOV `LF`/`LH` lag ≈2 lines behind source-region view under `--branch` |
-| ars-test-harness-leptos | 60%                   | 0%                      | Includes merged browser-only wasm harness coverage                 |
-| ars-test-harness-dioxus | 60%                   | 0%                      | Includes merged browser-only wasm harness coverage                 |
-| ars-derive              | 95%                   | 80%                     | Enforced from measured macro expansion coverage in test binaries   |
-| xtask                   | 30%                   | 35%                     | Tooling crate; ratcheted from current measured coverage            |
+| ars-test-harness-leptos | 60%                   | 0%                      | Includes merged browser-only wasm harness coverage                     |
+| ars-test-harness-dioxus | 60%                   | 0%                      | Includes merged browser-only wasm harness coverage using `web-intl`    |
+| ars-derive              | 95%                   | 80%                     | Enforced from measured macro expansion coverage in test binaries       |
+| xtask                   | 30%                   | 35%                     | Tooling crate; ratcheted from current measured coverage                |
 
 ### 2.3 Codecov Integration
 

--- a/xtask/src/coverage.rs
+++ b/xtask/src/coverage.rs
@@ -368,8 +368,8 @@ pub const fn default_wasm_coverage_targets() -> &'static [WasmCoverageTarget] {
         },
         WasmCoverageTarget {
             package: "ars-test-harness-dioxus",
-            features: &[],
-            no_default_features: false,
+            features: &["ars-i18n/web-intl"],
+            no_default_features: true,
         },
     ]
 }
@@ -1386,8 +1386,8 @@ version = "0.2.118"
         }));
         assert!(targets.iter().any(|target| {
             target.package == "ars-test-harness-dioxus"
-                && target.features.is_empty()
-                && !target.no_default_features
+                && target.features == ["ars-i18n/web-intl"]
+                && target.no_default_features
         }));
     }
 


### PR DESCRIPTION
## Summary
- run ars-test-harness-dioxus wasm coverage without default features and with ars-i18n/web-intl so browser coverage uses the browser Intl backend
- keep the harness ICU4X backend as the default feature for normal/native use while avoiding implicit ars-dioxus defaults in the wasm coverage target
- document the coverage target feature contract and upload partial coverage diagnostics when the Coverage job fails

This addresses the main Coverage failure as a browser-load timeout in the Dioxus harness wasm coverage bundle, not a threshold failure.

## Validation
- cargo test -p xtask coverage::
- cargo check -p ars-test-harness-dioxus --target wasm32-unknown-unknown --no-default-features --features ars-i18n/web-intl
- WASM_COVERAGE_CLANG=/opt/homebrew/opt/llvm/bin/clang cargo xtask coverage wasm --package ars-test-harness-dioxus --file target/coverage/ars-test-harness-dioxus-wasm.lcov --no-default-features --feature ars-i18n/web-intl
- cargo xtask spec validate
- cargo xci