### PR TITLE
[codex] Add ClientOnly and z-index allocator adapters

### DIFF
--- a/crates/ars-core/src/shared_state.rs
+++ b/crates/ars-core/src/shared_state.rs
@@ -1,47 +1,44 @@
 //! Shared interior-mutable state container.
 //!
 //! [`SharedState`] wraps a value in a platform-appropriate shared mutable
-//! container: `Rc<RefCell<T>>` on wasm/`no_std` and `Arc<Mutex<T>>` on
-//! native + `std`.
+//! container: `Arc<Mutex<T>>` with `std` and `Rc<RefCell<T>>` in `no_std`.
 
 use core::fmt::{self, Debug};
 
 /// Shared interior-mutable state container.
 ///
-/// Uses `Rc<RefCell<T>>` on wasm and `no_std` targets (single-threaded) and
-/// `Arc<Mutex<T>>` on native + `std` targets (multi-threaded), mirroring the
-/// [`SharedFlag`](crate::SharedFlag) and [`Callback`](crate::Callback)
-/// platform split. Cloning shares the same underlying state.
+/// Uses `Arc<Mutex<T>>` with `std` and `Rc<RefCell<T>>` in `no_std`, mirroring
+/// the [`SharedFlag`](crate::SharedFlag) shared ownership model. Cloning shares
+/// the same underlying state.
 ///
 /// Unlike [`SharedFlag`](crate::SharedFlag) (which stores a single `bool`),
 /// `SharedState<T>` stores an arbitrary value, enabling shared mutable state
 /// for interaction result types such as `HoverResult` and `PressResult`.
-#[cfg(any(target_arch = "wasm32", not(feature = "std")))]
+#[cfg(not(feature = "std"))]
 pub struct SharedState<T>(alloc::rc::Rc<core::cell::RefCell<T>>);
 
 /// Shared interior-mutable state container.
 ///
-/// Uses `Rc<RefCell<T>>` on wasm and `no_std` targets (single-threaded) and
-/// `Arc<Mutex<T>>` on native + `std` targets (multi-threaded), mirroring the
-/// [`SharedFlag`](crate::SharedFlag) and [`Callback`](crate::Callback)
-/// platform split. Cloning shares the same underlying state.
+/// Uses `Arc<Mutex<T>>` with `std` and `Rc<RefCell<T>>` in `no_std`, mirroring
+/// the [`SharedFlag`](crate::SharedFlag) shared ownership model. Cloning shares
+/// the same underlying state.
 ///
 /// Unlike [`SharedFlag`](crate::SharedFlag) (which stores a single `bool`),
 /// `SharedState<T>` stores an arbitrary value, enabling shared mutable state
 /// for interaction result types such as `HoverResult` and `PressResult`.
