### PR TITLE
feat(components): FocusRing + Keyboard agnostic core (#203)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,15 @@ jobs:
           components: rustfmt
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: Install leptosfmt
-        run: cargo install leptosfmt --locked --version 0.1.33
-      - name: Install dioxus-cli
-        run: cargo install dioxus-cli --locked --version 0.7.7
+      # `taiki-e/install-action` downloads pre-built binaries from each
+      # tool's GitHub Releases (via cargo-binstall under the hood for
+      # tools without a curated manifest). Replaces `cargo install …`
+      # which compiles dioxus-cli (huge dep tree) + leptosfmt from
+      # source on every cache miss — a multi-minute hit every time
+      # `Cargo.lock` or the rustc toolchain changes.
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: leptosfmt@0.1.33,dioxus-cli@0.7.7
       - name: Formatting
         run: cargo xtask ci fmt
 
@@ -67,8 +72,7 @@ jobs:
       - uses: ./.github/actions/install-dioxus-desktop-deps
       - name: Unit Tests
         run: cargo xtest unit
-      - name: Install cargo-insta
-        run: cargo install cargo-insta --locked
+      - uses: taiki-e/install-action@cargo-insta
       - name: Snapshot Tests
         run: cargo insta test --unreferenced=reject
         env:
@@ -87,8 +91,10 @@ jobs:
           fetch-depth: 0
       - name: Check for snapshot changes
         id: snap-changes
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          SNAP_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD | grep '\.snap$' || true)
+          SNAP_FILES=$(git diff --name-only "origin/${BASE_REF}...HEAD" | grep '\.snap$' || true)
           if [ -n "$SNAP_FILES" ]; then
             echo "has_snaps=true" >> "$GITHUB_OUTPUT"
           fi
