### PR TITLE
Implement AsChild adapter slots

### DIFF
--- a/crates/ars-dioxus/src/as_child.rs
+++ b/crates/ars-dioxus/src/as_child.rs
@@ -8,7 +8,7 @@
 
 use std::fmt::{self, Debug};
 
-use dioxus::prelude::*;
+use dioxus::{dioxus_core::AttributeValue, prelude::*};
 
 /// Props passed to the Dioxus `as_child` render callback.
 #[derive(Clone, Debug, PartialEq)]
@@ -16,6 +16,21 @@ pub struct AsChildRenderProps {
     /// Dioxus attributes produced by the hosting component, ready to spread
     /// with `..attrs` onto the callback root.
     pub attrs: Vec<Attribute>,
+}
+
+impl AsChildRenderProps {
+    /// Merges child-root attrs with the slot attrs before the callback spreads
+    /// them onto the root element.
+    ///
+    /// Use this when the callback root contributes attrs that would otherwise
+    /// duplicate slot attrs after `..attrs` spreading. `class`, `style`, and
+    /// tokenized relationship attrs are concatenated with child values first;
+    /// for other duplicate attrs the slot value wins to preserve component
+    /// semantics.
+    #[must_use]
+    pub fn merged_attrs(&self, child_attrs: Vec<Attribute>) -> Vec<Attribute> {
+        merge_dioxus_attrs(child_attrs, self.attrs.clone())
+    }
 }
 
 /// Props for [`AsChildSlot`].
@@ -44,4 +59,105 @@ impl Debug for AsChildSlotProps {
 #[component]
 pub fn AsChildSlot(props: AsChildSlotProps) -> Element {
     props.render.call(AsChildRenderProps { attrs: props.attrs })
+}
+
+/// Merges component attrs onto child attrs before they are spread onto a
+/// Dioxus callback root.
+///
+/// This native-attribute helper mirrors the core [`AsChildMerge`] behavior for
+/// attrs that are still visible as Dioxus [`Attribute`] values. Component attrs
+/// win for ordinary duplicate attributes, while `class`, `style`, and
+/// relationship token lists concatenate with child values first.
+///
+/// [`AsChildMerge`]: ars_components::utility::as_child::AsChildMerge
+#[must_use]
+pub fn merge_dioxus_attrs(
+    child_attrs: Vec<Attribute>,
+    component_attrs: Vec<Attribute>,
+) -> Vec<Attribute> {
+    let mut merged = child_attrs;
+
+    for component_attr in component_attrs {
+        merge_or_replace_attr(&mut merged, component_attr);
+    }
+
+    merged
+}
+
+fn merge_or_replace_attr(attrs: &mut Vec<Attribute>, component_attr: Attribute) {
+    let Some(index) = attrs.iter().position(|attr| {
+        attr.name == component_attr.name && attr.namespace == component_attr.namespace
+    }) else {
+        attrs.push(component_attr);
+
+        return;
+    };
+
+    let child_attr = &mut attrs[index];
+
+    if let Some(value) = merge_attribute_values(
+        component_attr.name,
+        &child_attr.value,
+        &component_attr.value,
+    ) {
+        child_attr.value = value;
+        child_attr.volatile |= component_attr.volatile;
+
+        return;
+    }
+
+    attrs[index] = component_attr;
+}
+
+fn merge_attribute_values(
+    name: &str,
+    child: &AttributeValue,
+    component: &AttributeValue,
+) -> Option<AttributeValue> {
+    let AttributeValue::Text(child) = child else {
+        return None;
+    };
+
+    let AttributeValue::Text(component) = component else {
+        return None;
+    };
+
+    match name {
+        "class" | "aria-labelledby" | "aria-describedby" | "aria-controls" | "aria-owns"
+        | "aria-flowto" | "aria-details" | "rel" => {
+            Some(AttributeValue::Text(merge_tokens(child, component, " ")))
+        }
+
+        "style" => Some(AttributeValue::Text(merge_style_text(child, component))),
+
+        _ => None,
+    }
+}
+
+fn merge_tokens(child: &str, component: &str, separator: &str) -> String {
+    if child.is_empty() {
+        return String::from(component);
+    }
+
+    if component.is_empty() {
+        return String::from(child);
+    }
+
+    let mut tokens = child.split_whitespace().collect::<Vec<_>>();
+
+    for token in component.split_whitespace() {
+        if !tokens.contains(&token) {
+            tokens.push(token);
+        }
+    }
+
+    tokens.join(separator)
+}
+
+fn merge_style_text(child: &str, component: &str) -> String {
+    match (child.trim_end_matches(';').trim(), component.trim()) {
+        ("", component) => String::from(component),
+        (child, "") => String::from(child),
+        (child, component) => format!("{child}; {component}"),
+    }
 }

--- a/crates/ars-dioxus/src/as_child.rs
+++ b/crates/ars-dioxus/src/as_child.rs
@@ -1,0 +1,47 @@
+//! Dioxus root-reassignment helper for the `as_child` pattern.
+//!
+//! The slot receives converted Dioxus attributes from a hosting component and
+//! passes them to an explicit render callback. The callback owns the root
+//! element and must spread the provided attrs onto that root. This avoids
+//! arbitrary `VNode` template mutation, which is not a stable Dioxus composition
+//! surface.
+
+use std::fmt::{self, Debug};
+
+use dioxus::prelude::*;
+
+/// Props passed to the Dioxus `as_child` render callback.
+#[derive(Clone, Debug, PartialEq)]
+pub struct AsChildRenderProps {
+    /// Dioxus attributes produced by the hosting component, ready to spread
+    /// with `..attrs` onto the callback root.
+    pub attrs: Vec<Attribute>,
+}
+
+/// Props for [`AsChildSlot`].
+#[derive(Props, Clone, PartialEq)]
+pub struct AsChildSlotProps {
+    /// Converted Dioxus attributes produced by the hosting component.
+    #[props(extends = GlobalAttributes)]
+    pub attrs: Vec<Attribute>,
+
+    /// Render callback that owns the single root element and spreads the
+    /// provided attrs onto it.
+    pub render: Callback<AsChildRenderProps, Element>,
+}
+
+impl Debug for AsChildSlotProps {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AsChildSlotProps")
+            .field("attrs", &self.attrs)
+            .field("render", &"<callback>")
+            .finish()
+    }
+}
+
+/// Renders the consumer-owned root returned by [`AsChildSlotProps::render`]
+/// without introducing an adapter wrapper node.
+#[component]
+pub fn AsChildSlot(props: AsChildSlotProps) -> Element {
+    props.render.call(AsChildRenderProps { attrs: props.attrs })
+}

--- a/crates/ars-dioxus/src/lib.rs
+++ b/crates/ars-dioxus/src/lib.rs
@@ -10,6 +10,7 @@
 //! - [`EphemeralRef`] — borrow wrapper preventing signal storage of borrowed APIs
 //! - [`use_stable_id`] — hook-slot-stable generated ID allocation
 
+pub mod as_child;
 mod attrs;
 mod callbacks;
 pub mod dismissable;

--- a/crates/ars-dioxus/src/prelude.rs
+++ b/crates/ars-dioxus/src/prelude.rs
@@ -59,6 +59,7 @@ pub use ars_i18n::{Direction, Locale, Orientation, ResolvedDirection, Translate}
 // re-export covers both the framework-agnostic types (`Props`, `Messages`,
 // `DismissReason`, …) and the Dioxus-side wrappers (`Handle`, `Region`,
 // `RegionProps`, `use_dismissable`).
+pub use crate::as_child;
 pub use crate::dismissable;
 // The `error_boundary` adapter module exposes the `ArsErrorBoundary`
 // wrapper component spec'd at

--- a/crates/ars-dioxus/tests/as_child.rs
+++ b/crates/ars-dioxus/tests/as_child.rs
@@ -7,7 +7,7 @@ use std::cell::RefCell;
 use ars_components::utility::as_child::AsChildMerge;
 use ars_core::{AriaAttr, AttrMap, CssProperty, HtmlAttr, StyleStrategy};
 use ars_dioxus::{
-    as_child::{AsChildRenderProps, AsChildSlot, AsChildSlotProps},
+    as_child::{AsChildRenderProps, AsChildSlot, AsChildSlotProps, merge_dioxus_attrs},
     attr_map_to_dioxus, attr_map_to_dioxus_inline_attrs,
 };
 use dioxus::{dioxus_core::AttributeValue, prelude::*};