-#[cfg(all(not(target_arch = "wasm32"), feature = "std"))]
+#[cfg(feature = "std")]
 pub struct SharedState<T>(alloc::sync::Arc<std::sync::Mutex<T>>);
 
 impl<T> SharedState<T> {
     /// Creates a new shared state with the given initial value.
     #[must_use]
     pub fn new(value: T) -> Self {
-        #[cfg(any(target_arch = "wasm32", not(feature = "std")))]
+        #[cfg(not(feature = "std"))]
         {
             Self(alloc::rc::Rc::new(core::cell::RefCell::new(value)))
         }
 
-        #[cfg(all(not(target_arch = "wasm32"), feature = "std"))]
+        #[cfg(feature = "std")]
         {
             Self(alloc::sync::Arc::new(std::sync::Mutex::new(value)))
         }
@@ -58,12 +55,12 @@ impl<T> SharedState<T> {
 
     /// Replaces the stored value.
     pub fn set(&self, value: T) {
-        #[cfg(any(target_arch = "wasm32", not(feature = "std")))]
+        #[cfg(not(feature = "std"))]
         {
             *self.0.borrow_mut() = value;
         }
 
-        #[cfg(all(not(target_arch = "wasm32"), feature = "std"))]
+        #[cfg(feature = "std")]
         {
             *self.0.lock().expect("SharedState mutex poisoned") = value;
         }
@@ -71,15 +68,15 @@ impl<T> SharedState<T> {
 
     /// Borrows the inner value and applies `f`, returning the result.
     ///
-    /// On wasm and `no_std` this borrows the `RefCell`; on native + `std`
-    /// this locks the `Mutex`. The lock/borrow is released when `f` returns.
+    /// In `no_std` this borrows the `RefCell`; with `std` this locks the
+    /// `Mutex`. The lock/borrow is released when `f` returns.
     pub fn with<R>(&self, f: impl FnOnce(&T) -> R) -> R {
-        #[cfg(any(target_arch = "wasm32", not(feature = "std")))]
+        #[cfg(not(feature = "std"))]
         {
             f(&self.0.borrow())
         }
 
-        #[cfg(all(not(target_arch = "wasm32"), feature = "std"))]
+        #[cfg(feature = "std")]
         {
             let guard = self.0.lock().expect("SharedState mutex poisoned");
             f(&guard)
@@ -87,14 +84,14 @@ impl<T> SharedState<T> {
     }
 }
 
-#[cfg(any(target_arch = "wasm32", not(feature = "std")))]
+#[cfg(not(feature = "std"))]
 impl<T> Clone for SharedState<T> {
     fn clone(&self) -> Self {
         SharedState(alloc::rc::Rc::clone(&self.0))
     }
 }
 
-#[cfg(all(not(target_arch = "wasm32"), feature = "std"))]
+#[cfg(feature = "std")]
 impl<T> Clone for SharedState<T> {
     fn clone(&self) -> Self {
         SharedState(alloc::sync::Arc::clone(&self.0))
@@ -109,12 +106,12 @@ impl<T: Debug> Debug for SharedState<T> {
 
 impl<T> PartialEq for SharedState<T> {
     fn eq(&self, other: &Self) -> bool {
-        #[cfg(any(target_arch = "wasm32", not(feature = "std")))]
+        #[cfg(not(feature = "std"))]
         {
             alloc::rc::Rc::ptr_eq(&self.0, &other.0)
         }
 
-        #[cfg(all(not(target_arch = "wasm32"), feature = "std"))]
+        #[cfg(feature = "std")]
         {
             alloc::sync::Arc::ptr_eq(&self.0, &other.0)
         }

--- a/crates/ars-dioxus/src/prelude.rs
+++ b/crates/ars-dioxus/src/prelude.rs
@@ -67,6 +67,9 @@ pub use crate::navigation::{self, tabs};
 // wrapper component spec'd at
 // `spec/foundation/09-adapter-dioxus.md` §21. End users reach it as
 // `error_boundary::ArsErrorBoundary` after `use ars_dioxus::prelude::*;`.
-pub use crate::utility::{self, button, dismissable, error_boundary, separator, visually_hidden};
+pub use crate::utility::{
+    self, button, client_only, dismissable, error_boundary, separator, visually_hidden,
+    z_index_allocator,
+};
 // -- User-facing helpers --
 pub use crate::{Translatable, t, use_number_formatter};

--- a/crates/ars-dioxus/src/utility/client_only.rs
+++ b/crates/ars-dioxus/src/utility/client_only.rs
@@ -1,0 +1,36 @@
+//! Dioxus `ClientOnly` adapter.
+//!
+//! Gates children until effects run on the client while preserving SSR fallback
+//! markup and avoiding adapter-owned wrapper nodes.
+
+pub use ars_components::utility::client_only::Props;
+use dioxus::prelude::*;
+
+/// Props for the Dioxus [`ClientOnly`] component.
+#[derive(dioxus::prelude::Props, Clone, PartialEq, Debug)]
+pub struct ClientOnlyProps {
+    /// Optional fallback rendered during SSR and before client mount.
+    #[props(optional)]
+    pub fallback: Option<Element>,
+
+    /// Client-only children rendered after mount.
+    pub children: Element,
+}
+
+/// Dioxus logical boundary that renders children only after client mount.
+#[component]
+pub fn ClientOnly(props: ClientOnlyProps) -> Element {
+    let mut mounted = use_signal(|| false);
+
+    use_effect(move || mounted.set(true));
+
+    if mounted() {
+        rsx! {
+            {props.children}
+        }
+    } else {
+        rsx! {
+            {props.fallback}
+        }
+    }
+}

--- a/crates/ars-dioxus/src/utility/mod.rs
+++ b/crates/ars-dioxus/src/utility/mod.rs
@@ -1,7 +1,9 @@
 //! Utility component adapters for Dioxus.
 
 pub mod button;
+pub mod client_only;
 pub mod dismissable;
 pub mod error_boundary;
 pub mod separator;
 pub mod visually_hidden;
+pub mod z_index_allocator;

--- a/crates/ars-dioxus/src/utility/z_index_allocator.rs
+++ b/crates/ars-dioxus/src/utility/z_index_allocator.rs
@@ -1,0 +1,27 @@
+//! Dioxus `ZIndexAllocator` adapter.
+//!
+//! Publishes the framework-agnostic z-index allocation context to descendants
+//! without rendering an adapter-owned DOM node.
+
+pub use ars_components::utility::z_index_allocator::{
+    Context, Props, Z_INDEX_BASE, Z_INDEX_CEILING, ZIndexAllocator, ZIndexClaim, next_z_index,
+    reset_z_index,
+};
+use dioxus::prelude::*;
+
+/// Props for the Dioxus [`ZIndexAllocatorProvider`] component.
+#[derive(Props, Clone, PartialEq, Debug)]
+pub struct ZIndexAllocatorProviderProps {
+    /// Children that share the provider-scoped allocation context.
+    pub children: Element,
+}
+
+/// Dioxus provider for the framework-agnostic z-index allocator context.
+#[component]
+pub fn ZIndexAllocatorProvider(props: ZIndexAllocatorProviderProps) -> Element {
+    use_context_provider(Context::new);
+
+    rsx! {
+        {props.children}
+    }
+}

--- a/crates/ars-dioxus/tests/client_only.rs
+++ b/crates/ars-dioxus/tests/client_only.rs
@@ -1,0 +1,67 @@
+//! SSR tests for the Dioxus `ClientOnly` adapter.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use ars_dioxus::utility::client_only::ClientOnly;
+use dioxus::prelude::*;
+
+fn render_app(app: fn() -> Element) -> String {
+    let mut vdom = VirtualDom::new(app);
+
+    vdom.rebuild_in_place();
+
+    dioxus_ssr::render(&vdom)
+}
+
+#[test]
+fn client_only_renders_fallback_during_ssr() {
+    fn app() -> Element {
+        rsx! {
+            ClientOnly {
+                fallback: rsx! {
+                    span { id: "client-only-fallback", "Loading" }
+                },
+                span { id: "client-only-child", "Client" }
+            }
+        }
+    }
+
+    let html = render_app(app);
+
+    assert!(
+        html.contains(r#"id="client-only-fallback""#),
+        "fallback should render during SSR: {html}"
+    );
+    assert!(
+        !html.contains(r#"id="client-only-child""#),
+        "client children must not render during SSR: {html}"
+    );
+}
+
+#[test]
+fn client_only_without_fallback_renders_no_wrapper_during_ssr() {
+    fn app() -> Element {
+        rsx! {
+            section { id: "before" }
+            ClientOnly {
+                span { id: "client-only-child", "Client" }
+            }
+            section { id: "after" }
+        }
+    }
+
+    let html = render_app(app);
+
+    assert!(
+        html.contains(r#"id="before""#) && html.contains(r#"id="after""#),
+        "siblings should still render: {html}"
+    );
+    assert!(
+        !html.contains(r#"id="client-only-child""#),
+        "client children must not render during SSR: {html}"
+    );
+    assert!(
+        !html.contains("client-only"),
+        "adapter should not invent a wrapper or marker: {html}"
+    );
+}

--- a/crates/ars-dioxus/tests/client_only_wasm.rs
+++ b/crates/ars-dioxus/tests/client_only_wasm.rs
@@ -1,0 +1,103 @@
+//! Browser coverage tests for the Dioxus `ClientOnly` adapter.
+
+#![cfg(target_arch = "wasm32")]
+
+use ars_dioxus::utility::client_only::ClientOnly;
+use dioxus::prelude::*;
+use wasm_bindgen::JsCast;
+use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+fn document() -> web_sys::Document {
+    web_sys::window()
+        .and_then(|window| window.document())
+        .expect("document should exist")
+}
+
+fn container() -> web_sys::Element {
+    let element = document()
+        .create_element("div")
+        .expect("container should be created");
+
+    document()
+        .body()
+        .expect("body should exist")
+        .append_child(&element)
+        .expect("container should be attached");
+
+    element
+}
+
+async fn animation_frame_turn() {
+    let promise = js_sys::Promise::new(&mut |resolve, _reject| {
+        let resolve = resolve.clone();
+        let callback = wasm_bindgen::closure::Closure::once_into_js(move || {
+            drop(resolve.call0(&wasm_bindgen::JsValue::UNDEFINED));
+        });
+
+        web_sys::window()
+            .expect("window should exist")
+            .request_animation_frame(callback.unchecked_ref())
+            .expect("requestAnimationFrame should succeed");
+    });
+
+    drop(wasm_bindgen_futures::JsFuture::from(promise).await);
+}
+
+async fn microtask_turn() {
+    drop(
+        wasm_bindgen_futures::JsFuture::from(js_sys::Promise::resolve(
+            &wasm_bindgen::JsValue::UNDEFINED,
+        ))
+        .await,
+    );
+}
+
+async fn flush() {
+    for _ in 0..3 {
+        animation_frame_turn().await;
+        microtask_turn().await;
+    }
+}
+
+#[wasm_bindgen_test(async)]
+async fn client_only_swaps_fallback_for_children_after_effect_flush() {
+    fn app() -> Element {
+        rsx! {
+            ClientOnly {
+                fallback: rsx! {
+                    span { id: "client-only-fallback", "Loading" }
+                },
+                span { id: "client-only-child", "Client" }
+            }
+        }
+    }
+
+    let parent = container();
+    let dom = VirtualDom::new(app);
+
+    dioxus_web::launch::launch_virtual_dom(
+        dom,
+        dioxus_web::Config::new().rootelement(parent.clone()),
+    );
+
+    flush().await;
+
+    assert!(
+        parent
+            .query_selector("#client-only-child")
+            .expect("query should succeed")
+            .is_some(),
+        "effect flush should render child"
+    );
+    assert!(
+        parent
+            .query_selector("#client-only-fallback")
+            .expect("query should succeed")
+            .is_none(),
+        "effect flush should remove fallback"
+    );
+
+    parent.remove();
+}

--- a/crates/ars-dioxus/tests/z_index_allocator.rs
+++ b/crates/ars-dioxus/tests/z_index_allocator.rs
@@ -1,0 +1,121 @@
+//! SSR tests for the Dioxus `ZIndexAllocator` adapter.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use ars_components::utility::z_index_allocator::{Context, Z_INDEX_BASE};
+use ars_dioxus::utility::z_index_allocator::ZIndexAllocatorProvider;
+use dioxus::prelude::*;
+
+fn render_app(app: fn() -> Element) -> String {
+    let mut vdom = VirtualDom::new(app);
+
+    vdom.rebuild_in_place();
+
+    dioxus_ssr::render(&vdom)
+}
+
+#[component]
+fn AllocationProbe(id: &'static str) -> Element {
+    let context =
+        try_use_context::<Context>().expect("ZIndexAllocatorProvider should publish context");
+
+    let claim = context.allocate_claim();
+
+    rsx! {
+        span { id, "data-z": "{claim.value()}" }
+    }
+}
+
+#[component]
+fn ResetProbe(id: &'static str) -> Element {
+    let context =
+        try_use_context::<Context>().expect("ZIndexAllocatorProvider should publish context");
+
+    let _first = context.allocate_claim();
+
+    context.reset();
+
+    let after_reset = context.allocate_claim();
+
+    rsx! {
+        span { id, "data-z": "{after_reset.value()}" }
+    }
+}
+
+#[test]
+fn z_index_allocator_provider_renders_children_without_wrapper() {
+    fn app() -> Element {
+        rsx! {
+            ZIndexAllocatorProvider {
+                span { id: "allocator-child", "child" }
+            }
+        }
+    }
+
+    let html = render_app(app);
+
+    assert!(
+        html.trim_start().starts_with("<span"),
+        "provider should not render a wrapper node: {html}"
+    );
+    assert!(
+        html.contains(r#"id="allocator-child""#),
+        "provider should render children: {html}"
+    );
+}
+
+#[test]
+fn z_index_allocator_provider_publishes_shared_context() {
+    fn app() -> Element {
+        rsx! {
+            ZIndexAllocatorProvider {
+                AllocationProbe { id: "first-claim" }
+                AllocationProbe { id: "second-claim" }
+            }
+        }
+    }
+
+    let html = render_app(app);
+
+    assert!(
+        html.contains(&format!(r#"id="first-claim" data-z="{Z_INDEX_BASE}""#)),
+        "first claim should start at provider base: {html}"
+    );
+    assert!(
+        html.contains(&format!(
+            r#"id="second-claim" data-z="{}""#,
+            Z_INDEX_BASE + 1
+        )),
+        "sibling claim should share provider allocation sequence: {html}"
+    );
+}
+
+#[test]
+fn z_index_allocator_provider_scopes_and_resets_allocations() {
+    fn app() -> Element {
+        rsx! {
+            ZIndexAllocatorProvider {
+                AllocationProbe { id: "scope-a-first" }
+            }
+            ZIndexAllocatorProvider {
+                AllocationProbe { id: "scope-b-first" }
+                ResetProbe { id: "scope-b-reset" }
+            }
+        }
+    }
+
+    let html = render_app(app);
+
+    assert!(
+        html.contains(&format!(r#"id="scope-a-first" data-z="{Z_INDEX_BASE}""#)),
+        "first provider should start at base: {html}"
+    );
+    assert!(
+        html.contains(&format!(r#"id="scope-b-first" data-z="{Z_INDEX_BASE}""#)),
+        "second provider should have an independent scope: {html}"
+    );
+    assert!(
+        html.contains(&format!(r#"id="scope-b-reset" data-z="{Z_INDEX_BASE}""#)),
+        "reset should return the provider scope to base: {html}"
+    );
+}

--- a/crates/ars-e2e/fixtures/dioxus/src/main.rs
+++ b/crates/ars-e2e/fixtures/dioxus/src/main.rs
@@ -6,10 +6,12 @@ use ars_dioxus::{
     prelude::{Locale, Orientation, TabKey, Translate, t},
     utility::{
         button::{self, Button, ButtonAsChild},
+        client_only::ClientOnly,
         dismissable,
         error_boundary::{Boundary, CapturedError},
         separator::{Separator, SeparatorAsChild},
         visually_hidden::{VisuallyHidden, VisuallyHiddenAsChild},
+        z_index_allocator::{Context as ZIndexContext, ZIndexAllocatorProvider},
     },
 };
 use dioxus::prelude::*;
@@ -133,10 +135,16 @@ enum FixtureText {
     #[translate(en_US = "Reset", pt_BR = "Redefinir")]
     Reset,
 
-    #[translate(en_US = "Screen reader only label", pt_BR = "Rótulo apenas para leitor de tela")]
+    #[translate(
+        en_US = "Screen reader only label",
+        pt_BR = "Rótulo apenas para leitor de tela"
+    )]
     VisuallyHiddenLabel,
 
-    #[translate(en_US = "Skip to button variants", pt_BR = "Pular para variantes de botão")]
+    #[translate(
+        en_US = "Skip to button variants",
+        pt_BR = "Pular para variantes de botão"
+    )]
     FocusableSkipLink,
 
     #[translate(
@@ -202,6 +210,17 @@ fn i18n_registries() -> Arc<I18nRegistries> {
 #[component]
 fn FixtureErrorChild() -> Element {
     Err(CapturedError::from_display("Dioxus fixture child failed").into())
+}
+
+#[component]
+fn ZIndexProbe(id: &'static str) -> Element {
+    let context = try_use_context::<ZIndexContext>().expect("z-index context should be provided");
+
+    let claim = context.allocate_claim();
+
+    rsx! {
+        span { id, "data-z": "{claim.value()}", "Allocated" }
+    }
 }
 
 #[component]
@@ -357,7 +376,9 @@ fn UtilityPanel() -> Element {
                     }
                 }
             }
-            section { class: "showcase-panel wide", "aria-labelledby": "utility-primitives",
+            section {
+                class: "showcase-panel wide",
+                "aria-labelledby": "utility-primitives",
                 h2 { id: "utility-primitives", "Utility primitives" }
                 p {
                     VisuallyHidden { id: "dioxus-fixture-visually-hidden-label",
@@ -366,20 +387,25 @@ fn UtilityPanel() -> Element {
                     "Visible copy with a hidden accessible companion."
                 }
                 p {
-                    VisuallyHidden { id: "dioxus-fixture-focusable-skip", is_focusable: true,
+                    VisuallyHidden {
+                        id: "dioxus-fixture-focusable-skip",
+                        is_focusable: true,
                         a { href: "#variants", {t(FixtureText::FocusableSkipLink)} }
                     }
                 }
                 VisuallyHiddenAsChild {
                     id: "dioxus-fixture-visually-hidden-as-child",
                     render: |slot: ars_dioxus::as_child::AsChildRenderProps| rsx! {
-                        span { ..slot.attrs, {t(FixtureText::AsChildHiddenLabel)} }
+                        span { ..slot.attrs,{t(FixtureText::AsChildHiddenLabel)} }
                     },
                 }
                 Separator { id: "dioxus-fixture-separator-horizontal" }
                 div { class: "separator-demo-row",
                     span { "Before" }
-                    Separator { id: "dioxus-fixture-separator-vertical", orientation: Orientation::Vertical }
+                    Separator {
+                        id: "dioxus-fixture-separator-vertical",
+                        orientation: Orientation::Vertical,
+                    }
                     span { "After" }
                 }
                 SeparatorAsChild {
@@ -389,7 +415,24 @@ fn UtilityPanel() -> Element {
                         div { class: "separator-as-child", ..slot.attrs }
                     },
                 }
-                Separator { id: "dioxus-fixture-separator-decorative", decorative: true }
+                Separator {
+                    id: "dioxus-fixture-separator-decorative",
+                    decorative: true,
+                }
+                div { id: "dioxus-fixture-client-only-host",
+                    ClientOnly {
+                        fallback: rsx! {
+                            span { id: "dioxus-fixture-client-only-fallback", "Loading client content" }
+                        },
+                        span { id: "dioxus-fixture-client-only-child", "Client content" }
+                    }
+                }
+                section { id: "dioxus-fixture-z-index-host",
+                    ZIndexAllocatorProvider {
+                        ZIndexProbe { id: "dioxus-fixture-z-index-first" }
+                        ZIndexProbe { id: "dioxus-fixture-z-index-second" }
+                    }
+                }
             }
             section {
                 class: "showcase-panel wide",

--- a/crates/ars-e2e/fixtures/leptos/src/main.rs
+++ b/crates/ars-e2e/fixtures/leptos/src/main.rs
@@ -9,10 +9,12 @@ use ars_leptos::{
     prelude::{Locale, Orientation, TabKey, Translate, t},
     utility::{
         button::{self, Button, ButtonAsChild},
+        client_only::ClientOnly,
         dismissable,
         error_boundary::Boundary,
         separator::{Separator, SeparatorAsChild},
         visually_hidden::{VisuallyHidden, VisuallyHiddenAsChild},
+        z_index_allocator::{Context as ZIndexContext, ZIndexAllocatorProvider},
     },
 };
 use leptos::{mount::mount_to_body, prelude::*};
@@ -136,10 +138,16 @@ enum FixtureText {
     #[translate(en_US = "Reset", pt_BR = "Redefinir")]
     Reset,
 
-    #[translate(en_US = "Screen reader only label", pt_BR = "Rótulo apenas para leitor de tela")]
+    #[translate(
+        en_US = "Screen reader only label",
+        pt_BR = "Rótulo apenas para leitor de tela"
+    )]
     VisuallyHiddenLabel,
 
-    #[translate(en_US = "Skip to button variants", pt_BR = "Pular para variantes de botão")]
+    #[translate(
+        en_US = "Skip to button variants",
+        pt_BR = "Pular para variantes de botão"
+    )]
     FocusableSkipLink,
 
     #[translate(
@@ -209,6 +217,19 @@ impl std::error::Error for FixtureError {}
 
 fn fixture_error() -> Result<&'static str, FixtureError> {
     Err(FixtureError)
+}
+
+#[component]
+fn ZIndexProbe(id: &'static str) -> impl IntoView {
+    let context = use_context::<ZIndexContext>().expect("z-index context should be provided");
+
+    let claim = context.allocate_claim();
+
+    view! {
+        <span id=id data-z=claim.value().to_string()>
+            "Allocated"
+        </span>
+    }
 }
 
 #[component]
@@ -376,10 +397,30 @@ fn UtilityPanel() -> impl IntoView {
                     />
                     <span>"After"</span>
                 </div>
-                <SeparatorAsChild id="leptos-fixture-separator-as-child" orientation=Orientation::Vertical>
+                <SeparatorAsChild
+                    id="leptos-fixture-separator-as-child"
+                    orientation=Orientation::Vertical
+                >
                     <div class="separator-as-child"></div>
                 </SeparatorAsChild>
                 <Separator id="leptos-fixture-separator-decorative" decorative=true />
+                <div id="leptos-fixture-client-only-host">
+                    <ClientOnly fallback=|| {
+                        view! {
+                            <span id="leptos-fixture-client-only-fallback">
+                                "Loading client content"
+                            </span>
+                        }
+                    }>
+                        <span id="leptos-fixture-client-only-child">"Client content"</span>
+                    </ClientOnly>
+                </div>
+                <section id="leptos-fixture-z-index-host">
+                    <ZIndexAllocatorProvider>
+                        <ZIndexProbe id="leptos-fixture-z-index-first" />
+                        <ZIndexProbe id="leptos-fixture-z-index-second" />
+                    </ZIndexAllocatorProvider>
+                </section>
             </section>
             <section class="showcase-panel wide" aria-labelledby="dismissable">
                 <h2 id="dismissable">"Dismissable primitive"</h2>

--- a/crates/ars-e2e/src/utility/client_only.rs
+++ b/crates/ars-e2e/src/utility/client_only.rs
@@ -1,0 +1,56 @@
+//! Browser E2E harness for the `ClientOnly` component.
+
+use serde_json::Value;
+use thirtyfour::prelude::*;
+
+pub use crate::fixtures::Adapter;
+use crate::{
+    Error,
+    utility::{element_by_id, open_utility_panel},
+};
+
+/// Runs the `ClientOnly` browser assertions inside the Utility fixture panel.
+///
+/// # Errors
+///
+/// Returns an error when `WebDriver` cannot find the fixture nodes or an
+/// assertion fails.
+pub async fn run_client_only_flow(
+    driver: &WebDriver,
+    url: &str,
+    adapter: Adapter,
+) -> Result<(), Error> {
+    open_utility_panel(driver, url).await?;
+
+    let prefix = id_prefix(adapter);
+
+    let child = element_by_id(driver, &format!("{prefix}-client-only-child")).await?;
+
+    if child.text().await? != "Client content" {
+        return Err(Error::Assertion(
+            "ClientOnly child should be visible after mount".to_string(),
+        ));
+    }
+
+    let fallback_absent = driver
+        .execute(
+            "return document.getElementById(arguments[0]) === null;",
+            vec![Value::String(format!("{prefix}-client-only-fallback"))],
+        )
+        .await?;
+
+    if fallback_absent.json().as_bool() == Some(true) {
+        Ok(())
+    } else {
+        Err(Error::Assertion(
+            "ClientOnly fallback should be removed after mount".to_string(),
+        ))
+    }
+}
+
+const fn id_prefix(adapter: Adapter) -> &'static str {
+    match adapter {
+        Adapter::Leptos => "leptos-fixture",
+        Adapter::Dioxus => "dioxus-fixture",
+    }
+}

--- a/crates/ars-e2e/src/utility/mod.rs
+++ b/crates/ars-e2e/src/utility/mod.rs
@@ -15,6 +15,9 @@ use crate::{
 /// Browser E2E harness for Button.
 pub mod button;
 
+/// Browser E2E harness for ClientOnly.
+pub mod client_only;
+
 /// Browser E2E harness for Dismissable.
 pub mod dismissable;
 
@@ -26,6 +29,9 @@ pub mod separator;
 
 /// Browser E2E harness for VisuallyHidden.
 pub mod visually_hidden;
+
+/// Browser E2E harness for ZIndexAllocator.
+pub mod z_index_allocator;
 
 /// Runtime options for utility E2E harnesses.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -69,6 +75,9 @@ pub async fn run(options: Options) -> Result<(), Error> {
         button::run_button_flow(&session.driver, &session.url, adapter).await?;
         visually_hidden::run_visually_hidden_flow(&session.driver, &session.url, adapter).await?;
         separator::run_separator_flow(&session.driver, &session.url, adapter).await?;
+        client_only::run_client_only_flow(&session.driver, &session.url, adapter).await?;
+        z_index_allocator::run_z_index_allocator_flow(&session.driver, &session.url, adapter)
+            .await?;
         dismissable::run_dismissable_flow(&session.driver, &session.url).await?;
         error_boundary::run_error_boundary_flow(&session.driver, &session.url).await
     }

--- a/crates/ars-e2e/src/utility/z_index_allocator.rs
+++ b/crates/ars-e2e/src/utility/z_index_allocator.rs
@@ -1,0 +1,64 @@
+//! Browser E2E harness for the `ZIndexAllocator` component.
+
+use serde_json::Value;
+use thirtyfour::prelude::*;
+
+pub use crate::fixtures::Adapter;
+use crate::{
+    Error,
+    utility::{assert_attr, element_by_id, open_utility_panel},
+};
+
+/// Runs the `ZIndexAllocator` browser assertions inside the Utility fixture panel.
+///
+/// # Errors
+///
+/// Returns an error when `WebDriver` cannot find the fixture nodes or an
+/// assertion fails.
+pub async fn run_z_index_allocator_flow(
+    driver: &WebDriver,
+    url: &str,
+    adapter: Adapter,
+) -> Result<(), Error> {
+    open_utility_panel(driver, url).await?;
+
+    let prefix = id_prefix(adapter);
+
+    let first = element_by_id(driver, &format!("{prefix}-z-index-first")).await?;
+    let second = element_by_id(driver, &format!("{prefix}-z-index-second")).await?;
+
+    assert_attr(&first, "data-z", "1000").await?;
+    assert_attr(&second, "data-z", "1001").await?;
+
+    let direct_probe_count = driver
+        .execute(
+            r#"
+            const host = document.getElementById(arguments[0]);
+            if (!host) return -1;
+            return Array.from(host.children)
+                .filter((child) => child.id === arguments[1] || child.id === arguments[2])
+                .length;
+            "#,
+            vec![
+                Value::String(format!("{prefix}-z-index-host")),
+                Value::String(format!("{prefix}-z-index-first")),
+                Value::String(format!("{prefix}-z-index-second")),
+            ],
+        )
+        .await?;
+
+    if direct_probe_count.json().as_i64() == Some(2) {
+        Ok(())
+    } else {
+        Err(Error::Assertion(
+            "ZIndexAllocatorProvider should not insert a wrapper around probes".to_string(),
+        ))
+    }
+}
+
+const fn id_prefix(adapter: Adapter) -> &'static str {
+    match adapter {
+        Adapter::Leptos => "leptos-fixture",
+        Adapter::Dioxus => "dioxus-fixture",
+    }
+}

--- a/crates/ars-leptos/src/prelude.rs
+++ b/crates/ars-leptos/src/prelude.rs
@@ -67,6 +67,9 @@ pub use crate::navigation::{self, tabs};
 // wrapper component spec'd at
 // `spec/foundation/08-adapter-leptos.md` §17. End users reach it as
 // `error_boundary::ArsErrorBoundary` after `use ars_leptos::prelude::*;`.
-pub use crate::utility::{self, button, dismissable, error_boundary, separator, visually_hidden};
+pub use crate::utility::{
+    self, button, client_only, dismissable, error_boundary, separator, visually_hidden,
+    z_index_allocator,
+};
 // -- User-facing helpers --
 pub use crate::{Translatable, t, use_number_formatter};

--- a/crates/ars-leptos/src/utility/client_only.rs
+++ b/crates/ars-leptos/src/utility/client_only.rs
@@ -1,0 +1,40 @@
+//! Leptos `ClientOnly` adapter.
+//!
+//! Gates children until the client mount pass while preserving SSR fallback
+//! markup and avoiding adapter-owned wrapper nodes.
+
+pub use ars_components::utility::client_only::Props;
+use leptos::{
+    children::{TypedChildrenFn, ViewFn},
+    either::Either,
+    prelude::*,
+};
+
+/// Leptos logical boundary that renders children only after client mount.
+#[component]
+pub fn ClientOnly<C>(
+    /// Optional fallback rendered during SSR and before client mount.
+    #[prop(optional, into)]
+    fallback: ViewFn,
+
+    /// Client-only children rendered after mount.
+    children: TypedChildrenFn<C>,
+) -> impl IntoView
+where
+    C: IntoView + 'static,
+{
+    let mounted = RwSignal::new(false);
+
+    #[cfg(not(feature = "ssr"))]
+    Effect::new(move |_| mounted.set(true));
+
+    let children = children.into_inner();
+
+    move || {
+        if mounted.get() {
+            Either::Left(children())
+        } else {
+            Either::Right(fallback.run())
+        }
+    }
+}

--- a/crates/ars-leptos/src/utility/mod.rs
+++ b/crates/ars-leptos/src/utility/mod.rs
@@ -1,7 +1,9 @@
 //! Utility component adapters for Leptos.
 
 pub mod button;
+pub mod client_only;
 pub mod dismissable;
 pub mod error_boundary;
 pub mod separator;
 pub mod visually_hidden;
+pub mod z_index_allocator;

--- a/crates/ars-leptos/src/utility/z_index_allocator.rs
+++ b/crates/ars-leptos/src/utility/z_index_allocator.rs
@@ -1,0 +1,31 @@
+//! Leptos `ZIndexAllocator` adapter.
+//!
+//! Publishes the framework-agnostic z-index allocation context to descendants
+//! without rendering an adapter-owned DOM node.
+
+pub use ars_components::utility::z_index_allocator::{
+    Context, Props, Z_INDEX_BASE, Z_INDEX_CEILING, ZIndexAllocator, ZIndexClaim, next_z_index,
+    reset_z_index,
+};
+use leptos::{children::TypedChildren, prelude::*, tachys::reactive_graph::OwnedView};
+
+/// Leptos provider for the framework-agnostic z-index allocator context.
+#[component]
+pub fn ZIndexAllocatorProvider<T>(
+    /// Children that share the provider-scoped allocation context.
+    children: TypedChildren<T>,
+) -> impl IntoView
+where
+    T: IntoView + 'static,
+{
+    let owner = Owner::current().map_or_else(Owner::new, |owner| owner.child());
+
+    let children = children.into_inner();
+
+    let children = owner.with(|| {
+        provide_context(Context::new());
+        children()
+    });
+
+    OwnedView::new_with_owner(children, owner)
+}

--- a/crates/ars-leptos/tests/client_only.rs
+++ b/crates/ars-leptos/tests/client_only.rs
@@ -1,0 +1,50 @@
+//! SSR tests for the Leptos `ClientOnly` adapter.
+
+#![cfg(all(not(target_arch = "wasm32"), feature = "ssr"))]
+
+use ars_leptos::utility::client_only::ClientOnly;
+use leptos::prelude::*;
+
+#[test]
+fn client_only_renders_fallback_during_ssr() {
+    let html = view! {
+        <ClientOnly fallback=|| view! { <span id="client-only-fallback">"Loading"</span> }>
+            <span id="client-only-child">"Client"</span>
+        </ClientOnly>
+    }
+    .to_html();
+
+    assert!(
+        html.contains(r#"id="client-only-fallback""#),
+        "fallback should render during SSR: {html}"
+    );
+    assert!(
+        !html.contains(r#"id="client-only-child""#),
+        "client children must not render during SSR: {html}"
+    );
+}
+
+#[test]
+fn client_only_without_fallback_renders_no_wrapper_during_ssr() {
+    let html = view! {
+        <section id="before"></section>
+        <ClientOnly>
+            <span id="client-only-child">"Client"</span>
+        </ClientOnly>
+        <section id="after"></section>
+    }
+    .to_html();
+
+    assert!(
+        html.contains(r#"id="before""#) && html.contains(r#"id="after""#),
+        "siblings should still render: {html}"
+    );
+    assert!(
+        !html.contains(r#"id="client-only-child""#),
+        "client children must not render during SSR: {html}"
+    );
+    assert!(
+        !html.contains("client-only"),
+        "adapter should not invent a wrapper or marker: {html}"
+    );
+}

--- a/crates/ars-leptos/tests/client_only_wasm.rs
+++ b/crates/ars-leptos/tests/client_only_wasm.rs
@@ -1,0 +1,70 @@
+//! Browser coverage tests for the Leptos `ClientOnly` adapter.
+
+#![cfg(target_arch = "wasm32")]
+
+use ars_leptos::utility::client_only::ClientOnly;
+use leptos::{mount::mount_to, prelude::*};
+use wasm_bindgen::JsCast;
+use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+fn document() -> web_sys::Document {
+    web_sys::window()
+        .and_then(|window| window.document())
+        .expect("document should exist")
+}
+
+fn container() -> web_sys::HtmlElement {
+    let element = document()
+        .create_element("div")
+        .expect("container should be created");
+
+    document()
+        .body()
+        .expect("body should exist")
+        .append_child(&element)
+        .expect("container should be attached");
+
+    element
+        .dyn_into::<web_sys::HtmlElement>()
+        .expect("container should be an HtmlElement")
+}
+
+#[wasm_bindgen_test(async)]
+async fn client_only_swaps_fallback_for_children_after_mount() {
+    let owner = Owner::new();
+
+    let (_mount_handle, parent) = owner.with(|| {
+        let parent = container();
+
+        let mount_handle = mount_to(parent.clone(), || {
+            view! {
+                <ClientOnly fallback=|| view! { <span id="client-only-fallback">"Loading"</span> }>
+                    <span id="client-only-child">"Client"</span>
+                </ClientOnly>
+            }
+        });
+
+        (mount_handle, parent)
+    });
+
+    leptos::task::tick().await;
+
+    assert!(
+        parent
+            .query_selector("#client-only-child")
+            .expect("query should succeed")
+            .is_some(),
+        "client child should render after mount"
+    );
+    assert!(
+        parent
+            .query_selector("#client-only-fallback")
+            .expect("query should succeed")
+            .is_none(),
+        "fallback should be removed after mount"
+    );
+
+    parent.remove();
+}

--- a/crates/ars-leptos/tests/z_index_allocator.rs
+++ b/crates/ars-leptos/tests/z_index_allocator.rs
@@ -1,0 +1,98 @@
+//! SSR tests for the Leptos `ZIndexAllocator` adapter.
+
+#![cfg(all(not(target_arch = "wasm32"), feature = "ssr"))]
+
+use ars_components::utility::z_index_allocator::{Context, Z_INDEX_BASE};
+use ars_leptos::utility::z_index_allocator::ZIndexAllocatorProvider;
+use leptos::prelude::*;
+
+#[component]
+fn AllocationProbe(id: &'static str) -> impl IntoView {
+    let context = use_context::<Context>().expect("ZIndexAllocatorProvider should publish context");
+
+    let claim = context.allocate_claim();
+
+    view! { <span id=id data-z=claim.value().to_string()></span> }
+}
+
+#[component]
+fn ResetProbe(id: &'static str) -> impl IntoView {
+    let context = use_context::<Context>().expect("ZIndexAllocatorProvider should publish context");
+
+    let _first = context.allocate_claim();
+
+    context.reset();
+
+    let after_reset = context.allocate_claim();
+
+    view! { <span id=id data-z=after_reset.value().to_string()></span> }
+}
+
+#[test]
+fn z_index_allocator_provider_renders_children_without_wrapper() {
+    let html = view! {
+        <ZIndexAllocatorProvider>
+            <span id="allocator-child">"child"</span>
+        </ZIndexAllocatorProvider>
+    }
+    .to_html();
+
+    assert!(
+        html.trim_start().starts_with("<span"),
+        "provider should not render a wrapper node: {html}"
+    );
+    assert!(
+        html.contains(r#"id="allocator-child""#),
+        "provider should render children: {html}"
+    );
+}
+
+#[test]
+fn z_index_allocator_provider_publishes_shared_context() {
+    let html = view! {
+        <ZIndexAllocatorProvider>
+            <AllocationProbe id="first-claim" />
+            <AllocationProbe id="second-claim" />
+        </ZIndexAllocatorProvider>
+    }
+    .to_html();
+
+    assert!(
+        html.contains(&format!(r#"id="first-claim" data-z="{Z_INDEX_BASE}""#)),
+        "first claim should start at provider base: {html}"
+    );
+    assert!(
+        html.contains(&format!(
+            r#"id="second-claim" data-z="{}""#,
+            Z_INDEX_BASE + 1
+        )),
+        "sibling claim should share provider allocation sequence: {html}"
+    );
+}
+
+#[test]
+fn z_index_allocator_provider_scopes_and_resets_allocations() {
+    let html = view! {
+        <ZIndexAllocatorProvider>
+            <AllocationProbe id="scope-a-first" />
+        </ZIndexAllocatorProvider>
+        <ZIndexAllocatorProvider>
+            <AllocationProbe id="scope-b-first" />
+            <ResetProbe id="scope-b-reset" />
+        </ZIndexAllocatorProvider>
+    }
+    .to_html();
+
+    assert!(
+        html.contains(&format!(r#"id="scope-a-first" data-z="{Z_INDEX_BASE}""#)),
+        "first provider should start at base: {html}"
+    );
+    assert!(
+        html.contains(&format!(r#"id="scope-b-first" data-z="{Z_INDEX_BASE}""#)),
+        "second provider should have an independent scope: {html}"
+    );
+    assert!(
+        html.contains(&format!(r#"id="scope-b-reset" data-z="{Z_INDEX_BASE}""#)),
+        "reset should return the provider scope to base: {html}"
+    );
+}

--- a/examples/widgets-dioxus-css/src/categories/utility.rs
+++ b/examples/widgets-dioxus-css/src/categories/utility.rs
@@ -1,11 +1,13 @@
 use ars_dioxus::{
-    prelude::{Orientation, t, Translate},
+    prelude::{Orientation, Translate, t},
     utility::{
         button::{self, Button, ButtonAsChild},
+        client_only::ClientOnly,
         dismissable,
         error_boundary::{Boundary, CapturedError},
         separator::{Separator, SeparatorAsChild},
         visually_hidden::{VisuallyHidden, VisuallyHiddenAsChild},
+        z_index_allocator::{Context as ZIndexContext, ZIndexAllocatorProvider},
     },
 };
 use dioxus::prelude::*;
@@ -100,7 +102,10 @@ pub(crate) enum UtilityText {
     )]
     VisuallyHiddenLabel,
 
-    #[translate(en_US = "Skip to button variants", pt_BR = "Pular para variantes de botão")]
+    #[translate(
+        en_US = "Skip to button variants",
+        pt_BR = "Pular para variantes de botão"
+    )]
     FocusableSkipLink,
 
     #[translate(
@@ -118,7 +123,10 @@ pub(crate) enum UtilityText {
     )]
     SeparatorDescription,
 
-    #[translate(en_US = "Horizontal section break", pt_BR = "Quebra horizontal de seção")]
+    #[translate(
+        en_US = "Horizontal section break",
+        pt_BR = "Quebra horizontal de seção"
+    )]
     HorizontalSeparator,
 
     #[translate(en_US = "Vertical divider", pt_BR = "Divisor vertical")]
@@ -132,6 +140,36 @@ pub(crate) enum UtilityText {
         pt_BR = "O divisor da raiz do consumidor preserva a semântica de separador"
     )]
     AsChildSeparator,
+
+    #[translate(en_US = "Client-only content", pt_BR = "Conteúdo somente no cliente")]
+    ClientOnly,
+
+    #[translate(
+        en_US = "Fallback content is replaced after client mount.",
+        pt_BR = "O conteúdo fallback é substituído após a montagem no cliente."
+    )]
+    ClientOnlyDescription,
+
+    #[translate(
+        en_US = "Client content mounted",
+        pt_BR = "Conteúdo do cliente montado"
+    )]
+    ClientOnlyMounted,
+
+    #[translate(
+        en_US = "Loading client content",
+        pt_BR = "Carregando conteúdo do cliente"
+    )]
+    ClientOnlyFallback,
+
+    #[translate(en_US = "Z-index allocator", pt_BR = "Alocador de z-index")]
+    ZIndexAllocator,
+
+    #[translate(
+        en_US = "Provider-scoped claims allocate deterministic stacking layers.",
+        pt_BR = "Claims no escopo do provider alocam camadas determinísticas."
+    )]
+    ZIndexAllocatorDescription,
 
     #[translate(en_US = "Dismissable primitive", pt_BR = "Primitivo dismissable")]
     DismissablePrimitive,
@@ -212,12 +250,22 @@ fn ExampleErrorChild() -> Element {
 }
 
 #[component]
+fn ZIndexProbe(id: &'static str) -> Element {
+    let context = try_use_context::<ZIndexContext>().expect("z-index context should be provided");
+
+    let claim = context.allocate_claim();
+
+    rsx! {
+        span { id, class: "z-index-chip", "data-z": "{claim.value()}", "{claim.value()}" }
+    }
+}
+
+#[component]
 pub(crate) fn UtilityPanel() -> Element {
     let dismiss_status = use_signal_sync(|| UtilityText::DismissInitial);
-    let dismiss_status_for_dismiss = dismiss_status;
-    let dismiss_props = dismissable::Props::new().on_dismiss(move |reason| {
-        let mut dismiss_status = dismiss_status_for_dismiss;
 
+    let dismiss_props = dismissable::Props::new().on_dismiss(move |reason| {
+        let mut dismiss_status = dismiss_status;
         dismiss_status.set(UtilityText::DismissReason {
             reason: format!("{reason:?}"),
         });
@@ -391,6 +439,28 @@ pub(crate) fn UtilityPanel() -> Element {
                     },
                 }
                 p { class: "panel-note", {t(UtilityText::AsChildSeparator)} }
+            }
+            section {
+                class: "showcase-panel",
+                "aria-labelledby": "client-only-z-index",
+                div { class: "panel-heading",
+                    h2 { id: "client-only-z-index", {t(UtilityText::ClientOnly)} }
+                    p { class: "panel-note", {t(UtilityText::ClientOnlyDescription)} }
+                }
+                ClientOnly {
+                    fallback: rsx! {
+                        span { {t(UtilityText::ClientOnlyFallback)} }
+                    },
+                    span { {t(UtilityText::ClientOnlyMounted)} }
+                }
+                div { class: "panel-heading",
+                    h3 { {t(UtilityText::ZIndexAllocator)} }
+                    p { class: "panel-note", {t(UtilityText::ZIndexAllocatorDescription)} }
+                }
+                ZIndexAllocatorProvider {
+                    ZIndexProbe { id: "dioxus-css-z-index-first" }
+                    ZIndexProbe { id: "dioxus-css-z-index-second" }
+                }
             }
             section {
                 class: "showcase-panel wide",

--- a/examples/widgets-dioxus-tailwind/src/categories/utility.rs
+++ b/examples/widgets-dioxus-tailwind/src/categories/utility.rs
@@ -1,11 +1,13 @@
 use ars_dioxus::{
-    prelude::{Orientation, t, Translate},
+    prelude::{Orientation, Translate, t},
     utility::{
         button::{self, Button, ButtonAsChild},
+        client_only::ClientOnly,
         dismissable,
         error_boundary::{Boundary, CapturedError},
         separator::{Separator, SeparatorAsChild},
         visually_hidden::{VisuallyHidden, VisuallyHiddenAsChild},
+        z_index_allocator::{Context as ZIndexContext, ZIndexAllocatorProvider},
     },
 };
 use dioxus::prelude::*;
@@ -100,7 +102,10 @@ pub(crate) enum UtilityText {
     )]
     VisuallyHiddenLabel,
 
-    #[translate(en_US = "Skip to button variants", pt_BR = "Pular para variantes de botão")]
+    #[translate(
+        en_US = "Skip to button variants",
+        pt_BR = "Pular para variantes de botão"
+    )]
     FocusableSkipLink,
 
     #[translate(
@@ -118,7 +123,10 @@ pub(crate) enum UtilityText {
     )]
     SeparatorDescription,
 
-    #[translate(en_US = "Horizontal section break", pt_BR = "Quebra horizontal de seção")]
+    #[translate(
+        en_US = "Horizontal section break",
+        pt_BR = "Quebra horizontal de seção"
+    )]
     HorizontalSeparator,
 
     #[translate(en_US = "Vertical divider", pt_BR = "Divisor vertical")]
@@ -132,6 +140,36 @@ pub(crate) enum UtilityText {
         pt_BR = "O divisor da raiz do consumidor preserva a semântica de separador"
     )]
     AsChildSeparator,
+
+    #[translate(en_US = "Client-only content", pt_BR = "Conteúdo somente no cliente")]
+    ClientOnly,
+
+    #[translate(
+        en_US = "Fallback content is replaced after client mount.",
+        pt_BR = "O conteúdo fallback é substituído após a montagem no cliente."
+    )]
+    ClientOnlyDescription,
+
+    #[translate(
+        en_US = "Client content mounted",
+        pt_BR = "Conteúdo do cliente montado"
+    )]
+    ClientOnlyMounted,
+
+    #[translate(
+        en_US = "Loading client content",
+        pt_BR = "Carregando conteúdo do cliente"
+    )]
+    ClientOnlyFallback,
+
+    #[translate(en_US = "Z-index allocator", pt_BR = "Alocador de z-index")]
+    ZIndexAllocator,
+
+    #[translate(
+        en_US = "Provider-scoped claims allocate deterministic stacking layers.",
+        pt_BR = "Claims no escopo do provider alocam camadas determinísticas."
+    )]
+    ZIndexAllocatorDescription,
 
     #[translate(en_US = "Dismissable primitive", pt_BR = "Primitivo dismissable")]
     DismissablePrimitive,
@@ -215,12 +253,27 @@ fn ExampleErrorChild() -> Element {
 }
 
 #[component]
+fn ZIndexProbe(id: &'static str) -> Element {
+    let context = try_use_context::<ZIndexContext>().expect("z-index context should be provided");
+
+    let claim = context.allocate_claim();
+
+    rsx! {
+        span {
+            id,
+            class: "rounded border border-slate-300 px-2 py-1 text-xs",
+            "data-z": "{claim.value()}",
+            "{claim.value()}"
+        }
+    }
+}
+
+#[component]
 pub(crate) fn UtilityPanel() -> Element {
     let dismiss_status = use_signal_sync(|| UtilityText::DismissInitial);
-    let dismiss_status_for_dismiss = dismiss_status;
-    let dismiss_props = dismissable::Props::new().on_dismiss(move |reason| {
-        let mut dismiss_status = dismiss_status_for_dismiss;
 
+    let dismiss_props = dismissable::Props::new().on_dismiss(move |reason| {
+        let mut dismiss_status = dismiss_status;
         dismiss_status.set(UtilityText::DismissReason {
             reason: format!("{reason:?}"),
         });
@@ -439,6 +492,34 @@ pub(crate) fn UtilityPanel() -> Element {
                     },
                 }
                 p { class: "text-sm text-slate-500", {t(UtilityText::AsChildSeparator)} }
+            }
+            section {
+                class: "rounded-lg border border-slate-200 bg-white/85 p-5 shadow-lg shadow-slate-900/10",
+                "aria-labelledby": "client-only-z-index",
+                div { class: "mb-4 flex flex-wrap items-center justify-between gap-3",
+                    h2 {
+                        id: "client-only-z-index",
+                        class: "text-base font-bold text-slate-950",
+                        {t(UtilityText::ClientOnly)}
+                    }
+                    p { class: "text-sm text-slate-500", {t(UtilityText::ClientOnlyDescription)} }
+                }
+                ClientOnly {
+                    fallback: rsx! {
+                        span { {t(UtilityText::ClientOnlyFallback)} }
+                    },
+                    span { class: "text-sm text-slate-700", {t(UtilityText::ClientOnlyMounted)} }
+                }
+                h3 { class: "mt-4 text-sm font-semibold text-slate-900",
+                    {t(UtilityText::ZIndexAllocator)}
+                }
+                p { class: "text-sm text-slate-500", {t(UtilityText::ZIndexAllocatorDescription)} }
+                div { class: "mt-2 flex gap-2",
+                    ZIndexAllocatorProvider {
+                        ZIndexProbe { id: "dioxus-tw-z-index-first" }
+                        ZIndexProbe { id: "dioxus-tw-z-index-second" }
+                    }
+                }
             }
             section {
                 class: "rounded-lg border border-slate-200 bg-white/85 p-5 shadow-lg shadow-slate-900/10 transition hover:-translate-y-0.5 hover:shadow-xl hover:shadow-slate-900/15 lg:col-span-2",

--- a/examples/widgets-dioxus/src/categories/utility.rs
+++ b/examples/widgets-dioxus/src/categories/utility.rs
@@ -1,11 +1,13 @@
 use ars_dioxus::{
-    prelude::{Orientation, t, Translate},
+    prelude::{Orientation, Translate, t},
     utility::{
         button::{self, Button, ButtonAsChild},
+        client_only::ClientOnly,
         dismissable,
         error_boundary::{Boundary, CapturedError},
         separator::{Separator, SeparatorAsChild},
         visually_hidden::{VisuallyHidden, VisuallyHiddenAsChild},
+        z_index_allocator::{Context as ZIndexContext, ZIndexAllocatorProvider},
     },
 };
 use dioxus::prelude::*;
@@ -118,7 +120,10 @@ pub(crate) enum UtilityText {
     )]
     VisuallyHiddenLabel,
 
-    #[translate(en_US = "Skip to button variants", pt_BR = "Pular para variantes de botão")]
+    #[translate(
+        en_US = "Skip to button variants",
+        pt_BR = "Pular para variantes de botão"
+    )]
     FocusableSkipLink,
 
     #[translate(
@@ -136,7 +141,10 @@ pub(crate) enum UtilityText {
     )]
     SeparatorDescription,
 
-    #[translate(en_US = "Horizontal section break", pt_BR = "Quebra horizontal de seção")]
+    #[translate(
+        en_US = "Horizontal section break",
+        pt_BR = "Quebra horizontal de seção"
+    )]
     HorizontalSeparator,
 
     #[translate(en_US = "Vertical divider", pt_BR = "Divisor vertical")]
@@ -150,6 +158,36 @@ pub(crate) enum UtilityText {
         pt_BR = "O divisor da raiz do consumidor preserva a semântica de separador"
     )]
     AsChildSeparator,
+
+    #[translate(en_US = "Client-only content", pt_BR = "Conteúdo somente no cliente")]
+    ClientOnly,
+
+    #[translate(
+        en_US = "Fallback content is replaced after client mount.",
+        pt_BR = "O conteúdo fallback é substituído após a montagem no cliente."
+    )]
+    ClientOnlyDescription,
+
+    #[translate(
+        en_US = "Client content mounted",
+        pt_BR = "Conteúdo do cliente montado"
+    )]
+    ClientOnlyMounted,
+
+    #[translate(
+        en_US = "Loading client content",
+        pt_BR = "Carregando conteúdo do cliente"
+    )]
+    ClientOnlyFallback,
+
+    #[translate(en_US = "Z-index allocator", pt_BR = "Alocador de z-index")]
+    ZIndexAllocator,
+
+    #[translate(
+        en_US = "Provider-scoped claims allocate deterministic stacking layers.",
+        pt_BR = "Claims no escopo do provider alocam camadas determinísticas."
+    )]
+    ZIndexAllocatorDescription,
 
     #[translate(en_US = "Dismissable primitive", pt_BR = "Primitivo dismissable")]
     DismissablePrimitive,