@@ -96,9 +102,11 @@ jobs:
         if: steps.snap-changes.outputs.has_snaps == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          BASE_REF: ${{ github.base_ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          if ! git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -q 'CHANGELOG'; then
-            if ! gh pr view ${{ github.event.pull_request.number }} --json labels -q '.labels[].name' | grep -q 'snapshot-reviewed'; then
+          if ! git diff --name-only "origin/${BASE_REF}...HEAD" | grep -q 'CHANGELOG'; then
+            if ! gh pr view "$PR_NUMBER" --json labels -q '.labels[].name' | grep -q 'snapshot-reviewed'; then
               echo "::error::PRs modifying .snap files must include a CHANGELOG entry or have the 'snapshot-reviewed' label"
               exit 1
             fi
@@ -114,8 +122,9 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
-      - name: Install wasm-pack
-        run: cargo install wasm-pack --locked --version 0.14.0
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack@0.14.0
       - name: I18n Browser Tests
         run: cargo xtest i18n-browser
 
@@ -129,8 +138,9 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
-      - name: Install wasm-pack
-        run: cargo install wasm-pack --locked --version 0.14.0
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack@0.14.0
       - name: DOM Browser Tests
         run: cargo xtest dom-browser
 
@@ -241,13 +251,17 @@ jobs:
           chmod +x /tmp/llvm.sh
           sudo /tmp/llvm.sh 22
           sudo apt-get install -y clang-22 lld-22
-      - name: Install matching wasm-bindgen CLI
+      - name: Resolve wasm-bindgen version
+        id: wasm-bindgen-version
         run: |
           version="$(
             cargo metadata --format-version 1 |
               python3 -c 'import json, sys; print(next(pkg["version"] for pkg in json.load(sys.stdin)["packages"] if pkg["name"] == "wasm-bindgen"))'
           )"
-          cargo install wasm-bindgen-cli --locked --version "$version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-bindgen-cli@${{ steps.wasm-bindgen-version.outputs.version }}
       - name: Configure wasm coverage clang
         run: echo "WASM_COVERAGE_CLANG=/usr/bin/clang-22" >> "$GITHUB_ENV"
       - uses: ./.github/actions/install-dioxus-desktop-deps

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -47,8 +47,9 @@ jobs:
           key: ${{ runner.os }}-cargo-nightly-a11y-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
-      - name: Install wasm-pack
-        run: cargo install wasm-pack --locked --version 0.14.0
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack@0.14.0
       - name: Accessibility Audit
         run: |
           wasm-pack test --headless --chrome crates/ars-leptos --test axe
@@ -167,20 +168,23 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            ~/.cargo/bin/cargo-mutants
             target
           # Key by package, not shard — every shard of the same crate
           # builds the same baseline, so they share the registry and
           # toolchain caches and only diverge on the per-shard scratch
-          # dirs that cargo-mutants manages internally.
+          # dirs that cargo-mutants manages internally. The cargo-mutants
+          # binary itself is no longer cached here — `taiki-e/install-action`
+          # downloads a pre-built release in seconds, so caching the
+          # `~/.cargo/bin/cargo-mutants` path bought us nothing useful.
           key: ${{ runner.os }}-cargo-nightly-mutants-${{ matrix.package }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
-      - name: Install cargo-mutants
-        # Pin to the version the scout run was validated against. Bump
-        # deliberately when upgrading and re-run the scout to confirm
-        # behaviour hasn't changed.
-        run: cargo install cargo-mutants --locked --version 27.0.0
+      # Pin to the version the scout run was validated against. Bump
+      # deliberately when upgrading and re-run the scout to confirm
+      # behaviour hasn't changed.
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-mutants@27.0.0
       - name: Run mutation testing on ${{ matrix.name }}
         env:
           PACKAGE: ${{ matrix.package }}

--- a/crates/ars-components/src/utility/focus_ring.rs
+++ b/crates/ars-components/src/utility/focus_ring.rs
@@ -1,0 +1,603 @@
+//! `FocusRing` component machine and connect API.
+//!
+//! `FocusRing` is a stateless attribute mapper that exposes a
+//! `data-ars-focus-visible` boolean attribute to the consumer's CSS so the
+//! focus ring can be styled conditionally based on the input modality
+//! (keyboard vs. pointer). It has no state machine — the framework-agnostic
+//! core consists solely of [`Props`], [`Context`], [`Part`], and [`Api`].
+//!
+//! Modality tracking itself is owned by the platform layer
+//! (`ars-dom::ModalityManager`) and feeds [`Context::focus_visible`] from
+//! outside; this crate only renders the resulting attribute.
+//!
+//! See `spec/components/utility/focus-ring.md` for the authoritative
+//! contract.
+
+use alloc::string::String;
+
+use ars_core::{AttrMap, ComponentPart, ConnectApi, HasId, HtmlAttr};
+
+/// Props for the `FocusRing` component.
+#[derive(Clone, Debug, Default, PartialEq, Eq, HasId)]
+pub struct Props {
+    /// Component instance ID.
+    pub id: String,
+
+    /// Track focus-within rather than direct focus. When `true`, the adapter
+    /// wires a focus-within listener instead of a focus listener and
+    /// `Context::focus_visible` becomes active when any descendant — not
+    /// only the root — receives keyboard focus.
+    pub within: bool,
+
+    /// Optional CSS class to apply when focused by any means. Adapter-only
+    /// hint; the agnostic-core attribute output is invariant under this
+    /// value.
+    pub focus_class: Option<String>,
+
+    /// Optional CSS class to apply only when focused by keyboard. Adapter-only
+    /// hint; the agnostic-core attribute output is invariant under this
+    /// value.
+    pub focus_visible_class: Option<String>,
+
+    /// When `true`, the focus ring is shown even on pointer-initiated focus.
+    /// Text inputs conventionally show focus indicators regardless of input
+    /// method, since users need to know where they are typing. Adapter-only
+    /// hint that influences how the platform layer derives
+    /// [`Context::focus_visible`]; the agnostic-core attribute output is
+    /// invariant under this flag once `Context` has been resolved. Default:
+    /// `false`.
+    pub is_text_input: bool,
+}
+
+impl Props {
+    /// Returns fresh [`Props`] with the documented defaults — equivalent
+    /// to [`Default::default`], offered as the entry point for the
+    /// builder chain.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the component instance ID.
+    #[must_use]
+    pub fn id(mut self, id: impl Into<String>) -> Self {
+        self.id = id.into();
+        self
+    }
+
+    /// Sets whether the component tracks focus-within instead of direct
+    /// focus.
+    #[must_use]
+    pub const fn within(mut self, value: bool) -> Self {
+        self.within = value;
+        self
+    }
+
+    /// Sets the optional CSS class applied when the element is focused by
+    /// any means.
+    #[must_use]
+    pub fn focus_class(mut self, value: impl Into<String>) -> Self {
+        self.focus_class = Some(value.into());
+        self
+    }
+
+    /// Sets the optional CSS class applied only when the element is focused
+    /// by keyboard.
+    #[must_use]
+    pub fn focus_visible_class(mut self, value: impl Into<String>) -> Self {
+        self.focus_visible_class = Some(value.into());
+        self
+    }
+
+    /// Sets the text-input hint controlling whether the focus ring is shown
+    /// for pointer-initiated focus.
+    #[must_use]
+    pub const fn is_text_input(mut self, value: bool) -> Self {
+        self.is_text_input = value;
+        self
+    }
+}
+
+/// The runtime context for the `FocusRing` component, supplied by the
+/// adapter from the shared modality tracker.
+///
+/// Carries only the resolved focus-visible state. The [`Props::within`]
+/// flag is the single source of truth for whether the adapter should
+/// wire focus-within vs. focus listeners — it does not appear on
+/// `Context` because duplicating it is just a chance for the two
+/// fields to disagree.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Context {
+    /// Whether the focus-visible state is currently active.
+    pub focus_visible: bool,
+}
+
+/// DOM parts of the `FocusRing` component.
+#[derive(ComponentPart)]
+#[scope = "focus-ring"]
+pub enum Part {
+    /// The root element. Any element that should expose
+    /// `data-ars-focus-visible` to CSS — the agnostic core does not impose
+    /// a tag.
+    Root,
+}
+
+/// The API for the `FocusRing` component.
+///
+/// Constructed via [`Api::new`] from a [`Context`] and [`Props`] and
+/// queried via [`Api::root_attrs`] or the [`ConnectApi`] dispatch.
+#[derive(Clone, Debug)]
+pub struct Api {
+    ctx: Context,
+    props: Props,
+}
+
+impl Api {
+    /// Creates a new `Api` instance from the given runtime context and
+    /// props.
+    #[must_use]
+    pub const fn new(ctx: Context, props: Props) -> Self {
+        Self { ctx, props }
+    }
+
+    /// Returns a reference to the underlying [`Props`].
+    ///
+    /// Adapters typically read individual fields through the dedicated
+    /// accessors; this method is the escape hatch for when the full
+    /// struct is needed (e.g., to clone it into a fresh [`Api`] for a
+    /// re-render).
+    #[must_use]
+    pub const fn props(&self) -> &Props {
+        &self.props
+    }
+
+    /// Returns a copy of the underlying [`Context`].
+    #[must_use]
+    pub const fn context(&self) -> Context {
+        self.ctx
+    }
+
+    /// Returns the component's instance ID.
+    #[must_use]
+    pub fn id(&self) -> &str {
+        &self.props.id
+    }
+
+    /// Returns whether the component tracks focus-within rather than
+    /// direct focus. Reads from [`Props::within`] — the adapter uses this
+    /// flag to decide whether to wire `focus`/`blur` or
+    /// `focusin`/`focusout` listeners.
+    #[must_use]
+    pub const fn within(&self) -> bool {
+        self.props.within
+    }
+
+    /// Returns whether the focus-visible state is currently active.
+    #[must_use]
+    pub const fn focus_visible(&self) -> bool {
+        self.ctx.focus_visible
+    }
+
+    /// Returns the optional CSS class applied when focused by any means.
+    #[must_use]
+    pub fn focus_class(&self) -> Option<&str> {
+        self.props.focus_class.as_deref()
+    }
+
+    /// Returns the optional CSS class applied only when focused by
+    /// keyboard.
+    #[must_use]
+    pub fn focus_visible_class(&self) -> Option<&str> {
+        self.props.focus_visible_class.as_deref()
+    }
+
+    /// Returns whether the component is configured for text-input focus
+    /// semantics (focus ring shown regardless of pointer vs. keyboard).
+    #[must_use]
+    pub const fn is_text_input(&self) -> bool {
+        self.props.is_text_input
+    }
+
+    /// Returns the attributes for the root element.
+    ///
+    /// Always emits `data-ars-scope="focus-ring"` and
+    /// `data-ars-part="root"`. When [`Context::focus_visible`] is `true`,
+    /// also emits the boolean `data-ars-focus-visible` attribute that
+    /// keyboard-focus stylesheets target. When it is `false`, the
+    /// attribute is omitted entirely so the bare `[data-ars-focus-visible]`
+    /// CSS selector does not match.
+    #[must_use]
+    pub fn root_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Root.data_attrs();
+
+        attrs.set(scope_attr, scope_val).set(part_attr, part_val);
+
+        if self.ctx.focus_visible {
+            attrs.set_bool(HtmlAttr::Data("ars-focus-visible"), true);
+        }
+
+        attrs
+    }
+}
+
+impl ConnectApi for Api {
+    type Part = Part;
+
+    fn part_attrs(&self, part: Part) -> AttrMap {
+        match part {
+            Part::Root => self.root_attrs(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ars_core::{AttrValue, HasId};
+    use insta::assert_snapshot;
+
+    use super::*;
+
+    fn snapshot_attrs(attrs: &AttrMap) -> String {
+        format!("{attrs:#?}")
+    }
+
+    fn ctx_inactive() -> Context {
+        Context::default()
+    }
+
+    fn ctx_focus_visible() -> Context {
+        Context {
+            focus_visible: true,
+        }
+    }
+
+    fn default_props() -> Props {
+        Props::default()
+    }
+
+    fn within_props() -> Props {
+        Props {
+            within: true,
+            ..Props::default()
+        }
+    }
+
+    fn classy_props() -> Props {
+        Props {
+            focus_class: Some(String::from("focused")),
+            focus_visible_class: Some(String::from("focused-keyboard")),
+            ..Props::default()
+        }
+    }
+
+    fn text_input_props() -> Props {
+        Props {
+            is_text_input: true,
+            ..Props::default()
+        }
+    }
+
+    // ── Props ──────────────────────────────────────────────────────
+
+    #[test]
+    fn props_default_values() {
+        let p = Props::default();
+
+        assert_eq!(p.id, "");
+        assert!(!p.within);
+        assert_eq!(p.focus_class, None);
+        assert_eq!(p.focus_visible_class, None);
+        assert!(!p.is_text_input);
+    }
+
+    #[test]
+    fn props_builder_round_trips() {
+        // `Props::new()` returns the documented defaults and the chained
+        // setters mutate exactly the matching fields, leaving the others
+        // at their default values.
+        let p = Props::new()
+            .id("ring-build")
+            .within(true)
+            .focus_class("focused")
+            .focus_visible_class("focused-keyboard")
+            .is_text_input(true);
+
+        assert_eq!(p.id, "ring-build");
+        assert!(p.within);
+        assert_eq!(p.focus_class.as_deref(), Some("focused"));
+        assert_eq!(p.focus_visible_class.as_deref(), Some("focused-keyboard"));
+        assert!(p.is_text_input);
+
+        // `Props::new()` is equivalent to `Default::default()`.
+        assert_eq!(Props::new(), Props::default());
+    }
+
+    #[test]
+    fn props_builder_setters_are_idempotent_per_field() {
+        // Each setter overrides only its own field; later calls overwrite
+        // earlier ones for the same field.
+        let p = Props::new()
+            .within(true)
+            .within(false)
+            .focus_class("a")
+            .focus_class("b")
+            .is_text_input(true);
+
+        assert!(!p.within);
+        assert_eq!(p.focus_class.as_deref(), Some("b"));
+        assert!(p.is_text_input);
+    }
+
+    #[test]
+    fn props_has_id_derive_round_trips() {
+        // Exercises the methods the `HasId` derive emits directly on
+        // `Props` (the `Api::id()` accessor only goes through one of them).
+        let mut p = Props::default().with_id(String::from("ring-1"));
+
+        assert_eq!(HasId::id(&p), "ring-1");
+
+        p.set_id(String::from("ring-2"));
+
+        assert_eq!(HasId::id(&p), "ring-2");
+    }
+
+    #[test]
+    fn props_clone_and_partial_eq_round_trip() {
+        let original = Props {
+            id: String::from("ring-clone"),
+            within: true,
+            focus_class: Some(String::from("focused")),
+            focus_visible_class: Some(String::from("focused-keyboard")),
+            is_text_input: true,
+        };
+
+        let cloned = original.clone();
+
+        assert_eq!(cloned, original);
+
+        let mutated = Props {
+            within: false,
+            ..original.clone()
+        };
+
+        assert_ne!(mutated, original);
+    }
+
+    #[test]
+    fn props_context_and_api_are_send_sync() {
+        // The agnostic core's public types must be `Send + Sync` so
+        // adapters and ahead-of-time computation paths can shuttle
+        // values between threads (web handlers, async server functions,
+        // etc. — see workspace `feedback_messagefn_send_sync.md`). This
+        // assertion fails to compile if a future refactor introduces a
+        // non-thread-safe field (e.g., `Rc`, `Cell`).
+        const fn assert_send_sync<T: Send + Sync>() {}
+
+        assert_send_sync::<Props>();
+        assert_send_sync::<Context>();
+        assert_send_sync::<Api>();
+        assert_send_sync::<Part>();
+    }
+
+    #[test]
+    fn api_clone_round_trips() {
+        // The `Clone` derive on `Api` must produce a value structurally
+        // equal to the source. This locks the property against a future
+        // refactor adding a non-clone-coherent field (instance counter,
+        // allocation ID, RNG state, etc.).
+        let original = Api::new(
+            ctx_focus_visible(),
+            Props {
+                id: String::from("ring-clone"),
+                within: true,
+                focus_class: Some(String::from("focused")),
+                focus_visible_class: Some(String::from("focused-keyboard")),
+                is_text_input: true,
+            },
+        );
+
+        let cloned = original.clone();
+
+        assert_eq!(cloned.props(), original.props());
+        assert_eq!(cloned.context(), original.context());
+        assert_eq!(cloned.root_attrs(), original.root_attrs());
+    }
+
+    #[test]
+    fn props_and_api_debug_impl_is_non_empty() {
+        // Smoke test guarding against an accidental empty `impl Debug`.
+        let api = Api::new(ctx_focus_visible(), within_props());
+
+        let props_dbg = format!("{:?}", api.props());
+
+        let api_dbg = format!("{api:?}");
+
+        assert!(props_dbg.contains("Props"), "Props Debug = {props_dbg}");
+        assert!(api_dbg.contains("Api"), "Api Debug = {api_dbg}");
+    }
+
+    // ── Context ────────────────────────────────────────────────────
+
+    #[test]
+    fn context_default_is_inactive() {
+        let ctx = Context::default();
+
+        assert!(!ctx.focus_visible);
+    }
+
+    #[test]
+    fn context_clone_copy_partial_eq_round_trip() {
+        let original = ctx_focus_visible();
+
+        let copy: Context = original;
+        let cloned = original;
+
+        assert_eq!(copy, original);
+        assert_eq!(cloned, original);
+        assert_ne!(original, ctx_inactive());
+    }
+
+    // ── Api accessors ──────────────────────────────────────────────
+
+    #[test]
+    fn api_id_returns_empty_str_for_default_props() {
+        // Direct assertion that the empty-id path through `Api::id()`
+        // produces `""` rather than e.g. panicking or returning a sentinel.
+        assert_eq!(Api::new(ctx_inactive(), Props::default()).id(), "");
+    }
+
+    #[test]
+    fn api_exposes_ctx_and_props_fields() {
+        let props = Props {
+            id: String::from("ring-7"),
+            within: true,
+            focus_class: Some(String::from("c1")),
+            focus_visible_class: Some(String::from("c2")),
+            is_text_input: true,
+        };
+
+        let api = Api::new(ctx_focus_visible(), props.clone());
+
+        assert_eq!(api.id(), "ring-7");
+
+        // `Api::within()` reads from `Props::within` — the single source
+        // of truth for the focus-within routing flag.
+        assert!(api.within());
+        assert!(api.focus_visible());
+        assert_eq!(api.focus_class(), Some("c1"));
+        assert_eq!(api.focus_visible_class(), Some("c2"));
+        assert!(api.is_text_input());
+        assert_eq!(api.props(), &props);
+        assert_eq!(api.context(), ctx_focus_visible());
+
+        let default_api = Api::new(ctx_inactive(), Props::default());
+
+        assert!(!default_api.within());
+        assert!(!default_api.focus_visible());
+        assert_eq!(default_api.focus_class(), None);
+        assert_eq!(default_api.focus_visible_class(), None);
+        assert!(!default_api.is_text_input());
+    }
+
+    // ── Connect / API ──────────────────────────────────────────────
+
+    #[test]
+    fn part_attrs_dispatches_root() {
+        let api = Api::new(ctx_inactive(), default_props());
+
+        let attrs = api.part_attrs(Part::Root);
+
+        assert_eq!(attrs.get(&HtmlAttr::Data("ars-scope")), Some("focus-ring"));
+        assert_eq!(attrs.get(&HtmlAttr::Data("ars-part")), Some("root"));
+    }
+
+    #[test]
+    fn part_attrs_root_equals_root_attrs() {
+        // The `ConnectApi` dispatch must produce exactly what the inherent
+        // `root_attrs` method produces. Asserted across both `focus_visible`
+        // values and across both `within` values, since `within` lives on
+        // `Props` (it could in principle leak into the AttrMap).
+        let cases = [
+            (ctx_inactive(), default_props()),
+            (ctx_inactive(), within_props()),
+            (ctx_focus_visible(), default_props()),
+            (ctx_focus_visible(), within_props()),
+        ];
+
+        for (ctx, props) in cases {
+            let api = Api::new(ctx, props);
+
+            assert_eq!(api.part_attrs(Part::Root), api.root_attrs());
+        }
+    }
+
+    // ── root_attrs branches ────────────────────────────────────────
+
+    #[test]
+    fn root_emits_focus_visible_when_keyboard_modality() {
+        // Spec §1.2: `ctx.focus_visible == true` => emit
+        // `data-ars-focus-visible` as a boolean attribute.
+        let attrs = Api::new(ctx_focus_visible(), default_props()).root_attrs();
+
+        assert_eq!(
+            attrs.get_value(&HtmlAttr::Data("ars-focus-visible")),
+            Some(&AttrValue::Bool(true))
+        );
+        assert!(attrs.contains(&HtmlAttr::Data("ars-focus-visible")));
+    }
+
+    #[test]
+    fn root_omits_focus_visible_when_pointer_modality() {
+        // Spec §1.2: `ctx.focus_visible == false` => attribute absent.
+        // The `[data-ars-focus-visible]` CSS selector must NOT match.
+        let attrs = Api::new(ctx_inactive(), default_props()).root_attrs();
+
+        assert_eq!(attrs.get(&HtmlAttr::Data("ars-focus-visible")), None);
+        assert_eq!(attrs.get_value(&HtmlAttr::Data("ars-focus-visible")), None);
+        assert!(!attrs.contains(&HtmlAttr::Data("ars-focus-visible")));
+    }
+
+    #[test]
+    fn within_prop_drives_within_accessor_and_does_not_affect_attrs() {
+        // `Props::within` is the single source of truth for whether the
+        // adapter wires focus-within or focus listeners. `Api::within()`
+        // surfaces it directly from `Props`, not from `Context`, so the
+        // two cannot disagree. The flag does not change `root_attrs`
+        // output — that is `focus_visible`'s job alone.
+        let api = Api::new(ctx_focus_visible(), within_props());
+
+        assert!(api.within());
+        assert!(api.props().within);
+
+        let with_within = Api::new(ctx_inactive(), within_props()).root_attrs();
+        let without_within = Api::new(ctx_inactive(), default_props()).root_attrs();
+
+        assert_eq!(with_within, without_within);
+    }
+
+    #[test]
+    fn class_props_do_not_affect_root_attrs() {
+        // Defensive regression test: `focus_class`, `focus_visible_class`,
+        // and `is_text_input` are adapter-only render hints. Holding
+        // `focus_visible` constant, varying these props MUST produce an
+        // identical `AttrMap`.
+        let baseline = Api::new(ctx_focus_visible(), default_props()).root_attrs();
+
+        for props in [classy_props(), text_input_props(), within_props()] {
+            let attrs = Api::new(ctx_focus_visible(), props).root_attrs();
+
+            assert_eq!(attrs, baseline);
+        }
+    }
+
+    #[test]
+    fn focus_visible_and_inactive_branches_produce_different_attrs() {
+        // Defensive cross-branch inequality: `focus_visible` is the only
+        // output-affecting flag; flipping it MUST change the `AttrMap`.
+        // Catches a regression where the boolean attribute accidentally
+        // stops being conditional.
+        let active = Api::new(ctx_focus_visible(), default_props()).root_attrs();
+        let inactive = Api::new(ctx_inactive(), default_props()).root_attrs();
+
+        assert_ne!(active, inactive);
+    }
+
+    // ── Snapshots ──────────────────────────────────────────────────
+
+    #[test]
+    fn focus_ring_root_inactive_snapshot() {
+        assert_snapshot!(
+            "focus_ring_root_inactive",
+            snapshot_attrs(&Api::new(ctx_inactive(), default_props()).root_attrs())
+        );
+    }
+
+    #[test]
+    fn focus_ring_root_focus_visible_snapshot() {
+        assert_snapshot!(
+            "focus_ring_root_focus_visible",
+            snapshot_attrs(&Api::new(ctx_focus_visible(), default_props()).root_attrs())
+        );
+    }
+}

--- a/crates/ars-components/src/utility/keyboard.rs
+++ b/crates/ars-components/src/utility/keyboard.rs
@@ -1,0 +1,1074 @@
+//! `Keyboard` component machine and connect API.
+//!
+//! `Keyboard` is a stateless attribute mapper that renders shortcut text
+//! inside a semantic `<kbd>` element with optional platform-aware modifier
+//! mapping (`Mod` → `⌘` on macOS, `Ctrl`/`Strg`/etc. on others) and
+//! locale-aware modifier names. It has no state machine — the
+//! framework-agnostic core consists solely of [`Props`], [`Part`], and
+//! [`Api`].
+//!
+//! Platform detection (`Props::is_mac`) is supplied by the adapter via
+//! `PlatformEffects::is_mac_platform()` (see
+//! `spec/foundation/01-architecture.md` §2.2.7); during SSR the adapter
+//! defaults the flag to `false` (non-Mac) and re-renders after hydration.
+//!
+//! See `spec/components/utility/keyboard.md` for the authoritative
+//! contract.
+
+use alloc::{string::String, vec::Vec};
+
+use ars_core::{AriaAttr, AttrMap, ComponentPart, ConnectApi, HasId, HtmlAttr};
+use ars_i18n::Locale;
+
+/// Props for the `Keyboard` component.
+#[derive(Clone, Debug, Default, PartialEq, Eq, HasId)]
+pub struct Props {
+    /// Component instance ID.
+    pub id: String,
+
+    /// The keyboard shortcut text to display (e.g., `"⌘C"`, `"Ctrl+Shift+P"`).
+    /// When [`Props::platform_aware`] is `true`, modifier tokens such as
+    /// `"Mod"`, `"Shift"`, `"Alt"`, `"Ctrl"`, and `"Meta"` are
+    /// auto-mapped to the platform-appropriate symbol or label.
+    pub shortcut: String,
+
+    /// When `true`, automatically maps generic modifier tokens to
+    /// platform-specific symbols: `"Mod"` → `"⌘"` (macOS) / `"Ctrl"`
+    /// (others), `"Alt"` → `"⌥"` (macOS) / `"Alt"`, `"Shift"` → `"⇧"`
+    /// (macOS) / `"Shift"`, `"Meta"` → `"⌘"` (macOS) / `"Win"` (others).
+    /// Default behaviour (`false`) renders the shortcut text as-is.
+    pub platform_aware: bool,
+
+    /// Whether the current platform is macOS. The adapter provides this
+    /// value via `PlatformEffects::is_mac_platform()` (see
+    /// `spec/foundation/01-architecture.md` §2.2.7). During SSR, defaults
+    /// to `false` (non-Mac); client-side hydration updates the display if
+    /// the actual platform differs.
+    pub is_mac: bool,
+
+    /// When `true`, the rendered `<kbd>` is purely decorative and the
+    /// agnostic core emits `aria-hidden="true"` on the root so screen
+    /// readers skip it. Use when the shortcut is a visual reminder only
+    /// and the action it triggers is announced through some other path
+    /// (e.g., a button label). Default: `false` — assistive tech announces
+    /// the shortcut text. Inside Menu items the parent `Shortcut` part
+    /// already manages `aria-hidden` on its own wrapper, so leave this
+    /// `false` there to avoid duplication.
+    pub decorative: bool,
+}
+
+impl Props {
+    /// Returns fresh [`Props`] with the documented defaults — equivalent
+    /// to [`Default::default`], offered as the entry point for the
+    /// builder chain.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the component instance ID.
+    #[must_use]
+    pub fn id(mut self, id: impl Into<String>) -> Self {
+        self.id = id.into();
+        self
+    }
+
+    /// Sets the shortcut text rendered inside the `<kbd>` element.
+    ///
+    /// When [`Props::platform_aware`] is `true`, modifier tokens
+    /// (`"Mod"`, `"Shift"`, `"Alt"`, `"Ctrl"`, `"Meta"`) inside the
+    /// string are auto-mapped to the platform-appropriate symbol or
+    /// label.
+    #[must_use]
+    pub fn shortcut(mut self, value: impl Into<String>) -> Self {
+        self.shortcut = value.into();
+        self
+    }
+
+    /// Enables or disables platform-aware modifier mapping.
+    #[must_use]
+    pub const fn platform_aware(mut self, value: bool) -> Self {
+        self.platform_aware = value;
+        self
+    }
+
+    /// Sets the macOS-platform flag.
+    ///
+    /// Adapter-supplied; tests pass it directly. See
+    /// `spec/foundation/01-architecture.md` §2.2.7.
+    #[must_use]
+    pub const fn is_mac(mut self, value: bool) -> Self {
+        self.is_mac = value;
+        self
+    }
+
+    /// Marks the rendered `<kbd>` as decorative — the agnostic core
+    /// will emit `aria-hidden="true"` on the root. See
+    /// [`Props::decorative`] for usage guidance.
+    #[must_use]
+    pub const fn decorative(mut self, value: bool) -> Self {
+        self.decorative = value;
+        self
+    }
+}
+
+/// DOM parts of the `Keyboard` component.
+#[derive(ComponentPart)]
+#[scope = "keyboard"]
+pub enum Part {
+    /// The root `<kbd>` element. Contains the formatted shortcut text.
+    Root,
+}
+
+/// The API for the `Keyboard` component.
+///
+/// Owns its [`Props`] (matching the stateless-Api convention shared with
+/// `separator`, `visually_hidden`, `landmark`, etc.) and is queried via
+/// [`Api::root_attrs`] and [`Api::display_text`], or through the
+/// [`ConnectApi`] dispatch.
+#[derive(Clone, Debug)]
+pub struct Api {
+    props: Props,
+}
+
+impl Api {
+    /// Creates a new `Api` instance owning the given props.
+    #[must_use]
+    pub const fn new(props: Props) -> Self {
+        Self { props }
+    }
+
+    /// Returns a reference to the underlying [`Props`].
+    #[must_use]
+    pub const fn props(&self) -> &Props {
+        &self.props
+    }
+
+    /// Returns the component's instance ID.
+    #[must_use]
+    pub fn id(&self) -> &str {
+        &self.props.id
+    }
+
+    /// Returns the raw shortcut string as it was provided in props,
+    /// unaffected by platform-aware mapping.
+    #[must_use]
+    pub fn shortcut(&self) -> &str {
+        &self.props.shortcut
+    }
+
+    /// Returns whether platform-aware modifier mapping is enabled.
+    #[must_use]
+    pub const fn platform_aware(&self) -> bool {
+        self.props.platform_aware
+    }
+
+    /// Returns whether the props were constructed for the macOS platform.
+    #[must_use]
+    pub const fn is_mac(&self) -> bool {
+        self.props.is_mac
+    }
+
+    /// Returns whether the root `<kbd>` is marked as decorative
+    /// (hidden from the accessibility tree via `aria-hidden`).
+    #[must_use]
+    pub const fn decorative(&self) -> bool {
+        self.props.decorative
+    }
+
+    /// Returns the attributes for the root `<kbd>` element.
+    ///
+    /// Always emits `data-ars-scope="keyboard"` and
+    /// `data-ars-part="root"`. When [`Props::decorative`] is `true`,
+    /// also emits `aria-hidden="true"` so the shortcut is skipped by
+    /// assistive technology — used when the action is already announced
+    /// elsewhere (e.g., via the parent button's label) and the `<kbd>`
+    /// is a visual reminder only. Inside Menu items the parent
+    /// `Shortcut` part owns the aria-hidden — keep [`Props::decorative`]
+    /// `false` there to avoid duplication.
+    #[must_use]
+    pub fn root_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Root.data_attrs();
+
+        attrs.set(scope_attr, scope_val).set(part_attr, part_val);
+
+        if self.props.decorative {
+            attrs.set(HtmlAttr::Aria(AriaAttr::Hidden), "true");
+        }
+
+        attrs
+    }
+
+    /// Returns the formatted shortcut text, applying platform-aware
+    /// modifier mapping when [`Props::platform_aware`] is `true` and
+    /// passing through `shortcut` verbatim otherwise.
+    ///
+    /// When `locale` is `Some`, modifier names are localised per spec
+    /// §3.2 (`Ctrl` → `Strg` in `de`, `Shift` → `Maj` in `fr`, `Shift`
+    /// → `Mayús` in `es`, `Shift` → `Maiusc` in `it`, …). Locales not
+    /// covered by the table fall back to English labels.
+    #[must_use]
+    pub fn display_text(&self, locale: Option<&Locale>) -> String {
+        if self.props.platform_aware {
+            format_platform_shortcut(&self.props.shortcut, self.props.is_mac, locale)
+        } else {
+            self.props.shortcut.clone()
+        }
+    }
+}
+
+impl ConnectApi for Api {
+    type Part = Part;
+
+    fn part_attrs(&self, part: Part) -> AttrMap {
+        match part {
+            Part::Root => self.root_attrs(),
+        }
+    }
+}
+
+/// Modifier keys recognised by [`format_platform_shortcut`].
+///
+/// Strongly typed so a typo in the formatter or in the localisation
+/// table is a compile error rather than a silent fall-through to the
+/// "unknown token" branch.
+#[derive(Clone, Copy)]
+enum Modifier {
+    /// The platform modifier — `⌘` on macOS, `Ctrl` (or its localised
+    /// equivalent) on every other platform.
+    Mod,
+
+    /// The shift key — `⇧` on macOS, `Shift` (or its localised
+    /// equivalent) on every other platform.
+    Shift,
+
+    /// The alt / option key — `⌥` on macOS, `Alt` on every other
+    /// platform.
+    Alt,
+
+    /// The literal control key — `⌃` on macOS, `Ctrl` (localised) on
+    /// every other platform.
+    Ctrl,
+
+    /// The OS / Windows / Super key — `⌘` on macOS, `Win` on every
+    /// other platform.
+    Meta,
+}
+
+impl Modifier {
+    /// Parses one segment of a `+`-separated shortcut into a
+    /// [`Modifier`], or returns `None` for unknown tokens (printable
+    /// keys, function keys, etc.).
+    fn parse(token: &str) -> Option<Self> {
+        Some(match token {
+            "Mod" => Self::Mod,
+            "Shift" => Self::Shift,
+            "Alt" => Self::Alt,
+            "Ctrl" => Self::Ctrl,
+            "Meta" => Self::Meta,
+            _ => return None,
+        })
+    }
+
+    /// Returns the macOS symbol for this modifier.
+    const fn mac_symbol(self) -> &'static str {
+        match self {
+            Self::Mod | Self::Meta => "⌘",
+            Self::Shift => "⇧",
+            Self::Alt => "⌥",
+            Self::Ctrl => "⌃",
+        }
+    }
+
+    /// Returns the default English label for this modifier on
+    /// non-macOS platforms.
+    const fn english_label(self) -> &'static str {
+        match self {
+            // `Mod` expands to `Ctrl` on non-mac platforms.
+            Self::Mod | Self::Ctrl => "Ctrl",
+            Self::Shift => "Shift",
+            Self::Alt => "Alt",
+            Self::Meta => "Win",
+        }
+    }
+}
+
+/// Returns the localised display name for a modifier key on non-macOS
+/// platforms.
+///
+/// Implements the modifier-localisation table from spec §3.2 — only the
+/// entries that diverge from English on physical keyboards are
+/// translated; all others fall back to [`Modifier::english_label`].
+fn localized_modifier(modifier: Modifier, locale: Option<&Locale>) -> &'static str {
+    let lang = locale.map_or("en", Locale::language);
+
+    match (modifier, lang) {
+        // German localises `Ctrl` (and `Mod`, which expands to Ctrl) to
+        // `Strg` and `Shift` to `Umschalt`.
+        (Modifier::Mod | Modifier::Ctrl, "de") => "Strg",
+
+        (Modifier::Shift, "de") => "Umschalt",
+
+        // French, Spanish, and Italian localise only `Shift`.
+        (Modifier::Shift, "fr") => "Maj",
+
+        (Modifier::Shift, "es") => "Mayús",
+
+        (Modifier::Shift, "it") => "Maiusc",
+
+        // Every other (modifier, language) pair falls back to the
+        // English label — including Japanese (which uses English labels
+        // on physical keyboards) and any locale not in the §3.2 table.
+        _ => modifier.english_label(),
+    }
+}
+
+/// Maps generic modifier tokens to platform-specific symbols.
+///
+/// `is_mac` is supplied by the caller (via the adapter's
+/// `PlatformEffects::is_mac_platform()` query). On macOS, modifier
+/// symbols are concatenated with no separator (`"⌘C"`); on every other
+/// platform tokens are joined with `"+"` (`"Ctrl+C"`).
+fn format_platform_shortcut(shortcut: &str, is_mac: bool, locale: Option<&Locale>) -> String {
+    shortcut
+        .split('+')
+        .map(|part| match (Modifier::parse(part), is_mac) {
+            (Some(modifier), true) => modifier.mac_symbol(),
+            (Some(modifier), false) => localized_modifier(modifier, locale),
+            (None, _) => part,
+        })
+        .collect::<Vec<_>>()
+        .join(if is_mac { "" } else { "+" })
+}
+
+#[cfg(test)]
+mod tests {
+    use ars_core::HasId;
+    use ars_i18n::Locale;
+    use insta::assert_snapshot;
+
+    use super::*;
+
+    fn snapshot_attrs(attrs: &AttrMap) -> String {
+        format!("{attrs:#?}")
+    }
+
+    fn props(shortcut: &str, platform_aware: bool, is_mac: bool) -> Props {
+        Props {
+            shortcut: String::from(shortcut),
+            platform_aware,
+            is_mac,
+            ..Props::default()
+        }
+    }
+
+    fn parse(tag: &str) -> Locale {
+        Locale::parse(tag).expect("locale tag should parse")
+    }
+
+    // ── Props ──────────────────────────────────────────────────────
+
+    #[test]
+    fn props_default_values() {
+        let p = Props::default();
+
+        assert_eq!(p.id, "");
+        assert_eq!(p.shortcut, "");
+        assert!(!p.platform_aware);
+        assert!(!p.is_mac);
+        assert!(!p.decorative);
+    }
+
+    #[test]
+    fn props_builder_round_trips() {
+        // `Props::new()` returns the documented defaults and the chained
+        // setters mutate exactly the matching fields, leaving the others
+        // at their default values.
+        let p = Props::new()
+            .id("kbd-build")
+            .shortcut("Mod+C")
+            .platform_aware(true)
+            .is_mac(true)
+            .decorative(true);
+
+        assert_eq!(p.id, "kbd-build");
+        assert_eq!(p.shortcut, "Mod+C");
+        assert!(p.platform_aware);
+        assert!(p.is_mac);
+        assert!(p.decorative);
+
+        // `Props::new()` is equivalent to `Default::default()`.
+        assert_eq!(Props::new(), Props::default());
+    }
+
+    #[test]
+    fn props_builder_setters_are_idempotent_per_field() {
+        // Each setter overrides only its own field; later calls overwrite
+        // earlier ones for the same field.
+        let p = Props::new()
+            .platform_aware(true)
+            .platform_aware(false)
+            .shortcut("Mod+A")
+            .shortcut("Mod+B");
+
+        assert!(!p.platform_aware);
+        assert_eq!(p.shortcut, "Mod+B");
+    }
+
+    #[test]
+    fn props_clone_and_partial_eq_round_trip() {
+        let original = Props {
+            id: String::from("kbd-clone"),
+            shortcut: String::from("Mod+S"),
+            platform_aware: true,
+            is_mac: false,
+            decorative: true,
+        };
+
+        let cloned = original.clone();
+
+        assert_eq!(cloned, original);
+
+        let mutated = Props {
+            is_mac: true,
+            ..original.clone()
+        };
+
+        assert_ne!(mutated, original);
+    }
+
+    #[test]
+    fn props_has_id_derive_round_trips() {
+        // Exercises the methods the `HasId` derive emits directly on
+        // `Props` (the `Api::id()` accessor only goes through one of them).
+        let mut p = props("Mod", false, false).with_id(String::from("kbd-a"));
+
+        assert_eq!(HasId::id(&p), "kbd-a");
+
+        p.set_id(String::from("kbd-b"));
+
+        assert_eq!(HasId::id(&p), "kbd-b");
+    }
+
+    #[test]
+    fn props_and_api_are_send_sync() {
+        // The agnostic core's public types must be `Send + Sync` so
+        // adapters and ahead-of-time computation paths can shuttle
+        // values between threads (web handlers, async server functions,
+        // etc. — see workspace `feedback_messagefn_send_sync.md`). This
+        // assertion fails to compile if a future refactor introduces a
+        // non-thread-safe field (e.g., `Rc`, `Cell`).
+        const fn assert_send_sync<T: Send + Sync>() {}
+
+        assert_send_sync::<Props>();
+        assert_send_sync::<Api>();
+        assert_send_sync::<Part>();
+    }
+
+    #[test]
+    fn api_clone_round_trips() {
+        // The `Clone` derive on `Api` must produce a value structurally
+        // equal to the source. This locks the property against a future
+        // refactor adding a non-clone-coherent field (instance counter,
+        // allocation ID, RNG state, etc.).
+        let original = Api::new(Props {
+            id: String::from("kbd-clone"),
+            shortcut: String::from("Mod+Shift+Q"),
+            platform_aware: true,
+            is_mac: true,
+            decorative: true,
+        });
+
+        let cloned = original.clone();
+
+        assert_eq!(cloned.props(), original.props());
+        assert_eq!(cloned.root_attrs(), original.root_attrs());
+        assert_eq!(
+            cloned.display_text(None),
+            original.display_text(None),
+            "cloned Api must produce identical display_text",
+        );
+    }
+
+    #[test]
+    fn props_and_api_debug_impl_is_non_empty() {
+        // Smoke test guarding against an accidental empty `impl Debug`.
+        let p = props("Mod+C", true, true);
+        let api = Api::new(p.clone());
+
+        let props_dbg = format!("{:?}", api.props());
+
+        let api_dbg = format!("{api:?}");
+
+        assert!(props_dbg.contains("Props"), "Props Debug = {props_dbg}");
+        assert!(api_dbg.contains("Api"), "Api Debug = {api_dbg}");
+    }
+
+    // ── Api accessors ──────────────────────────────────────────────
+
+    #[test]
+    fn api_exposes_props_fields() {
+        // Cover the `true` branch of every bool accessor with one
+        // Props, and the `false` branch with a default-constructed
+        // Props. Both branches are required: mutation testing surfaced
+        // that asserting only the `false` branch silently permits a
+        // regression where the accessor always returns `false`.
+        let truthy = Props {
+            id: String::from("kbd-7"),
+            shortcut: String::from("Mod+Shift+P"),
+            platform_aware: true,
+            is_mac: true,
+            decorative: true,
+        };
+
+        let api = Api::new(truthy.clone());
+
+        assert_eq!(api.id(), "kbd-7");
+        assert_eq!(api.shortcut(), "Mod+Shift+P");
+        assert!(api.platform_aware());
+        assert!(api.is_mac());
+        assert!(api.decorative());
+        assert_eq!(api.props(), &truthy);
+
+        let falsy = props("", false, false);
+        let falsy_api = Api::new(falsy.clone());
+
+        assert_eq!(falsy_api.id(), "");
+        assert_eq!(falsy_api.shortcut(), "");
+        assert!(!falsy_api.platform_aware());
+        assert!(!falsy_api.is_mac());
+        assert!(!falsy_api.decorative());
+    }
+
+    // ── Connect / API ──────────────────────────────────────────────
+
+    #[test]
+    fn part_attrs_dispatches_root() {
+        let p = props("Mod+C", true, true);
+
+        let api = Api::new(p.clone());
+
+        let attrs = api.part_attrs(Part::Root);
+
+        assert_eq!(attrs.get(&HtmlAttr::Data("ars-scope")), Some("keyboard"));
+        assert_eq!(attrs.get(&HtmlAttr::Data("ars-part")), Some("root"));
+    }
+
+    #[test]
+    fn api_root_attrs_equals_part_attrs_root_across_branches() {
+        // The `ConnectApi` dispatch must produce exactly what the
+        // inherent `root_attrs` method produces, across every output-
+        // affecting prop combination.
+        let cases = [
+            props("Mod", false, false),
+            props("Mod+C", true, true),
+            props("Meta", true, false),
+            props("Mod+Shift+P", true, true),
+            // decorative path:
+            Props {
+                decorative: true,
+                ..props("Mod+C", true, true)
+            },
+        ];
+
+        for p in cases {
+            let api = Api::new(p.clone());
+
+            assert_eq!(api.part_attrs(Part::Root), api.root_attrs());
+        }
+    }
+
+    // ── root_attrs branches ────────────────────────────────────────
+
+    #[test]
+    fn root_attrs_emit_scope_and_part() {
+        // Spec §1.2 / §2: agnostic core always emits
+        // `data-ars-scope="keyboard"` and `data-ars-part="root"`.
+        let p = props("Mod+C", true, true);
+
+        let attrs = Api::new(p.clone()).root_attrs();
+
+        assert_eq!(attrs.get(&HtmlAttr::Data("ars-scope")), Some("keyboard"));
+        assert_eq!(attrs.get(&HtmlAttr::Data("ars-part")), Some("root"));
+    }
+
+    #[test]
+    fn root_attrs_omit_aria_hidden_by_default() {
+        // Spec §3.1: when `decorative` is `false` (default), screen
+        // readers announce the shortcut text naturally — the agnostic
+        // core MUST NOT emit `aria-hidden`. Inside Menu items the
+        // parent `Shortcut` part owns aria-hidden on its wrapper, so
+        // the `<kbd>` itself must remain announced (the wrapper is the
+        // hidden node).
+        let p = props("Mod+C", true, true);
+
+        let attrs = Api::new(p.clone()).root_attrs();
+
+        assert_eq!(attrs.get(&HtmlAttr::Aria(AriaAttr::Hidden)), None);
+        assert!(!attrs.contains(&HtmlAttr::Aria(AriaAttr::Hidden)));
+    }
+
+    #[test]
+    fn root_attrs_emit_aria_hidden_when_decorative() {
+        // Spec §3.1: `decorative = true` ⇒ emit `aria-hidden="true"`
+        // on the `<kbd>` so assistive tech skips the purely-visual
+        // shortcut hint.
+        let p = Props {
+            decorative: true,
+            ..props("Mod+C", true, true)
+        };
+
+        let attrs = Api::new(p.clone()).root_attrs();
+
+        assert_eq!(attrs.get(&HtmlAttr::Aria(AriaAttr::Hidden)), Some("true"));
+    }
+
+    #[test]
+    fn decorative_and_non_decorative_branches_produce_different_attrs() {
+        // Defensive cross-branch inequality: flipping `decorative`
+        // MUST change the AttrMap, otherwise the boolean attribute
+        // accidentally became unconditional or got dropped.
+        let semantic = Api::new(props("Mod+C", true, true)).root_attrs();
+
+        let decorative = Api::new(Props {
+            decorative: true,
+            ..props("Mod+C", true, true)
+        })
+        .root_attrs();
+
+        assert_ne!(semantic, decorative);
+    }
+
+    #[test]
+    fn root_attrs_are_invariant_under_shortcut_and_platform() {
+        // Holding `decorative` constant, varying every other prop must
+        // produce an identical `AttrMap`.
+        let baseline = Api::new(props("Mod+C", true, true)).root_attrs();
+
+        for p in [
+            props("Mod+Shift+P", true, false),
+            props("Mod+C", false, false),
+            props("Meta", true, false),
+            props("", false, false),
+        ] {
+            assert_eq!(Api::new(p.clone()).root_attrs(), baseline);
+        }
+    }
+
+    // ── display_text branches ──────────────────────────────────────
+
+    #[test]
+    fn display_text_returns_shortcut_verbatim_when_platform_aware_false() {
+        // Covers the `else` branch: `platform_aware = false` ⇒ no
+        // mapping, no localisation; the shortcut string is returned
+        // exactly as it was passed in.
+        let p = props("Mod+C", false, true);
+
+        assert_eq!(Api::new(p.clone()).display_text(None), "Mod+C");
+        assert_eq!(
+            Api::new(p.clone()).display_text(Some(&parse("de"))),
+            "Mod+C"
+        );
+    }
+
+    #[test]
+    fn display_text_maps_mod_to_command_on_mac() {
+        // Issue test 4: `Mod+C` with `is_mac=true` ⇒ `⌘C`, no separator.
+        let p = props("Mod+C", true, true);
+
+        assert_eq!(Api::new(p.clone()).display_text(None), "⌘C");
+    }
+
+    #[test]
+    fn display_text_maps_meta_to_win_on_windows() {
+        // Issue test 5: `Meta` with `is_mac=false` ⇒ `Win`.
+        let p = props("Meta", true, false);
+
+        assert_eq!(Api::new(p.clone()).display_text(None), "Win");
+    }
+
+    #[test]
+    fn display_text_formats_human_readable_shortcut() {
+        // Issue test 6 (non-Mac): `Mod+Shift+P` ⇒ `Ctrl+Shift+P`.
+        let p = props("Mod+Shift+P", true, false);
+
+        assert_eq!(Api::new(p.clone()).display_text(None), "Ctrl+Shift+P");
+    }
+
+    #[test]
+    fn display_text_maps_full_modifier_set_on_mac() {
+        // Mac modifier symbols across the full set the spec maps.
+        let cases = [
+            ("Mod+C", "⌘C"),
+            ("Shift+Tab", "⇧Tab"),
+            ("Alt+Enter", "⌥Enter"),
+            ("Ctrl+K", "⌃K"),
+            ("Meta+Q", "⌘Q"),
+        ];
+
+        for (shortcut, expected) in cases {
+            let p = props(shortcut, true, true);
+
+            assert_eq!(Api::new(p.clone()).display_text(None), expected);
+        }
+    }
+
+    #[test]
+    fn display_text_maps_full_modifier_set_off_mac_default_locale() {
+        // Non-Mac modifier names without a locale fall back to English.
+        let cases = [
+            ("Mod+C", "Ctrl+C"),
+            ("Shift+Tab", "Shift+Tab"),
+            ("Alt+Enter", "Alt+Enter"),
+            ("Ctrl+K", "Ctrl+K"),
+            ("Meta+Q", "Win+Q"),
+        ];
+
+        for (shortcut, expected) in cases {
+            let p = props(shortcut, true, false);
+
+            assert_eq!(Api::new(p.clone()).display_text(None), expected);
+        }
+    }
+
+    #[test]
+    fn display_text_localizes_ctrl_to_strg_in_de() {
+        // Spec §3.2: German localises `Ctrl` ⇒ `Strg` (and `Mod`,
+        // which expands to Ctrl on non-Mac) and `Shift` ⇒ `Umschalt`.
+        let de = parse("de");
+
+        let mod_c = props("Mod+C", true, false);
+        let ctrl_c = props("Ctrl+C", true, false);
+        let shift_p = props("Shift+P", true, false);
+
+        assert_eq!(Api::new(mod_c.clone()).display_text(Some(&de)), "Strg+C");
+        assert_eq!(Api::new(ctrl_c.clone()).display_text(Some(&de)), "Strg+C");
+        assert_eq!(
+            Api::new(shift_p.clone()).display_text(Some(&de)),
+            "Umschalt+P"
+        );
+    }
+
+    #[test]
+    fn display_text_localizes_shift_to_maj_in_fr() {
+        // Spec §3.2: French localises `Shift` ⇒ `Maj`; `Ctrl` and
+        // `Alt` remain English.
+        let fr = parse("fr");
+
+        let shift_p = props("Shift+P", true, false);
+        let ctrl_c = props("Ctrl+C", true, false);
+
+        assert_eq!(Api::new(shift_p.clone()).display_text(Some(&fr)), "Maj+P");
+        assert_eq!(Api::new(ctrl_c.clone()).display_text(Some(&fr)), "Ctrl+C");
+    }
+
+    #[test]
+    fn display_text_localizes_shift_to_mayus_in_es() {
+        // Spec §3.2: Spanish localises `Shift` ⇒ `Mayús`.
+        let es = parse("es");
+
+        let shift_p = props("Shift+P", true, false);
+
+        assert_eq!(Api::new(shift_p.clone()).display_text(Some(&es)), "Mayús+P");
+    }
+
+    #[test]
+    fn display_text_localizes_shift_to_maiusc_in_it() {
+        // Spec §3.2: Italian localises `Shift` ⇒ `Maiusc`.
+        let it = parse("it");
+
+        let shift_p = props("Shift+P", true, false);
+
+        assert_eq!(
+            Api::new(shift_p.clone()).display_text(Some(&it)),
+            "Maiusc+P"
+        );
+    }
+
+    #[test]
+    fn display_text_uses_english_when_locale_none() {
+        // `locale = None` ⇒ `lang` defaults to `"en"` ⇒ no localisation
+        // table entry matches ⇒ the English label is returned.
+        let p = props("Mod+Shift+Alt+P", true, false);
+
+        assert_eq!(Api::new(p.clone()).display_text(None), "Ctrl+Shift+Alt+P");
+    }
+
+    #[test]
+    fn display_text_uses_english_for_unlocalised_languages() {
+        // Spec §3.2: Japanese (`ja`) uses English modifier labels on
+        // physical keyboards; languages outside the spec table also
+        // fall back to English. This locks the behaviour so an
+        // accidental wildcard branch cannot regress it.
+        let ja = parse("ja");
+        let pt = parse("pt-BR");
+
+        let mod_shift = props("Mod+Shift+P", true, false);
+
+        assert_eq!(
+            Api::new(mod_shift.clone()).display_text(Some(&ja)),
+            "Ctrl+Shift+P"
+        );
+        assert_eq!(
+            Api::new(mod_shift.clone()).display_text(Some(&pt)),
+            "Ctrl+Shift+P"
+        );
+    }
+
+    #[test]
+    fn display_text_handles_single_token() {
+        // Input with no `+` separator must still be mapped correctly
+        // — the splitter yields a single segment and the join is a
+        // no-op.
+        let mac_mod = props("Mod", true, true);
+        let win_meta = props("Meta", true, false);
+
+        assert_eq!(Api::new(mac_mod.clone()).display_text(None), "⌘");
+        assert_eq!(Api::new(win_meta.clone()).display_text(None), "Win");
+    }
+
+    #[test]
+    fn display_text_does_not_localize_alt_in_any_language() {
+        // Spec §3.2: `Alt` is `"Alt"` in every locale on the table —
+        // German, French, Spanish, Italian, Japanese all use the
+        // English label. This test catches an accidental
+        // `(Modifier::Alt, _) => "..."` entry that would diverge from
+        // the table.
+        for tag in ["de", "fr", "es", "it", "ja"] {
+            let p = props("Alt+Enter", true, false);
+
+            assert_eq!(
+                Api::new(p.clone()).display_text(Some(&parse(tag))),
+                "Alt+Enter",
+                "Alt should not be localised in `{tag}`",
+            );
+        }
+    }
+
+    #[test]
+    fn display_text_does_not_localize_ctrl_outside_german() {
+        // Spec §3.2: only German (`de`) translates `Ctrl` (and `Mod`,
+        // which expands to Ctrl). French, Spanish, Italian, and
+        // Japanese keep the English label. Catches an accidental
+        // `(Modifier::Ctrl, "fr") => "..."` entry.
+        for tag in ["fr", "es", "it", "ja"] {
+            let p = props("Ctrl+C", true, false);
+
+            assert_eq!(
+                Api::new(p.clone()).display_text(Some(&parse(tag))),
+                "Ctrl+C",
+                "Ctrl should not be localised in `{tag}`",
+            );
+        }
+    }
+
+    #[test]
+    fn display_text_handles_empty_and_malformed_input() {
+        // Defensive: empty / leading-`+` / trailing-`+` / consecutive-`+`
+        // shortcuts must not panic and must produce stable output.
+        // `split('+')` on these inputs yields empty segments which fall
+        // through `Modifier::parse` to the "unknown token" branch,
+        // emitting `""`. The join then drops them on macOS (concat with
+        // no separator) and preserves them on non-Mac (joined with `+`).
+        let mac = |s: &str| Api::new(props(s, true, true)).display_text(None);
+        let non_mac = |s: &str| Api::new(props(s, true, false)).display_text(None);
+
+        assert_eq!(mac(""), "");
+        assert_eq!(non_mac(""), "");
+
+        // Trailing `+` keeps a trailing separator on non-Mac.
+        assert_eq!(mac("Mod+"), "⌘");
+        assert_eq!(non_mac("Mod+"), "Ctrl+");
+
+        // Leading `+` keeps a leading separator on non-Mac.
+        assert_eq!(mac("+Mod"), "⌘");
+        assert_eq!(non_mac("+Mod"), "+Ctrl");
+
+        // Consecutive `+` produce empty segments; the formatter is
+        // tolerant rather than rejecting.
+        assert_eq!(mac("Mod++C"), "⌘C");
+        assert_eq!(non_mac("Mod++C"), "Ctrl++C");
+    }
+
+    #[test]
+    fn display_text_passes_unknown_tokens_through() {
+        // Tokens that are not in the modifier set are emitted verbatim
+        // on both platforms.
+        let mac = props("Mod+ArrowLeft", true, true);
+        let non_mac = props("Mod+ArrowLeft", true, false);
+
+        assert_eq!(Api::new(mac.clone()).display_text(None), "⌘ArrowLeft");
+        assert_eq!(
+            Api::new(non_mac.clone()).display_text(None),
+            "Ctrl+ArrowLeft"
+        );
+    }
+
+    // ── Cross-branch inequality ────────────────────────────────────
+
+    #[test]
+    fn mac_and_non_mac_produce_different_text_for_same_shortcut() {
+        // Defensive: the platform mapping MUST diverge between macOS
+        // and non-Mac for tokens in the modifier set, otherwise the
+        // platform-aware path collapses into a no-op.
+        let mac = props("Mod+C", true, true);
+        let non_mac = props("Mod+C", true, false);
+
+        assert_ne!(
+            Api::new(mac.clone()).display_text(None),
+            Api::new(non_mac.clone()).display_text(None)
+        );
+    }
+
+    #[test]
+    fn localized_and_default_produce_different_text() {
+        // Defensive: the locale parameter MUST be consulted for the
+        // languages in the table.
+        let p = props("Shift+P", true, false);
+
+        assert_ne!(
+            Api::new(p.clone()).display_text(None),
+            Api::new(p.clone()).display_text(Some(&parse("de")))
+        );
+    }
+
+    #[test]
+    fn display_text_ignores_locale_on_mac() {
+        // Spec §3.2: "macOS uses universal symbols (⌘ ⇧ ⌥ ⌃) regardless
+        // of language." Locks the invariant: when `is_mac == true`, the
+        // `locale` argument has no effect on `display_text`. Catches a
+        // regression where someone wires `locale` into the Mac path.
+        let p = props("Mod+Shift+Alt+Ctrl+P", true, true);
+        let baseline = Api::new(p.clone()).display_text(None);
+
+        for tag in ["de", "fr", "es", "it", "ja", "pt-BR"] {
+            assert_eq!(
+                Api::new(p.clone()).display_text(Some(&parse(tag))),
+                baseline,
+                "macOS output must be locale-invariant; diverged for `{tag}`",
+            );
+        }
+    }
+
+    #[test]
+    fn platform_aware_off_disables_localization() {
+        // Defensive: `platform_aware = false` ⇒ the locale parameter
+        // is ignored entirely.
+        let p = props("Mod+C", false, false);
+
+        assert_eq!(
+            Api::new(p.clone()).display_text(Some(&parse("de"))),
+            Api::new(p.clone()).display_text(None)
+        );
+    }
+
+    // ── Snapshots ──────────────────────────────────────────────────
+
+    #[test]
+    fn keyboard_root_attrs_snapshot() {
+        // `root_attrs` is invariant under every prop EXCEPT
+        // `decorative`, so the non-decorative path needs one snapshot.
+        let p = props("Mod+C", true, true);
+
+        assert_snapshot!(
+            "keyboard_root_attrs",
+            snapshot_attrs(&Api::new(p.clone()).root_attrs())
+        );
+    }
+
+    #[test]
+    fn keyboard_root_attrs_decorative_snapshot() {
+        // Locks the decorative branch's emission of
+        // `aria-hidden="true"`.
+        let p = Props {
+            decorative: true,
+            ..props("Mod+C", true, true)
+        };
+
+        assert_snapshot!(
+            "keyboard_root_attrs_decorative",
+            snapshot_attrs(&Api::new(p.clone()).root_attrs())
+        );
+    }
+
+    #[test]
+    fn keyboard_display_mod_c_mac_snapshot() {
+        let p = props("Mod+C", true, true);
+
+        assert_snapshot!(
+            "keyboard_display_mod_c_mac",
+            Api::new(p.clone()).display_text(None)
+        );
+    }
+
+    #[test]
+    fn keyboard_display_mod_c_non_mac_snapshot() {
+        let p = props("Mod+C", true, false);
+
+        assert_snapshot!(
+            "keyboard_display_mod_c_non_mac",
+            Api::new(p.clone()).display_text(None)
+        );
+    }
+
+    #[test]
+    fn keyboard_display_mod_c_de_snapshot() {
+        let p = props("Mod+C", true, false);
+
+        assert_snapshot!(
+            "keyboard_display_mod_c_de",
+            Api::new(p.clone()).display_text(Some(&parse("de")))
+        );
+    }
+
+    #[test]
+    fn keyboard_display_shift_p_fr_snapshot() {
+        let p = props("Shift+P", true, false);
+
+        assert_snapshot!(
+            "keyboard_display_shift_p_fr",
+            Api::new(p.clone()).display_text(Some(&parse("fr")))
+        );
+    }
+
+    #[test]
+    fn keyboard_display_shift_p_es_snapshot() {
+        let p = props("Shift+P", true, false);
+
+        assert_snapshot!(
+            "keyboard_display_shift_p_es",
+            Api::new(p.clone()).display_text(Some(&parse("es")))
+        );
+    }
+
+    #[test]
+    fn keyboard_display_shift_p_it_snapshot() {
+        let p = props("Shift+P", true, false);
+
+        assert_snapshot!(
+            "keyboard_display_shift_p_it",
+            Api::new(p.clone()).display_text(Some(&parse("it")))
+        );
+    }
+
+    #[test]
+    fn keyboard_display_verbatim_when_disabled_snapshot() {
+        let p = props("Mod+C", false, true);
+
+        assert_snapshot!(
+            "keyboard_display_verbatim_when_disabled",
+            Api::new(p.clone()).display_text(None)
+        );
+    }
+
+    #[test]
+    fn keyboard_display_meta_non_mac_snapshot() {
+        let p = props("Meta", true, false);
+
+        assert_snapshot!(
+            "keyboard_display_meta_non_mac",
+            Api::new(p.clone()).display_text(None)
+        );
+    }
+}

