### PR TITLE
Add navigation core components

### DIFF
--- a/crates/ars-components/src/navigation/breadcrumbs/mod.rs
+++ b/crates/ars-components/src/navigation/breadcrumbs/mod.rs
@@ -1,0 +1,467 @@
+//! Breadcrumb navigation component.
+//!
+//! Breadcrumbs is a stateless connect API for ordered navigation trails. It
+//! owns landmark/list/current-page attributes, separator text, collapsed-tail
+//! layout calculation, and URL sanitization for rendered crumb links.
+
+use alloc::string::{String, ToString as _};
+use core::ops::Range;
+
+use ars_core::{
+    AriaAttr, AttrMap, ComponentPart, ConnectApi, Direction, HtmlAttr, SafeUrl, sanitize_url,
+};
+
+use super::link::AriaCurrent;
+
+/// Visual separator token rendered between breadcrumb items.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+pub enum Separator {
+    /// The slash separator (`/`).
+    #[default]
+    Slash,
+
+    /// A chevron-like separator (`>`).
+    Chevron,
+
+    /// Consumer-provided separator text.
+    Custom(String),
+}
+
+impl Separator {
+    /// Returns the text that should be rendered inside the separator part.
+    #[must_use]
+    pub const fn as_str(&self) -> &str {
+        match self {
+            Self::Slash => "/",
+            Self::Chevron => ">",
+            Self::Custom(value) => value.as_str(),
+        }
+    }
+}
+
+/// A consumer-provided breadcrumb item.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct ItemDef {
+    /// Visible item label.
+    pub label: String,
+
+    /// Optional safe navigation target. Current items typically omit it.
+    pub href: Option<SafeUrl>,
+
+    /// Optional current-item semantic override.
+    pub current: Option<AriaCurrent>,
+}
+
+impl ItemDef {
+    /// Creates a breadcrumb item with the supplied visible label.
+    #[must_use]
+    pub fn new(label: impl Into<String>) -> Self {
+        Self {
+            label: label.into(),
+            href: None,
+            current: None,
+        }
+    }
+
+    /// Sets the item's navigation target.
+    #[must_use]
+    pub fn href(mut self, href: SafeUrl) -> Self {
+        self.href = Some(href);
+        self
+    }
+
+    /// Sets the item's current semantic.
+    #[must_use]
+    pub const fn current(mut self, current: AriaCurrent) -> Self {
+        self.current = Some(current);
+        self
+    }
+}
+
+/// Immutable configuration for a [`Breadcrumbs`](self) instance.
+#[derive(Clone, Debug, PartialEq, Eq, ars_core::HasId)]
+pub struct Props {
+    /// Component instance id.
+    pub id: String,
+
+    /// Separator text strategy rendered between visible items.
+    pub separator: Separator,
+
+    /// Text direction applied to the navigation landmark.
+    pub dir: Direction,
+
+    /// Localized accessible label for the navigation landmark.
+    pub nav_label: String,
+
+    /// Optional maximum number of visible items before the middle collapses.
+    pub max_items: Option<usize>,
+}
+
+impl Default for Props {
+    fn default() -> Self {
+        Self {
+            id: String::new(),
+            separator: Separator::default(),
+            dir: Direction::Ltr,
+            nav_label: "Breadcrumb".to_string(),
+            max_items: None,
+        }
+    }
+}
+
+impl Props {
+    /// Returns default breadcrumb props.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets [`id`](Self::id).
+    #[must_use]
+    pub fn id(mut self, id: impl Into<String>) -> Self {
+        self.id = id.into();
+        self
+    }
+
+    /// Sets [`separator`](Self::separator).
+    #[must_use]
+    pub fn separator(mut self, separator: Separator) -> Self {
+        self.separator = separator;
+        self
+    }
+
+    /// Sets [`dir`](Self::dir).
+    #[must_use]
+    pub const fn dir(mut self, dir: Direction) -> Self {
+        self.dir = dir;
+        self
+    }
+
+    /// Sets [`nav_label`](Self::nav_label).
+    #[must_use]
+    pub fn nav_label(mut self, label: impl Into<String>) -> Self {
+        self.nav_label = label.into();
+        self
+    }
+
+    /// Sets [`max_items`](Self::max_items).
+    #[must_use]
+    pub const fn max_items(mut self, max_items: Option<usize>) -> Self {
+        self.max_items = max_items;
+        self
+    }
+}
+
+/// Anatomy parts exposed by the breadcrumb connect API.
+#[derive(ComponentPart)]
+#[scope = "breadcrumbs"]
+pub enum Part {
+    /// Navigation landmark root.
+    Root,
+
+    /// Ordered list wrapper.
+    List,
+
+    /// A single breadcrumb list item.
+    Item,
+
+    /// A non-current navigation link.
+    Link {
+        /// Link target used by [`ConnectApi::part_attrs`].
+        #[part(default = SafeUrl::from_static("/"))]
+        href: SafeUrl,
+    },
+
+    /// Current-page item.
+    CurrentPage,
+
+    /// Decorative separator between visible items.
+    Separator,
+}
+
+/// Layout decision returned by [`Api::layout`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum BreadcrumbLayout {
+    /// Every breadcrumb item should be rendered.
+    Full,
+
+    /// The middle range should be replaced by an ellipsis trigger.
+    Collapsed {
+        /// The first visible item index.
+        first_index: usize,
+
+        /// The hidden range represented by the ellipsis trigger.
+        ellipsis_replaces: Range<usize>,
+
+        /// The visible tail range.
+        visible_tail: Range<usize>,
+    },
+}
+
+/// Stateless API for rendering breadcrumb attributes.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Api {
+    /// Immutable props backing this API.
+    props: Props,
+}
+
+impl Api {
+    /// Creates a stateless breadcrumb API from props.
+    #[must_use]
+    pub const fn new(props: Props) -> Self {
+        Self { props }
+    }
+
+    /// Borrows the props backing this API.
+    #[must_use]
+    pub const fn props(&self) -> &Props {
+        &self.props
+    }
+
+    /// Attributes for the navigation landmark.
+    #[must_use]
+    pub fn root_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_value), (part_attr, part_value)] = Part::Root.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_value)
+            .set(part_attr, part_value)
+            .set(
+                HtmlAttr::Aria(AriaAttr::Label),
+                self.props.nav_label.as_str(),
+            )
+            .set(HtmlAttr::Dir, self.props.dir.as_html_attr());
+
+        attrs
+    }
+
+    /// Attributes for the ordered list.
+    #[must_use]
+    pub fn list_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_value), (part_attr, part_value)] = Part::List.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_value)
+            .set(part_attr, part_value)
+            .set(HtmlAttr::Role, "list");
+
+        attrs
+    }
+
+    /// Attributes for a list item.
+    #[must_use]
+    pub fn item_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_value), (part_attr, part_value)] = Part::Item.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_value)
+            .set(part_attr, part_value);
+
+        attrs
+    }
+
+    /// Attributes for a breadcrumb link.
+    #[must_use]
+    pub fn link_attrs(&self, href: &SafeUrl) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_value), (part_attr, part_value)] = Part::Link {
+            href: SafeUrl::from_static("#"),
+        }
+        .data_attrs();
+
+        attrs
+            .set(scope_attr, scope_value)
+            .set(part_attr, part_value)
+            .set(HtmlAttr::Href, sanitize_url(href.as_str()));
+
+        attrs
+    }
+
+    /// Attributes for the current page item.
+    #[must_use]
+    pub fn current_page_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_value), (part_attr, part_value)] = Part::CurrentPage.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_value)
+            .set(part_attr, part_value)
+            .set(HtmlAttr::Aria(AriaAttr::Current), "page");
+
+        attrs
+    }
+
+    /// Attributes for a decorative separator.
+    #[must_use]
+    pub fn separator_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_value), (part_attr, part_value)] = Part::Separator.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_value)
+            .set(part_attr, part_value)
+            .set(HtmlAttr::Aria(AriaAttr::Hidden), "true");
+
+        attrs
+    }
+
+    /// Returns the configured separator text.
+    #[must_use]
+    pub const fn separator_text(&self) -> &str {
+        self.props.separator.as_str()
+    }
+
+    /// Computes the visible item layout for the supplied item count.
+    #[must_use]
+    pub const fn layout(&self, total_items: usize) -> BreadcrumbLayout {
+        if let Some(max_items) = self.props.max_items
+            && (total_items > max_items && max_items >= 2)
+        {
+            let visible_end_count = max_items - 1;
+
+            let tail_start = total_items.saturating_sub(visible_end_count);
+
+            BreadcrumbLayout::Collapsed {
+                first_index: 0,
+                ellipsis_replaces: 1..tail_start,
+                visible_tail: tail_start..total_items,
+            }
+        } else {
+            BreadcrumbLayout::Full
+        }
+    }
+}
+
+impl ConnectApi for Api {
+    type Part = Part;
+
+    fn part_attrs(&self, part: Part) -> AttrMap {
+        match part {
+            Part::Root => self.root_attrs(),
+            Part::List => self.list_attrs(),
+            Part::Item => self.item_attrs(),
+            Part::Link { href } => self.link_attrs(&href),
+            Part::CurrentPage => self.current_page_attrs(),
+            Part::Separator => self.separator_attrs(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn snapshot_attrs(attrs: &AttrMap) -> String {
+        format!("{attrs:#?}")
+    }
+
+    #[test]
+    fn root_list_item_current_and_separator_attrs_match_spec() {
+        let api = Api::new(
+            Props::new()
+                .id("crumbs")
+                .dir(Direction::Rtl)
+                .nav_label("Trail"),
+        );
+
+        insta::assert_snapshot!("breadcrumbs_root", snapshot_attrs(&api.root_attrs()));
+        insta::assert_snapshot!("breadcrumbs_list", snapshot_attrs(&api.list_attrs()));
+        insta::assert_snapshot!("breadcrumbs_item", snapshot_attrs(&api.item_attrs()));
+        insta::assert_snapshot!(
+            "breadcrumbs_current_page",
+            snapshot_attrs(&api.current_page_attrs())
+        );
+        insta::assert_snapshot!(
+            "breadcrumbs_separator",
+            snapshot_attrs(&api.separator_attrs())
+        );
+    }
+
+    #[test]
+    fn link_attrs_emit_sanitized_safe_href() {
+        let api = Api::new(Props::new());
+
+        let attrs = api.link_attrs(&SafeUrl::from_static("/products"));
+
+        assert_eq!(attrs.get(&HtmlAttr::Href), Some("/products"));
+        insta::assert_snapshot!("breadcrumbs_link", snapshot_attrs(&attrs));
+    }
+
+    #[test]
+    fn separator_text_uses_configured_token() {
+        assert_eq!(
+            Api::new(Props::new().separator(Separator::Chevron)).separator_text(),
+            ">"
+        );
+        assert_eq!(
+            Api::new(Props::new().separator(Separator::Custom("::".into()))).separator_text(),
+            "::"
+        );
+    }
+
+    #[test]
+    fn collapsed_layout_keeps_first_and_tail() {
+        let api = Api::new(Props::new().max_items(Some(4)));
+
+        assert_eq!(
+            api.layout(7),
+            BreadcrumbLayout::Collapsed {
+                first_index: 0,
+                ellipsis_replaces: 1..4,
+                visible_tail: 4..7,
+            }
+        );
+        assert_eq!(api.layout(4), BreadcrumbLayout::Full);
+        assert_eq!(
+            Api::new(Props::new().max_items(Some(1))).layout(7),
+            BreadcrumbLayout::Full
+        );
+    }
+
+    #[test]
+    fn item_def_records_label_href_and_current_semantics() {
+        let item = ItemDef::new("Checkout")
+            .href(SafeUrl::from_static("/checkout"))
+            .current(AriaCurrent::Step);
+
+        assert_eq!(item.label, "Checkout");
+        assert_eq!(item.href.as_ref().map(SafeUrl::as_str), Some("/checkout"));
+        assert_eq!(item.current, Some(AriaCurrent::Step));
+    }
+
+    #[test]
+    fn props_builder_sets_every_field() {
+        let props = Props::new()
+            .id("crumbs")
+            .separator(Separator::Chevron)
+            .dir(Direction::Rtl)
+            .nav_label("Trail")
+            .max_items(Some(3));
+
+        assert_eq!(props.id, "crumbs");
+        assert_eq!(props.separator, Separator::Chevron);
+        assert_eq!(props.dir, Direction::Rtl);
+        assert_eq!(props.nav_label, "Trail");
+        assert_eq!(props.max_items, Some(3));
+    }
+
+    #[test]
+    fn part_attrs_dispatches_every_part() {
+        let api = Api::new(Props::new());
+
+        let href = SafeUrl::from_static("/products");
+
+        assert_eq!(api.part_attrs(Part::Root), api.root_attrs());
+        assert_eq!(api.part_attrs(Part::List), api.list_attrs());
+        assert_eq!(api.part_attrs(Part::Item), api.item_attrs());
+        assert_eq!(
+            api.part_attrs(Part::Link { href: href.clone() }),
+            api.link_attrs(&href)
+        );
+        assert_eq!(api.part_attrs(Part::CurrentPage), api.current_page_attrs());
+        assert_eq!(api.part_attrs(Part::Separator), api.separator_attrs());
+    }
+}

--- a/crates/ars-components/src/navigation/breadcrumbs/snapshots/ars_components__navigation__breadcrumbs__tests__breadcrumbs_current_page.snap
+++ b/crates/ars-components/src/navigation/breadcrumbs/snapshots/ars_components__navigation__breadcrumbs__tests__breadcrumbs_current_page.snap
@@ -1,0 +1,33 @@
+---
+source: crates/ars-components/src/navigation/breadcrumbs.rs
+expression: snapshot_attrs(&api.current_page_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "current-page",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "breadcrumbs",
+            ),
+        ),
+        (
+            Aria(
+                Current,
+            ),
+            String(
+                "page",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/navigation/breadcrumbs/snapshots/ars_components__navigation__breadcrumbs__tests__breadcrumbs_item.snap
+++ b/crates/ars-components/src/navigation/breadcrumbs/snapshots/ars_components__navigation__breadcrumbs__tests__breadcrumbs_item.snap
@@ -1,0 +1,25 @@
+---
+source: crates/ars-components/src/navigation/breadcrumbs.rs
+expression: snapshot_attrs(&api.item_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "item",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "breadcrumbs",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/navigation/breadcrumbs/snapshots/ars_components__navigation__breadcrumbs__tests__breadcrumbs_link.snap
+++ b/crates/ars-components/src/navigation/breadcrumbs/snapshots/ars_components__navigation__breadcrumbs__tests__breadcrumbs_link.snap
@@ -1,0 +1,31 @@
+---
+source: crates/ars-components/src/navigation/breadcrumbs.rs
+expression: snapshot_attrs(&attrs)
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "link",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "breadcrumbs",
+            ),
+        ),
+        (
+            Href,
+            String(
+                "/products",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/navigation/breadcrumbs/snapshots/ars_components__navigation__breadcrumbs__tests__breadcrumbs_list.snap
+++ b/crates/ars-components/src/navigation/breadcrumbs/snapshots/ars_components__navigation__breadcrumbs__tests__breadcrumbs_list.snap
@@ -1,0 +1,31 @@
+---
+source: crates/ars-components/src/navigation/breadcrumbs.rs
+expression: snapshot_attrs(&api.list_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "list",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "breadcrumbs",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "list",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/navigation/breadcrumbs/snapshots/ars_components__navigation__breadcrumbs__tests__breadcrumbs_root.snap
+++ b/crates/ars-components/src/navigation/breadcrumbs/snapshots/ars_components__navigation__breadcrumbs__tests__breadcrumbs_root.snap
@@ -1,0 +1,39 @@
+---
+source: crates/ars-components/src/navigation/breadcrumbs.rs
+expression: snapshot_attrs(&api.root_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "breadcrumbs",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Trail",
+            ),
+        ),
+        (
+            Dir,
+            String(
+                "rtl",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/navigation/breadcrumbs/snapshots/ars_components__navigation__breadcrumbs__tests__breadcrumbs_separator.snap
+++ b/crates/ars-components/src/navigation/breadcrumbs/snapshots/ars_components__navigation__breadcrumbs__tests__breadcrumbs_separator.snap
@@ -1,0 +1,33 @@
+---
+source: crates/ars-components/src/navigation/breadcrumbs.rs
+expression: snapshot_attrs(&api.separator_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "separator",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "breadcrumbs",
+            ),
+        ),
+        (
+            Aria(
+                Hidden,
+            ),
+            String(
+                "true",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/navigation/link/mod.rs
+++ b/crates/ars-components/src/navigation/link/mod.rs
@@ -425,17 +425,28 @@ impl ars_core::Machine for Machine {
                 let is_current = props.is_current;
                 let disabled = props.disabled;
 
-                Some(TransitionPlan::context_only(move |ctx: &mut Context| {
-                    ctx.href = href;
-                    ctx.target = target;
-                    ctx.rel = rel;
-                    ctx.is_current = is_current;
-                    ctx.disabled = disabled;
-
-                    if disabled {
-                        ctx.pressed = false;
-                    }
-                }))
+                if disabled {
+                    Some(
+                        TransitionPlan::to(State::Idle).apply(move |ctx: &mut Context| {
+                            ctx.href = href;
+                            ctx.target = target;
+                            ctx.rel = rel;
+                            ctx.is_current = is_current;
+                            ctx.disabled = disabled;
+                            ctx.focused = false;
+                            ctx.focus_visible = false;
+                            ctx.pressed = false;
+                        }),
+                    )
+                } else {
+                    Some(TransitionPlan::context_only(move |ctx: &mut Context| {
+                        ctx.href = href;
+                        ctx.target = target;
+                        ctx.rel = rel;
+                        ctx.is_current = is_current;
+                        ctx.disabled = disabled;
+                    }))
+                }
             }
 
             _ => None,
@@ -840,7 +851,7 @@ mod tests {
 
         assert!(!result.state_changed);
         assert!(!result.context_changed);
-        assert_eq!(service.state(), &State::Pressed);
+        assert_eq!(service.state(), &State::Idle);
         assert!(!service.context().pressed);
     }
 
@@ -875,6 +886,28 @@ mod tests {
         assert_eq!(service.context().is_current, Some(AriaCurrent::Step));
         assert!(service.context().disabled);
         assert!(!service.context().pressed);
+    }
+
+    #[test]
+    fn disabling_focused_or_pressed_link_resets_interaction_state() {
+        let mut service = service(props());
+
+        drop(service.send(Event::Focus { is_keyboard: true }));
+        drop(service.send(Event::Press));
+
+        drop(service.set_props(props().disabled(true)));
+
+        assert_eq!(service.state(), &State::Idle);
+        assert!(service.context().disabled);
+        assert!(!service.context().focused);
+        assert!(!service.context().focus_visible);
+        assert!(!service.context().pressed);
+
+        let attrs = service.connect(&|_| {}).root_attrs();
+
+        assert_eq!(attrs.get(&HtmlAttr::Data("ars-state")), Some("idle"));
+        assert!(attrs.get(&HtmlAttr::Data("ars-focus-visible")).is_none());
+        assert!(attrs.get(&HtmlAttr::Data("ars-pressed")).is_none());
     }
 
     #[test]

--- a/crates/ars-components/src/navigation/link/mod.rs
+++ b/crates/ars-components/src/navigation/link/mod.rs
@@ -1,0 +1,930 @@
+//! Link navigation component.
+//!
+//! This module owns the framework-agnostic link state machine: focus,
+//! press, disabled guarding, current-item semantics, safe URL output, and
+//! target/relationship repair for links that open a new tab.
+
+use alloc::string::{String, ToString as _};
+use core::{
+    fmt::{self, Debug},
+    hash::Hash,
+};
+
+use ars_core::{
+    AriaAttr, AttrMap, Callback, ComponentIds, ComponentMessages, ComponentPart, ConnectApi, Env,
+    HtmlAttr, Locale, MessageFn, PendingEffect, SafeUrl, TransitionPlan, sanitize_url,
+};
+
+/// Describes the type of current-item indication for `aria-current`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum AriaCurrent {
+    /// The link represents the current page.
+    Page,
+
+    /// The link represents the current step.
+    Step,
+
+    /// The link represents the current location.
+    Location,
+
+    /// The link represents the current date.
+    Date,
+
+    /// The link represents the current time.
+    Time,
+
+    /// The link represents the current item using `aria-current="true"`.
+    True,
+}
+
+impl AriaCurrent {
+    /// Returns the token rendered into `aria-current`.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Page => "page",
+            Self::Step => "step",
+            Self::Location => "location",
+            Self::Date => "date",
+            Self::Time => "time",
+            Self::True => "true",
+        }
+    }
+}
+
+/// Navigation target for a link.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum Target {
+    /// Browser-native URL navigation.
+    Href(SafeUrl),
+
+    /// Client-side route. Adapters may intercept activation, but the core
+    /// still emits this string as an `href` for progressive enhancement.
+    Route(String),
+}
+
+impl Default for Target {
+    fn default() -> Self {
+        Self::Href(SafeUrl::from_static(""))
+    }
+}
+
+impl From<SafeUrl> for Target {
+    fn from(value: SafeUrl) -> Self {
+        Self::Href(value)
+    }
+}
+
+impl Target {
+    /// Returns the renderable href string for this target.
+    #[must_use]
+    pub fn href(&self) -> &str {
+        match self {
+            Self::Href(url) => url.as_str(),
+            Self::Route(route) => route.as_str(),
+        }
+    }
+
+    /// Returns `true` when this target is an absolute HTTP(S) URL.
+    #[must_use]
+    pub fn is_external(&self) -> bool {
+        let href = self.href();
+
+        href.starts_with("http://") || href.starts_with("https://")
+    }
+}
+
+/// States for the [`Link`](self) component.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum State {
+    /// Default resting state.
+    #[default]
+    Idle,
+
+    /// The link has focus.
+    Focused,
+
+    /// The link is actively being pressed.
+    Pressed,
+}
+
+impl State {
+    /// Returns the token rendered into `data-ars-state`.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Idle => "idle",
+            Self::Focused => "focused",
+            Self::Pressed => "pressed",
+        }
+    }
+}
+
+/// Events accepted by the link state machine.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Event {
+    /// The link received focus.
+    Focus {
+        /// Whether the focus came from keyboard modality.
+        is_keyboard: bool,
+    },
+
+    /// Focus left the link.
+    Blur,
+
+    /// Pointer or keyboard press started.
+    Press,
+
+    /// Pointer or keyboard press ended.
+    PressEnd,
+
+    /// The link was activated.
+    Navigate,
+
+    /// Synchronize render props into context.
+    SyncProps,
+}
+
+/// Typed effect intents emitted by the link machine.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Effect {
+    /// A non-disabled link was activated.
+    Navigate,
+}
+
+/// Localized link messages.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Messages {
+    /// Announcement text for links that open a new tab.
+    pub external_link_label: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
+}
+
+impl Default for Messages {
+    fn default() -> Self {
+        Self {
+            external_link_label: MessageFn::static_str("opens in new tab"),
+        }
+    }
+}
+
+impl ComponentMessages for Messages {}
+
+/// Immutable configuration for a [`Link`](self) instance.
+#[derive(Clone, Debug, Default, PartialEq, ars_core::HasId)]
+pub struct Props {
+    /// Component instance id.
+    pub id: String,
+
+    /// Navigation target.
+    pub href: Target,
+
+    /// Optional browsing context target.
+    pub target: Option<String>,
+
+    /// Optional relationship tokens.
+    pub rel: Option<String>,
+
+    /// Optional current-item semantic.
+    pub is_current: Option<AriaCurrent>,
+
+    /// Whether the link is non-interactive.
+    pub disabled: bool,
+
+    /// Callback fired by the navigate effect with the resolved target.
+    pub on_navigate: Option<Callback<dyn Fn(Target) + Send + Sync>>,
+
+    /// Callback fired by the navigate effect after `on_navigate`.
+    pub on_press: Option<Callback<dyn Fn() + Send + Sync>>,
+}
+
+impl Props {
+    /// Returns default link props.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets [`id`](Self::id).
+    #[must_use]
+    pub fn id(mut self, id: impl Into<String>) -> Self {
+        self.id = id.into();
+        self
+    }
+
+    /// Sets [`href`](Self::href).
+    #[must_use]
+    pub fn href(mut self, href: impl Into<Target>) -> Self {
+        self.href = href.into();
+        self
+    }
+
+    /// Sets [`target`](Self::target).
+    #[must_use]
+    pub fn target(mut self, target: impl Into<String>) -> Self {
+        self.target = Some(target.into());
+        self
+    }
+
+    /// Clears [`target`](Self::target).
+    #[must_use]
+    pub fn no_target(mut self) -> Self {
+        self.target = None;
+        self
+    }
+
+    /// Sets [`rel`](Self::rel).
+    #[must_use]
+    pub fn rel(mut self, rel: impl Into<String>) -> Self {
+        self.rel = Some(rel.into());
+        self
+    }
+
+    /// Clears [`rel`](Self::rel).
+    #[must_use]
+    pub fn no_rel(mut self) -> Self {
+        self.rel = None;
+        self
+    }
+
+    /// Sets [`is_current`](Self::is_current).
+    #[must_use]
+    pub const fn is_current(mut self, current: AriaCurrent) -> Self {
+        self.is_current = Some(current);
+        self
+    }
+
+    /// Clears [`is_current`](Self::is_current).
+    #[must_use]
+    pub const fn not_current(mut self) -> Self {
+        self.is_current = None;
+        self
+    }
+
+    /// Sets [`disabled`](Self::disabled).
+    #[must_use]
+    pub const fn disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
+    }
+
+    /// Sets [`on_navigate`](Self::on_navigate).
+    #[must_use]
+    pub fn on_navigate(
+        mut self,
+        callback: impl Into<Callback<dyn Fn(Target) + Send + Sync>>,
+    ) -> Self {
+        self.on_navigate = Some(callback.into());
+        self
+    }
+
+    /// Sets [`on_press`](Self::on_press).
+    #[must_use]
+    pub fn on_press(mut self, callback: impl Into<Callback<dyn Fn() + Send + Sync>>) -> Self {
+        self.on_press = Some(callback.into());
+        self
+    }
+}
+
+/// Runtime context for the link machine.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Context {
+    /// Current navigation target.
+    pub href: Target,
+
+    /// Current browsing context target.
+    pub target: Option<String>,
+
+    /// Current relationship tokens.
+    pub rel: Option<String>,
+
+    /// Current-item semantic.
+    pub is_current: Option<AriaCurrent>,
+
+    /// Disabled state.
+    pub disabled: bool,
+
+    /// Whether the link has focus.
+    pub focused: bool,
+
+    /// Whether focused styling should reflect keyboard modality.
+    pub focus_visible: bool,
+
+    /// Whether the link is actively pressed.
+    pub pressed: bool,
+
+    /// Stable ids derived from props.
+    pub ids: ComponentIds,
+
+    /// Active locale.
+    pub locale: Locale,
+
+    /// Localized messages.
+    pub messages: Messages,
+}
+
+/// Anatomy parts exposed by the link connect API.
+#[derive(ComponentPart)]
+#[scope = "link"]
+pub enum Part {
+    /// Root anchor or repaired non-anchor host.
+    Root,
+}
+
+/// Link state machine.
+#[derive(Debug)]
+pub struct Machine;
+
+impl ars_core::Machine for Machine {
+    type State = State;
+    type Event = Event;
+    type Context = Context;
+    type Props = Props;
+    type Messages = Messages;
+    type Effect = Effect;
+    type Api<'a> = Api<'a>;
+
+    fn init(
+        props: &Self::Props,
+        env: &Env,
+        messages: &Self::Messages,
+    ) -> (Self::State, Self::Context) {
+        (
+            State::Idle,
+            Context {
+                href: props.href.clone(),
+                target: props.target.clone(),
+                rel: props.rel.clone(),
+                is_current: props.is_current,
+                disabled: props.disabled,
+                focused: false,
+                focus_visible: false,
+                pressed: false,
+                ids: ComponentIds::from_id(&props.id),
+                locale: env.locale.clone(),
+                messages: messages.clone(),
+            },
+        )
+    }
+
+    fn transition(
+        _state: &Self::State,
+        event: &Self::Event,
+        ctx: &Self::Context,
+        props: &Self::Props,
+    ) -> Option<TransitionPlan<Self>> {
+        match event {
+            Event::Focus { is_keyboard } => {
+                let focus_visible = *is_keyboard;
+                Some(
+                    TransitionPlan::to(State::Focused).apply(move |ctx: &mut Context| {
+                        ctx.focused = true;
+                        ctx.focus_visible = focus_visible;
+                    }),
+                )
+            }
+
+            Event::Blur => Some(TransitionPlan::to(State::Idle).apply(|ctx: &mut Context| {
+                ctx.focused = false;
+                ctx.focus_visible = false;
+                ctx.pressed = false;
+            })),
+
+            Event::Press if !ctx.disabled => Some(TransitionPlan::to(State::Pressed).apply(
+                |ctx: &mut Context| {
+                    ctx.pressed = true;
+                },
+            )),
+
+            Event::PressEnd => Some(TransitionPlan::to(State::Focused).apply(
+                |ctx: &mut Context| {
+                    ctx.pressed = false;
+                },
+            )),
+
+            Event::Navigate if !ctx.disabled => Some(
+                TransitionPlan::context_only(|_| {}).with_effect(PendingEffect::new(
+                    Effect::Navigate,
+                    |ctx: &Context, props: &Props, _send| {
+                        if let Some(callback) = &props.on_navigate {
+                            (callback)(ctx.href.clone());
+                        }
+
+                        if let Some(callback) = &props.on_press {
+                            (callback)();
+                        }
+
+                        ars_core::no_cleanup()
+                    },
+                )),
+            ),
+
+            Event::SyncProps => {
+                let href = props.href.clone();
+                let target = props.target.clone();
+                let rel = props.rel.clone();
+                let is_current = props.is_current;
+                let disabled = props.disabled;
+
+                Some(TransitionPlan::context_only(move |ctx: &mut Context| {
+                    ctx.href = href;
+                    ctx.target = target;
+                    ctx.rel = rel;
+                    ctx.is_current = is_current;
+                    ctx.disabled = disabled;
+
+                    if disabled {
+                        ctx.pressed = false;
+                    }
+                }))
+            }
+
+            _ => None,
+        }
+    }
+
+    fn connect<'a>(
+        state: &'a Self::State,
+        ctx: &'a Self::Context,
+        props: &'a Self::Props,
+        send: &'a dyn Fn(Self::Event),
+    ) -> Self::Api<'a> {
+        Api {
+            state,
+            ctx,
+            props,
+            send,
+        }
+    }
+
+    fn on_props_changed(old: &Self::Props, new: &Self::Props) -> Vec<Self::Event> {
+        if old.href != new.href
+            || old.target != new.target
+            || old.rel != new.rel
+            || old.is_current != new.is_current
+            || old.disabled != new.disabled
+        {
+            vec![Event::SyncProps]
+        } else {
+            Vec::new()
+        }
+    }
+}
+
+/// Connected API for a [`Link`](self) service.
+pub struct Api<'a> {
+    /// Current state.
+    state: &'a State,
+
+    /// Current context.
+    ctx: &'a Context,
+
+    /// Current props.
+    props: &'a Props,
+
+    /// Event dispatcher.
+    send: &'a dyn Fn(Event),
+}
+
+impl Debug for Api<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Api")
+            .field("state", self.state)
+            .field("ctx", self.ctx)
+            .field("props", self.props)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Api<'_> {
+    /// Attributes for the root link host.
+    #[must_use]
+    pub fn root_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_value), (part_attr, part_value)] = Part::Root.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_value)
+            .set(part_attr, part_value)
+            .set(HtmlAttr::Data("ars-state"), self.state.as_str());
+
+        if self.ctx.disabled {
+            attrs.set(HtmlAttr::Aria(AriaAttr::Disabled), "true");
+        } else {
+            attrs.set(HtmlAttr::Href, sanitize_url(self.ctx.href.href()));
+
+            let target = self.resolved_target();
+
+            if let Some(target) = target.as_deref() {
+                attrs.set(HtmlAttr::Target, target);
+            }
+
+            let rel = self.resolved_rel(target.as_deref());
+
+            if let Some(rel) = rel {
+                attrs.set(HtmlAttr::Rel, rel);
+            }
+
+            if target.as_deref() == Some("_blank") {
+                attrs.set_bool(HtmlAttr::Data("ars-external"), true).set(
+                    HtmlAttr::Aria(AriaAttr::Description),
+                    (self.ctx.messages.external_link_label)(&self.ctx.locale),
+                );
+            }
+        }
+
+        if let Some(current) = self.ctx.is_current {
+            attrs.set(HtmlAttr::Aria(AriaAttr::Current), current.as_str());
+        }
+
+        if self.ctx.focus_visible {
+            attrs.set_bool(HtmlAttr::Data("ars-focus-visible"), true);
+        }
+
+        if self.ctx.pressed {
+            attrs.set_bool(HtmlAttr::Data("ars-pressed"), true);
+        }
+
+        attrs
+    }
+
+    /// Dispatches the link activation event.
+    pub fn on_click(&self) {
+        (self.send)(Event::Navigate);
+    }
+
+    /// Dispatches the focus event.
+    pub fn on_focus(&self, is_keyboard: bool) {
+        (self.send)(Event::Focus { is_keyboard });
+    }
+
+    /// Dispatches the blur event.
+    pub fn on_blur(&self) {
+        (self.send)(Event::Blur);
+    }
+
+    /// Dispatches the press-start event.
+    pub fn on_pointer_down(&self) {
+        (self.send)(Event::Press);
+    }
+
+    /// Dispatches the press-end event.
+    pub fn on_pointer_up(&self) {
+        (self.send)(Event::PressEnd);
+    }
+
+    /// Returns `true` when the link is disabled.
+    #[must_use]
+    pub const fn is_disabled(&self) -> bool {
+        self.ctx.disabled
+    }
+
+    /// Returns `true` when the link has keyboard-visible focus.
+    #[must_use]
+    pub const fn is_focus_visible(&self) -> bool {
+        self.ctx.focus_visible
+    }
+
+    /// Returns the target props used to create this API.
+    #[must_use]
+    pub const fn props(&self) -> &Props {
+        self.props
+    }
+
+    fn resolved_target(&self) -> Option<String> {
+        self.ctx
+            .target
+            .clone()
+            .or_else(|| self.ctx.href.is_external().then(|| "_blank".to_string()))
+    }
+
+    fn resolved_rel(&self, target: Option<&str>) -> Option<String> {
+        self.ctx
+            .rel
+            .clone()
+            .or_else(|| (target == Some("_blank")).then(|| "noopener noreferrer".to_string()))
+    }
+}
+
+impl ConnectApi for Api<'_> {
+    type Part = Part;
+
+    fn part_attrs(&self, part: Part) -> AttrMap {
+        match part {
+            Part::Root => self.root_attrs(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::{format, string::ToString as _, sync::Arc, vec::Vec};
+    use std::sync::{Mutex, MutexGuard};
+
+    use ars_core::{Service, StrongSend};
+
+    use super::*;
+
+    fn props() -> Props {
+        Props::new().id("link").href(SafeUrl::from_static("/docs"))
+    }
+
+    fn service(props: Props) -> Service<Machine> {
+        Service::<Machine>::new(props, &Env::default(), &Messages::default())
+    }
+
+    fn snapshot_attrs(attrs: &AttrMap) -> String {
+        format!("{attrs:#?}")
+    }
+
+    fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+        mutex.lock().expect("test mutex should not be poisoned")
+    }
+
+    #[test]
+    fn root_attrs_emit_href_and_state() {
+        let service = service(props());
+
+        insta::assert_snapshot!(
+            "link_root_default",
+            snapshot_attrs(&service.connect(&|_| {}).root_attrs())
+        );
+    }
+
+    #[test]
+    fn external_href_gets_target_rel_and_announcement() {
+        let service = service(
+            props()
+                .href(SafeUrl::from_static("https://example.com/docs"))
+                .is_current(AriaCurrent::Page),
+        );
+
+        let attrs = service.connect(&|_| {}).root_attrs();
+
+        assert_eq!(attrs.get(&HtmlAttr::Target), Some("_blank"));
+        assert_eq!(attrs.get(&HtmlAttr::Rel), Some("noopener noreferrer"));
+        assert_eq!(attrs.get(&HtmlAttr::Aria(AriaAttr::Current)), Some("page"));
+
+        insta::assert_snapshot!("link_root_external", snapshot_attrs(&attrs));
+    }
+
+    #[test]
+    fn explicit_blank_target_repairs_missing_rel() {
+        let service = service(props().target("_blank"));
+
+        let attrs = service.connect(&|_| {}).root_attrs();
+
+        assert_eq!(attrs.get(&HtmlAttr::Rel), Some("noopener noreferrer"));
+    }
+
+    #[test]
+    fn explicit_rel_wins_over_blank_target_repair() {
+        let service = service(props().target("_blank").rel("external"));
+
+        let attrs = service.connect(&|_| {}).root_attrs();
+
+        assert_eq!(attrs.get(&HtmlAttr::Rel), Some("external"));
+    }
+
+    #[test]
+    fn disabled_link_omits_href_and_sets_aria_disabled() {
+        let service = service(props().disabled(true));
+
+        let attrs = service.connect(&|_| {}).root_attrs();
+
+        assert_eq!(attrs.get(&HtmlAttr::Aria(AriaAttr::Disabled)), Some("true"));
+        assert!(attrs.get(&HtmlAttr::Href).is_none());
+
+        insta::assert_snapshot!("link_root_disabled", snapshot_attrs(&attrs));
+    }
+
+    #[test]
+    fn focus_and_press_states_update_attrs() {
+        let mut service = service(props());
+
+        drop(service.send(Event::Focus { is_keyboard: true }));
+
+        assert_eq!(service.state(), &State::Focused);
+        assert_eq!(
+            service
+                .connect(&|_| {})
+                .root_attrs()
+                .get(&HtmlAttr::Data("ars-focus-visible")),
+            Some("true")
+        );
+
+        drop(service.send(Event::Press));
+
+        assert_eq!(service.state(), &State::Pressed);
+        assert_eq!(
+            service
+                .connect(&|_| {})
+                .root_attrs()
+                .get(&HtmlAttr::Data("ars-pressed")),
+            Some("true")
+        );
+
+        drop(service.send(Event::PressEnd));
+
+        assert_eq!(service.state(), &State::Focused);
+
+        drop(service.send(Event::Blur));
+
+        assert_eq!(service.state(), &State::Idle);
+        assert!(!service.context().focus_visible);
+        assert!(!service.context().pressed);
+    }
+
+    #[test]
+    fn navigate_emits_effect_and_runs_callbacks() {
+        let navigated = Arc::new(Mutex::new(Vec::new()));
+        let pressed = Arc::new(Mutex::new(0usize));
+        let navigated_clone = Arc::clone(&navigated);
+        let pressed_clone = Arc::clone(&pressed);
+
+        let mut service = service(
+            props()
+                .href(Target::Route("/settings".to_string()))
+                .on_navigate(move |target| lock(&navigated_clone).push(target))
+                .on_press(move || *lock(&pressed_clone) += 1),
+        );
+
+        let result = service.send(Event::Navigate);
+
+        assert_eq!(result.pending_effects.len(), 1);
+        assert_eq!(result.pending_effects[0].name, Effect::Navigate);
+
+        let send: StrongSend<Event> = Arc::new(|_| {});
+
+        for effect in result.pending_effects {
+            drop(effect.run(service.context(), service.props(), Arc::clone(&send)));
+        }
+
+        assert_eq!(
+            lock(&navigated).as_slice(),
+            &[Target::Route("/settings".to_string())]
+        );
+        assert_eq!(*lock(&pressed), 1);
+    }
+
+    #[test]
+    fn disabled_navigate_does_not_emit_effect() {
+        let mut service = service(props().disabled(true));
+
+        assert!(service.send(Event::Navigate).pending_effects.is_empty());
+    }
+
+    #[test]
+    fn all_aria_current_variants_render_tokens() {
+        for (variant, token) in [
+            (AriaCurrent::Page, "page"),
+            (AriaCurrent::Step, "step"),
+            (AriaCurrent::Location, "location"),
+            (AriaCurrent::Date, "date"),
+            (AriaCurrent::Time, "time"),
+            (AriaCurrent::True, "true"),
+        ] {
+            let service = service(props().is_current(variant));
+
+            let attrs = service.connect(&|_| {}).root_attrs();
+
+            assert_eq!(attrs.get(&HtmlAttr::Aria(AriaAttr::Current)), Some(token));
+        }
+    }
+
+    #[test]
+    fn props_builder_clears_target_and_rel_without_resetting_other_fields() {
+        let props = props()
+            .href(Target::Route("/route".to_string()))
+            .target("_blank")
+            .rel("external")
+            .is_current(AriaCurrent::Location)
+            .disabled(true)
+            .no_target()
+            .no_rel();
+
+        assert_eq!(props.id, "link");
+        assert_eq!(props.href, Target::Route("/route".to_string()));
+        assert_eq!(props.target, None);
+        assert_eq!(props.rel, None);
+        assert_eq!(props.is_current, Some(AriaCurrent::Location));
+        assert!(props.disabled);
+    }
+
+    #[test]
+    fn disabled_press_is_ignored() {
+        let mut service = service(props().disabled(true));
+
+        let result = service.send(Event::Press);
+
+        assert!(!result.state_changed);
+        assert!(!result.context_changed);
+        assert_eq!(service.state(), &State::Idle);
+        assert!(!service.context().pressed);
+    }
+
+    #[test]
+    fn set_props_syncs_context_fields_and_clears_disabled_press() {
+        let mut service = service(
+            props()
+                .target("_blank")
+                .rel("external")
+                .is_current(AriaCurrent::Page),
+        );
+
+        drop(service.send(Event::Press));
+
+        assert!(service.context().pressed);
+
+        drop(
+            service.set_props(
+                props()
+                    .href(Target::Route("/updated".to_string()))
+                    .disabled(true)
+                    .is_current(AriaCurrent::Step),
+            ),
+        );
+
+        assert_eq!(
+            service.context().href,
+            Target::Route("/updated".to_string())
+        );
+        assert_eq!(service.context().target, None);
+        assert_eq!(service.context().rel, None);
+        assert_eq!(service.context().is_current, Some(AriaCurrent::Step));
+        assert!(service.context().disabled);
+        assert!(!service.context().pressed);
+    }
+
+    #[test]
+    fn on_props_changed_detects_each_context_field() {
+        let old = props()
+            .target("_blank")
+            .rel("external")
+            .is_current(AriaCurrent::Page);
+
+        assert!(<Machine as ars_core::Machine>::on_props_changed(&old, &old).is_empty());
+
+        for new in [
+            old.clone().href(Target::Route("/next".to_string())),
+            old.clone().target("_self"),
+            old.clone().rel("bookmark"),
+            old.clone().is_current(AriaCurrent::Step),
+            old.clone().disabled(true),
+        ] {
+            assert_eq!(
+                <Machine as ars_core::Machine>::on_props_changed(&old, &new),
+                [Event::SyncProps],
+                "expected SyncProps for {new:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn api_handlers_dispatch_events_and_accessors_report_context() {
+        let mut focused = service(props());
+
+        drop(focused.send(Event::Focus { is_keyboard: true }));
+
+        let focused_api = focused.connect(&|_| {});
+
+        assert!(!focused_api.is_disabled());
+        assert!(focused_api.is_focus_visible());
+
+        let disabled = service(props().disabled(true));
+        let disabled_api = disabled.connect(&|_| {});
+
+        assert!(disabled_api.is_disabled());
+        assert!(!disabled_api.is_focus_visible());
+
+        let sent = Mutex::new(Vec::new());
+        let send = |event| lock(&sent).push(event);
+
+        let api = disabled.connect(&send);
+
+        api.on_click();
+        api.on_focus(false);
+        api.on_blur();
+        api.on_pointer_down();
+        api.on_pointer_up();
+
+        assert_eq!(
+            lock(&sent).as_slice(),
+            &[
+                Event::Navigate,
+                Event::Focus { is_keyboard: false },
+                Event::Blur,
+                Event::Press,
+                Event::PressEnd,
+            ]
+        );
+    }
+
+    #[test]
+    fn part_attrs_dispatches_root_attrs() {
+        let service = service(props());
+
+        let api = service.connect(&|_| {});
+
+        assert_eq!(api.part_attrs(Part::Root), api.root_attrs());
+    }
+}

--- a/crates/ars-components/src/navigation/link/mod.rs
+++ b/crates/ars-components/src/navigation/link/mod.rs
@@ -395,7 +395,7 @@ impl ars_core::Machine for Machine {
                 },
             )),
 
-            Event::PressEnd => Some(TransitionPlan::to(State::Focused).apply(
+            Event::PressEnd if ctx.pressed => Some(TransitionPlan::to(State::Focused).apply(
                 |ctx: &mut Context| {
                     ctx.pressed = false;
                 },
@@ -819,6 +819,28 @@ mod tests {
         assert!(!result.state_changed);
         assert!(!result.context_changed);
         assert_eq!(service.state(), &State::Idle);
+        assert!(!service.context().pressed);
+    }
+
+    #[test]
+    fn press_end_without_active_press_is_ignored() {
+        let mut service = service(props());
+
+        let result = service.send(Event::PressEnd);
+
+        assert!(!result.state_changed);
+        assert!(!result.context_changed);
+        assert_eq!(service.state(), &State::Idle);
+        assert!(!service.context().pressed);
+
+        drop(service.send(Event::Press));
+        drop(service.set_props(props().disabled(true)));
+
+        let result = service.send(Event::PressEnd);
+
+        assert!(!result.state_changed);
+        assert!(!result.context_changed);
+        assert_eq!(service.state(), &State::Pressed);
         assert!(!service.context().pressed);
     }
 

--- a/crates/ars-components/src/navigation/link/snapshots/ars_components__navigation__link__tests__link_root_default.snap
+++ b/crates/ars-components/src/navigation/link/snapshots/ars_components__navigation__link__tests__link_root_default.snap
@@ -1,0 +1,39 @@
+---
+source: crates/ars-components/src/navigation/link.rs
+expression: "snapshot_attrs(&service.connect(&|_| {}).root_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "link",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "idle",
+            ),
+        ),
+        (
+            Href,
+            String(
+                "/docs",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/navigation/link/snapshots/ars_components__navigation__link__tests__link_root_disabled.snap
+++ b/crates/ars-components/src/navigation/link/snapshots/ars_components__navigation__link__tests__link_root_disabled.snap
@@ -1,0 +1,41 @@
+---
+source: crates/ars-components/src/navigation/link.rs
+expression: snapshot_attrs(&attrs)
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "link",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "idle",
+            ),
+        ),
+        (
+            Aria(
+                Disabled,
+            ),
+            String(
+                "true",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/navigation/link/snapshots/ars_components__navigation__link__tests__link_root_external.snap
+++ b/crates/ars-components/src/navigation/link/snapshots/ars_components__navigation__link__tests__link_root_external.snap
@@ -1,0 +1,75 @@
+---
+source: crates/ars-components/src/navigation/link.rs
+expression: snapshot_attrs(&attrs)
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-external",
+            ),
+            Bool(
+                true,
+            ),
+        ),
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "link",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "idle",
+            ),
+        ),
+        (
+            Aria(
+                Current,
+            ),
+            String(
+                "page",
+            ),
+        ),
+        (
+            Aria(
+                Description,
+            ),
+            String(
+                "opens in new tab",
+            ),
+        ),
+        (
+            Href,
+            String(
+                "https://example.com/docs",
+            ),
+        ),
+        (
+            Rel,
+            String(
+                "noopener noreferrer",
+            ),
+        ),
+        (
+            Target,
+            String(
+                "_blank",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/navigation/mod.rs
+++ b/crates/ars-components/src/navigation/mod.rs
@@ -3,5 +3,17 @@
 //! Components in this module help the user move between sections, pages, or
 //! views: tabbed interfaces, accordions, breadcrumbs, paginators, and so on.
 
+/// Breadcrumb navigation component.
+pub mod breadcrumbs;
+
+/// Link navigation component.
+pub mod link;
+
+/// Pagination navigation component.
+pub mod pagination;
+
+/// Steps navigation component.
+pub mod steps;
+
 /// Tabs component — a tab list paired with associated content panels.
 pub mod tabs;

--- a/crates/ars-components/src/navigation/pagination/mod.rs
+++ b/crates/ars-components/src/navigation/pagination/mod.rs
@@ -428,10 +428,16 @@ impl ars_core::Machine for Machine {
                 let new_count = Context::compute_page_count(ctx.total_items, new_size);
                 let target = clamp_page(current, new_count);
                 let emit = target != current;
+                let controlled = ctx.page.is_controlled();
 
                 let mut plan = TransitionPlan::context_only(move |ctx: &mut Context| {
                     ctx.page_size = new_size;
                     ctx.page_count = new_count;
+
+                    if controlled {
+                        ctx.page.sync_controlled(Some(target));
+                    }
+
                     ctx.page.set(target);
                 });
 
@@ -1060,6 +1066,21 @@ mod tests {
         }
 
         assert_eq!(lock(&pages).as_slice(), &[4]);
+    }
+
+    #[test]
+    fn controlled_set_page_size_clamps_visible_page() {
+        let mut service = service(props().page(10));
+
+        let result = service.send(Event::SetPageSize(
+            NonZeroU32::new(20).expect("non-zero page size"),
+        ));
+
+        assert_eq!(service.context().page_count, 5);
+        assert_eq!(*service.context().page.get(), 5);
+        assert!(service.connect(&|_| {}).is_last_page());
+        assert_eq!(result.pending_effects.len(), 1);
+        assert_eq!(result.pending_effects[0].name, Effect::PageChange);
     }
 
     #[test]

--- a/crates/ars-components/src/navigation/pagination/mod.rs
+++ b/crates/ars-components/src/navigation/pagination/mod.rs
@@ -1,0 +1,1084 @@
+//! Pagination navigation component.
+//!
+//! Pagination owns page-state transitions, range generation with ellipses,
+//! localized control labels, button-vs-link trigger attributes, and page-change
+//! effect intents for adapters.
+
+use alloc::{
+    format,
+    string::{String, ToString as _},
+    sync::Arc,
+    vec,
+    vec::Vec,
+};
+use core::{
+    fmt::{self, Debug},
+    num::NonZeroU32,
+};
+
+use ars_core::{
+    AriaAttr, AttrMap, Bindable, Callback, ComponentIds, ComponentMessages, ComponentPart,
+    ConnectApi, Env, HtmlAttr, Locale, MessageFn, PendingEffect, TransitionPlan, sanitize_url,
+};
+
+/// The only pagination machine state.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum State {
+    /// Current page is tracked in context.
+    #[default]
+    Idle,
+}
+
+/// Events accepted by the pagination state machine.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Event {
+    /// Navigate to a specific one-based page number.
+    GoToPage(u32),
+
+    /// Advance to the next page.
+    NextPage,
+
+    /// Move to the previous page.
+    PrevPage,
+
+    /// Jump to page one.
+    GoToFirstPage,
+
+    /// Jump to the final page.
+    GoToLastPage,
+
+    /// Change the page size and clamp the current page.
+    SetPageSize(NonZeroU32),
+
+    /// Synchronize render props into context.
+    SyncProps,
+}
+
+/// Typed effect intents emitted by the pagination machine.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Effect {
+    /// The current page changed.
+    PageChange,
+}
+
+/// Visual size variant for pagination controls.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum Size {
+    /// Compact controls for dense layouts.
+    Compact,
+
+    /// Standard controls.
+    #[default]
+    Medium,
+
+    /// Large controls for touch-oriented layouts.
+    Large,
+}
+
+impl Size {
+    /// Returns the rendered size token.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Compact => "compact",
+            Self::Medium => "medium",
+            Self::Large => "large",
+        }
+    }
+}
+
+/// Label template for a page-number trigger.
+pub type PageLabelFn = dyn Fn(usize, &Locale) -> String + Send + Sync;
+
+/// Announcement template for page changes.
+pub type PageChangeAnnouncementFn = dyn Fn(usize, usize, &Locale) -> String + Send + Sync;
+
+/// Localized pagination messages.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Messages {
+    /// Label for the root navigation landmark.
+    pub root_label: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
+
+    /// Label for the previous-page trigger.
+    pub prev_label: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
+
+    /// Label for the next-page trigger.
+    pub next_label: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
+
+    /// Label template for a page-number trigger.
+    pub page_label: MessageFn<PageLabelFn>,
+
+    /// Announcement template for page changes.
+    pub page_change_announcement: MessageFn<PageChangeAnnouncementFn>,
+}
+
+impl Default for Messages {
+    fn default() -> Self {
+        Self {
+            root_label: MessageFn::static_str("Pagination"),
+            prev_label: MessageFn::static_str("Go to previous page"),
+            next_label: MessageFn::static_str("Go to next page"),
+            page_label: MessageFn::new(|page: usize, _locale: &Locale| format!("Page {page}")),
+            page_change_announcement: MessageFn::new(Arc::new(
+                |current: usize, total: usize, _locale: &Locale| {
+                    format!("Page {current} of {total}")
+                },
+            )
+                as Arc<PageChangeAnnouncementFn>),
+        }
+    }
+}
+
+impl ComponentMessages for Messages {}
+
+/// Immutable configuration for a [`Pagination`](self) instance.
+#[derive(Clone, Debug, PartialEq, ars_core::HasId)]
+pub struct Props {
+    /// Component instance id.
+    pub id: String,
+
+    /// Controlled current page.
+    pub page: Option<u32>,
+
+    /// Initial uncontrolled page.
+    pub default_page: u32,
+
+    /// Number of items per page.
+    pub page_size: NonZeroU32,
+
+    /// Total item count.
+    pub total_items: u32,
+
+    /// Number of page buttons shown on each side of the current page.
+    pub sibling_count: u32,
+
+    /// Number of always-visible page buttons at each boundary.
+    pub boundary_count: u32,
+
+    /// Visual size token.
+    pub size: Size,
+
+    /// Optional one-based page URL generator.
+    pub get_page_url: Option<Callback<dyn Fn(u32) -> String + Send + Sync>>,
+
+    /// Callback fired by the page-change effect.
+    pub on_page_change: Option<Callback<dyn Fn(u32) + Send + Sync>>,
+}
+
+impl Default for Props {
+    fn default() -> Self {
+        Self {
+            id: String::new(),
+            page: None,
+            default_page: 1,
+            page_size: NonZeroU32::new(10).expect("literal is non-zero"),
+            total_items: 0,
+            sibling_count: 1,
+            boundary_count: 1,
+            size: Size::default(),
+            get_page_url: None,
+            on_page_change: None,
+        }
+    }
+}
+
+impl Props {
+    /// Returns default pagination props.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets [`id`](Self::id).
+    #[must_use]
+    pub fn id(mut self, id: impl Into<String>) -> Self {
+        self.id = id.into();
+        self
+    }
+
+    /// Sets [`page`](Self::page).
+    #[must_use]
+    pub const fn page(mut self, page: u32) -> Self {
+        self.page = Some(page);
+        self
+    }
+
+    /// Clears [`page`](Self::page), switching to uncontrolled mode.
+    #[must_use]
+    pub const fn uncontrolled(mut self) -> Self {
+        self.page = None;
+        self
+    }
+
+    /// Sets [`default_page`](Self::default_page).
+    #[must_use]
+    pub const fn default_page(mut self, page: u32) -> Self {
+        self.default_page = page;
+        self
+    }
+
+    /// Sets [`page_size`](Self::page_size).
+    #[must_use]
+    pub const fn page_size(mut self, page_size: NonZeroU32) -> Self {
+        self.page_size = page_size;
+        self
+    }
+
+    /// Sets [`total_items`](Self::total_items).
+    #[must_use]
+    pub const fn total_items(mut self, count: u32) -> Self {
+        self.total_items = count;
+        self
+    }
+
+    /// Sets [`sibling_count`](Self::sibling_count).
+    #[must_use]
+    pub const fn sibling_count(mut self, count: u32) -> Self {
+        self.sibling_count = count;
+        self
+    }
+
+    /// Sets [`boundary_count`](Self::boundary_count).
+    #[must_use]
+    pub const fn boundary_count(mut self, count: u32) -> Self {
+        self.boundary_count = count;
+        self
+    }
+
+    /// Sets [`size`](Self::size).
+    #[must_use]
+    pub const fn size(mut self, size: Size) -> Self {
+        self.size = size;
+        self
+    }
+
+    /// Sets [`get_page_url`](Self::get_page_url).
+    #[must_use]
+    pub fn get_page_url(
+        mut self,
+        callback: impl Into<Callback<dyn Fn(u32) -> String + Send + Sync>>,
+    ) -> Self {
+        self.get_page_url = Some(callback.into());
+        self
+    }
+
+    /// Sets [`on_page_change`](Self::on_page_change).
+    #[must_use]
+    pub fn on_page_change(
+        mut self,
+        callback: impl Into<Callback<dyn Fn(u32) + Send + Sync>>,
+    ) -> Self {
+        self.on_page_change = Some(callback.into());
+        self
+    }
+}
+
+/// Runtime context for the pagination machine.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Context {
+    /// Current one-based page.
+    pub page: Bindable<u32>,
+
+    /// Number of items per page.
+    pub page_size: NonZeroU32,
+
+    /// Total item count.
+    pub total_items: u32,
+
+    /// Number of sibling pages shown around the current page.
+    pub sibling_count: u32,
+
+    /// Number of boundary pages shown at each edge.
+    pub boundary_count: u32,
+
+    /// Derived page count, always at least one.
+    pub page_count: u32,
+
+    /// Stable ids derived from props.
+    pub ids: ComponentIds,
+
+    /// Active locale.
+    pub locale: Locale,
+
+    /// Localized messages.
+    pub messages: Messages,
+}
+
+impl Context {
+    /// Computes `ceil(total_items / page_size)`, clamped to at least one.
+    #[must_use]
+    pub fn compute_page_count(total_items: u32, page_size: NonZeroU32) -> u32 {
+        let size = page_size.get();
+
+        total_items.div_ceil(size).max(1)
+    }
+
+    /// Generates the visible one-based page range. `None` represents an ellipsis.
+    #[must_use]
+    pub fn page_range(&self) -> Vec<Option<u32>> {
+        page_range(
+            *self.page.get(),
+            self.page_count,
+            self.sibling_count,
+            self.boundary_count,
+        )
+    }
+}
+
+/// Anatomy parts exposed by the pagination connect API.
+#[derive(ComponentPart)]
+#[scope = "pagination"]
+pub enum Part {
+    /// Root navigation landmark.
+    Root,
+
+    /// Previous-page trigger.
+    PrevTrigger,
+
+    /// Next-page trigger.
+    NextTrigger,
+
+    /// Numbered page trigger.
+    PageTrigger {
+        /// One-based page number represented by this trigger.
+        #[part(default = 1)]
+        page_number: u32,
+    },
+
+    /// Non-interactive skipped page range marker.
+    Ellipsis,
+}
+
+/// Pagination state machine.
+#[derive(Debug)]
+pub struct Machine;
+
+impl ars_core::Machine for Machine {
+    type State = State;
+    type Event = Event;
+    type Context = Context;
+    type Props = Props;
+    type Messages = Messages;
+    type Effect = Effect;
+    type Api<'a> = Api<'a>;
+
+    fn init(
+        props: &Self::Props,
+        env: &Env,
+        messages: &Self::Messages,
+    ) -> (Self::State, Self::Context) {
+        let page_count = Context::compute_page_count(props.total_items, props.page_size);
+
+        let initial_page = clamp_page(props.page.unwrap_or(props.default_page), page_count);
+
+        let page = if props.page.is_some() {
+            Bindable::controlled(initial_page)
+        } else {
+            Bindable::uncontrolled(initial_page)
+        };
+
+        (
+            State::Idle,
+            Context {
+                page,
+                page_size: props.page_size,
+                total_items: props.total_items,
+                sibling_count: props.sibling_count,
+                boundary_count: props.boundary_count,
+                page_count,
+                ids: ComponentIds::from_id(&props.id),
+                locale: env.locale.clone(),
+                messages: messages.clone(),
+            },
+        )
+    }
+
+    fn transition(
+        _state: &Self::State,
+        event: &Self::Event,
+        ctx: &Self::Context,
+        props: &Self::Props,
+    ) -> Option<TransitionPlan<Self>> {
+        let current = *ctx.page.get();
+
+        match event {
+            Event::GoToPage(page) => {
+                page_change_plan(ctx, props, clamp_page(*page, ctx.page_count))
+            }
+
+            Event::NextPage => {
+                page_change_plan(ctx, props, clamp_page(current + 1, ctx.page_count))
+            }
+
+            Event::PrevPage => page_change_plan(
+                ctx,
+                props,
+                clamp_page(current.saturating_sub(1), ctx.page_count),
+            ),
+
+            Event::GoToFirstPage => page_change_plan(ctx, props, 1),
+
+            Event::GoToLastPage => page_change_plan(ctx, props, ctx.page_count),
+
+            Event::SetPageSize(page_size) => {
+                let new_size = *page_size;
+
+                let new_count = Context::compute_page_count(ctx.total_items, new_size);
+                let target = clamp_page(current, new_count);
+                let emit = target != current;
+
+                let mut plan = TransitionPlan::context_only(move |ctx: &mut Context| {
+                    ctx.page_size = new_size;
+                    ctx.page_count = new_count;
+                    ctx.page.set(target);
+                });
+
+                if emit {
+                    plan = with_page_change_effect(plan);
+                }
+
+                Some(plan)
+            }
+            Event::SyncProps => {
+                let page_size = props.page_size;
+                let total_items = props.total_items;
+                let sibling_count = props.sibling_count;
+                let boundary_count = props.boundary_count;
+
+                let new_count = Context::compute_page_count(total_items, page_size);
+                let controlled = props.page.map(|page| clamp_page(page, new_count));
+                let target = controlled.unwrap_or_else(|| clamp_page(current, new_count));
+
+                Some(TransitionPlan::context_only(move |ctx: &mut Context| {
+                    ctx.page_size = page_size;
+                    ctx.total_items = total_items;
+                    ctx.sibling_count = sibling_count;
+                    ctx.boundary_count = boundary_count;
+                    ctx.page_count = new_count;
+                    ctx.page.sync_controlled(controlled);
+                    ctx.page.set(target);
+                }))
+            }
+        }
+    }
+
+    fn connect<'a>(
+        state: &'a Self::State,
+        ctx: &'a Self::Context,
+        props: &'a Self::Props,
+        send: &'a dyn Fn(Self::Event),
+    ) -> Self::Api<'a> {
+        Api {
+            state,
+            ctx,
+            props,
+            send,
+        }
+    }
+
+    fn on_props_changed(old: &Self::Props, new: &Self::Props) -> Vec<Self::Event> {
+        if old.page != new.page
+            || old.default_page != new.default_page
+            || old.page_size != new.page_size
+            || old.total_items != new.total_items
+            || old.sibling_count != new.sibling_count
+            || old.boundary_count != new.boundary_count
+        {
+            vec![Event::SyncProps]
+        } else {
+            Vec::new()
+        }
+    }
+}
+
+/// Connected API for a [`Pagination`](self) service.
+pub struct Api<'a> {
+    /// Current state.
+    state: &'a State,
+
+    /// Current context.
+    ctx: &'a Context,
+
+    /// Current props.
+    props: &'a Props,
+
+    /// Event dispatcher.
+    send: &'a dyn Fn(Event),
+}
+
+impl Debug for Api<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Api")
+            .field("state", self.state)
+            .field("ctx", self.ctx)
+            .field("props", self.props)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Api<'_> {
+    /// Returns the current one-based page.
+    #[must_use]
+    pub fn current_page(&self) -> u32 {
+        *self.ctx.page.get()
+    }
+
+    /// Returns the total page count.
+    #[must_use]
+    pub const fn page_count(&self) -> u32 {
+        self.ctx.page_count
+    }
+
+    /// Returns `true` on the first page.
+    #[must_use]
+    pub fn is_first_page(&self) -> bool {
+        self.current_page() == 1
+    }
+
+    /// Returns `true` on the last page.
+    #[must_use]
+    pub fn is_last_page(&self) -> bool {
+        self.current_page() == self.page_count()
+    }
+
+    /// Returns the current page range.
+    #[must_use]
+    pub fn page_range(&self) -> Vec<Option<u32>> {
+        self.ctx.page_range()
+    }
+
+    /// Returns the current state.
+    #[must_use]
+    pub const fn state(&self) -> State {
+        *self.state
+    }
+
+    /// Attributes for the root navigation landmark.
+    #[must_use]
+    pub fn root_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_value), (part_attr, part_value)] = Part::Root.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_value)
+            .set(part_attr, part_value)
+            .set(HtmlAttr::Role, "navigation")
+            .set(
+                HtmlAttr::Aria(AriaAttr::Label),
+                (self.ctx.messages.root_label)(&self.ctx.locale),
+            )
+            .set(HtmlAttr::Data("ars-size"), self.props.size.as_str());
+
+        attrs
+    }
+
+    /// Attributes for the previous-page trigger.
+    #[must_use]
+    pub fn prev_trigger_attrs(&self) -> AttrMap {
+        let mut attrs = self.trigger_attrs(&Part::PrevTrigger);
+
+        attrs.set(
+            HtmlAttr::Aria(AriaAttr::Label),
+            (self.ctx.messages.prev_label)(&self.ctx.locale),
+        );
+
+        if self.is_first_page() {
+            attrs
+                .set_bool(HtmlAttr::Disabled, true)
+                .set(HtmlAttr::Aria(AriaAttr::Disabled), "true")
+                .set_bool(HtmlAttr::Data("ars-disabled"), true);
+        }
+
+        attrs
+    }
+
+    /// Attributes for the next-page trigger.
+    #[must_use]
+    pub fn next_trigger_attrs(&self) -> AttrMap {
+        let mut attrs = self.trigger_attrs(&Part::NextTrigger);
+
+        attrs.set(
+            HtmlAttr::Aria(AriaAttr::Label),
+            (self.ctx.messages.next_label)(&self.ctx.locale),
+        );
+
+        if self.is_last_page() {
+            attrs
+                .set_bool(HtmlAttr::Disabled, true)
+                .set(HtmlAttr::Aria(AriaAttr::Disabled), "true")
+                .set_bool(HtmlAttr::Data("ars-disabled"), true);
+        }
+
+        attrs
+    }
+
+    /// Attributes for a numbered page trigger.
+    #[must_use]
+    pub fn page_trigger_attrs(&self, page_number: u32) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_value), (part_attr, part_value)] =
+            (Part::PageTrigger { page_number }).data_attrs();
+
+        let page_number = clamp_page(page_number, self.ctx.page_count);
+
+        let current = self.current_page() == page_number;
+
+        attrs
+            .set(scope_attr, scope_value)
+            .set(part_attr, part_value)
+            .set(HtmlAttr::Data("ars-index"), page_number.to_string())
+            .set(
+                HtmlAttr::Aria(AriaAttr::Label),
+                (self.ctx.messages.page_label)(page_number as usize, &self.ctx.locale),
+            );
+
+        if let Some(get_url) = &self.props.get_page_url {
+            let href = get_url(page_number);
+
+            attrs.set(HtmlAttr::Href, sanitize_url(&href));
+        } else {
+            attrs.set(HtmlAttr::Type, "button");
+        }
+
+        if current {
+            attrs
+                .set(HtmlAttr::Aria(AriaAttr::Current), "page")
+                .set_bool(HtmlAttr::Data("ars-current"), true);
+        }
+
+        attrs
+    }
+
+    /// Attributes for an ellipsis marker.
+    #[must_use]
+    pub fn ellipsis_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_value), (part_attr, part_value)] = Part::Ellipsis.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_value)
+            .set(part_attr, part_value)
+            .set(HtmlAttr::Aria(AriaAttr::Hidden), "true")
+            .set(HtmlAttr::Role, "separator");
+
+        attrs
+    }
+
+    /// Dispatches previous-page navigation when not already at the first page.
+    pub fn on_prev_trigger_click(&self) {
+        if !self.is_first_page() {
+            (self.send)(Event::PrevPage);
+        }
+    }
+
+    /// Dispatches next-page navigation when not already at the last page.
+    pub fn on_next_trigger_click(&self) {
+        if !self.is_last_page() {
+            (self.send)(Event::NextPage);
+        }
+    }
+
+    /// Dispatches page navigation for a numbered trigger.
+    pub fn on_page_trigger_click(&self, page_number: u32) {
+        (self.send)(Event::GoToPage(page_number));
+    }
+
+    fn trigger_attrs(&self, part: &Part) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_value), (part_attr, part_value)] = part.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_value)
+            .set(part_attr, part_value)
+            .set(HtmlAttr::Type, "button");
+
+        attrs
+    }
+}
+
+impl ConnectApi for Api<'_> {
+    type Part = Part;
+
+    fn part_attrs(&self, part: Part) -> AttrMap {
+        match part {
+            Part::Root => self.root_attrs(),
+            Part::PrevTrigger => self.prev_trigger_attrs(),
+            Part::NextTrigger => self.next_trigger_attrs(),
+            Part::PageTrigger { page_number } => self.page_trigger_attrs(page_number),
+            Part::Ellipsis => self.ellipsis_attrs(),
+        }
+    }
+}
+
+fn clamp_page(page: u32, page_count: u32) -> u32 {
+    page.max(1).min(page_count.max(1))
+}
+
+fn page_change_plan(ctx: &Context, _props: &Props, target: u32) -> Option<TransitionPlan<Machine>> {
+    if target == *ctx.page.get() {
+        return None;
+    }
+
+    Some(with_page_change_effect(TransitionPlan::context_only(
+        move |ctx: &mut Context| {
+            ctx.page.set(target);
+        },
+    )))
+}
+
+fn with_page_change_effect(mut plan: TransitionPlan<Machine>) -> TransitionPlan<Machine> {
+    plan = plan.with_effect(PendingEffect::new(
+        Effect::PageChange,
+        |ctx: &Context, props: &Props, _send| {
+            if let Some(callback) = &props.on_page_change {
+                (callback)(*ctx.page.get());
+            }
+
+            ars_core::no_cleanup()
+        },
+    ));
+
+    plan
+}
+
+fn page_range(
+    current_page: u32,
+    page_count: u32,
+    sibling_count: u32,
+    boundary_count: u32,
+) -> Vec<Option<u32>> {
+    let total = page_count.max(1);
+
+    let current = clamp_page(current_page, total);
+
+    let boundary = boundary_count.max(1);
+
+    let siblings = sibling_count;
+
+    let all_count = boundary
+        .saturating_mul(2)
+        .saturating_add(siblings.saturating_mul(2))
+        .saturating_add(3);
+
+    if total <= all_count {
+        return (1..=total).map(Some).collect();
+    }
+
+    let left_boundary_end = boundary.min(total);
+    let right_boundary_start = total.saturating_sub(boundary).saturating_add(1).max(1);
+
+    let sibling_start = current.saturating_sub(siblings).max(left_boundary_end + 1);
+    let sibling_end = current
+        .saturating_add(siblings)
+        .min(right_boundary_start.saturating_sub(1));
+
+    let mut pages = Vec::new();
+
+    for page in 1..=left_boundary_end {
+        pages.push(Some(page));
+    }
+
+    if sibling_start > left_boundary_end + 1 {
+        pages.push(None);
+    } else {
+        for page in left_boundary_end + 1..sibling_start {
+            pages.push(Some(page));
+        }
+    }
+
+    for page in sibling_start..=sibling_end {
+        pages.push(Some(page));
+    }
+
+    if sibling_end + 1 < right_boundary_start {
+        pages.push(None);
+    } else {
+        for page in sibling_end + 1..right_boundary_start {
+            pages.push(Some(page));
+        }
+    }
+
+    for page in right_boundary_start..=total {
+        if pages.last() != Some(&Some(page)) {
+            pages.push(Some(page));
+        }
+    }
+
+    pages
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::{format, string::ToString as _, sync::Arc, vec};
+    use std::sync::{Mutex, MutexGuard};
+
+    use ars_core::{Service, StrongSend};
+
+    use super::*;
+
+    fn props() -> Props {
+        Props::new()
+            .id("pager")
+            .total_items(100)
+            .page_size(NonZeroU32::new(10).expect("non-zero"))
+    }
+
+    fn service(props: Props) -> Service<Machine> {
+        Service::<Machine>::new(props, &Env::default(), &Messages::default())
+    }
+
+    fn snapshot_attrs(attrs: &AttrMap) -> String {
+        format!("{attrs:#?}")
+    }
+
+    fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+        mutex.lock().expect("test mutex should not be poisoned")
+    }
+
+    #[test]
+    fn computes_page_count_and_range_with_ellipsis() {
+        let service = service(props().page(5).sibling_count(1).boundary_count(1));
+
+        let api = service.connect(&|_| {});
+
+        assert_eq!(api.page_count(), 10);
+        assert_eq!(
+            api.page_range(),
+            vec![Some(1), None, Some(4), Some(5), Some(6), None, Some(10)]
+        );
+    }
+
+    #[test]
+    fn page_range_handles_boundary_adjacency_cases() {
+        assert_eq!(
+            page_range(2, 10, 1, 1),
+            vec![Some(1), Some(2), Some(3), None, Some(10)]
+        );
+        assert_eq!(
+            page_range(9, 10, 1, 1),
+            vec![Some(1), None, Some(8), Some(9), Some(10)]
+        );
+        assert_eq!(
+            page_range(5, 12, 1, 2),
+            vec![
+                Some(1),
+                Some(2),
+                None,
+                Some(4),
+                Some(5),
+                Some(6),
+                None,
+                Some(11),
+                Some(12),
+            ]
+        );
+        assert_eq!(
+            page_range(4, 10, 1, 2),
+            vec![
+                Some(1),
+                Some(2),
+                Some(3),
+                Some(4),
+                Some(5),
+                None,
+                Some(9),
+                Some(10),
+            ]
+        );
+        assert_eq!(
+            page_range(7, 10, 1, 2),
+            vec![
+                Some(1),
+                Some(2),
+                None,
+                Some(6),
+                Some(7),
+                Some(8),
+                Some(9),
+                Some(10),
+            ]
+        );
+    }
+
+    #[test]
+    fn prev_next_and_current_attrs_match_spec() {
+        let service = service(props().default_page(1));
+
+        let api = service.connect(&|_| {});
+
+        insta::assert_snapshot!("pagination_root", snapshot_attrs(&api.root_attrs()));
+        insta::assert_snapshot!(
+            "pagination_prev_disabled",
+            snapshot_attrs(&api.prev_trigger_attrs())
+        );
+        insta::assert_snapshot!(
+            "pagination_next_enabled",
+            snapshot_attrs(&api.next_trigger_attrs())
+        );
+        insta::assert_snapshot!(
+            "pagination_page_current",
+            snapshot_attrs(&api.page_trigger_attrs(1))
+        );
+        insta::assert_snapshot!("pagination_ellipsis", snapshot_attrs(&api.ellipsis_attrs()));
+    }
+
+    #[test]
+    fn last_page_disables_next_trigger() {
+        let service = service(props().default_page(10));
+
+        let attrs = service.connect(&|_| {}).next_trigger_attrs();
+
+        assert_eq!(attrs.get(&HtmlAttr::Aria(AriaAttr::Disabled)), Some("true"));
+    }
+
+    #[test]
+    fn page_trigger_uses_sanitized_url_when_generator_exists() {
+        let service = service(props().get_page_url(|page| {
+            if page == 2 {
+                "javascript:alert(1)".to_string()
+            } else {
+                format!("/page/{page}")
+            }
+        }));
+
+        let api = service.connect(&|_| {});
+
+        assert_eq!(
+            api.page_trigger_attrs(3).get(&HtmlAttr::Href),
+            Some("/page/3")
+        );
+        assert_eq!(api.page_trigger_attrs(2).get(&HtmlAttr::Href), Some("#"));
+        assert!(api.page_trigger_attrs(2).get(&HtmlAttr::Type).is_none());
+    }
+
+    #[test]
+    fn page_navigation_clamps_at_bounds() {
+        let mut service = service(props().default_page(1));
+
+        assert!(service.send(Event::PrevPage).pending_effects.is_empty());
+        assert_eq!(*service.context().page.get(), 1);
+
+        drop(service.send(Event::NextPage));
+
+        assert_eq!(*service.context().page.get(), 2);
+
+        drop(service.send(Event::GoToPage(99)));
+
+        assert_eq!(*service.context().page.get(), 10);
+
+        assert!(service.send(Event::NextPage).pending_effects.is_empty());
+        assert_eq!(*service.context().page.get(), 10);
+    }
+
+    #[test]
+    fn page_change_effect_runs_callback() {
+        let pages = Arc::new(Mutex::new(Vec::new()));
+        let pages_clone = Arc::clone(&pages);
+        let mut service =
+            service(props().on_page_change(move |page| lock(&pages_clone).push(page)));
+
+        let result = service.send(Event::GoToPage(3));
+
+        assert_eq!(result.pending_effects[0].name, Effect::PageChange);
+
+        let send: StrongSend<Event> = Arc::new(|_| {});
+
+        for effect in result.pending_effects {
+            drop(effect.run(service.context(), service.props(), Arc::clone(&send)));
+        }
+
+        assert_eq!(lock(&pages).as_slice(), &[3]);
+    }
+
+    #[test]
+    fn api_handlers_dispatch_navigation_events() {
+        let sent = core::cell::RefCell::new(Vec::new());
+        let send = |event| sent.borrow_mut().push(event);
+
+        let service = service(props().default_page(2));
+
+        let api = service.connect(&send);
+
+        api.on_prev_trigger_click();
+        api.on_next_trigger_click();
+        api.on_page_trigger_click(4);
+
+        assert_eq!(
+            sent.borrow().as_slice(),
+            &[Event::PrevPage, Event::NextPage, Event::GoToPage(4)]
+        );
+    }
+
+    #[test]
+    fn set_page_size_clamps_and_emits_only_when_page_changes() {
+        let mut service = service(props().default_page(10));
+
+        let result = service.send(Event::SetPageSize(
+            NonZeroU32::new(20).expect("non-zero page size"),
+        ));
+
+        assert_eq!(*service.context().page.get(), 5);
+        assert_eq!(service.context().page_count, 5);
+        assert_eq!(result.pending_effects.len(), 1);
+        assert_eq!(result.pending_effects[0].name, Effect::PageChange);
+
+        let result = service.send(Event::SetPageSize(
+            NonZeroU32::new(25).expect("non-zero page size"),
+        ));
+
+        assert_eq!(*service.context().page.get(), 4);
+        assert_eq!(service.context().page_count, 4);
+        assert_eq!(result.pending_effects.len(), 1);
+
+        let result = service.send(Event::SetPageSize(
+            NonZeroU32::new(10).expect("non-zero page size"),
+        ));
+
+        assert_eq!(*service.context().page.get(), 4);
+        assert_eq!(service.context().page_count, 10);
+        assert!(result.pending_effects.is_empty());
+    }
+
+    #[test]
+    fn on_props_changed_detects_each_context_field() {
+        let old = props()
+            .page(2)
+            .default_page(3)
+            .sibling_count(1)
+            .boundary_count(1);
+
+        assert!(<Machine as ars_core::Machine>::on_props_changed(&old, &old).is_empty());
+
+        for new in [
+            old.clone().page(4),
+            old.clone().default_page(4),
+            old.clone()
+                .page_size(NonZeroU32::new(20).expect("non-zero page size")),
+            old.clone().total_items(200),
+            old.clone().sibling_count(2),
+            old.clone().boundary_count(2),
+        ] {
+            assert_eq!(
+                <Machine as ars_core::Machine>::on_props_changed(&old, &new),
+                [Event::SyncProps],
+                "expected SyncProps for {new:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn part_attrs_dispatches_every_part() {
+        let service = service(props().default_page(2));
+
+        let api = service.connect(&|_| {});
+
+        assert_eq!(api.part_attrs(Part::Root), api.root_attrs());
+        assert_eq!(api.part_attrs(Part::PrevTrigger), api.prev_trigger_attrs());
+        assert_eq!(api.part_attrs(Part::NextTrigger), api.next_trigger_attrs());
+        assert_eq!(
+            api.part_attrs(Part::PageTrigger { page_number: 2 }),
+            api.page_trigger_attrs(2)
+        );
+        assert_eq!(api.part_attrs(Part::Ellipsis), api.ellipsis_attrs());
+    }
+}

--- a/crates/ars-components/src/navigation/pagination/mod.rs
+++ b/crates/ars-components/src/navigation/pagination/mod.rs
@@ -406,9 +406,11 @@ impl ars_core::Machine for Machine {
                 page_change_plan(ctx, props, clamp_page(*page, ctx.page_count))
             }
 
-            Event::NextPage => {
-                page_change_plan(ctx, props, clamp_page(current + 1, ctx.page_count))
-            }
+            Event::NextPage => page_change_plan(
+                ctx,
+                props,
+                clamp_page(current.saturating_add(1), ctx.page_count),
+            ),
 
             Event::PrevPage => page_change_plan(
                 ctx,
@@ -434,7 +436,7 @@ impl ars_core::Machine for Machine {
                 });
 
                 if emit {
-                    plan = with_page_change_effect(plan);
+                    plan = with_page_change_effect(plan, target);
                 }
 
                 Some(plan)
@@ -719,19 +721,23 @@ fn page_change_plan(ctx: &Context, _props: &Props, target: u32) -> Option<Transi
         return None;
     }
 