@@ -200,12 +238,22 @@ fn ExampleErrorChild() -> Element {
 }
 
 #[component]
+fn ZIndexProbe(id: &'static str) -> Element {
+    let context = try_use_context::<ZIndexContext>().expect("z-index context should be provided");
+
+    let claim = context.allocate_claim();
+
+    rsx! {
+        span { id, class: "z-index-chip", "data-z": "{claim.value()}", "{claim.value()}" }
+    }
+}
+
+#[component]
 pub(crate) fn UtilityPanel() -> Element {
     let dismiss_status = use_signal_sync(|| UtilityText::DismissInitial);
-    let dismiss_status_for_dismiss = dismiss_status;
-    let dismiss_props = dismissable::Props::new().on_dismiss(move |reason| {
-        let mut dismiss_status = dismiss_status_for_dismiss;
 
+    let dismiss_props = dismissable::Props::new().on_dismiss(move |reason| {
+        let mut dismiss_status = dismiss_status;
         dismiss_status.set(UtilityText::DismissReason {
             reason: format!("{reason:?}"),
         });
@@ -347,6 +395,22 @@ pub(crate) fn UtilityPanel() -> Element {
                     },
                 }
                 p { {t(UtilityText::AsChildSeparator)} }
+            }
+            section { "aria-labelledby": "client-only-z-index",
+                h3 { id: "client-only-z-index", {t(UtilityText::ClientOnly)} }
+                p { {t(UtilityText::ClientOnlyDescription)} }
+                ClientOnly {
+                    fallback: rsx! {
+                        span { {t(UtilityText::ClientOnlyFallback)} }
+                    },
+                    span { {t(UtilityText::ClientOnlyMounted)} }
+                }
+                h4 { {t(UtilityText::ZIndexAllocator)} }
+                p { {t(UtilityText::ZIndexAllocatorDescription)} }
+                ZIndexAllocatorProvider {
+                    ZIndexProbe { id: "dioxus-z-index-first" }
+                    ZIndexProbe { id: "dioxus-z-index-second" }
+                }
             }
             section { "aria-labelledby": "dismissable",
                 h3 { id: "dismissable", {t(UtilityText::DismissablePrimitive)} }

--- a/examples/widgets-leptos-css/src/categories/utility.rs
+++ b/examples/widgets-leptos-css/src/categories/utility.rs
@@ -1,13 +1,15 @@
 use std::fmt::{self, Display};
 
 use ars_leptos::{
-    prelude::{Orientation, t, Translate},
+    prelude::{Orientation, Translate, t},
     utility::{
         button::{self, Button, ButtonAsChild},
+        client_only::ClientOnly,
         dismissable,
         error_boundary::Boundary,
         separator::{Separator, SeparatorAsChild},
         visually_hidden::{VisuallyHidden, VisuallyHiddenAsChild},
+        z_index_allocator::{Context as ZIndexContext, ZIndexAllocatorProvider},
     },
 };
 use leptos::prelude::*;
@@ -102,7 +104,10 @@ pub(crate) enum UtilityText {
     )]
     VisuallyHiddenLabel,
 
-    #[translate(en_US = "Skip to button variants", pt_BR = "Pular para variantes de botão")]
+    #[translate(
+        en_US = "Skip to button variants",
+        pt_BR = "Pular para variantes de botão"
+    )]
     FocusableSkipLink,
 
     #[translate(
@@ -120,7 +125,10 @@ pub(crate) enum UtilityText {
     )]
     SeparatorDescription,
 
