### PR TITLE
feat(components): add aspect ratio and frame core

### DIFF
--- a/crates/ars-components/src/layout/aspect_ratio.rs
+++ b/crates/ars-components/src/layout/aspect_ratio.rs
@@ -1,0 +1,208 @@
+//! `AspectRatio` component connect API.
+//!
+//! `AspectRatio` is a stateless, framework-agnostic attribute mapper for
+//! responsive containers that preserve a width-to-height ratio.
+
+use alloc::{format, string::String};
+
+use ars_core::{AttrMap, ComponentPart, ConnectApi, CssProperty};
+
+/// Props for the `AspectRatio` component.
+#[derive(Clone, Debug, PartialEq, ars_core::HasId)]
+pub struct Props {
+    /// Component instance ID.
+    pub id: String,
+
+    /// Width-to-height ratio.
+    ///
+    /// For example, `16.0 / 9.0` represents a widescreen container. The value
+    /// must be positive and finite.
+    pub ratio: f64,
+}
+
+impl Default for Props {
+    fn default() -> Self {
+        Self {
+            id: String::new(),
+            ratio: 1.0,
+        }
+    }
+}
+
+impl Props {
+    /// Returns fresh aspect-ratio props with the documented defaults.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the component instance ID.
+    #[must_use]
+    pub fn id(mut self, id: impl Into<String>) -> Self {
+        self.id = id.into();
+        self
+    }
+
+    /// Sets the width-to-height ratio.
+    #[must_use]
+    pub const fn ratio(mut self, ratio: f64) -> Self {
+        self.ratio = ratio;
+        self
+    }
+
+    /// CSS `padding-top` percentage that enforces the ratio.
+    ///
+    /// `padding-top: X%` is relative to element width, so `X = (1 / ratio) *
+    /// 100`.
+    #[must_use]
+    pub fn padding_top_percent(&self) -> f64 {
+        (1.0 / self.ratio) * 100.0
+    }
+}
+
+/// Structural parts exposed by the `AspectRatio` connect API.
+#[derive(ComponentPart)]
+#[scope = "aspect-ratio"]
+pub enum Part {
+    /// The root intrinsic-ratio container.
+    Root,
+}
+
+/// API for the `AspectRatio` component.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Api {
+    props: Props,
+}
+
+impl Api {
+    /// Creates a new API for the aspect-ratio container.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ars_components::layout::aspect_ratio::{Api, Props};
+    /// use ars_core::{CssProperty, HtmlAttr};
+    ///
+    /// let api = Api::new(Props::new().ratio(16.0 / 9.0));
+    /// let attrs = api.root_attrs();
+    ///
+    /// assert_eq!(
+    ///     attrs.get(&HtmlAttr::Data("ars-scope")),
+    ///     Some("aspect-ratio")
+    /// );
+    /// assert!(attrs
+    ///     .styles()
+    ///     .contains(&(CssProperty::PaddingTop, "56.2500%".to_string())));
+    /// ```
+    #[must_use]
+    pub const fn new(props: Props) -> Self {
+        Self { props }
+    }
+
+    /// Returns root container attributes.
+    #[must_use]
+    pub fn root_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Root.data_attrs();
+
+        let padding = self.props.padding_top_percent();
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set_style(CssProperty::Position, "relative")
+            .set_style(CssProperty::Width, "100%")
+            .set_style(CssProperty::PaddingTop, format!("{padding:.4}%"));
+
+        attrs
+    }
+}
+
+impl ConnectApi for Api {
+    type Part = Part;
+
+    fn part_attrs(&self, part: Self::Part) -> AttrMap {
+        match part {
+            Part::Root => self.root_attrs(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::{format, string::String};
+
+    use ars_core::{ConnectApi, CssProperty, HtmlAttr};
+    use insta::assert_snapshot;
+
+    use super::*;
+
+    fn snapshot_attrs(attrs: &AttrMap) -> String {
+        format!("{attrs:#?}")
+    }
+
+    #[test]
+    fn props_new_returns_default_values() {
+        assert_eq!(Props::new(), Props::default());
+    }
+
+    #[test]
+    fn props_builder_chain_applies_each_setter() {
+        let props = Props::new().id("media").ratio(16.0 / 9.0);
+
+        assert_eq!(props.id, "media");
+        assert_eq!(props.ratio, 16.0 / 9.0);
+    }
+
+    #[test]
+    fn padding_top_percent_calculates_common_ratios() {
+        let widescreen = Props::new().ratio(16.0 / 9.0);
+        let standard = Props::new().ratio(4.0 / 3.0);
+        let square = Props::new().ratio(1.0);
+
+        assert!((widescreen.padding_top_percent() - 56.25).abs() < f64::EPSILON);
+        assert!((standard.padding_top_percent() - 75.0).abs() < f64::EPSILON);
+        assert!((square.padding_top_percent() - 100.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn root_attrs_emit_scope_part_and_ratio_styles() {
+        let attrs = Api::new(Props::new().ratio(16.0 / 9.0)).root_attrs();
+
+        assert_eq!(
+            attrs.get(&HtmlAttr::Data("ars-scope")),
+            Some("aspect-ratio")
+        );
+        assert_eq!(attrs.get(&HtmlAttr::Data("ars-part")), Some("root"));
+        assert!(
+            attrs
+                .styles()
+                .contains(&(CssProperty::Position, String::from("relative")))
+        );
+        assert!(
+            attrs
+                .styles()
+                .contains(&(CssProperty::Width, String::from("100%")))
+        );
+        assert!(
+            attrs
+                .styles()
+                .contains(&(CssProperty::PaddingTop, String::from("56.2500%")))
+        );
+    }
+
+    #[test]
+    fn part_attrs_delegates_to_root_attrs() {
+        let api = Api::new(Props::new().ratio(4.0 / 3.0));
+
+        assert_eq!(api.part_attrs(Part::Root), api.root_attrs());
+    }
+
+    #[test]
+    fn aspect_ratio_root_snapshot() {
+        assert_snapshot!(
+            "aspect_ratio_root",
+            snapshot_attrs(&Api::new(Props::new().ratio(16.0 / 9.0)).root_attrs())
+        );
+    }
+}

--- a/crates/ars-components/src/layout/aspect_ratio.rs
+++ b/crates/ars-components/src/layout/aspect_ratio.rs
@@ -7,6 +7,14 @@ use alloc::{format, string::String};
 
 use ars_core::{AttrMap, ComponentPart, ConnectApi, CssProperty};
 
+fn positive_finite_or_default(ratio: f64) -> f64 {
+    if ratio.is_finite() && ratio > 0.0 {
+        ratio
+    } else {
+        1.0
+    }
+}
+
 /// Props for the `AspectRatio` component.
 #[derive(Clone, Debug, PartialEq, ars_core::HasId)]
 pub struct Props {
@@ -56,7 +64,7 @@ impl Props {
     /// 100`.
     #[must_use]
     pub fn padding_top_percent(&self) -> f64 {
-        (1.0 / self.ratio) * 100.0
+        (1.0 / positive_finite_or_default(self.ratio)) * 100.0
     }
 }
 
@@ -166,6 +174,13 @@ mod tests {
     }
 
     #[test]
+    fn padding_top_percent_normalizes_invalid_ratio_to_default() {
+        for ratio in [0.0, -1.0, f64::INFINITY, f64::NEG_INFINITY, f64::NAN] {
+            assert_eq!(Props::new().ratio(ratio).padding_top_percent(), 100.0);
+        }
+    }
+
+    #[test]
     fn root_attrs_emit_scope_part_and_ratio_styles() {
         let attrs = Api::new(Props::new().ratio(16.0 / 9.0)).root_attrs();
 
@@ -188,6 +203,17 @@ mod tests {
             attrs
                 .styles()
                 .contains(&(CssProperty::PaddingTop, String::from("56.2500%")))
+        );
+    }
+
+    #[test]
+    fn root_attrs_normalizes_invalid_ratio_to_default_styles() {
+        let attrs = Api::new(Props::new().ratio(0.0)).root_attrs();
+
+        assert!(
+            attrs
+                .styles()
+                .contains(&(CssProperty::PaddingTop, String::from("100.0000%")))
         );
     }
 

--- a/crates/ars-components/src/layout/aspect_ratio.rs
+++ b/crates/ars-components/src/layout/aspect_ratio.rs
@@ -7,11 +7,13 @@ use alloc::{format, string::String};
 
 use ars_core::{AttrMap, ComponentPart, ConnectApi, CssProperty};
 
-fn positive_finite_or_default(ratio: f64) -> f64 {
-    if ratio.is_finite() && ratio > 0.0 {
-        ratio
+fn padding_percent_or_default(ratio: f64) -> f64 {
+    let padding = 100.0 / ratio;
+
+    if padding.is_finite() && padding > 0.0 {
+        padding
     } else {
-        1.0
+        100.0
     }
 }
 
@@ -64,7 +66,7 @@ impl Props {
     /// 100`.
     #[must_use]
     pub fn padding_top_percent(&self) -> f64 {
-        (1.0 / positive_finite_or_default(self.ratio)) * 100.0
+        padding_percent_or_default(self.ratio)
     }
 }
 
@@ -175,7 +177,14 @@ mod tests {
 
     #[test]
     fn padding_top_percent_normalizes_invalid_ratio_to_default() {
-        for ratio in [0.0, -1.0, f64::INFINITY, f64::NEG_INFINITY, f64::NAN] {
+        for ratio in [
+            0.0,
+            -1.0,
+            1.0e-308,
+            f64::INFINITY,
+            f64::NEG_INFINITY,
+            f64::NAN,
+        ] {
             assert_eq!(Props::new().ratio(ratio).padding_top_percent(), 100.0);
         }
     }

--- a/crates/ars-components/src/layout/frame.rs
+++ b/crates/ars-components/src/layout/frame.rs
@@ -8,6 +8,14 @@ use alloc::{format, string::String};
 
 use ars_core::{AttrMap, ComponentPart, ConnectApi, CssProperty, HtmlAttr};
 
+fn positive_finite_or_default(ratio: f64) -> f64 {
+    if ratio.is_finite() && ratio > 0.0 {
+        ratio
+    } else {
+        1.0
+    }
+}
+
 /// Loading strategy for iframe content.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 pub enum LoadingStrategy {
@@ -195,7 +203,7 @@ impl Api {
         attrs.set(scope_attr, scope_val).set(part_attr, part_val);
 
         if let Some(ratio) = self.props.aspect_ratio {
-            let padding = (1.0 / ratio) * 100.0;
+            let padding = (1.0 / positive_finite_or_default(ratio)) * 100.0;
 
             attrs
                 .set_style(CssProperty::Position, "relative")
@@ -212,11 +220,15 @@ impl Api {
         let mut attrs = AttrMap::new();
         let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Iframe.data_attrs();
 
-        attrs
-            .set(scope_attr, scope_val)
-            .set(part_attr, part_val)
-            .set(HtmlAttr::Src, self.props.src.as_str())
-            .set(HtmlAttr::Title, self.props.title.as_str());
+        attrs.set(scope_attr, scope_val).set(part_attr, part_val);
+
+        if !self.props.src.is_empty() {
+            attrs.set(HtmlAttr::Src, self.props.src.as_str());
+        }
+
+        if !self.props.title.is_empty() {
+            attrs.set(HtmlAttr::Title, self.props.title.as_str());
+        }
 
         if let Some(sandbox) = &self.props.sandbox {
             attrs.set(HtmlAttr::Sandbox, sandbox.as_str());
@@ -337,6 +349,19 @@ mod tests {
     }
 
     #[test]
+    fn root_attrs_normalizes_invalid_aspect_ratio_to_default_styles() {
+        for ratio in [0.0, -1.0, f64::INFINITY, f64::NEG_INFINITY, f64::NAN] {
+            let attrs = Api::new(Props::new().aspect_ratio(ratio)).root_attrs();
+
+            assert!(
+                attrs
+                    .styles()
+                    .contains(&(CssProperty::PaddingTop, String::from("100.0000%")))
+            );
+        }
+    }
+
+    #[test]
     fn iframe_attrs_emit_required_src_title_and_default_sizing() {
         let attrs = Api::new(
             Props::new()
@@ -369,6 +394,14 @@ mod tests {
                 .styles()
                 .contains(&(CssProperty::Border, String::from("0")))
         );
+    }
+
+    #[test]
+    fn iframe_attrs_omit_empty_src_and_title() {
+        let attrs = Api::new(Props::new()).iframe_attrs();
+
+        assert!(!attrs.contains(&HtmlAttr::Src));
+        assert!(!attrs.contains(&HtmlAttr::Title));
     }
 
     #[test]

--- a/crates/ars-components/src/layout/frame.rs
+++ b/crates/ars-components/src/layout/frame.rs
@@ -218,12 +218,12 @@ impl Api {
     ///
     /// # Panics
     ///
-    /// Panics when the frame title is empty, because iframe titles are required
-    /// accessible names.
+    /// Panics when the frame title is empty or whitespace-only, because iframe
+    /// titles are required accessible names.
     #[must_use]
     pub fn iframe_attrs(&self) -> AttrMap {
         assert!(
-            !self.props.title.is_empty(),
+            !self.props.title.trim().is_empty(),
             "Frame title must be non-empty"
         );
 
@@ -408,6 +408,12 @@ mod tests {
     #[should_panic(expected = "Frame title must be non-empty")]
     fn iframe_attrs_requires_non_empty_title() {
         let _attrs = Api::new(Props::new()).iframe_attrs();
+    }
+
+    #[test]
+    #[should_panic(expected = "Frame title must be non-empty")]
+    fn iframe_attrs_rejects_whitespace_only_title() {
+        let _attrs = Api::new(Props::new().title("   ")).iframe_attrs();
     }
 
     #[test]

--- a/crates/ars-components/src/layout/frame.rs
+++ b/crates/ars-components/src/layout/frame.rs
@@ -8,11 +8,13 @@ use alloc::{format, string::String};
 
 use ars_core::{AttrMap, ComponentPart, ConnectApi, CssProperty, HtmlAttr};
 
-fn positive_finite_or_default(ratio: f64) -> f64 {
-    if ratio.is_finite() && ratio > 0.0 {
-        ratio
+fn padding_percent_or_default(ratio: f64) -> f64 {
+    let padding = 100.0 / ratio;
+
+    if padding.is_finite() && padding > 0.0 {
+        padding
     } else {
-        1.0
+        100.0
     }
 }
 
@@ -203,7 +205,7 @@ impl Api {
         attrs.set(scope_attr, scope_val).set(part_attr, part_val);
 
         if let Some(ratio) = self.props.aspect_ratio {
-            let padding = (1.0 / positive_finite_or_default(ratio)) * 100.0;
+            let padding = padding_percent_or_default(ratio);
 
             attrs
                 .set_style(CssProperty::Position, "relative")
@@ -358,7 +360,14 @@ mod tests {
 
     #[test]
     fn root_attrs_normalizes_invalid_aspect_ratio_to_default_styles() {
-        for ratio in [0.0, -1.0, f64::INFINITY, f64::NEG_INFINITY, f64::NAN] {
+        for ratio in [
+            0.0,
+            -1.0,
+            1.0e-308,
+            f64::INFINITY,
+            f64::NEG_INFINITY,
+            f64::NAN,
+        ] {
             let attrs = Api::new(Props::new().aspect_ratio(ratio)).root_attrs();
 
             assert!(

--- a/crates/ars-components/src/layout/frame.rs
+++ b/crates/ars-components/src/layout/frame.rs
@@ -215,8 +215,18 @@ impl Api {
     }
 
     /// Returns attributes for the iframe element.
+    ///
+    /// # Panics
+    ///
+    /// Panics when the frame title is empty, because iframe titles are required
+    /// accessible names.
     #[must_use]
     pub fn iframe_attrs(&self) -> AttrMap {
+        assert!(
+            !self.props.title.is_empty(),
+            "Frame title must be non-empty"
+        );
+
         let mut attrs = AttrMap::new();
         let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Iframe.data_attrs();
 
@@ -226,9 +236,7 @@ impl Api {
             attrs.set(HtmlAttr::Src, self.props.src.as_str());
         }
 
-        if !self.props.title.is_empty() {
-            attrs.set(HtmlAttr::Title, self.props.title.as_str());
-        }
+        attrs.set(HtmlAttr::Title, self.props.title.as_str());
 
         if let Some(sandbox) = &self.props.sandbox {
             attrs.set(HtmlAttr::Sandbox, sandbox.as_str());
@@ -397,11 +405,17 @@ mod tests {
     }
 
     #[test]
-    fn iframe_attrs_omit_empty_src_and_title() {
-        let attrs = Api::new(Props::new()).iframe_attrs();
+    #[should_panic(expected = "Frame title must be non-empty")]
+    fn iframe_attrs_requires_non_empty_title() {
+        let _attrs = Api::new(Props::new()).iframe_attrs();
+    }
+
+    #[test]
+    fn iframe_attrs_omits_empty_src_after_title_is_configured() {
+        let attrs = Api::new(Props::new().title("Example embed")).iframe_attrs();
 
         assert!(!attrs.contains(&HtmlAttr::Src));
-        assert!(!attrs.contains(&HtmlAttr::Title));
+        assert_eq!(attrs.get(&HtmlAttr::Title), Some("Example embed"));
     }
 
     #[test]
@@ -426,7 +440,8 @@ mod tests {
 
     #[test]
     fn iframe_attrs_emit_absolute_fill_styles_when_aspect_ratio_is_set() {
-        let attrs = Api::new(Props::new().aspect_ratio(16.0 / 9.0)).iframe_attrs();
+        let attrs =
+            Api::new(Props::new().title("Example embed").aspect_ratio(16.0 / 9.0)).iframe_attrs();
 
         assert!(
             attrs
@@ -457,7 +472,7 @@ mod tests {
 
     #[test]
     fn part_attrs_delegates_for_all_parts() {
-        let api = Api::new(Props::new().aspect_ratio(16.0 / 9.0));
+        let api = Api::new(Props::new().title("Example embed").aspect_ratio(16.0 / 9.0));
 
         assert_eq!(api.part_attrs(Part::Root), api.root_attrs());
         assert_eq!(api.part_attrs(Part::Iframe), api.iframe_attrs());
@@ -506,7 +521,10 @@ mod tests {
         );
         assert_snapshot!(
             "frame_iframe_aspect_ratio",
-            snapshot_attrs(&Api::new(Props::new().aspect_ratio(16.0 / 9.0)).iframe_attrs())
+            snapshot_attrs(
+                &Api::new(Props::new().title("Example embed").aspect_ratio(16.0 / 9.0))
+                    .iframe_attrs()
+            )
         );
     }
 }

--- a/crates/ars-components/src/layout/frame.rs
+++ b/crates/ars-components/src/layout/frame.rs
@@ -1,0 +1,479 @@
+//! Frame component connect API.
+//!
+//! `Frame` is a stateless, framework-agnostic attribute mapper for iframe
+//! embeds, including sandboxing, permissions policy, lazy loading, and
+//! optional responsive aspect-ratio sizing.
+
+use alloc::{format, string::String};
+
+use ars_core::{AttrMap, ComponentPart, ConnectApi, CssProperty, HtmlAttr};
+
+/// Loading strategy for iframe content.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum LoadingStrategy {
+    /// Load the iframe immediately using the browser's default behavior.
+    #[default]
+    Eager,
+
+    /// Defer loading until the iframe is near the viewport.
+    Lazy,
+}
+
+/// Props for the `Frame` component.
+#[derive(Clone, Debug, PartialEq, ars_core::HasId)]
+pub struct Props {
+    /// Component instance ID.
+    pub id: String,
+
+    /// URL of the content to embed.
+    pub src: String,
+
+    /// Accessible title for the iframe.
+    ///
+    /// Screen readers announce this as the frame's accessible name.
+    pub title: String,
+
+    /// Sandbox restrictions.
+    ///
+    /// Space-separated tokens such as `"allow-scripts allow-same-origin"` relax
+    /// the sandbox. `Some("")` applies maximum sandboxing, while `None` omits
+    /// the sandbox attribute.
+    pub sandbox: Option<String>,
+
+    /// Permissions policy for cross-origin features.
+    pub allow: Option<String>,
+
+    /// Loading strategy for iframe content.
+    pub loading: LoadingStrategy,
+
+    /// Optional width-to-height ratio for responsive sizing.
+    pub aspect_ratio: Option<f64>,
+
+    /// Explicit iframe or aspect-ratio container width as a CSS value.
+    pub width: String,
+
+    /// Explicit iframe height as a CSS value when no aspect ratio is set.
+    pub height: String,
+}
+
+impl Default for Props {
+    fn default() -> Self {
+        Self {
+            id: String::new(),
+            src: String::new(),
+            title: String::new(),
+            sandbox: None,
+            allow: None,
+            loading: LoadingStrategy::Eager,
+            aspect_ratio: None,
+            width: "100%".into(),
+            height: "auto".into(),
+        }
+    }
+}
+
+impl Props {
+    /// Returns fresh frame props with the documented defaults.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the component instance ID.
+    #[must_use]
+    pub fn id(mut self, id: impl Into<String>) -> Self {
+        self.id = id.into();
+        self
+    }
+
+    /// Sets the iframe source URL.
+    #[must_use]
+    pub fn src(mut self, src: impl Into<String>) -> Self {
+        self.src = src.into();
+        self
+    }
+
+    /// Sets the iframe accessible title.
+    #[must_use]
+    pub fn title(mut self, title: impl Into<String>) -> Self {
+        self.title = title.into();
+        self
+    }
+
+    /// Sets sandbox restrictions for the iframe.
+    #[must_use]
+    pub fn sandbox(mut self, sandbox: impl Into<String>) -> Self {
+        self.sandbox = Some(sandbox.into());
+        self
+    }
+
+    /// Sets the iframe permissions policy.
+    #[must_use]
+    pub fn allow(mut self, allow: impl Into<String>) -> Self {
+        self.allow = Some(allow.into());
+        self
+    }
+
+    /// Sets the iframe loading strategy.
+    #[must_use]
+    pub const fn loading(mut self, loading: LoadingStrategy) -> Self {
+        self.loading = loading;
+        self
+    }
+
+    /// Sets the responsive width-to-height ratio.
+    #[must_use]
+    pub const fn aspect_ratio(mut self, aspect_ratio: f64) -> Self {
+        self.aspect_ratio = Some(aspect_ratio);
+        self
+    }
+
+    /// Sets the explicit width CSS value.
+    #[must_use]
+    pub fn width(mut self, width: impl Into<String>) -> Self {
+        self.width = width.into();
+        self
+    }
+
+    /// Sets the explicit height CSS value.
+    #[must_use]
+    pub fn height(mut self, height: impl Into<String>) -> Self {
+        self.height = height.into();
+        self
+    }
+}
+
+/// Structural parts exposed by the `Frame` connect API.
+#[derive(ComponentPart)]
+#[scope = "frame"]
+pub enum Part {
+    /// The outer container for the iframe.
+    Root,
+
+    /// The iframe element.
+    Iframe,
+}
+
+/// API for the `Frame` component.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Api {
+    props: Props,
+}
+
+impl Api {
+    /// Creates a new API for the frame.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ars_components::layout::frame::{Api, LoadingStrategy, Props};
+    /// use ars_core::HtmlAttr;
+    ///
+    /// let api = Api::new(
+    ///     Props::new()
+    ///         .src("https://example.com/embed")
+    ///         .title("Example embed")
+    ///         .loading(LoadingStrategy::Lazy),
+    /// );
+    /// let attrs = api.iframe_attrs();
+    ///
+    /// assert_eq!(attrs.get(&HtmlAttr::Src), Some("https://example.com/embed"));
+    /// assert_eq!(attrs.get(&HtmlAttr::Title), Some("Example embed"));
+    /// assert_eq!(attrs.get(&HtmlAttr::Loading), Some("lazy"));
+    /// ```
+    #[must_use]
+    pub const fn new(props: Props) -> Self {
+        Self { props }
+    }
+
+    /// Returns attributes for the outer container.
+    #[must_use]
+    pub fn root_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Root.data_attrs();
+
+        attrs.set(scope_attr, scope_val).set(part_attr, part_val);
+
+        if let Some(ratio) = self.props.aspect_ratio {
+            let padding = (1.0 / ratio) * 100.0;
+
+            attrs
+                .set_style(CssProperty::Position, "relative")
+                .set_style(CssProperty::Width, self.props.width.as_str())
+                .set_style(CssProperty::PaddingTop, format!("{padding:.4}%"));
+        }
+
+        attrs
+    }
+
+    /// Returns attributes for the iframe element.
+    #[must_use]
+    pub fn iframe_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Iframe.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Src, self.props.src.as_str())
+            .set(HtmlAttr::Title, self.props.title.as_str());
+
+        if let Some(sandbox) = &self.props.sandbox {
+            attrs.set(HtmlAttr::Sandbox, sandbox.as_str());
+        }
+
+        if let Some(allow) = &self.props.allow {
+            attrs.set(HtmlAttr::Allow, allow.as_str());
+        }
+
+        if self.props.loading == LoadingStrategy::Lazy {
+            attrs.set(HtmlAttr::Loading, "lazy");
+        }
+
+        if self.props.aspect_ratio.is_some() {
+            attrs
+                .set_style(CssProperty::Position, "absolute")
+                .set_style(CssProperty::Inset, "0")
+                .set_style(CssProperty::Width, "100%")
+                .set_style(CssProperty::Height, "100%")
+                .set_style(CssProperty::Border, "0");
+        } else {
+            attrs
+                .set_style(CssProperty::Width, self.props.width.as_str())
+                .set_style(CssProperty::Height, self.props.height.as_str())
+                .set_style(CssProperty::Border, "0");
+        }
+
+        attrs
+    }
+}
+
+impl ConnectApi for Api {
+    type Part = Part;
+
+    fn part_attrs(&self, part: Self::Part) -> AttrMap {
+        match part {
+            Part::Root => self.root_attrs(),
+            Part::Iframe => self.iframe_attrs(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::{format, string::String};
+
+    use ars_core::{ConnectApi, CssProperty, HtmlAttr};
+    use insta::assert_snapshot;
+
+    use super::*;
+
+    fn snapshot_attrs(attrs: &AttrMap) -> String {
+        format!("{attrs:#?}")
+    }
+
+    #[test]
+    fn props_new_returns_default_values() {
+        assert_eq!(Props::new(), Props::default());
+    }
+
+    #[test]
+    fn props_builder_chain_applies_each_setter() {
+        let props = Props::new()
+            .id("demo-frame")
+            .src("https://example.com/embed")
+            .title("Demo embed")
+            .sandbox("allow-scripts")
+            .allow("camera; microphone")
+            .loading(LoadingStrategy::Lazy)
+            .aspect_ratio(16.0 / 9.0)
+            .width("640px")
+            .height("360px");
+
+        assert_eq!(props.id, "demo-frame");
+        assert_eq!(props.src, "https://example.com/embed");
+        assert_eq!(props.title, "Demo embed");
+        assert_eq!(props.sandbox.as_deref(), Some("allow-scripts"));
+        assert_eq!(props.allow.as_deref(), Some("camera; microphone"));
+        assert_eq!(props.loading, LoadingStrategy::Lazy);
+        assert_eq!(props.aspect_ratio, Some(16.0 / 9.0));
+        assert_eq!(props.width, "640px");
+        assert_eq!(props.height, "360px");
+    }
+
+    #[test]
+    fn loading_strategy_default_is_eager() {
+        assert_eq!(LoadingStrategy::default(), LoadingStrategy::Eager);
+    }
+
+    #[test]
+    fn root_attrs_emit_scope_and_part_without_aspect_styles() {
+        let attrs = Api::new(Props::new()).root_attrs();
+
+        assert_eq!(attrs.get(&HtmlAttr::Data("ars-scope")), Some("frame"));
+        assert_eq!(attrs.get(&HtmlAttr::Data("ars-part")), Some("root"));
+        assert!(attrs.styles().is_empty());
+    }
+
+    #[test]
+    fn root_attrs_emit_aspect_ratio_sizing_styles() {
+        let attrs = Api::new(Props::new().width("720px").aspect_ratio(4.0 / 3.0)).root_attrs();
+
+        assert!(
+            attrs
+                .styles()
+                .contains(&(CssProperty::Position, String::from("relative")))
+        );
+        assert!(
+            attrs
+                .styles()
+                .contains(&(CssProperty::Width, String::from("720px")))
+        );
+        assert!(
+            attrs
+                .styles()
+                .contains(&(CssProperty::PaddingTop, String::from("75.0000%")))
+        );
+    }
+
+    #[test]
+    fn iframe_attrs_emit_required_src_title_and_default_sizing() {
+        let attrs = Api::new(
+            Props::new()
+                .src("https://example.com/embed")
+                .title("Example embed")
+                .width("640px")
+                .height("360px"),
+        )
+        .iframe_attrs();
+
+        assert_eq!(attrs.get(&HtmlAttr::Data("ars-scope")), Some("frame"));
+        assert_eq!(attrs.get(&HtmlAttr::Data("ars-part")), Some("iframe"));
+        assert_eq!(attrs.get(&HtmlAttr::Src), Some("https://example.com/embed"));
+        assert_eq!(attrs.get(&HtmlAttr::Title), Some("Example embed"));
+        assert!(!attrs.contains(&HtmlAttr::Sandbox));
+        assert!(!attrs.contains(&HtmlAttr::Allow));
+        assert!(!attrs.contains(&HtmlAttr::Loading));
+        assert!(
+            attrs
+                .styles()
+                .contains(&(CssProperty::Width, String::from("640px")))
+        );
+        assert!(
+            attrs
+                .styles()
+                .contains(&(CssProperty::Height, String::from("360px")))
+        );
+        assert!(
+            attrs
+                .styles()
+                .contains(&(CssProperty::Border, String::from("0")))
+        );
+    }
+
+    #[test]
+    fn iframe_attrs_emit_sandbox_allow_and_lazy_loading() {
+        let attrs = Api::new(
+            Props::new()
+                .src("https://example.com/embed")
+                .title("Example embed")
+                .sandbox("allow-scripts allow-same-origin")
+                .allow("camera; microphone")
+                .loading(LoadingStrategy::Lazy),
+        )
+        .iframe_attrs();
+
+        assert_eq!(
+            attrs.get(&HtmlAttr::Sandbox),
+            Some("allow-scripts allow-same-origin")
+        );
+        assert_eq!(attrs.get(&HtmlAttr::Allow), Some("camera; microphone"));
+        assert_eq!(attrs.get(&HtmlAttr::Loading), Some("lazy"));
+    }
+
+    #[test]
+    fn iframe_attrs_emit_absolute_fill_styles_when_aspect_ratio_is_set() {
+        let attrs = Api::new(Props::new().aspect_ratio(16.0 / 9.0)).iframe_attrs();
+
+        assert!(
+            attrs
+                .styles()
+                .contains(&(CssProperty::Position, String::from("absolute")))
+        );
+        assert!(
+            attrs
+                .styles()
+                .contains(&(CssProperty::Inset, String::from("0")))
+        );
+        assert!(
+            attrs
+                .styles()
+                .contains(&(CssProperty::Width, String::from("100%")))
+        );
+        assert!(
+            attrs
+                .styles()
+                .contains(&(CssProperty::Height, String::from("100%")))
+        );
+        assert!(
+            attrs
+                .styles()
+                .contains(&(CssProperty::Border, String::from("0")))
+        );
+    }
+
+    #[test]
+    fn part_attrs_delegates_for_all_parts() {
+        let api = Api::new(Props::new().aspect_ratio(16.0 / 9.0));
+
+        assert_eq!(api.part_attrs(Part::Root), api.root_attrs());
+        assert_eq!(api.part_attrs(Part::Iframe), api.iframe_attrs());
+    }
+
+    #[test]
+    fn frame_root_snapshots() {
+        assert_snapshot!(
+            "frame_root_default",
+            snapshot_attrs(&Api::new(Props::new()).root_attrs())
+        );
+        assert_snapshot!(
+            "frame_root_aspect_ratio",
+            snapshot_attrs(
+                &Api::new(Props::new().width("720px").aspect_ratio(4.0 / 3.0)).root_attrs()
+            )
+        );
+    }
+
+    #[test]
+    fn frame_iframe_snapshots() {
+        assert_snapshot!(
+            "frame_iframe_default",
+            snapshot_attrs(
+                &Api::new(
+                    Props::new()
+                        .src("https://example.com/embed")
+                        .title("Example embed")
+                )
+                .iframe_attrs()
+            )
+        );
+        assert_snapshot!(
+            "frame_iframe_lazy_sandboxed",
+            snapshot_attrs(
+                &Api::new(
+                    Props::new()
+                        .src("https://example.com/embed")
+                        .title("Example embed")
+                        .sandbox("allow-scripts allow-same-origin")
+                        .allow("camera; microphone")
+                        .loading(LoadingStrategy::Lazy)
+                )
+                .iframe_attrs()
+            )
+        );
+        assert_snapshot!(
+            "frame_iframe_aspect_ratio",
+            snapshot_attrs(&Api::new(Props::new().aspect_ratio(16.0 / 9.0)).iframe_attrs())
+        );
+    }
+}

--- a/crates/ars-components/src/layout/mod.rs
+++ b/crates/ars-components/src/layout/mod.rs
@@ -1,4 +1,10 @@
 //! Layout component machines.
 
+/// `AspectRatio` component connect API.
+pub mod aspect_ratio;
+
+/// Frame component connect API.
+pub mod frame;
+
 /// Portal component machine.
 pub mod portal;

--- a/crates/ars-components/src/layout/snapshots/ars_components__layout__aspect_ratio__tests__aspect_ratio_root.snap
+++ b/crates/ars-components/src/layout/snapshots/ars_components__layout__aspect_ratio__tests__aspect_ratio_root.snap
@@ -1,0 +1,38 @@
+---
+source: crates/ars-components/src/layout/aspect_ratio.rs
+expression: "snapshot_attrs(&Api::new(Props::new().ratio(16.0 / 9.0)).root_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "aspect-ratio",
+            ),
+        ),
+    ],
+    styles: [
+        (
+            Width,
+            "100%",
+        ),
+        (
+            PaddingTop,
+            "56.2500%",
+        ),
+        (
+            Position,
+            "relative",
+        ),
+    ],
+}

--- a/crates/ars-components/src/layout/snapshots/ars_components__layout__frame__tests__frame_iframe_aspect_ratio.snap
+++ b/crates/ars-components/src/layout/snapshots/ars_components__layout__frame__tests__frame_iframe_aspect_ratio.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ars-components/src/layout/frame.rs
-expression: "snapshot_attrs(&Api::new(Props::new().aspect_ratio(16.0 /\n9.0)).iframe_attrs())"
+expression: "snapshot_attrs(&Api::new(Props::new().title(\"Example embed\").aspect_ratio(16.0\n/ 9.0)).iframe_attrs())"
 ---
 AttrMap {
     attrs: [
@@ -18,6 +18,12 @@ AttrMap {
             ),
             String(
                 "frame",
+            ),
+        ),
+        (
+            Title,
+            String(
+                "Example embed",
             ),
         ),
     ],

--- a/crates/ars-components/src/layout/snapshots/ars_components__layout__frame__tests__frame_iframe_aspect_ratio.snap
+++ b/crates/ars-components/src/layout/snapshots/ars_components__layout__frame__tests__frame_iframe_aspect_ratio.snap
@@ -20,18 +20,6 @@ AttrMap {
                 "frame",
             ),
         ),
-        (
-            Title,
-            String(
-                "",
-            ),
-        ),
-        (
-            Src,
-            String(
-                "",
-            ),
-        ),
     ],
     styles: [
         (

--- a/crates/ars-components/src/layout/snapshots/ars_components__layout__frame__tests__frame_iframe_aspect_ratio.snap
+++ b/crates/ars-components/src/layout/snapshots/ars_components__layout__frame__tests__frame_iframe_aspect_ratio.snap
@@ -1,0 +1,58 @@
+---
+source: crates/ars-components/src/layout/frame.rs
+expression: "snapshot_attrs(&Api::new(Props::new().aspect_ratio(16.0 /\n9.0)).iframe_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "iframe",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "frame",
+            ),
+        ),
+        (
+            Title,
+            String(
+                "",
+            ),
+        ),
+        (
+            Src,
+            String(
+                "",
+            ),
+        ),
+    ],
+    styles: [
+        (
+            Width,
+            "100%",
+        ),
+        (
+            Height,
+            "100%",
+        ),
+        (
+            Border,
+            "0",
+        ),
+        (
+            Inset,
+            "0",
+        ),
+        (
+            Position,
+            "absolute",
+        ),
+    ],
+}

--- a/crates/ars-components/src/layout/snapshots/ars_components__layout__frame__tests__frame_iframe_default.snap
+++ b/crates/ars-components/src/layout/snapshots/ars_components__layout__frame__tests__frame_iframe_default.snap
@@ -1,0 +1,50 @@
+---
+source: crates/ars-components/src/layout/frame.rs
+expression: "snapshot_attrs(&Api::new(Props::new().src(\"https://example.com/embed\").title(\"Example embed\")).iframe_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "iframe",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "frame",
+            ),
+        ),
+        (
+            Title,
+            String(
+                "Example embed",
+            ),
+        ),
+        (
+            Src,
+            String(
+                "https://example.com/embed",
+            ),
+        ),
+    ],
+    styles: [
+        (
+            Width,
+            "100%",
+        ),
+        (
+            Height,
+            "auto",
+        ),
+        (
+            Border,
+            "0",
+        ),
+    ],
+}

--- a/crates/ars-components/src/layout/snapshots/ars_components__layout__frame__tests__frame_iframe_lazy_sandboxed.snap
+++ b/crates/ars-components/src/layout/snapshots/ars_components__layout__frame__tests__frame_iframe_lazy_sandboxed.snap
@@ -1,0 +1,68 @@
+---
+source: crates/ars-components/src/layout/frame.rs
+expression: "snapshot_attrs(&Api::new(Props::new().src(\"https://example.com/embed\").title(\"Example embed\").sandbox(\"allow-scripts allow-same-origin\").allow(\"camera; microphone\").loading(LoadingStrategy::Lazy)).iframe_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "iframe",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "frame",
+            ),
+        ),
+        (
+            Title,
+            String(
+                "Example embed",
+            ),
+        ),
+        (
+            Allow,
+            String(
+                "camera; microphone",
+            ),
+        ),
+        (
+            Loading,
+            String(
+                "lazy",
+            ),
+        ),
+        (
+            Sandbox,
+            String(
+                "allow-scripts allow-same-origin",
+            ),
+        ),
+        (
+            Src,
+            String(
+                "https://example.com/embed",
+            ),
+        ),
+    ],
+    styles: [
+        (
+            Width,
+            "100%",
+        ),
+        (
+            Height,
+            "auto",
+        ),
+        (
+            Border,
+            "0",
+        ),
+    ],
+}

--- a/crates/ars-components/src/layout/snapshots/ars_components__layout__frame__tests__frame_root_aspect_ratio.snap
+++ b/crates/ars-components/src/layout/snapshots/ars_components__layout__frame__tests__frame_root_aspect_ratio.snap
@@ -1,0 +1,38 @@
+---
+source: crates/ars-components/src/layout/frame.rs
+expression: "snapshot_attrs(&Api::new(Props::new().width(\"720px\").aspect_ratio(4.0 /\n3.0)).root_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "frame",
+            ),
+        ),
+    ],
+    styles: [
+        (
+            Width,
+            "720px",
+        ),
+        (
+            PaddingTop,
+            "75.0000%",
+        ),
+        (
+            Position,
+            "relative",
+        ),
+    ],
+}

--- a/crates/ars-components/src/layout/snapshots/ars_components__layout__frame__tests__frame_root_default.snap
+++ b/crates/ars-components/src/layout/snapshots/ars_components__layout__frame__tests__frame_root_default.snap
@@ -1,0 +1,25 @@
+---
+source: crates/ars-components/src/layout/frame.rs
+expression: "snapshot_attrs(&Api::new(Props::new()).root_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "frame",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/tests/spec_conformance.rs
+++ b/crates/ars-components/tests/spec_conformance.rs
@@ -17,6 +17,9 @@
 #[path = "spec_conformance/helper.rs"]
 mod helper;
 
+#[path = "spec_conformance/layout.rs"]
+mod layout;
+
 #[path = "spec_conformance/navigation.rs"]
 mod navigation;
 

--- a/crates/ars-components/tests/spec_conformance/layout.rs
+++ b/crates/ars-components/tests/spec_conformance/layout.rs
@@ -1,0 +1,21 @@
+//! Spec-conformance tests for `crates/ars-components/src/layout/*`.
+//!
+//! Each test pulls the expected anatomy from the corresponding component
+//! spec's §2 anatomy table and asserts the impl's `Part` enum matches.
+
+use ars_components::layout::{aspect_ratio, frame};
+
+use super::helper::assert_anatomy;
+
+#[test]
+fn aspect_ratio_anatomy_matches_spec() {
+    assert_anatomy("aspect-ratio", &[(aspect_ratio::Part::Root, "root")]);
+}
+
+#[test]
+fn frame_anatomy_matches_spec() {
+    assert_anatomy(
+        "frame",
+        &[(frame::Part::Root, "root"), (frame::Part::Iframe, "iframe")],
+    );
+}

--- a/crates/ars-core/src/connect.rs
+++ b/crates/ars-core/src/connect.rs
@@ -1339,6 +1339,9 @@ pub enum CssProperty {
     /// `padding-block-end`
     PaddingBlockEnd,
 
+    /// `inset` shorthand for top, right, bottom, and left.
+    Inset,
+
     /// `inset-inline-start`
     InsetInlineStart,
 
@@ -1738,6 +1741,7 @@ impl Display for CssProperty {
             Self::PaddingBlock => "padding-block",
             Self::PaddingBlockStart => "padding-block-start",
             Self::PaddingBlockEnd => "padding-block-end",
+            Self::Inset => "inset",
             Self::InsetInlineStart => "inset-inline-start",
             Self::InsetInlineEnd => "inset-inline-end",
             Self::InsetBlockStart => "inset-block-start",
@@ -2867,6 +2871,7 @@ mod tests {
             (CssProperty::PaddingBlock, "padding-block"),
             (CssProperty::PaddingBlockStart, "padding-block-start"),
             (CssProperty::PaddingBlockEnd, "padding-block-end"),
+            (CssProperty::Inset, "inset"),
             (CssProperty::InsetInlineStart, "inset-inline-start"),
             (CssProperty::InsetInlineEnd, "inset-inline-end"),
             (CssProperty::InsetBlockStart, "inset-block-start"),

--- a/spec/components/layout/aspect-ratio.md
+++ b/spec/components/layout/aspect-ratio.md
@@ -24,8 +24,9 @@ pub struct Props {
     /// The id of the component.
     pub id: String,
     /// Width-to-height ratio. E.g. `16.0 / 9.0` for widescreen.
-    /// Must be positive and finite. Non-positive or non-finite values are
-    /// normalized to the default `1.0` ratio when attributes are generated.
+    /// Must be positive and finite. Values that are non-positive, non-finite,
+    /// or too small to produce finite padding are normalized to the default
+    /// `1.0` ratio when attributes are generated.
     pub ratio: f64,
 }
 
@@ -34,12 +35,12 @@ impl Props {
     /// `padding-top: X%` is relative to element width, so
     /// `X = (1 / ratio) * 100`.
     pub fn padding_top_percent(&self) -> f64 {
-        let ratio = if self.ratio.is_finite() && self.ratio > 0.0 {
-            self.ratio
+        let padding = 100.0 / self.ratio;
+        if padding.is_finite() && padding > 0.0 {
+            padding
         } else {
-            1.0
-        };
-        (1.0 / ratio) * 100.0
+            100.0
+        }
     }
 }
 

--- a/spec/components/layout/aspect-ratio.md
+++ b/spec/components/layout/aspect-ratio.md
@@ -24,7 +24,8 @@ pub struct Props {
     /// The id of the component.
     pub id: String,
     /// Width-to-height ratio. E.g. `16.0 / 9.0` for widescreen.
-    /// Must be positive and finite.
+    /// Must be positive and finite. Non-positive or non-finite values are
+    /// normalized to the default `1.0` ratio when attributes are generated.
     pub ratio: f64,
 }
 
@@ -33,7 +34,12 @@ impl Props {
     /// `padding-top: X%` is relative to element width, so
     /// `X = (1 / ratio) * 100`.
     pub fn padding_top_percent(&self) -> f64 {
-        (1.0 / self.ratio) * 100.0
+        let ratio = if self.ratio.is_finite() && self.ratio > 0.0 {
+            self.ratio
+        } else {
+            1.0
+        };
+        (1.0 / ratio) * 100.0
     }
 }
 

--- a/spec/components/layout/frame.md
+++ b/spec/components/layout/frame.md
@@ -47,6 +47,8 @@ pub struct Props {
     pub loading: LoadingStrategy,
     /// When set, wraps the iframe in an aspect-ratio container using the
     /// padding-top technique. Value is width/height (e.g., 16.0/9.0).
+    /// Non-positive or non-finite values are normalized to the default `1.0`
+    /// ratio when attributes are generated.
     pub aspect_ratio: Option<f64>,
     /// Explicit width (CSS value, e.g., "100%", "640px"). Defaults to "100%".
     pub width: String,
@@ -95,6 +97,7 @@ impl Api {
         attrs.set(scope_attr, scope_val);
         attrs.set(part_attr, part_val);
         if let Some(ratio) = self.props.aspect_ratio {
+            let ratio = if ratio.is_finite() && ratio > 0.0 { ratio } else { 1.0 };
             let padding = (1.0 / ratio) * 100.0;
             attrs.set_style(CssProperty::Position, "relative");
             attrs.set_style(CssProperty::Width, &self.props.width);
@@ -109,8 +112,12 @@ impl Api {
         let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Iframe.data_attrs();
         attrs.set(scope_attr, scope_val);
         attrs.set(part_attr, part_val);
-        attrs.set(HtmlAttr::Src, &self.props.src);
-        attrs.set(HtmlAttr::Title, &self.props.title);
+        if !self.props.src.is_empty() {
+            attrs.set(HtmlAttr::Src, &self.props.src);
+        }
+        if !self.props.title.is_empty() {
+            attrs.set(HtmlAttr::Title, &self.props.title);
+        }
         if let Some(sandbox) = &self.props.sandbox {
             attrs.set(HtmlAttr::Sandbox, sandbox);
         }

--- a/spec/components/layout/frame.md
+++ b/spec/components/layout/frame.md
@@ -107,10 +107,10 @@ impl Api {
     }
 
     /// Attributes for the iframe element.
-    /// Panics when `title` is empty because iframe titles are required
-    /// accessible names.
+    /// Panics when `title` is empty or whitespace-only because iframe titles
+    /// are required accessible names.
     pub fn iframe_attrs(&self) -> AttrMap {
-        assert!(!self.props.title.is_empty(), "Frame title must be non-empty");
+        assert!(!self.props.title.trim().is_empty(), "Frame title must be non-empty");
         let mut attrs = AttrMap::new();
         let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Iframe.data_attrs();
         attrs.set(scope_attr, scope_val);

--- a/spec/components/layout/frame.md
+++ b/spec/components/layout/frame.md
@@ -107,7 +107,10 @@ impl Api {
     }
 
     /// Attributes for the iframe element.
+    /// Panics when `title` is empty because iframe titles are required
+    /// accessible names.
     pub fn iframe_attrs(&self) -> AttrMap {
+        assert!(!self.props.title.is_empty(), "Frame title must be non-empty");
         let mut attrs = AttrMap::new();
         let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Iframe.data_attrs();
         attrs.set(scope_attr, scope_val);
@@ -115,9 +118,7 @@ impl Api {
         if !self.props.src.is_empty() {
             attrs.set(HtmlAttr::Src, &self.props.src);
         }
-        if !self.props.title.is_empty() {
-            attrs.set(HtmlAttr::Title, &self.props.title);
-        }
+        attrs.set(HtmlAttr::Title, &self.props.title);
         if let Some(sandbox) = &self.props.sandbox {
             attrs.set(HtmlAttr::Sandbox, sandbox);
         }

--- a/spec/components/layout/frame.md
+++ b/spec/components/layout/frame.md
@@ -47,8 +47,9 @@ pub struct Props {
     pub loading: LoadingStrategy,
     /// When set, wraps the iframe in an aspect-ratio container using the
     /// padding-top technique. Value is width/height (e.g., 16.0/9.0).
-    /// Non-positive or non-finite values are normalized to the default `1.0`
-    /// ratio when attributes are generated.
+    /// Values that are non-positive, non-finite, or too small to produce
+    /// finite padding are normalized to the default `1.0` ratio when
+    /// attributes are generated.
     pub aspect_ratio: Option<f64>,
     /// Explicit width (CSS value, e.g., "100%", "640px"). Defaults to "100%".
     pub width: String,
@@ -97,8 +98,8 @@ impl Api {
         attrs.set(scope_attr, scope_val);
         attrs.set(part_attr, part_val);
         if let Some(ratio) = self.props.aspect_ratio {
-            let ratio = if ratio.is_finite() && ratio > 0.0 { ratio } else { 1.0 };
-            let padding = (1.0 / ratio) * 100.0;
+            let padding = 100.0 / ratio;
+            let padding = if padding.is_finite() && padding > 0.0 { padding } else { 100.0 };
             attrs.set_style(CssProperty::Position, "relative");
             attrs.set_style(CssProperty::Width, &self.props.width);
             attrs.set_style(CssProperty::PaddingTop, format!("{:.4}%", padding));


### PR DESCRIPTION
## Summary

- Add framework-agnostic AspectRatio and Frame core modules in ars-components
- Add layout spec-conformance coverage and snapshots for the new anatomy parts
- Add CssProperty::Inset support for the Frame fill styles

Closes #270

## Validation

- cargo test -p ars-core css_property_display_matches_css_spelling
- cargo test -p ars-components layout::aspect_ratio::
- cargo test -p ars-components layout::frame::
- cargo test -p ars-components --test spec_conformance layout
- cargo test -p ars-components layout::
- cargo test -p ars-components --doc
- cargo xtask spec validate
- cargo insta test -p ars-components --features i18n --unreferenced=reject
- cargo llvm-cov test -p ars-components --lib --summary-only -- layout::aspect_ratio:: layout::frame::
- cargo mutants -p ars-components -f crates/ars-components/src/layout/aspect_ratio.rs
- cargo mutants -p ars-components -f crates/ars-components/src/layout/frame.rs
- cargo xci --profile fast