-    Some(with_page_change_effect(TransitionPlan::context_only(
-        move |ctx: &mut Context| {
+    Some(with_page_change_effect(
+        TransitionPlan::context_only(move |ctx: &mut Context| {
             ctx.page.set(target);
-        },
-    )))
+        }),
+        target,
+    ))
 }
 
-fn with_page_change_effect(mut plan: TransitionPlan<Machine>) -> TransitionPlan<Machine> {
+fn with_page_change_effect(
+    mut plan: TransitionPlan<Machine>,
+    target: u32,
+) -> TransitionPlan<Machine> {
     plan = plan.with_effect(PendingEffect::new(
         Effect::PageChange,
-        |ctx: &Context, props: &Props, _send| {
+        move |_ctx: &Context, props: &Props, _send| {
             if let Some(callback) = &props.on_page_change {
-                (callback)(*ctx.page.get());
+                (callback)(target);
             }
 
             ars_core::no_cleanup()
@@ -971,6 +977,23 @@ mod tests {
     }
 
     #[test]
+    fn next_page_at_u32_max_page_count_is_noop() {
+        let mut service = service(
+            Props::new()
+                .id("pager")
+                .page(u32::MAX)
+                .total_items(u32::MAX)
+                .page_size(NonZeroU32::new(1).expect("non-zero")),
+        );
+
+        let result = service.send(Event::NextPage);
+
+        assert!(result.pending_effects.is_empty());
+        assert!(!result.context_changed);
+        assert_eq!(*service.context().page.get(), u32::MAX);
+    }
+
+    #[test]
     fn page_change_effect_runs_callback() {
         let pages = Arc::new(Mutex::new(Vec::new()));
         let pages_clone = Arc::clone(&pages);
@@ -988,6 +1011,29 @@ mod tests {
         }
 
         assert_eq!(lock(&pages).as_slice(), &[3]);
+    }
+
+    #[test]
+    fn controlled_page_change_callback_receives_requested_target() {
+        let pages = Arc::new(Mutex::new(Vec::new()));
+        let pages_clone = Arc::clone(&pages);
+        let mut service = service(
+            props()
+                .page(2)
+                .on_page_change(move |page| lock(&pages_clone).push(page)),
+        );
+
+        let result = service.send(Event::GoToPage(4));
+
+        assert_eq!(*service.context().page.get(), 2);
+
+        let send: StrongSend<Event> = Arc::new(|_| {});
+
+        for effect in result.pending_effects {
+            drop(effect.run(service.context(), service.props(), Arc::clone(&send)));
+        }
+
+        assert_eq!(lock(&pages).as_slice(), &[4]);
     }
 
     #[test]

--- a/crates/ars-components/src/navigation/pagination/mod.rs
+++ b/crates/ars-components/src/navigation/pagination/mod.rs
@@ -757,7 +757,7 @@ fn page_range(
 
     let current = clamp_page(current_page, total);
 
-    let boundary = boundary_count.max(1);
+    let boundary = boundary_count;
 
     let siblings = sibling_count;
 
@@ -771,12 +771,27 @@ fn page_range(
     }
 
     let left_boundary_end = boundary.min(total);
-    let right_boundary_start = total.saturating_sub(boundary).saturating_add(1).max(1);
+    let right_boundary_start = if boundary == 0 {
+        total
+    } else {
+        total.saturating_sub(boundary).saturating_add(1).max(1)
+    };
 
-    let sibling_start = current.saturating_sub(siblings).max(left_boundary_end + 1);
+    let middle_min = left_boundary_end.saturating_add(1);
+    let middle_max = if boundary == 0 {
+        total
+    } else {
+        right_boundary_start.saturating_sub(1)
+    };
+
+    let sibling_start = current
+        .saturating_sub(siblings)
+        .max(middle_min)
+        .min(middle_max);
     let sibling_end = current
         .saturating_add(siblings)
-        .min(right_boundary_start.saturating_sub(1));
+        .min(middle_max)
+        .max(sibling_start);
 
     let mut pages = Vec::new();
 
@@ -784,10 +799,10 @@ fn page_range(
         pages.push(Some(page));
     }
 
-    if sibling_start > left_boundary_end + 1 {
+    if sibling_start > middle_min {
         pages.push(None);
     } else {
-        for page in left_boundary_end + 1..sibling_start {
+        for page in middle_min..sibling_start {
             pages.push(Some(page));
         }
     }
@@ -796,17 +811,19 @@ fn page_range(
         pages.push(Some(page));
     }
 
-    if sibling_end + 1 < right_boundary_start {
+    if sibling_end < middle_max {
         pages.push(None);
     } else {
-        for page in sibling_end + 1..right_boundary_start {
+        for page in sibling_end.saturating_add(1)..=middle_max {
             pages.push(Some(page));
         }
     }
 
-    for page in right_boundary_start..=total {
-        if pages.last() != Some(&Some(page)) {
-            pages.push(Some(page));
+    if boundary > 0 {
+        for page in right_boundary_start..=total {
+            if pages.last() != Some(&Some(page)) {
+                pages.push(Some(page));
+            }
         }
     }
 
@@ -904,6 +921,15 @@ mod tests {
                 Some(10),
             ]
         );
+    }
+
+    #[test]
+    fn page_range_honors_zero_boundary_count() {
+        let range = page_range(5, 10, 1, 0);
+
+        assert_eq!(range, vec![None, Some(4), Some(5), Some(6), None]);
+        assert!(!range.contains(&Some(1)));
+        assert!(!range.contains(&Some(10)));
     }
 
     #[test]

--- a/crates/ars-components/src/navigation/pagination/mod.rs
+++ b/crates/ars-components/src/navigation/pagination/mod.rs
@@ -428,16 +428,10 @@ impl ars_core::Machine for Machine {
                 let new_count = Context::compute_page_count(ctx.total_items, new_size);
                 let target = clamp_page(current, new_count);
                 let emit = target != current;
-                let controlled = ctx.page.is_controlled();
 
                 let mut plan = TransitionPlan::context_only(move |ctx: &mut Context| {
                     ctx.page_size = new_size;
                     ctx.page_count = new_count;
-
-                    if controlled {
-                        ctx.page.sync_controlled(Some(target));
-                    }
-
                     ctx.page.set(target);
                 });
 
@@ -1069,7 +1063,7 @@ mod tests {
     }
 
     #[test]
-    fn controlled_set_page_size_clamps_visible_page() {
+    fn controlled_set_page_size_preserves_controlled_page_until_sync() {
         let mut service = service(props().page(10));
 
         let result = service.send(Event::SetPageSize(
@@ -1077,8 +1071,7 @@ mod tests {
         ));
 
         assert_eq!(service.context().page_count, 5);
-        assert_eq!(*service.context().page.get(), 5);
-        assert!(service.connect(&|_| {}).is_last_page());
+        assert_eq!(*service.context().page.get(), 10);
         assert_eq!(result.pending_effects.len(), 1);
         assert_eq!(result.pending_effects[0].name, Effect::PageChange);
     }

--- a/crates/ars-components/src/navigation/pagination/snapshots/ars_components__navigation__pagination__tests__pagination_ellipsis.snap
+++ b/crates/ars-components/src/navigation/pagination/snapshots/ars_components__navigation__pagination__tests__pagination_ellipsis.snap
@@ -1,0 +1,39 @@
+---
+source: crates/ars-components/src/navigation/pagination.rs
+expression: snapshot_attrs(&api.ellipsis_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "ellipsis",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "pagination",
+            ),
+        ),
+        (
+            Aria(
+                Hidden,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "separator",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/navigation/pagination/snapshots/ars_components__navigation__pagination__tests__pagination_next_enabled.snap
+++ b/crates/ars-components/src/navigation/pagination/snapshots/ars_components__navigation__pagination__tests__pagination_next_enabled.snap
@@ -1,0 +1,39 @@
+---
+source: crates/ars-components/src/navigation/pagination.rs
+expression: snapshot_attrs(&api.next_trigger_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "next-trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "pagination",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Go to next page",
+            ),
+        ),
+        (
+            Type,
+            String(
+                "button",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/navigation/pagination/snapshots/ars_components__navigation__pagination__tests__pagination_page_current.snap
+++ b/crates/ars-components/src/navigation/pagination/snapshots/ars_components__navigation__pagination__tests__pagination_page_current.snap
@@ -1,0 +1,63 @@
+---
+source: crates/ars-components/src/navigation/pagination.rs
+expression: snapshot_attrs(&api.page_trigger_attrs(1))
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-current",
+            ),
+            Bool(
+                true,
+            ),
+        ),
+        (
+            Data(
+                "ars-index",
+            ),
+            String(
+                "1",
+            ),
+        ),
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "page-trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "pagination",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Page 1",
+            ),
+        ),
+        (
+            Aria(
+                Current,
+            ),
+            String(
+                "page",
+            ),
+        ),
+        (
+            Type,
+            String(
+                "button",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/navigation/pagination/snapshots/ars_components__navigation__pagination__tests__pagination_prev_disabled.snap
+++ b/crates/ars-components/src/navigation/pagination/snapshots/ars_components__navigation__pagination__tests__pagination_prev_disabled.snap
@@ -1,0 +1,61 @@
+---
+source: crates/ars-components/src/navigation/pagination.rs
+expression: snapshot_attrs(&api.prev_trigger_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-disabled",
+            ),
+            Bool(
+                true,
+            ),
+        ),
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "prev-trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "pagination",
+            ),
+        ),
+        (
+            Aria(
+                Disabled,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Go to previous page",
+            ),
+        ),
+        (
+            Disabled,
+            Bool(
+                true,
+            ),
+        ),
+        (
+            Type,
+            String(
+                "button",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/navigation/pagination/snapshots/ars_components__navigation__pagination__tests__pagination_root.snap
+++ b/crates/ars-components/src/navigation/pagination/snapshots/ars_components__navigation__pagination__tests__pagination_root.snap
@@ -1,0 +1,47 @@
+---
+source: crates/ars-components/src/navigation/pagination.rs
+expression: snapshot_attrs(&api.root_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "pagination",
+            ),
+        ),
+        (
+            Data(
+                "ars-size",
+            ),
+            String(
+                "medium",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Pagination",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "navigation",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/navigation/steps/mod.rs
+++ b/crates/ars-components/src/navigation/steps/mod.rs
@@ -415,7 +415,13 @@ impl ars_core::Machine for Machine {
         props: &Self::Props,
     ) -> Option<TransitionPlan<Self>> {
         match event {
-            Event::GoToStep(target) => step_change_plan(ctx, props, clamp_step(*target, ctx.count)),
+            Event::GoToStep(target) => {
+                if *target >= ctx.count.get() {
+                    return None;
+                }
+
+                step_change_plan(ctx, props, *target)
+            }
 
             Event::NextStep => {
                 let current = *ctx.step.get();
@@ -475,7 +481,6 @@ impl ars_core::Machine for Machine {
 
                 if step >= ctx.count.get()
                     || (status == Status::Current && ctx.step.is_controlled())
-                    || (status != Status::Current && step == *ctx.step.get())
                 {
                     return None;
                 }
@@ -1099,6 +1104,11 @@ mod tests {
 
         assert!(step_change_plan(service.context(), service.props(), 4).is_none());
         assert_eq!(service.context(), &context_before);
+
+        let result = service.send(Event::GoToStep(99));
+
+        assert!(!result.context_changed);
+        assert_eq!(service.context(), &context_before);
     }
 
     #[test]
@@ -1148,6 +1158,35 @@ mod tests {
         assert_eq!(*service.context().step.get(), 1);
         assert_eq!(service.context().statuses[1], Status::Current);
         assert_eq!(service.context().statuses[3], Status::Incomplete);
+    }
+
+    #[test]
+    fn set_status_can_mark_active_step_error() {
+        let mut service = service(props().default_step(1));
+
+        drop(service.send(Event::SetStatus {
+            step: 1,
+            status: Status::Error,
+        }));
+
+        assert_eq!(*service.context().step.get(), 1);
+        assert_eq!(service.context().statuses[1], Status::Error);
+        assert_eq!(
+            service
+                .context()
+                .statuses
+                .iter()
+                .filter(|status| **status == Status::Current)
+                .count(),
+            0
+        );
+        assert_eq!(
+            service
+                .connect(&|_| {})
+                .item_attrs(1)
+                .get(&HtmlAttr::Aria(AriaAttr::Current)),
+            Some("step")
+        );
     }
 
     #[test]

--- a/crates/ars-components/src/navigation/steps/mod.rs
+++ b/crates/ars-components/src/navigation/steps/mod.rs
@@ -869,6 +869,13 @@ fn step_change_plan(ctx: &Context, props: &Props, target: u32) -> Option<Transit
         return None;
     }
 
+    if target > current
+        && let Some(is_valid) = &props.is_step_valid
+        && !is_valid(current)
+    {
+        return None;
+    }
+
     if ctx.linear
         && matches!(target.checked_sub(current), Some(2..))
         && !can_skip_intermediate(props, current, target)
@@ -890,9 +897,9 @@ fn step_change_plan(ctx: &Context, props: &Props, target: u32) -> Option<Transit
         })
         .with_effect(PendingEffect::new(
             Effect::StepChange,
-            |ctx: &Context, props: &Props, _send| {
+            move |_ctx: &Context, props: &Props, _send| {
                 if let Some(callback) = &props.on_step_change {
-                    (callback)(*ctx.step.get());
+                    (callback)(target);
                 }
 
                 ars_core::no_cleanup()
@@ -1131,6 +1138,17 @@ mod tests {
     }
 
     #[test]
+    fn validation_blocks_direct_forward_navigation() {
+        let mut service = service(props().is_step_valid(|step| step != 0));
+
+        let result = service.send(Event::GoToStep(1));
+
+        assert!(!result.context_changed);
+        assert!(result.pending_effects.is_empty());
+        assert_eq!(*service.context().step.get(), 0);
+    }
+
+    #[test]
     fn step_change_and_complete_effects_run_callbacks() {
         let changed = Arc::new(Mutex::new(Vec::new()));
         let completed = Arc::new(Mutex::new(0usize));
@@ -1165,6 +1183,29 @@ mod tests {
 
         assert_eq!(lock(&changed).as_slice(), &[1]);
         assert_eq!(*lock(&completed), 1);
+    }
+
+    #[test]
+    fn controlled_step_change_callback_receives_requested_target() {
+        let changed = Arc::new(Mutex::new(Vec::new()));
+        let changed_clone = Arc::clone(&changed);
+        let mut service = service(
+            props()
+                .step(1)
+                .on_step_change(move |step| lock(&changed_clone).push(step)),
+        );
+
+        let result = service.send(Event::GoToStep(3));
+
+        assert_eq!(*service.context().step.get(), 1);
+
+        let send: StrongSend<Event> = Arc::new(|_| {});
+
+        for effect in result.pending_effects {
+            drop(effect.run(service.context(), service.props(), Arc::clone(&send)));
+        }
+
+        assert_eq!(lock(&changed).as_slice(), &[3]);
     }
 
     #[test]

--- a/crates/ars-components/src/navigation/steps/mod.rs
+++ b/crates/ars-components/src/navigation/steps/mod.rs
@@ -1,0 +1,1281 @@
+//! Steps navigation component.
+//!
+//! Steps owns the agnostic progress state for multi-step workflows:
+//! current-step tracking, per-step statuses, linear navigation guards,
+//! validation/skippable callbacks, orientation attributes, and completion
+//! effect intents.
+
+use alloc::{
+    format,
+    string::{String, ToString as _},
+    sync::Arc,
+    vec,
+    vec::Vec,
+};
+use core::{
+    cmp::Ordering,
+    fmt::{self, Debug},
+    num::NonZeroU32,
+};
+
+use ars_core::{
+    AriaAttr, AttrMap, Bindable, Callback, ComponentIds, ComponentMessages, ComponentPart,
+    ConnectApi, Env, HtmlAttr, Locale, MessageFn, Orientation, PendingEffect, TransitionPlan,
+};
+
+/// The only steps machine state.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum State {
+    /// Current step is tracked in context.
+    #[default]
+    Idle,
+}
+
+/// Status of a single step.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Status {
+    /// The step has not been visited.
+    Incomplete,
+
+    /// The step is the active step.
+    Current,
+
+    /// The step is complete.
+    Complete,
+
+    /// The step has an error.
+    Error,
+}
+
+impl Status {
+    /// Returns the token rendered into `data-ars-state`.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Incomplete => "incomplete",
+            Self::Current => "current",
+            Self::Complete => "complete",
+            Self::Error => "error",
+        }
+    }
+}
+
+/// Events accepted by the steps state machine.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Event {
+    /// Navigate directly to a zero-based step.
+    GoToStep(u32),
+
+    /// Advance to the next step.
+    NextStep,
+
+    /// Move to the previous step.
+    PrevStep,
+
+    /// Mark a step as complete.
+    CompleteStep(u32),
+
+    /// Explicitly set a step status.
+    SetStatus {
+        /// Zero-based step index.
+        step: u32,
+
+        /// New step status.
+        status: Status,
+    },
+
+    /// Synchronize render props into context.
+    SyncProps,
+}
+
+/// Typed effect intents emitted by the steps machine.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Effect {
+    /// The active step changed.
+    StepChange,
+
+    /// The user advanced past the final step.
+    Complete,
+}
+
+/// Per-item step label template.
+pub type StepLabelFn = dyn Fn(usize, usize, &Locale) -> String + Send + Sync;
+
+/// Localized steps messages.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Messages {
+    /// Root label.
+    pub root_label: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
+
+    /// Per-item step label template.
+    pub step_label: MessageFn<StepLabelFn>,
+}
+
+impl Default for Messages {
+    fn default() -> Self {
+        Self {
+            root_label: MessageFn::static_str("Steps"),
+            step_label: MessageFn::new(Arc::new(|current: usize, total: usize, _locale: &Locale| {
+                format!("Step {current} of {total}")
+            }) as Arc<StepLabelFn>),
+        }
+    }
+}
+
+impl ComponentMessages for Messages {}
+
+/// Immutable configuration for a [`Steps`](self) instance.
+#[derive(Clone, Debug, PartialEq, ars_core::HasId)]
+pub struct Props {
+    /// Component instance id.
+    pub id: String,
+
+    /// Controlled zero-based current step.
+    pub step: Option<u32>,
+
+    /// Initial uncontrolled zero-based step.
+    pub default_step: u32,
+
+    /// Total step count.
+    pub count: NonZeroU32,
+
+    /// Optional initial status list.
+    pub statuses: Option<Vec<Status>>,
+
+    /// Whether forward navigation is restricted to sequential advancement.
+    pub linear: bool,
+
+    /// Optional validation callback for the current step before advancing.
+    pub is_step_valid: Option<Callback<dyn Fn(u32) -> bool + Send + Sync>>,
+
+    /// Optional predicate that allows intermediate steps to be skipped.
+    pub is_step_skippable: Option<Callback<dyn Fn(u32) -> bool + Send + Sync>>,
+
+    /// Callback fired by the step-change effect.
+    pub on_step_change: Option<Callback<dyn Fn(u32) + Send + Sync>>,
+
+    /// Callback fired by the completion effect.
+    pub on_complete: Option<Callback<dyn Fn() + Send + Sync>>,
+
+    /// Visual stacking axis.
+    pub orientation: Orientation,
+}
+
+impl Default for Props {
+    fn default() -> Self {
+        Self {
+            id: String::new(),
+            step: None,
+            default_step: 0,
+            count: NonZeroU32::new(1).expect("literal is non-zero"),
+            statuses: None,
+            linear: false,
+            is_step_valid: None,
+            is_step_skippable: None,
+            on_step_change: None,
+            on_complete: None,
+            orientation: Orientation::Horizontal,
+        }
+    }
+}
+
+impl Props {
+    /// Returns default steps props.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets [`id`](Self::id).
+    #[must_use]
+    pub fn id(mut self, id: impl Into<String>) -> Self {
+        self.id = id.into();
+        self
+    }
+
+    /// Sets [`step`](Self::step).
+    #[must_use]
+    pub const fn step(mut self, step: u32) -> Self {
+        self.step = Some(step);
+        self
+    }
+
+    /// Clears [`step`](Self::step), switching to uncontrolled mode.
+    #[must_use]
+    pub const fn uncontrolled(mut self) -> Self {
+        self.step = None;
+        self
+    }
+
+    /// Sets [`default_step`](Self::default_step).
+    #[must_use]
+    pub const fn default_step(mut self, step: u32) -> Self {
+        self.default_step = step;
+        self
+    }
+
+    /// Sets [`count`](Self::count).
+    #[must_use]
+    pub const fn count(mut self, count: NonZeroU32) -> Self {
+        self.count = count;
+        self
+    }
+
+    /// Sets [`statuses`](Self::statuses).
+    #[must_use]
+    pub fn statuses(mut self, statuses: Vec<Status>) -> Self {
+        self.statuses = Some(statuses);
+        self
+    }
+
+    /// Sets [`linear`](Self::linear).
+    #[must_use]
+    pub const fn linear(mut self, linear: bool) -> Self {
+        self.linear = linear;
+        self
+    }
+
+    /// Sets [`is_step_valid`](Self::is_step_valid).
+    #[must_use]
+    pub fn is_step_valid(
+        mut self,
+        callback: impl Into<Callback<dyn Fn(u32) -> bool + Send + Sync>>,
+    ) -> Self {
+        self.is_step_valid = Some(callback.into());
+        self
+    }
+
+    /// Sets [`is_step_skippable`](Self::is_step_skippable).
+    #[must_use]
+    pub fn is_step_skippable(
+        mut self,
+        callback: impl Into<Callback<dyn Fn(u32) -> bool + Send + Sync>>,
+    ) -> Self {
+        self.is_step_skippable = Some(callback.into());
+        self
+    }
+
+    /// Sets [`on_step_change`](Self::on_step_change).
+    #[must_use]
+    pub fn on_step_change(
+        mut self,
+        callback: impl Into<Callback<dyn Fn(u32) + Send + Sync>>,
+    ) -> Self {
+        self.on_step_change = Some(callback.into());
+        self
+    }
+
+    /// Sets [`on_complete`](Self::on_complete).
+    #[must_use]
+    pub fn on_complete(mut self, callback: impl Into<Callback<dyn Fn() + Send + Sync>>) -> Self {
+        self.on_complete = Some(callback.into());
+        self
+    }
+
+    /// Sets [`orientation`](Self::orientation).
+    #[must_use]
+    pub const fn orientation(mut self, orientation: Orientation) -> Self {
+        self.orientation = orientation;
+        self
+    }
+}
+
+/// Runtime context for the steps machine.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Context {
+    /// Current zero-based step.
+    pub step: Bindable<u32>,
+
+    /// Total step count.
+    pub count: NonZeroU32,
+
+    /// Per-step statuses.
+    pub statuses: Vec<Status>,
+
+    /// Whether linear mode is enabled.
+    pub linear: bool,
+
+    /// Visual stacking axis.
+    pub orientation: Orientation,
+
+    /// Stable ids derived from props.
+    pub ids: ComponentIds,
+
+    /// Active locale.
+    pub locale: Locale,
+
+    /// Localized messages.
+    pub messages: Messages,
+}
+
+/// Anatomy parts exposed by the steps connect API.
+#[derive(ComponentPart)]
+#[scope = "steps"]
+pub enum Part {
+    /// Root wrapper.
+    Root,
+
+    /// List container.
+    List,
+
+    /// Step item.
+    Item {
+        /// Zero-based step index.
+        index: u32,
+    },
+
+    /// Step indicator.
+    Indicator {
+        /// Zero-based step index.
+        index: u32,
+    },
+
+    /// Step title.
+    Title {
+        /// Zero-based step index.
+        index: u32,
+    },
+
+    /// Step description.
+    Description {
+        /// Zero-based step index.
+        index: u32,
+    },
+
+    /// Progress separator after a step.
+    Separator {
+        /// Zero-based step index before this separator.
+        after_index: u32,
+    },
+
+    /// Step content panel.
+    Content {
+        /// Zero-based step index.
+        index: u32,
+    },
+
+    /// Previous-step trigger.
+    PrevTrigger,
+
+    /// Next-step trigger.
+    NextTrigger,
+}
+
+/// Steps state machine.
+#[derive(Debug)]
+pub struct Machine;
+
+impl ars_core::Machine for Machine {
+    type State = State;
+    type Event = Event;
+    type Context = Context;
+    type Props = Props;
+    type Messages = Messages;
+    type Effect = Effect;
+    type Api<'a> = Api<'a>;
+
+    fn init(
+        props: &Self::Props,
+        env: &Env,
+        messages: &Self::Messages,
+    ) -> (Self::State, Self::Context) {
+        let count = props.count;
+
+        let initial = clamp_step(props.step.unwrap_or(props.default_step), count);
+
+        let step = if props.step.is_some() {
+            Bindable::controlled(initial)
+        } else {
+            Bindable::uncontrolled(initial)
+        };
+
+        (
+            State::Idle,
+            Context {
+                step,
+                count,
+                statuses: normalized_statuses(props.statuses.clone(), count, initial),
+                linear: props.linear,
+                orientation: props.orientation,
+                ids: ComponentIds::from_id(&props.id),
+                locale: env.locale.clone(),
+                messages: messages.clone(),
+            },
+        )
+    }
+
+    fn transition(
+        _state: &Self::State,
+        event: &Self::Event,
+        ctx: &Self::Context,
+        props: &Self::Props,
+    ) -> Option<TransitionPlan<Self>> {
+        match event {
+            Event::GoToStep(target) => step_change_plan(ctx, props, clamp_step(*target, ctx.count)),
+
+            Event::NextStep => {
+                let current = *ctx.step.get();
+
+                if let Some(is_valid) = &props.is_step_valid
+                    && !is_valid(current)
+                {
+                    return None;
+                }
+
+                let next = current + 1;
+
+                if next >= ctx.count.get() {
+                    return Some(
+                        TransitionPlan::context_only(move |ctx: &mut Context| {
+                            if let Some(status) = ctx.statuses.get_mut(current as usize) {
+                                *status = Status::Complete;
+                            }
+                        })
+                        .with_effect(PendingEffect::new(
+                            Effect::Complete,
+                            |_ctx: &Context, props: &Props, _send| {
+                                if let Some(callback) = &props.on_complete {
+                                    (callback)();
+                                }
+
+                                ars_core::no_cleanup()
+                            },
+                        )),
+                    );
+                }
+
+                step_change_plan(ctx, props, next)
+            }
+            Event::PrevStep => {
+                let current = *ctx.step.get();
+
+                if current == 0 {
+                    return None;
+                }
+
+                step_change_plan(ctx, props, current - 1)
+            }
+            Event::CompleteStep(step) => {
+                let step = *step;
+
+                if step >= ctx.count.get() {
+                    return None;
+                }
+
+                Some(TransitionPlan::context_only(move |ctx: &mut Context| {
+                    if let Some(status) = ctx.statuses.get_mut(step as usize) {
+                        *status = Status::Complete;
+                    }
+                }))
+            }
+            Event::SetStatus { step, status } => {
+                let step = *step;
+                let status = *status;
+
+                if step >= ctx.count.get() {
+                    return None;
+                }
+
+                Some(TransitionPlan::context_only(move |ctx: &mut Context| {
+                    if let Some(slot) = ctx.statuses.get_mut(step as usize) {
+                        *slot = status;
+                    }
+
+                    if status == Status::Current {
+                        ctx.step.set(step);
+
+                        normalize_current_status(&mut ctx.statuses, step);
+                    }
+                }))
+            }
+            Event::SyncProps => {
+                let count = props.count;
+                let controlled = props.step.map(|step| clamp_step(step, count));
+                let target = controlled.unwrap_or_else(|| clamp_step(*ctx.step.get(), count));
+                let statuses = normalized_statuses(props.statuses.clone(), count, target);
+                let linear = props.linear;
+                let orientation = props.orientation;
+
+                Some(TransitionPlan::context_only(move |ctx: &mut Context| {
+                    ctx.count = count;
+                    ctx.step.sync_controlled(controlled);
+                    ctx.step.set(target);
+                    ctx.statuses = statuses;
+                    ctx.linear = linear;
+                    ctx.orientation = orientation;
+                }))
+            }
+        }
+    }
+
+    fn connect<'a>(
+        state: &'a Self::State,
+        ctx: &'a Self::Context,
+        props: &'a Self::Props,
+        send: &'a dyn Fn(Self::Event),
+    ) -> Self::Api<'a> {
+        Api {
+            state,
+            ctx,
+            props,
+            send,
+        }
+    }
+
+    fn on_props_changed(old: &Self::Props, new: &Self::Props) -> Vec<Self::Event> {
+        if old.step != new.step
+            || old.default_step != new.default_step
+            || old.count != new.count
+            || old.statuses != new.statuses
+            || old.linear != new.linear
+            || old.orientation != new.orientation
+        {
+            vec![Event::SyncProps]
+        } else {
+            Vec::new()
+        }
+    }
+}
+
+/// Connected API for a [`Steps`](self) service.
+pub struct Api<'a> {
+    /// Current state.
+    state: &'a State,
+
+    /// Current context.
+    ctx: &'a Context,
+
+    /// Current props.
+    props: &'a Props,
+
+    /// Event dispatcher.
+    send: &'a dyn Fn(Event),
+}
+
+impl Debug for Api<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Api")
+            .field("state", self.state)
+            .field("ctx", self.ctx)
+            .field("props", self.props)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Api<'_> {
+    /// Returns the current zero-based step.
+    #[must_use]
+    pub fn current_step(&self) -> u32 {
+        *self.ctx.step.get()
+    }
+
+    /// Returns the total step count.
+    #[must_use]
+    pub const fn step_count(&self) -> u32 {
+        self.ctx.count.get()
+    }
+
+    /// Returns `true` at the first step.
+    #[must_use]
+    pub fn is_first_step(&self) -> bool {
+        self.current_step() == 0
+    }
+
+    /// Returns `true` at the last step.
+    #[must_use]
+    pub fn is_last_step(&self) -> bool {
+        self.current_step() + 1 >= self.ctx.count.get()
+    }
+
+    /// Returns the status for a step.
+    #[must_use]
+    pub fn step_status(&self, index: u32) -> Option<&Status> {
+        self.ctx.statuses.get(index as usize)
+    }
+
+    /// Returns the current state.
+    #[must_use]
+    pub const fn state(&self) -> State {
+        *self.state
+    }
+
+    /// Returns the current props.
+    #[must_use]
+    pub const fn props(&self) -> &Props {
+        self.props
+    }
+
+    /// Attributes for the root wrapper.
+    #[must_use]
+    pub fn root_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_value), (part_attr, part_value)] = Part::Root.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_value)
+            .set(part_attr, part_value)
+            .set(
+                HtmlAttr::Data("ars-orientation"),
+                orientation_token(self.ctx.orientation),
+            )
+            .set(
+                HtmlAttr::Aria(AriaAttr::Label),
+                (self.ctx.messages.root_label)(&self.ctx.locale),
+            );
+
+        attrs
+    }
+
+    /// Attributes for the list container.
+    #[must_use]
+    pub fn list_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_value), (part_attr, part_value)] = Part::List.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_value)
+            .set(part_attr, part_value)
+            .set(HtmlAttr::Role, "list");
+
+        attrs
+    }
+
+    /// Attributes for a step item.
+    #[must_use]
+    pub fn item_attrs(&self, index: u32) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_value), (part_attr, part_value)] =
+            (Part::Item { index }).data_attrs();
+
+        let status = self.status_or_incomplete(index);
+
+        attrs
+            .set(scope_attr, scope_value)
+            .set(part_attr, part_value)
+            .set(HtmlAttr::Data("ars-index"), index.to_string())
+            .set(HtmlAttr::Data("ars-state"), status.as_str())
+            .set(HtmlAttr::Role, "listitem")
+            .set(
+                HtmlAttr::Aria(AriaAttr::Label),
+                (self.ctx.messages.step_label)(
+                    index as usize + 1,
+                    self.ctx.count.get() as usize,
+                    &self.ctx.locale,
+                ),
+            );
+
+        if self.current_step() == index {
+            attrs.set(HtmlAttr::Aria(AriaAttr::Current), "step");
+        }
+
+        attrs
+    }
+
+    /// Attributes for a step indicator.
+    #[must_use]
+    pub fn indicator_attrs(&self, index: u32) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_value), (part_attr, part_value)] =
+            (Part::Indicator { index }).data_attrs();
+
+        attrs
+            .set(scope_attr, scope_value)
+            .set(part_attr, part_value)
+            .set(
+                HtmlAttr::Data("ars-state"),
+                self.status_or_incomplete(index).as_str(),
+            )
+            .set(HtmlAttr::Aria(AriaAttr::Hidden), "true");
+
+        attrs
+    }
+
+    /// Attributes for a step title.
+    #[must_use]
+    pub fn title_attrs(&self, index: u32) -> AttrMap {
+        self.indexed_attrs(&Part::Title { index }, index)
+    }
+
+    /// Attributes for a step description.
+    #[must_use]
+    pub fn description_attrs(&self, index: u32) -> AttrMap {
+        self.indexed_attrs(&Part::Description { index }, index)
+    }
+
+    /// Attributes for a separator after a step.
+    #[must_use]
+    pub fn separator_attrs(&self, after_index: u32) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_value), (part_attr, part_value)] =
+            (Part::Separator { after_index }).data_attrs();
+
+        attrs
+            .set(scope_attr, scope_value)
+            .set(part_attr, part_value)
+            .set(HtmlAttr::Data("ars-index"), after_index.to_string())
+            .set_bool(
+                HtmlAttr::Data("ars-completed"),
+                after_index < self.current_step(),
+            )
+            .set(HtmlAttr::Role, "separator")
+            .set(HtmlAttr::Aria(AriaAttr::Hidden), "true");
+
+        attrs
+    }
+
+    /// Attributes for a step content panel.
+    #[must_use]
+    pub fn content_attrs(&self, index: u32) -> AttrMap {
+        let mut attrs = self.indexed_attrs(&Part::Content { index }, index);
+
+        if self.current_step() != index {
+            attrs.set_bool(HtmlAttr::Hidden, true);
+        }
+
+        attrs
+    }
+
+    /// Attributes for the previous-step trigger.
+    #[must_use]
+    pub fn prev_trigger_attrs(&self) -> AttrMap {
+        let mut attrs = self.button_attrs(&Part::PrevTrigger);
+
+        if self.is_first_step() {
+            attrs
+                .set_bool(HtmlAttr::Disabled, true)
+                .set_bool(HtmlAttr::Data("ars-disabled"), true);
+        }
+
+        attrs
+    }
+
+    /// Attributes for the next-step trigger.
+    #[must_use]
+    pub fn next_trigger_attrs(&self) -> AttrMap {
+        let mut attrs = self.button_attrs(&Part::NextTrigger);
+
+        if self.is_last_step() {
+            attrs
+                .set_bool(HtmlAttr::Disabled, true)
+                .set_bool(HtmlAttr::Data("ars-disabled"), true);
+        }
+
+        attrs
+    }
+
+    /// Dispatches previous-step navigation when not already at the first step.
+    pub fn on_prev_trigger_click(&self) {
+        if !self.is_first_step() {
+            (self.send)(Event::PrevStep);
+        }
+    }
+
+    /// Dispatches next-step navigation when not already at the last step.
+    pub fn on_next_trigger_click(&self) {
+        if !self.is_last_step() {
+            (self.send)(Event::NextStep);
+        }
+    }
+
+    /// Dispatches direct step navigation.
+    pub fn on_item_click(&self, index: u32) {
+        (self.send)(Event::GoToStep(index));
+    }
+
+    fn status_or_incomplete(&self, index: u32) -> Status {
+        self.ctx
+            .statuses
+            .get(index as usize)
+            .copied()
+            .unwrap_or(Status::Incomplete)
+    }
+
+    fn indexed_attrs(&self, part: &Part, index: u32) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_value), (part_attr, part_value)] = part.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_value)
+            .set(part_attr, part_value)
+            .set(HtmlAttr::Data("ars-index"), index.to_string());
+
+        attrs
+    }
+
+    fn button_attrs(&self, part: &Part) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_value), (part_attr, part_value)] = part.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_value)
+            .set(part_attr, part_value)
+            .set(HtmlAttr::Type, "button");
+
+        attrs
+    }
+}
+
+impl ConnectApi for Api<'_> {
+    type Part = Part;
+
+    fn part_attrs(&self, part: Part) -> AttrMap {
+        match part {
+            Part::Root => self.root_attrs(),
+            Part::List => self.list_attrs(),
+            Part::Item { index } => self.item_attrs(index),
+            Part::Indicator { index } => self.indicator_attrs(index),
+            Part::Title { index } => self.title_attrs(index),
+            Part::Description { index } => self.description_attrs(index),
+            Part::Separator { after_index } => self.separator_attrs(after_index),
+            Part::Content { index } => self.content_attrs(index),
+            Part::PrevTrigger => self.prev_trigger_attrs(),
+            Part::NextTrigger => self.next_trigger_attrs(),
+        }
+    }
+}
+
+fn clamp_step(step: u32, count: NonZeroU32) -> u32 {
+    step.min(count.get().saturating_sub(1))
+}
+
+fn normalized_statuses(
+    statuses: Option<Vec<Status>>,
+    count: NonZeroU32,
+    current: u32,
+) -> Vec<Status> {
+    let mut statuses = statuses.unwrap_or_else(|| vec![Status::Incomplete; count.get() as usize]);
+
+    statuses.resize(count.get() as usize, Status::Incomplete);
+
+    normalize_current_status(&mut statuses, current);
+
+    statuses
+}
+
+fn normalize_current_status(statuses: &mut [Status], current: u32) {
+    for (index, status) in statuses.iter_mut().enumerate() {
+        if index as u32 == current {
+            *status = Status::Current;
+        } else if *status == Status::Current {
+            *status = Status::Incomplete;
+        }
+    }
+}
+
+fn step_change_plan(ctx: &Context, props: &Props, target: u32) -> Option<TransitionPlan<Machine>> {
+    let current = *ctx.step.get();
+
+    if target == current || target >= ctx.count.get() {
+        return None;
+    }
+
+    if ctx.linear
+        && matches!(target.checked_sub(current), Some(2..))
+        && !can_skip_intermediate(props, current, target)
+    {
+        return None;
+    }
+
+    Some(
+        TransitionPlan::context_only(move |ctx: &mut Context| {
+            if matches!(target.cmp(&current), Ordering::Greater)
+                && let Some(status) = ctx.statuses.get_mut(current as usize)
+            {
+                *status = Status::Complete;
+            }
+
+            normalize_current_status(&mut ctx.statuses, target);
+
+            ctx.step.set(target);
+        })
+        .with_effect(PendingEffect::new(
+            Effect::StepChange,
+            |ctx: &Context, props: &Props, _send| {
+                if let Some(callback) = &props.on_step_change {
+                    (callback)(*ctx.step.get());
+                }
+
+                ars_core::no_cleanup()
+            },
+        )),
+    )
+}
+
+fn can_skip_intermediate(props: &Props, current: u32, target: u32) -> bool {
+    let Some(is_skippable) = &props.is_step_skippable else {
+        return false;
+    };
+
+    (current + 1..target).all(is_skippable.as_ref())
+}
+
+const fn orientation_token(orientation: Orientation) -> &'static str {
+    match orientation {
+        Orientation::Horizontal => "horizontal",
+        Orientation::Vertical => "vertical",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::{format, sync::Arc, vec, vec::Vec};
+    use std::sync::{Mutex, MutexGuard};
+
+    use ars_core::{Service, StrongSend};
+
+    use super::*;
+
+    fn props() -> Props {
+        Props::new()
+            .id("steps")
+            .count(NonZeroU32::new(4).expect("non-zero"))
+    }
+
+    fn service(props: Props) -> Service<Machine> {
+        Service::<Machine>::new(props, &Env::default(), &Messages::default())
+    }
+
+    fn snapshot_attrs(attrs: &AttrMap) -> String {
+        format!("{attrs:#?}")
+    }
+
+    fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+        mutex.lock().expect("test mutex should not be poisoned")
+    }
+
+    #[test]
+    fn attrs_cover_all_step_anatomy_parts() {
+        let service = service(
+            props()
+                .default_step(1)
+                .orientation(Orientation::Vertical)
+                .statuses(vec![
+                    Status::Complete,
+                    Status::Current,
+                    Status::Incomplete,
+                    Status::Error,
+                ]),
+        );
+        let api = service.connect(&|_| {});
+
+        insta::assert_snapshot!("steps_root_vertical", snapshot_attrs(&api.root_attrs()));
+        insta::assert_snapshot!("steps_list", snapshot_attrs(&api.list_attrs()));
+        insta::assert_snapshot!("steps_item_current", snapshot_attrs(&api.item_attrs(1)));
+        insta::assert_snapshot!("steps_item_error", snapshot_attrs(&api.item_attrs(3)));
+        insta::assert_snapshot!(
+            "steps_indicator_complete",
+            snapshot_attrs(&api.indicator_attrs(0))
+        );
+        insta::assert_snapshot!("steps_title", snapshot_attrs(&api.title_attrs(1)));
+        insta::assert_snapshot!(
+            "steps_description",
+            snapshot_attrs(&api.description_attrs(1))
+        );
+        insta::assert_snapshot!(
+            "steps_separator_completed",
+            snapshot_attrs(&api.separator_attrs(0))
+        );
+        insta::assert_snapshot!(
+            "steps_content_visible",
+            snapshot_attrs(&api.content_attrs(1))
+        );
+        insta::assert_snapshot!(
+            "steps_content_hidden",
+            snapshot_attrs(&api.content_attrs(2))
+        );
+        insta::assert_snapshot!(
+            "steps_prev_enabled",
+            snapshot_attrs(&api.prev_trigger_attrs())
+        );
+        insta::assert_snapshot!(
+            "steps_next_enabled",
+            snapshot_attrs(&api.next_trigger_attrs())
+        );
+    }
+
+    #[test]
+    fn first_and_last_steps_disable_respective_triggers() {
+        let first = service(props().default_step(0));
+
+        assert!(
+            first
+                .connect(&|_| {})
+                .prev_trigger_attrs()
+                .get_value(&HtmlAttr::Disabled)
+                .is_some()
+        );
+
+        let last = service(props().default_step(3));
+
+        assert!(
+            last.connect(&|_| {})
+                .next_trigger_attrs()
+                .get_value(&HtmlAttr::Disabled)
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn next_prev_and_direct_navigation_update_statuses() {
+        let mut service = service(props().default_step(0));
+
+        drop(service.send(Event::NextStep));
+
+        assert_eq!(*service.context().step.get(), 1);
+        assert_eq!(service.context().statuses[0], Status::Complete);
+        assert_eq!(service.context().statuses[1], Status::Current);
+
+        drop(service.send(Event::PrevStep));
+
+        assert_eq!(*service.context().step.get(), 0);
+        assert_eq!(service.context().statuses[0], Status::Current);
+        assert_eq!(service.context().statuses[1], Status::Incomplete);
+
+        drop(service.send(Event::GoToStep(3)));
+
+        assert_eq!(*service.context().step.get(), 3);
+        assert_eq!(service.context().statuses[3], Status::Current);
+    }
+
+    #[test]
+    fn current_and_out_of_range_navigation_are_noops() {
+        let mut service = service(props().default_step(1));
+
+        let result = service.send(Event::GoToStep(1));
+
+        assert!(!result.context_changed);
+        assert_eq!(*service.context().step.get(), 1);
+
+        let context_before = service.context().clone();
+
+        assert!(step_change_plan(service.context(), service.props(), 4).is_none());
+        assert_eq!(service.context(), &context_before);
+    }
+
+    #[test]
+    fn complete_and_status_events_ignore_out_of_range_steps() {
+        let mut service = service(props().default_step(1));
+
+        let before = service.context().clone();
+
+        let result = service.send(Event::CompleteStep(4));
+
+        assert!(!result.context_changed);
+        assert_eq!(service.context(), &before);
+
+        let result = service.send(Event::SetStatus {
+            step: 4,
+            status: Status::Error,
+        });
+
+        assert!(!result.context_changed);
+        assert_eq!(service.context(), &before);
+    }
+
+    #[test]
+    fn set_status_current_moves_active_step_and_normalizes() {
+        let mut service = service(props().default_step(1));
+
+        drop(service.send(Event::SetStatus {
+            step: 3,
+            status: Status::Current,
+        }));
+
+        assert_eq!(*service.context().step.get(), 3);
+        assert_eq!(service.context().statuses[1], Status::Incomplete);
+        assert_eq!(service.context().statuses[3], Status::Current);
+    }
+
+    #[test]
+    fn linear_mode_blocks_skipping_without_skippable_callback() {
+        let mut service = service(props().linear(true));
+
+        let result = service.send(Event::GoToStep(3));
+
+        assert!(!result.context_changed);
+        assert_eq!(*service.context().step.get(), 0);
+    }
+
+    #[test]
+    fn linear_mode_allows_adjacent_next_step() {
+        let mut service = service(props().linear(true));
+
+        drop(service.send(Event::NextStep));
+
+        assert_eq!(*service.context().step.get(), 1);
+        assert_eq!(service.context().statuses[0], Status::Complete);
+        assert_eq!(service.context().statuses[1], Status::Current);
+    }
+
+    #[test]
+    fn linear_mode_allows_skip_when_intermediate_steps_are_skippable() {
+        let mut service = service(
+            props()
+                .linear(true)
+                .is_step_skippable(|step| step == 1 || step == 2),
+        );
+
+        drop(service.send(Event::GoToStep(3)));
+
+        assert_eq!(*service.context().step.get(), 3);
+    }
+
+    #[test]
+    fn validation_blocks_next_step() {
+        let mut service = service(props().is_step_valid(|_| false));
+
+        let result = service.send(Event::NextStep);
+
+        assert!(!result.context_changed);
+        assert_eq!(*service.context().step.get(), 0);
+    }
+
+    #[test]
+    fn step_change_and_complete_effects_run_callbacks() {
+        let changed = Arc::new(Mutex::new(Vec::new()));
+        let completed = Arc::new(Mutex::new(0usize));
+        let changed_clone = Arc::clone(&changed);
+        let completed_clone = Arc::clone(&completed);
+
+        let mut service = service(
+            Props::new()
+                .id("steps")
+                .count(NonZeroU32::new(2).expect("non-zero"))
+                .on_step_change(move |step| lock(&changed_clone).push(step))
+                .on_complete(move || *lock(&completed_clone) += 1),
+        );
+
+        let send: StrongSend<Event> = Arc::new(|_| {});
+
+        let result = service.send(Event::NextStep);
+
+        assert_eq!(result.pending_effects[0].name, Effect::StepChange);
+
+        for effect in result.pending_effects {
+            drop(effect.run(service.context(), service.props(), Arc::clone(&send)));
+        }
+
+        let result = service.send(Event::NextStep);
+
+        assert_eq!(result.pending_effects[0].name, Effect::Complete);
+
+        for effect in result.pending_effects {
+            drop(effect.run(service.context(), service.props(), Arc::clone(&send)));
+        }
+
+        assert_eq!(lock(&changed).as_slice(), &[1]);
+        assert_eq!(*lock(&completed), 1);
+    }
+
+    #[test]
+    fn api_handlers_dispatch_navigation_events() {
+        let sent = core::cell::RefCell::new(Vec::new());
+        let send = |event| sent.borrow_mut().push(event);
+
+        let service = service(props().default_step(1));
+
+        let api = service.connect(&send);
+
+        api.on_prev_trigger_click();
+        api.on_next_trigger_click();
+        api.on_item_click(3);
+
+        assert_eq!(
+            sent.borrow().as_slice(),
+            &[Event::PrevStep, Event::NextStep, Event::GoToStep(3)]
+        );
+    }
+
+    #[test]
+    fn api_reports_count_status_and_separator_completion() {
+        let service = service(props().default_step(1).statuses(vec![
+            Status::Complete,
+            Status::Current,
+            Status::Incomplete,
+            Status::Error,
+        ]));
+
+        let api = service.connect(&|_| {});
+
+        assert_eq!(api.step_count(), 4);
+        assert_eq!(api.step_status(0), Some(&Status::Complete));
+        assert_eq!(api.step_status(3), Some(&Status::Error));
+        assert_eq!(api.step_status(4), None);
+        assert_eq!(
+            api.separator_attrs(0).get(&HtmlAttr::Data("ars-completed")),
+            Some("true")
+        );
+        assert_eq!(
+            api.separator_attrs(1).get(&HtmlAttr::Data("ars-completed")),
+            Some("false")
+        );
+    }
+
+    #[test]
+    fn on_props_changed_detects_each_context_field() {
+        let old = props()
+            .step(1)
+            .default_step(2)
+            .statuses(vec![
+                Status::Complete,
+                Status::Current,
+                Status::Incomplete,
+                Status::Error,
+            ])
+            .linear(true)
+            .orientation(Orientation::Vertical);
+
+        assert!(<Machine as ars_core::Machine>::on_props_changed(&old, &old).is_empty());
+
+        for new in [
+            old.clone().step(2),
+            old.clone().default_step(3),
+            old.clone()
+                .count(NonZeroU32::new(5).expect("non-zero step count")),
+            old.clone().statuses(vec![
+                Status::Current,
+                Status::Incomplete,
+                Status::Complete,
+                Status::Error,
+            ]),
+            old.clone().linear(false),
+            old.clone().orientation(Orientation::Horizontal),
+        ] {
+            assert_eq!(
+                <Machine as ars_core::Machine>::on_props_changed(&old, &new),
+                [Event::SyncProps],
+                "expected SyncProps for {new:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn part_attrs_dispatches_every_part() {
+        let service = service(props().default_step(1));
+
+        let api = service.connect(&|_| {});
+
+        assert_eq!(api.part_attrs(Part::Root), api.root_attrs());
+        assert_eq!(api.part_attrs(Part::List), api.list_attrs());
+        assert_eq!(api.part_attrs(Part::Item { index: 1 }), api.item_attrs(1));
+        assert_eq!(
+            api.part_attrs(Part::Indicator { index: 1 }),
+            api.indicator_attrs(1)
+        );
+        assert_eq!(api.part_attrs(Part::Title { index: 1 }), api.title_attrs(1));
+        assert_eq!(
+            api.part_attrs(Part::Description { index: 1 }),
+            api.description_attrs(1)
+        );
+        assert_eq!(
+            api.part_attrs(Part::Separator { after_index: 0 }),
+            api.separator_attrs(0)
+        );
+        assert_eq!(
+            api.part_attrs(Part::Content { index: 1 }),
+            api.content_attrs(1)
+        );
+        assert_eq!(api.part_attrs(Part::PrevTrigger), api.prev_trigger_attrs());
+        assert_eq!(api.part_attrs(Part::NextTrigger), api.next_trigger_attrs());
+    }
+}

--- a/crates/ars-components/src/navigation/steps/mod.rs
+++ b/crates/ars-components/src/navigation/steps/mod.rs
@@ -292,6 +292,9 @@ pub struct Context {
     /// Per-step statuses.
     pub statuses: Vec<Status>,
 
+    /// Last status prop seen by sync, used to preserve runtime progress across unrelated prop changes.
+    pub statuses_prop: Option<Vec<Status>>,
+
     /// Whether linear mode is enabled.
     pub linear: bool,
 
@@ -395,6 +398,7 @@ impl ars_core::Machine for Machine {
                 step,
                 count,
                 statuses: normalized_statuses(props.statuses.clone(), count, initial),
+                statuses_prop: props.statuses.clone(),
                 linear: props.linear,
                 orientation: props.orientation,
                 ids: ComponentIds::from_id(&props.id),
@@ -492,7 +496,12 @@ impl ars_core::Machine for Machine {
                 let count = props.count;
                 let controlled = props.step.map(|step| clamp_step(step, count));
                 let target = controlled.unwrap_or_else(|| clamp_step(*ctx.step.get(), count));
-                let statuses = normalized_statuses(props.statuses.clone(), count, target);
+                let statuses_prop = props.statuses.clone();
+                let statuses = if statuses_prop == ctx.statuses_prop {
+                    normalized_statuses(Some(ctx.statuses.clone()), count, target)
+                } else {
+                    normalized_statuses(statuses_prop.clone(), count, target)
+                };
                 let linear = props.linear;
                 let orientation = props.orientation;
 
@@ -501,6 +510,7 @@ impl ars_core::Machine for Machine {
                     ctx.step.sync_controlled(controlled);
                     ctx.step.set(target);
                     ctx.statuses = statuses;
+                    ctx.statuses_prop = statuses_prop;
                     ctx.linear = linear;
                     ctx.orientation = orientation;
                 }))
@@ -1091,6 +1101,25 @@ mod tests {
         assert_eq!(*service.context().step.get(), 3);
         assert_eq!(service.context().statuses[1], Status::Incomplete);
         assert_eq!(service.context().statuses[3], Status::Current);
+    }
+
+    #[test]
+    fn sync_props_preserves_runtime_statuses_when_status_prop_is_unchanged() {
+        let mut service = service(props().default_step(0));
+
+        drop(service.send(Event::NextStep));
+        drop(service.send(Event::SetStatus {
+            step: 2,
+            status: Status::Error,
+        }));
+
+        drop(service.set_props(props().default_step(0).orientation(Orientation::Vertical)));
+
+        assert_eq!(*service.context().step.get(), 1);
+        assert_eq!(service.context().statuses[0], Status::Complete);
+        assert_eq!(service.context().statuses[1], Status::Current);
+        assert_eq!(service.context().statuses[2], Status::Error);
+        assert_eq!(service.context().orientation, Orientation::Vertical);
     }
 
     #[test]

--- a/crates/ars-components/src/navigation/steps/mod.rs
+++ b/crates/ars-components/src/navigation/steps/mod.rs
@@ -430,21 +430,18 @@ impl ars_core::Machine for Machine {
 
                 if next >= ctx.count.get() {
                     return Some(
-                        TransitionPlan::context_only(move |ctx: &mut Context| {
-                            if let Some(status) = ctx.statuses.get_mut(current as usize) {
-                                *status = Status::Complete;
-                            }
-                        })
-                        .with_effect(PendingEffect::new(
-                            Effect::Complete,
-                            |_ctx: &Context, props: &Props, _send| {
-                                if let Some(callback) = &props.on_complete {
-                                    (callback)();
-                                }
+                        TransitionPlan::context_only(|_ctx: &mut Context| {}).with_effect(
+                            PendingEffect::new(
+                                Effect::Complete,
+                                |_ctx: &Context, props: &Props, _send| {
+                                    if let Some(callback) = &props.on_complete {
+                                        (callback)();
+                                    }
 
-                                ars_core::no_cleanup()
-                            },
-                        )),
+                                    ars_core::no_cleanup()
+                                },
+                            ),
+                        ),
                     );
                 }
 
@@ -462,7 +459,7 @@ impl ars_core::Machine for Machine {
             Event::CompleteStep(step) => {
                 let step = *step;
 
-                if step >= ctx.count.get() {
+                if step >= ctx.count.get() || step == *ctx.step.get() {
                     return None;
                 }
 
@@ -476,19 +473,24 @@ impl ars_core::Machine for Machine {
                 let step = *step;
                 let status = *status;
 
-                if step >= ctx.count.get() {
+                if step >= ctx.count.get()
+                    || (status == Status::Current && ctx.step.is_controlled())
+                    || (status != Status::Current && step == *ctx.step.get())
+                {
                     return None;
                 }
 
                 Some(TransitionPlan::context_only(move |ctx: &mut Context| {
-                    if let Some(slot) = ctx.statuses.get_mut(step as usize) {
-                        *slot = status;
-                    }
-
                     if status == Status::Current {
+                        if let Some(slot) = ctx.statuses.get_mut(step as usize) {
+                            *slot = status;
+                        }
+
                         ctx.step.set(step);
 
                         normalize_current_status(&mut ctx.statuses, step);
+                    } else if let Some(slot) = ctx.statuses.get_mut(step as usize) {
+                        *slot = status;
                     }
                 }))
             }
@@ -893,8 +895,14 @@ fn step_change_plan(ctx: &Context, props: &Props, target: u32) -> Option<Transit
         return None;
     }
 
+    let controlled = ctx.step.is_controlled();
+
     Some(
         TransitionPlan::context_only(move |ctx: &mut Context| {
+            if controlled {
+                return;
+            }
+
             if matches!(target.cmp(&current), Ordering::Greater)
                 && let Some(status) = ctx.statuses.get_mut(current as usize)
             {
@@ -1055,6 +1063,30 @@ mod tests {
     }
 
     #[test]
+    fn controlled_navigation_keeps_statuses_aligned_until_prop_sync() {
+        let mut service = service(props().step(1));
+
+        drop(service.send(Event::NextStep));
+
+        assert_eq!(*service.context().step.get(), 1);
+        assert_eq!(service.context().statuses[1], Status::Current);
+        assert_eq!(
+            service
+                .context()
+                .statuses
+                .iter()
+                .filter(|status| **status == Status::Current)
+                .count(),
+            1
+        );
+
+        drop(service.set_props(props().step(2)));
+
+        assert_eq!(*service.context().step.get(), 2);
+        assert_eq!(service.context().statuses[2], Status::Current);
+    }
+
+    #[test]
     fn current_and_out_of_range_navigation_are_noops() {
         let mut service = service(props().default_step(1));
 
@@ -1100,6 +1132,45 @@ mod tests {
 
         assert_eq!(*service.context().step.get(), 3);
         assert_eq!(service.context().statuses[1], Status::Incomplete);
+        assert_eq!(service.context().statuses[3], Status::Current);
+    }
+
+    #[test]
+    fn controlled_set_status_current_keeps_statuses_aligned() {
+        let mut service = service(props().step(1));
+
+        let result = service.send(Event::SetStatus {
+            step: 3,
+            status: Status::Current,
+        });
+
+        assert!(!result.context_changed);
+        assert_eq!(*service.context().step.get(), 1);
+        assert_eq!(service.context().statuses[1], Status::Current);
+        assert_eq!(service.context().statuses[3], Status::Incomplete);
+    }
+
+    #[test]
+    fn completing_current_step_preserves_current_status() {
+        let mut service = service(props().default_step(3));
+
+        drop(service.send(Event::NextStep));
+
+        assert_eq!(*service.context().step.get(), 3);
+        assert_eq!(service.context().statuses[3], Status::Current);
+        assert_eq!(
+            service
+                .context()
+                .statuses
+                .iter()
+                .filter(|status| **status == Status::Current)
+                .count(),
+            1
+        );
+
+        drop(service.send(Event::CompleteStep(3)));
+
+        assert_eq!(*service.context().step.get(), 3);
         assert_eq!(service.context().statuses[3], Status::Current);
     }
 

--- a/crates/ars-components/src/navigation/steps/mod.rs
+++ b/crates/ars-components/src/navigation/steps/mod.rs
@@ -465,7 +465,7 @@ impl ars_core::Machine for Machine {
             Event::CompleteStep(step) => {
                 let step = *step;
 
-                if step >= ctx.count.get() || step == *ctx.step.get() {
+                if step >= ctx.count.get() {
                     return None;
                 }
 
@@ -769,15 +769,7 @@ impl Api<'_> {
     /// Attributes for the next-step trigger.
     #[must_use]
     pub fn next_trigger_attrs(&self) -> AttrMap {
-        let mut attrs = self.button_attrs(&Part::NextTrigger);
-
-        if self.is_last_step() {
-            attrs
-                .set_bool(HtmlAttr::Disabled, true)
-                .set_bool(HtmlAttr::Data("ars-disabled"), true);
-        }
-
-        attrs
+        self.button_attrs(&Part::NextTrigger)
     }
 
     /// Dispatches previous-step navigation when not already at the first step.
@@ -787,11 +779,9 @@ impl Api<'_> {
         }
     }
 
-    /// Dispatches next-step navigation when not already at the last step.
+    /// Dispatches next-step navigation, including completion from the last step.
     pub fn on_next_trigger_click(&self) {
-        if !self.is_last_step() {
-            (self.send)(Event::NextStep);
-        }
+        (self.send)(Event::NextStep);
     }
 
     /// Dispatches direct step navigation.
@@ -1024,7 +1014,7 @@ mod tests {
     }
 
     #[test]
-    fn first_and_last_steps_disable_respective_triggers() {
+    fn first_step_disables_prev_but_last_step_keeps_next_enabled_for_completion() {
         let first = service(props().default_step(0));
 
         assert!(
@@ -1041,8 +1031,19 @@ mod tests {
             last.connect(&|_| {})
                 .next_trigger_attrs()
                 .get_value(&HtmlAttr::Disabled)
-                .is_some()
+                .is_none()
         );
+    }
+
+    #[test]
+    fn next_trigger_dispatches_completion_from_last_step() {
+        let sent = core::cell::RefCell::new(Vec::new());
+        let send = |event| sent.borrow_mut().push(event);
+        let service = service(props().default_step(3));
+
+        service.connect(&send).on_next_trigger_click();
+
+        assert_eq!(sent.borrow().as_slice(), &[Event::NextStep]);
     }
 
     #[test]
@@ -1190,7 +1191,7 @@ mod tests {
     }
 
     #[test]
-    fn completing_current_step_preserves_current_status() {
+    fn next_step_completion_preserves_current_status() {
         let mut service = service(props().default_step(3));
 
         drop(service.send(Event::NextStep));
@@ -1206,11 +1207,16 @@ mod tests {
                 .count(),
             1
         );
+    }
+
+    #[test]
+    fn complete_step_can_mark_active_step_complete() {
+        let mut service = service(props().default_step(3));
 
         drop(service.send(Event::CompleteStep(3)));
 
         assert_eq!(*service.context().step.get(), 3);
-        assert_eq!(service.context().statuses[3], Status::Current);
+        assert_eq!(service.context().statuses[3], Status::Complete);
     }
 
     #[test]

--- a/crates/ars-components/src/navigation/steps/snapshots/ars_components__navigation__steps__tests__steps_content_hidden.snap
+++ b/crates/ars-components/src/navigation/steps/snapshots/ars_components__navigation__steps__tests__steps_content_hidden.snap
@@ -1,0 +1,39 @@
+---
+source: crates/ars-components/src/navigation/steps.rs
+expression: snapshot_attrs(&api.content_attrs(2))
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-index",
+            ),
+            String(
+                "2",
+            ),
+        ),
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "content",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "steps",
+            ),
+        ),
+        (
+            Hidden,
+            Bool(
+                true,
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/navigation/steps/snapshots/ars_components__navigation__steps__tests__steps_content_visible.snap
+++ b/crates/ars-components/src/navigation/steps/snapshots/ars_components__navigation__steps__tests__steps_content_visible.snap
@@ -1,0 +1,33 @@
+---
+source: crates/ars-components/src/navigation/steps.rs
+expression: snapshot_attrs(&api.content_attrs(1))
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-index",
+            ),
+            String(
+                "1",
+            ),
+        ),
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "content",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "steps",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/navigation/steps/snapshots/ars_components__navigation__steps__tests__steps_description.snap
+++ b/crates/ars-components/src/navigation/steps/snapshots/ars_components__navigation__steps__tests__steps_description.snap
@@ -1,0 +1,33 @@
+---
+source: crates/ars-components/src/navigation/steps.rs
+expression: snapshot_attrs(&api.description_attrs(1))
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-index",
+            ),
+            String(
+                "1",
+            ),
+        ),
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "description",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "steps",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/navigation/steps/snapshots/ars_components__navigation__steps__tests__steps_indicator_complete.snap
+++ b/crates/ars-components/src/navigation/steps/snapshots/ars_components__navigation__steps__tests__steps_indicator_complete.snap
@@ -1,0 +1,41 @@
+---
+source: crates/ars-components/src/navigation/steps.rs
+expression: snapshot_attrs(&api.indicator_attrs(0))
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "indicator",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "steps",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "complete",
+            ),
+        ),
+        (
+            Aria(
+                Hidden,
+            ),
+            String(
+                "true",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/navigation/steps/snapshots/ars_components__navigation__steps__tests__steps_item_current.snap
+++ b/crates/ars-components/src/navigation/steps/snapshots/ars_components__navigation__steps__tests__steps_item_current.snap
@@ -1,0 +1,63 @@
+---
+source: crates/ars-components/src/navigation/steps.rs
+expression: snapshot_attrs(&api.item_attrs(1))
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-index",
+            ),
+            String(
+                "1",
+            ),
+        ),
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "item",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "steps",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "current",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Step 2 of 4",
+            ),
+        ),
+        (
+            Aria(
+                Current,
+            ),
+            String(
+                "step",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "listitem",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/navigation/steps/snapshots/ars_components__navigation__steps__tests__steps_item_error.snap
+++ b/crates/ars-components/src/navigation/steps/snapshots/ars_components__navigation__steps__tests__steps_item_error.snap
@@ -1,0 +1,55 @@
+---
+source: crates/ars-components/src/navigation/steps.rs
+expression: snapshot_attrs(&api.item_attrs(3))
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-index",
+            ),
+            String(
+                "3",
+            ),
+        ),
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "item",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "steps",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "error",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Step 4 of 4",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "listitem",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/navigation/steps/snapshots/ars_components__navigation__steps__tests__steps_list.snap
+++ b/crates/ars-components/src/navigation/steps/snapshots/ars_components__navigation__steps__tests__steps_list.snap
@@ -1,0 +1,31 @@
+---
+source: crates/ars-components/src/navigation/steps.rs
+expression: snapshot_attrs(&api.list_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "list",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "steps",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "list",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/navigation/steps/snapshots/ars_components__navigation__steps__tests__steps_next_enabled.snap
+++ b/crates/ars-components/src/navigation/steps/snapshots/ars_components__navigation__steps__tests__steps_next_enabled.snap
@@ -1,0 +1,31 @@
+---
+source: crates/ars-components/src/navigation/steps.rs
+expression: snapshot_attrs(&api.next_trigger_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "next-trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "steps",
+            ),
+        ),
+        (
+            Type,
+            String(
+                "button",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/navigation/steps/snapshots/ars_components__navigation__steps__tests__steps_prev_enabled.snap
+++ b/crates/ars-components/src/navigation/steps/snapshots/ars_components__navigation__steps__tests__steps_prev_enabled.snap
@@ -1,0 +1,31 @@
+---
+source: crates/ars-components/src/navigation/steps.rs
+expression: snapshot_attrs(&api.prev_trigger_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "prev-trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "steps",
+            ),
+        ),
+        (
+            Type,
+            String(
+                "button",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/navigation/steps/snapshots/ars_components__navigation__steps__tests__steps_root_vertical.snap
+++ b/crates/ars-components/src/navigation/steps/snapshots/ars_components__navigation__steps__tests__steps_root_vertical.snap
@@ -1,0 +1,41 @@
+---
+source: crates/ars-components/src/navigation/steps.rs
+expression: snapshot_attrs(&api.root_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-orientation",
+            ),
+            String(
+                "vertical",
+            ),
+        ),
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "steps",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Steps",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/navigation/steps/snapshots/ars_components__navigation__steps__tests__steps_separator_completed.snap
+++ b/crates/ars-components/src/navigation/steps/snapshots/ars_components__navigation__steps__tests__steps_separator_completed.snap
@@ -1,0 +1,55 @@
+---
+source: crates/ars-components/src/navigation/steps.rs
+expression: snapshot_attrs(&api.separator_attrs(0))
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-completed",
+            ),
+            Bool(
+                true,
+            ),
+        ),
+        (
+            Data(
+                "ars-index",
+            ),
+            String(
+                "0",
+            ),
+        ),
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "separator",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "steps",
+            ),
+        ),
+        (
+            Aria(
+                Hidden,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "separator",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/navigation/steps/snapshots/ars_components__navigation__steps__tests__steps_title.snap
+++ b/crates/ars-components/src/navigation/steps/snapshots/ars_components__navigation__steps__tests__steps_title.snap
@@ -1,0 +1,33 @@
+---
+source: crates/ars-components/src/navigation/steps.rs
+expression: snapshot_attrs(&api.title_attrs(1))
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-index",
+            ),
+            String(
+                "1",
+            ),
+        ),
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "title",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "steps",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/tests/proptest_state_machines/navigation.rs
+++ b/crates/ars-components/tests/proptest_state_machines/navigation.rs
@@ -598,15 +598,21 @@ fn assert_steps_invariants(service: &Service<steps::Machine>) -> TestCaseResult 
 
     prop_assert!(step < ctx.count.get());
     prop_assert_eq!(ctx.statuses.len(), ctx.count.get() as usize);
-    prop_assert_eq!(
-        ctx.statuses
-            .iter()
-            .filter(|status| **status == steps::Status::Current)
-            .count(),
-        1,
-        "steps must keep exactly one current status"
+    let current_positions = ctx
+        .statuses
+        .iter()
+        .enumerate()
+        .filter_map(|(index, status)| (*status == steps::Status::Current).then_some(index as u32))
+        .collect::<Vec<_>>();
+
+    prop_assert!(
+        current_positions.len() <= 1,
+        "steps must not keep multiple current statuses"
     );
-    prop_assert_eq!(ctx.statuses[step as usize], steps::Status::Current);
+
+    if let Some(current_position) = current_positions.first() {
+        prop_assert_eq!(*current_position, step);
+    }
 
     Ok(())
 }

--- a/crates/ars-components/tests/proptest_state_machines/navigation.rs
+++ b/crates/ars-components/tests/proptest_state_machines/navigation.rs
@@ -8,8 +8,9 @@
 use std::collections::BTreeSet;
 
 use ars_collections::Key;
-use ars_components::navigation::tabs::{
-    ActivationMode, Effect, Event, Machine, Messages, Props, State, TabRegistration,
+use ars_components::navigation::{
+    pagination, steps,
+    tabs::{ActivationMode, Effect, Event, Machine, Messages, Props, State, TabRegistration},
 };
 use ars_core::{AriaAttr, Direction, Env, HtmlAttr, Machine as MachineTrait, Orientation, Service};
 use proptest::{prelude::*, test_runner::TestCaseResult};
@@ -477,5 +478,183 @@ proptest! {
 
         prop_assert_eq!(api.next_reorder_index(&target, true), expected_next);
         prop_assert_eq!(api.next_reorder_index(&target, false), expected_prev);
+    }
+}
+
+fn arb_pagination_event() -> impl Strategy<Value = pagination::Event> {
+    prop_oneof![
+        (0u32..64).prop_map(pagination::Event::GoToPage),
+        Just(pagination::Event::NextPage),
+        Just(pagination::Event::PrevPage),
+        Just(pagination::Event::GoToFirstPage),
+        Just(pagination::Event::GoToLastPage),
+        (1u32..32).prop_map(|size| pagination::Event::SetPageSize(
+            core::num::NonZeroU32::new(size).expect("range starts at one")
+        )),
+    ]
+}
+
+fn arb_pagination_props() -> impl Strategy<Value = pagination::Props> {
+    (
+        prop::option::of(0u32..64),
+        0u32..64,
+        1u32..32,
+        0u32..256,
+        0u32..4,
+        1u32..3,
+    )
+        .prop_map(
+            |(page, default_page, page_size, total_items, sibling_count, boundary_count)| {
+                let mut props = pagination::Props::new()
+                    .id("pagination")
+                    .default_page(default_page)
+                    .page_size(core::num::NonZeroU32::new(page_size).expect("range starts at one"))
+                    .total_items(total_items)
+                    .sibling_count(sibling_count)
+                    .boundary_count(boundary_count);
+
+                if let Some(page) = page {
+                    props = props.page(page);
+                }
+
+                props
+            },
+        )
+}
+
+fn arb_step_status() -> impl Strategy<Value = steps::Status> {
+    prop_oneof![
+        Just(steps::Status::Incomplete),
+        Just(steps::Status::Current),
+        Just(steps::Status::Complete),
+        Just(steps::Status::Error),
+    ]
+}
+
+fn arb_steps_event() -> impl Strategy<Value = steps::Event> {
+    prop_oneof![
+        (0u32..12).prop_map(steps::Event::GoToStep),
+        Just(steps::Event::NextStep),
+        Just(steps::Event::PrevStep),
+        (0u32..12).prop_map(steps::Event::CompleteStep),
+        (0u32..12, arb_step_status())
+            .prop_map(|(step, status)| steps::Event::SetStatus { step, status }),
+    ]
+}
+
+fn arb_steps_props() -> impl Strategy<Value = steps::Props> {
+    (
+        prop::option::of(0u32..12),
+        0u32..12,
+        1u32..12,
+        any::<bool>(),
+        arb_orientation(),
+        prop::collection::vec(arb_step_status(), 0..12),
+    )
+        .prop_map(
+            |(step, default_step, count, linear, orientation, statuses)| {
+                let mut props = steps::Props::new()
+                    .id("steps")
+                    .default_step(default_step)
+                    .count(core::num::NonZeroU32::new(count).expect("range starts at one"))
+                    .linear(linear)
+                    .orientation(orientation)
+                    .statuses(statuses)
+                    .is_step_skippable(|_| true)
+                    .is_step_valid(|_| true);
+
+                if let Some(step) = step {
+                    props = props.step(step);
+                }
+
+                props
+            },
+        )
+}
+
+fn assert_pagination_invariants(service: &Service<pagination::Machine>) -> TestCaseResult {
+    let ctx = service.context();
+    let page = *ctx.page.get();
+
+    prop_assert!(page >= 1);
+    prop_assert!(page <= ctx.page_count);
+
+    let mut previous = None;
+
+    for entry in ctx.page_range().into_iter().flatten() {
+        if let Some(previous) = previous {
+            prop_assert!(entry > previous, "page range must be strictly increasing");
+        }
+
+        previous = Some(entry);
+    }
+
+    Ok(())
+}
+
+fn assert_steps_invariants(service: &Service<steps::Machine>) -> TestCaseResult {
+    let ctx = service.context();
+    let step = *ctx.step.get();
+
+    prop_assert!(step < ctx.count.get());
+    prop_assert_eq!(ctx.statuses.len(), ctx.count.get() as usize);
+    prop_assert_eq!(
+        ctx.statuses
+            .iter()
+            .filter(|status| **status == steps::Status::Current)
+            .count(),
+        1,
+        "steps must keep exactly one current status"
+    );
+    prop_assert_eq!(ctx.statuses[step as usize], steps::Status::Current);
+
+    Ok(())
+}
+
+proptest! {
+    #![proptest_config(super::common::proptest_config())]
+
+    /// Pagination keeps page state within the derived one-based bounds.
+    #[test]
+    #[ignore = "proptest — nightly extended-proptest job"]
+    fn proptest_pagination_page_bounds_and_ranges_hold(
+        props in arb_pagination_props(),
+        events in prop::collection::vec(arb_pagination_event(), 0..64),
+    ) {
+        let mut service = Service::<pagination::Machine>::new(
+            props,
+            &Env::default(),
+            &pagination::Messages::default(),
+        );
+
+        assert_pagination_invariants(&service)?;
+
+        for event in events {
+            drop(service.send(event));
+
+            assert_pagination_invariants(&service)?;
+        }
+    }
+
+    /// Steps keeps the current index in range and exactly one current status.
+    #[test]
+    #[ignore = "proptest — nightly extended-proptest job"]
+    fn proptest_steps_current_status_invariants_hold(
+        props in arb_steps_props(),
+        events in prop::collection::vec(arb_steps_event(), 0..64),
+    ) {
+        let mut service = Service::<steps::Machine>::new(
+            props,
+            &Env::default(),
+            &steps::Messages::default(),
+        );
+
+        assert_steps_invariants(&service)?;
+
+        for event in events {
+            drop(service.send(event));
+
+            assert_steps_invariants(&service)?;
+        }
     }
 }

--- a/crates/ars-components/tests/spec_conformance/navigation.rs
+++ b/crates/ars-components/tests/spec_conformance/navigation.rs
@@ -5,7 +5,8 @@
 //! matches the declared `(scope, part-name)` ordering.
 
 use ars_collections::Key;
-use ars_components::navigation::tabs;
+use ars_components::navigation::{breadcrumbs, link, pagination, steps, tabs};
+use ars_core::SafeUrl;
 
 use super::helper::assert_anatomy;
 
@@ -46,6 +47,67 @@ fn tabs_anatomy_matches_spec() {
                 },
                 "tab-close-trigger",
             ),
+        ],
+    );
+}
+
+#[test]
+fn breadcrumbs_anatomy_matches_spec() {
+    assert_anatomy(
+        "breadcrumbs",
+        &[
+            (breadcrumbs::Part::Root, "root"),
+            (breadcrumbs::Part::List, "list"),
+            (breadcrumbs::Part::Item, "item"),
+            (
+                breadcrumbs::Part::Link {
+                    href: SafeUrl::from_static("/"),
+                },
+                "link",
+            ),
+            (breadcrumbs::Part::CurrentPage, "current-page"),
+            (breadcrumbs::Part::Separator, "separator"),
+        ],
+    );
+}
+
+#[test]
+fn link_anatomy_matches_spec() {
+    assert_anatomy("link", &[(link::Part::Root, "root")]);
+}
+
+#[test]
+fn pagination_anatomy_matches_spec() {
+    assert_anatomy(
+        "pagination",
+        &[
+            (pagination::Part::Root, "root"),
+            (pagination::Part::PrevTrigger, "prev-trigger"),
+            (pagination::Part::NextTrigger, "next-trigger"),
+            (
+                pagination::Part::PageTrigger { page_number: 1 },
+                "page-trigger",
+            ),
+            (pagination::Part::Ellipsis, "ellipsis"),
+        ],
+    );
+}
+
+#[test]
+fn steps_anatomy_matches_spec() {
+    assert_anatomy(
+        "steps",
+        &[
+            (steps::Part::Root, "root"),
+            (steps::Part::List, "list"),
+            (steps::Part::Item { index: 0 }, "item"),
+            (steps::Part::Indicator { index: 0 }, "indicator"),
+            (steps::Part::Title { index: 0 }, "title"),
+            (steps::Part::Description { index: 0 }, "description"),
+            (steps::Part::Separator { after_index: 0 }, "separator"),
+            (steps::Part::Content { index: 0 }, "content"),
+            (steps::Part::PrevTrigger, "prev-trigger"),
+            (steps::Part::NextTrigger, "next-trigger"),
         ],
     );
 }

--- a/crates/ars-core/tests/derive_contract.rs
+++ b/crates/ars-core/tests/derive_contract.rs
@@ -63,6 +63,9 @@ where
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 struct CustomDefaultKey(&'static str);
 
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct CustomAnnotatedKey(&'static str);
+
 #[derive(ComponentPart)]
 #[scope = "named"]
 enum NamedPart {
@@ -95,6 +98,20 @@ enum OrderedPart {
 enum GroupPart {
     Group,
     GroupItem { index: usize },
+}
+
+#[derive(ComponentPart)]
+#[scope = "annotated"]
+enum AnnotatedDefaultPart {
+    Root,
+    Link {
+        #[part(default = CustomAnnotatedKey("root-link"))]
+        key: CustomAnnotatedKey,
+    },
+    PageTrigger {
+        #[part(default = 1)]
+        page_number: u32,
+    },
 }
 
 #[test]
@@ -301,6 +318,20 @@ fn component_part_derive_uses_first_unit_variant_as_root() {
     assert_eq!(
         GroupPart::all(),
         vec![GroupPart::Group, GroupPart::GroupItem { index: 0 }]
+    );
+}
+
+#[test]
+fn component_part_derive_supports_annotated_all_defaults() {
+    assert_eq!(
+        AnnotatedDefaultPart::all(),
+        vec![
+            AnnotatedDefaultPart::Root,
+            AnnotatedDefaultPart::Link {
+                key: CustomAnnotatedKey("root-link"),
+            },
+            AnnotatedDefaultPart::PageTrigger { page_number: 1 },
+        ]
     );
 }
 

--- a/crates/ars-core/tests/derive_contract.rs
+++ b/crates/ars-core/tests/derive_contract.rs
@@ -114,6 +114,32 @@ enum AnnotatedDefaultPart {
     },
 }
 
+trait AnnotatedPartValue {
+    fn annotated_part_value() -> Self;
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct GenericAnnotatedKey(&'static str);
+
+impl AnnotatedPartValue for GenericAnnotatedKey {
+    fn annotated_part_value() -> Self {
+        Self("generic-link")
+    }
+}
+
+#[derive(ComponentPart)]
+#[scope = "annotated-generic"]
+enum AnnotatedGenericPart<T>
+where
+    T: AnnotatedPartValue + 'static,
+{
+    Root,
+    Link {
+        #[part(default = T::annotated_part_value())]
+        key: T,
+    },
+}
+
 #[test]
 fn has_id_derive_exposes_spec_contract() {
     let mut props = Props {
@@ -331,6 +357,31 @@ fn component_part_derive_supports_annotated_all_defaults() {
                 key: CustomAnnotatedKey("root-link"),
             },
             AnnotatedDefaultPart::PageTrigger { page_number: 1 },
+        ]
+    );
+}
+
+#[test]
+fn component_part_derive_keeps_supertrait_bounds_for_annotated_generic_fields() {
+    let part = AnnotatedGenericPart::<GenericAnnotatedKey>::Link {
+        key: GenericAnnotatedKey("current"),
+    };
+    let clone = part.clone();
+
+    assert_eq!(part, clone);
+    assert!(format!("{clone:?}").contains("Link"));
+
+    let mut hasher = DefaultHasher::new();
+
+    clone.hash(&mut hasher);
+
+    assert_eq!(
+        AnnotatedGenericPart::<GenericAnnotatedKey>::all(),
+        vec![
+            AnnotatedGenericPart::Root,
+            AnnotatedGenericPart::Link {
+                key: GenericAnnotatedKey("generic-link"),
+            },
         ]
     );
 }

--- a/crates/ars-derive/src/component_part.rs
+++ b/crates/ars-derive/src/component_part.rs
@@ -25,17 +25,21 @@ pub(crate) fn expand(input: &DeriveInput) -> syn::Result<TokenStream> {
 
     let defaultless_field_types = collect_defaultless_field_types(data)?;
 
-    let component_part_generics = with_field_bounds(
+    let component_part_supertrait_generics = with_field_bounds(
         &input.generics,
-        &defaultless_field_types,
+        &field_types,
         &[
             quote!(::core::clone::Clone),
             quote!(::core::fmt::Debug),
             quote!(::core::cmp::PartialEq),
             quote!(::core::cmp::Eq),
             quote!(::core::hash::Hash),
-            quote!(::core::default::Default),
         ],
+    );
+    let component_part_generics = with_field_bounds(
+        &component_part_supertrait_generics,
+        &defaultless_field_types,
+        &[quote!(::core::default::Default)],
     );
 
     let clone_generics = with_field_bounds(

--- a/crates/ars-derive/src/component_part.rs
+++ b/crates/ars-derive/src/component_part.rs
@@ -2,7 +2,7 @@ use heck::ToKebabCase as _;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use syn::{
-    Data, DeriveInput, Expr, Fields, Generics, Lit, LitStr, Meta, Type, Variant, parse_quote,
+    Data, DeriveInput, Expr, Field, Fields, Generics, Lit, LitStr, Meta, Type, Variant, parse_quote,
 };
 
 pub(crate) fn expand(input: &DeriveInput) -> syn::Result<TokenStream> {
@@ -23,9 +23,11 @@ pub(crate) fn expand(input: &DeriveInput) -> syn::Result<TokenStream> {
 
     let field_types = collect_field_types(data);
 
+    let defaultless_field_types = collect_defaultless_field_types(data)?;
+
     let component_part_generics = with_field_bounds(
         &input.generics,
-        &field_types,
+        &defaultless_field_types,
         &[
             quote!(::core::clone::Clone),
             quote!(::core::fmt::Debug),
@@ -73,7 +75,13 @@ pub(crate) fn expand(input: &DeriveInput) -> syn::Result<TokenStream> {
     let (hash_impl_generics, hash_ty_generics, hash_where_clause) = hash_generics.split_for_impl();
 
     let name_arms = data.variants.iter().map(name_arm);
-    let all_values = data.variants.iter().map(all_value);
+
+    let all_values = data
+        .variants
+        .iter()
+        .map(all_value)
+        .collect::<syn::Result<Vec<_>>>()?;
+
     let clone_arms = data.variants.iter().map(clone_arm);
     let debug_arms = data.variants.iter().map(debug_arm);
 
@@ -207,6 +215,34 @@ fn collect_field_types(data: &syn::DataEnum) -> Vec<Type> {
         .collect()
 }
 
+fn collect_defaultless_field_types(data: &syn::DataEnum) -> syn::Result<Vec<Type>> {
+    let mut types = Vec::new();
+
+    for variant in &data.variants {
+        match &variant.fields {
+            Fields::Unit => {}
+
+            Fields::Unnamed(fields) => {
+                for field in &fields.unnamed {
+                    if field_default_expr(field)?.is_none() {
+                        types.push(field.ty.clone());
+                    }
+                }
+            }
+
+            Fields::Named(fields) => {
+                for field in &fields.named {
+                    if field_default_expr(field)?.is_none() {
+                        types.push(field.ty.clone());
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(types)
+}
+
 fn with_field_bounds(
     generics: &Generics,
     field_types: &[Type],
@@ -238,31 +274,72 @@ fn name_arm(variant: &Variant) -> TokenStream {
     }
 }
 
-fn all_value(variant: &Variant) -> TokenStream {
+fn all_value(variant: &Variant) -> syn::Result<TokenStream> {
     let ident = &variant.ident;
 
-    match &variant.fields {
+    Ok(match &variant.fields {
         Fields::Unit => quote!(Self::#ident),
 
         Fields::Unnamed(fields) => {
             let defaults = fields
                 .unnamed
                 .iter()
-                .map(|_| quote!(::core::default::Default::default()));
+                .map(field_all_expr)
+                .collect::<syn::Result<Vec<_>>>()?;
 
             quote!(Self::#ident(#(#defaults),*))
         }
 
         Fields::Named(fields) => {
-            let defaults = fields.named.iter().map(|field| {
-                let ident = field.ident.as_ref().expect("named field");
+            let defaults = fields
+                .named
+                .iter()
+                .map(|field| -> syn::Result<TokenStream> {
+                    let ident = field.ident.as_ref().expect("named field");
+                    let expr = field_all_expr(field)?;
 
-                quote!(#ident: ::core::default::Default::default())
-            });
+                    Ok(quote!(#ident: #expr))
+                })
+                .collect::<syn::Result<Vec<_>>>()?;
 
             quote!(Self::#ident { #(#defaults),* })
         }
+    })
+}
+
+fn field_all_expr(field: &Field) -> syn::Result<TokenStream> {
+    Ok(if let Some(expr) = field_default_expr(field)? {
+        quote!(#expr)
+    } else {
+        quote!(::core::default::Default::default())
+    })
+}
+
+fn field_default_expr(field: &Field) -> syn::Result<Option<Expr>> {
+    let mut default = None;
+
+    for attr in &field.attrs {
+        if !attr.path().is_ident("part") {
+            continue;
+        }
+
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("default") {
+                let value = meta.value()?;
+                let expr = value.parse::<Expr>()?;
+
+                if default.replace(expr).is_some() {
+                    return Err(meta.error("ComponentPart accepts only one field default"));
+                }
+
+                Ok(())
+            } else {
+                Err(meta.error("unknown ComponentPart field option; use default = expr"))
+            }
+        })?;
     }
+
+    Ok(default)
 }
 
 fn clone_arm(variant: &Variant) -> TokenStream {
@@ -550,6 +627,59 @@ mod tests {
         assert!(tokens.contains("Self :: Panel"));
         assert!(tokens.contains("debug_tuple"));
         assert!(tokens.contains("debug_struct"));
+    }
+
+    #[test]
+    fn expand_uses_field_defaults_for_all_values() {
+        let input: DeriveInput = parse_quote! {
+            #[scope = "pagination"]
+            enum Part {
+                Root,
+                PageTrigger {
+                    #[part(default = 1)]
+                    page_number: u32,
+                },
+                Link(
+                    #[part(default = SafeUrl::from_static("/"))]
+                    SafeUrl,
+                ),
+            }
+        };
+
+        let tokens = expand(&input)
+            .expect("component part should expand")
+            .to_string();
+
+        assert!(tokens.contains("page_number : 1"));
+        assert!(tokens.contains("SafeUrl :: from_static (\"/\")"));
+    }
+
+    #[test]
+    fn field_defaults_reject_malformed_options() {
+        let unknown_option: DeriveInput = parse_quote! {
+            #[scope = "bad"]
+            enum Part {
+                Root,
+                Item {
+                    #[part(value = 1)]
+                    index: usize,
+                },
+            }
+        };
+
+        let duplicate_default: DeriveInput = parse_quote! {
+            #[scope = "bad"]
+            enum Part {
+                Root,
+                Item {
+                    #[part(default = 1, default = 2)]
+                    index: usize,
+                },
+            }
+        };
+
+        assert!(expand(&unknown_option).is_err());
+        assert!(expand(&duplicate_default).is_err());
     }
 
     #[test]

--- a/crates/ars-derive/src/lib.rs
+++ b/crates/ars-derive/src/lib.rs
@@ -67,6 +67,9 @@ pub fn derive_has_id(input: TokenStream) -> TokenStream {
 /// - Unit, tuple, and struct variants are supported. Variants with fields
 ///   receive generated `Clone`, `Debug`, `PartialEq`, `Eq`, and `Hash`
 ///   implementations with the necessary field bounds.
+/// - Fields may use `#[part(default = expr)]` to control the value used for
+///   that field in `ComponentPart::all()`. Fields without that annotation use
+///   `Default::default()` and therefore require a `Default` bound.
 ///
 /// # Generated names
 ///
@@ -86,13 +89,16 @@ pub fn derive_has_id(input: TokenStream) -> TokenStream {
 ///     List,
 ///     Tab,
 ///     CloseTrigger,
-///     Panel,
+///     Panel {
+///         #[part(default = String::from("example-panel"))]
+///         id: String,
+///     },
 /// }
 ///
 /// assert_eq!(TabsPart::scope(), "tabs");
 /// assert_eq!(TabsPart::CloseTrigger.name(), "close-trigger");
 /// ```
-#[proc_macro_derive(ComponentPart, attributes(scope))]
+#[proc_macro_derive(ComponentPart, attributes(scope, part))]
 pub fn derive_component_part(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
 

--- a/spec/components/navigation/_category.md
+++ b/spec/components/navigation/_category.md
@@ -113,10 +113,10 @@ pub fn item_attrs(&self, item_id: &str) -> AttrMap {
 | `Accordion`   | `Idle`                       | `value: Bindable<BTreeSet<Key>>`, `multiple`, `collapsible`, `orientation`                                                                        | Open item IDs                          |
 | `Tabs`        | `Idle`, `Focused { tab }`    | `value: Bindable<String>`, `activation_mode`, `dir`, `loop_focus`                                                                                 | Selected tab ID                        |
 | `TreeView`    | `Idle`, `Focused`            | `items: TreeCollection<TreeItem>`, `selected: Bindable<selection::Set>`, `expanded: Bindable<BTreeSet<Key>>`, `selection_state: selection::State` | Tree data + selected + expanded        |
-| `Pagination`  | `Idle`                       | `page: Bindable<u32>`, `page_size`, `total_items`, `sibling_count`, `page_count`                                                                  | Current page number                    |
+| `Pagination`  | `Idle`                       | `page: Bindable<u32>`, `page_size`, `total_items`, `sibling_count`, `boundary_count`, `page_count`                                                | Current page number                    |
 | `Steps`       | `Idle`                       | `step: Bindable<u32>`, `count`, `statuses: Vec<steps::Status>`, `linear`, `orientation`                                                           | Current step index + per-step statuses |
-| `Breadcrumbs` | (no machine)                 | (stateless — Props only: `separator`, `dir`, `nav_label`)                                                                                         | (stateless)                            |
-| `Link`        | `Idle`, `Focused`, `Pressed` | `href`, `target`, `rel`, `is_current: Option<AriaCurrent>`, `disabled`, `focus_visible`                                                           | (stateless — no bindable value)        |
+| `Breadcrumbs` | (no machine)                 | (stateless — Props plus `ItemDef { label, href, current }`)                                                                                       | (stateless)                            |
+| `Link`        | `Idle`, `Focused`, `Pressed` | `href: Target`, `target`, `rel`, `is_current: Option<AriaCurrent>`, `disabled`, `focus_visible`, `pressed`                                        | (stateless — no bindable value)        |
 
 All seven components expose their parts through consistent data attributes:
 

--- a/spec/components/navigation/breadcrumbs.md
+++ b/spec/components/navigation/breadcrumbs.md
@@ -6,7 +6,7 @@ foundation_deps: [architecture, accessibility, interactions]
 shared_deps: []
 related: []
 references:
-  react-aria: Breadcrumbs
+    react-aria: Breadcrumbs
 ---
 
 # Breadcrumbs
@@ -22,14 +22,15 @@ DOM props.
 ### 1.1 Props
 
 ```rust
-use ars_i18n::Direction;
+use ars_core::{Direction, SafeUrl};
+use crate::navigation::link::AriaCurrent;
 
 /// The type of separator to use between breadcrumb items.
 #[derive(Clone, Debug, PartialEq)]
 pub enum Separator {
     /// "/" character (default).
     Slash,
-    /// "›" or similar chevron character.
+    /// ">" or similar chevron character.
     Chevron,
     /// Custom string, e.g. "•" or a locale-specific separator.
     Custom(String),
@@ -40,10 +41,21 @@ impl Separator {
     pub fn as_str(&self) -> &str {
         match self {
             Self::Slash         => "/",
-            Self::Chevron       => "›",
+            Self::Chevron       => ">",
             Self::Custom(s)     => s.as_str(),
         }
     }
+}
+
+/// Consumer-provided breadcrumb item metadata.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ItemDef {
+    /// Visible item label.
+    pub label: String,
+    /// Optional safe navigation target. Current items typically omit it.
+    pub href: Option<SafeUrl>,
+    /// Optional current-item semantic override.
+    pub current: Option<AriaCurrent>,
 }
 
 /// Props for the `Breadcrumbs` component.
@@ -88,7 +100,7 @@ pub enum Part {
     Root,
     List,
     Item,
-    Link { href: String },
+    Link { href: SafeUrl },
     CurrentPage,
     Separator,
 }
@@ -143,12 +155,13 @@ impl Api {
     /// Attrs for a navigation link (`<a>`).
     ///
     /// `href` — the target URL for this crumb.
-    pub fn link_attrs(&self, href: &str) -> AttrMap {
+    pub fn link_attrs(&self, href: &SafeUrl) -> AttrMap {
         let mut attrs = AttrMap::new();
-        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Link { href: Default::default() }.data_attrs();
+        let [(scope_attr, scope_val), (part_attr, part_val)] =
+            Part::Link { href: SafeUrl::from_static("/") }.data_attrs();
         attrs.set(scope_attr, scope_val);
         attrs.set(part_attr, part_val);
-        attrs.set(HtmlAttr::Href, href);
+        attrs.set(HtmlAttr::Href, sanitize_url(href.as_str()));
         attrs
     }
 

--- a/spec/components/navigation/link.md
+++ b/spec/components/navigation/link.md
@@ -38,11 +38,21 @@ external link detection.
 ### 1.3 Context
 
 ```rust
+/// Distinguishes browser URL navigation from adapter-owned client routing.
+#[derive(Clone, Debug, PartialEq)]
+pub enum Target {
+    /// Browser-native URL navigation.
+    Href(SafeUrl),
+    /// Client-side route. Adapters may intercept activation, but the core
+    /// still emits this string as an `href` for progressive enhancement.
+    Route(String),
+}
+
 /// Context for the `Link` component.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Context {
-    /// The destination URL (validated on construction via `SafeUrl`).
-    pub href: SafeUrl,
+    /// The current navigation target.
+    pub href: Target,
     /// Optional browsing context target (e.g. `_blank`).
     pub target: Option<String>,
     /// Optional link relationship (e.g. `noopener noreferrer`).
@@ -91,9 +101,8 @@ pub enum AriaCurrent {
 pub struct Props {
     /// Unique component identifier.
     pub id: String,
-    /// The destination URL (validated via `SafeUrl` — rejects `javascript:`, `data:`, `vbscript:` schemes).
-    /// See `01-architecture.md` §3.1.1.1 for allowed schemes.
-    pub href: SafeUrl,
+    /// The destination target. `Target::Href` values are validated via `SafeUrl`.
+    pub href: Target,
     /// Optional browsing context target (e.g. `_blank`).
     pub target: Option<String>,
     /// Optional link relationship (e.g. `noopener noreferrer`).
@@ -102,18 +111,23 @@ pub struct Props {
     pub is_current: Option<AriaCurrent>,
     /// Disables the link (removes href, sets `aria-disabled`).
     pub disabled: bool,
-    // Change callbacks provided by the adapter layer
+    /// Callback fired when a non-disabled link is activated.
+    pub on_navigate: Option<Callback<dyn Fn(Target) + Send + Sync>>,
+    /// Callback fired after `on_navigate` for press-style integrations.
+    pub on_press: Option<Callback<dyn Fn() + Send + Sync>>,
 }
 
 impl Default for Props {
     fn default() -> Self {
         Self {
             id: String::new(),
-            href: SafeUrl::from_static(""),
+            href: Target::Href(SafeUrl::from_static("")),
             target: None,
             rel: None,
             is_current: None,
             disabled: false,
+            on_navigate: None,
+            on_press: None,
         }
     }
 }
@@ -155,6 +169,8 @@ pub enum Event {
     PressEnd,
     /// The link was activated (click or keyboard confirm).
     Navigate,
+    /// Synchronize render props into context.
+    SyncProps,
 }
 
 // ── Machine ───────────────────────────────────────────────────────────────────
@@ -218,7 +234,7 @@ impl ars_core::Machine for Machine {
             }
 
             // ── Press ─────────────────────────────────────────────────────────
-            (State::Focused, Event::Press) if !ctx.disabled => {
+            (_, Event::Press) if !ctx.disabled => {
                 Some(TransitionPlan::to(State::Pressed)
                     .apply(|ctx| {
                         ctx.pressed = true;
@@ -226,7 +242,7 @@ impl ars_core::Machine for Machine {
             }
 
             // ── PressEnd ──────────────────────────────────────────────────────
-            (State::Pressed, Event::PressEnd) => {
+            (_, Event::PressEnd) => {
                 Some(TransitionPlan::to(State::Focused)
                     .apply(|ctx| {
                         ctx.pressed = false;
@@ -240,7 +256,7 @@ impl ars_core::Machine for Machine {
                 })
                 .with_effect(PendingEffect::new("navigate", |ctx, props, _send| {
                     if let Some(ref on_navigate) = props.on_navigate {
-                        on_navigate(&ctx.href);
+                        on_navigate(ctx.href.clone());
                     }
                     if let Some(ref on_press) = props.on_press {
                         on_press();
@@ -305,10 +321,9 @@ impl<'a> Api<'a> {
             attrs.set(HtmlAttr::Aria(AriaAttr::Disabled), "true");
         } else {
             // Resolve target and rel for external links.
-            let is_external = self.ctx.href.as_str().starts_with("http://")
-                || self.ctx.href.as_str().starts_with("https://");
+            let is_external = self.ctx.href.is_external();
 
-            attrs.set(HtmlAttr::Href, self.ctx.href.as_str());
+            attrs.set(HtmlAttr::Href, sanitize_url(self.ctx.href.href()));
 
             let target = match &self.ctx.target {
                 Some(t) => Some(t.as_str()),
@@ -321,9 +336,7 @@ impl<'a> Api<'a> {
 
             let rel = match &self.ctx.rel {
                 Some(r) => Some(r.as_str()),
-                None if is_external && self.ctx.target.is_none() => {
-                    Some("noopener noreferrer")
-                }
+                None if target == Some("_blank") => Some("noopener noreferrer"),
                 None => None,
             };
             if let Some(r) = rel {
@@ -355,6 +368,10 @@ impl<'a> Api<'a> {
 
         if self.ctx.focus_visible {
             attrs.set_bool(HtmlAttr::Data("ars-focus-visible"), true);
+        }
+
+        if self.ctx.pressed {
+            attrs.set_bool(HtmlAttr::Data("ars-pressed"), true);
         }
 
         // When the element is not a native <a>, add role and tabindex.
@@ -419,9 +436,9 @@ Link
 └── Root   <a> href="..."
 ```
 
-| Part   | Element | Key Attributes                                                                                                                                        |
-| ------ | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Root` | `<a>`   | `data-ars-scope="link"`, `data-ars-part="root"`, `data-ars-state`, `href`, `target`, `rel`, `aria-current`, `aria-disabled`, `data-ars-focus-visible` |
+| Part   | Element | Key Attributes                                                                                                                                                            |
+| ------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Root` | `<a>`   | `data-ars-scope="link"`, `data-ars-part="root"`, `data-ars-state`, `href`, `target`, `rel`, `aria-current`, `aria-disabled`, `data-ars-focus-visible`, `data-ars-pressed` |
 
 When the consumer renders a non-`<a>` element for the root, `root_props()` should be
 extended with `role="link"` and `tabindex="0"` to maintain keyboard accessibility.
@@ -457,14 +474,26 @@ when the link role is applied to a non-native element, matching the WAI-ARIA lin
 `Link` supports both traditional `<a href>` navigation and client-side router navigation via the `Target` enum:
 
 ```rust
-/// Distinguishes between standard href navigation and client-side routing.
-#[derive(Clone, Debug, PartialEq)]
-pub enum Target {
-    /// Standard URL — renders as `<a href="...">`. Navigates via browser.
-    Href(SafeUrl),
-    /// Client-side route — the adapter intercepts click and delegates to
-    /// the framework router (e.g., Leptos `use_navigate()`, Dioxus `navigator()`).
-    Route(String),
+impl From<SafeUrl> for Target {
+    fn from(value: SafeUrl) -> Self {
+        Self::Href(value)
+    }
+}
+
+impl Target {
+    /// Returns the renderable href string for this target.
+    pub fn href(&self) -> &str {
+        match self {
+            Self::Href(url) => url.as_str(),
+            Self::Route(route) => route.as_str(),
+        }
+    }
+
+    /// Returns true when this target is an absolute HTTP(S) URL.
+    pub fn is_external(&self) -> bool {
+        let href = self.href();
+        href.starts_with("http://") || href.starts_with("https://")
+    }
 }
 ```
 
@@ -477,7 +506,7 @@ When `Target::Route` is used:
 ```rust,no_check
 // Adapter-level auto-detection (e.g., in ars-leptos):
 let current_path = use_location().pathname.get();
-let auto_current = match &props.target {
+let auto_current = match &props.href {
     Target::Route(path) if props.is_current.is_none() => {
         if current_path == *path {
             Some(AriaCurrent::Page)
@@ -494,14 +523,14 @@ The `Props` struct accepts `Target` via the `href` field. For backward compatibi
 ## 5. External Link Detection
 
 When `href` starts with `http://` or `https://` and `target` is not explicitly set,
-`root_props()` automatically applies `target="_blank"` and `rel="noopener noreferrer"`.
+`root_attrs()` automatically applies `target="_blank"` and `rel="noopener noreferrer"`.
 This prevents the opened page from accessing `window.opener` and mitigates reverse
-tabnapping attacks. When `target` is explicitly provided, the automatic behavior is
-skipped — the consumer has full control.
+tabnapping attacks. When `target` is explicitly provided, automatic target selection is
+skipped; explicit `target="_blank"` still receives the `rel` repair described below.
 
 ### 5.1 Automatic `rel` for Explicit `target="_blank"`
 
-When the consumer explicitly sets `target: Some("_blank".into())`, the adapter MUST automatically append `rel="noopener noreferrer"` if `rel` is `None`. This ensures security protections are always applied for new-tab links, regardless of whether the URL is detected as external. Consumers can override by explicitly setting the `rel` prop.
+When the consumer explicitly sets `target: Some("_blank".into())`, the core API MUST automatically append `rel="noopener noreferrer"` if `rel` is `None`. This ensures security protections are always applied for new-tab links, regardless of whether the URL is detected as external. Consumers can override by explicitly setting the `rel` prop.
 
 ### 5.2 External Link Announcements and Iconography
 
@@ -545,19 +574,19 @@ impl ComponentMessages for Messages {}
 
 ### 7.1 Props
 
-| Feature         | ars-ui                            | React Aria       | Notes                          |
-| --------------- | --------------------------------- | ---------------- | ------------------------------ |
-| Href            | `href: SafeUrl`                   | `href: string`   | ars-ui validates via SafeUrl   |
-| Target          | `target`                          | `target`         | Full match                     |
-| Rel             | `rel`                             | `rel`            | Full match                     |
-| Disabled        | `disabled`                        | `isDisabled`     | Full match                     |
-| Is current      | `is_current: Option<AriaCurrent>` | --               | ars-ui addition (aria-current) |
-| Auto focus      | --                                | `autoFocus`      | Adapter concern                |
-| Download        | --                                | `download`       | See below                      |
-| Href lang       | --                                | `hrefLang`       | See below                      |
-| Ping            | --                                | `ping`           | See below                      |
-| Referrer policy | --                                | `referrerPolicy` | See below                      |
-| Router options  | `Target::Route` (section 4)       | `routerOptions`  | ars-ui has client-side routing |
+| Feature         | ars-ui                            | React Aria       | Notes                                |
+| --------------- | --------------------------------- | ---------------- | ------------------------------------ |
+| Href            | `href: Target`                    | `href: string`   | `Target::Href` validates via SafeUrl |
+| Target          | `target`                          | `target`         | Full match                           |
+| Rel             | `rel`                             | `rel`            | Full match                           |
+| Disabled        | `disabled`                        | `isDisabled`     | Full match                           |
+| Is current      | `is_current: Option<AriaCurrent>` | --               | ars-ui addition (aria-current)       |
+| Auto focus      | --                                | `autoFocus`      | Adapter concern                      |
+| Download        | --                                | `download`       | See below                            |
+| Href lang       | --                                | `hrefLang`       | See below                            |
+| Ping            | --                                | `ping`           | See below                            |
+| Referrer policy | --                                | `referrerPolicy` | See below                            |
+| Router options  | `Target::Route` (section 4)       | `routerOptions`  | ars-ui has client-side routing       |
 
 **Gaps:**
 

--- a/spec/components/navigation/pagination.md
+++ b/spec/components/navigation/pagination.md
@@ -35,6 +35,7 @@ in context. A single `Idle` state is used.
 | `GoToFirstPage`             | —                     | Jump to page 1.                                       |
 | `GoToLastPage`              | —                     | Jump to `page_count`.                                 |
 | `SetPageSize(NonZero<u32>)` | new page size         | Change items-per-page; resets or clamps current page. |
+| `SyncProps`                 | —                     | Synchronize controlled props into context.            |
 
 ### 1.3 Context
 
@@ -52,6 +53,8 @@ pub struct Context {
     pub total_items: u32,
     /// Number of page buttons shown on each side of the current page.
     pub sibling_count: u32,
+    /// Number of always-visible page buttons at each boundary.
+    pub boundary_count: u32,
     /// Derived: `ceil(total_items / page_size)`, always >= 1.
     pub page_count: u32,
     /// Resolved locale for i18n.
@@ -65,51 +68,15 @@ pub struct Context {
 impl Context {
     /// Compute the derived page_count from total_items / page_size.
     pub fn compute_page_count(total_items: u32, page_size: NonZero<u32>) -> u32 {
-        ((total_items as f64) / (page_size.get() as f64)).ceil() as u32
+        total_items.div_ceil(page_size.get()).max(1)
     }
 
     /// Generate the list of pages to display, inserting `None` for ellipsis.
     ///
-    /// Example (page=5, page_count=10, sibling_count=1):
+    /// Example (page=5, page_count=10, sibling_count=1, boundary_count=1):
     ///   [Some(1), None, Some(4), Some(5), Some(6), None, Some(10)]
     pub fn page_range(&self) -> Vec<Option<u32>> {
-        let page       = *self.page.get();
-        let total      = self.page_count;
-        let siblings   = self.sibling_count;
-        // Always show first and last page.
-        // Show [page - siblings .. page + siblings] in the middle.
-        let left_start  = page.saturating_sub(siblings);
-        let right_end   = (page + siblings).min(total);
-        let show_left_ellipsis  = left_start > 2;
-        let show_right_ellipsis = right_end < total.saturating_sub(1);
-
-        let mut pages = vec![Some(1)];
-
-        if show_left_ellipsis {
-            pages.push(None); // ellipsis
-        } else {
-            for p in 2..left_start {
-                pages.push(Some(p));
-            }
-        }
-
-        for p in left_start.max(2)..=right_end.min(total.saturating_sub(1)) {
-            pages.push(Some(p));
-        }
-
-        if show_right_ellipsis {
-            pages.push(None); // ellipsis
-        } else {
-            for p in (right_end + 1)..total {
-                pages.push(Some(p));
-            }
-        }
-
-        if total > 1 {
-            pages.push(Some(total));
-        }
-
-        pages
+        page_range(*self.page.get(), self.page_count, self.sibling_count, self.boundary_count)
     }
 }
 ```
@@ -144,6 +111,8 @@ pub struct Props {
     /// progressive enhancement and SEO-friendly pagination. The callback
     /// receives a 1-based page number and returns the URL string.
     pub get_page_url: Option<Callback<dyn Fn(u32) -> String + Send + Sync>>,
+    /// Callback fired after the current page changes.
+    pub on_page_change: Option<Callback<dyn Fn(u32) + Send + Sync>>,
 }
 
 /// Visual size variants for Pagination.
@@ -170,6 +139,7 @@ impl Default for Props {
             boundary_count: 1,
             size: Size::default(),
             get_page_url: None,
+            on_page_change: None,
         }
     }
 }
@@ -202,6 +172,15 @@ pub enum Event {
     GoToLastPage,
     /// Change items-per-page; resets or clamps current page.
     SetPageSize(NonZero<u32>),
+    /// Synchronize controlled props into context.
+    SyncProps,
+}
+
+/// Effects for the `Pagination` component.
+#[derive(Clone, Debug, PartialEq)]
+pub enum Effect {
+    /// The current page changed.
+    PageChange,
 }
 
 /// Machine for the `Pagination` component.
@@ -229,6 +208,7 @@ impl ars_core::Machine for Machine {
             page_size: props.page_size,
             total_items: props.total_items,
             sibling_count: props.sibling_count,
+            boundary_count: props.boundary_count,
             page_count,
             locale,
             ids,
@@ -240,7 +220,7 @@ impl ars_core::Machine for Machine {
         _state: &Self::State,
         event: &Self::Event,
         ctx: &Self::Context,
-        _props: &Self::Props,
+        props: &Self::Props,
     ) -> Option<TransitionPlan<Self>> {
         match event {
             Event::GoToPage(p) => {
@@ -248,7 +228,12 @@ impl ars_core::Machine for Machine {
                 if *ctx.page.get() == target { return None; }
                 Some(TransitionPlan::context_only(move |ctx| {
                     ctx.page.set(target);
-                }))
+                }).with_effect(PendingEffect::new(Effect::PageChange, |ctx, props, _send| {
+                    if let Some(ref cb) = props.on_page_change {
+                        cb(*ctx.page.get());
+                    }
+                    no_cleanup()
+                })))
             }
             Event::NextPage => {
                 let next = (*ctx.page.get() + 1).min(ctx.page_count);
@@ -283,6 +268,24 @@ impl ars_core::Machine for Machine {
                     ctx.page_size  = new_size;
                     ctx.page_count = new_count;
                     ctx.page.set(clamped);
+                }))
+            }
+            Event::SyncProps => {
+                let page_size = props.page_size;
+                let total_items = props.total_items;
+                let sibling_count = props.sibling_count;
+                let boundary_count = props.boundary_count;
+                let page_count = Context::compute_page_count(total_items, page_size);
+                let controlled = props.page.map(|page| page.max(1).min(page_count));
+                let target = controlled.unwrap_or_else(|| (*ctx.page.get()).max(1).min(page_count));
+                Some(TransitionPlan::context_only(move |ctx| {
+                    ctx.page_size = page_size;
+                    ctx.total_items = total_items;
+                    ctx.sibling_count = sibling_count;
+                    ctx.boundary_count = boundary_count;
+                    ctx.page_count = page_count;
+                    ctx.page.sync_controlled(controlled);
+                    ctx.page.set(target);
                 }))
             }
         }
@@ -345,6 +348,7 @@ impl<'a> Api<'a> {
         attrs.set(part_attr, part_val);
         attrs.set(HtmlAttr::Role, "navigation");
         attrs.set(HtmlAttr::Aria(AriaAttr::Label), (self.ctx.messages.root_label)(&self.ctx.locale));
+        attrs.set(HtmlAttr::Data("ars-size"), self.props.size.as_str());
         attrs
     }
 
@@ -398,14 +402,14 @@ impl<'a> Api<'a> {
     pub fn page_trigger_attrs(&self, page_number: u32) -> AttrMap {
         let mut attrs = AttrMap::new();
         let is_current = self.current_page() == page_number;
-        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::PageTrigger { page_number: Default::default() }.data_attrs();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::PageTrigger { page_number }.data_attrs();
         attrs.set(scope_attr, scope_val);
         attrs.set(part_attr, part_val);
 
         // When get_page_url is set, render as <a> for progressive enhancement.
         // Otherwise render as <button>.
         if let Some(ref get_url) = self.props.get_page_url {
-            attrs.set(HtmlAttr::Href, get_url(page_number));
+            attrs.set(HtmlAttr::Href, sanitize_url(&get_url(page_number)));
         } else {
             attrs.set(HtmlAttr::Type, "button");
         }

--- a/spec/components/navigation/steps.md
+++ b/spec/components/navigation/steps.md
@@ -24,13 +24,14 @@ and provides navigation between them.
 
 ### 1.2 Events
 
-| Event                        | Payload              | Description                            |
-| ---------------------------- | -------------------- | -------------------------------------- |
-| `GoToStep(u32)`              | step index (0-based) | Navigate to a specific step directly.  |
-| `NextStep`                   | —                    | Advance to step + 1.                   |
-| `PrevStep`                   | —                    | Go back to step - 1.                   |
-| `CompleteStep(u32)`          | step index           | Mark a step as `Complete`.             |
-| `SetStatus { step, status }` | `u32`, `Status`      | Explicitly set the status of any step. |
+| Event                        | Payload              | Description                                |
+| ---------------------------- | -------------------- | ------------------------------------------ |
+| `GoToStep(u32)`              | step index (0-based) | Navigate to a specific step directly.      |
+| `NextStep`                   | —                    | Advance to step + 1.                       |
+| `PrevStep`                   | —                    | Go back to step - 1.                       |
+| `CompleteStep(u32)`          | step index           | Mark a step as `Complete`.                 |
+| `SetStatus { step, status }` | `u32`, `Status`      | Explicitly set the status of any step.     |
+| `SyncProps`                  | —                    | Synchronize controlled props into context. |
 
 ### 1.3 Context
 
@@ -100,8 +101,10 @@ pub struct Props {
     /// Per-step skip predicate. When `Some`, allows the user to skip ahead past
     /// a step without completing it. Return `true` if the step is skippable.
     pub is_step_skippable: Option<Callback<dyn Fn(u32) -> bool + Send + Sync>>,
+    /// Callback fired after the current step changes.
+    pub on_step_change: Option<Callback<dyn Fn(u32) + Send + Sync>>,
     /// Callback fired when all steps are completed (the user advances past the last step).
-    pub on_complete: Option<Callback<()>>,
+    pub on_complete: Option<Callback<dyn Fn() + Send + Sync>>,
     /// Visual stacking axis.
     pub orientation: Orientation,
 }
@@ -117,6 +120,7 @@ impl Default for Props {
             linear: false,
             is_step_valid: None,
             is_step_skippable: None,
+            on_step_change: None,
             on_complete: None,
             orientation: Orientation::Horizontal,
         }
@@ -155,6 +159,17 @@ pub enum Event {
         /// New status.
         status: Status,
     },
+    /// Synchronize controlled props into context.
+    SyncProps,
+}
+
+/// Effects for the `Steps` component.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Effect {
+    /// The active step changed.
+    StepChange,
+    /// The user advanced past the final step.
+    Complete,
 }
 
 /// Machine for the `Steps` component.
@@ -198,7 +213,7 @@ impl ars_core::Machine for Machine {
         _state: &Self::State,
         event: &Self::Event,
         ctx: &Self::Context,
-        _props: &Self::Props,
+        props: &Self::Props,
     ) -> Option<TransitionPlan<Self>> {
         match event {
             Event::GoToStep(target) => {
@@ -225,12 +240,14 @@ impl ars_core::Machine for Machine {
                             *s = Status::Complete;
                         }
                     }
-                    // Update status of the new current step.
-                    if let Some(s) = ctx.statuses.get_mut(target as usize) {
-                        *s = Status::Current;
-                    }
+                    normalize_current_status(&mut ctx.statuses, target);
                     ctx.step.set(target);
-                }))
+                }).with_effect(PendingEffect::new(Effect::StepChange, |ctx, props, _send| {
+                    if let Some(ref cb) = props.on_step_change {
+                        cb(*ctx.step.get());
+                    }
+                    no_cleanup()
+                })))
             }
             Event::NextStep => {
                 let current = *ctx.step.get();
@@ -249,9 +266,9 @@ impl ars_core::Machine for Machine {
                         if let Some(s) = ctx.statuses.get_mut(current as usize) {
                             *s = Status::Complete;
                         }
-                    }).with_effect(PendingEffect::new("on-complete", |_ctx, props, _send| {
+                    }).with_effect(PendingEffect::new(Effect::Complete, |_ctx, props, _send| {
                         if let Some(ref cb) = props.on_complete {
-                            cb.call(());
+                            cb();
                         }
                         no_cleanup()
                     })));
@@ -261,11 +278,14 @@ impl ars_core::Machine for Machine {
                     if let Some(s) = ctx.statuses.get_mut(current as usize) {
                         *s = Status::Complete;
                     }
-                    if let Some(s) = ctx.statuses.get_mut(next as usize) {
-                        *s = Status::Current;
-                    }
+                    normalize_current_status(&mut ctx.statuses, next);
                     ctx.step.set(next);
-                }))
+                }).with_effect(PendingEffect::new(Effect::StepChange, |ctx, props, _send| {
+                    if let Some(ref cb) = props.on_step_change {
+                        cb(*ctx.step.get());
+                    }
+                    no_cleanup()
+                })))
             }
             Event::PrevStep => {
                 let current = *ctx.step.get();
@@ -276,11 +296,14 @@ impl ars_core::Machine for Machine {
                         // Going backward leaves the step as Incomplete (not wiping Complete).
                         *s = Status::Incomplete;
                     }
-                    if let Some(s) = ctx.statuses.get_mut(prev as usize) {
-                        *s = Status::Current;
-                    }
+                    normalize_current_status(&mut ctx.statuses, prev);
                     ctx.step.set(prev);
-                }))
+                }).with_effect(PendingEffect::new(Effect::StepChange, |ctx, props, _send| {
+                    if let Some(ref cb) = props.on_step_change {
+                        cb(*ctx.step.get());
+                    }
+                    no_cleanup()
+                })))
             }
             Event::CompleteStep(idx) => {
                 let idx = *idx as usize;
@@ -291,12 +314,33 @@ impl ars_core::Machine for Machine {
                 }))
             }
             Event::SetStatus { step, status } => {
-                let idx    = *step as usize;
+                let step_index = *step;
+                let idx    = step_index as usize;
                 let status = status.clone();
                 Some(TransitionPlan::context_only(move |ctx| {
                     if let Some(s) = ctx.statuses.get_mut(idx) {
                         *s = status;
                     }
+                    if status == Status::Current {
+                        ctx.step.set(step_index);
+                        normalize_current_status(&mut ctx.statuses, step_index);
+                    }
+                }))
+            }
+            Event::SyncProps => {
+                let count = props.count;
+                let controlled = props.step.map(|step| step.min(count.get().saturating_sub(1)));
+                let target = controlled.unwrap_or_else(|| (*ctx.step.get()).min(count.get().saturating_sub(1)));
+                let statuses = normalized_statuses(props.statuses.clone(), count, target);
+                let linear = props.linear;
+                let orientation = props.orientation;
+                Some(TransitionPlan::context_only(move |ctx| {
+                    ctx.count = count;
+                    ctx.step.sync_controlled(controlled);
+                    ctx.step.set(target);
+                    ctx.statuses = statuses;
+                    ctx.linear = linear;
+                    ctx.orientation = orientation;
                 }))
             }
         }
@@ -517,6 +561,11 @@ impl<'a> Api<'a> {
     /// Handle click event for the "next step" trigger button.
     pub fn on_next_trigger_click(&self) {
         if !self.is_last_step() { (self.send)(Event::NextStep); }
+    }
+
+    /// Handle direct step selection.
+    pub fn on_item_click(&self, index: u32) {
+        (self.send)(Event::GoToStep(index));
     }
 }
 

--- a/spec/dioxus-components/navigation/link.md
+++ b/spec/dioxus-components/navigation/link.md
@@ -10,7 +10,7 @@ source_foundation: foundation/09-adapter-dioxus.md
 
 ## 1. Purpose and Adapter Scope
 
-This spec maps the core [`Link`](../../components/navigation/link.md) contract onto a Dioxus 0.7.x component. The adapter preserves anchor-first semantics, router interception, current-item semantics, external-link security repair, and non-anchor fallback semantics when consumers intentionally opt out of `<a>`.
+This spec maps the core [`Link`](../../components/navigation/link.md) contract onto a Dioxus 0.7.x component. The adapter preserves anchor-first semantics, router interception, current-item semantics, core-owned external-link security repair, and non-anchor fallback semantics when consumers intentionally opt out of `<a>`.
 
 ## 2. Public Adapter API
 
@@ -40,7 +40,7 @@ The adapter renders a native anchor by default. `Target::Route` stays progressiv
 - Props parity: full parity with the core target, current-item, disabled, locale, and message contract.
 - State parity: full parity with focused, pressed, and disabled link behavior.
 - Part parity: full parity with the single `Root` part.
-- Adapter additions: explicit router interception, automatic external-link `rel` repair, and non-anchor semantic repair rules.
+- Adapter additions: explicit router interception and non-anchor semantic repair rules. External-link target/`rel` repair is emitted by `api.root_attrs()`.
 
 ## 4. Part Mapping
 
@@ -50,11 +50,11 @@ The adapter renders a native anchor by default. `Target::Route` stays progressiv
 
 ## 5. Attr Merge and Ownership Rules
 
-| Target node | Core attrs                                                                      | Adapter-owned attrs                                                                               | Consumer attrs                         | Merge order                                                                                                             | Ownership notes                      |
-| ----------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- | -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
-| `Root`      | `href`, `target`, `rel`, `aria-current`, `aria-disabled`, scope and state attrs | router click interception, external-link security repair, non-anchor `role` and `tabindex` repair | decoration attrs and trailing handlers | required navigation and security attrs win; handlers compose adapter before consumer when preventing invalid navigation | root remains the semantic link owner |
+| Target node | Core attrs                                                                      | Adapter-owned attrs                                                | Consumer attrs                         | Merge order                                                                                                             | Ownership notes                      |
+| ----------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------ | -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| `Root`      | `href`, `target`, `rel`, `aria-current`, `aria-disabled`, scope and state attrs | router click interception, non-anchor `role` and `tabindex` repair | decoration attrs and trailing handlers | required navigation and security attrs win; handlers compose adapter before consumer when preventing invalid navigation | root remains the semantic link owner |
 
-- When `target="_blank"` and `rel` is absent, the adapter must append `noopener noreferrer`.
+- When `target="_blank"` and `rel` is absent, the core attrs include `noopener noreferrer`.
 - When rendering a non-anchor host, the adapter must add `role="link"` and keyboard activation repair.
 - Consumers must not remove `aria-current` or `aria-disabled` once emitted by the adapter.
 
@@ -64,10 +64,10 @@ The adapter renders a native anchor by default. `Target::Route` stays progressiv
 
 ## 7. Prop Sync and Event Mapping
 
-| Adapter prop                          | Mode       | Sync trigger            | Machine event / update path | Visible effect                                 | Notes                         |
-| ------------------------------------- | ---------- | ----------------------- | --------------------------- | ---------------------------------------------- | ----------------------------- |
-| `disabled`                            | controlled | prop change after mount | `SetDisabled`               | updates disabled attrs and blocks activation   | only reactive prop by default |
-| `href`, `target`, `rel`, `is_current` | controlled | rerender with new props | machine or render rebuild   | updates destination and current-item semantics | no shadow state               |
+| Adapter prop                          | Mode       | Sync trigger            | Machine event / update path   | Visible effect                                 | Notes                         |
+| ------------------------------------- | ---------- | ----------------------- | ----------------------------- | ---------------------------------------------- | ----------------------------- |
+| `disabled`                            | controlled | prop change after mount | `SyncProps`                   | updates disabled attrs and blocks activation   | only reactive prop by default |
+| `href`, `target`, `rel`, `is_current` | controlled | rerender with new props | `SyncProps` or render rebuild | updates destination and current-item semantics | no shadow state               |
 
 | UI event                  | Preconditions             | Machine event / callback path                | Ordering notes                                                      | Notes                                   |
 | ------------------------- | ------------------------- | -------------------------------------------- | ------------------------------------------------------------------- | --------------------------------------- |
@@ -121,7 +121,7 @@ Each `Link` instance owns one semantic root. Server and client must preserve the
 
 ## 15. Performance Constraints
 
-- Avoid recomputing external-link security repair in multiple code paths; derive it once per render.
+- Do not recompute external-link security repair in adapter code; read the repaired attrs from `api.root_attrs()`.
 - Do not attach non-anchor keyboard repair listeners to native anchors.
 - Keep router comparison instance-local and avoid global polling.
 
@@ -216,7 +216,7 @@ rsx! {
 ## 28. Parity Summary and Intentional Deviations
 
 - Matches the core link contract without intentional adapter divergence.
-- Promotes router interception, progressive enhancement, external-link security repair, and non-anchor semantic repair into explicit Dioxus-facing rules.
+- Promotes router interception, progressive enhancement, core-owned external-link security repair, and non-anchor semantic repair into explicit Dioxus-facing rules.
 
 ## 29. Test Scenarios
 

--- a/spec/dioxus-components/navigation/pagination.md
+++ b/spec/dioxus-components/navigation/pagination.md
@@ -68,14 +68,14 @@ The adapter owns visible range derivation, repeated page-trigger rendering, and 
 
 | Adapter prop                                                  | Mode       | Sync trigger            | Machine event / update path | Visible effect                                      | Notes                                            |
 | ------------------------------------------------------------- | ---------- | ----------------------- | --------------------------- | --------------------------------------------------- | ------------------------------------------------ |
-| `page`                                                        | controlled | prop change after mount | `SetPage`                   | updates current page and visible range              | no controlled/uncontrolled switching after mount |
-| `page_size`, `total_items`, `sibling_count`, `boundary_count` | controlled | rerender with new props | core prop rebuild           | recomputes visible range and disabled edge triggers | no shadow state                                  |
+| `page`                                                        | controlled | prop change after mount | `SyncProps` or `GoToPage`   | updates current page and visible range              | no controlled/uncontrolled switching after mount |
+| `page_size`, `total_items`, `sibling_count`, `boundary_count` | controlled | rerender with new props | `SyncProps`                 | recomputes visible range and disabled edge triggers | no shadow state                                  |
 | `get_page_url`                                                | controlled | rerender with new props | adapter host selection      | switches trigger host between `<button>` and `<a>`  | page semantics stay identical                    |
 
 | UI event                      | Preconditions                           | Machine event / callback path              | Ordering notes                                      | Notes                                     |
 | ----------------------------- | --------------------------------------- | ------------------------------------------ | --------------------------------------------------- | ----------------------------------------- |
-| prev or next activation       | not at edge                             | `GoToPrevPage` / `GoToNextPage`            | announcement fires only after committed page change | host may be button or anchor              |
-| page activation               | page is visible and not already current | `SetPage(page)`                            | announcement uses committed page number             | buttons and anchors share callback timing |
+| prev or next activation       | not at edge                             | `PrevPage` / `NextPage`                    | announcement fires only after committed page change | host may be button or anchor              |
+| page activation               | page is visible and not already current | `GoToPage(page)`                           | announcement uses committed page number             | buttons and anchors share callback timing |
 | route-style anchor navigation | `get_page_url` present                  | optional browser navigation after callback | adapter does not block navigation by default        | current page still uses `aria-current`    |
 
 ## 8. Registration and Cleanup Contract

--- a/spec/dioxus-components/navigation/steps.md
+++ b/spec/dioxus-components/navigation/steps.md
@@ -73,9 +73,9 @@ The adapter owns repeated item rendering, step-status projection, current-conten
 
 | Adapter prop                           | Mode       | Sync trigger            | Machine event / update path | Visible effect                                                 | Notes                                            |
 | -------------------------------------- | ---------- | ----------------------- | --------------------------- | -------------------------------------------------------------- | ------------------------------------------------ |
-| `step`                                 | controlled | prop change after mount | `GoToStep`                  | updates current item, content, and edge-trigger disabled state | no controlled/uncontrolled switching after mount |
-| `statuses`                             | controlled | rerender with new props | core prop rebuild           | updates item and separator state                               | index alignment must stay stable                 |
-| `linear`, `orientation`, `interactive` | controlled | rerender with new props | core prop rebuild           | updates navigation guards and semantics                        | no shadow state                                  |
+| `step`                                 | controlled | prop change after mount | `SyncProps` or `GoToStep`   | updates current item, content, and edge-trigger disabled state | no controlled/uncontrolled switching after mount |
+| `statuses`                             | controlled | rerender with new props | `SyncProps`                 | updates item and separator state                               | index alignment must stay stable                 |
+| `linear`, `orientation`, `interactive` | controlled | rerender with new props | `SyncProps` or render-local | updates navigation guards and semantics                        | no shadow state                                  |
 
 | UI event                | Preconditions                              | Machine event / callback path | Ordering notes                                                    | Notes                                                |
 | ----------------------- | ------------------------------------------ | ----------------------------- | ----------------------------------------------------------------- | ---------------------------------------------------- |

--- a/spec/foundation/01-architecture.md
+++ b/spec/foundation/01-architecture.md
@@ -3585,7 +3585,7 @@ impl fmt::Display for UnsafeUrlError {
 
 Components that set URL-valued attributes must call `sanitize_url()`:
 
-- **Link**: `attrs.set(HtmlAttr::Href, sanitize_url(self.ctx.href.as_str()))`
+- **Link**: `attrs.set(HtmlAttr::Href, sanitize_url(self.ctx.href.href()))`
 - **Form**: `attrs.set(HtmlAttr::Action, sanitize_url(action))`
 
 #### 3.1.2 HtmlEvent

--- a/spec/leptos-components/navigation/link.md
+++ b/spec/leptos-components/navigation/link.md
@@ -10,7 +10,7 @@ source_foundation: foundation/08-adapter-leptos.md
 
 ## 1. Purpose and Adapter Scope
 
-This spec maps the core [`Link`](../../components/navigation/link.md) contract onto a Leptos 0.8.x component. The adapter preserves anchor-first semantics, router interception, current-item semantics, external-link security repair, and non-anchor fallback semantics when consumers intentionally opt out of `<a>`.
+This spec maps the core [`Link`](../../components/navigation/link.md) contract onto a Leptos 0.8.x component. The adapter preserves anchor-first semantics, router interception, current-item semantics, core-owned external-link security repair, and non-anchor fallback semantics when consumers intentionally opt out of `<a>`.
 
 ## 2. Public Adapter API
 
@@ -33,7 +33,7 @@ The adapter renders a native anchor by default. `Target::Route` stays progressiv
 - Props parity: full parity with the core target, current-item, disabled, locale, and message contract.
 - State parity: full parity with focused, pressed, and disabled link behavior.
 - Part parity: full parity with the single `Root` part.
-- Adapter additions: explicit router interception, automatic external-link `rel` repair, and non-anchor semantic repair rules.
+- Adapter additions: explicit router interception and non-anchor semantic repair rules. External-link target/`rel` repair is emitted by `api.root_attrs()`.
 
 ## 4. Part Mapping
 
@@ -43,11 +43,11 @@ The adapter renders a native anchor by default. `Target::Route` stays progressiv
 
 ## 5. Attr Merge and Ownership Rules
 
-| Target node | Core attrs                                                                      | Adapter-owned attrs                                                                               | Consumer attrs                         | Merge order                                                                                                             | Ownership notes                      |
-| ----------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- | -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
-| `Root`      | `href`, `target`, `rel`, `aria-current`, `aria-disabled`, scope and state attrs | router click interception, external-link security repair, non-anchor `role` and `tabindex` repair | decoration attrs and trailing handlers | required navigation and security attrs win; handlers compose adapter before consumer when preventing invalid navigation | root remains the semantic link owner |
+| Target node | Core attrs                                                                      | Adapter-owned attrs                                                | Consumer attrs                         | Merge order                                                                                                             | Ownership notes                      |
+| ----------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------ | -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| `Root`      | `href`, `target`, `rel`, `aria-current`, `aria-disabled`, scope and state attrs | router click interception, non-anchor `role` and `tabindex` repair | decoration attrs and trailing handlers | required navigation and security attrs win; handlers compose adapter before consumer when preventing invalid navigation | root remains the semantic link owner |
 
-- When `target="_blank"` and `rel` is absent, the adapter must append `noopener noreferrer`.
+- When `target="_blank"` and `rel` is absent, the core attrs include `noopener noreferrer`.
 - When rendering a non-anchor host, the adapter must add `role="link"` and keyboard activation repair.
 - Consumers must not remove `aria-current` or `aria-disabled` once emitted by the adapter.
 
@@ -57,10 +57,10 @@ The adapter renders a native anchor by default. `Target::Route` stays progressiv
 
 ## 7. Prop Sync and Event Mapping
 
-| Adapter prop                          | Mode       | Sync trigger              | Machine event / update path | Visible effect                                 | Notes                         |
-| ------------------------------------- | ---------- | ------------------------- | --------------------------- | ---------------------------------------------- | ----------------------------- |
-| `disabled`                            | controlled | signal change after mount | `SetDisabled`               | updates disabled attrs and blocks activation   | only reactive prop by default |
-| `href`, `target`, `rel`, `is_current` | controlled | rerender with new props   | machine or render rebuild   | updates destination and current-item semantics | no shadow state               |
+| Adapter prop                          | Mode       | Sync trigger              | Machine event / update path   | Visible effect                                 | Notes                         |
+| ------------------------------------- | ---------- | ------------------------- | ----------------------------- | ---------------------------------------------- | ----------------------------- |
+| `disabled`                            | controlled | signal change after mount | `SyncProps`                   | updates disabled attrs and blocks activation   | only reactive prop by default |
+| `href`, `target`, `rel`, `is_current` | controlled | rerender with new props   | `SyncProps` or render rebuild | updates destination and current-item semantics | no shadow state               |
 
 | UI event                  | Preconditions             | Machine event / callback path                | Ordering notes                                                      | Notes                                   |
 | ------------------------- | ------------------------- | -------------------------------------------- | ------------------------------------------------------------------- | --------------------------------------- |
@@ -114,7 +114,7 @@ Each `Link` instance owns one semantic root. Server and client must preserve the
 
 ## 15. Performance Constraints
 
-- Avoid recomputing external-link security repair in multiple code paths; derive it once per render.
+- Do not recompute external-link security repair in adapter code; read the repaired attrs from `api.root_attrs()`.
 - Do not attach non-anchor keyboard repair listeners to native anchors.
 - Keep router comparison instance-local and avoid global polling.
 
@@ -210,7 +210,7 @@ view! {
 ## 28. Parity Summary and Intentional Deviations
 
 - Matches the core link contract without intentional adapter divergence.
-- Promotes router interception, progressive enhancement, external-link security repair, and non-anchor semantic repair into explicit Leptos-facing rules.
+- Promotes router interception, progressive enhancement, core-owned external-link security repair, and non-anchor semantic repair into explicit Leptos-facing rules.
 
 ## 29. Test Scenarios
 

--- a/spec/leptos-components/navigation/pagination.md
+++ b/spec/leptos-components/navigation/pagination.md
@@ -63,14 +63,14 @@ The adapter owns visible range derivation, repeated page-trigger rendering, and 
 
 | Adapter prop                                                  | Mode       | Sync trigger              | Machine event / update path | Visible effect                                      | Notes                                            |
 | ------------------------------------------------------------- | ---------- | ------------------------- | --------------------------- | --------------------------------------------------- | ------------------------------------------------ |
-| `page`                                                        | controlled | signal change after mount | `SetPage`                   | updates current page and visible range              | no controlled/uncontrolled switching after mount |
-| `page_size`, `total_items`, `sibling_count`, `boundary_count` | controlled | rerender with new props   | core prop rebuild           | recomputes visible range and disabled edge triggers | no shadow state                                  |
+| `page`                                                        | controlled | signal change after mount | `SyncProps` or `GoToPage`   | updates current page and visible range              | no controlled/uncontrolled switching after mount |
+| `page_size`, `total_items`, `sibling_count`, `boundary_count` | controlled | rerender with new props   | `SyncProps`                 | recomputes visible range and disabled edge triggers | no shadow state                                  |
 | `get_page_url`                                                | controlled | rerender with new props   | adapter host selection      | switches trigger host between `<button>` and `<a>`  | page semantics stay identical                    |
 
 | UI event                      | Preconditions                           | Machine event / callback path              | Ordering notes                                      | Notes                                     |
 | ----------------------------- | --------------------------------------- | ------------------------------------------ | --------------------------------------------------- | ----------------------------------------- |
-| prev or next activation       | not at edge                             | `GoToPrevPage` / `GoToNextPage`            | announcement fires only after committed page change | host may be button or anchor              |
-| page activation               | page is visible and not already current | `SetPage(page)`                            | announcement uses committed page number             | buttons and anchors share callback timing |
+| prev or next activation       | not at edge                             | `PrevPage` / `NextPage`                    | announcement fires only after committed page change | host may be button or anchor              |
+| page activation               | page is visible and not already current | `GoToPage(page)`                           | announcement uses committed page number             | buttons and anchors share callback timing |
 | route-style anchor navigation | `get_page_url` present                  | optional browser navigation after callback | adapter does not block navigation by default        | current page still uses `aria-current`    |
 
 ## 8. Registration and Cleanup Contract

--- a/spec/leptos-components/navigation/steps.md
+++ b/spec/leptos-components/navigation/steps.md
@@ -67,9 +67,9 @@ The adapter owns repeated item rendering, step-status projection, current-conten
 
 | Adapter prop                           | Mode       | Sync trigger              | Machine event / update path | Visible effect                                                 | Notes                                            |
 | -------------------------------------- | ---------- | ------------------------- | --------------------------- | -------------------------------------------------------------- | ------------------------------------------------ |
-| `step`                                 | controlled | signal change after mount | `GoToStep`                  | updates current item, content, and edge-trigger disabled state | no controlled/uncontrolled switching after mount |
-| `statuses`                             | controlled | rerender with new props   | core prop rebuild           | updates item and separator state                               | index alignment must stay stable                 |
-| `linear`, `orientation`, `interactive` | controlled | rerender with new props   | core prop rebuild           | updates navigation guards and semantics                        | no shadow state                                  |
+| `step`                                 | controlled | signal change after mount | `SyncProps` or `GoToStep`   | updates current item, content, and edge-trigger disabled state | no controlled/uncontrolled switching after mount |
+| `statuses`                             | controlled | rerender with new props   | `SyncProps`                 | updates item and separator state                               | index alignment must stay stable                 |
+| `linear`, `orientation`, `interactive` | controlled | rerender with new props   | `SyncProps` or render-local | updates navigation guards and semantics                        | no shadow state                                  |
 
 | UI event                | Preconditions                              | Machine event / callback path | Ordering notes                                                    | Notes                                                |
 | ----------------------- | ------------------------------------------ | ----------------------------- | ----------------------------------------------------------------- | ---------------------------------------------------- |


### PR DESCRIPTION
## Summary

- Add framework-agnostic `Breadcrumbs`, `Link`, `Pagination`, and `Steps` core modules under `ars-components`.
- Add per-component navigation snapshot directories, spec-conformance coverage, and state-machine proptests.
- Extend `ComponentPart` derive with field default annotations for non-`Default` part payloads, then derive the new navigation part enums.
- Sync the navigation core and adapter specs with the implemented contracts.

## Validation

- `cargo xci --profile fast`

Closes #247.
Closes #257.
Closes #259.