-    #[translate(en_US = "Horizontal section break", pt_BR = "Quebra horizontal de seção")]
+    #[translate(
+        en_US = "Horizontal section break",
+        pt_BR = "Quebra horizontal de seção"
+    )]
     HorizontalSeparator,
 
     #[translate(en_US = "Vertical divider", pt_BR = "Divisor vertical")]
@@ -134,6 +142,36 @@ pub(crate) enum UtilityText {
         pt_BR = "O divisor da raiz do consumidor preserva a semântica de separador"
     )]
     AsChildSeparator,
+
+    #[translate(en_US = "Client-only content", pt_BR = "Conteúdo somente no cliente")]
+    ClientOnly,
+
+    #[translate(
+        en_US = "Fallback content is replaced after client mount.",
+        pt_BR = "O conteúdo fallback é substituído após a montagem no cliente."
+    )]
+    ClientOnlyDescription,
+
+    #[translate(
+        en_US = "Client content mounted",
+        pt_BR = "Conteúdo do cliente montado"
+    )]
+    ClientOnlyMounted,
+
+    #[translate(
+        en_US = "Loading client content",
+        pt_BR = "Carregando conteúdo do cliente"
+    )]
+    ClientOnlyFallback,
+
+    #[translate(en_US = "Z-index allocator", pt_BR = "Alocador de z-index")]
+    ZIndexAllocator,
+
+    #[translate(
+        en_US = "Provider-scoped claims allocate deterministic stacking layers.",
+        pt_BR = "Claims no escopo do provider alocam camadas determinísticas."
+    )]
+    ZIndexAllocatorDescription,
 
     #[translate(en_US = "Dismissable primitive", pt_BR = "Primitivo dismissable")]
     DismissablePrimitive,