--- a/crates/ars-components/src/utility/mod.rs
+++ b/crates/ars-components/src/utility/mod.rs
@@ -28,11 +28,19 @@ pub mod fieldset;
 /// Form machine.
 pub mod form;
 
+/// `FocusRing` component (stateless attribute mapper for keyboard-vs-pointer
+/// focus modality).
+pub mod focus_ring;
+
 /// Form submit machine.
 pub mod form_submit;
 
 /// `Heading` component (stateless heading-level mapper).
 pub mod heading;
+
+/// `Keyboard` component (stateless `<kbd>` shortcut renderer with
+/// platform-aware modifier mapping).
+pub mod keyboard;
 
 /// `Landmark` component (stateless ARIA landmark mapper).
 pub mod landmark;

--- a/crates/ars-components/src/utility/snapshots/ars_components__utility__focus_ring__tests__focus_ring_root_focus_visible.snap
+++ b/crates/ars-components/src/utility/snapshots/ars_components__utility__focus_ring__tests__focus_ring_root_focus_visible.snap
@@ -1,0 +1,33 @@
+---
+source: crates/ars-components/src/utility/focus_ring.rs
+expression: "snapshot_attrs(&Api::new(ctx_focus_visible(), default_props()).root_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-focus-visible",
+            ),
+            Bool(
+                true,
+            ),
+        ),
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "focus-ring",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/utility/snapshots/ars_components__utility__focus_ring__tests__focus_ring_root_inactive.snap
+++ b/crates/ars-components/src/utility/snapshots/ars_components__utility__focus_ring__tests__focus_ring_root_inactive.snap
@@ -1,0 +1,25 @@
+---
+source: crates/ars-components/src/utility/focus_ring.rs
+expression: "snapshot_attrs(&Api::new(ctx_inactive(), default_props()).root_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "focus-ring",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/utility/snapshots/ars_components__utility__keyboard__tests__keyboard_display_meta_non_mac.snap
+++ b/crates/ars-components/src/utility/snapshots/ars_components__utility__keyboard__tests__keyboard_display_meta_non_mac.snap
@@ -1,0 +1,5 @@
+---
+source: crates/ars-components/src/utility/keyboard.rs
+expression: "Api::new(&p).display_text(None)"
+---
+Win