@@ -272,6 +272,70 @@ fn as_child_slot_preserves_class_style_and_aria_values() {
     assert!(
         html.contains(r#"aria-labelledby="child-label component-label""#),
         "missing merged aria-labelledby: {html}"
+    );
+}
+
+#[test]
+fn as_child_render_props_merges_callback_root_attrs_before_spread() {
+    fn app() -> Element {
+        let mut attrs = AttrMap::new();
+
+        attrs
+            .set(HtmlAttr::Class, "component")
+            .set(HtmlAttr::Aria(AriaAttr::LabelledBy), "component-label");
+
+        let attrs = attr_map_to_dioxus_inline_attrs(attrs);
+
+        rsx! {
+            AsChildSlot {
+                attrs,
+                render: |slot: AsChildRenderProps| rsx! {
+                    button {
+                        r#type: "button",
+                        ..slot.merged_attrs(
+                            vec![
+                                native_dioxus_attr("class", "child"),
+                                native_dioxus_attr("aria-labelledby", "child-label"),
+                            ],
+                        ),
+                        "Launch"
+                    }
+                },
+            }
+        }
+    }
+
+    let html = render_app(app);
+
+    assert!(
+        html.contains(r#"class="child component""#),
+        "child and component classes should merge before spread: {html}"
+    );
+    assert!(
+        html.contains(r#"aria-labelledby="child-label component-label""#),
+        "child and component aria-labelledby values should merge before spread: {html}"
+    );
+}
+
+#[test]
+fn merge_dioxus_attrs_replaces_non_mergeable_conflicts_with_component_attrs() {
+    let attrs = merge_dioxus_attrs(
+        vec![
+            native_dioxus_attr("role", "link"),
+            native_dioxus_attr("data-ars-state", "closed"),
+        ],
+        vec![
+            native_dioxus_attr("role", "button"),
+            native_dioxus_attr("data-ars-state", "open"),
+        ],
+    );
+
+    assert_eq!(
+        attrs,
+        vec![
+            native_dioxus_attr("role", "button"),
+            native_dioxus_attr("data-ars-state", "open"),
+        ]
     );
 }
 

--- a/crates/ars-dioxus/tests/as_child.rs
+++ b/crates/ars-dioxus/tests/as_child.rs
@@ -57,6 +57,10 @@ fn native_dioxus_attr(name: &'static str, value: &'static str) -> Attribute {
     Attribute::new(name, AttributeValue::Text(String::from(value)), None, false)
 }
 
+fn native_dioxus_attr_value(name: &'static str, value: AttributeValue) -> Attribute {
+    Attribute::new(name, value, None, false)
+}
+
 #[test]
 fn as_child_slot_props_debug_redacts_render_callback() {
     thread_local! {
@@ -337,6 +341,101 @@ fn merge_dioxus_attrs_replaces_non_mergeable_conflicts_with_component_attrs() {
             native_dioxus_attr("data-ars-state", "open"),
         ]
     );
+}
+
+#[test]
+fn merge_dioxus_attrs_appends_non_conflicting_component_attrs() {
+    let attrs = merge_dioxus_attrs(
+        vec![native_dioxus_attr("data-child", "yes")],
+        vec![native_dioxus_attr("data-component", "yes")],
+    );
+
+    assert_eq!(
+        attrs,
+        vec![
+            native_dioxus_attr("data-child", "yes"),
+            native_dioxus_attr("data-component", "yes"),
+        ]
+    );
+}
+
+#[test]
+fn merge_dioxus_attrs_replaces_non_text_mergeable_conflicts() {
+    let attrs = merge_dioxus_attrs(
+        vec![
+            native_dioxus_attr_value("class", AttributeValue::Bool(true)),
+            native_dioxus_attr("aria-labelledby", "child-label"),
+        ],
+        vec![
+            native_dioxus_attr("class", "component"),
+            native_dioxus_attr_value("aria-labelledby", AttributeValue::Bool(false)),
+        ],
+    );
+
+    assert_eq!(
+        attrs,
+        vec![
+            native_dioxus_attr("class", "component"),
+            native_dioxus_attr_value("aria-labelledby", AttributeValue::Bool(false)),
+        ]
+    );
+}
+
+#[test]
+fn merge_dioxus_attrs_handles_empty_token_lists_and_styles() {
+    let attrs = merge_dioxus_attrs(
+        vec![
+            native_dioxus_attr("class", ""),
+            native_dioxus_attr("aria-describedby", "child-hint"),
+            native_dioxus_attr("aria-controls", "shared component"),
+            native_dioxus_attr("style", ""),
+            native_dioxus_attr("data-empty-style-component", "placeholder"),
+            native_dioxus_attr("data-full-style", "placeholder"),
+        ],
+        vec![
+            native_dioxus_attr("class", "component"),
+            native_dioxus_attr("aria-describedby", ""),
+            native_dioxus_attr("aria-controls", "component panel"),
+            native_dioxus_attr("style", "display: inline-flex;"),
+            native_dioxus_attr("data-empty-style-component", "placeholder"),
+            native_dioxus_attr("data-full-style", "placeholder"),
+        ],
+    );
+
+    assert!(attrs.contains(&native_dioxus_attr("class", "component")));
+    assert!(attrs.contains(&native_dioxus_attr("aria-describedby", "child-hint")));
+    assert!(attrs.contains(&native_dioxus_attr(
+        "aria-controls",
+        "shared component panel"
+    )));
+    assert!(attrs.contains(&native_dioxus_attr("style", "display: inline-flex;")));
+
+    let attrs = merge_dioxus_attrs(
+        vec![
+            native_dioxus_attr("style", "color: red;"),
+            native_dioxus_attr("aria-owns", "child-owner"),
+        ],
+        vec![
+            native_dioxus_attr("style", ""),
+            native_dioxus_attr("aria-owns", "child-owner component-owner"),
+        ],
+    );
+
+    assert!(attrs.contains(&native_dioxus_attr("style", "color: red")));
+    assert!(attrs.contains(&native_dioxus_attr(
+        "aria-owns",
+        "child-owner component-owner"
+    )));
+
+    let attrs = merge_dioxus_attrs(
+        vec![native_dioxus_attr("style", "color: red;")],
+        vec![native_dioxus_attr("style", "display: inline-flex;")],
+    );
+
+    assert!(attrs.contains(&native_dioxus_attr(
+        "style",
+        "color: red; display: inline-flex;"
+    )));
 }
 
 #[test]

--- a/crates/ars-dioxus/tests/as_child.rs
+++ b/crates/ars-dioxus/tests/as_child.rs
@@ -1,0 +1,343 @@
+//! SSR tests for the Dioxus `as_child` adapter slot.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::cell::RefCell;
+
+use ars_components::utility::as_child::AsChildMerge;
+use ars_core::{AriaAttr, AttrMap, CssProperty, HtmlAttr, StyleStrategy};
+use ars_dioxus::{
+    as_child::{AsChildRenderProps, AsChildSlot, AsChildSlotProps},
+    attr_map_to_dioxus, attr_map_to_dioxus_inline_attrs,
+};
+use dioxus::{dioxus_core::AttributeValue, prelude::*};
+
+fn render_app(app: fn() -> Element) -> String {
+    let mut vdom = VirtualDom::new(app);
+
+    vdom.rebuild_in_place();
+
+    dioxus_ssr::render(&vdom)
+}
+
+fn component_attrs() -> AttrMap {
+    let mut attrs = AttrMap::new();
+
+    attrs
+        .set(HtmlAttr::Id, "trigger")
+        .set(HtmlAttr::Role, "button")
+        .set(HtmlAttr::Data("ars-scope"), "as-child-test")
+        .set(HtmlAttr::Data("ars-part"), "trigger")
+        .set(HtmlAttr::Aria(AriaAttr::Expanded), "false");
+
+    attrs
+}
+
+fn merged_attrs() -> AttrMap {
+    let mut child_attrs = AttrMap::new();
+
+    child_attrs
+        .set(HtmlAttr::Class, "child")
+        .set(HtmlAttr::Aria(AriaAttr::DescribedBy), "child-hint")
+        .set(HtmlAttr::Aria(AriaAttr::LabelledBy), "child-label")
+        .set_style(CssProperty::Color, "red");
+
+    let mut component_attrs = component_attrs();
+
+    component_attrs
+        .set(HtmlAttr::Class, "component")
+        .set(HtmlAttr::Aria(AriaAttr::DescribedBy), "component-hint")
+        .set(HtmlAttr::Aria(AriaAttr::LabelledBy), "component-label")
+        .set_style(CssProperty::Display, "inline-flex");
+
+    component_attrs.merge_onto(child_attrs)
+}
+
+fn native_dioxus_attr(name: &'static str, value: &'static str) -> Attribute {
+    Attribute::new(name, AttributeValue::Text(String::from(value)), None, false)
+}
+
+#[test]
+fn as_child_slot_props_debug_redacts_render_callback() {
+    thread_local! {
+        static DEBUG_OUTPUT: RefCell<Option<String>> = const { RefCell::new(None) };
+    }
+
+    fn app() -> Element {
+        let props = AsChildSlotProps {
+            attrs: vec![native_dioxus_attr("data-direct", "yes")],
+            render: Callback::new(|slot: AsChildRenderProps| {
+                rsx! {
+                    button { r#type: "button", ..slot.attrs, "Launch" }
+                }
+            }),
+        };
+
+        DEBUG_OUTPUT.with(|debug| {
+            debug.borrow_mut().replace(format!("{props:?}"));
+        });
+
+        rsx! {
+            div {}
+        }
+    }
+
+    DEBUG_OUTPUT.with(|debug| debug.borrow_mut().take());
+
+    let html = render_app(app);
+
+    let debug = DEBUG_OUTPUT
+        .with(|debug| debug.borrow().clone())
+        .unwrap_or_else(|| panic!("debug output was not captured: {html}"));
+
+    assert!(
+        debug.contains("AsChildSlotProps"),
+        "missing props name: {debug}"
+    );
+    assert!(debug.contains("attrs"), "missing attrs field: {debug}");
+    assert!(
+        debug.contains("render: \"<callback>\""),
+        "render callback should be redacted: {debug}"
+    );
+}
+
+#[test]
+fn as_child_slot_passes_converted_attrs_to_render_callback() {
+    thread_local! {
+        static RECEIVED_ATTRS: RefCell<Vec<usize>> = const { RefCell::new(Vec::new()) };
+    }
+
+    fn app() -> Element {
+        let attrs = attr_map_to_dioxus_inline_attrs(component_attrs());
+
+        rsx! {
+            AsChildSlot {
+                attrs,
+                render: move |slot: AsChildRenderProps| {
+                    RECEIVED_ATTRS.with(|received| received.borrow_mut().push(slot.attrs.len()));
+
+                    rsx! {
+                        button { r#type: "button", ..slot.attrs, "Launch" }
+                    }
+                },
+            }
+        }
+    }
+
+    RECEIVED_ATTRS.with(|received| received.borrow_mut().clear());
+
+    let html = render_app(app);
+
+    let received = RECEIVED_ATTRS.with(|received| received.borrow().clone());
+
+    assert_eq!(received, vec![5], "callback did not receive attrs: {html}");
+    assert!(html.contains(r#"id="trigger""#), "missing id: {html}");
+    assert!(html.contains(r#"role="button""#), "missing role: {html}");
+    assert!(
+        html.contains(r#"data-ars-scope="as-child-test""#),
+        "missing scope: {html}"
+    );
+    assert!(
+        html.contains(r#"data-ars-part="trigger""#),
+        "missing part: {html}"
+    );
+    assert!(
+        html.contains(r#"aria-expanded="false""#),
+        "missing aria-expanded: {html}"
+    );
+}
+
+#[test]
+fn as_child_slot_accepts_native_attrs_without_attr_map_conversion() {
+    fn app() -> Element {
+        let attrs = vec![
+            native_dioxus_attr("data-direct", "yes"),
+            native_dioxus_attr("aria-label", "Native label"),
+        ];
+
+        rsx! {
+            AsChildSlot {
+                attrs,
+                render: |slot: AsChildRenderProps| rsx! {
+                    button { r#type: "button", ..slot.attrs, "Launch" }
+                },
+            }
+        }
+    }
+
+    let html = render_app(app);
+
+    assert!(
+        html.contains(r#"data-direct="yes""#),
+        "missing direct data attr: {html}"
+    );
+    assert!(
+        html.contains(r#"aria-label="Native label""#),
+        "missing direct aria attr: {html}"
+    );
+}
+
+#[test]
+fn as_child_slot_collects_extended_global_attrs() {
+    fn app() -> Element {
+        rsx! {
+            AsChildSlot {
+                id: "extended-trigger",
+                role: "button",
+                class: "extended-class",
+                aria_label: "Extended label",
+                render: |slot: AsChildRenderProps| rsx! {
+                    button { r#type: "button", ..slot.attrs, "Launch" }
+                },
+            }
+        }
+    }
+
+    let html = render_app(app);
+
+    assert!(
+        html.contains(r#"id="extended-trigger""#),
+        "missing extended id: {html}"
+    );
+    assert!(
+        html.contains(r#"role="button""#),
+        "missing extended role: {html}"
+    );
+    assert!(
+        html.contains(r#"class="extended-class""#),
+        "missing extended class: {html}"
+    );
+    assert!(
+        html.contains(r#"aria-label="Extended label""#),
+        "missing extended aria-label: {html}"
+    );
+}
+
+#[test]
+fn as_child_slot_render_callback_spreads_attrs_without_wrapper() {
+    fn app() -> Element {
+        let attrs = attr_map_to_dioxus_inline_attrs(component_attrs());
+
+        rsx! {
+            AsChildSlot {
+                attrs,
+                render: |slot: AsChildRenderProps| rsx! {
+                    button { r#type: "button", ..slot.attrs, "Launch" }
+                },
+            }
+        }
+    }
+
+    let html = render_app(app);
+
+    assert!(
+        html.trim_start().starts_with("<button"),
+        "slot should render the child root directly: {html}"
+    );
+    assert!(!html.contains("<div"), "unexpected wrapper div: {html}");
+}
+
+#[test]
+fn as_child_slot_preserves_class_style_and_aria_values() {
+    fn app() -> Element {
+        let attrs = attr_map_to_dioxus_inline_attrs(merged_attrs());
+
+        rsx! {
+            AsChildSlot {
+                attrs,
+                render: |slot: AsChildRenderProps| rsx! {
+                    button { r#type: "button", ..slot.attrs, "Launch" }
+                },
+            }
+        }
+    }
+
+    let html = render_app(app);
+
+    assert!(html.contains(r#"class=""#), "missing class attr: {html}");
+    assert!(html.contains("child"), "missing child class token: {html}");
+    assert!(
+        html.contains("component"),
+        "missing component class token: {html}"
+    );
+    assert!(html.contains("color: red;"), "missing color style: {html}");
+    assert!(
+        html.contains("display: inline-flex;"),
+        "missing display style: {html}"
+    );
+    assert!(
+        html.contains(r#"aria-describedby="child-hint component-hint""#),
+        "missing merged aria-describedby: {html}"
+    );
+    assert!(
+        html.contains(r#"aria-labelledby="child-label component-label""#),
+        "missing merged aria-labelledby: {html}"
+    );
+}
+
+#[test]
+fn as_child_slot_ssr_markup_is_hydration_stable() {
+    fn app() -> Element {
+        let attrs = attr_map_to_dioxus_inline_attrs(component_attrs());
+
+        rsx! {
+            AsChildSlot {
+                attrs,
+                render: |slot: AsChildRenderProps| rsx! {
+                    a { href: "/docs", ..slot.attrs, "Docs" }
+                },
+            }
+        }
+    }
+
+    let html = render_app(app);
+
+    assert!(
+        html.trim_start().starts_with("<a"),
+        "expected anchor as SSR root: {html}"
+    );
+    assert!(html.contains(r#"href="/docs""#), "missing href: {html}");
+    assert!(
+        html.contains(r#"data-ars-part="trigger""#),
+        "missing forwarded part: {html}"
+    );
+    assert!(
+        !html.contains("as-child-slot"),
+        "slot should not add adapter marker markup: {html}"
+    );
+}
+
+#[test]
+fn attr_map_to_dioxus_preserves_as_child_style_strategy_payloads() {
+    let mut attrs = component_attrs();
+
+    attrs.set_style(CssProperty::Color, "red");
+
+    let cssom = attr_map_to_dioxus(attrs.clone(), &StyleStrategy::Cssom, None);
+
+    assert!(
+        cssom
+            .attrs
+            .iter()
+            .all(|attr| !format!("{attr:?}").contains("style")),
+        "CSSOM strategy should not inline style attrs: {:?}",
+        cssom.attrs
+    );
+    assert_eq!(
+        cssom.cssom_styles,
+        vec![(CssProperty::Color, String::from("red"))]
+    );
+
+    let nonce = attr_map_to_dioxus(
+        attrs,
+        &StyleStrategy::Nonce(String::from("nonce")),
+        Some("trigger"),
+    );
+
+    assert_eq!(nonce.nonce_css_key.as_deref(), Some("trigger"));
+    assert!(
+        nonce.nonce_css.contains("color: red;"),
+        "missing nonce CSS declaration: {}",
+        nonce.nonce_css
+    );
+}

--- a/crates/ars-leptos/src/as_child.rs
+++ b/crates/ars-leptos/src/as_child.rs
@@ -1,0 +1,33 @@
+//! Leptos root-reassignment helper for the `as_child` pattern.
+//!
+//! The slot receives converted Leptos attributes from a hosting component and
+//! applies them to one typed child root. It deliberately uses [`TypedChildren`]
+//! plus [`AddAnyAttr`] instead of opaque child vnode mutation, which is not a
+//! stable Leptos composition surface.
+
+use leptos::{children::TypedChildren, prelude::*, tachys::view::add_attr::AddAnyAttr};
+
+use crate::LeptosAttribute;
+
+/// Applies converted Leptos attributes to a typed child without rendering an
+/// adapter wrapper node.
+///
+/// Hosting components are responsible for building the final merged
+/// framework-agnostic attrs and converting them according to the active style
+/// strategy before calling this slot. The slot renders the typed child root and
+/// attaches the converted attrs through [`AddAnyAttr`].
+#[component]
+pub fn AsChildSlot<T>(
+    /// Converted Leptos attributes produced by the hosting component.
+    attrs: Vec<LeptosAttribute>,
+    /// Typed child root that receives the converted attributes.
+    children: TypedChildren<T>,
+) -> impl IntoView
+where
+    View<T>: AddAnyAttr,
+    <View<T> as AddAnyAttr>::Output<Vec<LeptosAttribute>>: IntoView,
+{
+    let child = children.into_inner()();
+
+    child.add_any_attr(attrs)
+}

--- a/crates/ars-leptos/src/as_child.rs
+++ b/crates/ars-leptos/src/as_child.rs
@@ -5,9 +5,56 @@
 //! plus [`AddAnyAttr`] instead of opaque child vnode mutation, which is not a
 //! stable Leptos composition surface.
 
+use ars_components::utility::as_child::AsChildMerge;
+use ars_core::AttrMap;
 use leptos::{children::TypedChildren, prelude::*, tachys::view::add_attr::AddAnyAttr};
 
-use crate::LeptosAttribute;
+use crate::{LeptosAttribute, attr_map_to_leptos_inline_attrs};
+
+/// Converted attributes ready for a Leptos `as_child` slot.
+///
+/// Use [`Self::from_merged_attr_maps`] when a hosting component has both
+/// framework-agnostic component attrs and framework-agnostic child attrs. That
+/// keeps `class`, `style`, and tokenized ARIA merging in [`AsChildMerge`]
+/// before the attrs become opaque Leptos values.
+#[derive(Clone, Debug)]
+pub struct AsChildAttrs {
+    attrs: Vec<LeptosAttribute>,
+}
+
+impl AsChildAttrs {
+    /// Converts an already merged [`AttrMap`] into inline Leptos attributes.
+    #[must_use]
+    pub fn from_attr_map(attrs: AttrMap) -> Self {
+        Self {
+            attrs: attr_map_to_leptos_inline_attrs(attrs),
+        }
+    }
+
+    /// Merges component attrs onto child attrs, then converts the result.
+    ///
+    /// This is the supported path when the child root contributes mergeable
+    /// attrs such as `class`, `style`, `aria-labelledby`, or
+    /// `aria-describedby`. Literal attrs already baked into the typed Leptos
+    /// child cannot be inspected after rendering, so component adapters should
+    /// collect child attrs as an [`AttrMap`] before calling the slot.
+    #[must_use]
+    pub fn from_merged_attr_maps(component_attrs: AttrMap, child_attrs: AttrMap) -> Self {
+        Self::from_attr_map(component_attrs.merge_onto(child_attrs))
+    }
+
+    /// Returns the converted Leptos attributes.
+    #[must_use]
+    pub fn into_inner(self) -> Vec<LeptosAttribute> {
+        self.attrs
+    }
+}
+
+impl From<Vec<LeptosAttribute>> for AsChildAttrs {
+    fn from(attrs: Vec<LeptosAttribute>) -> Self {
+        Self { attrs }
+    }
+}
 
 /// Applies converted Leptos attributes to a typed child without rendering an
 /// adapter wrapper node.
@@ -19,7 +66,8 @@ use crate::LeptosAttribute;
 #[component]
 pub fn AsChildSlot<T>(
     /// Converted Leptos attributes produced by the hosting component.
-    attrs: Vec<LeptosAttribute>,
+    #[prop(into)]
+    attrs: AsChildAttrs,
     /// Typed child root that receives the converted attributes.
     children: TypedChildren<T>,
 ) -> impl IntoView
@@ -29,5 +77,5 @@ where
 {
     let child = children.into_inner()();
 
-    child.add_any_attr(attrs)
+    child.add_any_attr(attrs.into_inner())
 }

--- a/crates/ars-leptos/src/lib.rs
+++ b/crates/ars-leptos/src/lib.rs
@@ -10,6 +10,7 @@
 //! - [`EphemeralRef`] — borrow wrapper preventing signal storage of borrowed APIs
 //! - [`use_id`] — hydration-safe deterministic ID generation
 
+pub mod as_child;
 mod attrs;
 mod callbacks;
 mod controlled;

--- a/crates/ars-leptos/src/prelude.rs
+++ b/crates/ars-leptos/src/prelude.rs
@@ -59,6 +59,7 @@ pub use ars_i18n::{Direction, Locale, Orientation, ResolvedDirection, Translate}
 // re-export covers both the framework-agnostic types (`Props`, `Messages`,
 // `DismissReason`, …) and the Leptos-side wrappers (`Handle`, `Region`,
 // `RegionProps`, `use_dismissable`).
+pub use crate::as_child;
 pub use crate::dismissable;
 // The `error_boundary` adapter module exposes the `ArsErrorBoundary`
 // wrapper component spec'd at

--- a/crates/ars-leptos/tests/as_child.rs
+++ b/crates/ars-leptos/tests/as_child.rs
@@ -1,0 +1,208 @@
+//! SSR tests for the Leptos `as_child` adapter slot.
+
+#![cfg(all(not(target_arch = "wasm32"), feature = "ssr"))]
+
+use ars_components::utility::as_child::AsChildMerge;
+use ars_core::{AriaAttr, AttrMap, CssProperty, HtmlAttr, StyleStrategy};
+use ars_leptos::{as_child::AsChildSlot, attr_map_to_leptos, attr_map_to_leptos_inline_attrs};
+use leptos::prelude::*;
+
+fn component_attrs() -> AttrMap {
+    let mut attrs = AttrMap::new();
+
+    attrs
+        .set(HtmlAttr::Id, "trigger")
+        .set(HtmlAttr::Role, "button")
+        .set(HtmlAttr::Data("ars-scope"), "as-child-test")
+        .set(HtmlAttr::Data("ars-part"), "trigger")
+        .set(HtmlAttr::Aria(AriaAttr::Expanded), "false");
+
+    attrs
+}
+
+fn merged_attrs() -> AttrMap {
+    let mut child_attrs = AttrMap::new();
+
+    child_attrs
+        .set(HtmlAttr::Class, "child")
+        .set(HtmlAttr::Aria(AriaAttr::DescribedBy), "child-hint")
+        .set(HtmlAttr::Aria(AriaAttr::LabelledBy), "child-label")
+        .set_style(CssProperty::Color, "red");
+
+    let mut component_attrs = component_attrs();
+
+    component_attrs
+        .set(HtmlAttr::Class, "component")
+        .set(HtmlAttr::Aria(AriaAttr::DescribedBy), "component-hint")
+        .set(HtmlAttr::Aria(AriaAttr::LabelledBy), "component-label")
+        .set_style(CssProperty::Display, "inline-flex");
+
+    component_attrs.merge_onto(child_attrs)
+}
+
+fn native_leptos_attr(name: &'static str, value: &'static str) -> ars_leptos::LeptosAttribute {
+    leptos::attr::custom::custom_attribute(name, value).into_any_attr()
+}
+
+#[test]
+fn as_child_slot_applies_attrs_to_typed_root() {
+    let attrs = attr_map_to_leptos_inline_attrs(component_attrs());
+
+    let html = view! {
+        <AsChildSlot attrs=attrs>
+            <button type="button">"Launch"</button>
+        </AsChildSlot>
+    }
+    .to_html();
+
+    assert!(html.contains("<button"), "expected button root: {html}");
+    assert!(html.contains(r#"id="trigger""#), "missing id: {html}");
+    assert!(html.contains(r#"role="button""#), "missing role: {html}");
+    assert!(
+        html.contains(r#"data-ars-scope="as-child-test""#),
+        "missing scope: {html}"
+    );
+    assert!(
+        html.contains(r#"data-ars-part="trigger""#),
+        "missing part: {html}"
+    );
+    assert!(
+        html.contains(r#"aria-expanded="false""#),
+        "missing aria-expanded: {html}"
+    );
+}
+
+#[test]
+fn as_child_slot_accepts_native_attrs_without_attr_map_conversion() {
+    let attrs = vec![
+        native_leptos_attr("data-direct", "yes"),
+        native_leptos_attr("aria-label", "Native label"),
+    ];
+
+    let html = view! {
+        <AsChildSlot attrs=attrs>
+            <button type="button">"Launch"</button>
+        </AsChildSlot>
+    }
+    .to_html();
+
+    assert!(
+        html.contains(r#"data-direct="yes""#),
+        "missing direct data attr: {html}"
+    );
+    assert!(
+        html.contains(r#"aria-label="Native label""#),
+        "missing direct aria attr: {html}"
+    );
+}
+
+#[test]
+fn as_child_slot_does_not_render_wrapper() {
+    let attrs = attr_map_to_leptos_inline_attrs(component_attrs());
+
+    let html = view! {
+        <AsChildSlot attrs=attrs>
+            <button type="button">"Launch"</button>
+        </AsChildSlot>
+    }
+    .to_html();
+
+    assert!(
+        html.trim_start().starts_with("<button"),
+        "slot should render the child root directly: {html}"
+    );
+    assert!(!html.contains("<div"), "unexpected wrapper div: {html}");
+}
+
+#[test]
+fn as_child_slot_preserves_merged_class_style_and_aria_tokens() {
+    let attrs = attr_map_to_leptos_inline_attrs(merged_attrs());
+
+    let html = view! {
+        <AsChildSlot attrs=attrs>
+            <button type="button">"Launch"</button>
+        </AsChildSlot>
+    }
+    .to_html();
+
+    assert!(html.contains(r#"class=""#), "missing class attr: {html}");
+    assert!(html.contains("child"), "missing child class token: {html}");
+    assert!(
+        html.contains("component"),
+        "missing component class token: {html}"
+    );
+    assert!(html.contains("color: red;"), "missing color style: {html}");
+    assert!(
+        html.contains("display: inline-flex;"),
+        "missing display style: {html}"
+    );
+    assert!(
+        html.contains(r#"aria-describedby="child-hint component-hint""#),
+        "missing merged aria-describedby: {html}"
+    );
+    assert!(
+        html.contains(r#"aria-labelledby="child-label component-label""#),
+        "missing merged aria-labelledby: {html}"
+    );
+}
+
+#[test]
+fn as_child_slot_ssr_markup_is_hydration_stable() {
+    let attrs = attr_map_to_leptos_inline_attrs(component_attrs());
+
+    let html = view! {
+        <AsChildSlot attrs=attrs>
+            <a href="/docs">"Docs"</a>
+        </AsChildSlot>
+    }
+    .to_html();
+
+    assert!(
+        html.trim_start().starts_with("<a"),
+        "expected anchor as SSR root: {html}"
+    );
+    assert!(html.contains(r#"href="/docs""#), "missing href: {html}");
+    assert!(
+        html.contains(r#"data-ars-part="trigger""#),
+        "missing forwarded part: {html}"
+    );
+    assert!(
+        !html.contains("as-child-slot"),
+        "slot should not add adapter marker markup: {html}"
+    );
+}
+
+#[test]
+fn attr_map_to_leptos_preserves_as_child_style_strategy_payloads() {
+    let mut attrs = component_attrs();
+
+    attrs.set_style(CssProperty::Color, "red");
+
+    let cssom = attr_map_to_leptos(attrs.clone(), &StyleStrategy::Cssom, None);
+
+    assert!(
+        cssom
+            .attrs
+            .iter()
+            .all(|attr| !format!("{attr:?}").contains("style")),
+        "CSSOM strategy should not inline style attrs: {:?}",
+        cssom.attrs
+    );
+    assert_eq!(
+        cssom.cssom_styles,
+        vec![(CssProperty::Color, String::from("red"))]
+    );
+
+    let nonce = attr_map_to_leptos(
+        attrs,
+        &StyleStrategy::Nonce(String::from("nonce")),
+        Some("trigger"),
+    );
+
+    assert_eq!(nonce.nonce_css_key.as_deref(), Some("trigger"));
+    assert!(
+        nonce.nonce_css.contains("color: red;"),
+        "missing nonce CSS declaration: {}",
+        nonce.nonce_css
+    );
+}

--- a/crates/ars-leptos/tests/as_child.rs
+++ b/crates/ars-leptos/tests/as_child.rs
@@ -4,7 +4,10 @@
 
 use ars_components::utility::as_child::AsChildMerge;
 use ars_core::{AriaAttr, AttrMap, CssProperty, HtmlAttr, StyleStrategy};
-use ars_leptos::{as_child::AsChildSlot, attr_map_to_leptos, attr_map_to_leptos_inline_attrs};
+use ars_leptos::{
+    as_child::{AsChildAttrs, AsChildSlot},
+    attr_map_to_leptos, attr_map_to_leptos_inline_attrs,
+};
 use leptos::prelude::*;
 
 fn component_attrs() -> AttrMap {
@@ -143,6 +146,39 @@ fn as_child_slot_preserves_merged_class_style_and_aria_tokens() {
     assert!(
         html.contains(r#"aria-labelledby="child-label component-label""#),
         "missing merged aria-labelledby: {html}"
+    );
+}
+
+#[test]
+fn as_child_attrs_merges_child_attrs_before_conversion() {
+    let mut component_attrs = AttrMap::new();
+
+    component_attrs
+        .set(HtmlAttr::Class, "component")
+        .set(HtmlAttr::Aria(AriaAttr::LabelledBy), "component-label");
+
+    let mut child_attrs = AttrMap::new();
+
+    child_attrs
+        .set(HtmlAttr::Class, "child")
+        .set(HtmlAttr::Aria(AriaAttr::LabelledBy), "child-label");
+
+    let attrs = AsChildAttrs::from_merged_attr_maps(component_attrs, child_attrs);
+
+    let html = view! {
+        <AsChildSlot attrs=attrs>
+            <button type="button">"Launch"</button>
+        </AsChildSlot>
+    }
+    .to_html();
+
+    assert!(
+        html.contains(r#"class="child component""#),
+        "child and component classes should merge before conversion: {html}"
+    );
+    assert!(
+        html.contains(r#"aria-labelledby="child-label component-label""#),
+        "child and component aria-labelledby values should merge before conversion: {html}"
     );
 }
 

--- a/crates/ars-leptos/tests/as_child_wasm.rs
+++ b/crates/ars-leptos/tests/as_child_wasm.rs
@@ -1,0 +1,55 @@
+//! Browser coverage tests for the Leptos `as_child` adapter slot.
+
+#![cfg(target_arch = "wasm32")]
+
+use ars_core::{AriaAttr, AttrMap, HtmlAttr};
+use ars_leptos::{
+    as_child::{AsChildAttrs, AsChildSlot},
+    attr_map_to_leptos_inline_attrs,
+};
+use leptos::prelude::*;
+use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+fn attr_map_with_class(class: &'static str, labelled_by: &'static str) -> AttrMap {
+    let mut attrs = AttrMap::new();
+
+    attrs
+        .set(HtmlAttr::Class, class)
+        .set(HtmlAttr::Aria(AriaAttr::LabelledBy), labelled_by);
+
+    attrs
+}
+
+#[wasm_bindgen_test]
+fn as_child_attrs_cover_conversion_paths_in_browser() {
+    let attrs = AsChildAttrs::from_attr_map(attr_map_with_class("component", "component-label"));
+
+    assert_eq!(attrs.into_inner().len(), 2);
+
+    let attrs = AsChildAttrs::from_merged_attr_maps(
+        attr_map_with_class("component", "component-label"),
+        attr_map_with_class("child", "child-label"),
+    );
+
+    assert_eq!(attrs.into_inner().len(), 2);
+
+    let attrs = AsChildAttrs::from(attr_map_to_leptos_inline_attrs(attr_map_with_class(
+        "native",
+        "native-label",
+    )));
+
+    assert_eq!(attrs.into_inner().len(), 2);
+}
+
+#[wasm_bindgen_test]
+fn as_child_slot_builds_typed_child_in_browser() {
+    let attrs = AsChildAttrs::from_attr_map(attr_map_with_class("component", "component-label"));
+
+    let _view = view! {
+        <AsChildSlot attrs=attrs>
+            <button type="button">"Launch"</button>
+        </AsChildSlot>
+    };
+}

--- a/spec/components/specialized/color-picker.md
+++ b/spec/components/specialized/color-picker.md
@@ -4,16 +4,7 @@ category: specialized
 tier: complex
 foundation_deps: [architecture, accessibility, interactions]
 shared_deps: []
-related:
-    [
-        color-area,
-        color-slider,
-        color-field,
-        color-swatch,
-        color-swatch-picker,
-        color-wheel,
-        angle-slider,
-    ]
+related: [angle-slider, color-area, color-field, color-slider, color-swatch, color-swatch-picker, color-wheel]
 references:
     ark-ui: ColorPicker
     react-aria: ColorPicker

--- a/spec/dioxus-components/utility/as-child.md
+++ b/spec/dioxus-components/utility/as-child.md
@@ -20,6 +20,12 @@ pub struct AsChildRenderProps {
     pub attrs: Vec<Attribute>,
 }
 
+impl AsChildRenderProps {
+    pub fn merged_attrs(&self, child_attrs: Vec<Attribute>) -> Vec<Attribute>;
+}
+
+pub fn merge_dioxus_attrs(child_attrs: Vec<Attribute>, component_attrs: Vec<Attribute>) -> Vec<Attribute>;
+
 #[derive(Props, Clone, PartialEq)]
 pub struct AsChildSlotProps {
     #[props(extends = GlobalAttributes)]
@@ -40,6 +46,10 @@ components choose the active style strategy and own any CSSOM or nonce-style sid
 The `attrs` field uses `#[props(extends = GlobalAttributes)]` so callers may pass native
 Dioxus global attributes directly to `AsChildSlot` when they are already operating in
 Dioxus attr space.
+`AsChildRenderProps::merged_attrs` is the supported native-attribute merge path when a
+callback root has attrs that would otherwise duplicate slot attrs after `..attrs`
+spreading. It mirrors core `AsChildMerge` for `class`, `style`, and relationship token
+lists while preserving component attrs for ordinary conflicts.
 Hosting components should use `attr_map_to_dioxus(attrs, strategy, element_id)` so
 inline, CSSOM, and nonce style strategy payloads are handled consistently before the slot
 receives native attrs.
@@ -68,6 +78,7 @@ receives native attrs.
 - If the child already has `role`, `tabindex`, or `aria-*`, the merge result must preserve required core semantics instead of blindly preferring the child value.
 - If a child handler calls `prevent_default()`, later notification-only handlers may observe that state but must not re-enable a blocked action; this composition is owned by the hosting component.
 - The slot passes final converted Dioxus attrs to the callback; it must not mutate arbitrary `VNode` templates.
+- Literal callback-root attrs are not automatically deduplicated by the slot; callback roots with duplicate-prone attrs must use `AsChildRenderProps::merged_attrs` or receive pre-merged attrs from the hosting component.
 - Inline attr conversion through `attr_map_to_dioxus_inline_attrs` is only a convenience for simple callers and tests; production component adapters must preserve their active style strategy before calling the slot.
 
 ## 6. Composition / Context Contract
@@ -185,6 +196,7 @@ Exactly one render callback root element is required. Context behavior of the ho
 | Helper concept                    | Required? | Responsibility                                                                                                    | Reused by                                                             | Notes                                                                                                   |
 | --------------------------------- | --------- | ----------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
 | `as_child` render callback helper | required  | Pass already-converted `Vec<Attribute>` to a callback that owns the root element.                                 | `as-child`, `button`, `visually-hidden`, any polymorphic root utility | This helper owns root reassignment without deleting the conceptual root part or mutating opaque vnodes. |
+| native Dioxus attr merge helper   | required  | Merge callback-root attrs with slot attrs before spreading when attrs are still visible as Dioxus `Attribute`s.   | `as-child`, callback-based polymorphic root utilities                 | This avoids duplicate `class`, `style`, and relationship attrs without mutating the returned `VNode`.   |
 | semantic-warning helper           | optional  | Emit semantic-mismatch diagnostics in debug builds when the hosting component has enough explicit child metadata. | `button`, `download-trigger`, `action-group`                          | Warnings are host-level diagnostics, not slot behavior.                                                 |
 
 ## 23. Framework-Specific Behavior
@@ -194,7 +206,8 @@ mutation is not a stable API. The supported mechanism is to pass already-convert
 attributes as `AsChildRenderProps { attrs }` and require the callback to spread `..attrs`
 onto exactly one root element. Hosting components convert the merged `AttrMap` with the
 active style strategy before calling the slot, and they own any CSSOM synchronization or
-nonce-style injection.
+nonce-style injection. When the callback root contributes native attrs directly, the
+callback must merge them with `AsChildRenderProps::merged_attrs` before spreading.
 
 ## 24. Canonical Implementation Sketch
 
@@ -202,6 +215,10 @@ nonce-style injection.
 #[derive(Clone, Debug, PartialEq)]
 pub struct AsChildRenderProps {
     pub attrs: Vec<Attribute>,
+}
+
+impl AsChildRenderProps {
+    pub fn merged_attrs(&self, child_attrs: Vec<Attribute>) -> Vec<Attribute>;
 }
 
 #[derive(Props, Clone, PartialEq)]

--- a/spec/dioxus-components/utility/as-child.md
+++ b/spec/dioxus-components/utility/as-child.md
@@ -15,10 +15,16 @@ This spec maps the core [`AsChild`](../../components/utility/as-child.md) patter
 ## 2. Public Adapter API
 
 ```rust,no_check
+#[derive(Clone, Debug, PartialEq)]
+pub struct AsChildRenderProps {
+    pub attrs: Vec<Attribute>,
+}
+
 #[derive(Props, Clone, PartialEq)]
 pub struct AsChildSlotProps {
-    pub attrs: AttrMap,
-    pub child: Element,
+    #[props(extends = GlobalAttributes)]
+    pub attrs: Vec<Attribute>,
+    pub render: Callback<AsChildRenderProps, Element>,
 }
 
 #[component]
@@ -26,56 +32,69 @@ pub fn AsChildSlot(props: AsChildSlotProps) -> Element
 ```
 
 `as_child: bool` is surfaced by the hosting component, not by a standalone core component.
+The explicit `render` callback is required intentionally: Dioxus does not expose a stable
+API for arbitrary `VNode` template mutation. The consumer or hosting component owns the root
+element and must spread the provided attrs onto that root.
+`attrs` is already converted to Dioxus attributes before it reaches the slot; hosting
+components choose the active style strategy and own any CSSOM or nonce-style side effects.
+The `attrs` field uses `#[props(extends = GlobalAttributes)]` so callers may pass native
+Dioxus global attributes directly to `AsChildSlot` when they are already operating in
+Dioxus attr space.
+Hosting components should use `attr_map_to_dioxus(attrs, strategy, element_id)` so
+inline, CSSOM, and nonce style strategy payloads are handled consistently before the slot
+receives native attrs.
 
 ## 3. Mapping to Core Component Contract
 
 - Pattern parity: the adapter must preserve root reassignment semantics.
-- Attr parity: component attrs merge onto the consumer child.
-- Event parity: component handlers and child handlers must both be preserved.
+- Attr parity: hosting components merge component attrs onto consumer-child attrs before converting to Dioxus attributes.
+- Event parity: event handler composition belongs to the hosting component adapter, not to `AsChildSlot`.
 
 ## 4. Part Mapping
 
-| Core part / structure      | Required?                     | Adapter rendering target      | Ownership        | Attr source                | Notes                                                             |
-| -------------------------- | ----------------------------- | ----------------------------- | ---------------- | -------------------------- | ----------------------------------------------------------------- |
-| reassigned root            | required when `as_child=true` | single consumer child element | consumer-owned   | merged component `AttrMap` | The conceptual root remains; only the rendering target changes.   |
-| suppressed default wrapper | conditional                   | no DOM output                 | adapter behavior | none                       | Must be documented whenever default wrapper rendering is skipped. |
+| Core part / structure      | Required?                     | Adapter rendering target      | Ownership        | Attr source            | Notes                                                             |
+| -------------------------- | ----------------------------- | ----------------------------- | ---------------- | ---------------------- | ----------------------------------------------------------------- |
+| reassigned root            | required when `as_child=true` | single consumer child element | consumer-owned   | converted Dioxus attrs | The conceptual root remains; only the rendering target changes.   |
+| suppressed default wrapper | conditional                   | no DOM output                 | adapter behavior | none                   | Must be documented whenever default wrapper rendering is skipped. |
 
 ## 5. Attr Merge and Ownership Rules
 
-| Target node           | Core attrs                                                                    | Adapter-owned attrs                                                           | Consumer attrs                                  | Merge order                                                                                                                                                                                                                                   | Ownership notes                                                                                 |
-| --------------------- | ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| reassigned root child | forwarded component `AttrMap` including ARIA, role, state, and event handlers | any adapter-local structural `data-*` markers needed by the hosting component | the child element's original attrs and handlers | core required ARIA/state attrs win when conflict would break the contract; child `class`/`style` merge additively; handler order is adapter normalization first for guard logic, then child handler, then adapter notification-only callbacks | rendered node is consumer-owned, but semantic root ownership remains with the hosting component |
+| Target node           | Core attrs                                                                     | Adapter-owned attrs                                                           | Consumer attrs                                        | Merge order                                                                                                                                                                                                                                                                                                                                   | Ownership notes                                                                                 |
+| --------------------- | ------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- | ----------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| reassigned root child | converted Dioxus attrs produced from the hosting component's merged root attrs | any adapter-local structural `data-*` markers needed by the hosting component | the render callback's root element attrs and handlers | hosting components must merge framework-agnostic attrs before conversion; core required ARIA/state attrs win when conflict would break the contract; child `class`/`style` and ARIA token lists merge through the core `AsChildMerge` rules before reaching the slot; handler order remains the hosting component's normalized event contract | rendered node is consumer-owned, but semantic root ownership remains with the hosting component |
 
-- Exactly one child element is allowed.
+- The render callback must return exactly one root element and spread `..attrs` onto that root.
 - No wrapper node may be introduced in `as_child` mode.
 - If the child already has `role`, `tabindex`, or `aria-*`, the merge result must preserve required core semantics instead of blindly preferring the child value.
-- If a child handler calls `prevent_default()`, later notification-only handlers may observe that state but must not re-enable a blocked action.
+- If a child handler calls `prevent_default()`, later notification-only handlers may observe that state but must not re-enable a blocked action; this composition is owned by the hosting component.
+- The slot passes final converted Dioxus attrs to the callback; it must not mutate arbitrary `VNode` templates.
+- Inline attr conversion through `attr_map_to_dioxus_inline_attrs` is only a convenience for simple callers and tests; production component adapters must preserve their active style strategy before calling the slot.
 
 ## 6. Composition / Context Contract
 
-Exactly one child element is required. Context behavior of the hosting component does not change under root reassignment.
+Exactly one render callback root element is required. Context behavior of the hosting component does not change under root reassignment.
 
 ## 7. Prop Sync and Event Mapping
 
-`AsChild` itself has no independent machine state. The hosting component remains responsible for prop sync. This adapter slot only normalizes forwarded attrs and handlers.
+`AsChild` itself has no independent machine state. The hosting component remains responsible for prop sync. This adapter slot only passes forwarded native attrs to the render callback.
 
-| Adapter prop      | Mode                      | Sync trigger                         | Machine event / update path                | Visible effect                                       | Notes                                       |
-| ----------------- | ------------------------- | ------------------------------------ | ------------------------------------------ | ---------------------------------------------------- | ------------------------------------------- |
-| forwarded `attrs` | non-reactive adapter prop | each render of the hosting component | forwarded directly to the reassigned child | child receives the hosting component's root contract | no independent controlled/uncontrolled mode |
+| Adapter prop      | Mode                      | Sync trigger                         | Machine event / update path | Visible effect                                                                         | Notes                                           |
+| ----------------- | ------------------------- | ------------------------------------ | --------------------------- | -------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| forwarded `attrs` | non-reactive adapter prop | each render of the hosting component | passed to `render`          | callback root receives the hosting component's root contract when it spreads `..attrs` | attrs are already converted to `Vec<Attribute>` |
 
-| UI event             | Preconditions                   | Machine event / callback path           | Ordering notes                                                                                                                                                   | Notes                                                                            |
-| -------------------- | ------------------------------- | --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| child event handlers | exactly one valid child element | composed hosting-component handler path | guard logic runs before child-only behavior when the hosting component needs to prevent invalid activation; notification-only callbacks run after child handlers | actual machine events are defined by the hosting component, not by `AsChildSlot` |
+| UI event             | Preconditions                     | Machine event / callback path           | Ordering notes                                                                                                                                                   | Notes                                                                                       |
+| -------------------- | --------------------------------- | --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| child event handlers | exactly one callback root element | composed hosting-component handler path | guard logic runs before child-only behavior when the hosting component needs to prevent invalid activation; notification-only callbacks run after child handlers | event composition is defined and implemented by the hosting component, not by `AsChildSlot` |
 
 ## 8. Registration and Cleanup Contract
 
-- No registration lifecycle exists beyond validating that exactly one child is present.
-- Child-count validation happens at render time.
+- No registration lifecycle exists beyond invoking the render callback.
+- Root ownership is explicit in the render callback; opaque child-count validation is intentionally not performed through vnode mutation.
 - Cleanup is ordinary vnode disposal; no persistent listeners or timers belong to the slot helper itself.
 
-| Registered entity       | Registration trigger | Identity key               | Cleanup trigger                  | Cleanup action                    | Notes                                                                    |
-| ----------------------- | -------------------- | -------------------------- | -------------------------------- | --------------------------------- | ------------------------------------------------------------------------ |
-| child validation result | each render          | hosting component instance | next render or component cleanup | discard previous validation state | multiple children and zero-child cases are immediate contract violations |
+| Registered entity      | Registration trigger | Identity key               | Cleanup trigger                  | Cleanup action          | Notes                                                                         |
+| ---------------------- | -------------------- | -------------------------- | -------------------------------- | ----------------------- | ----------------------------------------------------------------------------- |
+| render callback result | each render          | hosting component instance | next render or component cleanup | ordinary vnode disposal | the callback is responsible for one root and for spreading the provided attrs |
 
 ## 9. Ref and Node Contract
 
@@ -92,9 +111,10 @@ Exactly one child element is required. Context behavior of the hosting component
 
 ## 11. Callback Payload Contract
 
-| Callback                                                               | Payload source | Payload shape | Timing         | Cancelable? | Notes                                                                                                                 |
-| ---------------------------------------------------------------------- | -------------- | ------------- | -------------- | ----------- | --------------------------------------------------------------------------------------------------------------------- |
-| no public adapter-specific callback beyond normalized component events | none           | none          | not applicable | no          | When wrappers expose callbacks, they must preserve the normalized timing documented in `Prop Sync and Event Mapping`. |
+| Callback                     | Payload source         | Payload shape          | Timing         | Cancelable?        | Notes                                                                    |
+| ---------------------------- | ---------------------- | ---------------------- | -------------- | ------------------ | ------------------------------------------------------------------------ |
+| `render` structural callback | converted native attrs | [`AsChildRenderProps`] | during render  | no                 | Owns the root element and must spread the provided attrs onto that root. |
+| component event callbacks    | hosting component      | component-specific     | event dispatch | component-specific | Event callback composition is outside the slot helper.                   |
 
 ## 12. Failure and Degradation Rules
 
@@ -155,35 +175,45 @@ Exactly one child element is required. Context behavior of the hosting component
 
 ## 21. Debug Diagnostics and Production Policy
 
-| Condition                                                                           | Debug build behavior | Production behavior | Notes                                                                                       |
-| ----------------------------------------------------------------------------------- | -------------------- | ------------------- | ------------------------------------------------------------------------------------------- |
-| anchor-like child receives button semantics without equivalent Space-key activation | debug warning        | no diagnostic       | Diagnostic only; merged semantics remain unchanged until the host fixes the child behavior. |
-| zero or multiple children in root reassignment mode                                 | fail fast            | fail fast           | `as_child` requires exactly one concrete child element.                                     |
+| Condition                                      | Debug build behavior    | Production behavior     | Notes                                                                       |
+| ---------------------------------------------- | ----------------------- | ----------------------- | --------------------------------------------------------------------------- |
+| render callback does not spread provided attrs | contract violation      | contract violation      | the slot cannot repair omitted attrs without mutating opaque Dioxus vnodes. |
+| arbitrary `VNode` template mutation requested  | fail fast at API review | fail fast at API review | use the explicit render callback instead.                                   |
 
 ## 22. Shared Adapter Helper Notes
 
-| Helper concept                | Required?   | Responsibility                                                                      | Reused by                                                             | Notes                                                                         |
-| ----------------------------- | ----------- | ----------------------------------------------------------------------------------- | --------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| `as_child` vnode merge helper | required    | Clone or rebuild exactly one child with merged attrs, handlers, and guard ordering. | `as-child`, `button`, `visually-hidden`, any polymorphic root utility | This helper owns root reassignment without deleting the conceptual root part. |
-| debug-warning helper          | recommended | Emit semantic-mismatch diagnostics in debug builds only.                            | `as-child`, `button`, `download-trigger`, `action-group`              | Warnings must never silently alter runtime semantics.                         |
+| Helper concept                    | Required? | Responsibility                                                                                                    | Reused by                                                             | Notes                                                                                                   |
+| --------------------------------- | --------- | ----------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `as_child` render callback helper | required  | Pass already-converted `Vec<Attribute>` to a callback that owns the root element.                                 | `as-child`, `button`, `visually-hidden`, any polymorphic root utility | This helper owns root reassignment without deleting the conceptual root part or mutating opaque vnodes. |
+| semantic-warning helper           | optional  | Emit semantic-mismatch diagnostics in debug builds when the hosting component has enough explicit child metadata. | `button`, `download-trigger`, `action-group`                          | Warnings are host-level diagnostics, not slot behavior.                                                 |
 
 ## 23. Framework-Specific Behavior
 
-Dioxus needs an adapter-local vnode merge helper to rebuild the child with merged attrs. In debug builds, the adapter should emit a warning when `as_child` forwards button semantics such as `role="button"` onto an anchor-like child that still lacks Space-key activation semantics, because the merged result may look valid while remaining keyboard-incomplete.
+Dioxus needs an adapter-local render callback helper because arbitrary `VNode` template
+mutation is not a stable API. The supported mechanism is to pass already-converted Dioxus
+attributes as `AsChildRenderProps { attrs }` and require the callback to spread `..attrs`
+onto exactly one root element. Hosting components convert the merged `AttrMap` with the
+active style strategy before calling the slot, and they own any CSSOM synchronization or
+nonce-style injection.
 
 ## 24. Canonical Implementation Sketch
 
 ```rust
+#[derive(Clone, Debug, PartialEq)]
+pub struct AsChildRenderProps {
+    pub attrs: Vec<Attribute>,
+}
+
 #[derive(Props, Clone, PartialEq)]
 pub struct AsChildSlotSketchProps {
-    pub attrs: AttrMap,
-    pub child: Element,
+    #[props(extends = GlobalAttributes)]
+    pub attrs: Vec<Attribute>,
+    pub render: Callback<AsChildRenderProps, Element>,
 }
 
 #[component]
 pub fn AsChildSlot(props: AsChildSlotSketchProps) -> Element {
-    // Adapter-local helper: rebuild exactly one child with merged attrs.
-    rsx! { {props.child} }
+    props.render.call(AsChildRenderProps { attrs: props.attrs })
 }
 ```
 
@@ -193,36 +223,45 @@ No expanded skeleton beyond the canonical sketch is required for this utility.
 
 ## 26. Adapter Invariants
 
-- Exactly one consumer child is required whenever root reassignment is used.
+- Exactly one consumer-owned callback root is required whenever root reassignment is used.
 - Root reassignment must not delete the conceptual root part; it only changes ownership of the rendered node.
-- Handler composition order must be explicit so consumer handlers and adapter handlers do not race unpredictably.
+- Handler composition order must be explicit in each hosting component so consumer handlers and adapter handlers do not race unpredictably.
 - Role, ARIA, and state attr merge rules must remain explicit when attrs are forwarded onto the child.
+- Arbitrary `VNode` template mutation is forbidden for this helper.
+- The slot must not force inline styles; style-strategy conversion happens before attrs reach the slot.
 
 ## 27. Accessibility and SSR Notes
 
-Semantic correctness of the final root element remains the responsibility of the hosting component and consumer.
-When `as_child` merges button semantics onto an anchor-like child, the adapter should warn in debug builds if the resulting element still relies on link-native keyboard behavior and therefore does not activate on Space.
+Semantic correctness of the final root element remains the responsibility of the hosting component and consumer. Slot-level code cannot infer whether the callback root spread the attrs or whether the selected tag has equivalent keyboard behavior.
 
 ## 28. Parity Summary and Intentional Deviations
 
 Parity summary: full pattern parity.
 
-Intentional deviations: none.
+Intentional deviations: opaque-child vnode mutation is not part of parity; an explicit render
+callback is the Dioxus-supported way to provide the same root reassignment contract. The
+slot accepts native attrs so hosting components can preserve inline, CSSOM, and nonce style
+strategies outside the slot.
 
 ## 29. Test Scenarios
 
 - root reassignment
 - suppressed wrapper documentation
-- merged handler preservation
-- debug warning for anchor-like children that receive button semantics without equivalent Space-key activation
+- render callback receives converted attrs
+- `#[props(extends = GlobalAttributes)]` collects native Dioxus global attrs for the callback
+- consumer spreads attrs onto one root without a wrapper
+- merged class, style, and ARIA preservation through the hosting component's converted attrs
+- `attr_map_to_dioxus` preserves CSSOM and nonce style payloads for hosting components
+- SSR output with the same root element shape and attrs as the client path
 
 ## 30. Test Oracle Notes
 
-| Behavior                               | Preferred oracle type | Notes                                                                                                           |
-| -------------------------------------- | --------------------- | --------------------------------------------------------------------------------------------------------------- |
-| structural rendering and part presence | rendered structure    | Verify the documented part mapping rather than incidental wrapper details.                                      |
-| accessibility and state attrs          | DOM attrs             | Assert the normalized attrs emitted by the adapter-owned node.                                                  |
-| semantic-mismatch warning              | cleanup side effects  | Verify debug-only warning or equivalent diagnostic fires for anchor-like children with merged button semantics. |
+| Behavior                               | Preferred oracle type | Notes                                                                                                                             |
+| -------------------------------------- | --------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| structural rendering and part presence | rendered structure    | Verify the documented part mapping rather than incidental wrapper details.                                                        |
+| accessibility and state attrs          | DOM attrs             | Assert the normalized attrs emitted by the adapter-owned node.                                                                    |
+| style-strategy preservation            | component integration | Verify concrete hosting components convert attrs before calling the slot and handle CSSOM or nonce side effects.                  |
+| concrete callback spreading            | component integration | Every concrete Dioxus component adopting `as_child` must prove its render callback spreads provided attrs onto the intended root. |
 
 ## 31. Implementation Checklist
 
@@ -230,5 +269,8 @@ Intentional deviations: none.
 - [ ] Attr merge precedence matches the documented contract.
 - [ ] Prop sync and event normalization follow the documented machine paths.
 - [ ] Cleanup releases every resource owned by the component instance.
-- [ ] Debug-only semantic-mismatch warnings are documented for anchor-like children that receive button semantics through `as_child`.
 - [ ] SSR/client boundary behavior matches the documented structure and test oracles.
+- [ ] Arbitrary `VNode` mutation is not used; root ownership stays in the explicit render callback.
+- [ ] The slot accepts native Dioxus attrs through explicit `attrs` and `#[props(extends = GlobalAttributes)]` and does not force inline-only conversion.
+- [ ] Hosting components use `attr_map_to_dioxus` before calling the slot.
+- [ ] Each concrete Dioxus component adopting `as_child` tests that its callback spreads attrs onto the intended root.

--- a/spec/leptos-components/utility/as-child.md
+++ b/spec/leptos-components/utility/as-child.md
@@ -21,9 +21,18 @@ use leptos::{
     tachys::view::add_attr::AddAnyAttr,
 };
 
+#[derive(Clone, Debug)]
+pub struct AsChildAttrs;
+
+impl AsChildAttrs {
+    pub fn from_attr_map(attrs: AttrMap) -> Self;
+    pub fn from_merged_attr_maps(component_attrs: AttrMap, child_attrs: AttrMap) -> Self;
+    pub fn into_inner(self) -> Vec<LeptosAttribute>;
+}
+
 #[component]
 pub fn AsChildSlot<T>(
-    attrs: Vec<LeptosAttribute>,
+    #[prop(into)] attrs: AsChildAttrs,
     children: TypedChildren<T>,
 ) -> impl IntoView
 where
@@ -39,6 +48,10 @@ components choose the active style strategy and own any CSSOM or nonce-style sid
 Hosting components should use `attr_map_to_leptos(attrs, strategy, element_id)` so
 inline, CSSOM, and nonce style strategy payloads are handled consistently before the slot
 receives native attrs.
+`AsChildAttrs::from_merged_attr_maps` is an inline-style convenience for simple callers
+that still have both component and child attrs as `AttrMap`s. Production components with
+CSSOM or nonce side effects should merge the `AttrMap`s first and then use
+`attr_map_to_leptos` directly so the non-inline payloads remain visible to the host.
 
 ## 3. Mapping to Core Component Contract
 
@@ -64,6 +77,7 @@ receives native attrs.
 - If the child already has `role`, `tabindex`, or `aria-*`, the merge result must preserve required core semantics instead of blindly preferring the child value.
 - If a child handler calls `prevent_default()`, later notification-only handlers may observe that state but must not re-enable a blocked action; this composition is owned by the hosting component.
 - The slot receives final converted attrs and applies them with Leptos `AddAnyAttr`; it does not inspect or mutate an already-rendered opaque child vnode.
+- Literal attrs already baked into the typed child root cannot be inspected after rendering; child attrs that need `AsChildMerge` semantics must be supplied to the hosting component before conversion.
 - Inline attr conversion through `attr_map_to_leptos_inline_attrs` is only a convenience for simple callers and tests; production component adapters must preserve their active style strategy before calling the slot.
 
 ## 6. Composition / Context Contract
@@ -176,10 +190,11 @@ Exactly one typed child root is required. Context behavior of the hosting compon
 
 ## 22. Shared Adapter Helper Notes
 
-| Helper concept               | Required? | Responsibility                                                                                                    | Reused by                                                             | Notes                                                                                                   |
-| ---------------------------- | --------- | ----------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| `as_child` typed slot helper | required  | Apply already-converted `Vec<LeptosAttribute>` to `TypedChildren<T>` with `AddAnyAttr`.                           | `as-child`, `button`, `visually-hidden`, any polymorphic root utility | This helper owns root reassignment without deleting the conceptual root part or mutating opaque vnodes. |
-| semantic-warning helper      | optional  | Emit semantic-mismatch diagnostics in debug builds when the hosting component has enough explicit child metadata. | `button`, `download-trigger`, `action-group`                          | Warnings are host-level diagnostics, not slot behavior.                                                 |
+| Helper concept               | Required? | Responsibility                                                                                                    | Reused by                                                             | Notes                                                                                                               |
+| ---------------------------- | --------- | ----------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `as_child` typed slot helper | required  | Apply already-converted `AsChildAttrs` to `TypedChildren<T>` with `AddAnyAttr`.                                   | `as-child`, `button`, `visually-hidden`, any polymorphic root utility | This helper owns root reassignment without deleting the conceptual root part or mutating opaque vnodes.             |
+| `AsChildAttrs` merge helper  | required  | Preserve the supported pre-conversion merge path for simple inline-style callers that still have child attrs.     | `as-child`, adapter tests, simple polymorphic root utilities          | Components with CSSOM or nonce style side effects should merge maps first and use the full attr converter directly. |
+| semantic-warning helper      | optional  | Emit semantic-mismatch diagnostics in debug builds when the hosting component has enough explicit child metadata. | `button`, `download-trigger`, `action-group`                          | Warnings are host-level diagnostics, not slot behavior.                                                             |
 
 ## 23. Framework-Specific Behavior
 
@@ -187,20 +202,21 @@ Leptos needs an adapter-local helper because arbitrary vnode mutation is not a s
 The supported mechanism is to keep the child typed with `TypedChildren<T>` and apply
 already-converted Leptos attributes with `AddAnyAttr` before the view is erased. Hosting
 components convert the merged `AttrMap` with the active style strategy before calling the
-slot, and they own any CSSOM synchronization or nonce-style injection.
+slot, and they own any CSSOM synchronization or nonce-style injection. The slot cannot
+deduplicate literal child-root attrs that were already embedded in the typed child view.
 
 ## 24. Canonical Implementation Sketch
 
 ```rust
 #[component]
-pub fn AsChildSlot<T>(attrs: Vec<LeptosAttribute>, children: TypedChildren<T>) -> impl IntoView
+pub fn AsChildSlot<T>(#[prop(into)] attrs: AsChildAttrs, children: TypedChildren<T>) -> impl IntoView
 where
     View<T>: AddAnyAttr,
     <View<T> as AddAnyAttr>::Output<Vec<LeptosAttribute>>: IntoView,
 {
     let child = children.into_inner()();
 
-    child.add_any_attr(attrs)
+    child.add_any_attr(attrs.into_inner())
 }
 ```
 

--- a/spec/leptos-components/utility/as-child.md
+++ b/spec/leptos-components/utility/as-child.md
@@ -15,64 +15,82 @@ This spec maps the core [`AsChild`](../../components/utility/as-child.md) patter
 ## 2. Public Adapter API
 
 ```rust,no_check
+use leptos::{
+    children::TypedChildren,
+    prelude::*,
+    tachys::view::add_attr::AddAnyAttr,
+};
+
 #[component]
-pub fn AsChildSlot(
-    attrs: AttrMap,
-    children: Children,
+pub fn AsChildSlot<T>(
+    attrs: Vec<LeptosAttribute>,
+    children: TypedChildren<T>,
 ) -> impl IntoView
+where
+    View<T>: AddAnyAttr,
+    <View<T> as AddAnyAttr>::Output<Vec<LeptosAttribute>>: IntoView;
 ```
 
 `as_child: bool` is surfaced by the hosting component, not by a standalone core component.
+`TypedChildren<T>` is required intentionally: opaque `Children` erases the root type before
+the adapter can apply attrs and cannot preserve a typed single-root reassignment contract.
+`attrs` is already converted to Leptos attributes before it reaches the slot; hosting
+components choose the active style strategy and own any CSSOM or nonce-style side effects.
+Hosting components should use `attr_map_to_leptos(attrs, strategy, element_id)` so
+inline, CSSOM, and nonce style strategy payloads are handled consistently before the slot
+receives native attrs.
 
 ## 3. Mapping to Core Component Contract
 
 - Pattern parity: the adapter must preserve root reassignment semantics.
-- Attr parity: component attrs merge onto the consumer child.
-- Event parity: component handlers and child handlers must both be preserved.
+- Attr parity: hosting components merge component attrs onto consumer-child attrs before converting to Leptos attributes.
+- Event parity: event handler composition belongs to the hosting component adapter, not to `AsChildSlot`.
 
 ## 4. Part Mapping
 
-| Core part / structure      | Required?                     | Adapter rendering target      | Ownership        | Attr source                | Notes                                                             |
-| -------------------------- | ----------------------------- | ----------------------------- | ---------------- | -------------------------- | ----------------------------------------------------------------- |
-| reassigned root            | required when `as_child=true` | single consumer child element | consumer-owned   | merged component `AttrMap` | The conceptual root remains; only the rendering target changes.   |
-| suppressed default wrapper | conditional                   | no DOM output                 | adapter behavior | none                       | Must be documented whenever default wrapper rendering is skipped. |
+| Core part / structure      | Required?                     | Adapter rendering target      | Ownership        | Attr source            | Notes                                                             |
+| -------------------------- | ----------------------------- | ----------------------------- | ---------------- | ---------------------- | ----------------------------------------------------------------- |
+| reassigned root            | required when `as_child=true` | single consumer child element | consumer-owned   | converted Leptos attrs | The conceptual root remains; only the rendering target changes.   |
+| suppressed default wrapper | conditional                   | no DOM output                 | adapter behavior | none                   | Must be documented whenever default wrapper rendering is skipped. |
 
 ## 5. Attr Merge and Ownership Rules
 
-| Target node           | Core attrs                                                                    | Adapter-owned attrs                                                           | Consumer attrs                                  | Merge order                                                                                                                                                                                                                                   | Ownership notes                                                                                 |
-| --------------------- | ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| reassigned root child | forwarded component `AttrMap` including ARIA, role, state, and event handlers | any adapter-local structural `data-*` markers needed by the hosting component | the child element's original attrs and handlers | core required ARIA/state attrs win when conflict would break the contract; child `class`/`style` merge additively; handler order is adapter normalization first for guard logic, then child handler, then adapter notification-only callbacks | rendered node is consumer-owned, but semantic root ownership remains with the hosting component |
+| Target node           | Core attrs                                                                     | Adapter-owned attrs                                                           | Consumer attrs                                  | Merge order                                                                                                                                                                                                                                                                                                                                   | Ownership notes                                                                                 |
+| --------------------- | ------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- | ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| reassigned root child | converted Leptos attrs produced from the hosting component's merged root attrs | any adapter-local structural `data-*` markers needed by the hosting component | the child element's original attrs and handlers | hosting components must merge framework-agnostic attrs before conversion; core required ARIA/state attrs win when conflict would break the contract; child `class`/`style` and ARIA token lists merge through the core `AsChildMerge` rules before reaching the slot; handler order remains the hosting component's normalized event contract | rendered node is consumer-owned, but semantic root ownership remains with the hosting component |
 
-- Exactly one child element is allowed.
+- Exactly one typed child root is allowed.
 - No wrapper node may be introduced in `as_child` mode.
 - If the child already has `role`, `tabindex`, or `aria-*`, the merge result must preserve required core semantics instead of blindly preferring the child value.
-- If a child handler calls `prevent_default()`, later notification-only handlers may observe that state but must not re-enable a blocked action.
+- If a child handler calls `prevent_default()`, later notification-only handlers may observe that state but must not re-enable a blocked action; this composition is owned by the hosting component.
+- The slot receives final converted attrs and applies them with Leptos `AddAnyAttr`; it does not inspect or mutate an already-rendered opaque child vnode.
+- Inline attr conversion through `attr_map_to_leptos_inline_attrs` is only a convenience for simple callers and tests; production component adapters must preserve their active style strategy before calling the slot.
 
 ## 6. Composition / Context Contract
 
-Exactly one child element is required. Context behavior of the hosting component does not change under root reassignment.
+Exactly one typed child root is required. Context behavior of the hosting component does not change under root reassignment.
 
 ## 7. Prop Sync and Event Mapping
 
-`AsChild` itself has no independent machine state. The hosting component remains responsible for prop sync. This adapter slot only normalizes forwarded attrs and handlers.
+`AsChild` itself has no independent machine state. The hosting component remains responsible for prop sync. This adapter slot only applies forwarded native attrs.
 
-| Adapter prop      | Mode                      | Sync trigger                         | Machine event / update path                | Visible effect                                       | Notes                                       |
-| ----------------- | ------------------------- | ------------------------------------ | ------------------------------------------ | ---------------------------------------------------- | ------------------------------------------- |
-| forwarded `attrs` | non-reactive adapter prop | each render of the hosting component | forwarded directly to the reassigned child | child receives the hosting component's root contract | no independent controlled/uncontrolled mode |
+| Adapter prop      | Mode                      | Sync trigger                         | Machine event / update path              | Visible effect                                       | Notes                                                 |
+| ----------------- | ------------------------- | ------------------------------------ | ---------------------------------------- | ---------------------------------------------------- | ----------------------------------------------------- |
+| forwarded `attrs` | non-reactive adapter prop | each render of the hosting component | applied directly to the reassigned child | child receives the hosting component's root contract | attrs are already converted to `Vec<LeptosAttribute>` |
 
-| UI event             | Preconditions                   | Machine event / callback path           | Ordering notes                                                                                                                                                   | Notes                                                                            |
-| -------------------- | ------------------------------- | --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| child event handlers | exactly one valid child element | composed hosting-component handler path | guard logic runs before child-only behavior when the hosting component needs to prevent invalid activation; notification-only callbacks run after child handlers | actual machine events are defined by the hosting component, not by `AsChildSlot` |
+| UI event             | Preconditions                | Machine event / callback path           | Ordering notes                                                                                                                                                   | Notes                                                                                       |
+| -------------------- | ---------------------------- | --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| child event handlers | exactly one typed child root | composed hosting-component handler path | guard logic runs before child-only behavior when the hosting component needs to prevent invalid activation; notification-only callbacks run after child handlers | event composition is defined and implemented by the hosting component, not by `AsChildSlot` |
 
 ## 8. Registration and Cleanup Contract
 
-- No registration lifecycle exists beyond validating that exactly one child is present.
-- Child-count validation happens at render time.
+- No registration lifecycle exists beyond the typed child root accepted by `TypedChildren<T>`.
+- Opaque child-count validation is intentionally not performed by this helper because the supported API avoids opaque `Children`.
 - Cleanup is ordinary vnode disposal; no persistent listeners or timers belong to the slot helper itself.
 
-| Registered entity       | Registration trigger | Identity key               | Cleanup trigger                  | Cleanup action                    | Notes                                                                    |
-| ----------------------- | -------------------- | -------------------------- | -------------------------------- | --------------------------------- | ------------------------------------------------------------------------ |
-| child validation result | each render          | hosting component instance | next render or component cleanup | discard previous validation state | multiple children and zero-child cases are immediate contract violations |
+| Registered entity | Registration trigger | Identity key               | Cleanup trigger                  | Cleanup action          | Notes                                                                  |
+| ----------------- | -------------------- | -------------------------- | -------------------------------- | ----------------------- | ---------------------------------------------------------------------- |
+| typed child root  | each render          | hosting component instance | next render or component cleanup | ordinary vnode disposal | the child root remains typed until attrs are applied with `AddAnyAttr` |
 
 ## 9. Ref and Node Contract
 
@@ -89,9 +107,9 @@ Exactly one child element is required. Context behavior of the hosting component
 
 ## 11. Callback Payload Contract
 
-| Callback                                                               | Payload source | Payload shape | Timing         | Cancelable? | Notes                                                                                                                 |
-| ---------------------------------------------------------------------- | -------------- | ------------- | -------------- | ----------- | --------------------------------------------------------------------------------------------------------------------- |
-| no public adapter-specific callback beyond normalized component events | none           | none          | not applicable | no          | When wrappers expose callbacks, they must preserve the normalized timing documented in `Prop Sync and Event Mapping`. |
+| Callback               | Payload source | Payload shape | Timing         | Cancelable? | Notes                                                                                       |
+| ---------------------- | -------------- | ------------- | -------------- | ----------- | ------------------------------------------------------------------------------------------- |
+| slot callback payloads | none           | none          | not applicable | no          | `AsChildSlot` has no callback payloads. Event callbacks are owned by the hosting component. |
 
 ## 12. Failure and Degradation Rules
 
@@ -152,29 +170,37 @@ Exactly one child element is required. Context behavior of the hosting component
 
 ## 21. Debug Diagnostics and Production Policy
 
-| Condition                                                                           | Debug build behavior | Production behavior | Notes                                                                                       |
-| ----------------------------------------------------------------------------------- | -------------------- | ------------------- | ------------------------------------------------------------------------------------------- |
-| anchor-like child receives button semantics without equivalent Space-key activation | debug warning        | no diagnostic       | Diagnostic only; merged semantics remain unchanged until the host fixes the child behavior. |
-| zero or multiple children in root reassignment mode                                 | fail fast            | fail fast           | `as_child` requires exactly one concrete child element.                                     |
+| Condition                                    | Debug build behavior    | Production behavior     | Notes                                                                      |
+| -------------------------------------------- | ----------------------- | ----------------------- | -------------------------------------------------------------------------- |
+| opaque `Children` used for root reassignment | fail fast at API review | fail fast at API review | `as_child` requires a typed root so attrs can be applied before rendering. |
 
 ## 22. Shared Adapter Helper Notes
 
-| Helper concept                | Required?   | Responsibility                                                                      | Reused by                                                             | Notes                                                                         |
-| ----------------------------- | ----------- | ----------------------------------------------------------------------------------- | --------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| `as_child` vnode merge helper | required    | Clone or rebuild exactly one child with merged attrs, handlers, and guard ordering. | `as-child`, `button`, `visually-hidden`, any polymorphic root utility | This helper owns root reassignment without deleting the conceptual root part. |
-| debug-warning helper          | recommended | Emit semantic-mismatch diagnostics in debug builds only.                            | `as-child`, `button`, `download-trigger`, `action-group`              | Warnings must never silently alter runtime semantics.                         |
+| Helper concept               | Required? | Responsibility                                                                                                    | Reused by                                                             | Notes                                                                                                   |
+| ---------------------------- | --------- | ----------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `as_child` typed slot helper | required  | Apply already-converted `Vec<LeptosAttribute>` to `TypedChildren<T>` with `AddAnyAttr`.                           | `as-child`, `button`, `visually-hidden`, any polymorphic root utility | This helper owns root reassignment without deleting the conceptual root part or mutating opaque vnodes. |
+| semantic-warning helper      | optional  | Emit semantic-mismatch diagnostics in debug builds when the hosting component has enough explicit child metadata. | `button`, `download-trigger`, `action-group`                          | Warnings are host-level diagnostics, not slot behavior.                                                 |
 
 ## 23. Framework-Specific Behavior
 
-Leptos needs an adapter-local helper because arbitrary vnode mutation is not built in. In debug builds, the adapter should emit a warning when `as_child` forwards button semantics such as `role="button"` onto an anchor-like child that still lacks Space-key activation semantics, because the merged result may look valid while remaining keyboard-incomplete.
+Leptos needs an adapter-local helper because arbitrary vnode mutation is not a stable API.
+The supported mechanism is to keep the child typed with `TypedChildren<T>` and apply
+already-converted Leptos attributes with `AddAnyAttr` before the view is erased. Hosting
+components convert the merged `AttrMap` with the active style strategy before calling the
+slot, and they own any CSSOM synchronization or nonce-style injection.
 
 ## 24. Canonical Implementation Sketch
 
 ```rust
 #[component]
-pub fn AsChildSlot(attrs: AttrMap, children: Children) -> impl IntoView {
-    // Adapter-local helper: render exactly one child with merged attrs.
-    view! { <>{children()}</> }
+pub fn AsChildSlot<T>(attrs: Vec<LeptosAttribute>, children: TypedChildren<T>) -> impl IntoView
+where
+    View<T>: AddAnyAttr,
+    <View<T> as AddAnyAttr>::Output<Vec<LeptosAttribute>>: IntoView,
+{
+    let child = children.into_inner()();
+
+    child.add_any_attr(attrs)
 }
 ```
 
@@ -184,36 +210,42 @@ No expanded skeleton beyond the canonical sketch is required for this utility.
 
 ## 26. Adapter Invariants
 
-- Exactly one consumer child is required whenever root reassignment is used.
+- Exactly one typed consumer child root is required whenever root reassignment is used.
 - Root reassignment must not delete the conceptual root part; it only changes ownership of the rendered node.
-- Handler composition order must be explicit so consumer handlers and adapter handlers do not race unpredictably.
+- Handler composition order must be explicit in each hosting component so consumer handlers and adapter handlers do not race unpredictably.
 - Role, ARIA, and state attr merge rules must remain explicit when attrs are forwarded onto the child.
+- Opaque `Children` and arbitrary vnode rebuilding are forbidden for this helper.
+- The slot must not force inline styles; style-strategy conversion happens before attrs reach the slot.
 
 ## 27. Accessibility and SSR Notes
 
-Semantic correctness of the final root element remains the responsibility of the hosting component and consumer.
-When `as_child` merges button semantics onto an anchor-like child, the adapter should warn in debug builds if the resulting element still relies on link-native keyboard behavior and therefore does not activate on Space.
+Semantic correctness of the final root element remains the responsibility of the hosting component and consumer. Slot-level code cannot infer the concrete tag or keyboard behavior from `TypedChildren<T>`.
 
 ## 28. Parity Summary and Intentional Deviations
 
 Parity summary: full pattern parity.
 
-Intentional deviations: none.
+Intentional deviations: opaque-child vnode mutation is not part of parity; `TypedChildren<T>`
+plus `AddAnyAttr` is the Leptos-supported way to provide the same root reassignment
+contract. The slot accepts native attrs so hosting components can preserve inline, CSSOM,
+and nonce style strategies outside the slot.
 
 ## 29. Test Scenarios
 
 - root reassignment
 - suppressed wrapper documentation
-- merged handler preservation
-- debug warning for anchor-like children that receive button semantics without equivalent Space-key activation
+- native Leptos attrs are applied to the typed child root
+- merged class, style, and ARIA preservation through the hosting component's converted attrs
+- `attr_map_to_leptos` preserves CSSOM and nonce style payloads for hosting components
+- SSR output with the same root element shape and attrs as the client path
 
 ## 30. Test Oracle Notes
 
-| Behavior                               | Preferred oracle type | Notes                                                                                                           |
-| -------------------------------------- | --------------------- | --------------------------------------------------------------------------------------------------------------- |
-| structural rendering and part presence | rendered structure    | Verify the documented part mapping rather than incidental wrapper details.                                      |
-| accessibility and state attrs          | DOM attrs             | Assert the normalized attrs emitted by the adapter-owned node.                                                  |
-| semantic-mismatch warning              | cleanup side effects  | Verify debug-only warning or equivalent diagnostic fires for anchor-like children with merged button semantics. |
+| Behavior                               | Preferred oracle type | Notes                                                                                                            |
+| -------------------------------------- | --------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| structural rendering and part presence | rendered structure    | Verify the documented part mapping rather than incidental wrapper details.                                       |
+| accessibility and state attrs          | DOM attrs             | Assert the normalized attrs emitted by the adapter-owned node.                                                   |
+| style-strategy preservation            | component integration | Verify concrete hosting components convert attrs before calling the slot and handle CSSOM or nonce side effects. |
 
 ## 31. Implementation Checklist
 
@@ -221,5 +253,7 @@ Intentional deviations: none.
 - [ ] Attr merge precedence matches the documented contract.
 - [ ] Prop sync and event normalization follow the documented machine paths.
 - [ ] Cleanup releases every resource owned by the component instance.
-- [ ] Debug-only semantic-mismatch warnings are documented for anchor-like children that receive button semantics through `as_child`.
 - [ ] SSR/client boundary behavior matches the documented structure and test oracles.
+- [ ] Opaque `Children` is not used for root reassignment; attrs are applied to `TypedChildren<T>` via `AddAnyAttr`.
+- [ ] The slot accepts native Leptos attrs and does not force inline-only conversion.
+- [ ] Hosting components use `attr_map_to_leptos` before calling the slot.


### PR DESCRIPTION
## Summary
- add Leptos and Dioxus AsChild slot helpers using supported typed/callback composition
- update adapter specs to avoid opaque vnode mutation and document direct attr conversion
- cover SSR/no-wrapper attr forwarding, Dioxus GlobalAttributes extension, style-strategy payload preservation, and debug behavior
- normalize ColorPicker related frontmatter so spec validation passes against the manifest

## Validation
- `cargo test -p ars-leptos --test as_child --features ssr`
- `cargo test -p ars-dioxus --test as_child --features ssr`
- `cargo clippy -p ars-leptos --all-targets --all-features -- -D warnings`
- `cargo clippy -p ars-dioxus --all-targets --all-features -- -D warnings`
- `cargo xtask spec validate`
- `CHROMEDRIVER=$HOME/.cache/ars-ui-chromedriver/chromedriver-mac-arm64/chromedriver PATH=$HOME/.cargo/bin:$HOME/.cache/ars-ui-chromedriver/chromedriver-mac-arm64:$PATH cargo xci` up to coverage, then coverage rerun after transient profraw corruption
- `CHROMEDRIVER=$HOME/.cache/ars-ui-chromedriver/chromedriver-mac-arm64/chromedriver PATH=$HOME/.cargo/bin:$HOME/.cache/ars-ui-chromedriver/chromedriver-mac-arm64:$PATH cargo xtask ci coverage`
- `CHROMEDRIVER=$HOME/.cache/ars-ui-chromedriver/chromedriver-mac-arm64/chromedriver PATH=$HOME/.cargo/bin:$HOME/.cache/ars-ui-chromedriver/chromedriver-mac-arm64:$PATH cargo xtask ci snapshot-count spec-compile-snippets error-variant-coverage feature-matrix mutual-exclusion`

Closes #321
Closes #418