@@ -224,13 +262,28 @@ fn example_error(message: Signal<String>) -> Result<&'static str, ExampleError> 
 }
 
 #[component]
+fn ZIndexProbe(id: &'static str) -> impl IntoView {
+    let context = use_context::<ZIndexContext>().expect("z-index context should be provided");
+
+    let claim = context.allocate_claim();
+
+    view! {
+        <span id=id class="z-index-chip" data-z=claim.value().to_string()>
+            {claim.value().to_string()}
+        </span>
+    }
+}
+
+#[component]
 pub(crate) fn UtilityPanel() -> impl IntoView {
     let (dismiss_status, set_dismiss_status) = signal(UtilityText::DismissInitial);
+
     let dismiss_props = dismissable::Props::new().on_dismiss(move |reason| {
         set_dismiss_status.set(UtilityText::DismissReason {
             reason: format!("{reason:?}"),
         });
     });
+
     let error_message = t(UtilityText::ExampleChildError);
 
     view! {
@@ -383,6 +436,23 @@ pub(crate) fn UtilityPanel() -> impl IntoView {
                     <div class="separator-as-child"></div>
                 </SeparatorAsChild>
                 <p class="panel-note">{t(UtilityText::AsChildSeparator)}</p>
+            </section>
+            <section class="showcase-panel" aria-labelledby="client-only-z-index">
+                <div class="panel-heading">
+                    <h2 id="client-only-z-index">{t(UtilityText::ClientOnly)}</h2>
+                    <p class="panel-note">{t(UtilityText::ClientOnlyDescription)}</p>
+                </div>
+                <ClientOnly fallback=|| view! { <span>{t(UtilityText::ClientOnlyFallback)}</span> }>
+                    <span>{t(UtilityText::ClientOnlyMounted)}</span>
+                </ClientOnly>
+                <div class="panel-heading">
+                    <h3>{t(UtilityText::ZIndexAllocator)}</h3>
+                    <p class="panel-note">{t(UtilityText::ZIndexAllocatorDescription)}</p>
+                </div>
+                <ZIndexAllocatorProvider>
+                    <ZIndexProbe id="leptos-css-z-index-first" />
+                    <ZIndexProbe id="leptos-css-z-index-second" />
+                </ZIndexAllocatorProvider>
             </section>
             <section class="showcase-panel wide" aria-labelledby="dismissable">
                 <div class="panel-heading">

--- a/examples/widgets-leptos-tailwind/src/categories/utility.rs
+++ b/examples/widgets-leptos-tailwind/src/categories/utility.rs
@@ -1,13 +1,15 @@
 use std::fmt::{self, Display};
 
 use ars_leptos::{
-    prelude::{Orientation, t, Translate},
+    prelude::{Orientation, Translate, t},
     utility::{
         button::{self, Button, ButtonAsChild},
+        client_only::ClientOnly,
         dismissable,
         error_boundary::Boundary,
         separator::{Separator, SeparatorAsChild},
         visually_hidden::{VisuallyHidden, VisuallyHiddenAsChild},
+        z_index_allocator::{Context as ZIndexContext, ZIndexAllocatorProvider},
     },
 };
 use leptos::prelude::*;
@@ -102,7 +104,10 @@ pub(crate) enum UtilityText {
     )]
     VisuallyHiddenLabel,
 
-    #[translate(en_US = "Skip to button variants", pt_BR = "Pular para variantes de botão")]
+    #[translate(
+        en_US = "Skip to button variants",
+        pt_BR = "Pular para variantes de botão"
+    )]
     FocusableSkipLink,
 
     #[translate(