--- a/crates/ars-components/src/utility/snapshots/ars_components__utility__keyboard__tests__keyboard_display_mod_c_de.snap
+++ b/crates/ars-components/src/utility/snapshots/ars_components__utility__keyboard__tests__keyboard_display_mod_c_de.snap
@@ -1,0 +1,5 @@
+---
+source: crates/ars-components/src/utility/keyboard.rs
+expression: "Api::new(&p).display_text(Some(&parse(\"de\")))"
+---
+Strg+C

--- a/crates/ars-components/src/utility/snapshots/ars_components__utility__keyboard__tests__keyboard_display_mod_c_mac.snap
+++ b/crates/ars-components/src/utility/snapshots/ars_components__utility__keyboard__tests__keyboard_display_mod_c_mac.snap
@@ -1,0 +1,5 @@
+---
+source: crates/ars-components/src/utility/keyboard.rs
+expression: "Api::new(&p).display_text(None)"
+---
+⌘C

--- a/crates/ars-components/src/utility/snapshots/ars_components__utility__keyboard__tests__keyboard_display_mod_c_non_mac.snap
+++ b/crates/ars-components/src/utility/snapshots/ars_components__utility__keyboard__tests__keyboard_display_mod_c_non_mac.snap
@@ -1,0 +1,5 @@
+---
+source: crates/ars-components/src/utility/keyboard.rs
+expression: "Api::new(&p).display_text(None)"
+---
+Ctrl+C

