### PR TITLE
[codex] Upgrade upload-artifact to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,7 +269,7 @@ jobs:
         run: cargo xtask ci coverage
       - name: Upload coverage diagnostics
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-diagnostics
           path: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -203,7 +203,7 @@ jobs:
       # passing run are valuable feedback for follow-up tightening.
       - name: Upload mutation report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: mutants-${{ matrix.name }}
           path: mutants.out/mutants.out/


### PR DESCRIPTION
## Summary

- Upgrade the coverage diagnostics upload in CI from `actions/upload-artifact@v4` to `@v7`.
- Upgrade the Nightly mutation report upload from `actions/upload-artifact@v4` to `@v7`.
- Keep the Nightly `#22` mutation diagnosis scoped: the failed `Mutation Tests (a11y)` job was interrupted by runner shutdown and did not produce confirmed missed mutants.

## Why

GitHub Actions now warns that Node.js 20 actions are deprecated. `actions/upload-artifact@v4` declares `runs.using: node20`; upstream `actions/upload-artifact@v7` declares `runs.using: node24`. Other workflow actions were checked and did not require a Node 24-related bump.

## Validation

- `rg -n "actions/upload-artifact@v4" .github/workflows` -> no output
- `rg -n "actions/upload-artifact@v7" .github/workflows` -> two expected matches
- `cargo xtask spec validate` -> passed, `Validated 340 files (components + adapters). All checks passed.`
- `cargo mutants -p ars-a11y --output /tmp/ars-ui-a11y-mutants-local` -> previously completed locally with `509 mutants tested in 18m: 478 caught, 31 unviable`, `0` missed, `0` timeouts

`cargo xci` was run and stopped at the existing `i18n-browser` step on `provider::provider_web_intl_tests::web_intl_convert_date_recovers_chinese_leap_month_ordinal`. A focused rerun with the repo chromedriver reproduced the same unrelated failure: `153 passed; 1 failed`.