@@ -120,7 +125,10 @@ pub(crate) enum UtilityText {
     )]
     SeparatorDescription,
 
-    #[translate(en_US = "Horizontal section break", pt_BR = "Quebra horizontal de seção")]
+    #[translate(
+        en_US = "Horizontal section break",
+        pt_BR = "Quebra horizontal de seção"
+    )]
     HorizontalSeparator,
 
     #[translate(en_US = "Vertical divider", pt_BR = "Divisor vertical")]
@@ -134,6 +142,36 @@ pub(crate) enum UtilityText {
         pt_BR = "O divisor da raiz do consumidor preserva a semântica de separador"
     )]
     AsChildSeparator,
+
+    #[translate(en_US = "Client-only content", pt_BR = "Conteúdo somente no cliente")]
+    ClientOnly,
+
+    #[translate(
+        en_US = "Fallback content is replaced after client mount.",
+        pt_BR = "O conteúdo fallback é substituído após a montagem no cliente."
+    )]
+    ClientOnlyDescription,
+
+    #[translate(
+        en_US = "Client content mounted",
+        pt_BR = "Conteúdo do cliente montado"
+    )]
+    ClientOnlyMounted,
+
+    #[translate(
+        en_US = "Loading client content",
+        pt_BR = "Carregando conteúdo do cliente"
+    )]
+    ClientOnlyFallback,
+
+    #[translate(en_US = "Z-index allocator", pt_BR = "Alocador de z-index")]
+    ZIndexAllocator,
+
+    #[translate(
+        en_US = "Provider-scoped claims allocate deterministic stacking layers.",
+        pt_BR = "Claims no escopo do provider alocam camadas determinísticas."
+    )]
+    ZIndexAllocatorDescription,
 
     #[translate(en_US = "Dismissable primitive", pt_BR = "Primitivo dismissable")]
     DismissablePrimitive,