--- a/crates/ars-components/src/utility/snapshots/ars_components__utility__keyboard__tests__keyboard_display_shift_p_es.snap
+++ b/crates/ars-components/src/utility/snapshots/ars_components__utility__keyboard__tests__keyboard_display_shift_p_es.snap
@@ -1,0 +1,5 @@
+---
+source: crates/ars-components/src/utility/keyboard.rs
+expression: "Api::new(&p).display_text(Some(&parse(\"es\")))"
+---
+Mayús+P

--- a/crates/ars-components/src/utility/snapshots/ars_components__utility__keyboard__tests__keyboard_display_shift_p_fr.snap
+++ b/crates/ars-components/src/utility/snapshots/ars_components__utility__keyboard__tests__keyboard_display_shift_p_fr.snap
@@ -1,0 +1,5 @@
+---
+source: crates/ars-components/src/utility/keyboard.rs
+expression: "Api::new(&p).display_text(Some(&parse(\"fr\")))"
+---
+Maj+P

--- a/crates/ars-components/src/utility/snapshots/ars_components__utility__keyboard__tests__keyboard_display_shift_p_it.snap
+++ b/crates/ars-components/src/utility/snapshots/ars_components__utility__keyboard__tests__keyboard_display_shift_p_it.snap
@@ -1,0 +1,5 @@
+---
+source: crates/ars-components/src/utility/keyboard.rs
+expression: "Api::new(&p).display_text(Some(&parse(\"it\")))"
+---
+Maiusc+P

