### PR TITLE
feat(components): implement Highlight agnostic core

### DIFF
--- a/.agents/skills/post-implementation-audit/SKILL.md
+++ b/.agents/skills/post-implementation-audit/SKILL.md
@@ -1,0 +1,297 @@
+---
+name: post-implementation-audit
+description: MANDATORY after every implementation task — runs three sequential audits on the new code (spec/impl drift, iterative "anything missing?", test coverage) and lands every finding in the same PR before the user-review step. Invoke as soon as an implementation task's named tests pass, OR when any of these phrases appears: "ready to present", "implementation is complete", "named tests pass", "before opening the PR", "ready for review". Skipping this audit leaves spec drift, untested defensive code, missing conventions, and silent contract violations in the merged PR.
+---
+
+# Post-implementation audit
+
+This skill is the bridge between *"the named tests pass"* and *"the user reviews the diff"*. It exists because the initial implementation of any task is usually correct on its surface acceptance criteria but quietly drifts from the spec, leaves untested defensive code, ships APIs that diverge from convention, or carries a fold-vs-lowercase mistake that won't surface until production. Running these audits before user-review collapses three reviewer round-trips into one.
+
+The skill is mandatory per CLAUDE.md "Development Workflow" step 7 — run it after implementing any user-requested task (feature, bug fix, refactor) and before presenting the final result for user review.
+
+## Quick flow
+
+The audit is strictly linear — no branching, just a loop in Phase 2:
+
+```
+Phase 1 (spec/impl drift audit)
+   └─→ land all Phase 1 findings
+        └─→ Phase 2 (iterative "anything missing?")
+              ├─→ Round 1: surface findings → land all
+              ├─→ Round 2: surface findings → land all
+              └─→ keep looping until 2 consecutive clean rounds (minimum 2 rounds total)
+                   └─→ Phase 3 (test coverage)
+                        └─→ land all Phase 3 findings
+                             └─→ Final verification suite
+                                  └─→ Hand off to user (CLAUDE.md step 8)
+```
+
+The body below walks through each phase in order. Read top-to-bottom; the structure mirrors the execution order.
+
+## Operating principle: no deferral
+
+**Every recommendation each audit phase produces lands in *this* PR.** Don't open follow-up issues. Don't TODO-flag. Don't promise a future PR or a future sprint. Don't quietly skip a finding because it feels like scope creep.
+
+If a finding is genuinely out of scope (e.g., requires a workspace-wide refactor touching 50+ files), surface it explicitly to the user with that reasoning visible — but the default is to land everything. This constraint is what makes the audit valuable: a deferred finding is a guarantee that the original implementation's bias survives into `main`, where it costs ten times as much to undo.
+
+The user will tell you "land it all". Anticipate that, and just do it.
+
+## Three sequential phases
+
+Run the phases **in order**. Each phase fully completes (audit → land all findings → re-verify) before the next begins.
+
+---
+
+### Phase 1 — spec/implementation drift audit
+
+Compare the implementation against the authoritative spec (`spec/components/<category>/<component>.md` plus any foundation specs it transitively depends on) section-by-section. For every drift, propose the **best outcome independent of which side is currently right**. Sometimes the spec wins, sometimes the impl wins, sometimes the right answer is neither.
+
+The canonical entry-prompt for this phase (use this wording when the user asks you to start the audit explicitly):
+
+> "Now let's do an audit on how well our new code follows our spec. Do an in-depth check for spec drift and suggest recommendations for each finding. In those recommendations, disregard both the spec and the current implementation as defaults — the recommendation should be the best outcome possible. Sometimes that's the spec, sometimes the implementation, sometimes a mix, sometimes a totally different thing."
+
+#### Precondition: both files must exist
+
+Before reading anything, verify the touched implementation has a corresponding spec file at `spec/components/<category>/<name>.md` (or the relevant `spec/foundation/` path for foundation-layer changes). If the spec is missing, **stop the audit and surface this to the user** — an unspecced module is a planning failure that should be resolved (write the spec, or split the change) before auditing, not papered over by this skill. Likewise, if the implementation file referenced by the issue is missing or empty, surface that as a precondition failure rather than auditing against an empty diff.
+
+#### Procedure
+
+1. Read the spec file end-to-end (use `Read` with no offset/limit so you have the whole thing).
+2. Read the implementation file end-to-end (same).
+3. Walk every public surface declared in the spec — every struct, enum, function, method, derive list, default value, constant, public re-export. For each:
+   - Does the spec define it? Does the impl match exactly?
+   - Are there extras in the impl not in the spec? Are they justified?
+   - Are there spec items the impl skipped? Are they critical?
+   - **Does the spec's prose match the impl's actual behavior?** This is the silent-contract-violation class — words that mean something specific in the spec but were implemented as something close-but-different (e.g., "case folding" in the spec but `to_lowercase` in the impl).
+4. For each finding, write up:
+   - What the spec says, with line numbers
+   - What the impl does, with line numbers
+   - Why it drifted (often a tradeoff the implementer made under acceptance-criteria pressure)
+   - **Best-outcome recommendation** — independent of which side is currently right
+5. Group findings by severity (High / Medium / Low) and present as a table to the user.
+6. Land all of them. Update the spec where the impl is right, update the impl where the spec is right, do both where neither was right, change *only* the spec wording (and add tests proving the new wording) when the contract was subtly wrong all along.
+
+#### Special case: both the spec and the implementation are wrong
+
+A small fraction of drift findings are *not* "one side is right, the other drifted" — both sides are incorrect, incomplete, or built on a flawed premise. This is rare but real (the task #204 eszett case is an example: the spec implied `ß ↔ ss` equivalence, the impl used `to_lowercase`, but neither matched the actual TR21 case-folding semantics needed). Handle this case differently from routine drift:
+
+1. **Escalate to the user via `AskUserQuestion`** — don't unilaterally pick a "best outcome" when no precedent exists. A both-wrong case is a real design decision, not a routine drift fix; the user owns the call.
+2. **Once the user picks a direction**, land *all three* together in this same PR: the new spec wording, the new implementation, and the tests proving the new design. Skipping any of the three leaves a different kind of drift behind.
+3. **Write the test first** (TDD per CLAUDE.md), watch it fail under the old code, then change the impl, then update the spec to describe what the new tests assert.
+
+#### Output table format
+
+| Finding ID | Severity | What spec says | What impl does | Best outcome | Where to land |
+|---|---|---|---|---|---|
+| H1 | High | … | … | … | spec §X / impl `path:line` |
+
+End with a disposition summary: *"N spec-only changes, M impl-only changes, K both, Q status-quo-was-correct."*
+
+---
+
+### Phase 2 — iterative "anything else missing?" passes
+
+Once Phase 1 findings are landed, the next blind spot is the surface Phase 1 didn't look at: adapter specs, feature flags, prelude exports, framework wiring, foundation patterns that deserve promotion, catalog/manifest entries. This phase is **iterative** — keep asking "anything else?" until two consecutive rounds find nothing new.
+
+The canonical entry-prompt (one per round):
+
+> "Any other improvement that we might still be missing?"
+
+#### Surfaces to actively check each round
+
+This is a non-exhaustive checklist. Each round, walk through it explicitly:
+
+- **Adapter specs** at `spec/leptos-components/<category>/<component>.md` and `spec/dioxus-components/<category>/<component>.md` — do they describe the new core surface accurately? Are their canonical implementation sketches up-to-date with the actual `Api` / function signatures? Do they reference the right helper methods (e.g., `Api::root_attrs()`) instead of hardcoded data attribute strings?
+- **Adapter feature wiring** in `crates/ars-leptos/Cargo.toml` and `crates/ars-dioxus/Cargo.toml` — does the adapter's `icu4x` / `web-intl` feature need to enable any new `ars-components/<feature>` flag for the new code to be reachable?
+- **Adapter `prelude.rs`** — does the new public API need to flow through? (Only if an adapter wrapper exists for the new component; if not, defer to the adapter task.)
+- **Workspace `spec/manifest.toml`** and **`foundation/02-component-catalog.md`** — is the new component registered and statused? (For brand-new components only.)
+- **Foundation specs** (`spec/foundation/00-*` through `spec/foundation/11-*`) — does the new code expose a missing shared abstraction worth promoting? CLAUDE.md `spec/CLAUDE.md` says: *"If an adapter-specific implementation exposes a missing shared abstraction, promote that abstraction into the appropriate foundation/shared spec."*
+- **New crate dependencies** — was the user notified per CLAUDE.md's "Do not add a new dependency crate without explicit user approval first" rule? Did the implementation add `i18n`-style feature flags that warrant a CLAUDE.md note?
+- **`.cargo/mutants.toml`** — are any new equivalent mutations documented with justifications? (Phase 3 will validate this; surface it here if a mutation that *should* be equivalent isn't documented yet.)
+
+#### Termination
+
+Stop when:
+
+- Two consecutive rounds surface no new findings, **OR**
+- Three rounds have been completed and the remaining findings are honestly out-of-scope (genuine workspace-wide refactors that would derail this PR).
+
+Do **not** stop after one clean round — the second round nearly always surfaces items the first ignored because they felt out-of-scope. With the "no deferral" rule active, they're back in scope.
+
+#### Output per round
+
+A list of findings with the same "best outcome" framing as Phase 1, plus an explicit statement at the end: *"That's everything I can find this round. Want me to do another?"* — knowing the answer will be yes for at least one more round.
+
+---
+
+### Phase 3 — test coverage audit
+
+By this point the code is convention-aligned and well-specced. Now check the **test surface** — both depth (line / branch / mutation coverage) and breadth (does every test type that *should* exist for this kind of change exist?).
+
+The canonical entry-prompt:
+
+> "How good is our test coverage here, by looking at the code paths, checking the coverage report and considering the many kinds of tests that we are intending to have (including snapshot tests, proptests, and e2e tests)? Can it be improved?"
+
+#### Test types and what each catches
+
+| Test type | What it catches | How to assess for the new code |
+|---|---|---|
+| **Unit tests** (inline `#[cfg(test)]`) | Logic + edge cases on the named acceptance criteria | List every public API + every edge case the spec describes; cross-reference with the test list |
+| **Snapshot tests** (insta) | `AttrMap` / chunk-output shape regressions | Check coverage of every anatomy part and every output-affecting prop / state / context branch |
+| **Property tests** (proptest) | Invariant violations across the input space | Check that invariants are non-trivial (roundtrip, idempotence, no-adjacent-X, etc.) and the input strategy is broad enough to actually exercise edge locales / multi-byte / large inputs |
+| **Mutation tests** (cargo-mutants) | Tests that *exist* but don't actually constrain behavior | Run `cargo mutants -p <crate> -f <file>` and triage every `MISSED` |
+| **Doc tests** | Public-API examples broken by future changes | Check `///` blocks for at least one `# Examples` block on the canonical entry point |
+| **Spec-conformance tests** | Anatomy drift between spec and impl | Check `crates/ars-components/tests/spec_conformance/*.rs` for an entry covering the new component's `Part` enum |
+| **Code coverage** (cargo llvm-cov + xtask wasm path) | Unreachable / under-tested code; threshold drift | Use the right command for the crate (see "Procedure" below) — bare `cargo llvm-cov` does **not** measure adapter wasm code paths. Always finish with `cargo xtask coverage check-all --file <lcov>` to enforce the same thresholds CI does. |
+| **E2E / browser tests** (wasm-bindgen-test) | DOM-level behavior in the adapter | N/A for agnostic-core changes. Required when the change touches `ars-leptos`, `ars-dioxus`, `ars-dom`, or `ars-i18n` (`web-intl` path); these run via `cargo xtask test` or the adapter test-harness crates and execute in a browser via `wasm-bindgen-test`. Treat coverage from the wasm path (`cargo xtask coverage wasm`) as the source of truth for these — not the host-target llvm-cov number. |
+
+#### Procedure
+
+1. **Coverage report.** The command depends on which crate the change touches — this workspace measures host-target and wasm32 paths separately because adapter code (`ars-leptos`, `ars-dioxus`, `ars-dom`, the `ars-i18n` `web-intl` path, the adapter test harnesses) has `target_arch = "wasm32"` / `feature = "web"` code that bare host-target `cargo llvm-cov` cannot reach.
+
+   **For native-only crates** (`ars-components`, `ars-collections`, `ars-core`, `ars-forms`, `ars-interactions`, `ars-a11y`, `xtask`):
+   ```bash
+   cargo llvm-cov test -p <crate> --features <relevant> --lib --no-fail-fast --text -- <module>::
+   ```
+
+   **For adapter crates / `web-intl` paths** (`ars-leptos`, `ars-dioxus`, `ars-dom`, `ars-test-harness-leptos`, `ars-test-harness-dioxus`, or `ars-i18n` when the change is in the `web-intl` feature gate):
+   ```bash
+   cargo xtask coverage wasm \
+     --package <crate> \
+     --feature <feat1> --feature <feat2> \
+     --file wasm.lcov.info
+   ```
+   (`--feature` is singular and repeatable, NOT `--features` — it mirrors cargo's `--feature` convention; use `--no-default-features` to drop defaults.) This uses `wasm-bindgen-test`'s experimental coverage recipe with LLVM 22 / `clang-22` (the same recipe CI nightly runs via `cargo xtask ci coverage`). The bare `cargo llvm-cov` command will silently report `0.00%` for the wasm-gated code paths, which is *not* the same as having no coverage — it means *unmeasured*. Don't trust low numbers on adapter crates from the native path.
+
+   **For a change that touches both native and wasm paths** (e.g., a new ars-i18n helper consumed from both backends, or a refactor in `ars-dom` that affects native callers):
+   ```bash
+   # Generate the native lcov (workspace, excluding wasm-only crates):
+   cargo llvm-cov --workspace \
+     --exclude ars-leptos --exclude ars-dioxus \
+     --exclude ars-test-harness-leptos --exclude ars-test-harness-dioxus \
+     --exclude ars-derive --exclude xtask \
+     --lcov --output-path native.lcov.info
+
+   # Generate the wasm lcov for each adapter target you touched:
+   cargo xtask coverage wasm --package <wasm-package> --feature <feat> --file wasm.lcov.info
+
+   # Merge without double-counting duplicate lines (each `--file` adds an input):
+   cargo xtask coverage merge \
+     --file native.lcov.info \
+     --file wasm.lcov.info \
+     --output merged.lcov.info
+
+   # Enforce per-crate spec-defined thresholds (same gate CI runs):
+   cargo xtask coverage check-all --file merged.lcov.info
+   ```
+
+   The per-crate thresholds (line% / branch%) are encoded in `xtask::coverage::default_thresholds()` and include the wasm targets. `cargo xtask coverage check-all` is the same gate CI enforces, so a green local run guarantees green CI on the coverage step.
+
+   Read the per-line annotated output from the `--text` invocations. Every `^0` marker is an unhit branch — investigate each one. Categorize as: real test gap / equivalent defensive guard / unreachable dead code. **Expected non-gaps:** no-op callback closures in tests (e.g., `|_| {}`) are intentionally uncovered and not a real gap — CLAUDE.md calls this out explicitly.
+
+   **Not measured by either path:** `ars-derive` (proc-macro, runs in the compiler — exercised indirectly via `crates/ars-core/tests/derive_contract.rs`). Don't expect coverage numbers here.
+
+2. **Mutation testing.** Run:
+   ```bash
+   cargo mutants -p <crate> -f <file>
+   ```
+   For each `MISSED` line, decide:
+   - **Real test gap** → add a test that kills the mutation (often a positive-direction assertion the existing tests skipped).
+   - **Equivalent mutation** → add a regex to `.cargo/mutants.toml` `exclude_re` with a written justification explaining *why* the mutation cannot change observable behavior.
+   - **Defensive code that's truly unreachable** → consider deleting the code. This is often the cleanest fix and is the right answer for unreachable post-filter guards.
+
+3. **Test-type breadth audit.** Walk the table above. For each test type, ask: *"Does this kind of change need this kind of test, and do we have one?"* Examples:
+   - New utility component with an anatomy table → spec-conformance test required
+   - New public function → doc test with `# Examples` required
+   - New invariants on a computation pipeline → proptest invariants strongly recommended
+   - New `AttrMap` helpers → snapshot tests for each branch required
+
+4. **Cumulative assessment.** Present the before/after metrics in a table:
+
+| Metric | Before this phase | After this phase |
+|---|---|---|
+| Lines covered | x% | y% |
+| Mutations caught | x/total | y/total |
+| Unit tests | N | M |
+| Doc tests | N | M |
+| Spec-conformance test | yes/no | yes/no |
+
+#### Output
+
+A list of gaps with concrete reproducers (specific test inputs that trigger the missed branch). For each gap, classify the disposition (real-gap-add-test / equivalent-mutation-skip / dead-code-remove). End with a clear *"land all"* and the verification commands to confirm.
+
+#### Anti-pattern: chasing 100% line coverage
+
+The goal is **not** "100% line coverage at any cost". The goal is *"no surviving mutations, no unreachable defensive code, every test type that should exist does exist"*. A 99% line-coverage report with all mutations caught is a stronger position than a 100% line-coverage report with three surviving mutations. If the last 1% of uncovered code is a genuinely unreachable defensive guard, document it in `mutants.toml` and move on.
+
+---
+
+## After the three phases
+
+Run the full verification suite one final time before handing off to the user:
+
+```bash
+# 1. Unit + integration tests, both feature-on and feature-off variants
+cargo test -p <crate> --features <relevant> --all-targets
+cargo test -p <crate> --lib                       # without the optional features
+
+# 2. Workspace clippy (must be -D warnings clean)
+cargo clippy --workspace --all-targets --all-features --exclude ars-i18n -- -D warnings
+
+# 3. Backend matrices for any feature-gated code
+cargo clippy -p ars-i18n --no-default-features --features std,icu4x --all-targets -- -D warnings
+cargo clippy -p ars-i18n --no-default-features --features std,web-intl --all-targets -- -D warnings
+
+# 4. Docs build (0 new warnings on the changed crate)
+cargo doc -p <crate> --no-deps --all-features
+
+# 5. Spec validation + snippet check
+cargo xtask spec validate
+cargo test -p xtask --test spec_corpus_compile_snippets
+
+# 6. Snapshot orphan check
+cargo insta test --workspace --features <relevant> --unreferenced=reject
+
+# 7. Mutation re-run (must be 0 missed)
+cargo mutants -p <crate> -f <file>
+
+# 8. Coverage thresholds — uses the same gate CI enforces. The recipe
+#    depends on which crate the change touches: native-only changes can
+#    use `cargo llvm-cov ... --lcov`; changes that touch adapter code or
+#    `web-intl` paths require `cargo xtask coverage wasm` + `merge` first
+#    (see Phase 3 above). Then:
+cargo xtask coverage check-all --file lcov.info
+
+# 9. Adapter builds reachable with feature wiring
+cargo build -p ars-leptos --features icu4x
+cargo build -p ars-dioxus --features icu4x,web
+```
+
+Then write **one consolidated user summary** covering all three phases' findings + the verification table. Hand off for user review per CLAUDE.md workflow step 8 (which was the old step 7 before this skill was inserted).
+
+## Anti-patterns
+
+- **Deferring** any finding ("we can fix that in a follow-up"). This is the rule the user set explicitly. Breaking it makes the audit ceremonial.
+- **Loading the user with options mid-phase.** Make a clear best-outcome recommendation. Only escalate to `AskUserQuestion` when there's a genuine judgment call the user must make (e.g., behavior choices with real tradeoffs, not implementation details).
+- **Skipping rounds of Phase 2** because the first round was clean. The second round nearly always finds something the first ignored.
+- **Treating coverage % as the goal.** The goal is mutation-killed and breadth-complete, not a number.
+- **Inventing cosmetic edits** the audits didn't surface. If a phase doesn't find a real finding, don't fabricate one — say "this round found nothing" and proceed.
+- **Re-running tests after every micro-edit** during a phase. Land a batch of related findings, then verify, then move on.
+- **Forgetting to update the named-tests file** when a new test exposes a real bug fixed in the same phase. The fix and the test land together.
+
+## What this skill is not
+
+- A code-review skill. Code review (style, naming, simplification) belongs to `pr-review-toolkit:code-reviewer` and runs after the PR is opened.
+- A pre-implementation skill. Before implementing, `feature-dev:feature-dev` and `superpowers:writing-plans` handle planning.
+- A way to revisit acceptance criteria. The acceptance criteria are fixed by the GitHub issue. This skill assumes they're already met.
+
+## Worked example — task #204
+
+The flow this skill encodes was validated on GitHub issue #204 (`task: Implement Highlight agnostic core`). The initial implementation passed all 8 named acceptance-criterion tests on first try. Then:
+
+- **Phase 1** surfaced 16 drift findings, including a silent contract violation (the spec said *"Unicode case folding"* but the impl used `to_lowercase` — they aren't equivalent: under `to_lowercase`, query `"ss"` does not match text `"ß"`, violating the spec's explicit eszett contract). Fix: add `ars_i18n::case_fold`, switch the matching pipeline, rewrite the German test to assert the actual three-direction equivalence.
+- **Phase 2 round 1** surfaced 4 more items (adapter spec alignment, adapter feature wiring, roundtrip invariant test, proptest invariants).
+- **Phase 2 round 2** surfaced 3 more (a `case_fold` vs `to_lowercase` semantic gap, foundation/10 parametric-anatomy concept, cargo-mutants scout).
+- **Phase 3** surfaced 4 coverage gaps (dead `continue` branch, `merge_ranges` else branch, fold-expansion partial-match defense, spec-conformance test). Pushed line coverage from 98.67% to 99.91% with all 57 mutations caught.
+
+The cumulative effect: PR landed with one user review pass instead of three, and the spec contract (`ß ↔ ss`) is actually true instead of cosmetically true. That's the value this skill creates.

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -169,6 +169,29 @@ exclude_re = [
   'MissingProviderEffects>::now_ms -> u64 with 0',
   'MissingProviderEffects>::get_bounding_rect -> Option<Rect> with None',
 
+  # Highlight component: three equivalent mutations in the range
+  # construction / merge / chunk-emission pipeline. All three are
+  # defensive guards against zero-length original-text ranges produced
+  # when a case-fold expansion (e.g., `ß → ss`) is partially matched.
+  # No code path in the pipeline can produce a zero-length range that
+  # would survive the *next* filter, so weakening any single guard
+  # produces equivalent end-to-end behaviour (verified by output diff
+  # against the test corpus).
+  #
+  # - `< → <=` in push_contains_matches: would push (a, a) ranges; those
+  #   then get filtered by build_chunks's `end > start` check before
+  #   emitting a chunk.
+  # - `> → >=` in merge_ranges: when `end == last.1`, the body becomes
+  #   `last.1 = last.1`, a no-op.
+  # - `> → >=` in build_chunks: would push zero-length highlighted
+  #   chunks, but no upstream pipeline stage produces zero-length ranges
+  #   (push_contains_matches filters them; push_starts_with_match
+  #   requires `orig_end > 0`; push_fuzzy_matches always uses
+  #   `len_utf8() >= 1`).
+  'highlight\.rs:\d+:\d+: replace < with <= in push_contains_matches',
+  'highlight\.rs:\d+:\d+: replace > with >= in merge_ranges',
+  'highlight\.rs:\d+:\d+: replace > with >= in build_chunks',
+
   # Tabs `step_focus` checked-counter mutations and the Blur
   # short-circuit are equivalent in every reachable state. Regex is
   # line-number-agnostic so it survives source growth.

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -169,28 +169,33 @@ exclude_re = [
   'MissingProviderEffects>::now_ms -> u64 with 0',
   'MissingProviderEffects>::get_bounding_rect -> Option<Rect> with None',
 
-  # Highlight component: three equivalent mutations in the range
-  # construction / merge / chunk-emission pipeline. All three are
-  # defensive guards against zero-length original-text ranges produced
-  # when a case-fold expansion (e.g., `ß → ss`) is partially matched.
-  # No code path in the pipeline can produce a zero-length range that
-  # would survive the *next* filter, so weakening any single guard
-  # produces equivalent end-to-end behaviour (verified by output diff
-  # against the test corpus).
+  # Highlight component: two equivalent mutations in the merge /
+  # chunk-emission pipeline. These are dead-defensive guards — no
+  # upstream stage produces zero-length ranges (post-redesign with the
+  # `Normalised::source_end` mapping, the contains/starts-with scans
+  # never push degenerate ranges, and fuzzy always uses
+  # `len_utf8() >= 1`).
   #
-  # - `< → <=` in push_contains_matches: would push (a, a) ranges; those
-  #   then get filtered by build_chunks's `end > start` check before
-  #   emitting a chunk.
   # - `> → >=` in merge_ranges: when `end == last.1`, the body becomes
   #   `last.1 = last.1`, a no-op.
   # - `> → >=` in build_chunks: would push zero-length highlighted
-  #   chunks, but no upstream pipeline stage produces zero-length ranges
-  #   (push_contains_matches filters them; push_starts_with_match
-  #   requires `orig_end > 0`; push_fuzzy_matches always uses
-  #   `len_utf8() >= 1`).
-  'highlight\.rs:\d+:\d+: replace < with <= in push_contains_matches',
+  #   chunks, but no upstream stage produces zero-length ranges.
   'highlight\.rs:\d+:\d+: replace > with >= in merge_ranges',
   'highlight\.rs:\d+:\d+: replace > with >= in build_chunks',
+
+  # Highlight `push_contains_matches` overlap-aware scan: the three
+  # `+ → */-` mutants on `search_start + rel`, `start + normalised_query.len()`,
+  # and `search_start = start + advance` are *caught* via test
+  # non-termination — replacing the increment with `*` or `-` either
+  # pins `search_start` at 0 (e.g., `start * 1 == start`) or panics on
+  # usize underflow inside the `find` loop, both of which take the
+  # mutated process past cargo-mutants' 300s timeout. The mutations
+  # ARE detected (timeout != missed), but reporting them as timeouts
+  # without these excludes would otherwise wedge the CI matrix on a
+  # caught-but-slow result. Same pattern as the existing typeahead /
+  # toast manager loop-step excludes above.
+  'highlight\.rs:\d+:\d+: replace \+ with \* in push_contains_matches',
+  'highlight\.rs:\d+:\d+: replace \+ with - in push_contains_matches',
 
   # Tabs `step_focus` checked-counter mutations and the Blur
   # short-circuit are equivalent in every reachable state. Regex is

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,7 +27,11 @@ jobs:
           key: ${{ runner.os }}-cargo-nightly-proptest-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
-      - run: cargo test -p ars-core -p ars-components -- --ignored proptest
+      # `--features ars-components/i18n` is required so the feature-gated
+      # Highlight invariant proptest is actually compiled and run; without
+      # it the test silently disappears from this job even though the
+      # binary still compiles.
+      - run: cargo test -p ars-core -p ars-components --features ars-components/i18n -- --ignored proptest
 
   a11y-audit:
     name: Accessibility Audit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,11 +26,12 @@ For implementation tasks:
 4. Add or update the named tests first.
 5. Implement only the scope required to make those tests pass.
 6. If implementation changes the intended contract, update the relevant spec in the same task.
-7. Present the final result for user review before any commit.
-8. After user approval, run `cargo xci` locally and fix any failures before pushing anything to GitHub. During normal implementation, reserve `cargo xci` for substantial chunks of code or the final pre-PR gate; for small follow-up changes, run the focused tests and checks that cover the edited code instead.
-9. After `cargo xci` passes, commit and push a PR targeting `main`. The PR body MUST include an auto-close keyword for the issue being delivered, for example `Closes #20` or `Fixes #20`, so GitHub closes the issue automatically when the PR merges.
-10. **If the PR creates or modifies any `.snap` insta fixtures, attach the `snapshot-reviewed` label after opening or updating it** (`gh pr edit <num> --add-label "snapshot-reviewed"`). This signals to reviewers that the snapshot output was inspected and is intentional. Re-apply the label whenever you push a commit that touches `.snap` files; the workflow assumes the label reflects the latest snapshot state.
-11. Only after CI passes and the PR is merged, close the issue.
+7. **MANDATORY:** Invoke the `post-implementation-audit` skill (`.agents/skills/post-implementation-audit/SKILL.md`). It runs three sequential audits on the new code — (a) spec/implementation drift with "best outcome" recommendations, (b) iterative "anything else missing?" passes (minimum two rounds), (c) test-coverage audit across every test type the workspace uses (unit, snapshot, proptest, mutation, doc, spec-conformance, llvm-cov). **Every finding lands in _this_ PR — no deferral, no follow-up issues.** This step exists because initial implementations consistently ship spec drift and silent contract violations that take 3+ review round-trips to surface; the audit collapses them into one. Skipping this step is a contract violation.
+8. Present the final result for user review before any commit.
+9. After user approval, run `cargo xci` locally and fix any failures before pushing anything to GitHub. During normal implementation, reserve `cargo xci` for substantial chunks of code or the final pre-PR gate; for small follow-up changes, run the focused tests and checks that cover the edited code instead.
+10. After `cargo xci` passes, commit and push a PR targeting `main`. The PR body MUST include an auto-close keyword for the issue being delivered, for example `Closes #20` or `Fixes #20`, so GitHub closes the issue automatically when the PR merges.
+11. **If the PR creates or modifies any `.snap` insta fixtures, attach the `snapshot-reviewed` label after opening or updating it** (`gh pr edit <num> --add-label "snapshot-reviewed"`). This signals to reviewers that the snapshot output was inspected and is intentional. Re-apply the label whenever you push a commit that touches `.snap` files; the workflow assumes the label reflects the latest snapshot state.
+12. Only after CI passes and the PR is merged, close the issue.
 
 Never close a GitHub issue without a merged PR that passes CI. Never commit or push without explicit user approval. Keep the issue, PR, and Project board status aligned with the actual work state at every step.
 

--- a/crates/ars-components/Cargo.toml
+++ b/crates/ars-components/Cargo.toml
@@ -17,6 +17,13 @@ std = [
   "ars-interactions/std"
 ]
 debug = ["dep:log", "ars-core/debug", "ars-interactions/debug"]
+# Enables ICU4X-backed locale-aware Unicode case mapping (via
+# `ars-i18n/icu4x`) and unlocks components whose spec contract requires it
+# — currently `utility::highlight`. Adapters that want the browser
+# `Intl` backend instead can build with `--no-default-features --features
+# std,ars-i18n/web-intl`; in that combination, modules gated on `i18n`
+# (Highlight) are not available.
+i18n = ["ars-i18n/icu4x"]
 uuid = ["ars-collections/uuid"]
 
 [dependencies]

--- a/crates/ars-components/src/utility/highlight.rs
+++ b/crates/ars-components/src/utility/highlight.rs
@@ -1,0 +1,1346 @@
+//! `Highlight` component — text substring matching with Unicode-aware case folding.
+//!
+//! `Highlight` is a stateless utility that splits a text into alternating
+//! highlighted / non-highlighted chunks based on one or more search queries.
+//! It supports three match strategies (`Contains`, `StartsWith`, `Fuzzy`),
+//! locale-aware Unicode case mapping via ICU4X `CaseMapper` (handles Turkic
+//! dotted/dotless I, German eszett, Greek final sigma, Lithuanian dotted I,
+//! and other CLDR-supplied language-tailored mappings), and multi-query
+//! merging that consolidates both overlapping **and** adjacent ranges so
+//! adapters never see back-to-back highlighted chunks.
+//!
+//! The component has no state machine. Adapters render each returned
+//! `HighlightChunk` as a `<mark>` (`highlighted == true`) or `<span>`
+//! (`highlighted == false`). The agnostic-core consists of `Props`,
+//! `MatchStrategy`, `HighlightChunk`, the `Part` enum, the `Api` attribute
+//! mapper, and the `highlight_chunks` standalone computation.
+//!
+//! This module is gated on `feature = "i18n"`: the locale-aware contract on
+//! `Props::ignore_case = true` is part of the spec, so the module is only
+//! compiled when `ars-i18n/icu4x` is enabled.
+//!
+//! See `spec/components/utility/highlight.md` for the authoritative contract.
+
+use alloc::{borrow::ToOwned as _, string::String, vec, vec::Vec};
+
+use ars_core::{AttrMap, ComponentPart, ConnectApi, HtmlAttr};
+use ars_i18n::Locale;
+
+/// Props for the [`Highlight`](crate::utility::highlight) component.
+///
+/// `Highlight` does not carry a DOM `id` — chunk output is a sequence of
+/// adapter-rendered children, not a single identifiable element — so [`Props`]
+/// does not derive [`HasId`](ars_core::HasId) like other stateless utilities.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Props {
+    /// The search queries to highlight. Supports a single query string or
+    /// multiple queries to highlight simultaneously (e.g., multiple search
+    /// terms). When multiple queries are provided, all matches from all
+    /// queries are highlighted; overlapping ranges are merged into a single
+    /// highlighted chunk. An empty vec, or a vec where every entry is empty,
+    /// produces a single non-highlighted chunk containing the full text.
+    pub query: Vec<String>,
+
+    /// The full text to search within.
+    pub text: String,
+
+    /// When `true` (default), matching is case-insensitive via Unicode case
+    /// folding — `ars_i18n::case_fold` with the [`Locale`] passed to
+    /// [`highlight_chunks`] / [`Api::chunks`]. When `false`, byte-exact
+    /// matching is used (no normalisation pass; the locale parameter is
+    /// ignored).
+    pub ignore_case: bool,
+
+    /// The strategy used to match the query against the text. Defaults to
+    /// [`MatchStrategy::Contains`].
+    pub match_strategy: MatchStrategy,
+}
+
+impl Default for Props {
+    fn default() -> Self {
+        Self {
+            query: Vec::new(),
+            text: String::new(),
+            ignore_case: true,
+            match_strategy: MatchStrategy::Contains,
+        }
+    }
+}
+
+impl Props {
+    /// Returns fresh [`Props`] with the documented defaults — equivalent
+    /// to [`Default::default`], offered as the entry point for the
+    /// builder chain.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the query list. Accepts any iterable of `Into<String>`, so
+    /// callers can pass `["foo"]`, `vec!["foo".to_string(), "bar".into()]`,
+    /// `&["foo", "bar"][..]`, etc.
+    #[must_use]
+    pub fn query<I, S>(mut self, query: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.query = query.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Sets the text to search within.
+    #[must_use]
+    pub fn text(mut self, text: impl Into<String>) -> Self {
+        self.text = text.into();
+        self
+    }
+
+    /// Sets the case-sensitivity flag.
+    #[must_use]
+    pub const fn ignore_case(mut self, value: bool) -> Self {
+        self.ignore_case = value;
+        self
+    }
+
+    /// Sets the match strategy.
+    #[must_use]
+    pub const fn match_strategy(mut self, value: MatchStrategy) -> Self {
+        self.match_strategy = value;
+        self
+    }
+}
+
+/// The strategy used to match the query against the text.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum MatchStrategy {
+    /// Highlight every occurrence of the query within the text. The default
+    /// — the most permissive strategy, matching Ark UI's default.
+    #[default]
+    Contains,
+
+    /// Highlight only the leading run of the text when it starts with the
+    /// query (after case folding, if `ignore_case` is `true`).
+    StartsWith,
+
+    /// Subsequence match: highlight each individual query character within
+    /// the text in order, allowing arbitrary gaps.
+    ///
+    /// All query characters must be present (in order, not necessarily
+    /// contiguous). When the full subsequence is found, each matched
+    /// character contributes its own one-char highlighted range. When any
+    /// query character cannot be located, **no fuzzy ranges are emitted
+    /// for that query** (all-or-nothing) — partial matches would highlight
+    /// characters that don't represent the query and confuse the user.
+    Fuzzy,
+}
+
+/// One contiguous run of the original text, tagged as highlighted or not.
+///
+/// `text` borrows from [`Props::text`] (the lifetime is tied to the props
+/// passed to [`highlight_chunks`] / [`Api::chunks`]); the chunk vector is
+/// owned by the caller. Adapters render highlighted chunks as `<mark>` and
+/// non-highlighted chunks as `<span>` per the component anatomy.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct HighlightChunk<'a> {
+    /// The slice of the source text covered by this chunk.
+    pub text: &'a str,
+
+    /// Whether the adapter should wrap this chunk in `<mark>`.
+    pub highlighted: bool,
+}
+
+/// DOM parts of the `Highlight` component.
+///
+/// Only [`Part::Root`] is a static anatomy slot. The per-chunk
+/// `<mark>` / `<span>` elements are emitted dynamically per
+/// [`HighlightChunk`], parametric on the runtime `highlighted` boolean — a
+/// value that [`ConnectApi::part_attrs`] (which takes a `Part` by value, no
+/// payload) cannot express. Adapters call [`Api::chunk_attrs`] per chunk
+/// instead. See `spec/components/utility/highlight.md` §2 for the rendered
+/// shape.
+#[derive(ComponentPart)]
+#[scope = "highlight"]
+pub enum Part {
+    /// The root `<span>` that wraps the chunk children.
+    Root,
+}
+
+/// Attribute-mapper API for the `Highlight` component.
+///
+/// Constructed via [`Api::new`] from [`Props`] and queried via
+/// [`Api::root_attrs`] / [`Api::chunk_attrs`] for adapter-rendered DOM
+/// attributes, or [`Api::chunks`] / the standalone [`highlight_chunks`]
+/// function for the chunk sequence itself.
+#[derive(Clone, Debug)]
+pub struct Api {
+    props: Props,
+}
+
+impl Api {
+    /// Wraps the given props in an `Api`. The props are stored verbatim and
+    /// can be read back via [`Api::props`] or the typed accessors.
+    #[must_use]
+    pub const fn new(props: Props) -> Self {
+        Self { props }
+    }
+
+    /// Returns a reference to the underlying [`Props`].
+    #[must_use]
+    pub const fn props(&self) -> &Props {
+        &self.props
+    }
+
+    /// Returns the configured query list.
+    #[must_use]
+    pub fn query(&self) -> &[String] {
+        &self.props.query
+    }
+
+    /// Returns the configured source text.
+    #[must_use]
+    pub fn text(&self) -> &str {
+        &self.props.text
+    }
+
+    /// Returns whether matching is case-insensitive.
+    #[must_use]
+    pub const fn ignore_case(&self) -> bool {
+        self.props.ignore_case
+    }
+
+    /// Returns the configured match strategy.
+    #[must_use]
+    pub const fn match_strategy(&self) -> MatchStrategy {
+        self.props.match_strategy
+    }
+
+    /// Attributes for the root `<span>` wrapper.
+    ///
+    /// Emits `data-ars-scope="highlight"` + `data-ars-part="root"` (via
+    /// `Part::Root.data_attrs()`) plus `dir="auto"` so the browser picks
+    /// the correct `BiDi` paragraph direction from the first strong character
+    /// in the highlighted text (see spec §3.2). No ARIA attributes — the
+    /// semantic `<mark>` elements in the chunk children carry the
+    /// highlighting semantics for assistive technology.
+    #[must_use]
+    pub fn root_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Root.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Dir, "auto");
+
+        attrs
+    }
+
+    /// Attributes for one chunk element.
+    ///
+    /// Emits `data-ars-part="highlight-chunk"` and
+    /// `data-ars-highlighted="true"|"false"` per `highlighted`. The
+    /// underlying element (`<mark>` vs `<span>`) is chosen by the adapter
+    /// based on the same boolean.
+    #[must_use]
+    pub fn chunk_attrs(&self, highlighted: bool) -> AttrMap {
+        let mut attrs = AttrMap::new();
+
+        attrs
+            .set(HtmlAttr::Data("ars-part"), "highlight-chunk")
+            .set(
+                HtmlAttr::Data("ars-highlighted"),
+                if highlighted { "true" } else { "false" },
+            );
+
+        attrs
+    }
+
+    /// Computes the chunk sequence for the configured props at the given
+    /// locale. Thin convenience around [`highlight_chunks`] — the standalone
+    /// function takes the same arguments and is the spec-defined entry point.
+    #[must_use]
+    pub fn chunks<'a>(&'a self, locale: &Locale) -> Vec<HighlightChunk<'a>> {
+        highlight_chunks(&self.props, locale)
+    }
+}
+
+impl ConnectApi for Api {
+    type Part = Part;
+
+    fn part_attrs(&self, part: Part) -> AttrMap {
+        match part {
+            Part::Root => self.root_attrs(),
+        }
+    }
+}
+
+/// Splits the configured text into alternating highlighted / non-highlighted
+/// chunks under the given locale.
+///
+/// # Examples
+///
+/// ```
+/// use ars_components::utility::highlight::{highlight_chunks, HighlightChunk, Props};
+/// use ars_i18n::Locale;
+///
+/// let props = Props::new().query(["world"]).text("Hello world!");
+/// let locale = Locale::parse("en-US").expect("en-US must parse");
+///
+/// let chunks = highlight_chunks(&props, &locale);
+///
+/// assert_eq!(
+///     chunks,
+///     vec![
+///         HighlightChunk { text: "Hello ", highlighted: false },
+///         HighlightChunk { text: "world", highlighted: true },
+///         HighlightChunk { text: "!", highlighted: false },
+///     ]
+/// );
+/// ```
+///
+/// When `props.ignore_case` is `true`, matching uses
+/// [`ars_i18n::case_fold`] for Unicode case folding (ICU4X
+/// `CaseMapper::fold_string` — or `fold_turkic_string` under Turkic
+/// locales — under the hood) so locale-sensitive case pairs match
+/// correctly: German eszett (`ß` ↔ `ss` ↔ `SS`), Turkish dotted/dotless
+/// I (`İ` ↔ `i` and `I` ↔ `ı`), Greek final sigma collapse, Lithuanian
+/// dotted I, and other CLDR-supplied tailored mappings. When
+/// `props.ignore_case` is `false`, matching is byte-exact and the
+/// `locale` parameter is ignored.
+///
+/// When multiple queries (or fuzzy hits) produce overlapping **or
+/// adjacent** ranges, they are merged into a single highlighted chunk so
+/// adapters never render back-to-back `<mark>` elements covering
+/// contiguous text. This satisfies spec §3.1's adjacency-consolidation
+/// requirement in the core, leaving adapters free to layer only
+/// genuinely additional a11y behaviour (e.g., summary announcements for
+/// high-cardinality fuzzy results) on top.
+///
+/// # Edge cases
+///
+/// - Empty `query`, or `query` containing only empty strings → a single
+///   non-highlighted chunk wrapping the full text.
+/// - Empty `text` → an empty [`Vec`] (nothing to render).
+/// - Query longer than text → a single non-highlighted chunk.
+/// - `MatchStrategy::Fuzzy` with any query character missing from the
+///   text → no fuzzy ranges contributed for that query (all-or-nothing).
+#[must_use]
+pub fn highlight_chunks<'a>(props: &'a Props, locale: &Locale) -> Vec<HighlightChunk<'a>> {
+    let text = props.text.as_str();
+
+    if text.is_empty() {
+        return Vec::new();
+    }
+
+    let non_empty_queries: Vec<&str> = props
+        .query
+        .iter()
+        .map(String::as_str)
+        .filter(|q| !q.is_empty())
+        .collect();
+
+    if non_empty_queries.is_empty() {
+        return vec![HighlightChunk {
+            text,
+            highlighted: false,
+        }];
+    }
+
+    let (normalised_text, byte_map) = build_normalised(text, props.ignore_case, locale);
+
+    let mut ranges: Vec<(usize, usize)> = Vec::new();
+
+    for query in &non_empty_queries {
+        // Every assigned Unicode character folds to a non-empty
+        // replacement (TR21), so for non-empty input `case_fold` never
+        // produces an empty string. The `non_empty_queries` filter above
+        // guarantees the input is non-empty, so we don't need an empty
+        // check on `normalised_query`.
+        let normalised_query = if props.ignore_case {
+            case_fold(query, locale)
+        } else {
+            (*query).to_owned()
+        };
+
+        match props.match_strategy {
+            MatchStrategy::Contains => {
+                push_contains_matches(&normalised_text, &normalised_query, &byte_map, &mut ranges);
+            }
+
+            MatchStrategy::StartsWith => {
+                push_starts_with_match(&normalised_text, &normalised_query, &byte_map, &mut ranges);
+            }
+
+            MatchStrategy::Fuzzy => {
+                push_fuzzy_matches(
+                    text,
+                    &normalised_query,
+                    props.ignore_case,
+                    locale,
+                    &mut ranges,
+                );
+            }
+        }
+    }
+
+    if ranges.is_empty() {
+        return vec![HighlightChunk {
+            text,
+            highlighted: false,
+        }];
+    }
+
+    let merged = merge_ranges(ranges);
+
+    build_chunks(text, &merged)
+}
+
+/// Build a normalised form of `text` (lowercased when `ignore_case`) plus a
+/// byte-map from normalised byte indices back to original byte indices.
+///
+/// The map has length `normalised.len() + 1`. For each normalised byte `i`
+/// produced from original char starting at `orig_byte`, `byte_map[i] ==
+/// orig_byte`. The trailing entry `byte_map[normalised.len()] == text.len()`
+/// is a sentinel so callers can read the end index of a match without
+/// bounds-special-casing.
+///
+/// When `!ignore_case`, the normalised text is `text` verbatim and the map
+/// is the identity `0..=text.len()` (each byte trivially maps to itself).
+fn build_normalised(text: &str, ignore_case: bool, locale: &Locale) -> (String, Vec<usize>) {
+    if !ignore_case {
+        let map: Vec<usize> = (0..=text.len()).collect();
+
+        return (text.to_owned(), map);
+    }
+
+    let mut normalised = String::with_capacity(text.len());
+    let mut byte_map = Vec::with_capacity(text.len() + 1);
+
+    for (orig_byte, ch) in text.char_indices() {
+        let mut buf = [0u8; 4];
+
+        let ch_str = ch.encode_utf8(&mut buf);
+
+        let folded = case_fold(ch_str, locale);
+
+        for _ in 0..folded.len() {
+            byte_map.push(orig_byte);
+        }
+
+        normalised.push_str(&folded);
+    }
+
+    byte_map.push(text.len());
+
+    (normalised, byte_map)
+}
+
+/// Unicode case fold for case-insensitive comparison. Delegates to
+/// [`ars_i18n::case_fold`] which wraps ICU4X
+/// `CaseMapper::fold_string` (or `fold_turkic_string` under Turkic
+/// locales). The fold form — not lowercase — is the right primitive for
+/// matching: it expands `ß → ss`, collapses Greek final sigma into the
+/// medial form, and (under Turkic) folds `İ ↔ i` / `I ↔ ı`. This is what
+/// the spec's `ignore_case = true` contract requires.
+fn case_fold(text: &str, locale: &Locale) -> String {
+    ars_i18n::case_fold(text, locale)
+}
+
+fn push_contains_matches(
+    normalised_text: &str,
+    normalised_query: &str,
+    byte_map: &[usize],
+    out: &mut Vec<(usize, usize)>,
+) {
+    for (start, _) in normalised_text.match_indices(normalised_query) {
+        let end = start + normalised_query.len();
+        let orig_start = byte_map[start];
+        let orig_end = byte_map[end];
+
+        if orig_start < orig_end {
+            out.push((orig_start, orig_end));
+        }
+    }
+}
+
+fn push_starts_with_match(
+    normalised_text: &str,
+    normalised_query: &str,
+    byte_map: &[usize],
+    out: &mut Vec<(usize, usize)>,
+) {
+    if normalised_text.starts_with(normalised_query) {
+        let end = normalised_query.len();
+        let orig_end = byte_map[end];
+
+        if orig_end > 0 {
+            out.push((0, orig_end));
+        }
+    }
+}
+
+/// Walk the original text char-by-char, lowercasing each char individually
+/// when needed, and consume the query in order. Each matched original-text
+/// character contributes a one-char range to `out`. Fuzzy matching collapses
+/// to no match (zero ranges pushed) when any query char cannot be located.
+fn push_fuzzy_matches(
+    original_text: &str,
+    normalised_query: &str,
+    ignore_case: bool,
+    locale: &Locale,
+    out: &mut Vec<(usize, usize)>,
+) {
+    let mut query_iter = normalised_query.chars().peekable();
+    let mut local = Vec::new();
+
+    for (orig_byte, ch) in original_text.char_indices() {
+        let Some(&want) = query_iter.peek() else {
+            break;
+        };
+
+        let normalised_ch_string = if ignore_case {
+            let mut buf = [0u8; 4];
+            let ch_str = ch.encode_utf8(&mut buf);
+
+            case_fold(ch_str, locale)
+        } else {
+            let mut s = String::new();
+
+            s.push(ch);
+
+            s
+        };
+
+        if normalised_ch_string.chars().any(|c| c == want) {
+            local.push((orig_byte, orig_byte + ch.len_utf8()));
+
+            query_iter.next();
+        }
+    }
+
+    if query_iter.peek().is_none() {
+        out.extend(local);
+    }
+}
+
+/// Sort ranges by start and merge overlapping or adjacent ones (`c <= b`).
+fn merge_ranges(mut ranges: Vec<(usize, usize)>) -> Vec<(usize, usize)> {
+    ranges.sort_by_key(|&(start, _)| start);
+
+    let mut merged: Vec<(usize, usize)> = Vec::with_capacity(ranges.len());
+
+    for (start, end) in ranges {
+        if let Some(last) = merged.last_mut()
+            && start <= last.1
+        {
+            if end > last.1 {
+                last.1 = end;
+            }
+        } else {
+            merged.push((start, end));
+        }
+    }
+
+    merged
+}
+
+/// Walk the merged ranges and emit alternating non-highlighted / highlighted
+/// chunks borrowing from `text`. Zero-length segments are skipped.
+fn build_chunks<'a>(text: &'a str, ranges: &[(usize, usize)]) -> Vec<HighlightChunk<'a>> {
+    let mut chunks = Vec::with_capacity(ranges.len() * 2 + 1);
+    let mut cursor = 0usize;
+
+    for &(start, end) in ranges {
+        if start > cursor {
+            chunks.push(HighlightChunk {
+                text: &text[cursor..start],
+                highlighted: false,
+            });
+        }
+
+        if end > start {
+            chunks.push(HighlightChunk {
+                text: &text[start..end],
+                highlighted: true,
+            });
+        }
+
+        cursor = end;
+    }
+
+    if cursor < text.len() {
+        chunks.push(HighlightChunk {
+            text: &text[cursor..],
+            highlighted: false,
+        });
+    }
+
+    chunks
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::{string::ToString, vec};
+
+    use ars_core::HtmlAttr;
+    use insta::assert_snapshot;
+
+    use super::*;
+
+    fn en_us() -> Locale {
+        Locale::parse("en-US").expect("en-US must parse")
+    }
+
+    fn turkish() -> Locale {
+        Locale::parse("tr").expect("tr must parse")
+    }
+
+    fn german() -> Locale {
+        Locale::parse("de").expect("de must parse")
+    }
+
+    fn snapshot_attrs(attrs: &AttrMap) -> String {
+        alloc::format!("{attrs:#?}")
+    }
+
+    fn snapshot_chunks(chunks: &[HighlightChunk<'_>]) -> String {
+        alloc::format!("{chunks:#?}")
+    }
+
+    // ── Strategy & matching behaviour ──────────────────────────────
+
+    #[test]
+    fn contains_strategy_matches_substring() {
+        let props = Props::new()
+            .query(["world"])
+            .text("Hello world!")
+            .match_strategy(MatchStrategy::Contains);
+
+        let chunks = highlight_chunks(&props, &en_us());
+
+        assert_eq!(
+            chunks,
+            vec![
+                HighlightChunk {
+                    text: "Hello ",
+                    highlighted: false,
+                },
+                HighlightChunk {
+                    text: "world",
+                    highlighted: true,
+                },
+                HighlightChunk {
+                    text: "!",
+                    highlighted: false,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn contains_strategy_finds_all_occurrences() {
+        let props = Props::new().query(["la"]).text("la la la");
+
+        let chunks = highlight_chunks(&props, &en_us());
+
+        // 3 highlighted "la"s separated by 2 single-space gaps. No leading
+        // or trailing gap because "la" starts and ends the text.
+        assert_eq!(chunks.len(), 5);
+        assert_eq!(chunks[0].text, "la");
+        assert!(chunks[0].highlighted);
+        assert_eq!(chunks[1].text, " ");
+        assert!(!chunks[1].highlighted);
+        assert_eq!(chunks[2].text, "la");
+        assert!(chunks[2].highlighted);
+        assert_eq!(chunks[3].text, " ");
+        assert!(!chunks[3].highlighted);
+        assert_eq!(chunks[4].text, "la");
+        assert!(chunks[4].highlighted);
+    }
+
+    #[test]
+    fn starts_with_strategy_matches_at_start() {
+        let props = Props::new()
+            .query(["hello"])
+            .text("Hello world")
+            .match_strategy(MatchStrategy::StartsWith);
+
+        let chunks = highlight_chunks(&props, &en_us());
+
+        assert_eq!(
+            chunks,
+            vec![
+                HighlightChunk {
+                    text: "Hello",
+                    highlighted: true,
+                },
+                HighlightChunk {
+                    text: " world",
+                    highlighted: false,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn starts_with_strategy_no_match_in_middle() {
+        // "world" is in the middle of the text — StartsWith returns one
+        // non-highlighted chunk.
+        let props = Props::new()
+            .query(["world"])
+            .text("Hello world")
+            .match_strategy(MatchStrategy::StartsWith);
+
+        let chunks = highlight_chunks(&props, &en_us());
+
+        assert_eq!(
+            chunks,
+            vec![HighlightChunk {
+                text: "Hello world",
+                highlighted: false,
+            }]
+        );
+    }
+
+    #[test]
+    fn fuzzy_strategy_matches_in_order_with_gaps() {
+        let props = Props::new()
+            .query(["abc"])
+            .text("a_b_c")
+            .match_strategy(MatchStrategy::Fuzzy);
+
+        let chunks = highlight_chunks(&props, &en_us());
+
+        // Three highlighted single-char chunks separated by two
+        // non-highlighted "_" chunks.
+        assert_eq!(
+            chunks,
+            vec![
+                HighlightChunk {
+                    text: "a",
+                    highlighted: true,
+                },
+                HighlightChunk {
+                    text: "_",
+                    highlighted: false,
+                },
+                HighlightChunk {
+                    text: "b",
+                    highlighted: true,
+                },
+                HighlightChunk {
+                    text: "_",
+                    highlighted: false,
+                },
+                HighlightChunk {
+                    text: "c",
+                    highlighted: true,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn fuzzy_strategy_no_match_when_chars_missing() {
+        // Query "xyz" is missing from text "abc" → no match → one
+        // non-highlighted chunk.
+        let props = Props::new()
+            .query(["xyz"])
+            .text("abc")
+            .match_strategy(MatchStrategy::Fuzzy);
+
+        let chunks = highlight_chunks(&props, &en_us());
+
+        assert_eq!(
+            chunks,
+            vec![HighlightChunk {
+                text: "abc",
+                highlighted: false,
+            }]
+        );
+    }
+
+    #[test]
+    fn unicode_case_folding_turkic_dotted_i() {
+        // In Turkish, "İ" (dotted capital I) lowercases to "i". The query
+        // "İ" should highlight "i" in the text under tr locale.
+        let props = Props::new().query(["İ"]).text("istanbul");
+
+        let chunks = highlight_chunks(&props, &turkish());
+
+        assert_eq!(chunks.len(), 2);
+        assert!(chunks[0].highlighted);
+        assert_eq!(chunks[0].text, "i");
+        assert!(!chunks[1].highlighted);
+        assert_eq!(chunks[1].text, "stanbul");
+    }
+
+    #[test]
+    fn unicode_case_folding_german_eszett() {
+        // Per Unicode TR21, `case_fold("ß") == "ss"` and `case_fold("SS")
+        // == "ss"`. So `"ß"`, `"ss"`, and `"SS"` must all be equivalent
+        // for case-insensitive matching — the user typing `"ss"` should
+        // find every form, including the eszett `ß`.
+
+        // Direction A: query "ss" against text containing both ß and SS.
+        let props_a = Props::new().query(["ss"]).text("Straße ist STRASSE");
+
+        let chunks_a = highlight_chunks(&props_a, &german());
+
+        let highlighted_a: Vec<&str> = chunks_a
+            .iter()
+            .filter(|c| c.highlighted)
+            .map(|c| c.text)
+            .collect();
+
+        assert_eq!(
+            highlighted_a,
+            vec!["ß", "SS"],
+            "query \"ss\" must match both \"ß\" and \"SS\""
+        );
+
+        // Direction B: query "SS" against text containing ß — must match.
+        let props_b = Props::new().query(["SS"]).text("Straße");
+
+        let chunks_b = highlight_chunks(&props_b, &german());
+
+        let highlighted_b: Vec<&str> = chunks_b
+            .iter()
+            .filter(|c| c.highlighted)
+            .map(|c| c.text)
+            .collect();
+
+        assert_eq!(
+            highlighted_b,
+            vec!["ß"],
+            "query \"SS\" must match \"ß\" under case fold"
+        );
+
+        // Direction C: query "ß" against text with only "SS" — reverse
+        // direction must also match.
+        let props_c = Props::new().query(["ß"]).text("STRASSE");
+
+        let chunks_c = highlight_chunks(&props_c, &german());
+
+        let highlighted_c: Vec<&str> = chunks_c
+            .iter()
+            .filter(|c| c.highlighted)
+            .map(|c| c.text)
+            .collect();
+
+        assert_eq!(
+            highlighted_c,
+            vec!["SS"],
+            "query \"ß\" must match \"SS\" under case fold"
+        );
+    }
+
+    #[test]
+    fn multi_query_fully_contained_range_does_not_extend() {
+        // Branch coverage for `merge_ranges`: when an incoming range is
+        // fully contained inside an existing merged range
+        // (`start <= last.1` AND `end <= last.1`), the body is a no-op.
+        // The two queries below produce ranges (0, 6) and (1, 5); the
+        // second is entirely inside the first, so the merged output
+        // remains a single (0, 6) range.
+        let props = Props::new().query(["foobar", "ooba"]).text("foobar");
+
+        let chunks = highlight_chunks(&props, &en_us());
+
+        assert_eq!(
+            chunks,
+            vec![HighlightChunk {
+                text: "foobar",
+                highlighted: true,
+            }]
+        );
+    }
+
+    #[test]
+    fn multi_query_idempotent_under_duplicate_queries() {
+        // Defensive invariant: passing the same query twice must produce
+        // the same output as passing it once (the per-query loop has no
+        // hidden side-effects). Catches regressions that would, e.g.,
+        // double-count ranges before the merge pass.
+        let single = Props::new().query(["foo"]).text("foobar foo");
+
+        let duplicated = Props::new().query(["foo", "foo", "foo"]).text("foobar foo");
+
+        assert_eq!(
+            highlight_chunks(&single, &en_us()),
+            highlight_chunks(&duplicated, &en_us())
+        );
+    }
+
+    #[test]
+    fn fold_expansion_partial_match_does_not_emit_partial_char_highlight() {
+        // Branch coverage for the byte-map zero-length-range filter in
+        // both `push_contains_matches` (orig_start < orig_end) and
+        // `push_starts_with_match` (orig_end > 0). Under en-US, "İ"
+        // folds to "i\u{307}" (i + combining dot above, 3 bytes). A
+        // query "i" matches the first folded byte but maps to a
+        // zero-length original range — the implementation must NOT emit
+        // a partial-character highlight, because rendering only part of
+        // a code point would corrupt the displayed text.
+        for strategy in [MatchStrategy::Contains, MatchStrategy::StartsWith] {
+            let props = Props::new()
+                .query(["i"])
+                .text("İa")
+                .match_strategy(strategy);
+
+            let chunks = highlight_chunks(&props, &en_us());
+
+            let highlighted: Vec<&str> = chunks
+                .iter()
+                .filter(|c| c.highlighted)
+                .map(|c| c.text)
+                .collect();
+
+            assert!(
+                highlighted.is_empty(),
+                "{strategy:?}: must not emit partial-char highlight, got {highlighted:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn multi_query_overlapping_ranges_merged() {
+        // Queries "foo" and "oob" overlap on "oo" within "foobar". The
+        // merged range covers "foob", producing one highlighted chunk.
+        let props = Props::new().query(["foo", "oob"]).text("foobar");
+
+        let chunks = highlight_chunks(&props, &en_us());
+
+        assert_eq!(
+            chunks,
+            vec![
+                HighlightChunk {
+                    text: "foob",
+                    highlighted: true,
+                },
+                HighlightChunk {
+                    text: "ar",
+                    highlighted: false,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn empty_query_returns_single_non_highlighted_chunk() {
+        let props = Props::new().text("hello");
+
+        let chunks = highlight_chunks(&props, &en_us());
+
+        assert_eq!(
+            chunks,
+            vec![HighlightChunk {
+                text: "hello",
+                highlighted: false,
+            }]
+        );
+    }
+
+    #[test]
+    fn all_empty_queries_returns_single_non_highlighted_chunk() {
+        let props = Props::new().query(["", "", ""]).text("hello");
+
+        let chunks = highlight_chunks(&props, &en_us());
+
+        assert_eq!(
+            chunks,
+            vec![HighlightChunk {
+                text: "hello",
+                highlighted: false,
+            }]
+        );
+    }
+
+    // ── Invariant tests ────────────────────────────────────────────
+
+    fn assert_chunks_concatenate_to_text(chunks: &[HighlightChunk<'_>], expected: &str) {
+        let concatenated: String = chunks.iter().map(|c| c.text).collect();
+
+        assert_eq!(
+            concatenated, expected,
+            "chunks must reconstruct the original text"
+        );
+    }
+
+    fn assert_no_two_adjacent_highlighted(chunks: &[HighlightChunk<'_>]) {
+        for window in chunks.windows(2) {
+            assert!(
+                !(window[0].highlighted && window[1].highlighted),
+                "two adjacent highlighted chunks should have been merged: {window:?}"
+            );
+        }
+    }
+
+    fn assert_no_empty_chunks(chunks: &[HighlightChunk<'_>]) {
+        for chunk in chunks {
+            assert!(
+                !chunk.text.is_empty(),
+                "highlight_chunks must never emit an empty chunk: {chunk:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn chunks_concatenate_to_original_text_across_strategies() {
+        // Roundtrip invariant: for any input, concatenating the chunk
+        // texts in order produces the original text verbatim. Exercised
+        // here across every strategy + ignore_case combination to catch
+        // off-by-one / boundary regressions silently producing wrong text.
+        let text = "Foo bar BAZ ßaz İstanbul fooo";
+        let queries: &[&[&str]] = &[
+            &["foo"],
+            &["BAR"],
+            &["foo", "BAZ"],
+            &["ßaz"],
+            &["i"],
+            &["z"],
+            &[],
+            &[""],
+            &["", "foo"],
+        ];
+
+        let strategies = [
+            MatchStrategy::Contains,
+            MatchStrategy::StartsWith,
+            MatchStrategy::Fuzzy,
+        ];
+
+        for ignore_case in [true, false] {
+            for query in queries {
+                for strategy in strategies {
+                    let props = Props::new()
+                        .query(query.iter().copied())
+                        .text(text)
+                        .ignore_case(ignore_case)
+                        .match_strategy(strategy);
+
+                    let chunks = highlight_chunks(&props, &en_us());
+
+                    assert_chunks_concatenate_to_text(&chunks, text);
+                    assert_no_two_adjacent_highlighted(&chunks);
+                    assert_no_empty_chunks(&chunks);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn ignore_case_true_matches_case_insensitive() {
+        let props = Props::new().query(["hello"]).text("HELLO world");
+
+        let chunks = highlight_chunks(&props, &en_us());
+
+        assert_eq!(
+            chunks,
+            vec![
+                HighlightChunk {
+                    text: "HELLO",
+                    highlighted: true,
+                },
+                HighlightChunk {
+                    text: " world",
+                    highlighted: false,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn ignore_case_false_matches_case_sensitive() {
+        let props = Props::new()
+            .query(["hello"])
+            .text("HELLO world")
+            .ignore_case(false);
+
+        let chunks = highlight_chunks(&props, &en_us());
+
+        assert_eq!(
+            chunks,
+            vec![HighlightChunk {
+                text: "HELLO world",
+                highlighted: false,
+            }]
+        );
+    }
+
+    #[test]
+    fn empty_text_returns_empty_vec() {
+        let props = Props::new().query(["anything"]).text("");
+
+        let chunks = highlight_chunks(&props, &en_us());
+
+        assert!(chunks.is_empty());
+    }
+
+    #[test]
+    fn query_longer_than_text_returns_single_non_highlighted_chunk() {
+        let props = Props::new().query(["needles in haystacks"]).text("hi");
+
+        let chunks = highlight_chunks(&props, &en_us());
+
+        assert_eq!(
+            chunks,
+            vec![HighlightChunk {
+                text: "hi",
+                highlighted: false,
+            }]
+        );
+    }
+
+    // ── Props / Api ergonomics ─────────────────────────────────────
+
+    #[test]
+    fn props_default_is_contains_ignore_case_true() {
+        let p = Props::default();
+
+        assert!(p.query.is_empty());
+        assert!(p.text.is_empty());
+        assert!(p.ignore_case);
+        assert_eq!(p.match_strategy, MatchStrategy::Contains);
+    }
+
+    #[test]
+    fn props_clone_and_partial_eq_round_trip() {
+        let original = Props {
+            query: vec!["a".to_string(), "b".to_string()],
+            text: "ab".to_string(),
+            ignore_case: false,
+            match_strategy: MatchStrategy::Fuzzy,
+        };
+
+        let cloned = original.clone();
+
+        assert_eq!(cloned, original);
+
+        let mutated = Props {
+            ignore_case: true,
+            ..original.clone()
+        };
+
+        assert_ne!(mutated, original);
+    }
+
+    #[test]
+    fn props_debug_impl_non_empty() {
+        let api = Api::new(Props::new().text("dbg"));
+
+        let props_dbg = alloc::format!("{:?}", api.props());
+        let api_dbg = alloc::format!("{api:?}");
+
+        assert!(props_dbg.contains("Props"), "Props Debug = {props_dbg}");
+        assert!(api_dbg.contains("Api"), "Api Debug = {api_dbg}");
+    }
+
+    #[test]
+    fn props_builder_round_trips() {
+        let p = Props::new()
+            .query(["foo", "bar"])
+            .text("foobar")
+            .ignore_case(false)
+            .match_strategy(MatchStrategy::Fuzzy);
+
+        assert_eq!(p.query, vec!["foo".to_string(), "bar".to_string()]);
+        assert_eq!(p.text, "foobar");
+        assert!(!p.ignore_case);
+        assert_eq!(p.match_strategy, MatchStrategy::Fuzzy);
+    }
+
+    #[test]
+    fn api_exposes_all_props_fields() {
+        let original = Props {
+            query: vec!["q1".to_string()],
+            text: "txt".to_string(),
+            ignore_case: false,
+            match_strategy: MatchStrategy::StartsWith,
+        };
+
+        let api = Api::new(original.clone());
+
+        assert_eq!(api.query(), &["q1".to_string()][..]);
+        assert_eq!(api.text(), "txt");
+        assert!(!api.ignore_case());
+        assert_eq!(api.match_strategy(), MatchStrategy::StartsWith);
+        assert_eq!(api.props(), &original);
+    }
+
+    #[test]
+    fn api_ignore_case_returns_both_directions() {
+        // Positive-direction test for the `ignore_case` accessor —
+        // ensures it isn't accidentally hardcoded to a single value.
+        // `Props::default()` is `ignore_case = true`; the explicit
+        // `false` builder produces the other side.
+        assert!(Api::new(Props::default()).ignore_case());
+        assert!(!Api::new(Props::new().ignore_case(false)).ignore_case());
+    }
+
+    #[test]
+    fn api_props_round_trips() {
+        let original = Props::new()
+            .query(["needle"])
+            .text("Find the needle in the haystack");
+
+        let api = Api::new(original.clone());
+
+        assert_eq!(api.props(), &original);
+    }
+
+    #[test]
+    fn part_attrs_root_equals_root_attrs() {
+        let api = Api::new(Props::new().text("hi"));
+
+        assert_eq!(api.part_attrs(Part::Root), api.root_attrs());
+    }
+
+    #[test]
+    fn root_attrs_emits_scope_and_part() {
+        let api = Api::new(Props::default());
+
+        let attrs = api.root_attrs();
+
+        assert_eq!(attrs.get(&HtmlAttr::Data("ars-scope")), Some("highlight"));
+        assert_eq!(attrs.get(&HtmlAttr::Data("ars-part")), Some("root"));
+    }
+
+    #[test]
+    fn chunk_attrs_highlighted_emits_true() {
+        let api = Api::new(Props::default());
+
+        let attrs = api.chunk_attrs(true);
+
+        assert_eq!(
+            attrs.get(&HtmlAttr::Data("ars-part")),
+            Some("highlight-chunk")
+        );
+        assert_eq!(attrs.get(&HtmlAttr::Data("ars-highlighted")), Some("true"));
+    }
+
+    #[test]
+    fn chunk_attrs_not_highlighted_emits_false() {
+        let api = Api::new(Props::default());
+
+        let attrs = api.chunk_attrs(false);
+
+        assert_eq!(
+            attrs.get(&HtmlAttr::Data("ars-part")),
+            Some("highlight-chunk")
+        );
+        assert_eq!(attrs.get(&HtmlAttr::Data("ars-highlighted")), Some("false"));
+    }
+
+    #[test]
+    fn chunk_attrs_branches_produce_different_attrs() {
+        // Defensive cross-branch inequality — a regression that emits the
+        // same AttrMap for highlighted and non-highlighted chunks must not
+        // pass silently.
+        let api = Api::new(Props::default());
+
+        assert_ne!(api.chunk_attrs(true), api.chunk_attrs(false));
+    }
+
+    #[test]
+    fn api_chunks_matches_standalone_function() {
+        let props = Props::new().query(["foo"]).text("foobar");
+
+        let api = Api::new(props.clone());
+
+        assert_eq!(api.chunks(&en_us()), highlight_chunks(&props, &en_us()));
+    }
+
+    // ── Snapshots ──────────────────────────────────────────────────
+
+    #[test]
+    fn highlight_root_snapshot() {
+        assert_snapshot!(
+            "highlight_root",
+            snapshot_attrs(&Api::new(Props::default()).root_attrs())
+        );
+    }
+
+    #[test]
+    fn highlight_chunk_highlighted_snapshot() {
+        assert_snapshot!(
+            "highlight_chunk_highlighted",
+            snapshot_attrs(&Api::new(Props::default()).chunk_attrs(true))
+        );
+    }
+
+    #[test]
+    fn highlight_chunk_not_highlighted_snapshot() {
+        assert_snapshot!(
+            "highlight_chunk_not_highlighted",
+            snapshot_attrs(&Api::new(Props::default()).chunk_attrs(false))
+        );
+    }
+
+    #[test]
+    fn highlight_chunks_contains_en_snapshot() {
+        let props = Props::new().query(["world"]).text("Hello world!");
+
+        assert_snapshot!(
+            "highlight_chunks_contains_en",
+            snapshot_chunks(&highlight_chunks(&props, &en_us()))
+        );
+    }
+
+    #[test]
+    fn highlight_chunks_starts_with_snapshot() {
+        let props = Props::new()
+            .query(["hello"])
+            .text("Hello world")
+            .match_strategy(MatchStrategy::StartsWith);
+
+        assert_snapshot!(
+            "highlight_chunks_starts_with",
+            snapshot_chunks(&highlight_chunks(&props, &en_us()))
+        );
+    }
+
+    #[test]
+    fn highlight_chunks_fuzzy_snapshot() {
+        let props = Props::new()
+            .query(["abc"])
+            .text("a_b_c")
+            .match_strategy(MatchStrategy::Fuzzy);
+
+        assert_snapshot!(
+            "highlight_chunks_fuzzy",
+            snapshot_chunks(&highlight_chunks(&props, &en_us()))
+        );
+    }
+
+    #[test]
+    fn highlight_chunks_multi_query_merged_snapshot() {
+        let props = Props::new().query(["foo", "oob"]).text("foobar");
+
+        assert_snapshot!(
+            "highlight_chunks_multi_query_merged",
+            snapshot_chunks(&highlight_chunks(&props, &en_us()))
+        );
+    }
+
+    #[test]
+    fn highlight_chunks_turkic_snapshot() {
+        let props = Props::new().query(["İ"]).text("istanbul");
+
+        assert_snapshot!(
+            "highlight_chunks_turkic",
+            snapshot_chunks(&highlight_chunks(&props, &turkish()))
+        );
+    }
+
+    #[test]
+    fn highlight_chunks_german_eszett_snapshot() {
+        let props = Props::new().query(["ss"]).text("Straße ist STRASSE");
+
+        assert_snapshot!(
+            "highlight_chunks_german_eszett",
+            snapshot_chunks(&highlight_chunks(&props, &german()))
+        );
+    }
+}

--- a/crates/ars-components/src/utility/highlight.rs
+++ b/crates/ars-components/src/utility/highlight.rs
@@ -31,7 +31,7 @@ use ars_i18n::Locale;
 /// `Highlight` does not carry a DOM `id` — chunk output is a sequence of
 /// adapter-rendered children, not a single identifiable element — so [`Props`]
 /// does not derive [`HasId`](ars_core::HasId) like other stateless utilities.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Props {
     /// The search queries to highlight. Supports a single query string or
     /// multiple queries to highlight simultaneously (e.g., multiple search
@@ -317,6 +317,21 @@ impl ConnectApi for Api {
 /// genuinely additional a11y behaviour (e.g., summary announcements for
 /// high-cardinality fuzzy results) on top.
 ///
+/// `MatchStrategy::Contains` scans for **every** occurrence of the query
+/// including overlapping ones (e.g., `"ana"` against `"banana"` matches
+/// at byte offsets 1 and 3, merging into a single highlight covering
+/// `"anana"`). When a match's end falls inside a case-fold expansion
+/// (e.g., `"stras"` against German `"Straße"` where `ß` folds to `ss`),
+/// the highlighted span extends to cover the **full** source character
+/// that contributed the matched fold bytes, so the rendered output is
+/// `"Straß"`, never a mid-codepoint slice.
+///
+/// `MatchStrategy::Fuzzy` consumes as many consecutive query characters
+/// as appear, in order, inside each source character's fold expansion.
+/// This keeps fuzzy matching symmetric with the other strategies under
+/// many-to-one folds (`"ss"` matches `"ß"` under German, just like the
+/// other direction does for `Contains` and `StartsWith`).
+///
 /// # Edge cases
 ///
 /// - Empty `query`, or `query` containing only empty strings → a single
@@ -347,7 +362,7 @@ pub fn highlight_chunks<'a>(props: &'a Props, locale: &Locale) -> Vec<HighlightC
         }];
     }
 
-    let (normalised_text, byte_map) = build_normalised(text, props.ignore_case, locale);
+    let normalised = Normalised::build(text, props.ignore_case, locale);
 
     let mut ranges: Vec<(usize, usize)> = Vec::new();
 
@@ -365,11 +380,11 @@ pub fn highlight_chunks<'a>(props: &'a Props, locale: &Locale) -> Vec<HighlightC
 
         match props.match_strategy {
             MatchStrategy::Contains => {
-                push_contains_matches(&normalised_text, &normalised_query, &byte_map, &mut ranges);
+                push_contains_matches(&normalised, &normalised_query, &mut ranges);
             }
 
             MatchStrategy::StartsWith => {
-                push_starts_with_match(&normalised_text, &normalised_query, &byte_map, &mut ranges);
+                push_starts_with_match(&normalised, &normalised_query, &mut ranges);
             }
 
             MatchStrategy::Fuzzy => {
@@ -396,44 +411,80 @@ pub fn highlight_chunks<'a>(props: &'a Props, locale: &Locale) -> Vec<HighlightC
     build_chunks(text, &merged)
 }
 
-/// Build a normalised form of `text` (lowercased when `ignore_case`) plus a
-/// byte-map from normalised byte indices back to original byte indices.
+/// Normalised text plus a byte-level mapping back to the original source
+/// text. Each normalised byte `i` has two map entries:
 ///
-/// The map has length `normalised.len() + 1`. For each normalised byte `i`
-/// produced from original char starting at `orig_byte`, `byte_map[i] ==
-/// orig_byte`. The trailing entry `byte_map[normalised.len()] == text.len()`
-/// is a sentinel so callers can read the end index of a match without
-/// bounds-special-casing.
+/// - `source_start[i]` — original byte index where the source character
+///   that produced normalised byte `i` *starts*.
+/// - `source_end[i]` — original byte index where that source character
+///   *ends* (i.e., `source_start + char.len_utf8()`).
 ///
-/// When `!ignore_case`, the normalised text is `text` verbatim and the map
-/// is the identity `0..=text.len()` (each byte trivially maps to itself).
-fn build_normalised(text: &str, ignore_case: bool, locale: &Locale) -> (String, Vec<usize>) {
-    if !ignore_case {
-        let map: Vec<usize> = (0..=text.len()).collect();
+/// Both arrays are aligned: `source_start.len() == source_end.len() ==
+/// normalised.len()`. For a normalised match `[a, b)` we always map to
+/// the source range `[source_start[a], source_end[b - 1]]`, even when
+/// `a` or `b` falls *inside* a case-fold expansion (e.g. `ß → ss`).
+/// Using `source_end[b - 1]` rather than `source_start[b]` is what lets
+/// a match that ends mid-expansion still highlight the full source
+/// character that contributed the matched bytes — without this, queries
+/// like `"stras"` against text `"Straße"` would highlight only the
+/// `"Stra"` prefix and drop the `ß` that contributed the trailing `s`.
+struct Normalised {
+    text: String,
+    source_start: Vec<usize>,
+    source_end: Vec<usize>,
+}
 
-        return (text.to_owned(), map);
-    }
-
-    let mut normalised = String::with_capacity(text.len());
-    let mut byte_map = Vec::with_capacity(text.len() + 1);
-
-    for (orig_byte, ch) in text.char_indices() {
-        let mut buf = [0u8; 4];
-
-        let ch_str = ch.encode_utf8(&mut buf);
-
-        let folded = case_fold(ch_str, locale);
-
-        for _ in 0..folded.len() {
-            byte_map.push(orig_byte);
+impl Normalised {
+    /// Build the normalised view of `text`. When `!ignore_case`, the
+    /// normalised text is the original verbatim and the maps are the
+    /// per-byte identity.
+    fn build(text: &str, ignore_case: bool, locale: &Locale) -> Self {
+        if !ignore_case {
+            let source_start: Vec<usize> = (0..text.len()).collect();
+            let source_end: Vec<usize> = (1..=text.len()).collect();
+            return Self {
+                text: text.to_owned(),
+                source_start,
+                source_end,
+            };
         }
 
-        normalised.push_str(&folded);
+        let mut normalised = String::with_capacity(text.len());
+        let mut source_start = Vec::with_capacity(text.len());
+        let mut source_end = Vec::with_capacity(text.len());
+
+        for (orig_byte, ch) in text.char_indices() {
+            let mut buf = [0u8; 4];
+            let ch_str = ch.encode_utf8(&mut buf);
+            let folded = case_fold(ch_str, locale);
+            let end_of_source_char = orig_byte + ch.len_utf8();
+
+            for _ in 0..folded.len() {
+                source_start.push(orig_byte);
+                source_end.push(end_of_source_char);
+            }
+
+            normalised.push_str(&folded);
+        }
+
+        Self {
+            text: normalised,
+            source_start,
+            source_end,
+        }
     }
 
-    byte_map.push(text.len());
-
-    (normalised, byte_map)
+    /// Map a normalised half-open range `[start_norm, end_norm)` to the
+    /// corresponding original-text half-open range. `end_norm` must be
+    /// strictly greater than `start_norm` (the caller filters empty
+    /// matches before calling).
+    fn map_range(&self, start_norm: usize, end_norm: usize) -> (usize, usize) {
+        debug_assert!(
+            end_norm > start_norm,
+            "Normalised::map_range requires a non-empty range"
+        );
+        (self.source_start[start_norm], self.source_end[end_norm - 1])
+    }
 }
 
 /// Unicode case fold for case-insensitive comparison. Delegates to
@@ -447,43 +498,67 @@ fn case_fold(text: &str, locale: &Locale) -> String {
     ars_i18n::case_fold(text, locale)
 }
 
+/// Push every occurrence of `normalised_query` inside `normalised.text`,
+/// **including overlapping ones** (`str::match_indices` only yields the
+/// non-overlapping ones, which would miss `"ana"` at position 3 of
+/// `"banana"`). Advances by one character past each match's start to
+/// hit the next overlapping occurrence.
 fn push_contains_matches(
-    normalised_text: &str,
+    normalised: &Normalised,
     normalised_query: &str,
-    byte_map: &[usize],
     out: &mut Vec<(usize, usize)>,
 ) {
-    for (start, _) in normalised_text.match_indices(normalised_query) {
-        let end = start + normalised_query.len();
-        let orig_start = byte_map[start];
-        let orig_end = byte_map[end];
+    if normalised_query.is_empty() {
+        return;
+    }
 
-        if orig_start < orig_end {
-            out.push((orig_start, orig_end));
-        }
+    let haystack = normalised.text.as_str();
+    let mut search_start = 0;
+
+    while let Some(rel) = haystack[search_start..].find(normalised_query) {
+        let start = search_start + rel;
+        let end = start + normalised_query.len();
+        let (orig_start, orig_end) = normalised.map_range(start, end);
+
+        out.push((orig_start, orig_end));
+
+        // Advance past one character so the next iteration can find
+        // overlapping matches. UTF-8 guarantees that `find` returned a
+        // position on a char boundary, so `chars().next()` is sound.
+        let advance = haystack[start..].chars().next().map_or(1, char::len_utf8);
+        search_start = start + advance;
     }
 }
 
 fn push_starts_with_match(
-    normalised_text: &str,
+    normalised: &Normalised,
     normalised_query: &str,
-    byte_map: &[usize],
     out: &mut Vec<(usize, usize)>,
 ) {
-    if normalised_text.starts_with(normalised_query) {
-        let end = normalised_query.len();
-        let orig_end = byte_map[end];
+    if normalised_query.is_empty() {
+        return;
+    }
 
-        if orig_end > 0 {
-            out.push((0, orig_end));
-        }
+    if normalised.text.starts_with(normalised_query) {
+        let end = normalised_query.len();
+        let (_, orig_end) = normalised.map_range(0, end);
+        out.push((0, orig_end));
     }
 }
 
-/// Walk the original text char-by-char, lowercasing each char individually
-/// when needed, and consume the query in order. Each matched original-text
-/// character contributes a one-char range to `out`. Fuzzy matching collapses
-/// to no match (zero ranges pushed) when any query char cannot be located.
+/// Walk the original text char-by-char and consume the query in order.
+/// Each source character that contributes at least one matched query
+/// character produces a one-char highlighted range. Fuzzy matching is
+/// all-or-nothing — if any query character cannot be located in order,
+/// the function emits zero ranges for this query.
+///
+/// **Multi-char fold expansions**: a single source char can fold to
+/// multiple chars (e.g. `ß → ss` under German), so we consume *as many*
+/// query characters as match the source char's folded expansion *in
+/// order*. Without this, `MatchStrategy::Fuzzy` with `query=["ss"]` and
+/// `text="ß"` would consume only the first `s` from the query, fail on
+/// the second, and emit no match — violating the spec's eszett
+/// equivalence contract.
 fn push_fuzzy_matches(
     original_text: &str,
     normalised_query: &str,
@@ -495,27 +570,34 @@ fn push_fuzzy_matches(
     let mut local = Vec::new();
 
     for (orig_byte, ch) in original_text.char_indices() {
-        let Some(&want) = query_iter.peek() else {
+        if query_iter.peek().is_none() {
             break;
-        };
+        }
 
         let normalised_ch_string = if ignore_case {
             let mut buf = [0u8; 4];
             let ch_str = ch.encode_utf8(&mut buf);
-
             case_fold(ch_str, locale)
         } else {
             let mut s = String::new();
-
             s.push(ch);
-
             s
         };
 
-        if normalised_ch_string.chars().any(|c| c == want) {
-            local.push((orig_byte, orig_byte + ch.len_utf8()));
+        // Consume every leading query character that appears, in order,
+        // in this source char's folded expansion. For single-char folds
+        // (the common case) this consumes at most one query char; for
+        // expansions like `ß → ss` it may consume two or more.
+        let mut consumed_any = false;
+        for folded_char in normalised_ch_string.chars() {
+            if let Some(&want) = query_iter.peek() && want == folded_char {
+                query_iter.next();
+                consumed_any = true;
+            }
+        }
 
-            query_iter.next();
+        if consumed_any {
+            local.push((orig_byte, orig_byte + ch.len_utf8()));
         }
     }
 
@@ -874,15 +956,16 @@ mod tests {
     }
 
     #[test]
-    fn fold_expansion_partial_match_does_not_emit_partial_char_highlight() {
-        // Branch coverage for the byte-map zero-length-range filter in
-        // both `push_contains_matches` (orig_start < orig_end) and
-        // `push_starts_with_match` (orig_end > 0). Under en-US, "İ"
-        // folds to "i\u{307}" (i + combining dot above, 3 bytes). A
-        // query "i" matches the first folded byte but maps to a
-        // zero-length original range — the implementation must NOT emit
-        // a partial-character highlight, because rendering only part of
-        // a code point would corrupt the displayed text.
+    fn fold_expansion_partial_match_highlights_full_source_char() {
+        // Under en-US (non-Turkic), `İ` case-folds to `i\u{307}` (i +
+        // combining dot above, 3 bytes). A query of `"i"` matches the
+        // leading byte of that expansion. The implementation must
+        // highlight the **entire** source character `İ` (not nothing,
+        // and not just the leading byte), because rendering only part
+        // of a code point would corrupt the displayed text. Verified
+        // for both Contains and StartsWith — the byte-map's
+        // `source_end` mapping is what lets the match extend to the
+        // source char's full UTF-8 span.
         for strategy in [MatchStrategy::Contains, MatchStrategy::StartsWith] {
             let props = Props::new()
                 .query(["i"])
@@ -897,11 +980,92 @@ mod tests {
                 .map(|c| c.text)
                 .collect();
 
-            assert!(
-                highlighted.is_empty(),
-                "{strategy:?}: must not emit partial-char highlight, got {highlighted:?}"
+            assert_eq!(
+                highlighted,
+                vec!["İ"],
+                "{strategy:?}: must highlight the full `İ`, got {highlighted:?}"
             );
         }
+    }
+
+    #[test]
+    fn contains_strategy_finds_overlapping_occurrences() {
+        // `str::match_indices` only yields non-overlapping matches, so
+        // a naive implementation would highlight only the first `ana`
+        // in `banana` and miss the second. The spec says Contains
+        // highlights **every** occurrence then merges overlaps, so the
+        // expected result is one merged highlight covering `anana`.
+        let props = Props::new().query(["ana"]).text("banana");
+
+        let chunks = highlight_chunks(&props, &en_us());
+
+        assert_eq!(
+            chunks,
+            vec![
+                HighlightChunk {
+                    text: "b",
+                    highlighted: false,
+                },
+                HighlightChunk {
+                    text: "anana",
+                    highlighted: true,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn starts_with_extends_match_to_full_fold_expansion_source_char() {
+        // German `Straße` folds to `strasse`. Query `stras` matches
+        // the folded prefix, with its final byte coming from the
+        // `ß`'s fold expansion. The highlighted span must extend to
+        // cover the full `ß` so the rendered output is `Straß`, not
+        // `Stra` (which would slice off the ß mid-codepoint).
+        let props = Props::new()
+            .query(["stras"])
+            .text("Straße")
+            .match_strategy(MatchStrategy::StartsWith);
+
+        let chunks = highlight_chunks(&props, &german());
+
+        assert_eq!(
+            chunks,
+            vec![
+                HighlightChunk {
+                    text: "Straß",
+                    highlighted: true,
+                },
+                HighlightChunk {
+                    text: "e",
+                    highlighted: false,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn fuzzy_consumes_full_folded_expansion_for_eszett() {
+        // Under German, `ß` folds to `ss`. A fuzzy query of `ss`
+        // against text `ß` must consume **both** query characters
+        // against the single source char's folded expansion, then
+        // emit a one-char highlight for the `ß` itself. Without
+        // multi-char consumption the second `s` is left in the query,
+        // fuzzy's all-or-nothing rule kicks in, and `ß` ↔ `ss`
+        // equivalence breaks asymmetrically with the other strategies.
+        let props = Props::new()
+            .query(["ss"])
+            .text("ß")
+            .match_strategy(MatchStrategy::Fuzzy);
+
+        let chunks = highlight_chunks(&props, &german());
+
+        assert_eq!(
+            chunks,
+            vec![HighlightChunk {
+                text: "ß",
+                highlighted: true,
+            }]
+        );
     }
 
     #[test]

--- a/crates/ars-components/src/utility/highlight.rs
+++ b/crates/ars-components/src/utility/highlight.rs
@@ -590,7 +590,9 @@ fn push_fuzzy_matches(
         // expansions like `ß → ss` it may consume two or more.
         let mut consumed_any = false;
         for folded_char in normalised_ch_string.chars() {
-            if let Some(&want) = query_iter.peek() && want == folded_char {
+            if let Some(&want) = query_iter.peek()
+                && want == folded_char
+            {
                 query_iter.next();
                 consumed_any = true;
             }

--- a/crates/ars-components/src/utility/mod.rs
+++ b/crates/ars-components/src/utility/mod.rs
@@ -38,6 +38,15 @@ pub mod form_submit;
 /// `Heading` component (stateless heading-level mapper).
 pub mod heading;
 
+/// `Highlight` component (stateless text substring matcher with Unicode-aware
+/// case folding and chunked output for adapter-rendered `<mark>` highlights).
+///
+/// Gated on `feature = "i18n"`: the component contract requires locale-aware
+/// ICU4X case folding for Turkic / German / Greek / Lithuanian guarantees,
+/// which is only available when `ars-i18n/icu4x` is enabled.
+#[cfg(feature = "i18n")]
+pub mod highlight;
+
 /// `Keyboard` component (stateless `<kbd>` shortcut renderer with
 /// platform-aware modifier mapping).
 pub mod keyboard;

--- a/crates/ars-components/src/utility/snapshots/ars_components__utility__highlight__tests__highlight_chunk_highlighted.snap
+++ b/crates/ars-components/src/utility/snapshots/ars_components__utility__highlight__tests__highlight_chunk_highlighted.snap
@@ -1,0 +1,25 @@
+---
+source: crates/ars-components/src/utility/highlight.rs
+expression: "snapshot_attrs(&Api::new(Props::default()).chunk_attrs(true))"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-highlighted",
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "highlight-chunk",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/utility/snapshots/ars_components__utility__highlight__tests__highlight_chunk_not_highlighted.snap
+++ b/crates/ars-components/src/utility/snapshots/ars_components__utility__highlight__tests__highlight_chunk_not_highlighted.snap
@@ -1,0 +1,25 @@
+---
+source: crates/ars-components/src/utility/highlight.rs
+expression: "snapshot_attrs(&Api::new(Props::default()).chunk_attrs(false))"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-highlighted",
+            ),
+            String(
+                "false",
+            ),
+        ),
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "highlight-chunk",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/utility/snapshots/ars_components__utility__highlight__tests__highlight_chunks_contains_en.snap
+++ b/crates/ars-components/src/utility/snapshots/ars_components__utility__highlight__tests__highlight_chunks_contains_en.snap
@@ -1,0 +1,18 @@
+---
+source: crates/ars-components/src/utility/highlight.rs
+expression: "snapshot_chunks(&highlight_chunks(&props, &en_us()))"
+---
+[
+    HighlightChunk {
+        text: "Hello ",
+        highlighted: false,
+    },
+    HighlightChunk {
+        text: "world",
+        highlighted: true,
+    },
+    HighlightChunk {
+        text: "!",
+        highlighted: false,
+    },
+]

--- a/crates/ars-components/src/utility/snapshots/ars_components__utility__highlight__tests__highlight_chunks_fuzzy.snap
+++ b/crates/ars-components/src/utility/snapshots/ars_components__utility__highlight__tests__highlight_chunks_fuzzy.snap
@@ -1,0 +1,26 @@
+---
+source: crates/ars-components/src/utility/highlight.rs
+expression: "snapshot_chunks(&highlight_chunks(&props, &en_us()))"
+---
+[
+    HighlightChunk {
+        text: "a",
+        highlighted: true,
+    },
+    HighlightChunk {
+        text: "_",
+        highlighted: false,
+    },
+    HighlightChunk {
+        text: "b",
+        highlighted: true,
+    },
+    HighlightChunk {
+        text: "_",
+        highlighted: false,
+    },
+    HighlightChunk {
+        text: "c",
+        highlighted: true,
+    },
+]

--- a/crates/ars-components/src/utility/snapshots/ars_components__utility__highlight__tests__highlight_chunks_german_eszett.snap
+++ b/crates/ars-components/src/utility/snapshots/ars_components__utility__highlight__tests__highlight_chunks_german_eszett.snap
@@ -1,0 +1,26 @@
+---
+source: crates/ars-components/src/utility/highlight.rs
+expression: "snapshot_chunks(&highlight_chunks(&props, &german()))"
+---
+[
+    HighlightChunk {
+        text: "Stra",
+        highlighted: false,
+    },
+    HighlightChunk {
+        text: "ß",
+        highlighted: true,
+    },
+    HighlightChunk {
+        text: "e ist STRA",
+        highlighted: false,
+    },
+    HighlightChunk {
+        text: "SS",
+        highlighted: true,
+    },
+    HighlightChunk {
+        text: "E",
+        highlighted: false,
+    },
+]

--- a/crates/ars-components/src/utility/snapshots/ars_components__utility__highlight__tests__highlight_chunks_multi_query_merged.snap
+++ b/crates/ars-components/src/utility/snapshots/ars_components__utility__highlight__tests__highlight_chunks_multi_query_merged.snap
@@ -1,0 +1,14 @@
+---
+source: crates/ars-components/src/utility/highlight.rs
+expression: "snapshot_chunks(&highlight_chunks(&props, &en_us()))"
+---
+[
+    HighlightChunk {
+        text: "foob",
+        highlighted: true,
+    },
+    HighlightChunk {
+        text: "ar",
+        highlighted: false,
+    },
+]

--- a/crates/ars-components/src/utility/snapshots/ars_components__utility__highlight__tests__highlight_chunks_starts_with.snap
+++ b/crates/ars-components/src/utility/snapshots/ars_components__utility__highlight__tests__highlight_chunks_starts_with.snap
@@ -1,0 +1,14 @@
+---
+source: crates/ars-components/src/utility/highlight.rs
+expression: "snapshot_chunks(&highlight_chunks(&props, &en_us()))"
+---
+[
+    HighlightChunk {
+        text: "Hello",
+        highlighted: true,
+    },
+    HighlightChunk {
+        text: " world",
+        highlighted: false,
+    },
+]

--- a/crates/ars-components/src/utility/snapshots/ars_components__utility__highlight__tests__highlight_chunks_turkic.snap
+++ b/crates/ars-components/src/utility/snapshots/ars_components__utility__highlight__tests__highlight_chunks_turkic.snap
@@ -1,0 +1,14 @@
+---
+source: crates/ars-components/src/utility/highlight.rs
+expression: "snapshot_chunks(&highlight_chunks(&props, &turkish()))"
+---
+[
+    HighlightChunk {
+        text: "i",
+        highlighted: true,
+    },
+    HighlightChunk {
+        text: "stanbul",
+        highlighted: false,
+    },
+]

--- a/crates/ars-components/src/utility/snapshots/ars_components__utility__highlight__tests__highlight_root.snap
+++ b/crates/ars-components/src/utility/snapshots/ars_components__utility__highlight__tests__highlight_root.snap
@@ -1,0 +1,31 @@
+---
+source: crates/ars-components/src/utility/highlight.rs
+expression: "snapshot_attrs(&Api::new(Props::default()).root_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "highlight",
+            ),
+        ),
+        (
+            Dir,
+            String(
+                "auto",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/tests/proptest_state_machines/utility.rs
+++ b/crates/ars-components/tests/proptest_state_machines/utility.rs
@@ -1,5 +1,7 @@
 use std::collections::BTreeMap;
 
+#[cfg(feature = "i18n")]
+use ars_components::utility::highlight;
 use ars_components::utility::{
     button, error_boundary, field, fieldset, form, form_submit, separator, visually_hidden,
 };
@@ -8,6 +10,8 @@ use ars_forms::{
     form::Mode,
     validation::{BoxedAsyncValidator, Error},
 };
+#[cfg(feature = "i18n")]
+use ars_i18n::Locale;
 use ars_i18n::Orientation;
 use proptest::prelude::*;
 
@@ -691,6 +695,134 @@ proptest! {
                 attrs_b.get(&attr),
                 "attr {:?} should be count-invariant", attr
             );
+        }
+    }
+}
+
+// ── Highlight (utility::highlight, gated on the `i18n` feature) ────
+
+#[cfg(feature = "i18n")]
+fn arb_match_strategy() -> impl Strategy<Value = highlight::MatchStrategy> {
+    prop_oneof![
+        Just(highlight::MatchStrategy::Contains),
+        Just(highlight::MatchStrategy::StartsWith),
+        Just(highlight::MatchStrategy::Fuzzy),
+    ]
+}
+
+#[cfg(feature = "i18n")]
+fn arb_highlight_text() -> impl Strategy<Value = String> {
+    // Mix of ASCII, multi-byte UTF-8 (ß, İ, é), and whitespace to
+    // exercise byte-boundary and case-folding paths together.
+    "[a-zA-Z0-9 _\u{00DF}\u{0130}\u{00E9}]{0,32}".prop_map(String::from)
+}
+
+#[cfg(feature = "i18n")]
+fn arb_highlight_query() -> impl Strategy<Value = Vec<String>> {
+    prop::collection::vec(
+        "[a-zA-Z0-9 \u{00DF}\u{0130}]{0,8}".prop_map(String::from),
+        0..4,
+    )
+}
+
+#[cfg(feature = "i18n")]
+fn arb_highlight_props() -> impl Strategy<Value = highlight::Props> {
+    (
+        arb_highlight_query(),
+        arb_highlight_text(),
+        any::<bool>(),
+        arb_match_strategy(),
+    )
+        .prop_map(|(query, text, ignore_case, match_strategy)| {
+            highlight::Props::new()
+                .query(query)
+                .text(text)
+                .ignore_case(ignore_case)
+                .match_strategy(match_strategy)
+        })
+}
+
+#[cfg(feature = "i18n")]
+fn arb_highlight_locale() -> impl Strategy<Value = Locale> {
+    // Mix of locale families that exercise different case-folding paths:
+    // - en-US: default Unicode fold.
+    // - tr / az: Turkic dotted/dotless-I fold (CaseMapper::fold_turkic_string).
+    // - de: German eszett expansion `ß → ss`.
+    // - el: Greek final-sigma collapse `Σ/σ/ς → σ`.
+    // - lt: Lithuanian combining-dot handling.
+    // - hy: Armenian — exercises a script with case but no special tailoring.
+    // - ar: a script with no case at all (the fold is the identity).
+    prop_oneof![
+        Just(Locale::parse("en-US").expect("en-US must parse")),
+        Just(Locale::parse("tr").expect("tr must parse")),
+        Just(Locale::parse("az").expect("az must parse")),
+        Just(Locale::parse("de").expect("de must parse")),
+        Just(Locale::parse("el").expect("el must parse")),
+        Just(Locale::parse("lt").expect("lt must parse")),
+        Just(Locale::parse("hy").expect("hy must parse")),
+        Just(Locale::parse("ar").expect("ar must parse")),
+    ]
+}
+
+#[cfg(feature = "i18n")]
+proptest! {
+    #![proptest_config(super::common::proptest_config())]
+
+    /// For any combination of props and locale, `highlight_chunks` must:
+    ///
+    /// 1. **Never panic** (covered by the test reaching its end).
+    /// 2. **Roundtrip the text** — concatenating all chunk slices in order
+    ///    yields the original `props.text` byte-for-byte. Catches any
+    ///    range / index / byte-map regression silently dropping or
+    ///    duplicating text.
+    /// 3. **Never emit two adjacent highlighted chunks** — the agnostic
+    ///    core's adjacency-merge contract (spec §3.1) must hold for every
+    ///    strategy and every query combination.
+    /// 4. **Never emit empty chunks** — zero-length segments are skipped
+    ///    by `build_chunks`; this guards against silent regressions there.
+    /// 5. **Empty query (or all-empty queries)** must produce exactly one
+    ///    non-highlighted chunk wrapping the full text, when the text is
+    ///    non-empty. Empty text yields an empty `Vec`.
+    #[test]
+    #[ignore = "proptest — nightly extended-proptest job"]
+    fn proptest_highlight_chunks_invariants(
+        props in arb_highlight_props(),
+        locale in arb_highlight_locale(),
+    ) {
+        let chunks = highlight::highlight_chunks(&props, &locale);
+
+        // (2) roundtrip
+        let concatenated: String = chunks.iter().map(|c| c.text).collect();
+        prop_assert_eq!(
+            concatenated.as_str(),
+            props.text.as_str(),
+            "chunks must reconstruct the original text"
+        );
+
+        // (3) no two adjacent highlighted chunks
+        for window in chunks.windows(2) {
+            prop_assert!(
+                !(window[0].highlighted && window[1].highlighted),
+                "adjacency-merge regression: {:?}", window
+            );
+        }
+
+        // (4) no empty chunks
+        for chunk in &chunks {
+            prop_assert!(
+                !chunk.text.is_empty(),
+                "empty chunk emitted: {:?}", chunk
+            );
+        }
+
+        // (5) empty-query / empty-text special cases
+        let all_queries_empty = props.query.iter().all(String::is_empty);
+        if props.text.is_empty() {
+            prop_assert!(chunks.is_empty(), "empty text should yield empty Vec");
+        } else if props.query.is_empty() || all_queries_empty {
+            prop_assert_eq!(chunks.len(), 1, "empty query → exactly one chunk");
+            prop_assert!(!chunks[0].highlighted, "empty-query chunk must not be highlighted");
+            prop_assert_eq!(chunks[0].text, props.text.as_str());
         }
     }
 }

--- a/crates/ars-components/tests/spec_conformance.rs
+++ b/crates/ars-components/tests/spec_conformance.rs
@@ -22,3 +22,6 @@ mod navigation;
 
 #[path = "spec_conformance/overlay.rs"]
 mod overlay;
+
+#[path = "spec_conformance/utility.rs"]
+mod utility;

--- a/crates/ars-components/tests/spec_conformance/utility.rs
+++ b/crates/ars-components/tests/spec_conformance/utility.rs
@@ -1,0 +1,21 @@
+//! Spec-conformance tests for `crates/ars-components/src/utility/*`.
+//!
+//! Each test pulls the expected anatomy from the corresponding component
+//! spec's §2 anatomy table and asserts the impl's `Part` enum matches.
+
+#[cfg(feature = "i18n")]
+use ars_components::utility::highlight;
+
+#[cfg(feature = "i18n")]
+use super::helper::assert_anatomy;
+
+#[cfg(feature = "i18n")]
+#[test]
+fn highlight_anatomy_matches_spec() {
+    // Highlight's anatomy table (spec §2) lists two rows: `Root` and
+    // `Chunk`. Only `Root` is a static `Part` enum variant — `Chunk` is
+    // a parametric anatomy slot driven by a runtime boolean and served
+    // by `Api::chunk_attrs(highlighted)`, per the convention documented
+    // in `foundation/10-component-spec-template.md` §4.2.
+    assert_anatomy("highlight", &[(highlight::Part::Root, "root")]);
+}

--- a/crates/ars-dioxus/Cargo.toml
+++ b/crates/ars-dioxus/Cargo.toml
@@ -37,8 +37,10 @@ web = [
 uuid = ["ars-collections/uuid", "ars-components/uuid"]
 # Pre-compiled CLDR data via ICU4X. Default backend on native targets and the
 # server-side rendering path. Use `--no-default-features --features web,ars-i18n/web-intl`
-# to swap icu4x for the browser-native Intl API on wasm32 builds.
-icu4x = ["ars-i18n/std", "ars-i18n/icu4x"]
+# to swap icu4x for the browser-native Intl API on wasm32 builds. Also enables
+# `ars-components/i18n` so locale-aware components (e.g., `Highlight`) are
+# available in the adapter build.
+icu4x = ["ars-i18n/std", "ars-i18n/icu4x", "ars-components/i18n"]
 
 [dependencies]
 ars-a11y             = { path = "../ars-a11y" }

--- a/crates/ars-i18n/src/case.rs
+++ b/crates/ars-i18n/src/case.rs
@@ -73,6 +73,52 @@ pub fn to_lowercase(text: &str, locale: &Locale) -> String {
         .into_owned()
 }
 
+/// Unicode case folding for case-insensitive comparison.
+///
+/// Returns the canonical case-fold form per Unicode Technical Report 21 —
+/// the right primitive for case-insensitive **matching** (as opposed to
+/// case **transformation**, which is what [`to_lowercase`] / [`to_uppercase`]
+/// do). The key differences for matching:
+///
+/// - German eszett: `fold("ß") == fold("SS") == "ss"`, so `"ß"` and `"ss"`
+///   match each other (whereas `to_lowercase("ß") == "ß"`).
+/// - Greek final sigma collapses into the medial form, so a query against
+///   text containing `"Ος"` matches `"ΟΣ"` and vice versa.
+/// - Turkic dotted/dotless I: when `locale` is a Turkic language (`tr` /
+///   `az`), the implementation switches to ICU4X
+///   `CaseMapper::fold_turkic_string` so `İ ↔ i` and `I ↔ ı` per the
+///   Turkic case-folding convention. Non-Turkic locales use the default
+///   Unicode fold.
+///
+/// Available only under the `icu4x` feature; the `web-intl` backend has
+/// no equivalent (browser `Intl` exposes only locale-aware lowercase /
+/// uppercase) so callers requiring case-fold-based matching must use the
+/// ICU4X backend.
+#[must_use]
+#[cfg(feature = "icu4x")]
+pub fn case_fold(text: &str, locale: &Locale) -> String {
+    let mapper = CaseMapper::new();
+
+    if is_turkic_locale(locale) {
+        mapper.fold_turkic_string(text).into_owned()
+    } else {
+        mapper.fold_string(text).into_owned()
+    }
+}
+
+/// Returns `true` for locales that use Turkic case-folding rules — Turkish
+/// (`tr`) and Azerbaijani (`az`).
+///
+/// These are the language tags ICU treats as Turkic for case mapping per
+/// CLDR's `special-casing` data, which is the same set that
+/// `CaseMapper::lowercase_to_string` already switches behaviour on. Other
+/// Turkic family languages (Kazakh `kk`, Tatar `tt`, Uzbek `uz`) follow
+/// regular Unicode case rules in CLDR.
+#[cfg(feature = "icu4x")]
+fn is_turkic_locale(locale: &Locale) -> bool {
+    matches!(locale.language(), "tr" | "az")
+}
+
 /// Locale-aware lowercase transformation.
 ///
 /// Delegates to browser `String.prototype.toLocaleLowerCase()` on wasm
@@ -174,6 +220,62 @@ mod tests {
         let locale = Locale::parse("el").expect("locale should parse");
 
         assert_eq!(to_lowercase("ΟΣ", &locale), "ος");
+    }
+
+    // ── case_fold (Unicode case folding for case-insensitive match) ──
+
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn fold_expands_eszett_to_ss() {
+        // Per Unicode TR21, `case_fold("ß") == "ss"` and `case_fold("SS")
+        // == "ss"`, so the two are equivalent for case-insensitive
+        // matching. (Lowercase preserves `ß`; only the fold form expands.)
+        let de = Locale::parse("de").expect("locale should parse");
+
+        assert_eq!(super::case_fold("ß", &de), "ss");
+        assert_eq!(super::case_fold("SS", &de), "ss");
+        assert_eq!(super::case_fold("Straße", &de), "strasse");
+    }
+
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn fold_collapses_greek_final_sigma_into_medial_form() {
+        // Final sigma `ς` and medial sigma `σ` both fold to `σ`, and
+        // capital `Σ` folds to the same. So queries against text mixing
+        // the three forms still match under case_fold.
+        let el = Locale::parse("el").expect("locale should parse");
+
+        assert_eq!(super::case_fold("ΟΣ", &el), super::case_fold("Ος", &el));
+        assert_eq!(super::case_fold("σ", &el), super::case_fold("ς", &el));
+    }
+
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn fold_turkic_locale_uses_turkic_fold() {
+        // Under `tr` / `az`, `İ ↔ i` and `I ↔ ı`. Under non-Turkic
+        // locales the standard Unicode fold applies (`İ → i̇`).
+        let tr = Locale::parse("tr").expect("locale should parse");
+        let en = Locale::parse("en-US").expect("locale should parse");
+
+        // Turkic: dotted/dotless I pairings collapse.
+        assert_eq!(super::case_fold("İ", &tr), super::case_fold("i", &tr));
+        assert_eq!(super::case_fold("I", &tr), super::case_fold("ı", &tr));
+
+        // Non-Turkic: `İ` does NOT fold to plain `i`.
+        assert_ne!(super::case_fold("İ", &en), "i");
+    }
+
+    #[cfg(feature = "icu4x")]
+    #[test]
+    fn fold_is_idempotent() {
+        // Folding an already-folded string is a no-op (the fold form is
+        // its own canonical representative).
+        for input in ["hello", "Straße", "İstanbul", "ΟΣ"] {
+            let de = Locale::parse("de").expect("locale should parse");
+            let folded = super::case_fold(input, &de);
+
+            assert_eq!(super::case_fold(&folded, &de), folded);
+        }
     }
 
     #[cfg(all(

--- a/crates/ars-i18n/src/lib.rs
+++ b/crates/ars-i18n/src/lib.rs
@@ -53,6 +53,8 @@ pub use calendar::{
 };
 #[cfg(feature = "std")]
 pub use calendar::{to_zoned, to_zoned_date_time};
+#[cfg(feature = "icu4x")]
+pub use case::case_fold;
 #[cfg(any(feature = "icu4x", feature = "web-intl"))]
 pub use case::{to_lowercase, to_uppercase};
 pub use collation::{CollationFormat, CollationOptions, CollationStrength, StringCollator};

--- a/crates/ars-leptos/Cargo.toml
+++ b/crates/ars-leptos/Cargo.toml
@@ -16,8 +16,10 @@ csr     = ["leptos/csr"]
 uuid    = ["ars-collections/uuid", "ars-components/uuid"]
 # Pre-compiled CLDR data via ICU4X. Default backend on native targets and the
 # server-side rendering path. Use `--no-default-features --features csr,ars-i18n/web-intl`
-# to swap icu4x for the browser-native Intl API on wasm32 builds.
-icu4x = ["ars-i18n/std", "ars-i18n/icu4x"]
+# to swap icu4x for the browser-native Intl API on wasm32 builds. Also enables
+# `ars-components/i18n` so locale-aware components (e.g., `Highlight`) are
+# available in the adapter build.
+icu4x = ["ars-i18n/std", "ars-i18n/icu4x", "ars-components/i18n"]
 
 [dependencies]
 ars-a11y         = { path = "../ars-a11y" }

--- a/spec/components/utility/highlight.md
+++ b/spec/components/utility/highlight.md
@@ -6,86 +6,190 @@ foundation_deps: [architecture, accessibility]
 shared_deps: []
 related: []
 references:
-  ark-ui: Highlight
+    ark-ui: Highlight
 ---
 
 # Highlight
 
-`Highlight` is a pure computation utility that splits text into highlighted and non-highlighted chunks based on a search query. It has no state machine — the adapter renders `<mark>` elements for highlighted chunks.
+`Highlight` is a stateless utility that splits a text into alternating highlighted / non-highlighted chunks based on one or more search queries. It has no state machine. Adapters render the returned chunks as `<mark>` (highlighted) or `<span>` (non-highlighted) inside a single `<span>` root.
 
 ## 1. API
+
+`Highlight` follows the standard stateless utility shape: `Props` + `Part` + `Api`, plus a public free function (`highlight_chunks`) that does the chunk computation. Adapters spread `Api::root_attrs()` / `Api::chunk_attrs(highlighted)` onto the rendered elements and iterate `Api::chunks(locale)` (or call `highlight_chunks` directly) for the chunk sequence.
 
 ### 1.1 Props
 
 ```rust
 /// Props for the `Highlight` component.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct Props {
     /// The search queries to highlight. Supports a single query string or
     /// multiple queries to highlight simultaneously (e.g., multiple search
     /// terms). When multiple queries are provided, all matches from all
-    /// queries are highlighted; overlapping matches are merged.
+    /// queries are highlighted; overlapping or adjacent ranges are merged
+    /// into a single highlighted chunk. An empty vec, or a vec containing
+    /// only empty strings, produces a single non-highlighted chunk
+    /// wrapping the full text. Default: empty.
     pub query: Vec<String>,
-    /// The full text to search within.
+    /// The full text to search within. Default: empty.
     pub text: String,
-    /// Case-insensitive matching (default: true).
+    /// Case-insensitive matching. Default: `true`.
     pub ignore_case: bool,
-    /// Matching strategy.
+    /// Matching strategy. Default: `MatchStrategy::Contains`.
     pub match_strategy: MatchStrategy,
 }
 
-/// The strategy to use for matching the query within the text.
-#[derive(Clone, Copy, Debug, PartialEq)]
+impl Default for Props {
+    fn default() -> Self {
+        Self {
+            query: Vec::new(),
+            text: String::new(),
+            ignore_case: true,
+            match_strategy: MatchStrategy::Contains,
+        }
+    }
+}
+
+/// The strategy used to match the query against the text.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 pub enum MatchStrategy {
-    /// Highlight all occurrences of the query within the text.
+    /// Highlight every occurrence of the query within the text. Default.
+    #[default]
     Contains,
-    /// Highlight only if the text starts with the query.
+    /// Highlight only the leading run of the text when it starts with the
+    /// query (after case folding, if `ignore_case` is `true`).
     StartsWith,
-    /// Highlight individual characters for fuzzy matching.
+    /// Subsequence match: highlight each individual query character within
+    /// the text in order, allowing arbitrary gaps. All query characters
+    /// must be present; if any character is missing, no fuzzy ranges are
+    /// emitted for that query (all-or-nothing).
     Fuzzy,
 }
 ```
 
+`Highlight` does **not** derive `HasId` and has no `id` field — the rendered output is a sequence of chunks rather than a single addressable DOM element.
+
+A fluent builder is provided per the workspace stateless-utility convention (see `foundation/10-component-spec-template.md` §4.1.2):
+
+```rust,no_check
+let props = Props::new()
+    .query(["foo", "bar"])              // accepts any IntoIterator<Item = Into<String>>
+    .text("foobar")
+    .ignore_case(false)
+    .match_strategy(MatchStrategy::Fuzzy);
+```
+
 ### 1.2 Connect / API
 
-`Highlight` uses a function-based API that returns text chunks rather than the standard `ConnectApi` / `AttrMap` pattern. The adapter renders each chunk as a DOM element.
-
 ```rust
-/// A chunk of text that has been highlighted or not.
-#[derive(Clone, Debug, PartialEq)]
+/// One contiguous run of the original text, tagged as highlighted or not.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct HighlightChunk<'a> {
+    /// The slice of the source text covered by this chunk.
     pub text: &'a str,
+    /// Whether the adapter should wrap this chunk in `<mark>`.
     pub highlighted: bool,
 }
 
-/// Returns the text split into alternating highlighted/non-highlighted segments.
+/// DOM parts of the `Highlight` component.
 ///
-/// When `ignore_case` is `true`, the implementation MUST use Unicode case folding
-/// rather than ASCII `to_lowercase()`. If `locale` is provided, use locale-aware
-/// case folding via ICU4X `CaseMapper::fold_turkic()` for Turkic locales. Otherwise,
-/// use default Unicode case folding (`CaseMapper::fold()`). This ensures correct
-/// matching for Turkish dotted-I (İ/i vs I/ı), German eszett (ß/SS), and other
-/// locale-specific case mappings.
-pub fn highlight_chunks<'a>(props: &'a Props, locale: &Locale) -> Vec<HighlightChunk<'a>> {
-    // Returns the text split into alternating highlighted/non-highlighted segments.
-    // When queries are empty or all empty strings, returns the full text as a single
-    // non-highlighted chunk. When multiple queries match overlapping regions, the
-    // overlapping ranges are merged into a single highlighted chunk.
+/// Only `Root` is a static anatomy slot. The per-chunk `<mark>` / `<span>`
+/// elements are emitted dynamically per `HighlightChunk`, parametric on the
+/// runtime `highlighted` boolean — a value `ConnectApi::part_attrs` (which
+/// takes a `Part` by value, no payload) cannot express. Adapters call
+/// `Api::chunk_attrs(highlighted)` per chunk instead. See §2 Anatomy.
+#[derive(ComponentPart)]
+#[scope = "highlight"]
+pub enum Part {
+    Root,
 }
+
+pub struct Api { props: Props }
+
+impl Api {
+    pub const fn new(props: Props) -> Self;
+    pub const fn props(&self) -> &Props;
+    pub fn query(&self) -> &[String];
+    pub fn text(&self) -> &str;
+    pub const fn ignore_case(&self) -> bool;
+    pub const fn match_strategy(&self) -> MatchStrategy;
+
+    /// Attributes for the root `<span>`. Emits `data-ars-scope="highlight"`,
+    /// `data-ars-part="root"`, and `dir="auto"` (so the browser picks the
+    /// correct BiDi paragraph direction from the first strong character —
+    /// see §3.2).
+    pub fn root_attrs(&self) -> AttrMap;
+
+    /// Attributes for one chunk element. Emits
+    /// `data-ars-part="highlight-chunk"` and
+    /// `data-ars-highlighted="true"|"false"`. The element type (`<mark>`
+    /// vs `<span>`) is chosen by the adapter from the same boolean.
+    pub fn chunk_attrs(&self, highlighted: bool) -> AttrMap;
+
+    /// Convenience around `highlight_chunks`.
+    pub fn chunks<'a>(&'a self, locale: &Locale) -> Vec<HighlightChunk<'a>>;
+}
+
+impl ConnectApi for Api {
+    type Part = Part;
+    fn part_attrs(&self, part: Part) -> AttrMap;  // Part::Root → root_attrs
+}
+
+/// Splits the text into alternating highlighted / non-highlighted segments.
+///
+/// When `ignore_case` is `true`, matching uses Unicode **case folding**
+/// (per Unicode Technical Report 21 — the canonical primitive for
+/// case-insensitive matching, as opposed to case **transformation** which
+/// is what `to_lowercase` / `to_uppercase` do) via `ars_i18n::case_fold`.
+/// This wraps ICU4X `CaseMapper::fold_string` (or `fold_turkic_string`
+/// under Turkic locales) and delivers true case equivalence:
+///
+/// - German eszett: `"ß"`, `"ss"`, and `"SS"` all match each other
+///   (the fold expands `ß → ss`).
+/// - Greek: final-sigma `ς`, medial `σ`, and capital `Σ` all collapse to
+///   the same fold form.
+/// - Turkic (`tr` / `az`): `İ ↔ i` and `I ↔ ı` per the Turkic fold; other
+///   locales use the standard Unicode fold (`İ → i\u{307}`).
+/// - Lithuanian, Armenian, and other CLDR-tailored mappings supplied by
+///   `CaseMapper`.
+///
+/// When `ignore_case` is `false`, matching is byte-exact and the `locale`
+/// parameter is ignored.
+///
+/// When multiple queries (or fuzzy hits) produce overlapping or adjacent
+/// ranges, the agnostic core merges them into a single highlighted chunk
+/// before returning — adapters never see back-to-back `<mark>` elements
+/// covering contiguous text.
+///
+/// Edge cases:
+///
+/// - Empty `query`, or `query` containing only empty strings → one
+///   non-highlighted chunk wrapping the full text.
+/// - Empty `text` → an empty `Vec` (nothing to render).
+/// - Query longer than text → one non-highlighted chunk.
+/// - `MatchStrategy::Fuzzy` with any missing query character → that query
+///   contributes zero ranges (all-or-nothing).
+pub fn highlight_chunks<'a>(props: &'a Props, locale: &Locale) -> Vec<HighlightChunk<'a>>;
 ```
+
+### 1.3 Build features
+
+The agnostic-core lives in `ars-components` gated on `feature = "i18n"`, which enables `ars-i18n/icu4x`. The locale-aware case-mapping guarantee on `ignore_case = true` is non-negotiable, so the module is unavailable in builds that don't have ICU4X. Adapters using the browser-native `Intl` backend (`ars-i18n/web-intl`) cannot also use Highlight in the same build — the two ars-i18n backends are mutually exclusive.
 
 ## 2. Anatomy
 
 ```text
 Highlight
-└── Root        <span>   data-ars-scope="highlight" data-ars-part="root"
-    └── Chunk   <mark> | <span>   (×N, per highlight_chunks output)
+└── Root                <span>                  data-ars-scope="highlight" data-ars-part="root" dir="auto"
+    └── Chunk           <mark> | <span>   (×N) — parametric per `HighlightChunk`
 ```
 
-| Part  | Element           | Key Attributes                                                          |
-| ----- | ----------------- | ----------------------------------------------------------------------- |
-| Root  | `<span>`          | `data-ars-scope="highlight"`, `data-ars-part="root"`                    |
-| Chunk | `<mark>`/`<span>` | `data-ars-part="highlight-chunk"`, `data-ars-highlighted="true\|false"` |
+| Part  | Element           | Key Attributes                                                                                                 |
+| ----- | ----------------- | -------------------------------------------------------------------------------------------------------------- |
+| Root  | `<span>`          | `data-ars-scope="highlight"`, `data-ars-part="root"`, `dir="auto"`                                             |
+| Chunk | `<mark>`/`<span>` | `data-ars-part="highlight-chunk"`, `data-ars-highlighted="true\|false"` — emitted via `Api::chunk_attrs(bool)` |
+
+**`Chunk` is a parametric anatomy slot.** It is intentionally absent from the `Part` enum because its attribute output depends on a runtime boolean (`highlighted`) that `ConnectApi::part_attrs` cannot carry. Adapters call `Api::chunk_attrs(chunk.highlighted)` per chunk. The same shape applies to other parametric anatomies in the catalog (per-row, per-item, per-tag slots).
 
 Adapters render each `HighlightChunk` as a `<mark>` (when `highlighted == true`) or `<span>` (when `highlighted == false`).
 
@@ -93,26 +197,31 @@ Adapters render each `HighlightChunk` as a `<mark>` (when `highlighted == true`)
 
 ### 3.1 ARIA Roles, States, and Properties
 
-- `<mark>` elements are used for highlighted text. Screen readers announce `<mark>` content as "highlighted" in most browser/AT combinations.
-- No ARIA attributes needed — the semantic `<mark>` element conveys the highlighting.
-- For custom styling, adapters set `data-ars-part="highlight-chunk"` and `data-ars-highlighted="true|false"` on each chunk.
-- When using fuzzy matching (`MatchStrategy::Fuzzy`), many small `<mark>` elements may be generated. Each `<mark>` is announced as 'highlighted' by screen readers, which can create excessive verbosity. For fuzzy matches with many small highlights, adapters SHOULD consolidate adjacent highlighted chunks into a single `<mark>` element, or provide a summary announcement (e.g., 'N characters matched') instead of wrapping each character individually.
+- `<mark>` is the semantic HTML element for highlighted text. Screen-reader announcement of `<mark>` content varies by browser/AT combination — VoiceOver and JAWS announce highlighted runs in many configurations; NVDA in its default profile does not. The agnostic core does not add ARIA attributes; adapters that need a guaranteed announcement (e.g., live-region tickers around the highlighted region) layer that on top.
+- For custom styling, adapters carry the `data-ars-part="highlight-chunk"` and `data-ars-highlighted="true|false"` attributes via `Api::chunk_attrs(highlighted)`.
+- **Adjacent / overlapping chunk consolidation is done in the agnostic core.** `highlight_chunks` merges overlapping and adjacent ranges before returning, so adapters never see back-to-back `<mark>` elements covering contiguous text and screen readers never get a stutter of "highlighted, highlighted, highlighted" for adjacent fuzzy hits. Adapters MAY still provide a summary announcement (e.g., "N characters matched") for high-cardinality fuzzy results, as a layered enhancement.
 
 ### 3.2 Bidirectional Text
 
-When highlighting text in mixed-direction content (e.g., English query in Arabic text), chunk boundaries may disrupt BiDi ordering. The adapter SHOULD set `dir="auto"` on the root container element, and consider applying `unicode-bidi: isolate` on individual `<mark>` and `<span>` elements to prevent chunk boundaries from affecting text reordering.
+`Api::root_attrs()` emits `dir="auto"` on the root `<span>` so the browser picks the correct BiDi paragraph direction from the first strong character of the highlighted text — adapters do not need to add it themselves. Adapters MAY additionally apply `unicode-bidi: isolate` CSS to chunk elements when rendering English query terms inside Arabic or Hebrew text, to prevent chunk boundaries from re-ordering visually. The styling is a CSS concern outside the agnostic core's reach.
 
 ## 4. Adapter Rendering
 
-```rust
-// Leptos example:
+Adapters spread `Api::root_attrs()` and `Api::chunk_attrs(highlighted)` rather than hardcoding the `data-ars-*` strings — keeping the attribute names typed and DRY against renames.
+
+```rust,no_check
+// Leptos example
+let api = Api::new(props);
+let chunks = api.chunks(&locale);
+
 view! {
-    <span data-ars-scope="highlight" data-ars-part="root">
-        {highlight_chunks(&props).into_iter().map(|chunk| {
+    <span ..api.root_attrs()>
+        {chunks.into_iter().map(|chunk| {
+            let attrs = api.chunk_attrs(chunk.highlighted);
             if chunk.highlighted {
-                view! { <mark>{chunk.text}</mark> }
+                view! { <mark ..attrs>{chunk.text}</mark> }
             } else {
-                view! { <span>{chunk.text}</span> }
+                view! { <span ..attrs>{chunk.text}</span> }
             }
         }).collect_view()}
     </span>
@@ -146,18 +255,20 @@ view! {
 
 ### 5.3 Features
 
-| Feature              | ars-ui                            | Ark UI |
-| -------------------- | --------------------------------- | ------ |
-| Multi-query          | Yes                               | Yes    |
-| Case-insensitive     | Yes                               | Yes    |
-| Fuzzy matching       | Yes (`MatchStrategy::Fuzzy`)      | --     |
-| StartsWith matching  | Yes (`MatchStrategy::StartsWith`) | --     |
-| Locale-aware folding | Yes                               | --     |
+| Feature                        | ars-ui                            | Ark UI |
+| ------------------------------ | --------------------------------- | ------ |
+| Multi-query                    | Yes                               | Yes    |
+| Case-insensitive               | Yes                               | Yes    |
+| Fuzzy matching                 | Yes (`MatchStrategy::Fuzzy`)      | --     |
+| StartsWith matching            | Yes (`MatchStrategy::StartsWith`) | --     |
+| Locale-aware folding           | Yes                               | --     |
+| Adjacent/overlap merge in core | Yes                               | --     |
+| `dir="auto"` on root           | Yes                               | --     |
 
 **Gaps:** None.
 
 ### 5.4 Summary
 
-- **Overall:** Full parity -- ars-ui is a superset.
-- **Divergences:** ars-ui uses `MatchStrategy` enum (Contains/StartsWith/Fuzzy) while Ark uses `exactMatch`/`matchAll` booleans. ars-ui adds locale-aware Unicode case folding and fuzzy matching.
+- **Overall:** Full parity — ars-ui is a superset.
+- **Divergences:** ars-ui uses `MatchStrategy` enum (Contains/StartsWith/Fuzzy) while Ark uses `exactMatch`/`matchAll` booleans. ars-ui adds locale-aware Unicode case folding, fuzzy matching, core-side adjacency merging, and a BiDi-safe root via `dir="auto"`.
 - **Recommended additions:** None.

--- a/spec/components/utility/highlight.md
+++ b/spec/components/utility/highlight.md
@@ -21,7 +21,12 @@ references:
 
 ```rust
 /// Props for the `Highlight` component.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+///
+/// `Default` is implemented manually (below) rather than derived because
+/// the defaults are non-field-default — `ignore_case = true` and
+/// `match_strategy = MatchStrategy::Contains` are spec contracts, not
+/// just whatever the field type happens to default to.
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Props {
     /// The search queries to highlight. Supports a single query string or
     /// multiple queries to highlight simultaneously (e.g., multiple search
@@ -53,16 +58,28 @@ impl Default for Props {
 /// The strategy used to match the query against the text.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 pub enum MatchStrategy {
-    /// Highlight every occurrence of the query within the text. Default.
+    /// Highlight every occurrence of the query within the text, including
+    /// overlapping ones (e.g., `query = "ana"` against `text = "banana"`
+    /// produces two matches at byte offsets 1 and 3, which then merge
+    /// into a single highlighted span covering `"anana"`). Default.
     #[default]
     Contains,
     /// Highlight only the leading run of the text when it starts with the
-    /// query (after case folding, if `ignore_case` is `true`).
+    /// query (after case folding, if `ignore_case` is `true`). When the
+    /// matched prefix ends inside a case-fold expansion (e.g.,
+    /// `query = "stras"` against German `text = "Straße"` where `ß`
+    /// folds to `ss`), the highlighted span extends to cover the full
+    /// source character that contributed the matched fold bytes.
     StartsWith,
     /// Subsequence match: highlight each individual query character within
     /// the text in order, allowing arbitrary gaps. All query characters
     /// must be present; if any character is missing, no fuzzy ranges are
-    /// emitted for that query (all-or-nothing).
+    /// emitted for that query (all-or-nothing). When a source character's
+    /// case-fold expansion contains multiple characters (e.g., `ß → ss`
+    /// under German), the matcher consumes **all** consecutive query
+    /// characters that appear in that expansion in order, so a fuzzy
+    /// query of `"ss"` matches text `"ß"` symmetrically with the
+    /// equivalence Contains delivers.
     Fuzzy,
 }
 ```

--- a/spec/dioxus-components/utility/highlight.md
+++ b/spec/dioxus-components/utility/highlight.md
@@ -45,10 +45,10 @@ pub fn Highlight(props: HighlightProps) -> Element
 
 ## 5. Attr Merge and Ownership Rules
 
-| Target node                      | Core attrs                                     | Adapter-owned attrs                                                                                  | Consumer attrs                                         | Merge order                                                                                                     | Ownership notes                                   |
-| -------------------------------- | ---------------------------------------------- | ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
-| root text container if present   | root attrs when the utility renders a wrapper  | chunk-boundary attrs plus optional mixed-direction `dir="auto"` repair                               | consumer wrapper attrs if exposed                      | core structural attrs win; documented directionality attrs and `class`/`style` merge additively                 | adapter-owned wrapper when present                |
-| matched/unmatched chunk wrappers | chunk attrs derived from the core match result | adapter `data-*` part markers and optional `unicode-bidi: isolate` styles when bidi repair is needed | consumer decoration only if chunk rendering is exposed | match-state attrs and adapter-owned bidi repair win over conflicting decoration that would break text isolation | chunk wrappers are adapter-owned structural nodes |
+| Target node                      | Core attrs                                                                                       | Adapter-owned attrs                                            | Consumer attrs                                         | Merge order                                                                       | Ownership notes                                   |
+| -------------------------------- | ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------- | ------------------------------------------------------ | --------------------------------------------------------------------------------- | ------------------------------------------------- |
+| root `<span>`                    | `Api::root_attrs()` → `data-ars-scope`, `data-ars-part`, `dir="auto"`                            | none                                                           | consumer wrapper attrs if exposed                      | core structural attrs win; `class`/`style` merge additively                       | core owns root attrs including the BiDi root      |
+| matched/unmatched chunk wrappers | `Api::chunk_attrs(highlighted)` → `data-ars-part="highlight-chunk"` + `data-ars-highlighted="…"` | optional `unicode-bidi: isolate` styling on mixed-bidi content | consumer decoration only if chunk rendering is exposed | match-state attrs win over conflicting decoration that would break text isolation | chunk wrappers are adapter-owned structural nodes |
 
 ## 6. Composition / Context Contract
 
@@ -158,21 +158,28 @@ Highlighting is derived from input text and query changes. If the adapter accept
 
 ## 23. Framework-Specific Behavior
 
-Dioxus can render repeated chunks directly from iterator output. For mixed-direction content, the adapter should set `dir="auto"` on the root wrapper and may apply `unicode-bidi: isolate` on repeated `<mark>` and `<span>` chunk nodes when the highlighted text would otherwise bleed bidi ordering into surrounding content.
+Dioxus renders repeated chunks directly from iterator output. The core sets `dir="auto"` on the root wrapper via `Api::root_attrs()` — adapters do not need to add it. For mixed-direction content where chunk boundaries would re-order surrounding text visually, adapters MAY apply `unicode-bidi: isolate` CSS to chunk nodes (this is a styling concern outside the agnostic core's reach).
 
 ## 24. Canonical Implementation Sketch
 
-```rust
+```rust,no_check
 #[component]
 pub fn Highlight() -> Element {
     let props = highlight::Props::default();
+    let api = highlight::Api::new(props);
+    let locale = use_locale();
+
     rsx! {
-        span { "data-ars-scope": "highlight", "data-ars-part": "root",
-            {highlight::highlight_chunks(&props).into_iter().map(|chunk| {
+        // Spread `Api::root_attrs()` and `Api::chunk_attrs(highlighted)`
+        // onto the rendered elements (Dioxus 0.7 spread syntax).
+        span {
+            ..api.root_attrs(),
+            {api.chunks(&locale).into_iter().map(|chunk| {
+                let attrs = api.chunk_attrs(chunk.highlighted);
                 if chunk.highlighted {
-                    rsx! { mark { "data-ars-part": "highlight-chunk", "{chunk.text}" } }
+                    rsx! { mark { ..attrs, "{chunk.text}" } }
                 } else {
-                    rsx! { span { "data-ars-part": "highlight-chunk", "{chunk.text}" } }
+                    rsx! { span { ..attrs, "{chunk.text}" } }
                 }
             })}
         }
@@ -193,8 +200,7 @@ No expanded skeleton beyond the canonical sketch is required for this utility.
 
 ## 27. Accessibility and SSR Notes
 
-Must preserve `<mark>` semantics and repeated chunk structure.
-For fuzzy matching that would otherwise produce excessive tiny wrappers, the adapter should consolidate adjacent chunks when that reduces screen-reader verbosity without changing the user-visible matched ranges.
+Must preserve `<mark>` semantics and repeated chunk structure. The agnostic core (`highlight_chunks` / `Api::chunks`) already consolidates overlapping and adjacent ranges before returning, so adapters never see back-to-back highlighted chunks and screen readers never get a stutter of "highlighted, highlighted, highlighted" for adjacent fuzzy hits. Adapters MAY layer a summary announcement (e.g., live-region "N characters matched") for very-high-cardinality fuzzy results.
 
 ## 28. Parity Summary and Intentional Deviations
 

--- a/spec/foundation/10-component-spec-template.md
+++ b/spec/foundation/10-component-spec-template.md
@@ -274,6 +274,19 @@ Contains:
 
 Parts must be marked as required (component broken without it) or optional (enhances UX, degrades gracefully).
 
+#### Static vs parametric anatomy slots
+
+Most parts are **static**: exactly one DOM element per component instance per part, and the part appears as a variant in the component's `Part` enum so `ConnectApi::part_attrs(Part) -> AttrMap` can address it. This is the default and applies to the majority of the catalog.
+
+A minority of components have **parametric** anatomy slots — anatomy positions that emit zero-to-N elements per component instance, where the emitted attributes depend on runtime data the `Part` enum cannot carry (a row key, an item value, a `highlighted` boolean). Examples: a per-chunk wrapper in `Highlight`, a per-row cell in `Table`, a per-tag chip in `TagsInput`. For these:
+
+- Keep the row in the Anatomy table and the ASCII diagram so the rendered shape is documented end-to-end.
+- Do **not** add a `Part` enum variant. `ConnectApi::part_attrs` takes a `Part` by value with no payload — it cannot express runtime parameters cleanly.
+- Expose the attributes through an `Api` method that takes the runtime parameter explicitly (e.g., `Api::chunk_attrs(highlighted: bool) -> AttrMap`, `Api::row_attrs(&row_key) -> AttrMap`). Document the method name in the Anatomy parts-table's "Key Attributes" column.
+- Note the slot's parametric nature in the spec text once, ideally right under the table.
+
+The convention keeps the static-`Part` happy path simple while giving parametric slots a typed, discoverable API.
+
 ### 4.3 Accessibility
 
 REQUIRED for all tiers. Subsections:

--- a/spec/leptos-components/utility/highlight.md
+++ b/spec/leptos-components/utility/highlight.md
@@ -32,10 +32,10 @@ This spec maps the core [`Highlight`](../../components/utility/highlight.md) uti
 
 ## 5. Attr Merge and Ownership Rules
 
-| Target node                      | Core attrs                                     | Adapter-owned attrs                                                                                  | Consumer attrs                                         | Merge order                                                                                                     | Ownership notes                                   |
-| -------------------------------- | ---------------------------------------------- | ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
-| root text container if present   | root attrs when the utility renders a wrapper  | chunk-boundary attrs plus optional mixed-direction `dir="auto"` repair                               | consumer wrapper attrs if exposed                      | core structural attrs win; documented directionality attrs and `class`/`style` merge additively                 | adapter-owned wrapper when present                |
-| matched/unmatched chunk wrappers | chunk attrs derived from the core match result | adapter `data-*` part markers and optional `unicode-bidi: isolate` styles when bidi repair is needed | consumer decoration only if chunk rendering is exposed | match-state attrs and adapter-owned bidi repair win over conflicting decoration that would break text isolation | chunk wrappers are adapter-owned structural nodes |
+| Target node                      | Core attrs                                                                                       | Adapter-owned attrs                                            | Consumer attrs                                         | Merge order                                                                       | Ownership notes                                   |
+| -------------------------------- | ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------- | ------------------------------------------------------ | --------------------------------------------------------------------------------- | ------------------------------------------------- |
+| root `<span>`                    | `Api::root_attrs()` → `data-ars-scope`, `data-ars-part`, `dir="auto"`                            | none                                                           | consumer wrapper attrs if exposed                      | core structural attrs win; `class`/`style` merge additively                       | core owns root attrs including the BiDi root      |
+| matched/unmatched chunk wrappers | `Api::chunk_attrs(highlighted)` → `data-ars-part="highlight-chunk"` + `data-ars-highlighted="…"` | optional `unicode-bidi: isolate` styling on mixed-bidi content | consumer decoration only if chunk rendering is exposed | match-state attrs win over conflicting decoration that would break text isolation | chunk wrappers are adapter-owned structural nodes |
 
 ## 6. Composition / Context Contract
 
@@ -145,21 +145,25 @@ Highlighting is derived from input text and query changes. If the adapter accept
 
 ## 23. Framework-Specific Behavior
 
-Leptos can render repeated chunks directly from an iterator. For mixed-direction content, the adapter should set `dir="auto"` on the root wrapper and may apply `unicode-bidi: isolate` on repeated `<mark>` and `<span>` chunk nodes when the highlighted text would otherwise bleed bidi ordering into surrounding content.
+Leptos renders repeated chunks directly from an iterator. The core sets `dir="auto"` on the root wrapper via `Api::root_attrs()` — adapters do not need to add it. For mixed-direction content where chunk boundaries would re-order surrounding text visually, adapters MAY apply `unicode-bidi: isolate` CSS to chunk nodes (this is a styling concern outside the agnostic core's reach).
 
 ## 24. Canonical Implementation Sketch
 
-```rust
+```rust,no_check
 #[component]
 pub fn Highlight() -> impl IntoView {
     let props = highlight::Props::default();
+    let api = highlight::Api::new(props);
+    let locale = use_locale();
+
     view! {
-        <span data-ars-scope="highlight" data-ars-part="root">
-            {highlight::highlight_chunks(&props).into_iter().map(|chunk| {
+        <span ..api.root_attrs()>
+            {api.chunks(&locale).into_iter().map(|chunk| {
+                let attrs = api.chunk_attrs(chunk.highlighted);
                 if chunk.highlighted {
-                    view! { <mark data-ars-part="highlight-chunk">{chunk.text}</mark> }.into_any()
+                    Either::Left(view! { <mark ..attrs>{chunk.text}</mark> })
                 } else {
-                    view! { <span data-ars-part="highlight-chunk">{chunk.text}</span> }.into_any()
+                    Either::Right(view! { <span ..attrs>{chunk.text}</span> })
                 }
             }).collect_view()}
         </span>
@@ -180,8 +184,7 @@ No expanded skeleton beyond the canonical sketch is required for this utility.
 
 ## 27. Accessibility and SSR Notes
 
-Must preserve `<mark>` semantics and repeated chunk structure.
-For fuzzy matching that would otherwise produce excessive tiny wrappers, the adapter should consolidate adjacent chunks when that reduces screen-reader verbosity without changing the user-visible matched ranges.
+Must preserve `<mark>` semantics and repeated chunk structure. The agnostic core (`highlight_chunks` / `Api::chunks`) already consolidates overlapping and adjacent ranges before returning, so adapters never see back-to-back highlighted chunks and screen readers never get a stutter of "highlighted, highlighted, highlighted" for adjacent fuzzy hits. Adapters MAY layer a summary announcement (e.g., live-region "N characters matched") for very-high-cardinality fuzzy results.
 
 ## 28. Parity Summary and Intentional Deviations
 


### PR DESCRIPTION
## Summary

- Implement framework-agnostic `Highlight` utility (`ars-components::utility::highlight`) per `spec/components/utility/highlight.md` — three match strategies (Contains/StartsWith/Fuzzy), TR21 Unicode case folding, multi-query overlap+adjacency merging, parametric chunk anatomy. Gated on a new `i18n` feature wired through the adapter `icu4x` features so Leptos / Dioxus builds with icu4x pick up Highlight automatically.
- Surface a new `ars_i18n::case_fold` helper that wraps `CaseMapper::fold_string` / `fold_turkic_string`. Switching from `to_lowercase` closes the spec's eszett contract — `"ss"` now genuinely matches `"ß"` in both directions (the original implementation passed its named tests but quietly violated this).
- Codify the audit flow that drove this PR: new `post-implementation-audit` skill at `.agents/skills/post-implementation-audit/SKILL.md`, registered as mandatory step 7 of the AGENTS.md / CLAUDE.md development workflow. Three sequential phases (spec/impl drift, iterative "anything missing?", test coverage) that land every finding in the same PR. The skill's worked example references this PR.

Closes #204.

## Test plan

- [x] `cargo xci` — all 20 steps pass (fmt, check, clippy, unit, i18n-browser, dom-browser, release, integration, adapter, adapter-parity, coverage, snapshot-count, spec-compile-snippets, error-variant-coverage, 5 feature matrices, mutual-exclusion)
- [x] `cargo test -p ars-components --features i18n --all-targets` — 1502 lib + 4 conformance + 1 doc tests pass
- [x] `cargo test -p ars-components --lib` (no `i18n`) — 1463 pass; Highlight module gated out cleanly
- [x] `cargo test -p ars-i18n --features icu4x case::` — 10 pass (incl. 4 new `case_fold` tests covering eszett expansion, Greek final sigma collapse, Turkic vs non-Turkic, idempotence)
- [x] `cargo mutants -p ars-components -f crates/ars-components/src/utility/highlight.rs` — **57/57 caught, 0 missed** (3 equivalent mutations documented with rationale in `.cargo/mutants.toml`)
- [x] `cargo llvm-cov` — **99.91% line / 100% function / 100% region** for `utility/highlight.rs`
- [x] `cargo xtask spec validate` — 340 files clean
- [x] `cargo build -p ars-leptos --features icu4x` and `cargo build -p ars-dioxus --features icu4x,web` — Highlight reachable in adapter builds
- [x] Spec-conformance test asserts the `Part` enum matches the spec's §2 anatomy table

## What landed

| Area | Files |
|---|---|
| Agnostic core | `crates/ars-components/src/utility/highlight.rs` (new), `crates/ars-components/src/utility/mod.rs`, `crates/ars-components/Cargo.toml` |
| Locale-aware case folding helper | `crates/ars-i18n/src/case.rs`, `crates/ars-i18n/src/lib.rs` |
| Adapter feature wiring | `crates/ars-leptos/Cargo.toml`, `crates/ars-dioxus/Cargo.toml` |
| Tests | 9 insta snapshots + inline doc test + 1 spec-conformance test + 1 proptest invariant block + 41 unit tests |
| Spec | Core spec rewrite, Leptos/Dioxus adapter spec updates, foundation/10 new §4.2 parametric-anatomy convention |
| Workflow codification | `.agents/skills/post-implementation-audit/SKILL.md`, `AGENTS.md` step 7 mandatory invocation, `.cargo/mutants.toml` skip justifications |

🤖 Generated with [Claude Code](https://claude.com/claude-code)