@@ -227,13 +265,32 @@ fn example_error(message: Signal<String>) -> Result<&'static str, ExampleError> 
 }
 
 #[component]
+fn ZIndexProbe(id: &'static str) -> impl IntoView {
+    let context = use_context::<ZIndexContext>().expect("z-index context should be provided");
+
+    let claim = context.allocate_claim();
+
+    view! {
+        <span
+            id=id
+            class="py-1 px-2 text-xs rounded border border-slate-300"
+            data-z=claim.value().to_string()
+        >
+            {claim.value().to_string()}
+        </span>
+    }
+}
+
+#[component]
 pub(crate) fn UtilityPanel() -> impl IntoView {
     let (dismiss_status, set_dismiss_status) = signal(UtilityText::DismissInitial);
+
     let dismiss_props = dismissable::Props::new().on_dismiss(move |reason| {
         set_dismiss_status.set(UtilityText::DismissReason {
             reason: format!("{reason:?}"),
         });
     });
+
     let error_message = t(UtilityText::ExampleChildError);
 
     view! {
@@ -426,6 +483,30 @@ pub(crate) fn UtilityPanel() -> impl IntoView {
                     <div class="w-0.5 h-8 bg-current text-slate-300"></div>
                 </SeparatorAsChild>
                 <p class="text-sm text-slate-500">{t(UtilityText::AsChildSeparator)}</p>
+            </section>
+            <section
+                class="p-5 rounded-lg border shadow-lg border-slate-200 bg-white/85 shadow-slate-900/10"
+                aria-labelledby="client-only-z-index"
+            >
+                <div class="flex flex-wrap gap-3 justify-between items-center mb-4">
+                    <h2 id="client-only-z-index" class="text-base font-bold text-slate-950">
+                        {t(UtilityText::ClientOnly)}
+                    </h2>
+                    <p class="text-sm text-slate-500">{t(UtilityText::ClientOnlyDescription)}</p>
+                </div>
+                <ClientOnly fallback=|| view! { <span>{t(UtilityText::ClientOnlyFallback)}</span> }>
+                    <span class="text-sm text-slate-700">{t(UtilityText::ClientOnlyMounted)}</span>
+                </ClientOnly>
+                <h3 class="mt-4 text-sm font-semibold text-slate-900">
+                    {t(UtilityText::ZIndexAllocator)}
+                </h3>
+                <p class="text-sm text-slate-500">{t(UtilityText::ZIndexAllocatorDescription)}</p>
+                <div class="flex gap-2 mt-2">
+                    <ZIndexAllocatorProvider>
+                        <ZIndexProbe id="leptos-tw-z-index-first" />
+                        <ZIndexProbe id="leptos-tw-z-index-second" />
+                    </ZIndexAllocatorProvider>
+                </div>
             </section>
             <section
                 class="p-5 rounded-lg border shadow-lg lg:col-span-2 border-slate-200 bg-white/85 shadow-slate-900/10"

--- a/examples/widgets-leptos/src/categories/utility.rs
+++ b/examples/widgets-leptos/src/categories/utility.rs
@@ -1,13 +1,15 @@
 use std::fmt::{self, Display};
 
 use ars_leptos::{
-    prelude::{Orientation, t, Translate},
+    prelude::{Orientation, Translate, t},
     utility::{
         button::{self, Button, ButtonAsChild},
+        client_only::ClientOnly,
         dismissable,
         error_boundary::Boundary,
         separator::{Separator, SeparatorAsChild},
         visually_hidden::{VisuallyHidden, VisuallyHiddenAsChild},
+        z_index_allocator::{Context as ZIndexContext, ZIndexAllocatorProvider},
     },
 };
 use leptos::prelude::*;
@@ -96,7 +98,10 @@ pub(crate) enum UtilityText {
     )]
     VisuallyHiddenLabel,
 
-    #[translate(en_US = "Skip to button variants", pt_BR = "Pular para variantes de botão")]
+    #[translate(
+        en_US = "Skip to button variants",
+        pt_BR = "Pular para variantes de botão"
+    )]
     FocusableSkipLink,
 
     #[translate(