--- a/crates/ars-components/src/utility/snapshots/ars_components__utility__keyboard__tests__keyboard_display_verbatim_when_disabled.snap
+++ b/crates/ars-components/src/utility/snapshots/ars_components__utility__keyboard__tests__keyboard_display_verbatim_when_disabled.snap
@@ -1,0 +1,5 @@
+---
+source: crates/ars-components/src/utility/keyboard.rs
+expression: "Api::new(&p).display_text(None)"
+---
+Mod+C

--- a/crates/ars-components/src/utility/snapshots/ars_components__utility__keyboard__tests__keyboard_root_attrs.snap
+++ b/crates/ars-components/src/utility/snapshots/ars_components__utility__keyboard__tests__keyboard_root_attrs.snap
@@ -1,0 +1,25 @@
+---
+source: crates/ars-components/src/utility/keyboard.rs
+expression: "snapshot_attrs(&Api::new(&p).root_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "keyboard",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/utility/snapshots/ars_components__utility__keyboard__tests__keyboard_root_attrs_decorative.snap
+++ b/crates/ars-components/src/utility/snapshots/ars_components__utility__keyboard__tests__keyboard_root_attrs_decorative.snap
@@ -1,0 +1,33 @@
+---
+source: crates/ars-components/src/utility/keyboard.rs
+expression: "snapshot_attrs(&Api::new(&p).root_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "keyboard",
+            ),
+        ),
+        (
+            Aria(
+                Hidden,
+            ),
+            String(
+                "true",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/spec/components/utility/focus-ring.md
+++ b/spec/components/utility/focus-ring.md
@@ -19,45 +19,46 @@ references:
 
 ```rust
 /// Props for the `FocusRing` component.
-#[derive(Clone, Debug, PartialEq, Eq, HasId)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, HasId)]
 pub struct Props {
     /// Component instance ID.
     pub id: String,
-    /// Track focus-within rather than direct focus.
+    /// Track focus-within rather than direct focus. The adapter reads this
+    /// flag (NOT a duplicate on `Context`) to decide whether to wire
+    /// `focus`/`blur` or `focusin`/`focusout` listeners.
     pub within: bool,
-    /// Optional CSS class to apply when focused by any means.
+    /// Optional CSS class to apply when focused by any means. Adapter-only
+    /// hint; the agnostic-core attribute output is invariant under this
+    /// value.
     pub focus_class: Option<String>,
     /// Optional CSS class to apply only when focused by keyboard.
+    /// Adapter-only hint; the agnostic-core attribute output is invariant
+    /// under this value.
     pub focus_visible_class: Option<String>,
     /// When true, the focus ring is shown even on pointer-initiated focus.
     /// Text inputs conventionally show focus indicators regardless of input
-    /// method, since users need to know where they are typing.
+    /// method, since users need to know where they are typing. Adapter-only
+    /// hint that influences how the platform layer derives
+    /// `Context::focus_visible`; the agnostic-core attribute output is
+    /// invariant under this flag once `Context` has been resolved.
     /// Default: false.
     pub is_text_input: bool,
-}
-
-impl Default for Props {
-    fn default() -> Self {
-        Self {
-            id: String::new(),
-            within: false,
-            focus_class: None,
-            focus_visible_class: None,
-            is_text_input: false,
-        }
-    }
 }
 ```
 
 ### 1.2 Connect / API
 
 ```rust
-/// The context for the `FocusRing` component.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+/// The runtime context for the `FocusRing` component, supplied by the
+/// adapter from the shared modality tracker.
+///
+/// Carries only the resolved focus-visible state. `Props::within` is the
+/// single source of truth for whether the adapter should wire
+/// focus-within vs. focus listeners — duplicating it on `Context` would
+/// just create a chance for the two values to disagree.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct Context {
-    /// When true, `focus_visible` is set when any descendant is focused (focus-within mode).
-    pub within: bool,
-    /// Whether focus-visible is active.
+    /// Whether focus-visible is currently active.
     pub focus_visible: bool,
 }
 
@@ -68,26 +69,37 @@ pub enum Part {
 }
 
 /// The API for the `FocusRing` component.
+#[derive(Clone, Debug)]
 pub struct Api {
     ctx: Context,
     props: Props,
 }
 
 impl Api {
-    pub fn new(ctx: Context, props: Props) -> Self {
+    pub const fn new(ctx: Context, props: Props) -> Self {
         Self { ctx, props }
     }
 
+    pub const fn props(&self) -> &Props { &self.props }
+    pub const fn context(&self) -> Context { self.ctx }
+    pub fn id(&self) -> &str { &self.props.id }
+    /// Reads from `Props::within` — the single source of truth for the
+    /// focus-within routing flag.
+    pub const fn within(&self) -> bool { self.props.within }
+    pub const fn focus_visible(&self) -> bool { self.ctx.focus_visible }
+    pub fn focus_class(&self) -> Option<&str> { self.props.focus_class.as_deref() }
+    pub fn focus_visible_class(&self) -> Option<&str> { self.props.focus_visible_class.as_deref() }
+    pub const fn is_text_input(&self) -> bool { self.props.is_text_input }
+
     /// Attributes applied to the element that should show the focus ring.
     pub fn root_attrs(&self) -> AttrMap {
-        let mut p = AttrMap::new();
+        let mut attrs = AttrMap::new();
         let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Root.data_attrs();
-        p.set(scope_attr, scope_val);
-        p.set(part_attr, part_val);
+        attrs.set(scope_attr, scope_val).set(part_attr, part_val);
         if self.ctx.focus_visible {
-            p.set_bool(HtmlAttr::Data("ars-focus-visible"), true);
+            attrs.set_bool(HtmlAttr::Data("ars-focus-visible"), true);
         }
-        p
+        attrs
     }
 }
 
@@ -101,6 +113,11 @@ impl ConnectApi for Api {
     }
 }
 ```
+
+Adapter consumers may also construct `Props` through the chained-builder
+form (`Props::new().id("…").within(true).is_text_input(true)`), which
+mirrors the convention used by every other stateless utility in
+`crates/ars-components/src/utility/`.
 
 ## 2. Anatomy
 
@@ -194,14 +211,14 @@ Individual component focus handlers consult the shared modality context to deter
 
 ### 6.1 Props
 
-| Feature             | ars-ui                | React Aria       | Notes                                        |
-| ------------------- | --------------------- | ---------------- | -------------------------------------------- |
-| Within              | `within`              | `within`         | Both libraries support focus-within tracking |
-| Focus class         | `focus_class`         | --               | ars-ui addition                              |
-| Focus visible class | `focus_visible_class` | `focusRingClass` | Similar concept                              |
-| Auto-focus tracking | `auto_focus`          | `autoFocus`      | Both libraries                               |
+| Feature             | ars-ui                | React Aria       | Notes                                                               |
+| ------------------- | --------------------- | ---------------- | ------------------------------------------------------------------- |
+| Within              | `within`              | `within`         | Both libraries support focus-within tracking                        |
+| Focus class         | `focus_class`         | --               | ars-ui addition                                                     |
+| Focus visible class | `focus_visible_class` | `focusRingClass` | Similar concept                                                     |
+| Text-input mode     | `is_text_input`       | --               | ars-ui addition: keep ring visible for pointer focus on text inputs |
 
-**Gaps:** None.
+**Gaps:** None — auto-focus is the focused element's responsibility (HTML `autofocus`, or a sibling component), not FocusRing's, in either library.
 
 ### 6.2 Anatomy
 

--- a/spec/components/utility/keyboard.md
+++ b/spec/components/utility/keyboard.md
@@ -6,7 +6,7 @@ foundation_deps: [architecture, accessibility]
 shared_deps: []
 related: []
 references:
-  react-aria: Keyboard
+    react-aria: Keyboard
 ---
 
 # Keyboard
@@ -19,7 +19,7 @@ A stateless utility component that renders keyboard shortcut text inside semanti
 
 ```rust
 /// Props for the `Keyboard` component.
-#[derive(Clone, Debug, PartialEq, HasId)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, HasId)]
 pub struct Props {
     /// Component instance ID.
     pub id: String,
@@ -28,7 +28,7 @@ pub struct Props {
     pub shortcut: String,
     /// When true, automatically maps generic modifier tokens to platform-specific
     /// symbols: "Mod" → "⌘" (macOS) / "Ctrl" (others), "Alt" → "⌥" (macOS) / "Alt",
-    /// "Shift" → "⇧" (macOS) / "Shift", "Meta" → "⌘" (macOS) / "⊞" (Windows).
+    /// "Shift" → "⇧" (macOS) / "Shift", "Meta" → "⌘" (macOS) / "Win" (others).
     /// Default: false (render shortcut text as-is).
     pub platform_aware: bool,
     /// Whether the current platform is macOS. The adapter provides this value
@@ -36,6 +36,14 @@ pub struct Props {
     /// During SSR, defaults to `false` (non-Mac); client-side hydration updates
     /// the display if the actual platform differs.
     pub is_mac: bool,
+    /// When true, the rendered `<kbd>` is purely decorative and the agnostic
+    /// core emits `aria-hidden="true"` on the root so screen readers skip it.
+    /// Use when the action is announced through some other path (e.g., the
+    /// parent button's accessible name) and the `<kbd>` is a visual reminder
+    /// only. Default: false. Inside Menu items, the parent `Shortcut` part
+    /// already manages aria-hidden on its own wrapper, so leave this `false`
+    /// there to avoid duplication.
+    pub decorative: bool,
 }
 ```
 
@@ -49,21 +57,39 @@ pub enum Part {
 }
 
 /// API for the `Keyboard` component.
-pub struct Api<'a> {
-    props: &'a Props,
+///
+/// Owns its `Props` (matching the stateless-Api convention shared with
+/// `separator`, `visually_hidden`, `landmark`, etc. — see
+/// `foundation/10-component-spec-template.md` §4.1.2).
+#[derive(Clone, Debug)]
+pub struct Api {
+    props: Props,
 }
 
-impl<'a> Api<'a> {
-    pub fn new(props: &'a Props) -> Self {
+impl Api {
+    pub const fn new(props: Props) -> Self {
         Self { props }
     }
 
-    /// Root <kbd> element attributes.
+    pub const fn props(&self) -> &Props { &self.props }
+    pub fn id(&self) -> &str { &self.props.id }
+    pub fn shortcut(&self) -> &str { &self.props.shortcut }
+    pub const fn platform_aware(&self) -> bool { self.props.platform_aware }
+    pub const fn is_mac(&self) -> bool { self.props.is_mac }
+    pub const fn decorative(&self) -> bool { self.props.decorative }
+
+    /// Root `<kbd>` element attributes.
+    ///
+    /// Always emits `data-ars-scope="keyboard"` and `data-ars-part="root"`.
+    /// When `decorative` is `true`, also emits `aria-hidden="true"` so
+    /// assistive technology skips the purely-visual shortcut hint.
     pub fn root_attrs(&self) -> AttrMap {
         let mut attrs = AttrMap::new();
         let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Root.data_attrs();
-        attrs.set(scope_attr, scope_val);
-        attrs.set(part_attr, part_val);
+        attrs.set(scope_attr, scope_val).set(part_attr, part_val);
+        if self.props.decorative {
+            attrs.set(HtmlAttr::Aria(AriaAttr::Hidden), "true");
+        }
         attrs
     }
 
@@ -78,7 +104,7 @@ impl<'a> Api<'a> {
     }
 }
 
-impl ConnectApi for Api<'_> {
+impl ConnectApi for Api {
     type Part = Part;
 
     fn part_attrs(&self, part: Part) -> AttrMap {
@@ -94,15 +120,60 @@ impl ConnectApi for Api<'_> {
 // to `false` (non-Mac). Client-side hydration updates the display if the
 // actual platform differs.
 
-/// Returns the localized display name for a modifier key.
-fn localized_modifier(key: &str, locale: Option<&Locale>) -> String {
-    let lang = locale.map(|l| l.language()).unwrap_or("en");
-    match (key, lang) {
-        ("Ctrl", "de") => "Strg",
-        ("Shift", "de") => "Umschalt",
-        ("Shift", "fr") => "Maj",
-        _ => key,
-    }.to_string()
+/// Modifier keys recognised by `format_platform_shortcut`.
+///
+/// Strongly typed so a typo in the formatter or in the localisation
+/// table is a compile error rather than a silent fall-through to the
+/// "unknown token" branch.
+#[derive(Clone, Copy)]
+enum Modifier { Mod, Shift, Alt, Ctrl, Meta }
+
+impl Modifier {
+    fn parse(token: &str) -> Option<Self> {
+        Some(match token {
+            "Mod" => Self::Mod,
+            "Shift" => Self::Shift,
+            "Alt" => Self::Alt,
+            "Ctrl" => Self::Ctrl,
+            "Meta" => Self::Meta,
+            _ => return None,
+        })
+    }
+
+    const fn mac_symbol(self) -> &'static str {
+        match self {
+            // `Mod` and `Meta` both render as `⌘` on macOS.
+            Self::Mod | Self::Meta => "⌘",
+            Self::Shift => "⇧",
+            Self::Alt => "⌥",
+            Self::Ctrl => "⌃",
+        }
+    }
+
+    const fn english_label(self) -> &'static str {
+        match self {
+            // `Mod` expands to `Ctrl` on non-mac platforms.
+            Self::Mod | Self::Ctrl => "Ctrl",
+            Self::Shift => "Shift",
+            Self::Alt => "Alt",
+            Self::Meta => "Win",
+        }
+    }
+}
+
+/// Returns the localised display name for a modifier key on non-macOS
+/// platforms. Implements the §3.2 modifier-localisation table.
+fn localized_modifier(modifier: Modifier, locale: Option<&Locale>) -> String {
+    let lang = locale.map_or("en", Locale::language);
+    match (modifier, lang) {
+        (Modifier::Mod | Modifier::Ctrl, "de") => "Strg",
+        (Modifier::Shift, "de") => "Umschalt",
+        (Modifier::Shift, "fr") => "Maj",
+        (Modifier::Shift, "es") => "Mayús",
+        (Modifier::Shift, "it") => "Maiusc",
+        _ => modifier.english_label(),
+    }
+    .to_string()
 }
 
 /// Maps generic modifier tokens to platform-specific symbols.
@@ -110,22 +181,20 @@ fn localized_modifier(key: &str, locale: Option<&Locale>) -> String {
 fn format_platform_shortcut(shortcut: &str, is_mac: bool, locale: Option<&Locale>) -> String {
     shortcut
         .split('+')
-        .map(|part| match (part, is_mac) {
-            ("Mod", true) => "⌘".to_string(),
-            ("Mod", false) => localized_modifier("Ctrl", locale),
-            ("Shift", true) => "⇧".to_string(),
-            ("Shift", false) => localized_modifier("Shift", locale),
-            ("Alt", true) => "⌥".to_string(),
-            ("Alt", false) => localized_modifier("Alt", locale),
-            ("Ctrl", true) => "⌃".to_string(),
-            ("Meta", true) => "⌘".to_string(),
-            ("Meta", false) => "Win".to_string(),
-            (key, _) => key.to_string(),
+        .map(|part| match (Modifier::parse(part), is_mac) {
+            (Some(modifier), true)  => modifier.mac_symbol().to_string(),
+            (Some(modifier), false) => localized_modifier(modifier, locale),
+            (None, _)               => part.to_string(),
         })
         .collect::<Vec<_>>()
         .join(if is_mac { "" } else { "+" })
 }
 ```
+
+Adapter consumers may also construct `Props` through the chained-builder
+form (`Props::new().shortcut("Mod+S").platform_aware(true).is_mac(true)`),
+which mirrors the convention used by every other stateless utility in
+`crates/ars-components/src/utility/`.
 
 ## 2. Anatomy
 
@@ -145,8 +214,8 @@ Keyboard
 ### 3.1 ARIA Roles, States, and Properties
 
 - The `<kbd>` element is semantically appropriate for keyboard input text (HTML spec).
-- When used inside Menu items, the parent `Shortcut` part already sets `aria-hidden="true"` — no duplication needed.
-- When used standalone, the `<kbd>` text is announced by screen readers naturally. If the shortcut is purely decorative, the consumer should add `aria-hidden="true"` to the parent.
+- When used inside Menu items, the parent `Shortcut` part already sets `aria-hidden="true"` on its wrapper — keep `Props::decorative = false` here so the agnostic core does not duplicate the attribute.
+- When used standalone, the `<kbd>` text is announced by screen readers naturally. If the shortcut is purely decorative (e.g., the action is already announced through the parent button's accessible name), set `Props::decorative = true` and the agnostic core emits `aria-hidden="true"` directly on the `<kbd>`.
 - Integration with `menu::Item.aria_keyshortcuts` for programmatic shortcut announcement is the consumer's responsibility (already defined in `selection/menu.md` §6).
 
 ### 3.2 Locale Handling
@@ -191,6 +260,18 @@ view! {
 }
 ```
 
+**Decorative shortcut hint** (the action is already announced through the
+parent button's accessible name; the `<kbd>` is a visual reminder only):
+
+```rust
+view! {
+    <button aria-label="Save document">
+        "Save"
+        <Keyboard shortcut="Mod+S" platform_aware=true decorative=true />
+    </button>
+}
+```
+
 ## 5. Relationship to `Menu` `Shortcut`
 
 The `Menu` component's `Shortcut` part (`selection/menu.md` §6) handles the **layout and accessibility** of shortcut hints within menu items. The `Keyboard` component handles the **rendering and formatting** of the shortcut text itself. They compose: `Keyboard` renders inside the `Menu`'s `Shortcut` slot.
@@ -201,35 +282,34 @@ The `Menu` component's `Shortcut` part (`selection/menu.md` §6) handles the **l
 
 ### 6.1 Props
 
-| Feature        | ars-ui           | React Aria | Notes                                          |
-| -------------- | ---------------- | ---------- | ---------------------------------------------- |
-| Shortcut text  | `shortcut`       | children   | RA uses children; ars-ui uses a string prop    |
-| Platform-aware | `platform_aware` | --         | ars-ui addition for auto-mapping modifier keys |
-| Separator      | `separator`      | --         | ars-ui addition for customizable key separator |
+| Feature        | ars-ui           | React Aria | Notes                                                                           |
+| -------------- | ---------------- | ---------- | ------------------------------------------------------------------------------- |
+| Shortcut text  | `shortcut`       | children   | RA uses children; ars-ui uses a string prop                                     |
+| Platform-aware | `platform_aware` | --         | ars-ui addition for auto-mapping modifier keys                                  |
+| Decorative     | `decorative`     | --         | ars-ui addition: emits `aria-hidden="true"` on the root for purely-visual hints |
 
 **Gaps:** None.
 
 ### 6.2 Anatomy
 
-| Part | ars-ui                 | React Aria           | Notes                              |
-| ---- | ---------------------- | -------------------- | ---------------------------------- |
-| Root | `Root` (`<kbd>`)       | `Keyboard` (`<kbd>`) | Both libraries                     |
-| Key  | `Key` (nested `<kbd>`) | (nested `<kbd>`)     | Both render nested `<kbd>` per key |
+| Part | ars-ui           | React Aria           | Notes          |
+| ---- | ---------------- | -------------------- | -------------- |
+| Root | `Root` (`<kbd>`) | `Keyboard` (`<kbd>`) | Both libraries |
 
 **Gaps:** None.
 
 ### 6.3 Features
 
-| Feature                   | ars-ui | React Aria |
-| ------------------------- | ------ | ---------- |
-| Semantic `<kbd>` elements | Yes    | Yes        |
-| Nested `<kbd>` per key    | Yes    | Yes        |
-| Platform modifier mapping | Yes    | --         |
+| Feature                     | ars-ui | React Aria |
+| --------------------------- | ------ | ---------- |
+| Semantic `<kbd>` elements   | Yes    | Yes        |
+| Platform modifier mapping   | Yes    | --         |
+| Locale-aware modifier names | Yes    | --         |
 
 **Gaps:** None.
 
 ### 6.4 Summary
 
 - **Overall:** Full parity -- ars-ui is a superset.
-- **Divergences:** ars-ui adds platform-aware modifier mapping (`Mod` -> platform symbol) and configurable separator. React Aria's Keyboard is a simpler `<kbd>` renderer.
+- **Divergences:** ars-ui adds platform-aware modifier mapping (`Mod` → platform symbol), locale-aware modifier names (de/fr/es/it), and the `decorative` prop. React Aria's Keyboard is a simpler `<kbd>` renderer with no platform or locale awareness. Both render the formatted shortcut as a single string inside one `<kbd>` rather than splitting into nested per-key elements.
 - **Recommended additions:** None.

--- a/spec/dioxus-components/utility/focus-ring.md
+++ b/spec/dioxus-components/utility/focus-ring.md
@@ -170,7 +170,7 @@ pub struct FocusRingSketchProps {
 
 #[component]
 pub fn FocusRing(props: FocusRingSketchProps) -> Element {
-    let api = focus_ring::Api::new(focus_ring::Context { within: false, focus_visible: false }, focus_ring::Props::default());
+    let api = focus_ring::Api::new(focus_ring::Context { focus_visible: false }, focus_ring::Props::default());
     rsx! { span { ..api.root_attrs(), {props.children} } }
 }
 ```

--- a/spec/dioxus-components/utility/keyboard.md
+++ b/spec/dioxus-components/utility/keyboard.md
@@ -24,6 +24,11 @@ pub struct KeyboardProps {
     pub platform_aware: bool,
     #[props(default = false)]
     pub is_mac: bool,
+    /// When `true`, the rendered `<kbd>` is purely decorative and the
+    /// agnostic core emits `aria-hidden="true"` on the root. See core
+    /// `keyboard::Props::decorative` for usage guidance.
+    #[props(default = false)]
+    pub decorative: bool,
     #[props(optional)]
     pub locale: Option<Locale>,
 }

--- a/spec/leptos-components/utility/focus-ring.md
+++ b/spec/leptos-components/utility/focus-ring.md
@@ -149,7 +149,7 @@ Leptos can derive focus-visible attrs reactively.
 ```rust
 #[component]
 pub fn FocusRing(children: Children) -> impl IntoView {
-    let api = focus_ring::Api::new(focus_ring::Context { within: false, focus_visible: false }, focus_ring::Props::default());
+    let api = focus_ring::Api::new(focus_ring::Context { focus_visible: false }, focus_ring::Props::default());
     view! { <span {..api.root_attrs()}>{children()}</span> }
 }
 ```


### PR DESCRIPTION
## Summary

Implements the framework-agnostic core for two stateless utility components in `ars-components` (epic #10, task #203):

- **`FocusRing`** (`spec/components/utility/focus-ring.md`) — stateless attribute mapper that exposes `data-ars-focus-visible` to CSS so adapters can style focus rings conditionally on keyboard-vs-pointer modality. Modality tracking lives in `ars-dom::ModalityManager` (already implemented); this crate only renders the resulting attribute.
- **`Keyboard`** (`spec/components/utility/keyboard.md`) — renders shortcut text inside a semantic `<kbd>` element with platform-aware modifier mapping (`Mod` → `⌘` on macOS, `Ctrl`/`Strg`/etc. elsewhere) and locale-aware modifier names (`de`/`fr`/`es`/`it`).

## Spec changes (synchronised with code per CLAUDE.md spec/code mismatch rule)

- **`keyboard.md`**: adds `decorative` prop (emits `aria-hidden=\"true\"`), `Default` derive, builder convention, owned `Api` form (matches every other stateless utility), `Modifier` enum so a typo in the formatter or localisation table is a compile error, full §3.2 locale table coverage, drops never-implemented `separator` prop and `Key` part rows from §6 parity tables.
- **`focus-ring.md`**: drops `Context::within` (the duplicated routing flag — `Props::within` is now the single source of truth), drops manual `impl Default` (replaced with derive), drops never-implemented `auto_focus` parity row.
- **Adapter specs** (`leptos-components/utility/focus-ring.md`, `dioxus-components/utility/{focus-ring,keyboard}.md`): updated to match the new core API surface; Dioxus `KeyboardProps` gains the `decorative` field with `#[props(default = false)]`.

## Test plan

- [x] `cargo xci` passes all 20 steps locally (fmt, check, clippy, unit, i18n-browser, dom-browser, release, integration, adapter, adapter-parity, coverage, snapshot-count, spec-compile-snippets, error-variant-coverage, feature-matrix-{core,i18n,subsystems,leptos,dioxus}, mutual-exclusion)
- [x] 100% line / region / function coverage on both new files
- [x] `cargo mutants` catches 54/54 viable mutations on both files (one survivor — `Api::is_mac -> bool with false` — was caught and fixed during local scout)
- [x] Per-component snapshot tests for every output-affecting branch (committed `.snap` fixtures, `cargo insta test --unreferenced=reject` clean)
- [x] Cross-branch inequality assertions, edge-case tests for empty/malformed shortcut input, locale-invariance test for the macOS path, `Send + Sync` compile-time assertions, and `Clone` round-trip coverage on every public type

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)