### PR TITLE
Improve ars-components coverage and mutation coverage

### DIFF
--- a/.agents/skills/post-implementation-audit/SKILL.md
+++ b/.agents/skills/post-implementation-audit/SKILL.md
@@ -139,9 +139,9 @@ The canonical entry-prompt:
 | **Unit tests** (inline `#[cfg(test)]`) | Logic + edge cases on the named acceptance criteria | List every public API + every edge case the spec describes; cross-reference with the test list |
 | **Snapshot tests** (insta) | `AttrMap` / chunk-output shape regressions | Check coverage of every anatomy part and every output-affecting prop / state / context branch |
 | **Property tests** (proptest) | Invariant violations across the input space | Check that invariants are non-trivial (roundtrip, idempotence, no-adjacent-X, etc.) and the input strategy is broad enough to actually exercise edge locales / multi-byte / large inputs |
-| **Mutation tests** (cargo-mutants) | Tests that *exist* but don't actually constrain behavior | Run `cargo mutants -p <crate> -f <file>` and triage every `MISSED` |
+| **Mutation tests** (cargo-mutants) | Tests that *exist* but don't actually constrain behavior | Run `cargo mutants -p <crate> -f <file>` and triage every `MISSED`; this is mandatory for every new or materially changed framework-agnostic component |
 | **Doc tests** | Public-API examples broken by future changes | Check `///` blocks for at least one `# Examples` block on the canonical entry point |
-| **Spec-conformance tests** | Anatomy drift between spec and impl | Check `crates/ars-components/tests/spec_conformance/*.rs` for an entry covering the new component's `Part` enum |
+| **Spec-conformance tests** | Anatomy drift between spec and impl | Check `crates/ars-components/tests/spec_conformance/*.rs` for an entry covering the new component's `Part` enum and public API/attribute contract; this is mandatory for every new framework-agnostic component |
 | **Code coverage** (cargo llvm-cov + xtask wasm path) | Unreachable / under-tested code; threshold drift | Use the right command for the crate (see "Procedure" below) — bare `cargo llvm-cov` does **not** measure adapter wasm code paths. Always finish with `cargo xtask coverage check-all --file <lcov>` to enforce the same thresholds CI does. |
 | **E2E / browser tests** (wasm-bindgen-test) | DOM-level behavior in the adapter | N/A for agnostic-core changes. Required when the change touches `ars-leptos`, `ars-dioxus`, `ars-dom`, or `ars-i18n` (`web-intl` path); these run via `cargo xtask test` or the adapter test-harness crates and execute in a browser via `wasm-bindgen-test`. Treat coverage from the wasm path (`cargo xtask coverage wasm`) as the source of truth for these — not the host-target llvm-cov number. |
 
@@ -195,13 +195,20 @@ The canonical entry-prompt:
    ```bash
    cargo mutants -p <crate> -f <file>
    ```
+   For framework-agnostic component work in `ars-components`, run this against the component's source file, usually:
+   ```bash
+   cargo mutants -p ars-components -f crates/ars-components/src/<category>/<component>/mod.rs
+   ```
+   Use the actual file path for single-file modules.
+
    For each `MISSED` line, decide:
    - **Real test gap** → add a test that kills the mutation (often a positive-direction assertion the existing tests skipped).
    - **Equivalent mutation** → add a regex to `.cargo/mutants.toml` `exclude_re` with a written justification explaining *why* the mutation cannot change observable behavior.
    - **Defensive code that's truly unreachable** → consider deleting the code. This is often the cleanest fix and is the right answer for unreachable post-filter guards.
 
 3. **Test-type breadth audit.** Walk the table above. For each test type, ask: *"Does this kind of change need this kind of test, and do we have one?"* Examples:
-   - New utility component with an anatomy table → spec-conformance test required
+   - New framework-agnostic component with an anatomy table → spec-conformance test required
+   - New or materially changed framework-agnostic component → targeted cargo-mutants run required before handoff
    - New public function → doc test with `# Examples` required
    - New invariants on a computation pipeline → proptest invariants strongly recommended
    - New `AttrMap` helpers → snapshot tests for each branch required

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -33,8 +33,9 @@ exclude_re = [
   'built_in.rs:633:.*is_valid_url',
   'validator.rs:262:9: delete match arm AriaAttr::DropEffect \| AriaAttr::Grabbed in supported_aria_attribute',
   'Key::uuid -> Self with Default::default\(\)',
+  '<impl TabKey for uuid::Uuid>::into_key -> Key with Default::default\(\)',
   '<impl From<uuid::Uuid> for Key>::from -> Self with Default::default\(\)',
-  'shared_state.rs:93:9: replace <impl Clone for SharedState<T>>::clone -> Self with Default::default\(\)',
+  'shared_state.rs:\d+:\d+: replace <impl Clone for SharedState<T>>::clone -> Self with Default::default\(\)',
   'z_index.rs:69:5: replace next_z_index_impl -> u32 with [01]',
   'z_index.rs:72:41: replace >= with < in next_z_index_impl',
   'z_index.rs:75:41: replace \+ with [-*] in next_z_index_impl',
@@ -197,6 +198,61 @@ exclude_re = [
   'highlight\.rs:\d+:\d+: replace \+ with \* in push_contains_matches',
   'highlight\.rs:\d+:\d+: replace \+ with - in push_contains_matches',
 
+  # DownloadTrigger URL scanners: these index-advance mutants are caught by
+  # nontermination on existing slash / percent / scheme-prefix inputs, but
+  # cargo-mutants reports them as timeouts. Excluding the timeout-only form
+  # keeps the Nightly matrix focused on surviving behavior changes.
+  'download_trigger\.rs:\d+:\d+: replace \+= with \*= in http_https_authority_rest',
+  'download_trigger\.rs:\d+:\d+: replace \+= with [-*]= in percent_decode_host',
+  'download_trigger\.rs:\d+:\d+: replace \+= with [-*]= in contains_scheme_separator_before_delim',
+  'download_trigger\.rs:\d+:\d+: replace \+= with \*= in starts_with_ignore_case',
+  'download_trigger\.rs:\d+:\d+: replace \|\| with && in classify_href',
+  'download_trigger\.rs:\d+:\d+: replace == with != in is_relative_reference',
+  'download_trigger\.rs:\d+:\d+: delete ! in is_relative_reference',
+  'download_trigger\.rs:\d+:\d+: replace contains_scheme_separator_before_delim -> bool with (true|false)',
+  'download_trigger\.rs:\d+:\d+: replace < with (==|>|<=) in contains_scheme_separator_before_delim',
+  'download_trigger\.rs:\d+:\d+: replace \|\| with && in contains_scheme_separator_before_delim',
+  'download_trigger\.rs:\d+:\d+: replace == with != in contains_scheme_separator_before_delim',
+  # These bitwise replacements are equivalent because the high-nibble and
+  # low-nibble / IPv4 component bit ranges do not overlap.
+  'download_trigger\.rs:\d+:\d+: replace \| with \^ in percent_decode_host',
+  'download_trigger\.rs:\d+:\d+: replace \| with \^ in parse_ipv4_address_relaxed',
+  # Empty strings and colon-containing strings already fail the downstream
+  # IPv4 parsers, so weakening this early guard does not change the result.
+  'download_trigger\.rs:\d+:\d+: replace \|\| with && in parse_ipv4_address_relaxed',
+  # Raw "0" parses to the same numeric value as decimal or octal; the branch is
+  # only there to select radix for multi-byte leading-zero components.
+  'download_trigger\.rs:\d+:\d+: replace > with >= in parse_ipv4_component_value',
+  # Once the explicit slash branch is preserved, weakening the later relative
+  # prefixes (`?`, `#`, `./`, `../`) is equivalent because the final
+  # no-scheme fallback still classifies them as relative.
+  'download_trigger\.rs:\d+:\d+: replace \|\| with && in is_relative_reference',
+
+  # Table helper wildcard arms clone through Empty/All. Deleting the explicit
+  # arm falls through to the non-exhaustive wildcard, which performs the same
+  # clone for these variants.
+  'table/mod\.rs:\d+:\d+: delete match arm selection::Set::Empty \| selection::Set::All in prune_selection_against',
+  'table/mod\.rs:\d+:\d+: delete match arm selection::Set::Empty \| selection::Set::All in restrict_selection_to_rows',
+  # Equality at the clamp boundary assigns the same value.
+  'table/mod\.rs:\d+:\d+: replace < with <= in <impl ars_core::Machine for Machine>::transition',
+
+  # NumberInput exact-boundary helpers:
+  # - `clamp` equality rewrites assign the same selected bound when the
+  #   input is exactly equal to `min` or `max`.
+  # - `baseline` boolean/equality rewrites only diverge for invalid NaN
+  #   bounds or exact zero bounds; all valid zero-bound cases still return
+  #   the same finite baseline (`0.0`).
+  'number_input/mod\.rs:\d+:\d+: replace > with >= in clamp',
+  'number_input/mod\.rs:\d+:\d+: replace < with <= in clamp',
+  'number_input/mod\.rs:\d+:\d+: replace && with \|\| in baseline',
+  'number_input/mod\.rs:\d+:\d+: replace > with >= in baseline',
+  'number_input/mod\.rs:\d+:\d+: replace < with <= in baseline',
+
+  # PinInput paste caps `filtered` with `take(length - start)`, so the
+  # enumerated `pos` values are always strictly less than `length`; allowing
+  # equality cannot change reachable behavior.
+  'pin_input/mod\.rs:\d+:\d+: replace < with <= in <impl ars_core::Machine for Machine>::transition',
+
   # Tabs `step_focus` checked-counter mutations and the Blur
   # short-circuit are equivalent in every reachable state. Regex is
   # line-number-agnostic so it survives source growth.
@@ -214,5 +270,13 @@ exclude_re = [
   'tabs/mod\.rs:\d+:\d+: replace \+= with \*= in step_focus',
   'tabs/mod\.rs:\d+:\d+: replace > with == in step_focus',
   'tabs/mod\.rs:\d+:\d+: replace > with >= in step_focus',
-  'tabs/mod\.rs:\d+:\d+: replace && with \|\| in <impl ars_core::Machine for Machine>::transition'
+  'tabs/mod\.rs:\d+:\d+: replace && with \|\| in <impl ars_core::Machine for Machine>::transition',
+
+  # HoverCard title registration is an idempotent private context flag used
+  # only to choose between `aria-label` and `aria-labelledby`. Replacing either
+  # mount/unmount guard with `true` only repeats the same boolean assignment
+  # for already-mounted/already-unmounted events; first mount/unmount behavior
+  # and the resulting content attributes are covered by tests.
+  'hover_card\.rs:\d+:\d+: replace match guard !ctx\.has_title with true',
+  'hover_card\.rs:\d+:\d+: replace match guard ctx\.has_title with true'
 ]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,12 @@ cargo mutants -p ars-components -f crates/ars-components/src/overlay/popover.rs 
 cargo mutants -p ars-components
 ```
 
+**Agnostic component implementation gate:** whenever an agent implements a new framework-agnostic component, or materially changes an existing one, the delivery must include:
+
+- a targeted mutation run for the component source file, usually `cargo mutants -p ars-components -f crates/ars-components/src/<category>/<component>/mod.rs` (adjust the path for single-file modules);
+- spec-conformance tests for the component's anatomy/public contract, including its `Part` enum and required API/attribute surface;
+- same-task triage of every `MISSED` mutant: add tests for real gaps, or add a justified line-agnostic `.cargo/mutants.toml` exclude only for true equivalent mutations.
+
 **Reading the output:** Results land in `mutants.out/mutants.out/` (gitignored). The two files that matter:
 
 - `caught.txt` — mutations that broke at least one test ✅

--- a/crates/ars-components/src/data_display/table/tests.rs
+++ b/crates/ars-components/src/data_display/table/tests.rs
@@ -100,9 +100,584 @@ fn snapshot_attrs(attrs: &AttrMap) -> String {
     format!("{attrs:#?}")
 }
 
+fn set(keys: &[&str]) -> BTreeSet<Key> {
+    keys.iter().map(|value| key(value)).collect()
+}
+
 // ────────────────────────────────────────────────────────────────────
 // 1. Root / table element role + caption labelling
 // ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn selection_helper_functions_cover_prune_restrict_normalize_and_materialize() {
+    let disabled = set(&["r2", "r3"]);
+
+    assert_eq!(
+        prune_selection_against(&selection::Set::Single(key("r1")), &disabled),
+        selection::Set::Single(key("r1"))
+    );
+    assert_eq!(
+        prune_selection_against(&selection::Set::Single(key("r2")), &disabled),
+        selection::Set::Empty
+    );
+    assert_eq!(
+        prune_selection_against(
+            &selection::Set::Multiple(set(&["r1", "r2", "r3"])),
+            &disabled
+        ),
+        selection::Set::Single(key("r1"))
+    );
+    assert_eq!(
+        prune_selection_against(&selection::Set::Multiple(BTreeSet::new()), &disabled),
+        selection::Set::Empty
+    );
+    assert_eq!(
+        prune_selection_against(&selection::Set::Empty, &disabled),
+        selection::Set::Empty
+    );
+    assert_eq!(
+        prune_selection_against(&selection::Set::All, &disabled),
+        selection::Set::All
+    );
+
+    let rows = vec![key("r1"), key("r3")];
+
+    assert_eq!(
+        restrict_selection_to_rows(&selection::Set::Single(key("r2")), &rows),
+        selection::Set::Empty
+    );
+    assert_eq!(
+        restrict_selection_to_rows(&selection::Set::Multiple(set(&["r1", "r2", "r3"])), &rows),
+        selection::Set::Multiple(set(&["r1", "r3"]))
+    );
+    assert_eq!(
+        restrict_selection_to_rows(&selection::Set::Multiple(BTreeSet::new()), &rows),
+        selection::Set::Empty
+    );
+    assert_eq!(
+        restrict_selection_to_rows(&selection::Set::Multiple(set(&["r1", "r2"])), &rows),
+        selection::Set::Single(key("r1"))
+    );
+    assert_eq!(
+        restrict_selection_to_rows(&selection::Set::Empty, &rows),
+        selection::Set::Empty
+    );
+    assert_eq!(
+        restrict_selection_to_rows(&selection::Set::All, &rows),
+        selection::Set::All
+    );
+
+    assert_eq!(
+        normalize_selection_for_mode(selection::Set::Single(key("r1")), selection::Mode::Single),
+        selection::Set::Single(key("r1"))
+    );
+    assert_eq!(
+        normalize_selection_for_mode(selection::Set::All, selection::Mode::Single),
+        selection::Set::Empty
+    );
+    assert_eq!(
+        normalize_selection_for_mode(
+            selection::Set::Multiple(set(&["r2", "r1"])),
+            selection::Mode::Single,
+        ),
+        selection::Set::Single(key("r1"))
+    );
+    assert_eq!(
+        normalize_selection_for_mode(selection::Set::Single(key("r1")), selection::Mode::None),
+        selection::Set::Empty
+    );
+
+    let mut state = selection::State::new(selection::Mode::Multiple, selection::Behavior::Toggle);
+
+    state.selected_keys = selection::Set::All;
+    state.disabled_keys = disabled;
+
+    assert_eq!(
+        materialize_all_against_rows(&state, &rows).selected_keys,
+        selection::Set::Single(key("r1"))
+    );
+
+    state.disabled_keys = set(&["r1", "r3"]);
+
+    assert_eq!(
+        materialize_all_against_rows(&state, &rows).selected_keys,
+        selection::Set::Empty
+    );
+
+    let mut selected =
+        selection::State::new(selection::Mode::Multiple, selection::Behavior::Toggle);
+
+    selected.selected_keys = selection::Set::Single(key("r1"));
+
+    assert_eq!(
+        materialize_all_against_rows(&selected, &rows).selected_keys,
+        selection::Set::Single(key("r1"))
+    );
+}
+
+#[test]
+fn prop_delta_helpers_cover_controlled_and_context_fields() {
+    assert!(!bindable_controlled_state_changed(
+        &Bindable::controlled(true),
+        &Bindable::controlled(true),
+    ));
+    assert!(bindable_controlled_state_changed(
+        &Bindable::controlled(true),
+        &Bindable::controlled(false),
+    ));
+    assert!(bindable_controlled_state_changed(
+        &Bindable::controlled(true),
+        &Bindable::uncontrolled(true),
+    ));
+    assert!(!bindable_controlled_state_changed(
+        &Bindable::uncontrolled(true),
+        &Bindable::uncontrolled(false),
+    ));
+
+    let old = test_props();
+    let mut new = old.clone();
+
+    assert!(!non_dir_context_props_changed(&old, &new));
+
+    new.id = "next".to_string();
+
+    assert!(non_dir_context_props_changed(&old, &new));
+
+    new = old.clone();
+    new.disabled_keys = set(&["r1"]);
+
+    assert!(non_dir_context_props_changed(&old, &new));
+
+    new = old.clone();
+    new.min_column_width = 75.5;
+
+    assert!(non_dir_context_props_changed(&old, &new));
+
+    new = old.clone();
+    new.column_resize_step = 2.5;
+
+    assert!(non_dir_context_props_changed(&old, &new));
+
+    new = old.clone();
+    new.escape_key_behavior = EscapeKeyBehavior::None;
+
+    assert!(non_dir_context_props_changed(&old, &new));
+
+    new = old.clone();
+    new.select_all_mode = SelectAllMode::AllData { total_count: 42 };
+
+    assert!(non_dir_context_props_changed(&old, &new));
+
+    new = old.clone();
+    new.virtual_scrolling = true;
+
+    assert!(non_dir_context_props_changed(&old, &new));
+
+    new = old.clone();
+    new.total_rows = 10;
+
+    assert!(non_dir_context_props_changed(&old, &new));
+
+    new = old.clone();
+    new.total_cols = 4;
+
+    assert!(non_dir_context_props_changed(&old, &new));
+
+    new = old.clone();
+    new.dir = Direction::Rtl;
+
+    assert!(!non_dir_context_props_changed(&old, &new));
+}
+
+#[test]
+fn would_empty_and_some_selected_report_exact_selection_state() {
+    assert!(would_empty_after_deselect(
+        &selection::Set::Single(key("r1")),
+        &key("r1")
+    ));
+    assert!(!would_empty_after_deselect(
+        &selection::Set::Single(key("r1")),
+        &key("r2")
+    ));
+    assert!(would_empty_after_deselect(
+        &selection::Set::Multiple(set(&["r1"])),
+        &key("r1")
+    ));
+    assert!(!would_empty_after_deselect(
+        &selection::Set::Multiple(set(&["r1", "r2"])),
+        &key("r1")
+    ));
+    assert!(!would_empty_after_deselect(
+        &selection::Set::All,
+        &key("r1")
+    ));
+
+    let rows = vec![key("r1"), key("r2"), key("r3")];
+    let row_refs = rows.iter().collect::<Vec<_>>();
+
+    let service = service_with_rows(
+        Props {
+            default_selected_rows: selection::Set::Single(key("r2")),
+            disabled_keys: set(&["r1"]),
+            ..test_props_multi()
+        },
+        &rows,
+    );
+
+    let api = service.connect(&|_| {});
+
+    assert!(api.some_selected(&row_refs));
+
+    let all_service = service_with_rows(
+        Props {
+            default_selected_rows: selection::Set::All,
+            disabled_keys: set(&["r1", "r2", "r3"]),
+            ..test_props_multi()
+        },
+        &rows,
+    );
+
+    let all_api = all_service.connect(&|_| {});
+
+    assert!(!all_api.some_selected(&row_refs));
+}
+
+#[test]
+fn cell_keydown_and_format_width_cover_boundary_noops() {
+    assert_eq!(format_width(120.0), "120");
+    assert_eq!(format_width(120.5), "120.5");
+
+    let rows = vec![key("r1")];
+    let row_refs = rows.iter().collect::<Vec<_>>();
+
+    let service = service_with_rows(
+        Props {
+            interactive: true,
+            ..test_props()
+        },
+        &rows,
+    );
+
+    let recorder = EventRecorder::default();
+
+    let send = |event| record(&recorder, event);
+
+    let api = service.connect(&send);
+
+    api.on_cell_keydown(
+        &key("missing"),
+        0,
+        &keydown(KeyboardKey::ArrowRight),
+        &row_refs,
+        2,
+    );
+    api.on_cell_keydown(
+        &key("r1"),
+        1,
+        &keydown(KeyboardKey::ArrowRight),
+        &row_refs,
+        2,
+    );
+    api.on_cell_keydown(
+        &key("r1"),
+        0,
+        &keydown(KeyboardKey::ArrowLeft),
+        &row_refs,
+        2,
+    );
+
+    assert!(recorder.borrow().is_empty());
+}
+
+#[test]
+fn cell_keydown_home_end_without_ctrl_stay_on_current_row() {
+    let rows = vec![key("r1"), key("r2"), key("r3")];
+    let row_refs = rows.iter().collect::<Vec<_>>();
+
+    let service = service_with_rows(
+        Props {
+            interactive: true,
+            ..test_props()
+        },
+        &rows,
+    );
+
+    let recorder = EventRecorder::default();
+
+    let send = |event| record(&recorder, event);
+
+    let api = service.connect(&send);
+
+    api.on_cell_keydown(&key("r2"), 2, &keydown(KeyboardKey::Home), &row_refs, 4);
+    api.on_cell_keydown(&key("r2"), 1, &keydown(KeyboardKey::End), &row_refs, 4);
+
+    assert_eq!(
+        *recorder.borrow(),
+        vec![
+            Event::FocusCell {
+                row: key("r2"),
+                col: 0,
+                row_index: 1,
+            },
+            Event::FocusCell {
+                row: key("r2"),
+                col: 3,
+                row_index: 1,
+            },
+        ]
+    );
+}
+
+#[test]
+fn selection_transition_guards_cover_noop_and_allowed_edges() {
+    let mut none_mode = service_with_rows(
+        Props {
+            default_selected_rows: selection::Set::Single(key("r1")),
+            ..test_props()
+        },
+        &[key("r1")],
+    );
+
+    let result = none_mode.send(Event::DeselectRow(key("r1")));
+
+    assert!(!result.context_changed);
+    assert_eq!(
+        none_mode.context().selected_rows.get(),
+        &selection::Set::Single(key("r1"))
+    );
+
+    let mut unselected = service_with_rows(test_props_multi(), &[key("r1"), key("r2")]);
+    let result = unselected.send(Event::DeselectRow(key("r2")));
+
+    assert!(!result.context_changed);
+    assert_eq!(
+        unselected.context().selected_rows.get(),
+        &selection::Set::Empty
+    );
+
+    let mut deselect_allowed = service_with_rows(
+        Props {
+            default_selected_rows: selection::Set::Single(key("r1")),
+            disallow_empty_selection: false,
+            ..test_props_multi()
+        },
+        &[key("r1")],
+    );
+
+    let result = deselect_allowed.send(Event::DeselectRow(key("r1")));
+
+    assert!(result.context_changed);
+    assert_eq!(
+        deselect_allowed.context().selected_rows.get(),
+        &selection::Set::Empty
+    );
+
+    let mut toggle_allowed = service_with_rows(
+        Props {
+            default_selected_rows: selection::Set::Single(key("r1")),
+            disallow_empty_selection: false,
+            ..test_props_multi()
+        },
+        &[key("r1")],
+    );
+
+    let result = toggle_allowed.send(Event::ToggleRow(key("r1")));
+
+    assert!(result.context_changed);
+    assert_eq!(
+        toggle_allowed.context().selected_rows.get(),
+        &selection::Set::Empty
+    );
+
+    let mut toggle_unselected_disallow = service_with_rows(
+        Props {
+            disallow_empty_selection: true,
+            ..test_props_multi()
+        },
+        &[key("r1")],
+    );
+
+    let result = toggle_unselected_disallow.send(Event::ToggleRow(key("r1")));
+
+    assert!(result.context_changed);
+    assert_eq!(
+        toggle_unselected_disallow.context().selected_rows.get(),
+        &selection::Set::Multiple(set(&["r1"]))
+    );
+
+    let mut all_data_single = service_with_rows(
+        Props {
+            default_selected_rows: selection::Set::Single(key("r1")),
+            select_all_mode: SelectAllMode::AllData { total_count: 10 },
+            ..test_props_multi()
+        },
+        &[key("r1")],
+    );
+
+    let result = all_data_single.send(Event::DeselectRow(key("r1")));
+
+    assert!(result.context_changed);
+    assert_eq!(
+        all_data_single.context().selected_rows.get(),
+        &selection::Set::Empty
+    );
+}
+
+#[test]
+fn select_all_and_deselect_all_edges_cover_empty_single_and_none_mode() {
+    let mut no_visible = service_with_rows(test_props_multi(), &[]);
+    let result = no_visible.send(Event::SelectAll);
+
+    assert!(result.context_changed);
+    assert_eq!(
+        no_visible.context().selected_rows.get(),
+        &selection::Set::Empty
+    );
+
+    let mut one_visible = service_with_rows(test_props_multi(), &[key("r1")]);
+
+    let result = one_visible.send(Event::SelectAll);
+
+    assert!(result.context_changed);
+    assert_eq!(
+        one_visible.context().selected_rows.get(),
+        &selection::Set::Single(key("r1"))
+    );
+
+    let mut none_mode = service_with_rows(
+        Props {
+            default_selected_rows: selection::Set::Single(key("r1")),
+            ..test_props()
+        },
+        &[key("r1")],
+    );
+
+    let result = none_mode.send(Event::DeselectAll);
+
+    assert!(!result.context_changed);
+    assert_eq!(
+        none_mode.context().selected_rows.get(),
+        &selection::Set::Single(key("r1"))
+    );
+}
+
+#[test]
+fn sync_props_edges_cover_selection_demotion_and_expansion_control() {
+    let mut empty_rows = service_with_rows(
+        Props {
+            default_selected_rows: selection::Set::All,
+            select_all_mode: SelectAllMode::AllData { total_count: 10 },
+            ..test_props_multi()
+        },
+        &[],
+    );
+
+    drop(empty_rows.set_props(Props {
+        select_all_mode: SelectAllMode::AllVisible,
+        ..test_props_multi()
+    }));
+
+    assert_eq!(
+        empty_rows.context().selected_rows.get(),
+        &selection::Set::Empty
+    );
+
+    let mut one_row = service_with_rows(
+        Props {
+            default_selected_rows: selection::Set::All,
+            select_all_mode: SelectAllMode::AllData { total_count: 10 },
+            ..test_props_multi()
+        },
+        &[key("r1")],
+    );
+
+    drop(one_row.set_props(Props {
+        select_all_mode: SelectAllMode::AllVisible,
+        ..test_props_multi()
+    }));
+
+    assert_eq!(
+        one_row.context().selected_rows.get(),
+        &selection::Set::Single(key("r1"))
+    );
+
+    let mut uncontrolled_expansion = service_with_rows(
+        Props {
+            default_expanded_rows: set(&["r1", "r2"]),
+            ..test_props()
+        },
+        &[key("r1"), key("r2")],
+    );
+
+    drop(uncontrolled_expansion.set_props(Props {
+        disabled_keys: set(&["r2"]),
+        ..test_props()
+    }));
+
+    assert_eq!(
+        uncontrolled_expansion.context().expanded_rows.get(),
+        &set(&["r1"])
+    );
+
+    let mut controlled_expansion = service_with_rows(
+        Props {
+            expanded_rows: Some(set(&["r1", "r2"])),
+            ..test_props()
+        },
+        &[key("r1"), key("r2")],
+    );
+
+    drop(controlled_expansion.set_props(Props {
+        expanded_rows: Some(set(&["r1", "r2"])),
+        disabled_keys: set(&["r2"]),
+        ..test_props()
+    }));
+
+    assert_eq!(
+        controlled_expansion.context().expanded_rows.get(),
+        &set(&["r1", "r2"])
+    );
+}
+
+#[test]
+fn props_changed_syncs_controlled_selection_and_expansion() {
+    let mut service = service_with_rows(test_props_multi(), &[key("r1"), key("r2")]);
+
+    drop(service.set_props(Props {
+        selected_rows: Some(selection::Set::Single(key("r1"))),
+        ..test_props_multi()
+    }));
+
+    assert_eq!(
+        service.context().selected_rows.get(),
+        &selection::Set::Single(key("r1"))
+    );
+
+    drop(service.set_props(Props {
+        selected_rows: Some(selection::Set::Single(key("r1"))),
+        expanded_rows: Some(set(&["r2"])),
+        ..test_props_multi()
+    }));
+
+    assert_eq!(service.context().expanded_rows.get(), &set(&["r2"]));
+}
+
+#[test]
+fn init_preserves_controlled_selected_rows() {
+    let service = service_with_rows(
+        Props {
+            selected_rows: Some(selection::Set::Single(key("r1"))),
+            ..test_props_multi()
+        },
+        &[key("r1")],
+    );
+
+    assert_eq!(
+        service.context().selected_rows.get(),
+        &selection::Set::Single(key("r1"))
+    );
+    assert!(service.context().selection_state.is_selected(&key("r1")));
+}
 
 #[test]
 fn table_root_produces_table_role() {
@@ -1591,6 +2166,45 @@ fn table_set_row_counts_idempotent_when_unchanged() {
 }
 
 #[test]
+fn table_set_row_counts_updates_when_only_one_axis_changes() {
+    let mut rows_service = service_with_rows(
+        Props {
+            total_rows: 5,
+            total_cols: 3,
+            ..test_props()
+        },
+        &[],
+    );
+
+    let result = rows_service.send(Event::SetRowCounts {
+        total_rows: 6,
+        total_cols: 3,
+    });
+
+    assert!(result.context_changed);
+    assert_eq!(rows_service.context().total_rows, 6);
+    assert_eq!(rows_service.context().total_cols, 3);
+
+    let mut cols_service = service_with_rows(
+        Props {
+            total_rows: 5,
+            total_cols: 3,
+            ..test_props()
+        },
+        &[],
+    );
+
+    let result = cols_service.send(Event::SetRowCounts {
+        total_rows: 5,
+        total_cols: 4,
+    });
+
+    assert!(result.context_changed);
+    assert_eq!(cols_service.context().total_rows, 5);
+    assert_eq!(cols_service.context().total_cols, 4);
+}
+
+#[test]
 fn table_init_seeds_selection_state_from_default_selected_rows() {
     // Regression guard for spec drift D1: `selection_state.selected_keys`
     // must reflect `default_selected_rows` at init so subsequent
@@ -1606,6 +2220,24 @@ fn table_init_seeds_selection_state_from_default_selected_rows() {
 
     assert!(service.context().selection_state.is_selected(&key("r1")));
     assert!(!service.context().selection_state.is_selected(&key("r2")));
+}
+
+#[test]
+fn table_init_seeds_selection_state_before_rows_register() {
+    let service = Service::<Machine>::new(
+        Props {
+            selection_mode: selection::Mode::Multiple,
+            default_selected_rows: selection::Set::Single(key("r1")),
+            ..test_props()
+        },
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    assert_eq!(
+        service.context().selection_state.selected_keys,
+        selection::Set::Single(key("r1"))
+    );
 }
 
 // ────────────────────────────────────────────────────────────────────
@@ -2218,6 +2850,7 @@ fn table_part_attrs_dispatcher_covers_every_variant() {
 
     for part in parts {
         let attrs = api.part_attrs(part);
+
         // Every part should yield at least the scope/part attrs unless
         // intentionally short-circuited (SelectAllCheckbox in mode
         // None — but we're in Multiple here, so all are populated).
@@ -2238,10 +2871,13 @@ fn codex_sync_props_copies_updated_disabled_keys_into_context() {
     // Codex P1 (thread PRRT_kwDORp4enM6DRmcb).
     // SyncProps must mirror Props → Context for the non-Bindable fields.
     let service = service_with_rows(test_props_multi(), &[key("r1"), key("r2")]);
+
     assert!(service.context().disabled_keys.is_empty());
 
     let mut new_disabled = BTreeSet::new();
+
     new_disabled.insert(key("r1"));
+
     let new_props = Props {
         selection_mode: selection::Mode::Multiple,
         disabled_keys: new_disabled,
@@ -2249,6 +2885,7 @@ fn codex_sync_props_copies_updated_disabled_keys_into_context() {
     };
 
     let mut service = service;
+
     drop(service.set_props(new_props));
 
     assert!(
@@ -2261,13 +2898,16 @@ fn codex_sync_props_copies_updated_disabled_keys_into_context() {
 fn codex_sync_props_copies_updated_interactive_flag() {
     // Codex P1 — SyncProps interactivity update.
     let service = service_with_rows(test_props(), &[key("r1")]);
+
     assert!(!service.context().interactive);
 
     let new_props = Props {
         interactive: true,
         ..test_props()
     };
+
     let mut service = service;
+
     drop(service.set_props(new_props));
 
     assert!(service.context().interactive);
@@ -2299,8 +2939,11 @@ fn codex_on_props_changed_dispatches_sync_events() {
     // which calls `on_props_changed` and then dispatches the returned
     // events.
     let old_props = test_props_multi();
+
     let mut disabled = BTreeSet::new();
+
     disabled.insert(key("r1"));
+
     let new_props = Props {
         disabled_keys: disabled.clone(),
         dir: Direction::Rtl,
@@ -2308,7 +2951,9 @@ fn codex_on_props_changed_dispatches_sync_events() {
     };
 
     let service = service_with_rows(old_props, &[key("r1"), key("r2")]);
+
     let mut service = service;
+
     drop(service.set_props(new_props));
 
     // `SetDirection` must have flowed.
@@ -2328,6 +2973,7 @@ fn codex_select_all_in_all_visible_mode_materializes_current_rows() {
     drop(service.send(Event::SelectAll));
 
     let sel = service.context().selected_rows.get().clone();
+
     assert!(
         !matches!(sel, selection::Set::All),
         "AllVisible select-all must not write Set::All — that means dataset-wide"
@@ -2365,6 +3011,7 @@ fn codex_sort_column_does_not_leave_is_sorting_stuck() {
     // stuck `true` in the synchronous-sort path. The flag becomes
     // adapter-controlled via `SetIsSorting(bool)`.
     let mut service = service_with_rows(test_props(), &[]);
+
     drop(service.send(Event::SortColumn {
         column: "name".to_string(),
     }));
@@ -2380,12 +3027,15 @@ fn codex_set_is_sorting_event_toggles_flag() {
     // Codex P2 follow-up — the new `SetIsSorting` event lets adapters
     // drive the async-sort indicator explicitly.
     let mut service = service_with_rows(test_props(), &[]);
+
     assert!(!service.context().is_sorting);
 
     drop(service.send(Event::SetIsSorting(true)));
+
     assert!(service.context().is_sorting);
 
     drop(service.send(Event::SetIsSorting(false)));
+
     assert!(!service.context().is_sorting);
 }
 
@@ -2397,6 +3047,7 @@ fn codex_select_all_attrs_gated_on_mode_multiple() {
     // because `Event::SelectAll` is rejected in those modes and the
     // checkbox would render but never work.
     let service = service_with_rows(test_props_single(), &[key("r1")]);
+
     let attrs = service.connect(&|_| {}).select_all_attrs(&[&key("r1")]);
 
     assert!(
@@ -2408,6 +3059,7 @@ fn codex_select_all_attrs_gated_on_mode_multiple() {
 #[test]
 fn codex_select_all_attrs_empty_when_mode_none() {
     let service = service_with_rows(test_props(), &[key("r1")]);
+
     let attrs = service.connect(&|_| {}).select_all_attrs(&[&key("r1")]);
 
     assert!(attrs.iter_attrs().next().is_none());
@@ -2426,11 +3078,13 @@ fn codex_set_rows_rebases_focused_cell_when_row_moves_index() {
         },
         &[key("r1"), key("r2"), key("r3")],
     );
+
     drop(service.send(Event::FocusCell {
         row: key("r2"),
         col: 1,
         row_index: 1,
     }));
+
     assert_eq!(service.context().focused_cell, Some((1, 1)));
 
     // Reorder: r2 was at index 1, now at index 0.
@@ -2460,6 +3114,7 @@ fn codex_round2_uncontrolled_to_controlled_sort_dispatches_sync() {
         sort_descriptor: Bindable::uncontrolled(None),
         ..test_props()
     };
+
     let new_props = Props {
         sort_descriptor: Bindable::controlled(Some(SortDescriptor {
             column: "name".to_string(),
@@ -2469,7 +3124,9 @@ fn codex_round2_uncontrolled_to_controlled_sort_dispatches_sync() {
     };
 
     let service = service_with_rows(old_props, &[]);
+
     let mut service = service;
+
     drop(service.set_props(new_props));
 
     assert!(
@@ -2500,13 +3157,16 @@ fn codex_round2_controlled_to_uncontrolled_sort_dispatches_sync() {
         })),
         ..test_props()
     };
+
     let new_props = Props {
         sort_descriptor: Bindable::uncontrolled(None),
         ..test_props()
     };
 
     let service = service_with_rows(old_props, &[]);
+
     let mut service = service;
+
     drop(service.set_props(new_props));
 
     assert!(
@@ -2524,13 +3184,16 @@ fn codex_round2_controlled_loading_syncs_on_props_change() {
         loading: Bindable::controlled(false),
         ..test_props()
     };
+
     let new_props = Props {
         loading: Bindable::controlled(true),
         ..test_props()
     };
 
     let service = service_with_rows(old_props, &[]);
+
     let mut service = service;
+
     drop(service.set_props(new_props));
 
     assert!(
@@ -2547,9 +3210,11 @@ fn codex_round2_sync_props_does_not_corrupt_controlled_selection() {
     // SyncProps must not silently desync `selection_state.selected_keys`
     // from the actually-visible selection — re-sync from `get()`.
     let mut disabled = BTreeSet::new();
+
     disabled.insert(key("r1"));
 
     let mut controlled = BTreeSet::new();
+
     controlled.insert(key("r1"));
     controlled.insert(key("r2"));
 
@@ -2569,6 +3234,7 @@ fn codex_round2_sync_props_does_not_corrupt_controlled_selection() {
         disabled_keys: disabled.clone(),
         ..test_props()
     };
+
     drop(service.set_props(new_props));
 
     // For controlled bindables, the user-visible value is whatever the
@@ -2589,6 +3255,7 @@ fn codex_round2_sync_props_prunes_uncontrolled_selection() {
     // Codex P1 follow-up — pruning still applies in the uncontrolled
     // case where the agnostic core owns the value.
     let mut new_disabled = BTreeSet::new();
+
     new_disabled.insert(key("r1"));
 
     let mut service = service_with_rows(
@@ -2616,9 +3283,11 @@ fn codex_round2_sync_props_prunes_uncontrolled_selection() {
         }),
         ..test_props()
     };
+
     drop(service.set_props(new_props));
 
     let sel = service.context().selected_rows.get().clone();
+
     assert!(
         !sel.contains(&key("r1")),
         "uncontrolled selection must be pruned of disabled rows"
@@ -2634,6 +3303,7 @@ fn codex_round2_sync_props_resyncs_id_and_caption_id() {
     // `aria-labelledby` and `aria-controls` ids stay stale after a
     // parent rename).
     let mut service = service_with_rows(test_props(), &[]);
+
     assert_eq!(service.context().id, "table");
     assert_eq!(service.context().caption_id, "table-caption");
 
@@ -2641,6 +3311,7 @@ fn codex_round2_sync_props_resyncs_id_and_caption_id() {
         id: "orders".to_string(),
         ..test_props()
     };
+
     drop(service.set_props(new_props));
 
     assert_eq!(
@@ -2663,6 +3334,7 @@ fn codex_round2_part_attrs_select_all_uses_ctx_rows() {
     // and therefore "aria-checked=false" even when every registered row
     // was selected. The dispatcher must route through `ctx.rows`.
     let mut service = service_with_rows(test_props_multi(), &[key("r1"), key("r2")]);
+
     drop(service.send(Event::SelectAll));
 
     let attrs = service.connect(&|_| {}).part_attrs(Part::SelectAllCheckbox);
@@ -2691,8 +3363,10 @@ fn codex_round3_set_rows_keeps_selection_state_aligned_when_controlled() {
     // pruned/restricted internal write — otherwise transition guards
     // and API reads disagree.
     let mut controlled = BTreeSet::new();
+
     controlled.insert(key("r1"));
     controlled.insert(key("r2"));
+
     let mut service = service_with_rows(
         Props {
             selection_mode: selection::Mode::Multiple,
@@ -2724,8 +3398,10 @@ fn codex_round3_sync_controlled_selected_rows_leave_controlled_resyncs_state() {
     // `selection_state.selected_keys` must reflect the internal value
     // that `get()` now returns.
     let mut controlled = BTreeSet::new();
+
     controlled.insert(key("r1"));
     controlled.insert(key("r2"));
+
     let mut service = service_with_rows(
         Props {
             selection_mode: selection::Mode::Multiple,
@@ -2738,6 +3414,7 @@ fn codex_round3_sync_controlled_selected_rows_leave_controlled_resyncs_state() {
         },
         &[key("r1"), key("r2"), key("r3")],
     );
+
     assert_eq!(
         service.context().selection_state.selected_keys,
         selection::Set::Multiple(controlled),
@@ -2777,7 +3454,9 @@ fn codex_round4_deselect_row_keeps_set_all_in_all_data_mode() {
         },
         &[key("r1"), key("r2"), key("r3")],
     );
+
     drop(service.send(Event::SelectAll));
+
     assert!(matches!(
         service.context().selected_rows.get(),
         selection::Set::All
@@ -2804,6 +3483,7 @@ fn codex_round4_toggle_row_keeps_set_all_in_all_data_mode() {
         },
         &[key("r1"), key("r2"), key("r3")],
     );
+
     drop(service.send(Event::SelectAll));
 
     drop(service.send(Event::ToggleRow(key("r2"))));
@@ -2815,12 +3495,57 @@ fn codex_round4_toggle_row_keeps_set_all_in_all_data_mode() {
 }
 
 #[test]
+fn table_toggle_row_all_data_single_selection_can_toggle_off() {
+    let mut service = service_with_rows(
+        Props {
+            selection_mode: selection::Mode::Multiple,
+            select_all_mode: SelectAllMode::AllData { total_count: 10 },
+            default_selected_rows: selection::Set::Single(key("r1")),
+            ..test_props()
+        },
+        &[key("r1"), key("r2")],
+    );
+
+    let result = service.send(Event::ToggleRow(key("r1")));
+
+    assert!(result.context_changed);
+    assert_eq!(
+        service.context().selected_rows.get(),
+        &selection::Set::Empty
+    );
+}
+
+#[test]
+fn table_toggle_row_all_visible_set_all_materializes_and_deselects() {
+    let mut service = service_with_rows(
+        Props {
+            selection_mode: selection::Mode::Multiple,
+            default_selected_rows: selection::Set::All,
+            ..test_props()
+        },
+        &[key("r1"), key("r2")],
+    );
+
+    assert_eq!(service.context().selected_rows.get(), &selection::Set::All);
+
+    let result = service.send(Event::ToggleRow(key("r1")));
+
+    assert!(result.context_changed);
+    assert_eq!(
+        service.context().selected_rows.get(),
+        &selection::Set::Multiple(set(&["r2"]))
+    );
+}
+
+#[test]
 fn codex_round4_on_row_keydown_skips_disabled_when_arrow_down() {
     // Codex P2 (thread PRRT_kwDORp4enM6DTElY).
     // Arrow-key row navigation must skip disabled rows so adapter focus
     // wiring doesn't land on `aria-disabled` rows.
     let mut disabled = BTreeSet::new();
+
     disabled.insert(key("r2"));
+
     let service = service_with_rows(
         Props {
             interactive: true,
@@ -2829,12 +3554,17 @@ fn codex_round4_on_row_keydown_skips_disabled_when_arrow_down() {
         },
         &[key("r1"), key("r2"), key("r3")],
     );
+
     let recorder = EventRecorder::default();
+
     let rows = [key("r1"), key("r2"), key("r3")];
     let row_refs: Vec<&Key> = rows.iter().collect();
+
     {
         let send = |e| record(&recorder, e);
+
         let api = service.connect(&send);
+
         api.on_row_keydown(&key("r1"), &keydown(KeyboardKey::ArrowDown), &row_refs);
     }
 
@@ -2847,7 +3577,9 @@ fn codex_round4_on_row_keydown_skips_disabled_when_arrow_down() {
 #[test]
 fn codex_round4_on_row_keydown_skips_disabled_when_arrow_up() {
     let mut disabled = BTreeSet::new();
+
     disabled.insert(key("r2"));
+
     let service = service_with_rows(
         Props {
             interactive: true,
@@ -2856,12 +3588,17 @@ fn codex_round4_on_row_keydown_skips_disabled_when_arrow_up() {
         },
         &[key("r1"), key("r2"), key("r3")],
     );
+
     let recorder = EventRecorder::default();
+
     let rows = [key("r1"), key("r2"), key("r3")];
     let row_refs: Vec<&Key> = rows.iter().collect();
+
     {
         let send = |e| record(&recorder, e);
+
         let api = service.connect(&send);
+
         api.on_row_keydown(&key("r3"), &keydown(KeyboardKey::ArrowUp), &row_refs);
     }
 
@@ -2875,7 +3612,9 @@ fn codex_round4_on_row_keydown_skips_disabled_when_arrow_up() {
 fn codex_round4_on_cell_keydown_arrow_down_skips_disabled_row() {
     // Codex P2 (thread PRRT_kwDORp4enM6DTElb).
     let mut disabled = BTreeSet::new();
+
     disabled.insert(key("r2"));
+
     let service = service_with_rows(
         Props {
             interactive: true,
@@ -2884,12 +3623,17 @@ fn codex_round4_on_cell_keydown_arrow_down_skips_disabled_row() {
         },
         &[key("r1"), key("r2"), key("r3")],
     );
+
     let recorder = EventRecorder::default();
+
     let rows = [key("r1"), key("r2"), key("r3")];
     let row_refs: Vec<&Key> = rows.iter().collect();
+
     {
         let send = |e| record(&recorder, e);
+
         let api = service.connect(&send);
+
         api.on_cell_keydown(
             &key("r1"),
             0,
@@ -2904,6 +3648,7 @@ fn codex_round4_on_cell_keydown_arrow_down_skips_disabled_row() {
             assert_eq!(row, &key("r3"), "must skip disabled r2");
             assert_eq!(*row_index, 2);
         }
+
         other => panic!("expected FocusCell(r3), got {other:?}"),
     }
 }
@@ -2919,6 +3664,7 @@ fn codex_round4_table_attrs_emits_aria_multiselectable_on_interactive_grid() {
         },
         &[key("r1")],
     );
+
     let attrs = service.connect(&|_| {}).table_attrs();
 
     assert_eq!(
@@ -2940,6 +3686,7 @@ fn codex_round4_table_attrs_omits_aria_multiselectable_in_single_mode() {
         },
         &[key("r1")],
     );
+
     let attrs = service.connect(&|_| {}).table_attrs();
 
     assert!(
@@ -2960,6 +3707,7 @@ fn codex_round4_table_attrs_omits_aria_multiselectable_when_non_interactive() {
         },
         &[key("r1")],
     );
+
     let attrs = service.connect(&|_| {}).table_attrs();
 
     assert!(
@@ -3010,7 +3758,9 @@ fn codex_round4_on_row_keydown_home_skips_disabled_first_row() {
     // Home must land on the first ENABLED row, skipping any leading
     // disabled rows.
     let mut disabled = BTreeSet::new();
+
     disabled.insert(key("r1"));
+
     let service = service_with_rows(
         Props {
             interactive: true,
@@ -3019,12 +3769,17 @@ fn codex_round4_on_row_keydown_home_skips_disabled_first_row() {
         },
         &[key("r1"), key("r2"), key("r3")],
     );
+
     let recorder = EventRecorder::default();
+
     let rows = [key("r1"), key("r2"), key("r3")];
     let row_refs: Vec<&Key> = rows.iter().collect();
+
     {
         let send = |e| record(&recorder, e);
+
         let api = service.connect(&send);
+
         api.on_row_keydown(&key("r3"), &keydown(KeyboardKey::Home), &row_refs);
     }
 
@@ -3037,7 +3792,9 @@ fn codex_round4_on_row_keydown_home_skips_disabled_first_row() {
 #[test]
 fn codex_round4_on_row_keydown_end_skips_disabled_last_row() {
     let mut disabled = BTreeSet::new();
+
     disabled.insert(key("r3"));
+
     let service = service_with_rows(
         Props {
             interactive: true,
@@ -3046,12 +3803,17 @@ fn codex_round4_on_row_keydown_end_skips_disabled_last_row() {
         },
         &[key("r1"), key("r2"), key("r3")],
     );
+
     let recorder = EventRecorder::default();
+
     let rows = [key("r1"), key("r2"), key("r3")];
     let row_refs: Vec<&Key> = rows.iter().collect();
+
     {
         let send = |e| record(&recorder, e);
+
         let api = service.connect(&send);
+
         api.on_row_keydown(&key("r1"), &keydown(KeyboardKey::End), &row_refs);
     }
 
@@ -3066,8 +3828,10 @@ fn codex_round4_on_row_keydown_arrow_no_op_when_all_remaining_disabled() {
     // When every row after the current one is disabled, ArrowDown
     // must emit no event (no FocusRow to land on).
     let mut disabled = BTreeSet::new();
+
     disabled.insert(key("r2"));
     disabled.insert(key("r3"));
+
     let service = service_with_rows(
         Props {
             interactive: true,
@@ -3076,12 +3840,17 @@ fn codex_round4_on_row_keydown_arrow_no_op_when_all_remaining_disabled() {
         },
         &[key("r1"), key("r2"), key("r3")],
     );
+
     let recorder = EventRecorder::default();
+
     let rows = [key("r1"), key("r2"), key("r3")];
     let row_refs: Vec<&Key> = rows.iter().collect();
+
     {
         let send = |e| record(&recorder, e);
+
         let api = service.connect(&send);
+
         api.on_row_keydown(&key("r1"), &keydown(KeyboardKey::ArrowDown), &row_refs);
     }
 
@@ -3094,7 +3863,9 @@ fn codex_round4_on_row_keydown_arrow_no_op_when_all_remaining_disabled() {
 #[test]
 fn codex_round4_ctrl_home_skips_disabled_first_row_in_cell_nav() {
     let mut disabled = BTreeSet::new();
+
     disabled.insert(key("r1"));
+
     let service = service_with_rows(
         Props {
             interactive: true,
@@ -3103,12 +3874,17 @@ fn codex_round4_ctrl_home_skips_disabled_first_row_in_cell_nav() {
         },
         &[key("r1"), key("r2"), key("r3")],
     );
+
     let recorder = EventRecorder::default();
+
     let rows = [key("r1"), key("r2"), key("r3")];
     let row_refs: Vec<&Key> = rows.iter().collect();
+
     {
         let send = |e| record(&recorder, e);
+
         let api = service.connect(&send);
+
         api.on_cell_keydown(
             &key("r3"),
             2,
@@ -3123,6 +3899,7 @@ fn codex_round4_ctrl_home_skips_disabled_first_row_in_cell_nav() {
             assert_eq!(row, &key("r2"), "Ctrl+Home must skip disabled r1");
             assert_eq!(*row_index, 1);
         }
+
         other => panic!("expected FocusCell(r2), got {other:?}"),
     }
 }
@@ -3147,16 +3924,19 @@ fn codex_round5_sync_props_reclamps_column_widths_below_new_min() {
         },
         &[],
     );
+
     drop(service.send(Event::ColumnResize {
         column: "name".to_string(),
         width: 60.0,
     }));
+
     assert_eq!(service.context().column_widths.get("name"), Some(&60.0));
 
     let new_props = Props {
         min_column_width: 100.0,
         ..test_props()
     };
+
     drop(service.set_props(new_props));
 
     assert_eq!(
@@ -3174,7 +3954,9 @@ fn codex_round5_is_row_selected_excludes_disabled_in_set_all() {
     // non-selectable", not "disabled rows happen to be selected when
     // everyone is".
     let mut disabled = BTreeSet::new();
+
     disabled.insert(key("r1"));
+
     let service = service_with_rows(
         Props {
             selection_mode: selection::Mode::Multiple,
@@ -3185,6 +3967,7 @@ fn codex_round5_is_row_selected_excludes_disabled_in_set_all() {
         },
         &[key("r1"), key("r2")],
     );
+
     let api = service.connect(&|_| {});
 
     assert!(
@@ -3203,7 +3986,9 @@ fn codex_round5_all_selected_excludes_disabled() {
     // filter the disabled set so the result reflects "every SELECTABLE
     // row is selected".
     let mut disabled = BTreeSet::new();
+
     disabled.insert(key("r3"));
+
     let mut service = service_with_rows(
         Props {
             selection_mode: selection::Mode::Multiple,
@@ -3216,13 +4001,16 @@ fn codex_round5_all_selected_excludes_disabled() {
 
     let ids = [key("r1"), key("r2"), key("r3")];
     let id_refs: Vec<&Key> = ids.iter().collect();
+
     let api = service.connect(&|_| {});
 
     assert!(
         api.all_selected(&id_refs),
         "all_selected must filter disabled rows when checking",
     );
+
     let attrs = api.select_all_attrs(&id_refs);
+
     assert_eq!(
         attrs
             .get(&HtmlAttr::Aria(AriaAttr::Checked))
@@ -3245,7 +4033,9 @@ fn codex_round5_set_rows_rebases_focused_cell_without_focused_row() {
         },
         &[key("r1"), key("r2"), key("r3")],
     );
+
     drop(service.send(Event::Focus { cell: (1, 2) }));
+
     assert_eq!(service.context().focused_cell, Some((1, 2)));
     assert!(service.context().focused_row.is_none());
 
@@ -3264,12 +4054,14 @@ fn codex_round5_part_attrs_column_header_sortable_field() {
     // `Part::ColumnHeader` now carries a `sortable: bool` so the
     // dispatcher honors caller intent.
     let service = service_with_rows(test_props(), &[]);
+
     let api = service.connect(&|_| {});
 
     let sortable = api.part_attrs(Part::ColumnHeader {
         header: "name".to_string(),
         sortable: true,
     });
+
     assert!(
         sortable.get(&HtmlAttr::Aria(AriaAttr::Sort)).is_some(),
         "sortable=true must emit aria-sort",
@@ -3279,6 +4071,7 @@ fn codex_round5_part_attrs_column_header_sortable_field() {
         header: "avatar".to_string(),
         sortable: false,
     });
+
     assert!(
         non_sortable.get(&HtmlAttr::Aria(AriaAttr::Sort)).is_none(),
         "sortable=false must omit aria-sort",
@@ -3306,6 +4099,7 @@ fn codex_round6_set_direction_resolves_auto_from_locale() {
         },
         &[],
     );
+
     assert_eq!(service.context().dir, Direction::Rtl);
 
     // Adapter / parent flips the prop back to `Auto` (asks the
@@ -3332,12 +4126,14 @@ fn codex_round6_set_direction_auto_via_props_change() {
         },
         &[],
     );
+
     assert_eq!(service.context().dir, Direction::Rtl);
 
     let new_props = Props {
         dir: Direction::Auto,
         ..test_props()
     };
+
     drop(service.set_props(new_props));
 
     assert_ne!(
@@ -3360,9 +4156,11 @@ fn codex_round7_sync_props_normalizes_selection_when_mode_tightens_to_single() {
     // selection state that's invalid for the active mode until the
     // next user-driven selection event.
     let mut starting = BTreeSet::new();
+
     starting.insert(key("r1"));
     starting.insert(key("r2"));
     starting.insert(key("r3"));
+
     let mut service = service_with_rows(
         Props {
             selection_mode: selection::Mode::Multiple,
@@ -3371,15 +4169,18 @@ fn codex_round7_sync_props_normalizes_selection_when_mode_tightens_to_single() {
         },
         &[key("r1"), key("r2"), key("r3")],
     );
+
     assert_eq!(service.context().selected_rows.get().len(), 3);
 
     let new_props = Props {
         selection_mode: selection::Mode::Single,
         ..test_props()
     };
+
     drop(service.set_props(new_props));
 
     let sel = service.context().selected_rows.get().clone();
+
     assert!(
         sel.len() <= 1,
         "Mode::Single must hold at most one selected row after SyncProps, got {sel:?}",
@@ -3396,8 +4197,10 @@ fn codex_round7_sync_props_clears_selection_when_mode_becomes_none() {
     // Same root cause, harder constraint: `Mode::None` must hold an
     // empty selection.
     let mut starting = BTreeSet::new();
+
     starting.insert(key("r1"));
     starting.insert(key("r2"));
+
     let mut service = service_with_rows(
         Props {
             selection_mode: selection::Mode::Multiple,
@@ -3406,12 +4209,14 @@ fn codex_round7_sync_props_clears_selection_when_mode_becomes_none() {
         },
         &[key("r1"), key("r2")],
     );
+
     assert!(!service.context().selected_rows.get().is_empty());
 
     let new_props = Props {
         selection_mode: selection::Mode::None,
         ..test_props()
     };
+
     drop(service.set_props(new_props));
 
     assert!(
@@ -3426,6 +4231,7 @@ fn codex_round7_part_attrs_resize_handle_uses_cached_width() {
     // `part_attrs(Part::ColumnResizeHandle)` must reflect the cached
     // width from `ctx.column_widths`, not a hard-coded 0.
     let mut service = service_with_rows(test_props(), &[]);
+
     drop(service.send(Event::ColumnResize {
         column: "name".to_string(),
         width: 180.0,
@@ -3497,7 +4303,9 @@ fn codex_round7_sync_props_demotes_set_all_when_mode_leaves_all_data() {
         },
         &[key("r1"), key("r2"), key("r3")],
     );
+
     drop(service.send(Event::SelectAll));
+
     assert!(matches!(
         service.context().selected_rows.get(),
         selection::Set::All
@@ -3508,9 +4316,11 @@ fn codex_round7_sync_props_demotes_set_all_when_mode_leaves_all_data() {
         select_all_mode: SelectAllMode::AllVisible,
         ..test_props()
     };
+
     drop(service.set_props(new_props));
 
     let sel = service.context().selected_rows.get().clone();
+
     assert!(
         !matches!(sel, selection::Set::All),
         "leaving AllData mode must demote Set::All to Multiple(ctx.rows), got {sel:?}",

--- a/crates/ars-components/src/input/number_input/mod.rs
+++ b/crates/ars-components/src/input/number_input/mod.rs
@@ -1244,6 +1244,13 @@ mod tests {
         props().min(0.0).max(100.0).step(1.0).large_step(10.0)
     }
 
+    fn fmt_opts() -> FormatOptions {
+        FormatOptions {
+            use_grouping: false,
+            ..FormatOptions::default()
+        }
+    }
+
     fn service(props: Props) -> Service<Machine> {
         Service::<Machine>::new(props, &Env::default(), &Messages::default())
     }
@@ -1369,6 +1376,7 @@ mod tests {
         drop(svc.send(Event::Change("999".to_string())));
 
         let api = svc.connect(&|_| {});
+
         let attrs = api.input_attrs();
 
         assert_eq!(attrs.get(&HtmlAttr::Value), Some("999"));
@@ -1378,6 +1386,7 @@ mod tests {
     #[test]
     fn number_input_keydown_returns_false_when_disabled() {
         let svc = service(bounded_props().disabled(true));
+
         let api = svc.connect(&|_| {});
 
         for key in [
@@ -1389,6 +1398,7 @@ mod tests {
             KeyboardKey::End,
         ] {
             let data = keyboard_event(key, false);
+
             assert!(
                 !api.on_input_keydown(&data),
                 "disabled machine must not claim {key:?} as handled"
@@ -1399,10 +1409,12 @@ mod tests {
     #[test]
     fn number_input_keydown_returns_false_when_readonly() {
         let svc = service(bounded_props().readonly(true));
+
         let api = svc.connect(&|_| {});
 
         for key in [KeyboardKey::ArrowUp, KeyboardKey::Home] {
             let data = keyboard_event(key, false);
+
             assert!(!api.on_input_keydown(&data));
         }
     }
@@ -1416,6 +1428,7 @@ mod tests {
 
         for non_finite in ["inf", "-inf", "NaN", "infinity", "-infinity"] {
             drop(svc.send(Event::Change(non_finite.to_string())));
+
             assert_eq!(
                 svc.context().value.get(),
                 &Some(7.0),
@@ -1435,6 +1448,7 @@ mod tests {
         drop(svc.send(Event::IncrementToMax));
 
         let value = svc.context().value.get().expect("value set");
+
         assert!(value <= 1.5, "stored value {value} must not exceed max");
         assert_eq!(svc.context().value.get(), &Some(1.5));
     }
@@ -1448,6 +1462,7 @@ mod tests {
         drop(svc.send(Event::DecrementToMin));
 
         let value = svc.context().value.get().expect("value set");
+
         assert!(value >= -1.5, "stored value {value} must not undercut min");
         assert_eq!(svc.context().value.get(), &Some(-1.5));
     }
@@ -1464,6 +1479,7 @@ mod tests {
         drop(svc.send(Event::Increment));
 
         let value = svc.context().value.get().expect("value set");
+
         assert!(value <= 1.5, "stepped value {value} must respect max");
     }
 
@@ -1475,6 +1491,7 @@ mod tests {
         let mut svc = service(bounded_props().default_value(10.0));
 
         drop(svc.send(Event::StartScrub));
+
         assert!(svc.context().scrubbing);
 
         drop(svc.send(Event::Blur));
@@ -1486,7 +1503,9 @@ mod tests {
     #[test]
     fn number_input_required_sets_native_required_alongside_aria_required() {
         let svc = service(bounded_props().required(true));
+
         let api = svc.connect(&|_| {});
+
         let attrs = api.input_attrs();
 
         assert!(attrs.contains(&HtmlAttr::Required));
@@ -1544,8 +1563,139 @@ mod tests {
     }
 
     #[test]
+    fn number_input_private_numeric_helpers_cover_boundaries() {
+        assert_eq!(clamp(0.0, 0.0, 10.0), 0.0);
+        assert_eq!(clamp(10.0, 0.0, 10.0), 10.0);
+        assert_eq!(clamp(-1.0, 0.0, 10.0), 0.0);
+        assert_eq!(clamp(11.0, 0.0, 10.0), 10.0);
+
+        let both_finite = service(props().min(5.0).max(10.0));
+
+        assert_eq!(baseline(both_finite.context()), 5.0);
+
+        let positive_min = service(props().min(5.0));
+
+        assert_eq!(baseline(positive_min.context()), 5.0);
+
+        let negative_max = service(props().max(-5.0));
+
+        assert_eq!(baseline(negative_max.context()), -5.0);
+
+        let negative_min_unbounded_max = service(props().min(-5.0));
+
+        assert_eq!(baseline(negative_min_unbounded_max.context()), 0.0);
+
+        let positive_max_unbounded_min = service(props().max(5.0));
+
+        assert_eq!(baseline(positive_max_unbounded_min.context()), 0.0);
+
+        let unbounded = service(props());
+
+        assert_eq!(baseline(unbounded.context()), 0.0);
+    }
+
+    #[test]
+    fn number_input_props_output_changed_covers_each_render_field() {
+        let old = bounded_props().min(1.0).max(2.0).step(1.0).large_step(1.0);
+
+        assert!(!props_output_changed(&old, &old));
+
+        let mut epsilon_only = old.clone();
+
+        epsilon_only.min += f64::EPSILON;
+
+        assert!(!props_output_changed(&old, &epsilon_only));
+
+        epsilon_only = old.clone();
+        epsilon_only.max -= f64::EPSILON;
+
+        assert!(!props_output_changed(&old, &epsilon_only));
+
+        epsilon_only = old.clone();
+        epsilon_only.step += f64::EPSILON;
+
+        assert!(!props_output_changed(&old, &epsilon_only));
+
+        epsilon_only = old.clone();
+        epsilon_only.large_step -= f64::EPSILON;
+
+        assert!(!props_output_changed(&old, &epsilon_only));
+
+        let mut new = old.clone();
+
+        new.min = 1.5;
+
+        assert!(props_output_changed(&old, &new));
+
+        new = old.clone();
+        new.max = 99.0;
+
+        assert!(props_output_changed(&old, &new));
+
+        new = old.clone();
+        new.step = 2.0;
+
+        assert!(props_output_changed(&old, &new));
+
+        new = old.clone();
+        new.large_step = 20.0;
+
+        assert!(props_output_changed(&old, &new));
+
+        new = old.clone();
+        new.precision = Some(2);
+
+        assert!(props_output_changed(&old, &new));
+
+        new = old.clone();
+        new.disabled = true;
+
+        assert!(props_output_changed(&old, &new));
+
+        new = old.clone();
+        new.readonly = true;
+
+        assert!(props_output_changed(&old, &new));
+
+        new = old.clone();
+        new.invalid = true;
+
+        assert!(props_output_changed(&old, &new));
+
+        new = old.clone();
+        new.required = true;
+
+        assert!(props_output_changed(&old, &new));
+
+        new = old.clone();
+        new.name = Some("amount".to_string());
+
+        assert!(props_output_changed(&old, &new));
+
+        new = old.clone();
+        new.form = Some("order".to_string());
+
+        assert!(props_output_changed(&old, &new));
+
+        new = old.clone();
+        new.spin_on_press = false;
+
+        assert!(props_output_changed(&old, &new));
+
+        new = old.clone();
+        new.allow_mouse_wheel = true;
+
+        assert!(props_output_changed(&old, &new));
+
+        new = old.clone();
+        new.clamp_value_on_blur = false;
+
+        assert!(props_output_changed(&old, &new));
+    }
+
+    #[test]
     fn number_input_scrub_lifecycle_uses_scrubbing_state() {
-        let mut svc = service(bounded_props().default_value(10.0));
+        let mut svc = service(bounded_props().step(2.0).default_value(10.0));
 
         drop(svc.send(Event::StartScrub));
 
@@ -1554,7 +1704,7 @@ mod tests {
 
         drop(svc.send(Event::Scrub(3.0)));
 
-        assert_eq!(svc.context().value.get(), &Some(13.0));
+        assert_eq!(svc.context().value.get(), &Some(16.0));
 
         drop(svc.send(Event::EndScrub));
 
@@ -1583,6 +1733,7 @@ mod tests {
         drop(svc.send(Event::Increment));
 
         let value = svc.context().value.get().expect("value set after step");
+
         assert!(value.is_finite(), "value must remain finite after stepping");
         assert!(
             (value - 1.0).abs() < f64::EPSILON,
@@ -1597,6 +1748,7 @@ mod tests {
         drop(svc.send(Event::Decrement));
 
         let value = svc.context().value.get().expect("value set after step");
+
         assert!(value.is_finite());
         assert!((value - -1.0).abs() < f64::EPSILON);
     }
@@ -1689,10 +1841,12 @@ mod tests {
         // would serialize as `"NaN"`/`"inf"` into the visible input
         // attribute — same defect class `Change` already guards against.
         let mut svc = service(bounded_props().value(10.0));
+
         assert_eq!(svc.context().value.get(), &Some(10.0));
 
         for bad in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
             drop(svc.send(Event::SyncValue(Some(bad))));
+
             assert_eq!(
                 svc.context().value.get(),
                 &Some(10.0),
@@ -1706,10 +1860,12 @@ mod tests {
         let mut svc = service(bounded_props().value(10.0));
 
         drop(svc.send(Event::SyncValue(Some(42.0))));
+
         assert_eq!(svc.context().value.get(), &Some(42.0));
         assert!(svc.context().value.is_controlled());
 
         drop(svc.send(Event::SyncValue(None)));
+
         assert!(!svc.context().value.is_controlled());
     }
 
@@ -1727,6 +1883,7 @@ mod tests {
         // (1.5 itself if precision is capped where it can preserve
         // the value, or a small rounding artefact).
         let value = svc.context().value.get().expect("value set");
+
         assert!(value.is_finite(), "value {value} must be finite");
         assert!((value - 1.5).abs() < 1.0, "value {value} must be near 1.5");
     }
@@ -1763,15 +1920,18 @@ mod tests {
         let mut svc = service(bounded_props().default_value(10.0));
 
         drop(svc.send(Event::StartScrub));
+
         assert_eq!(svc.state(), &State::Scrubbing);
 
         // Parent disables mid-drag.
         drop(svc.set_props(bounded_props().default_value(10.0).disabled(true)));
+
         assert!(svc.context().disabled);
 
         // Pointer-up: adapter fires EndScrub. Must transition out of
         // Scrubbing despite the disabled guard.
         let result = svc.send(Event::EndScrub);
+
         assert!(result.state_changed);
         assert!(!svc.context().scrubbing);
         assert_ne!(svc.state(), &State::Scrubbing);
@@ -1780,11 +1940,13 @@ mod tests {
     #[test]
     fn number_input_end_scrub_processable_when_readonly() {
         let mut svc = service(bounded_props().default_value(10.0));
+
         drop(svc.send(Event::StartScrub));
 
         drop(svc.set_props(bounded_props().default_value(10.0).readonly(true)));
 
         let result = svc.send(Event::EndScrub);
+
         assert!(result.state_changed);
         assert!(!svc.context().scrubbing);
     }
@@ -1826,6 +1988,7 @@ mod tests {
         // zero, but the actual stored bits push it just barely below the
         // half-way mark; verify a numerically robust upper bound instead).
         let value = svc.context().value.get().expect("value set");
+
         assert!(
             (value - 2.3).abs() < f64::EPSILON || (value - 2.4).abs() < f64::EPSILON,
             "value {value} must be reround'd to 2.3 or 2.4 (precision 1)"
@@ -1842,6 +2005,55 @@ mod tests {
         drop(svc.set_props(bounded_props().default_value(7.0).name("qty2")));
 
         assert_eq!(svc.context().value.get(), &Some(7.0));
+    }
+
+    #[test]
+    fn number_input_blur_and_set_props_ignore_epsilon_only_value_deltas() {
+        let edge = 1.0 + f64::EPSILON;
+
+        let mut blur_svc = service(props().min(0.0).max(1.0).default_value(edge));
+
+        drop(blur_svc.send(Event::Focus { is_keyboard: false }));
+        drop(blur_svc.send(Event::Blur));
+
+        assert_eq!(blur_svc.context().value.get(), &Some(edge));
+
+        let mut props_svc = service(props().min(0.0).max(1.0).default_value(edge));
+
+        drop(props_svc.set_props(props().min(0.0).max(1.0 - f64::EPSILON).default_value(edge)));
+
+        assert_eq!(props_svc.context().value.get(), &Some(edge));
+    }
+
+    #[test]
+    fn number_input_set_props_render_change_does_not_reclamp_epsilon_only_bounds() {
+        let edge = 2.0 + f64::EPSILON;
+
+        let mut svc = service(props().min(1.0).max(2.0).name("amount").default_value(edge));
+
+        drop(
+            svc.set_props(
+                props()
+                    .min(1.0 + f64::EPSILON)
+                    .max(2.0 - f64::EPSILON)
+                    .name("total")
+                    .default_value(edge),
+            ),
+        );
+
+        assert_eq!(svc.context().value.get(), &Some(edge));
+    }
+
+    #[test]
+    fn number_input_zero_wheel_delta_is_noop() {
+        let mut svc = service(bounded_props().allow_mouse_wheel(true).default_value(10.0));
+
+        drop(svc.send(Event::Focus { is_keyboard: false }));
+
+        let result = svc.send(Event::Wheel { delta: 0.0 });
+
+        assert!(!result.context_changed);
+        assert_eq!(svc.context().value.get(), &Some(10.0));
     }
 
     #[test]
@@ -1879,6 +2091,7 @@ mod tests {
             Event::Wheel { delta: 1.0 },
         ] {
             let result = svc.send(event);
+
             assert!(!result.context_changed);
         }
 
@@ -1904,7 +2117,6 @@ mod tests {
         assert!(!idle_result.context_changed);
 
         drop(svc.send(Event::Focus { is_keyboard: false }));
-
         drop(svc.send(Event::Wheel { delta: 1.0 }));
 
         assert_eq!(svc.context().value.get(), &Some(11.0));
@@ -1938,6 +2150,91 @@ mod tests {
         assert_eq!(attrs.get(&HtmlAttr::Aria(AriaAttr::ValueNow)), Some("42"));
         assert_eq!(attrs.get(&HtmlAttr::Aria(AriaAttr::ValueMin)), Some("0"));
         assert_eq!(attrs.get(&HtmlAttr::Aria(AriaAttr::ValueMax)), Some("100"));
+    }
+
+    #[test]
+    fn number_input_format_option_builders_round_trip() {
+        let p = props()
+            .format_options(fmt_opts())
+            .display_format(FormatOptions {
+                min_fraction_digits: 2,
+                max_fraction_digits: 2,
+                ..FormatOptions::default()
+            });
+
+        assert_eq!(p.format_options, Some(fmt_opts()));
+        assert_eq!(
+            p.display_format
+                .as_ref()
+                .map(|options| options.min_fraction_digits),
+            Some(2)
+        );
+    }
+
+    #[test]
+    fn number_input_static_attrs_and_boundary_helpers_are_observable() {
+        let min_svc = service(bounded_props().default_value(0.0));
+
+        let min_api = min_svc.connect(&|_| {});
+
+        assert_eq!(min_api.label_attrs().get(&HtmlAttr::Id), Some("num-label"));
+        assert_eq!(min_api.label_attrs().get(&HtmlAttr::For), Some("num-input"));
+        assert_eq!(
+            min_api.description_attrs().get(&HtmlAttr::Id),
+            Some("num-description")
+        );
+        assert_eq!(
+            min_api.error_message_attrs().get(&HtmlAttr::Id),
+            Some("num-error-message")
+        );
+        assert_eq!(
+            min_api
+                .error_message_attrs()
+                .get(&HtmlAttr::Aria(AriaAttr::Live)),
+            Some("polite")
+        );
+        assert!(
+            min_api
+                .decrement_trigger_attrs()
+                .contains(&HtmlAttr::Disabled)
+        );
+        assert!(
+            !min_api
+                .increment_trigger_attrs()
+                .contains(&HtmlAttr::Disabled)
+        );
+
+        let disabled_svc = service(bounded_props().default_value(50.0).disabled(true));
+        let disabled_api = disabled_svc.connect(&|_| {});
+
+        assert!(
+            disabled_api
+                .increment_trigger_attrs()
+                .contains(&HtmlAttr::Disabled)
+        );
+
+        let readonly_svc = service(bounded_props().default_value(50.0).readonly(true));
+        let readonly_api = readonly_svc.connect(&|_| {});
+
+        assert!(
+            readonly_api
+                .decrement_trigger_attrs()
+                .contains(&HtmlAttr::Disabled)
+        );
+
+        let max_svc = service(bounded_props().default_value(100.0));
+        let max_api = max_svc.connect(&|_| {});
+
+        assert!(
+            max_api
+                .increment_trigger_attrs()
+                .contains(&HtmlAttr::Disabled)
+        );
+        assert!(
+            !max_api
+                .decrement_trigger_attrs()
+                .contains(&HtmlAttr::Disabled)
+        );
     }
 
     #[test]

--- a/crates/ars-components/src/input/password_input/mod.rs
+++ b/crates/ars-components/src/input/password_input/mod.rs
@@ -1088,6 +1088,18 @@ mod tests {
     }
 
     #[test]
+    fn password_input_label_attrs_points_to_input() {
+        let service = service(props());
+
+        let api = service.connect(&|_| {});
+
+        let attrs = api.label_attrs();
+
+        assert_eq!(attrs.get(&HtmlAttr::Id), Some("pwd-label"));
+        assert_eq!(attrs.get(&HtmlAttr::For), Some("pwd-input"));
+    }
+
+    #[test]
     fn password_input_disabled_root_carries_data_attrs() {
         let service = service(
             props()
@@ -1289,16 +1301,18 @@ mod tests {
         let api = service.connect(&send);
 
         api.on_input_focus(true);
+        api.on_input_change("secret".to_string());
         api.on_input_blur();
         api.on_toggle_click();
 
-        assert_eq!(count.get(), 3);
+        assert_eq!(count.get(), 4);
 
         let events = received.borrow();
 
         assert_eq!(events[0], Event::Focus { is_keyboard: true });
-        assert_eq!(events[1], Event::Blur);
-        assert_eq!(events[2], Event::ToggleVisibility);
+        assert_eq!(events[1], Event::Change("secret".to_string()));
+        assert_eq!(events[2], Event::Blur);
+        assert_eq!(events[3], Event::ToggleVisibility);
     }
 
     #[test]

--- a/crates/ars-components/src/input/pin_input/mod.rs
+++ b/crates/ars-components/src/input/pin_input/mod.rs
@@ -1496,6 +1496,10 @@ mod tests {
         }
     }
 
+    fn string_vec(values: &[&str]) -> Vec<String> {
+        values.iter().map(ToString::to_string).collect()
+    }
+
     #[test]
     fn pin_input_initial_state_is_idle_with_empty_cells() {
         let svc = service(props());
@@ -1519,6 +1523,90 @@ mod tests {
 
         assert_eq!(svc.state(), &State::Completed);
         assert!(svc.context().complete);
+    }
+
+    #[test]
+    fn pin_input_private_helpers_cover_next_empty_and_output_props() {
+        let values = string_vec(&["1", "", "3", ""]);
+
+        assert_eq!(next_empty_index(&values, 0), Some(1));
+        assert_eq!(next_empty_index(&values, 1), Some(3));
+        assert_eq!(next_empty_index(&values, 3), None);
+
+        let old = props();
+
+        assert!(!props_output_changed(&old, &old));
+
+        let mut new = old.clone();
+
+        new.length = 5;
+
+        assert!(props_output_changed(&old, &new));
+
+        new = old.clone();
+        new.disabled = true;
+
+        assert!(props_output_changed(&old, &new));
+
+        new = old.clone();
+        new.invalid = true;
+
+        assert!(props_output_changed(&old, &new));
+
+        new = old.clone();
+        new.otp = true;
+
+        assert!(props_output_changed(&old, &new));
+
+        new = old.clone();
+        new.mask = true;
+
+        assert!(props_output_changed(&old, &new));
+
+        new = old.clone();
+        new.placeholder = Some("*".to_string());
+
+        assert!(props_output_changed(&old, &new));
+
+        new = old.clone();
+        new.mode = Mode::Alphanumeric;
+
+        assert!(props_output_changed(&old, &new));
+
+        new = old.clone();
+        new.name = Some("pin".to_string());
+
+        assert!(props_output_changed(&old, &new));
+
+        new = old.clone();
+        new.form = Some("login".to_string());
+
+        assert!(props_output_changed(&old, &new));
+
+        new = old.clone();
+        new.required = true;
+
+        assert!(props_output_changed(&old, &new));
+
+        new = old.clone();
+        new.readonly = true;
+
+        assert!(props_output_changed(&old, &new));
+
+        new = old.clone();
+        new.select_on_focus = true;
+
+        assert!(props_output_changed(&old, &new));
+
+        new = old.clone();
+        new.blur_on_complete = true;
+
+        assert!(props_output_changed(&old, &new));
+
+        new = old.clone();
+        new.dir = Direction::Rtl;
+
+        assert!(props_output_changed(&old, &new));
     }
 
     #[test]
@@ -1568,6 +1656,28 @@ mod tests {
         assert_eq!(svc.context().focused_index, Some(1));
         assert_eq!(result.pending_effects.len(), 1);
         assert_eq!(result.pending_effects[0].name, Effect::FocusCell);
+    }
+
+    #[test]
+    fn pin_input_input_char_completes_when_last_empty_cell_fills() {
+        let mut svc =
+            service(props().default_value(vec!["1".into(), "2".into(), "3".into(), String::new()]));
+
+        drop(svc.send(Event::Focus {
+            index: 3,
+            is_keyboard: false,
+        }));
+        drop(svc.send(Event::InputChar {
+            index: 3,
+            char: '4',
+        }));
+
+        assert_eq!(svc.state(), &State::Completed);
+        assert!(svc.context().complete);
+        assert_eq!(
+            svc.context().value.get(),
+            &string_vec(&["1", "2", "3", "4"])
+        );
     }
 
     #[test]
@@ -1906,11 +2016,13 @@ mod tests {
         // one cell tabbable so keyboard users can enter the group — otherwise
         // every cell carries `tabindex="-1"` and the group is unreachable.
         let svc = service(props());
+
         assert_eq!(svc.context().focused_index, None);
 
         let api = svc.connect(&|_| {});
 
         assert_eq!(api.input_attrs(0).get(&HtmlAttr::TabIndex), Some("0"));
+
         for index in 1..4 {
             assert_eq!(
                 api.input_attrs(index).get(&HtmlAttr::TabIndex),
@@ -2012,6 +2124,7 @@ mod tests {
         assert_eq!(svc.context().value.get().len(), 2);
 
         let api = svc.connect(&|_| {});
+
         assert_eq!(api.hidden_input_attrs().get(&HtmlAttr::Value), Some("12"));
     }
 
@@ -2092,12 +2205,84 @@ mod tests {
             index: 3,
             is_keyboard: false,
         }));
+
         assert_eq!(svc.state(), &State::Focused { index: 3 });
 
         drop(svc.set_props(props().length(2)));
 
         assert_eq!(svc.state(), &State::Idle);
         assert_eq!(svc.context().focused_index, None);
+    }
+
+    #[test]
+    fn pin_input_set_props_invalidates_focus_at_exact_new_length() {
+        let mut svc = service(props().length(4));
+
+        drop(svc.send(Event::Focus {
+            index: 3,
+            is_keyboard: false,
+        }));
+
+        assert_eq!(svc.state(), &State::Focused { index: 3 });
+
+        drop(svc.set_props(props().length(3)));
+
+        assert_eq!(svc.state(), &State::Idle);
+        assert_eq!(svc.context().focused_index, None);
+    }
+
+    #[test]
+    fn pin_input_set_props_recomputes_completion_for_full_and_zero_length_values() {
+        let mut full_svc = service(props().length(4).default_value(vec![
+            "1".into(),
+            "2".into(),
+            "3".into(),
+            String::new(),
+        ]));
+
+        assert_eq!(full_svc.state(), &State::Idle);
+
+        drop(
+            full_svc.set_props(
+                props()
+                    .length(4)
+                    .default_value(vec!["1".into(), "2".into(), "3".into(), String::new()])
+                    .value(vec!["1".into(), "2".into(), "3".into(), "4".into()]),
+            ),
+        );
+
+        assert_eq!(full_svc.state(), &State::Completed);
+        assert!(full_svc.context().complete);
+
+        let mut empty_svc = service(props().length(1).default_value(vec!["1".into()]));
+
+        assert_eq!(empty_svc.state(), &State::Completed);
+
+        drop(empty_svc.set_props(props().length(0).default_value(vec!["1".into()])));
+
+        assert_eq!(empty_svc.state(), &State::Idle);
+        assert!(!empty_svc.context().complete);
+        assert!(empty_svc.context().value.get().is_empty());
+    }
+
+    #[test]
+    fn pin_input_set_props_preserves_completion_for_full_existing_value() {
+        let mut svc =
+            service(props().default_value(vec!["1".into(), "2".into(), "3".into(), "4".into()]));
+
+        assert_eq!(svc.state(), &State::Completed);
+        assert!(svc.context().complete);
+
+        drop(
+            svc.set_props(
+                props()
+                    .default_value(vec!["1".into(), "2".into(), "3".into(), "4".into()])
+                    .name("otp"),
+            ),
+        );
+
+        assert_eq!(svc.state(), &State::Completed);
+        assert!(svc.context().complete);
     }
 
     #[test]
@@ -2119,6 +2304,7 @@ mod tests {
         assert_eq!(svc.context().focused_index, None);
 
         let api = svc.connect(&|_| {});
+
         assert_eq!(api.input_attrs(0).get(&HtmlAttr::TabIndex), Some("0"));
         assert_eq!(api.input_attrs(1).get(&HtmlAttr::TabIndex), Some("-1"));
     }
@@ -2336,6 +2522,7 @@ mod tests {
         assert!(api.on_cell_keydown(1, &keyboard_event(KeyboardKey::ArrowRight, false)));
 
         let events = received.borrow();
+
         assert_eq!(events[0], Event::FocusNext);
         assert_eq!(events[1], Event::FocusPrev);
     }
@@ -2344,6 +2531,7 @@ mod tests {
     fn pin_input_clear_cell_on_filled_clears_without_navigation() {
         let mut svc =
             service(props().default_value(vec!["1".into(), "2".into(), "3".into(), "4".into()]));
+
         drop(svc.send(Event::Focus {
             index: 2,
             is_keyboard: false,
@@ -2366,6 +2554,7 @@ mod tests {
             String::new(),
             String::new(),
         ]));
+
         drop(svc.send(Event::Focus {
             index: 2,
             is_keyboard: false,
@@ -2388,6 +2577,7 @@ mod tests {
 
         for key in [KeyboardKey::Backspace, KeyboardKey::Delete] {
             let data = keyboard_event(key, false);
+
             assert!(
                 !api.on_cell_keydown(0, &data),
                 "readonly must not claim {key:?} as handled"
@@ -2402,6 +2592,7 @@ mod tests {
 
         for key in [KeyboardKey::Backspace, KeyboardKey::Delete] {
             let data = keyboard_event(key, false);
+
             assert!(!api.on_cell_keydown(0, &data));
         }
     }
@@ -2433,6 +2624,28 @@ mod tests {
         assert_eq!(svc.context().value.get().len(), 6);
         assert_eq!(svc.context().value.get()[4], "5");
         assert_eq!(svc.context().value.get()[5], "6");
+    }
+
+    #[test]
+    fn pin_input_static_attrs_expose_label_description_and_error_ids() {
+        let svc = service(props());
+
+        let api = svc.connect(&|_| {});
+
+        assert_eq!(api.label_attrs().get(&HtmlAttr::Id), Some("pin-label"));
+        assert_eq!(
+            api.description_attrs().get(&HtmlAttr::Id),
+            Some("pin-description")
+        );
+        assert_eq!(
+            api.error_message_attrs().get(&HtmlAttr::Id),
+            Some("pin-error-message")
+        );
+        assert_eq!(
+            api.error_message_attrs()
+                .get(&HtmlAttr::Aria(AriaAttr::Live)),
+            Some("polite")
+        );
     }
 
     #[test]

--- a/crates/ars-components/src/input/search_input/mod.rs
+++ b/crates/ars-components/src/input/search_input/mod.rs
@@ -1007,6 +1007,26 @@ mod tests {
     }
 
     #[test]
+    fn search_input_props_builder_clearers_round_trip() {
+        let props = Props::new()
+            .id("search")
+            .placeholder("Search")
+            .no_placeholder()
+            .name("q")
+            .no_name()
+            .form("search-form")
+            .no_form()
+            .debounce(Duration::from_millis(50))
+            .no_debounce();
+
+        assert_eq!(props.id, "search");
+        assert_eq!(props.placeholder, None);
+        assert_eq!(props.name, None);
+        assert_eq!(props.form, None);
+        assert_eq!(props.debounce, None);
+    }
+
+    #[test]
     fn search_input_change_schedules_debounce_effect() {
         let mut service = service(props().debounce(Duration::from_millis(200)));
 
@@ -1064,6 +1084,18 @@ mod tests {
 
         assert_eq!(result.cancel_effects, alloc::vec![Effect::SearchDebounce]);
         assert_eq!(service.context().value.get(), "");
+    }
+
+    #[test]
+    fn search_input_clear_noops_when_disabled_or_readonly() {
+        for props in [props().disabled(true), props().readonly(true)] {
+            let mut service = service(props.default_value("query"));
+
+            let result = service.send(Event::Clear);
+
+            assert!(!result.context_changed);
+            assert_eq!(service.context().value.get(), "query");
+        }
     }
 
     #[test]
@@ -1203,6 +1235,7 @@ mod tests {
         let result = svc.set_props(props().debounce(Duration::from_millis(500)));
 
         assert!(result.pending_effects.is_empty());
+        assert!(!svc.context().debounce_pending);
     }
 
     #[test]
@@ -1390,6 +1423,66 @@ mod tests {
                 "part_attrs disagrees with explicit accessor"
             );
         }
+    }
+
+    #[test]
+    fn search_input_label_attrs_points_to_input() {
+        let service = service(props());
+
+        let api = service.connect(&|_| {});
+
+        let attrs = api.label_attrs();
+
+        assert_eq!(attrs.get(&HtmlAttr::Id), Some("search-label"));
+        assert_eq!(attrs.get(&HtmlAttr::For), Some("search-input"));
+    }
+
+    #[test]
+    fn search_input_props_output_changed_covers_each_render_field() {
+        let old = props();
+
+        assert!(!props_output_changed(&old, &old));
+
+        let mut new = old.clone();
+
+        new.disabled = true;
+
+        assert!(props_output_changed(&old, &new));
+
+        new = old.clone();
+        new.readonly = true;
+
+        assert!(props_output_changed(&old, &new));
+
+        new = old.clone();
+        new.invalid = true;
+
+        assert!(props_output_changed(&old, &new));
+
+        new = old.clone();
+        new.required = true;
+
+        assert!(props_output_changed(&old, &new));
+
+        new = old.clone();
+        new.placeholder = Some("Find".to_string());
+
+        assert!(props_output_changed(&old, &new));
+
+        new = old.clone();
+        new.name = Some("q".to_string());
+
+        assert!(props_output_changed(&old, &new));
+
+        new = old.clone();
+        new.form = Some("form".to_string());
+
+        assert!(props_output_changed(&old, &new));
+
+        new = old.clone();
+        new.debounce = Some(Duration::from_millis(100));
+
+        assert!(props_output_changed(&old, &new));
     }
 
     #[test]

--- a/crates/ars-components/src/overlay/hover_card.rs
+++ b/crates/ars-components/src/overlay/hover_card.rs
@@ -1185,6 +1185,83 @@ mod tests {
     }
 
     #[test]
+    fn props_builder_sets_identity_and_initial_open_state() {
+        let props = Props::new()
+            .id("profile-card")
+            .open(true)
+            .default_open(false);
+
+        assert_eq!(props.id, "profile-card");
+        assert_eq!(props.open, Some(true));
+        assert!(!props.default_open);
+    }
+
+    #[test]
+    fn props_changed_tracks_only_runtime_sync_inputs() {
+        let base = test_props();
+
+        assert!(!props_changed(&base, &base));
+
+        assert!(props_changed(
+            &base,
+            &Props {
+                disabled: true,
+                ..base.clone()
+            }
+        ));
+        assert!(props_changed(
+            &base,
+            &Props {
+                open_delay: Duration::from_millis(100),
+                ..base.clone()
+            }
+        ));
+        assert!(props_changed(
+            &base,
+            &Props {
+                close_delay: Duration::from_millis(50),
+                ..base.clone()
+            }
+        ));
+        assert!(props_changed(
+            &base,
+            &Props {
+                positioning: PositioningOptions {
+                    placement: Placement::LeftEnd,
+                    ..PositioningOptions::default()
+                },
+                ..base.clone()
+            }
+        ));
+
+        assert!(!props_changed(
+            &base,
+            &Props {
+                open: Some(true),
+                default_open: true,
+                lazy_mount: true,
+                unmount_on_exit: true,
+                ..base.clone()
+            }
+        ));
+    }
+
+    #[test]
+    fn close_plan_carries_state_context_effects_and_cancellation() {
+        let plan = close_plan(Some(Effect::CloseDelay));
+
+        assert_eq!(plan.target, Some(State::Closed));
+        assert_eq!(
+            plan.effects
+                .iter()
+                .map(|effect| effect.name)
+                .collect::<Vec<_>>(),
+            vec![Effect::OpenChange, Effect::ReleaseZIndex]
+        );
+        assert_eq!(plan.cancel_effects, vec![Effect::CloseDelay]);
+    }
+
+    #[test]
     fn hover_trigger_opens_after_delay() {
         let mut service =
             Service::<Machine>::new(test_props(), &Env::default(), &Messages::default());
@@ -1324,6 +1401,110 @@ mod tests {
     }
 
     #[test]
+    fn focus_leave_during_pending_open_cancels_open_delay() {
+        let mut service =
+            Service::<Machine>::new(test_props(), &Env::default(), &Messages::default());
+
+        drop(service.send(Event::TriggerFocus));
+
+        let blur = service.send(Event::TriggerBlur);
+
+        assert_eq!(service.state(), &State::Closed);
+        assert!(!service.context().focus_active);
+        assert_eq!(blur.cancel_effects, vec![Effect::OpenDelay]);
+        assert!(blur.pending_effects.is_empty());
+    }
+
+    #[test]
+    fn pending_open_only_closes_after_every_activation_source_leaves() {
+        let mut pointer_only =
+            Service::<Machine>::new(test_props(), &Env::default(), &Messages::default());
+
+        drop(pointer_only.send(Event::TriggerPointerEnter));
+
+        let pointer_leave = pointer_only.send(Event::TriggerPointerLeave);
+
+        assert_eq!(pointer_only.state(), &State::Closed);
+        assert!(!pointer_only.context().hover_active);
+        assert_eq!(pointer_leave.cancel_effects, vec![Effect::OpenDelay]);
+
+        let mut pointer_and_focus =
+            Service::<Machine>::new(test_props(), &Env::default(), &Messages::default());
+
+        drop(pointer_and_focus.send(Event::TriggerPointerEnter));
+        drop(pointer_and_focus.send(Event::TriggerFocus));
+
+        let blur = pointer_and_focus.send(Event::TriggerBlur);
+
+        assert_eq!(pointer_and_focus.state(), &State::OpenPending);
+        assert!(pointer_and_focus.context().hover_active);
+        assert!(!pointer_and_focus.context().focus_active);
+        assert!(blur.pending_effects.is_empty());
+        assert!(blur.cancel_effects.is_empty());
+    }
+
+    #[test]
+    fn open_card_stays_open_while_hover_or_focus_remains_active() {
+        let mut focused = Service::<Machine>::new(
+            Props {
+                default_open: true,
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages::default(),
+        );
+
+        drop(focused.send(Event::TriggerFocus));
+
+        let pointer_leave = focused.send(Event::TriggerPointerLeave);
+
+        assert_eq!(focused.state(), &State::Open);
+        assert!(!focused.context().hover_active);
+        assert!(focused.context().focus_active);
+        assert!(effect_names(&pointer_leave).is_empty());
+
+        let blur = focused.send(Event::TriggerBlur);
+
+        assert_eq!(focused.state(), &State::ClosePending);
+        assert!(!focused.context().focus_active);
+        assert_eq!(effect_names(&blur), vec![Effect::CloseDelay]);
+
+        let reopen = focused.send(Event::Open);
+
+        assert_eq!(focused.state(), &State::Open);
+        assert!(focused.context().open);
+        assert_eq!(reopen.cancel_effects, vec![Effect::CloseDelay]);
+        assert_eq!(
+            effect_names(&reopen),
+            vec![Effect::OpenChange, Effect::AllocateZIndex]
+        );
+
+        let mut hovered = Service::<Machine>::new(
+            Props {
+                default_open: true,
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages::default(),
+        );
+
+        drop(hovered.send(Event::TriggerPointerEnter));
+        drop(hovered.send(Event::ContentFocus));
+
+        let content_blur = hovered.send(Event::ContentBlur);
+
+        assert_eq!(hovered.state(), &State::Open);
+        assert!(hovered.context().hover_active);
+        assert!(!hovered.context().focus_active);
+        assert!(effect_names(&content_blur).is_empty());
+
+        let pointer_leave = hovered.send(Event::ContentPointerLeave);
+
+        assert_eq!(hovered.state(), &State::ClosePending);
+        assert_eq!(effect_names(&pointer_leave), vec![Effect::CloseDelay]);
+    }
+
+    #[test]
     fn content_focus_cancels_close_delay_after_trigger_blur() {
         let mut service = Service::<Machine>::new(
             Props {
@@ -1352,6 +1533,25 @@ mod tests {
         assert_eq!(service.state(), &State::ClosePending);
         assert!(!service.context().focus_active);
         assert_eq!(effect_names(&content_blur), vec![Effect::CloseDelay]);
+    }
+
+    #[test]
+    fn content_focus_marks_open_card_focused() {
+        let mut service = Service::<Machine>::new(
+            Props {
+                default_open: true,
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages::default(),
+        );
+
+        let focus = service.send(Event::ContentFocus);
+
+        assert_eq!(service.state(), &State::Open);
+        assert!(service.context().focus_active);
+        assert!(focus.pending_effects.is_empty());
+        assert!(focus.cancel_effects.is_empty());
     }
 
     #[test]
@@ -1484,6 +1684,126 @@ mod tests {
         assert_eq!(service.state(), &State::Open);
         assert_eq!(controlled_open.cancel_effects, vec![Effect::CloseDelay]);
         assert_eq!(effect_names(&controlled_open), vec![Effect::AllocateZIndex]);
+    }
+
+    #[test]
+    fn controlled_sync_noops_and_close_pending_cleanup_are_explicit() {
+        let mut closed =
+            Service::<Machine>::new(test_props(), &Env::default(), &Messages::default());
+
+        let closed_sync = closed.send(Event::SetControlledOpen(false));
+
+        assert_eq!(closed.state(), &State::Closed);
+        assert!(!closed_sync.state_changed);
+        assert!(closed_sync.pending_effects.is_empty());
+
+        let mut open = Service::<Machine>::new(
+            Props {
+                default_open: true,
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages::default(),
+        );
+
+        let open_sync = open.send(Event::SetControlledOpen(true));
+
+        assert_eq!(open.state(), &State::Open);
+        assert!(!open_sync.state_changed);
+        assert!(open_sync.pending_effects.is_empty());
+
+        drop(open.send(Event::TriggerPointerLeave));
+
+        let close_pending_sync = open.send(Event::SetControlledOpen(false));
+
+        assert_eq!(open.state(), &State::Closed);
+        assert_eq!(close_pending_sync.cancel_effects, vec![Effect::CloseDelay]);
+        assert_eq!(
+            effect_names(&close_pending_sync),
+            vec![Effect::ReleaseZIndex]
+        );
+    }
+
+    #[test]
+    fn programmatic_open_close_and_escape_cover_controlled_pending_states() {
+        let mut already_open = Service::<Machine>::new(
+            Props {
+                default_open: true,
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages::default(),
+        );
+
+        let redundant_open = already_open.send(Event::Open);
+
+        assert_eq!(already_open.state(), &State::Open);
+        assert!(!redundant_open.state_changed);
+
+        drop(already_open.send(Event::TriggerPointerLeave));
+
+        let close_pending_open = already_open.send(Event::Open);
+
+        assert_eq!(already_open.state(), &State::Open);
+        assert_eq!(close_pending_open.cancel_effects, vec![Effect::CloseDelay]);
+        assert_eq!(
+            effect_names(&close_pending_open),
+            vec![Effect::OpenChange, Effect::AllocateZIndex]
+        );
+
+        let mut controlled_closed = Service::<Machine>::new(
+            Props {
+                open: Some(false),
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages::default(),
+        );
+
+        drop(controlled_closed.send(Event::TriggerPointerEnter));
+
+        let open_request = controlled_closed.send(Event::Open);
+
+        assert_eq!(controlled_closed.state(), &State::Closed);
+        assert_eq!(open_request.cancel_effects, vec![Effect::OpenDelay]);
+        assert_eq!(effect_names(&open_request), vec![Effect::OpenChange]);
+
+        let mut controlled_open = Service::<Machine>::new(
+            Props {
+                open: Some(true),
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages::default(),
+        );
+
+        drop(controlled_open.send(Event::TriggerPointerLeave));
+
+        let escape = controlled_open.send(Event::CloseOnEscape);
+
+        assert_eq!(controlled_open.state(), &State::Open);
+        assert_eq!(escape.cancel_effects, vec![Effect::CloseDelay]);
+        assert_eq!(effect_names(&escape), vec![Effect::OpenChange]);
+
+        let mut controlled_pending = Service::<Machine>::new(
+            Props {
+                open: Some(true),
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages::default(),
+        );
+
+        drop(controlled_pending.set_props(Props {
+            open: Some(false),
+            ..test_props()
+        }));
+        drop(controlled_pending.send(Event::TriggerFocus));
+
+        let close_request = controlled_pending.send(Event::Close);
+
+        assert_eq!(controlled_pending.state(), &State::Closed);
+        assert_eq!(close_request.cancel_effects, vec![Effect::OpenDelay]);
     }
 
     #[test]
@@ -1678,6 +1998,46 @@ mod tests {
     }
 
     #[test]
+    fn props_sync_updates_timing_and_title_registration_is_idempotent() {
+        let mut service =
+            Service::<Machine>::new(test_props(), &Env::default(), &Messages::default());
+
+        drop(service.set_props(Props {
+            open_delay: Duration::from_millis(100),
+            close_delay: Duration::from_millis(50),
+            ..test_props()
+        }));
+
+        assert_eq!(service.context().open_delay, Duration::from_millis(100));
+        assert_eq!(service.context().close_delay, Duration::from_millis(50));
+
+        drop(service.send(Event::TitleMount));
+
+        let second_mount = service.send(Event::TitleMount);
+
+        assert!(!second_mount.state_changed);
+        assert!(service.context().has_title);
+
+        drop(service.send(Event::TitleUnmount));
+
+        let second_unmount = service.send(Event::TitleUnmount);
+
+        assert!(!second_unmount.state_changed);
+        assert!(!service.context().has_title);
+    }
+
+    #[test]
+    fn open_change_effect_is_noop_without_callback() {
+        let service = Service::<Machine>::new(test_props(), &Env::default(), &Messages::default());
+
+        let send: StrongSend<Event> = Arc::new(|_| {});
+
+        let cleanup = open_change_effect(true).run(service.context(), service.props(), send);
+
+        drop(cleanup);
+    }
+
+    #[test]
     fn positioning_title_and_attrs_reflect_state() {
         let mut service = Service::<Machine>::new(
             Props {
@@ -1750,6 +2110,135 @@ mod tests {
             Some("Hover card")
         );
         assert!(!fallback.contains(&HtmlAttr::Aria(AriaAttr::LabelledBy)));
+    }
+
+    #[test]
+    fn api_event_helpers_dispatch_expected_events() {
+        let observed = Rc::new(RefCell::new(Vec::new()));
+        let send = {
+            let observed = Rc::clone(&observed);
+            move |event| observed.borrow_mut().push(event)
+        };
+
+        let service = Service::<Machine>::new(test_props(), &Env::default(), &Messages::default());
+
+        let api = service.connect(&send);
+
+        api.on_trigger_pointer_enter();
+        api.on_trigger_pointer_leave();
+        api.on_trigger_focus();
+        api.on_trigger_blur();
+        api.on_content_pointer_enter();
+        api.on_content_pointer_leave();
+        api.on_content_focus();
+        api.on_content_blur();
+        api.on_title_mount();
+        api.on_title_unmount();
+        api.on_dismiss_button_click();
+
+        assert_eq!(
+            &*observed.borrow(),
+            &[
+                Event::TriggerPointerEnter,
+                Event::TriggerPointerLeave,
+                Event::TriggerFocus,
+                Event::TriggerBlur,
+                Event::ContentPointerEnter,
+                Event::ContentPointerLeave,
+                Event::ContentFocus,
+                Event::ContentBlur,
+                Event::TitleMount,
+                Event::TitleUnmount,
+                Event::Close,
+            ]
+        );
+    }
+
+    #[test]
+    fn api_mount_flags_reflect_props() {
+        let defaults = Service::<Machine>::new(test_props(), &Env::default(), &Messages::default());
+
+        let default_api = defaults.connect(&|_| {});
+
+        assert!(!default_api.lazy_mount());
+        assert!(!default_api.unmount_on_exit());
+
+        let mounted = Service::<Machine>::new(
+            Props {
+                lazy_mount: true,
+                unmount_on_exit: true,
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages::default(),
+        );
+
+        let mounted_api = mounted.connect(&|_| {});
+
+        assert!(mounted_api.lazy_mount());
+        assert!(mounted_api.unmount_on_exit());
+    }
+
+    #[test]
+    fn part_attrs_dispatches_each_anatomy_part() {
+        let service = Service::<Machine>::new(
+            Props {
+                default_open: true,
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages::default(),
+        );
+
+        let api = service.connect(&|_| {});
+
+        assert_eq!(api.part_attrs(Part::Root), api.root_attrs());
+        assert_eq!(api.part_attrs(Part::Trigger), api.trigger_attrs());
+        assert_eq!(api.part_attrs(Part::Positioner), api.positioner_attrs());
+        assert_eq!(api.part_attrs(Part::Content), api.content_attrs());
+        assert_eq!(api.part_attrs(Part::Arrow), api.arrow_attrs());
+        assert_eq!(api.part_attrs(Part::Title), api.title_attrs());
+        assert_eq!(
+            api.part_attrs(Part::DismissButton),
+            api.dismiss_button_attrs()
+        );
+    }
+
+    #[test]
+    fn initial_effects_allocate_z_index_only_for_open_state() {
+        let service = Service::<Machine>::new(
+            Props {
+                default_open: true,
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages::default(),
+        );
+
+        let open_effects = <Machine as ars_core::Machine>::initial_effects(
+            service.state(),
+            service.context(),
+            service.props(),
+        );
+
+        assert_eq!(
+            open_effects
+                .iter()
+                .map(|effect| effect.name)
+                .collect::<Vec<_>>(),
+            vec![Effect::OpenChange, Effect::AllocateZIndex]
+        );
+
+        let closed = Service::<Machine>::new(test_props(), &Env::default(), &Messages::default());
+
+        assert!(
+            <Machine as ars_core::Machine>::initial_effects(
+                closed.state(),
+                closed.context(),
+                closed.props()
+            )
+            .is_empty()
+        );
     }
 
     #[test]

--- a/crates/ars-components/src/utility/download_trigger.rs
+++ b/crates/ars-components/src/utility/download_trigger.rs
@@ -812,14 +812,14 @@ fn parse_authority(scheme: &str, authority: &str) -> Option<ParsedOrigin> {
 
         let port = if after.is_empty() {
             default_http_port(scheme)
-        } else if let Some(port_raw) = after.strip_prefix(':') {
+        } else {
+            let port_raw = after.strip_prefix(':')?;
+
             if port_raw.is_empty() {
                 default_http_port(scheme)
             } else {
                 port_raw.parse::<u16>().ok()?
             }
-        } else {
-            return None;
         };
 
         return Some(ParsedOrigin {
@@ -1619,5 +1619,224 @@ mod tests {
                 .root_attrs(),
             )
         );
+    }
+
+    #[test]
+    fn clear_builders_and_api_accessors_report_current_props() {
+        let props = Props::new()
+            .id("dl-clear")
+            .href("/before.bin")
+            .filename("before.bin")
+            .mime_type("application/octet-stream")
+            .disabled(true)
+            .document_origin("https://example.com")
+            .clear_filename()
+            .clear_mime_type()
+            .clear_document_origin();
+
+        assert_eq!(props.filename, None);
+        assert_eq!(props.mime_type, None);
+        assert_eq!(props.document_origin, None);
+
+        let cleared = api(props);
+
+        assert_eq!(cleared.id(), "dl-clear");
+        assert!(cleared.is_disabled());
+        assert_eq!(cleared.filename(), None);
+
+        let enabled = api(Props::new()
+            .id("dl-file")
+            .href("/file.txt")
+            .filename("file.txt"));
+
+        assert!(!enabled.is_disabled());
+        assert_eq!(enabled.filename(), Some("file.txt"));
+    }
+
+    #[test]
+    fn scheme_prefix_validation_accepts_only_rfc3986_scheme_bytes() {
+        assert!(scheme_prefix_bytes_valid(b"a"));
+        assert!(scheme_prefix_bytes_valid(b"a+1-z."));
+        assert!(scheme_prefix_bytes_valid(b"web+test-1.2"));
+
+        assert!(!scheme_prefix_bytes_valid(b""));
+        assert!(!scheme_prefix_bytes_valid(b"1http"));
+        assert!(!scheme_prefix_bytes_valid(b"+http"));
+        assert!(!scheme_prefix_bytes_valid(b"http_"));
+        assert!(!scheme_prefix_bytes_valid(b"http:"));
+    }
+
+    #[test]
+    fn starts_with_ignore_case_checks_length_and_ascii_case() {
+        assert!(starts_with_ignore_case(b"HTTPS://example.com", b"https:"));
+        assert!(starts_with_ignore_case(b"data:", b"data:"));
+
+        assert!(!starts_with_ignore_case(b"data", b"data:"));
+        assert!(!starts_with_ignore_case(b"mailto:", b"tel:"));
+        assert!(!starts_with_ignore_case(b"DATB:", b"data:"));
+    }
+
+    #[test]
+    fn relative_reference_scheme_scan_stops_at_url_delimiters() {
+        assert!(contains_scheme_separator_before_delim(b"web+app.1:path"));
+        assert!(!contains_scheme_separator_before_delim(b"/x:y"));
+        assert!(!contains_scheme_separator_before_delim(b"?x:y"));
+        assert!(!contains_scheme_separator_before_delim(b"#x:y"));
+        assert!(!contains_scheme_separator_before_delim(b"a/b:c"));
+        assert!(!contains_scheme_separator_before_delim(b"a?b:c"));
+        assert!(!contains_scheme_separator_before_delim(b"a#b:c"));
+        assert!(!contains_scheme_separator_before_delim(b"1bad:path"));
+        assert!(!contains_scheme_separator_before_delim(
+            b"not a scheme:path"
+        ));
+
+        assert!(is_relative_reference("./a:b"));
+        assert!(is_relative_reference("../a:b"));
+        assert!(is_relative_reference("/a:b"));
+        assert!(is_relative_reference("?a:b"));
+        assert!(is_relative_reference("#a:b"));
+        assert!(!is_relative_reference("mailto:user@example.com"));
+        assert!(!is_relative_reference("//example.com/file"));
+    }
+
+    #[test]
+    fn low_level_origin_helpers_cover_ports_userinfo_and_host_normalization() {
+        assert_eq!(
+            http_https_authority_rest("//example.com"),
+            Some("example.com")
+        );
+        assert_eq!(http_https_authority_rest("//"), Some(""));
+        assert_eq!(
+            http_https_authority_rest(r"\\\example.com/path"),
+            Some("example.com/path")
+        );
+        assert_eq!(http_https_authority_rest("/example.com"), None);
+
+        assert_eq!(default_http_port("http"), 80);
+        assert_eq!(default_http_port("https"), 443);
+        assert_eq!(default_http_port("HTTPS"), 443);
+
+        assert_eq!(hex_value(b'0'), Some(0));
+        assert_eq!(hex_value(b'9'), Some(9));
+        assert_eq!(hex_value(b'a'), Some(10));
+        assert_eq!(hex_value(b'F'), Some(15));
+        assert_eq!(hex_value(b'g'), None);
+
+        assert_eq!(percent_decode_host("exa%6Dple.com").as_ref(), "example.com");
+        assert_eq!(percent_decode_host("%").as_ref(), "%");
+        assert_eq!(percent_decode_host("%6").as_ref(), "%6");
+        assert_eq!(percent_decode_host("a%20b").as_ref(), "a b");
+        assert_eq!(percent_decode_host("%ff").as_ref(), "%ff");
+
+        assert_eq!(
+            authority_without_userinfo("user:pass@example.com"),
+            "example.com"
+        );
+        assert_eq!(authority_without_userinfo("[::1]"), "[::1]");
+        assert_eq!(authority_without_userinfo("user@[::1]:443"), "[::1]:443");
+        assert_eq!(
+            authority_without_userinfo("[::1]@example.com"),
+            "example.com"
+        );
+        assert_eq!(
+            authority_without_userinfo("[fe80::1%25en@0]:443"),
+            "[fe80::1%25en@0]:443"
+        );
+        assert_eq!(
+            authority_without_userinfo("[a@b]@example.com"),
+            "example.com"
+        );
+
+        assert_eq!(
+            parse_authority("https", "EXAMPLE.com:").unwrap(),
+            ParsedOrigin {
+                scheme: "https".to_string(),
+                host: "example.com".to_string(),
+                port: 443,
+            }
+        );
+        assert_eq!(
+            parse_authority("http", "[::1]:8080").unwrap(),
+            ParsedOrigin {
+                scheme: "http".to_string(),
+                host: "::1".to_string(),
+                port: 8080,
+            }
+        );
+        assert_eq!(parse_authority("https", "[::1]evil"), None);
+    }
+
+    #[test]
+    fn relaxed_ipv4_parser_covers_shorthand_radix_and_bounds() {
+        assert_eq!(
+            parse_ipv4_address_relaxed("127.1"),
+            Some(Ipv4Addr::new(127, 0, 0, 1))
+        );
+        assert_eq!(
+            parse_ipv4_address_relaxed("127.0.0.1"),
+            Some(Ipv4Addr::new(127, 0, 0, 1))
+        );
+        assert_eq!(
+            parse_ipv4_address_relaxed("0177.0.0.1"),
+            Some(Ipv4Addr::new(127, 0, 0, 1))
+        );
+        assert_eq!(
+            parse_ipv4_address_relaxed("127.0x1.01"),
+            Some(Ipv4Addr::new(127, 1, 0, 1))
+        );
+        assert_eq!(
+            parse_ipv4_address_relaxed("1.2.65535"),
+            Some(Ipv4Addr::new(1, 2, 255, 255))
+        );
+        assert_eq!(
+            parse_ipv4_address_relaxed("1.16777215"),
+            Some(Ipv4Addr::new(1, 255, 255, 255))
+        );
+        assert_eq!(
+            parse_ipv4_address_relaxed("0x7f000001"),
+            Some(Ipv4Addr::new(127, 0, 0, 1))
+        );
+        assert_eq!(parse_ipv4_address_relaxed(""), None);
+        assert_eq!(parse_ipv4_address_relaxed("127.0.0.256"), None);
+        assert_eq!(parse_ipv4_address_relaxed("1.2.65536"), None);
+        assert_eq!(parse_ipv4_address_relaxed("1.16777216"), None);
+        assert_eq!(parse_ipv4_address_relaxed("127.0.0.0.1"), None);
+        assert_eq!(parse_ipv4_address_relaxed("127:"), None);
+
+        assert_eq!(parse_ipv4_component_value("010"), Some(8));
+        assert_eq!(parse_ipv4_component_value("0X10"), Some(16));
+        assert_eq!(parse_ipv4_component_value(""), None);
+        assert_eq!(parse_ipv4_component_value("0x"), None);
+    }
+
+    #[test]
+    fn scheme_policy_helpers_cover_protocol_pairs_and_document_scheme() {
+        assert_eq!(
+            classify_href("blob:https://example.com/id", None),
+            DownloadPolicy::Native
+        );
+        assert_eq!(
+            classify_href("data:text/plain,hello", None),
+            DownloadPolicy::Native
+        );
+        assert_eq!(
+            classify_href("mailto:user@example.com", None),
+            DownloadPolicy::NoDownloadHint
+        );
+        assert_eq!(
+            classify_href("tel:+15551212", None),
+            DownloadPolicy::NoDownloadHint
+        );
+
+        assert_eq!(
+            document_origin_scheme(Some("http://example.com")),
+            Some("http")
+        );
+        assert_eq!(
+            document_origin_scheme(Some("https://example.com")),
+            Some("https")
+        );
+        assert_eq!(document_origin_scheme(Some("ftp://example.com")), None);
+        assert_eq!(document_origin_scheme(None), None);
     }
 }

--- a/crates/ars-components/src/utility/highlight.rs
+++ b/crates/ars-components/src/utility/highlight.rs
@@ -1418,6 +1418,90 @@ mod tests {
         assert_eq!(api.chunks(&en_us()), highlight_chunks(&props, &en_us()));
     }
 
+    #[test]
+    fn normalised_identity_and_case_fold_mapping_are_observable() {
+        let identity = Normalised::build("Ab", false, &en_us());
+
+        assert_eq!(identity.text, "Ab");
+        assert_eq!(identity.map_range(0, 1), (0, 1));
+        assert_eq!(identity.map_range(1, 2), (1, 2));
+
+        let folded = Normalised::build("Straße", true, &german());
+
+        assert_eq!(folded.text, "strasse");
+        assert_eq!(folded.map_range(4, 6), (4, 6));
+        assert_eq!(folded.map_range(5, 7), (4, 7));
+    }
+
+    #[test]
+    fn private_match_pushers_cover_empty_and_positive_paths() {
+        let normalised = Normalised::build("banana", false, &en_us());
+
+        let mut ranges = Vec::new();
+
+        push_contains_matches(&normalised, "", &mut ranges);
+
+        assert!(ranges.is_empty());
+
+        push_contains_matches(&normalised, "ana", &mut ranges);
+
+        assert_eq!(ranges, vec![(1, 4), (3, 6)]);
+
+        let mut starts = Vec::new();
+
+        push_starts_with_match(&normalised, "", &mut starts);
+        push_starts_with_match(&normalised, "ban", &mut starts);
+        push_starts_with_match(&normalised, "nan", &mut starts);
+
+        assert_eq!(starts, vec![(0, 3)]);
+
+        let mut fuzzy = Vec::new();
+
+        push_fuzzy_matches("a_b_c", "abc", false, &en_us(), &mut fuzzy);
+
+        assert_eq!(fuzzy, vec![(0, 1), (2, 3), (4, 5)]);
+
+        let mut missing = Vec::new();
+
+        push_fuzzy_matches("a_b_c", "abcd", false, &en_us(), &mut missing);
+
+        assert!(missing.is_empty());
+    }
+
+    #[test]
+    fn merge_ranges_and_build_chunks_cover_boundaries() {
+        assert_eq!(
+            merge_ranges(vec![(5, 7), (1, 3), (3, 5), (10, 12)]),
+            vec![(1, 7), (10, 12)]
+        );
+
+        assert_eq!(
+            build_chunks("0123456789", &[(0, 2), (4, 6), (8, 10)]),
+            vec![
+                HighlightChunk {
+                    text: "01",
+                    highlighted: true,
+                },
+                HighlightChunk {
+                    text: "23",
+                    highlighted: false,
+                },
+                HighlightChunk {
+                    text: "45",
+                    highlighted: true,
+                },
+                HighlightChunk {
+                    text: "67",
+                    highlighted: false,
+                },
+                HighlightChunk {
+                    text: "89",
+                    highlighted: true,
+                },
+            ]
+        );
+    }
+
     // ── Snapshots ──────────────────────────────────────────────────
 
     #[test]

--- a/docs/implementation/README.md
+++ b/docs/implementation/README.md
@@ -7,6 +7,7 @@ The repo is expected to operate with these rules:
 - Build the platform first: workspace, core contracts, subsystems, harnesses, then components.
 - Run TDD-style delivery: define the exact tests first, then implement the minimum code needed.
 - Keep the specification synchronized with implementation. If implementation changes the intended contract, update the relevant spec in the same task.
+- For every new or materially changed framework-agnostic component, add spec-conformance tests for its anatomy/public contract and run a targeted mutation test for the component source file (`cargo mutants -p ars-components -f crates/ars-components/src/<category>/<component>/mod.rs` or the equivalent file path). Triage every `MISSED` mutant in the same task: add tests for real gaps, or document true equivalence in `.cargo/mutants.toml`.
 - Use GitHub Projects with issue-backed items only.
 - Keep most agent-ready tasks at `1`, `2`, `3`, or `5` points. `8` is exceptional. `13` must be split before pickup.
 


### PR DESCRIPTION
## Summary

- add focused `ars-components` tests for HoverCard, Table, utility helpers, and the newly merged agnostic input components
- document the agnostic component gate for targeted `cargo mutants` runs and spec-conformance tests
- add justified mutation excludes for equivalent or timeout-only mutants surfaced during triage

## Verification

- `cargo +nightly fmt --check`
- `cargo test -p ars-components --all-targets`
- `cargo +nightly llvm-cov nextest --branch -p ars-components --lcov --output-path target/coverage/ars-components-local.lcov --no-fail-fast`
- `cargo xtask coverage check --file target/coverage/ars-components-local.lcov --package ars-components --min 90 --branch-min 90` — lines `98.9% (37066/37495)`, branches `91.8% (2747/2992)`
- `cargo clippy -p ars-components --all-targets --all-features -- -D warnings`
- targeted `cargo mutants` runs for HoverCard, Highlight, PasswordInput, SearchInput, NumberInput, PinInput, DownloadTrigger, Table, plus the Nightly CI mutant survivors in `ars-core` and `ars-collections`
- `cargo xci-fast`