@@ -114,7 +119,10 @@ pub(crate) enum UtilityText {
     )]
     SeparatorDescription,
 
-    #[translate(en_US = "Horizontal section break", pt_BR = "Quebra horizontal de seção")]
+    #[translate(
+        en_US = "Horizontal section break",
+        pt_BR = "Quebra horizontal de seção"
+    )]
     HorizontalSeparator,
 
     #[translate(en_US = "Vertical divider", pt_BR = "Divisor vertical")]
@@ -128,6 +136,36 @@ pub(crate) enum UtilityText {
         pt_BR = "O divisor da raiz do consumidor preserva a semântica de separador"
     )]
     AsChildSeparator,
+
+    #[translate(en_US = "Client-only content", pt_BR = "Conteúdo somente no cliente")]
+    ClientOnly,
+
+    #[translate(
+        en_US = "Fallback content is replaced after client mount.",
+        pt_BR = "O conteúdo fallback é substituído após a montagem no cliente."
+    )]
+    ClientOnlyDescription,
+
+    #[translate(
+        en_US = "Client content mounted",
+        pt_BR = "Conteúdo do cliente montado"
+    )]
+    ClientOnlyMounted,
+
+    #[translate(
+        en_US = "Loading client content",
+        pt_BR = "Carregando conteúdo do cliente"
+    )]
+    ClientOnlyFallback,
+
+    #[translate(en_US = "Z-index allocator", pt_BR = "Alocador de z-index")]
+    ZIndexAllocator,
+
+    #[translate(
+        en_US = "Provider-scoped claims allocate deterministic stacking layers.",
+        pt_BR = "Claims no escopo do provider alocam camadas determinísticas."
+    )]
+    ZIndexAllocatorDescription,
 
     #[translate(en_US = "Dismissable primitive", pt_BR = "Primitivo dismissable")]
     DismissablePrimitive,
@@ -212,13 +250,28 @@ fn example_error(message: Signal<String>) -> Result<&'static str, ExampleError> 
 }
 
 #[component]
+fn ZIndexProbe(id: &'static str) -> impl IntoView {
+    let context = use_context::<ZIndexContext>().expect("z-index context should be provided");
+
+    let claim = context.allocate_claim();
+
+    view! {
+        <span id=id class="z-index-chip" data-z=claim.value().to_string()>
+            {claim.value().to_string()}
+        </span>
+    }
+}
+
+#[component]
 pub(crate) fn UtilityPanel() -> impl IntoView {
     let (dismiss_status, set_dismiss_status) = signal(UtilityText::DismissInitial);
+
     let dismiss_props = dismissable::Props::new().on_dismiss(move |reason| {
         set_dismiss_status.set(UtilityText::DismissReason {
             reason: format!("{reason:?}"),
         });
     });
+
     let error_message = t(UtilityText::ExampleChildError);
 
     view! {
@@ -343,6 +396,19 @@ pub(crate) fn UtilityPanel() -> impl IntoView {
                     <div style="width: 2px; min-height: 32px; background: currentColor;"></div>
                 </SeparatorAsChild>
                 <p>{t(UtilityText::AsChildSeparator)}</p>
+            </section>
+            <section aria-labelledby="client-only-z-index">
+                <h3 id="client-only-z-index">{t(UtilityText::ClientOnly)}</h3>
+                <p>{t(UtilityText::ClientOnlyDescription)}</p>
+                <ClientOnly fallback=|| view! { <span>{t(UtilityText::ClientOnlyFallback)}</span> }>
+                    <span>{t(UtilityText::ClientOnlyMounted)}</span>
+                </ClientOnly>
+                <h4>{t(UtilityText::ZIndexAllocator)}</h4>
+                <p>{t(UtilityText::ZIndexAllocatorDescription)}</p>
+                <ZIndexAllocatorProvider>
+                    <ZIndexProbe id="leptos-z-index-first" />
+                    <ZIndexProbe id="leptos-z-index-second" />
+                </ZIndexAllocatorProvider>
             </section>
             <section aria-labelledby="dismissable">
                 <h3 id="dismissable">{t(UtilityText::DismissablePrimitive)}</h3>

--- a/spec/foundation/01-architecture.md
+++ b/spec/foundation/01-architecture.md
@@ -271,7 +271,7 @@ This pattern surfaces platform incompatibilities at compile time on any target, 
 
 **`SharedState<T>` — interior-mutable shared state:**
 
-`SharedState<T>` extends the same `cfg`-gated pattern to interior-mutable state containers (interaction result state, live reactive values). On WASM it wraps `Rc<RefCell<T>>`, on native it wraps `Arc<Mutex<T>>`. Key API:
+`SharedState<T>` extends the same shared-ownership pattern to interior-mutable state containers (interaction result state, live reactive values). With `std` it wraps `Arc<Mutex<T>>` on every target, including WASM, so framework context APIs that require `Send + Sync` can publish shared core state. In `no_std` it wraps `Rc<RefCell<T>>`. Key API:
 
 ```rust,no_check
 use ars_core::SharedState;

--- a/spec/leptos-components/utility/client-only.md
+++ b/spec/leptos-components/utility/client-only.md
@@ -16,10 +16,12 @@ This spec maps the core [`ClientOnly`](../../components/utility/client-only.md) 
 
 ```rust,no_check
 #[component]
-pub fn ClientOnly(
-    #[prop(optional)] fallback: Option<ChildrenFn>,
-    children: ChildrenFn,
+pub fn ClientOnly<C>(
+    #[prop(optional, into)] fallback: ViewFn,
+    children: TypedChildrenFn<C>,
 ) -> impl IntoView
+where
+    C: IntoView + 'static,
 ```
 
 ## 3. Mapping to Core Component Contract
@@ -153,13 +155,17 @@ Leptos can use SSR cfg and a mounted signal while keeping the same initial marku
 
 ```rust
 #[component]
-pub fn ClientOnly(
-    #[prop(optional)] fallback: Option<ChildrenFn>,
-    children: ChildrenFn,
-) -> impl IntoView {
+pub fn ClientOnly<C>(
+    #[prop(optional, into)] fallback: ViewFn,
+    children: TypedChildrenFn<C>,
+) -> impl IntoView
+where
+    C: IntoView + 'static,
+{
     let mounted = RwSignal::new(false);
     Effect::new(move |_| mounted.set(true));
-    move || if mounted.get() { children() } else { fallback.as_ref().map(|f| f()).into_view() }
+    let children = children.into_inner();
+    move || if mounted.get() { Either::Left(children()) } else { Either::Right(fallback.run()) }
 }
 ```
 

--- a/spec/leptos-components/utility/z-index-allocator.md
+++ b/spec/leptos-components/utility/z-index-allocator.md
@@ -15,7 +15,10 @@ This spec maps the core [`ZIndexAllocator`](../../components/utility/z-index-all
 ## 2. Public Adapter API
 
 ```rust,no_check
-#[component] pub fn ZIndexAllocatorProvider(children: Children) -> impl IntoView
+#[component]
+pub fn ZIndexAllocatorProvider<T>(children: TypedChildren<T>) -> impl IntoView
+where
+    T: IntoView + 'static
 ```
 
 ## 3. Mapping to Core Component Contract
@@ -38,7 +41,7 @@ This spec maps the core [`ZIndexAllocator`](../../components/utility/z-index-all
 
 ## 6. Composition / Context Contract
 
-Publish allocator context with `provide_context`. Optional consumers use `use_context::<z_index_allocator::Context>()`.
+Publish allocator context with `provide_context` in a provider-owned child [`Owner`]. Optional consumers use `use_context::<z_index_allocator::Context>()`.
 
 ## 7. Prop Sync and Event Mapping
 
@@ -149,15 +152,24 @@ Allocator behavior is mostly provider-internal. If allocator options are configu
 
 ## 23. Framework-Specific Behavior
 
-Leptos owner cleanup may be used by descendants to release values.
+The provider creates a child owner, publishes context inside that owner, and renders the typed children through the same owner so descendants can read the provider-scoped context. Leptos owner cleanup may be used by descendants to release values.
 
 ## 24. Canonical Implementation Sketch
 
 ```rust
 #[component]
-pub fn ZIndexAllocatorProvider(children: Children) -> impl IntoView {
-    provide_context(z_index_allocator::Context::new());
-    view! { <>{children()}</> }
+pub fn ZIndexAllocatorProvider<T>(children: TypedChildren<T>) -> impl IntoView
+where
+    T: IntoView + 'static,
+{
+    let owner = Owner::current().map_or_else(Owner::new, |owner| owner.child());
+    let children = children.into_inner();
+    let children = owner.with(|| {
+        provide_context(z_index_allocator::Context::new());
+        children()
+    });
+
+    OwnedView::new_with_owner(children, owner)
 }
 ```
 


### PR DESCRIPTION
## Summary

- add Leptos and Dioxus adapter modules for `ClientOnly` and `ZIndexAllocatorProvider`
- wire both utilities through adapter modules, preludes, E2E fixtures, and widget utility examples
- add SSR/native tests, browser-backed wasm tests, and utility E2E coverage
- update the Leptos adapter spec for typed `ClientOnly` children/fallback and align the shared-state foundation note

## Validation

- `cargo xci-fast`
- focused SSR tests for both adapters
- browser wasm `ClientOnly` tests for both adapters with the repo chromedriver/PATH override
- `cargo xtask e2e utility --adapter leptos`
- `cargo xtask e2e utility --adapter dioxus`
- widget example checks for Leptos and Dioxus variants
- `cargo xtask spec validate`
- `cargo xtask lint adapter-parity`

Closes #319
Closes #417