### PR TITLE
Finish ArsProvider Leptos and Dioxus adapters

### DIFF
--- a/crates/ars-dioxus/src/lib.rs
+++ b/crates/ars-dioxus/src/lib.rs
@@ -76,9 +76,9 @@ pub use platform::{
     default_dioxus_platform, use_platform,
 };
 pub use provider::{
-    ArsContext, ArsProvider, ArsProviderProps, Translatable, resolve_locale, t, use_intl_backend,
-    use_locale, use_messages, use_modality_context, use_number_formatter, use_platform_effects,
-    warn_missing_provider,
+    ArsContext, ArsProvider, ArsProviderProps, Translatable, resolve_locale, t, use_direction,
+    use_intl_backend, use_locale, use_messages, use_modality_context, use_number_formatter,
+    use_platform_effects, warn_missing_provider,
 };
 #[cfg(feature = "web")]
 pub use safe_listener::{

--- a/crates/ars-dioxus/src/prelude.rs
+++ b/crates/ars-dioxus/src/prelude.rs
@@ -46,7 +46,11 @@
 
 // -- User-facing traits --
 pub use ars_collections::{Key, TabKey};
-pub use ars_core::{I18nRegistries, MessageFn, MessagesRegistry, SafeUrl, UnsafeUrlError};
+// `ColorMode` is a configuration enum that end users pass to `ArsProvider`
+// via the `color_mode` prop; it belongs with the configuration types.
+pub use ars_core::{
+    ColorMode, I18nRegistries, MessageFn, MessagesRegistry, SafeUrl, UnsafeUrlError,
+};
 pub use ars_i18n::{Direction, IntlBackend, Locale, Orientation, ResolvedDirection, Translate};
 
 // -- Component modules --
@@ -71,5 +75,13 @@ pub use crate::utility::{
     self, button, client_only, dismissable, error_boundary, separator, visually_hidden,
     z_index_allocator,
 };
+// -- Root provider --
+// `ArsProvider` is the single root provider every ars-ui application wraps its
+// tree with. It publishes locale, direction, color mode, disabled/read-only,
+// portal/root nodes, platform effects, and style strategy via context. The
+// explicit `ArsProviderProps` struct is re-exported so end users can build
+// props value at call sites without importing it separately. See
+// `spec/dioxus-components/utility/ars-provider.md`.
+pub use crate::{ArsProvider, ArsProviderProps};
 // -- User-facing helpers --
 pub use crate::{Translatable, t, use_number_formatter};

--- a/crates/ars-dioxus/src/provider.rs
+++ b/crates/ars-dioxus/src/provider.rs
@@ -380,6 +380,26 @@ pub fn use_locale() -> Signal<Locale> {
     )
 }
 
+/// Returns the resolved reading-direction memo from provider context.
+///
+/// Falls back to a memo of [`Direction::Ltr`] when no
+/// [`ArsProvider`] is in scope. Defined by
+/// `spec/dioxus-components/utility/ars-provider.md` §6 — the parallel to
+/// [`use_locale`] for direction-dependent components.
+#[must_use]
+pub fn use_direction() -> Memo<Direction> {
+    let fallback = use_memo(|| Direction::Ltr);
+
+    try_use_context::<ArsContext>().map_or_else(
+        || {
+            warn_missing_provider("use_direction");
+
+            fallback
+        },
+        |ctx| ctx.direction,
+    )
+}
+
 /// Resolves the effective locale for an adapter component instance.
 ///
 /// Returns `adapter_props_locale.cloned()` when set, otherwise reads the
@@ -712,6 +732,21 @@ mod tests {
     fn use_locale_falls_back_without_provider() {
         fn app() -> Element {
             assert_eq!(use_locale()().to_bcp47(), "en-US");
+
+            rsx! {
+                div {}
+            }
+        }
+
+        let mut dom = VirtualDom::new(app);
+
+        dom.rebuild_in_place();
+    }
+
+    #[test]
+    fn use_direction_falls_back_to_ltr_without_provider() {
+        fn app() -> Element {
+            assert_eq!(*use_direction().read(), Direction::Ltr);
 
             rsx! {
                 div {}

--- a/crates/ars-dioxus/tests/ars_provider.rs
+++ b/crates/ars-dioxus/tests/ars_provider.rs
@@ -1,0 +1,292 @@
+//! SSR oracle tests for the Dioxus `ArsProvider` adapter.
+//!
+//! Covers spec §28 / §29 scenarios from
+//! `spec/dioxus-components/utility/ars-provider.md`: `<div dir>` wrapper
+//! rendering, direction inference vs. explicit override, provider-owned
+//! auto-render of `ArsNonceStyle` when `style_strategy` is
+//! `StyleStrategy::Nonce(...)`, and `dioxus_platform` default resolution via
+//! feature flags. Browser DOM and reactive-update oracles live in the inline
+//! `wasm_tests` module of `src/provider.rs` and in `tests/ars_provider_wasm.rs`.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use ars_core::{ColorMode, StyleStrategy};
+use ars_dioxus::{ArsContext, ArsProvider, ArsProviderProps, default_dioxus_platform};
+use ars_i18n::{Direction, Locale};
+use dioxus::prelude::*;
+
+fn render_app(app: fn() -> Element) -> String {
+    let mut vdom = VirtualDom::new(app);
+
+    vdom.rebuild_in_place();
+
+    dioxus_ssr::render(&vdom)
+}
+
+#[test]
+fn ars_provider_renders_ltr_wrapper_for_default_props() {
+    fn app() -> Element {
+        rsx! {
+            ArsProvider {
+                span { id: "child", "hello" }
+            }
+        }
+    }
+
+    let html = render_app(app);
+
+    assert!(
+        html.contains(r#"dir="ltr""#),
+        "default provider should render dir=\"ltr\": {html}"
+    );
+    assert!(
+        html.contains(r#"id="child""#),
+        "children should render inside the provider wrapper: {html}"
+    );
+    assert!(
+        !html.contains("<style nonce"),
+        "default StyleStrategy::Inline must not emit a nonce style tag: {html}"
+    );
+}
+
+#[test]
+fn ars_provider_infers_rtl_direction_from_rtl_locale() {
+    fn app() -> Element {
+        let locale = use_signal(|| Locale::parse("ar-SA").expect("locale should parse"));
+
+        rsx! {
+            ArsProvider { locale,
+                span { id: "child", "hello" }
+            }
+        }
+    }
+
+    let html = render_app(app);
+
+    assert!(
+        html.contains(r#"dir="rtl""#),
+        "RTL locale should produce dir=\"rtl\": {html}"
+    );
+    assert!(
+        html.contains(r#"id="child""#),
+        "children should render inside the RTL wrapper: {html}"
+    );
+}
+
+#[test]
+fn ars_provider_explicit_direction_overrides_locale_inferred_direction() {
+    fn app() -> Element {
+        let locale = use_signal(|| Locale::parse("ar-SA").expect("locale should parse"));
+        let direction = use_signal(|| Direction::Ltr);
+
+        rsx! {
+            ArsProvider { locale, direction,
+                span { id: "child", "hello" }
+            }
+        }
+    }
+
+    let html = render_app(app);
+
+    assert!(
+        html.contains(r#"dir="ltr""#),
+        "explicit direction prop must override locale-inferred RTL: {html}"
+    );
+    assert!(
+        !html.contains(r#"dir="rtl""#),
+        "no rtl marker should remain after explicit override: {html}"
+    );
+}
+
+#[test]
+fn ars_provider_with_nonce_style_strategy_emits_style_tag_with_nonce_attribute() {
+    fn app() -> Element {
+        rsx! {
+            ArsProvider { style_strategy: StyleStrategy::Nonce(String::from("test-nonce")),
+                span { id: "child", "hello" }
+            }
+        }
+    }
+
+    let html = render_app(app);
+
+    assert!(
+        html.contains(r#"<style nonce="test-nonce""#),
+        "StyleStrategy::Nonce must auto-render <style nonce=...> tag: {html}"
+    );
+    assert!(
+        html.contains(r#"id="child""#),
+        "children must still render alongside the nonce style tag: {html}"
+    );
+}
+
+#[test]
+fn ars_provider_with_inline_style_strategy_emits_no_nonce_style_tag() {
+    fn app() -> Element {
+        rsx! {
+            ArsProvider { style_strategy: StyleStrategy::Inline,
+                span { id: "child", "hello" }
+            }
+        }
+    }
+
+    let html = render_app(app);
+
+    assert!(
+        !html.contains("<style nonce"),
+        "StyleStrategy::Inline must not emit a nonce style tag: {html}"
+    );
+}
+
+#[test]
+fn ars_provider_with_cssom_style_strategy_emits_no_nonce_style_tag() {
+    fn app() -> Element {
+        rsx! {
+            ArsProvider { style_strategy: StyleStrategy::Cssom,
+                span { id: "child", "hello" }
+            }
+        }
+    }
+
+    let html = render_app(app);
+
+    assert!(
+        !html.contains("<style nonce"),
+        "StyleStrategy::Cssom must not emit a nonce style tag: {html}"
+    );
+}
+
+#[component]
+fn PlatformProbe() -> Element {
+    let context = try_use_context::<ArsContext>().expect("ArsProvider should publish ArsContext");
+
+    let context_id = context.dioxus_platform.new_id();
+    let direct_id = default_dioxus_platform().new_id();
+    let context_id_len = context_id.len();
+    let direct_id_len = direct_id.len();
+    let context_id_hyphens = context_id.chars().filter(|c| *c == '-').count();
+    let direct_id_hyphens = direct_id.chars().filter(|c| *c == '-').count();
+
+    rsx! {
+        span { "data-testid": "context-id", "{context_id}" }
+        span { "data-testid": "direct-id", "{direct_id}" }
+        span { "data-testid": "context-id-len", "{context_id_len}" }
+        span { "data-testid": "direct-id-len", "{direct_id_len}" }
+        span { "data-testid": "context-id-hyphens", "{context_id_hyphens}" }
+        span { "data-testid": "direct-id-hyphens", "{direct_id_hyphens}" }
+    }
+}
+
+#[test]
+fn ars_provider_resolves_dioxus_platform_default_via_feature_flag_when_prop_absent() {
+    fn app() -> Element {
+        rsx! {
+            ArsProvider { PlatformProbe {} }
+        }
+    }
+
+    let html = render_app(app);
+
+    // Spec §29 oracle: "`use_platform()` returns the feature-flag-appropriate
+    // impl without explicit prop." Test is feature-flag-agnostic — the context
+    // platform must produce IDs in the same family (same length, same hyphen
+    // count) as a freshly-constructed `default_dioxus_platform()`. On native
+    // SSR without `desktop`, both produce `null-id-N`. With `--all-features`
+    // active, `desktop` engages and both produce v4 UUIDs.
+    assert!(
+        html.contains(r#"data-testid="context-id""#),
+        "PlatformProbe should render inside the provider: {html}"
+    );
+
+    // Extract the rendered length values from the HTML; both must agree.
+    // We just spot-check the equality fingerprint pair is present.
+    let context_len = html
+        .split(r#"data-testid="context-id-len">"#)
+        .nth(1)
+        .and_then(|tail| tail.split('<').next())
+        .expect("context-id-len span should be present");
+
+    let direct_len = html
+        .split(r#"data-testid="direct-id-len">"#)
+        .nth(1)
+        .and_then(|tail| tail.split('<').next())
+        .expect("direct-id-len span should be present");
+
+    assert_eq!(
+        context_len, direct_len,
+        "context-resolved platform and direct default_dioxus_platform() \
+         should produce IDs of the same length (proves same impl family): {html}"
+    );
+
+    let context_hyphens = html
+        .split(r#"data-testid="context-id-hyphens">"#)
+        .nth(1)
+        .and_then(|tail| tail.split('<').next())
+        .expect("context-id-hyphens span should be present");
+
+    let direct_hyphens = html
+        .split(r#"data-testid="direct-id-hyphens">"#)
+        .nth(1)
+        .and_then(|tail| tail.split('<').next())
+        .expect("direct-id-hyphens span should be present");
+
+    assert_eq!(
+        context_hyphens, direct_hyphens,
+        "context-resolved platform and direct default_dioxus_platform() \
+         should produce IDs with the same hyphen count: {html}"
+    );
+}
+
+#[test]
+fn ars_provider_renders_color_mode_disabled_and_read_only_without_extra_wrapper_attrs() {
+    fn app() -> Element {
+        let color_mode = use_signal(|| ColorMode::Dark);
+        let disabled = use_signal(|| true);
+        let read_only = use_signal(|| true);
+
+        rsx! {
+            ArsProvider { color_mode, disabled, read_only,
+                span { id: "child", "hello" }
+            }
+        }
+    }
+
+    let html = render_app(app);
+
+    assert!(
+        html.contains(r#"dir="ltr""#),
+        "wrapper still emits dir attribute regardless of color/disabled/read-only props: {html}"
+    );
+    assert!(
+        !html.contains(r#"data-color-mode"#),
+        "provider wrapper must not emit color-mode markup: {html}"
+    );
+    assert!(
+        !html.contains(r#"aria-disabled"#),
+        "provider wrapper must not emit aria-disabled: {html}"
+    );
+}
+
+#[test]
+fn ars_provider_props_default_is_eq_to_itself() {
+    let lhs = ArsProviderProps {
+        locale: None,
+        direction: None,
+        color_mode: None,
+        disabled: None,
+        read_only: None,
+        id_prefix: None,
+        portal_container_id: None,
+        root_node_id: None,
+        platform: None,
+        intl_backend: None,
+        i18n_registries: None,
+        style_strategy: None,
+        dioxus_platform: None,
+        children: Ok(VNode::placeholder()),
+    };
+
+    let rhs = lhs.clone();
+
+    assert_eq!(lhs, rhs, "ArsProviderProps PartialEq must be reflexive");
+}

--- a/crates/ars-dioxus/tests/ars_provider_wasm.rs
+++ b/crates/ars-dioxus/tests/ars_provider_wasm.rs
@@ -1,0 +1,264 @@
+//! Browser tests for the Dioxus `ArsProvider` adapter.
+//!
+//! Complements the SSR oracle (`tests/ars_provider.rs`) and the inline
+//! `wasm_tests` module of `src/provider.rs`. The inline tests cover
+//! mutation-log oracles for context publication and reactivity; this file
+//! adds the integration-tier scenarios that require a real DOM mount via
+//! `dioxus_web::launch::launch_virtual_dom`:
+//!
+//! - Provider auto-renders `<style nonce="...">` into the DOM when
+//!   `style_strategy` is `StyleStrategy::Nonce(...)`.
+//! - `use_platform()` outside any `ArsProvider` falls back to
+//!   `default_dioxus_platform()`, which on `wasm32 + feature = "web"` is
+//!   `WebPlatform`. The fingerprint is `new_id()` returning a UUID rather
+//!   than `NullPlatform`'s `null-id-N` strings.
+
+#![cfg(all(target_arch = "wasm32", feature = "web"))]
+
+use std::{cell::RefCell, rc::Rc};
+
+use ars_core::StyleStrategy;
+use ars_dioxus::{ArsContext, ArsProvider, default_dioxus_platform, use_platform};
+use dioxus::prelude::*;
+use wasm_bindgen::JsCast;
+use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+fn document() -> web_sys::Document {
+    web_sys::window()
+        .and_then(|window| window.document())
+        .expect("document should exist")
+}
+
+fn container() -> web_sys::HtmlElement {
+    let element = document()
+        .create_element("div")
+        .expect("container should be created");
+
+    document()
+        .body()
+        .expect("body should exist")
+        .append_child(&element)
+        .expect("container should attach");
+
+    element
+        .dyn_into::<web_sys::HtmlElement>()
+        .expect("container should be an HtmlElement")
+}
+
+async fn animation_frame_turn() {
+    let promise = js_sys::Promise::new(&mut |resolve, _reject| {
+        let callback = wasm_bindgen::closure::Closure::once_into_js({
+            let resolve = resolve.clone();
+            move || {
+                drop(resolve.call0(&wasm_bindgen::JsValue::UNDEFINED));
+            }
+        });
+
+        web_sys::window()
+            .expect("window should exist")
+            .request_animation_frame(callback.unchecked_ref())
+            .expect("requestAnimationFrame should succeed");
+    });
+
+    drop(wasm_bindgen_futures::JsFuture::from(promise).await);
+}
+
+#[component]
+fn NonceTrigger() -> Element {
+    let nonce_context = try_use_context::<ars_dioxus::ArsNonceCssCtx>()
+        .expect("ArsProvider should publish nonce context");
+
+    ars_dioxus::append_nonce_css(String::from(".probe { color: red; }"));
+
+    rsx! {
+        span { "data-testid": "nonce-rules-count", "{nonce_context.rules.read().len()}" }
+    }
+}
+
+fn nonce_app() -> Element {
+    rsx! {
+        ArsProvider { style_strategy: StyleStrategy::Nonce(String::from("dom-nonce")), NonceTrigger {} }
+    }
+}
+
+#[wasm_bindgen_test(async)]
+async fn ars_provider_with_nonce_strategy_auto_renders_style_tag_in_dom_on_wasm() {
+    let parent = container();
+
+    let dom = VirtualDom::new(nonce_app);
+
+    dioxus_web::launch::launch_virtual_dom(
+        dom,
+        dioxus_web::Config::new().rootelement(parent.clone().into()),
+    );
+
+    animation_frame_turn().await;
+    animation_frame_turn().await;
+
+    let style = parent
+        .query_selector("style[nonce='dom-nonce']")
+        .expect("selector should be valid")
+        .expect("nonce-bearing style tag should be in the DOM");
+
+    let css = style
+        .text_content()
+        .expect("style tag should have CSS text");
+
+    assert!(
+        css.contains(".probe { color: red; }"),
+        "appended CSS rule should land in the nonce style tag on wasm: {css}"
+    );
+
+    let wrapper = parent
+        .query_selector("[dir='ltr']")
+        .expect("selector should be valid")
+        .expect("provider wrapper should exist");
+
+    assert_eq!(wrapper.get_attribute("dir").as_deref(), Some("ltr"));
+
+    parent.remove();
+}
+
+#[derive(Clone, Props)]
+struct PlatformIdProbeProps {
+    outputs: Rc<RefCell<Vec<String>>>,
+}
+
+impl PartialEq for PlatformIdProbeProps {
+    fn eq(&self, other: &Self) -> bool {
+        Rc::ptr_eq(&self.outputs, &other.outputs)
+    }
+}
+
+#[expect(
+    clippy::needless_pass_by_value,
+    reason = "Dioxus component props are passed by value"
+)]
+#[expect(non_snake_case, reason = "Dioxus components use PascalCase names")]
+fn PlatformIdProbe(props: PlatformIdProbeProps) -> Element {
+    let platform = use_platform();
+
+    props.outputs.borrow_mut().push(platform.new_id());
+
+    rsx! {
+        div { "data-testid": "platform-id-probe" }
+    }
+}
+
+#[wasm_bindgen_test]
+fn use_platform_falls_back_to_web_platform_without_provider_on_wasm() {
+    let outputs = Rc::new(RefCell::new(Vec::<String>::new()));
+
+    fn app(outputs: Rc<RefCell<Vec<String>>>) -> Element {
+        rsx! {
+            PlatformIdProbe { outputs }
+        }
+    }
+
+    let mut dom = VirtualDom::new_with_props(app, Rc::clone(&outputs));
+
+    dom.rebuild_in_place();
+
+    let ids = outputs.borrow();
+
+    assert_eq!(ids.len(), 1, "PlatformIdProbe should have run once");
+
+    let id = &ids[0];
+
+    assert!(
+        !id.starts_with("null-id-"),
+        "on wasm32 + feature=\"web\", use_platform without provider must \
+         resolve to WebPlatform (UUID), not NullPlatform: got {id}"
+    );
+
+    // `WebPlatform::new_id()` delegates to `crypto.randomUUID()`, which
+    // produces strings of the form `xxxxxxxx-xxxx-Mxxx-Nxxx-xxxxxxxxxxxx`
+    // (36 chars with four hyphens). Spot-check the shape so the oracle
+    // catches future regressions where the fallback chain reorders.
+    assert_eq!(
+        id.len(),
+        36,
+        "WebPlatform::new_id() should return a UUID (got {id})"
+    );
+    assert_eq!(
+        id.chars().filter(|c| *c == '-').count(),
+        4,
+        "UUID v4 has 4 hyphen separators (got {id})"
+    );
+}
+
+#[derive(Clone, Props)]
+struct ContextPlatformProbeProps {
+    outputs: Rc<RefCell<Vec<String>>>,
+}
+
+impl PartialEq for ContextPlatformProbeProps {
+    fn eq(&self, other: &Self) -> bool {
+        Rc::ptr_eq(&self.outputs, &other.outputs)
+    }
+}
+
+#[expect(
+    clippy::needless_pass_by_value,
+    reason = "Dioxus component props are passed by value"
+)]
+#[expect(non_snake_case, reason = "Dioxus components use PascalCase names")]
+fn ContextPlatformProbe(props: ContextPlatformProbeProps) -> Element {
+    let context = try_use_context::<ArsContext>().expect("ArsProvider should publish ArsContext");
+
+    props
+        .outputs
+        .borrow_mut()
+        .push(context.dioxus_platform.new_id());
+
+    rsx! {
+        div {}
+    }
+}
+
+#[wasm_bindgen_test]
+fn ars_provider_publishes_default_dioxus_platform_when_prop_absent_on_wasm() {
+    let outputs = Rc::new(RefCell::new(Vec::<String>::new()));
+
+    fn app(outputs: Rc<RefCell<Vec<String>>>) -> Element {
+        rsx! {
+            ArsProvider {
+                ContextPlatformProbe { outputs }
+            }
+        }
+    }
+
+    let mut dom = VirtualDom::new_with_props(app, Rc::clone(&outputs));
+
+    dom.rebuild_in_place();
+
+    let ids = outputs.borrow();
+
+    assert_eq!(ids.len(), 1, "ContextPlatformProbe should have run once");
+
+    let context_id = &ids[0];
+
+    // Sanity-check by allocating a fresh `default_dioxus_platform()` and
+    // confirming both produce IDs in the same family. On wasm32 + web that
+    // family is UUID (36 chars, 4 hyphens). This pins the §29 oracle:
+    // "use_platform() returns the feature-flag-appropriate impl".
+    let direct_id = default_dioxus_platform().new_id();
+
+    assert_eq!(
+        context_id.len(),
+        direct_id.len(),
+        "context-resolved platform and direct default should produce \
+         IDs of the same family (context={context_id} direct={direct_id})"
+    );
+    assert_eq!(
+        context_id.chars().filter(|c| *c == '-').count(),
+        direct_id.chars().filter(|c| *c == '-').count(),
+        "same hyphen count proves the same platform family"
+    );
+    assert!(
+        !context_id.starts_with("null-id-"),
+        "feature=\"web\" on wasm32 must publish WebPlatform, not NullPlatform"
+    );
+}

--- a/crates/ars-leptos/src/lib.rs
+++ b/crates/ars-leptos/src/lib.rs
@@ -69,7 +69,7 @@ pub use nonce::{
     use_nonce_css_context_provider, use_nonce_css_from_attrs, use_nonce_css_rule,
 };
 pub use provider::{
-    ArsContext, ArsProvider, Translatable, provide_ars_context, resolve_locale, t,
+    ArsContext, ArsProvider, Translatable, provide_ars_context, resolve_locale, t, use_direction,
     use_intl_backend, use_locale, use_messages, use_modality_context, use_number_formatter,
     use_platform_effects, warn_missing_provider,
 };

--- a/crates/ars-leptos/src/prelude.rs
+++ b/crates/ars-leptos/src/prelude.rs
@@ -46,9 +46,19 @@
 
 // -- User-facing traits --
 pub use ars_collections::{Key, TabKey};
-pub use ars_core::{I18nRegistries, MessageFn, MessagesRegistry, SafeUrl, UnsafeUrlError};
+// `ColorMode` is a configuration enum that end users pass to `ArsProvider`
+// via the `color_mode` prop; it belongs with the configuration types.
+pub use ars_core::{
+    ColorMode, I18nRegistries, MessageFn, MessagesRegistry, SafeUrl, UnsafeUrlError,
+};
 pub use ars_i18n::{Direction, IntlBackend, Locale, Orientation, ResolvedDirection, Translate};
 
+// -- Root provider --
+// `ArsProvider` is the single root provider every ars-ui application wraps its
+// tree with. It publishes locale, direction, color mode, disabled/read-only,
+// portal/root nodes, platform effects, and style strategy via context. See
+// `spec/leptos-components/utility/ars-provider.md`.
+pub use crate::ArsProvider;
 // -- Component modules --
 //
 // Consumers reach component types via the module qualifier

--- a/crates/ars-leptos/src/provider.rs
+++ b/crates/ars-leptos/src/provider.rs
@@ -278,6 +278,24 @@ pub fn use_locale() -> Signal<Locale> {
     )
 }
 
+/// Returns the resolved reading direction signal from provider context.
+///
+/// Falls back to [`Direction::Ltr`] when no [`ArsProvider`] is in scope.
+/// Defined by `spec/leptos-components/utility/ars-provider.md` §22 — the
+/// adapter-required parallel to [`use_locale`] for direction-dependent
+/// components.
+#[must_use]
+pub fn use_direction() -> Signal<Direction> {
+    current_ars_context().map_or_else(
+        || {
+            warn_missing_provider("use_direction");
+
+            Signal::stored(Direction::Ltr)
+        },
+        |ctx| Signal::derive(move || ctx.direction.get()),
+    )
+}
+
 /// Resolves the current ICU provider from provider context.
 #[must_use]
 pub fn use_intl_backend() -> Arc<dyn IntlBackend> {
@@ -512,8 +530,8 @@ mod tests {
     use leptos::prelude::{Get, GetUntracked, Memo, Owner, RwSignal, Set, Signal};
 
     use super::{
-        ArsContext, current_ars_context, resolve_locale, t, translated_text, use_intl_backend,
-        use_locale, use_messages, use_modality_context, use_number_formatter,
+        ArsContext, current_ars_context, resolve_locale, t, translated_text, use_direction,
+        use_intl_backend, use_locale, use_messages, use_modality_context, use_number_formatter,
         use_resolved_number_formatter,
     };
 
@@ -694,6 +712,29 @@ mod tests {
         let owner = Owner::new();
         owner.with(|| {
             assert_eq!(use_locale().get_untracked().to_bcp47(), "en-US");
+        });
+    }
+
+    #[test]
+    fn use_direction_falls_back_to_ltr_without_provider() {
+        let owner = Owner::new();
+        owner.with(|| {
+            assert_eq!(use_direction().get_untracked(), Direction::Ltr);
+        });
+    }
+
+    #[test]
+    fn use_direction_tracks_provider_direction_when_explicitly_set() {
+        let owner = Owner::new();
+        owner.with(|| {
+            let (context, _) = reactive_test_context(
+                Locale::parse("en-US").expect("locale should parse"),
+                Arc::new(StubIntlBackend),
+            );
+
+            crate::provide_ars_context(context);
+
+            assert_eq!(use_direction().get_untracked(), Direction::Ltr);
         });
     }
 

--- a/crates/ars-leptos/tests/ars_provider.rs
+++ b/crates/ars-leptos/tests/ars_provider.rs
@@ -1,0 +1,158 @@
+//! SSR oracle tests for the Leptos `ArsProvider` adapter.
+//!
+//! These tests cover spec §28 scenarios from
+//! `spec/leptos-components/utility/ars-provider.md`:
+//! `<div dir>` wrapper rendering, direction inference vs. explicit override,
+//! and provider-owned auto-render of `ArsNonceStyle` when
+//! `style_strategy` is `StyleStrategy::Nonce(...)`. The wasm DOM and
+//! reactive-update oracles live in `tests/ars_provider_wasm.rs` and the
+//! inline `wasm_tests` module in `src/provider.rs`.
+
+#![cfg(all(not(target_arch = "wasm32"), feature = "ssr"))]
+
+use ars_core::{ColorMode, StyleStrategy};
+use ars_i18n::{Direction, Locale};
+use ars_leptos::ArsProvider;
+use leptos::prelude::*;
+
+#[test]
+fn ars_provider_renders_ltr_wrapper_for_default_props() {
+    let html = view! {
+        <ArsProvider>
+            <span id="child">"hello"</span>
+        </ArsProvider>
+    }
+    .to_html();
+
+    assert!(
+        html.contains(r#"dir="ltr""#),
+        "default provider should render dir=\"ltr\": {html}"
+    );
+    assert!(
+        html.contains(r#"id="child""#),
+        "children should render inside the provider wrapper: {html}"
+    );
+    assert!(
+        !html.contains("<style nonce"),
+        "default StyleStrategy::Inline must not emit a nonce style tag: {html}"
+    );
+}
+
+#[test]
+fn ars_provider_infers_rtl_direction_from_rtl_locale() {
+    let locale = Signal::stored(Locale::parse("ar-SA").expect("locale should parse"));
+
+    let html = view! {
+        <ArsProvider locale=locale>
+            <span id="child">"hello"</span>
+        </ArsProvider>
+    }
+    .to_html();
+
+    assert!(
+        html.contains(r#"dir="rtl""#),
+        "RTL locale should produce dir=\"rtl\": {html}"
+    );
+    assert!(
+        html.contains(r#"id="child""#),
+        "children should render inside the RTL wrapper: {html}"
+    );
+}
+
+#[test]
+fn ars_provider_explicit_direction_overrides_locale_inferred_direction() {
+    let locale = Signal::stored(Locale::parse("ar-SA").expect("locale should parse"));
+    let direction = Signal::stored(Direction::Ltr);
+
+    let html = view! {
+        <ArsProvider locale=locale direction=direction>
+            <span id="child">"hello"</span>
+        </ArsProvider>
+    }
+    .to_html();
+
+    assert!(
+        html.contains(r#"dir="ltr""#),
+        "explicit direction prop must override locale-inferred RTL: {html}"
+    );
+    assert!(
+        !html.contains(r#"dir="rtl""#),
+        "no rtl marker should remain after explicit override: {html}"
+    );
+}
+
+#[test]
+fn ars_provider_with_nonce_style_strategy_emits_style_tag_with_nonce_attribute() {
+    let html = view! {
+        <ArsProvider style_strategy=StyleStrategy::Nonce(String::from("test-nonce"))>
+            <span id="child">"hello"</span>
+        </ArsProvider>
+    }
+    .to_html();
+
+    assert!(
+        html.contains(r#"<style nonce="test-nonce""#),
+        "StyleStrategy::Nonce must auto-render <style nonce=...> tag: {html}"
+    );
+    assert!(
+        html.contains(r#"id="child""#),
+        "children must still render alongside the nonce style tag: {html}"
+    );
+}
+
+#[test]
+fn ars_provider_with_inline_style_strategy_emits_no_nonce_style_tag() {
+    let html = view! {
+        <ArsProvider style_strategy=StyleStrategy::Inline>
+            <span id="child">"hello"</span>
+        </ArsProvider>
+    }
+    .to_html();
+
+    assert!(
+        !html.contains("<style nonce"),
+        "StyleStrategy::Inline must not emit a nonce style tag: {html}"
+    );
+}
+
+#[test]
+fn ars_provider_with_cssom_style_strategy_emits_no_nonce_style_tag() {
+    let html = view! {
+        <ArsProvider style_strategy=StyleStrategy::Cssom>
+            <span id="child">"hello"</span>
+        </ArsProvider>
+    }
+    .to_html();
+
+    assert!(
+        !html.contains("<style nonce"),
+        "StyleStrategy::Cssom must not emit a nonce style tag: {html}"
+    );
+}
+
+#[test]
+fn ars_provider_renders_color_mode_disabled_and_read_only_without_extra_attributes_on_wrapper() {
+    let html = view! {
+        <ArsProvider
+            color_mode=Signal::stored(ColorMode::Dark)
+            disabled=Signal::stored(true)
+            read_only=Signal::stored(true)
+        >
+            <span id="child">"hello"</span>
+        </ArsProvider>
+    }
+    .to_html();
+
+    assert!(
+        html.contains(r#"dir="ltr""#),
+        "wrapper still emits dir attribute regardless of color/disabled/read-only props: {html}"
+    );
+    assert!(
+        !html.contains(r#"data-color-mode"#),
+        "provider wrapper must not emit color-mode markup (consumer-owned): {html}"
+    );
+    assert!(
+        !html.contains(r#"aria-disabled"#),
+        "provider wrapper must not emit aria-disabled (descendants own that semantics): {html}"
+    );
+}

--- a/crates/ars-leptos/tests/ars_provider_wasm.rs
+++ b/crates/ars-leptos/tests/ars_provider_wasm.rs
@@ -1,0 +1,232 @@
+//! Browser tests for the Leptos `ArsProvider` adapter.
+//!
+//! Complements the SSR oracle (`tests/ars_provider.rs`) and the inline wasm
+//! tests in `src/provider.rs::wasm_tests`. These tests cover the spec §28
+//! scenarios that require a real DOM:
+//!
+//! - All-props configuration round-trip observable via context.
+//! - Nonce auto-render attaches a `<style nonce="...">` element under the
+//!   provider boundary.
+//! - `use_style_strategy()` falls back to `StyleStrategy::Inline` outside of
+//!   any provider.
+
+#![cfg(target_arch = "wasm32")]
+
+use ars_core::{ColorMode, StyleStrategy};
+use ars_i18n::{Direction, Locale};
+use ars_leptos::{
+    ArsContext, ArsNonceCssCtx, ArsProvider, append_nonce_css, use_direction, use_style_strategy,
+};
+use leptos::{mount::mount_to, prelude::*};
+use wasm_bindgen::JsCast;
+use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+fn document() -> web_sys::Document {
+    web_sys::window()
+        .and_then(|window| window.document())
+        .expect("document should exist")
+}
+
+fn container() -> web_sys::HtmlElement {
+    let element = document()
+        .create_element("div")
+        .expect("container should be created");
+
+    document()
+        .body()
+        .expect("body should exist")
+        .append_child(&element)
+        .expect("container should attach");
+
+    element
+        .dyn_into::<web_sys::HtmlElement>()
+        .expect("container should be an HtmlElement")
+}
+
+#[leptos::component]
+fn ConfigProbe() -> impl IntoView {
+    let context = use_context::<ArsContext>().expect("ArsProvider should publish ArsContext");
+    let style_strategy_label = format!("{:?}", use_style_strategy());
+
+    // Dogfood `use_direction()` (spec §22 required helper) at the
+    // integration tier — the inline tests cover the unit-level fallback
+    // contract; this verifies the hook resolves correctly when read from
+    // inside a real `ArsProvider`-mounted subtree.
+    let direction = use_direction();
+    let locale = context.locale;
+    let color_mode = context.color_mode;
+    let disabled = context.disabled;
+    let read_only = context.read_only;
+    let id_prefix = context.id_prefix;
+    let portal_container_id = context.portal_container_id;
+    let root_node_id = context.root_node_id;
+
+    view! {
+        <div data-testid="config-probe">
+            <span data-testid="locale">{move || locale.get().to_bcp47()}</span>
+            <span data-testid="direction">{move || direction.get().as_html_attr()}</span>
+            <span data-testid="color-mode">{move || format!("{:?}", color_mode.get())}</span>
+            <span data-testid="disabled">{move || disabled.get().to_string()}</span>
+            <span data-testid="read-only">{move || read_only.get().to_string()}</span>
+            <span data-testid="id-prefix">{move || id_prefix.get().unwrap_or_default()}</span>
+            <span data-testid="portal-container-id">
+                {move || portal_container_id.get().unwrap_or_default()}
+            </span>
+            <span data-testid="root-node-id">{move || root_node_id.get().unwrap_or_default()}</span>
+            <span data-testid="style-strategy">{style_strategy_label}</span>
+        </div>
+    }
+}
+
+#[leptos::component]
+fn NonceProbe() -> impl IntoView {
+    let nonce_context =
+        use_context::<ArsNonceCssCtx>().expect("ArsProvider should publish nonce context");
+
+    append_nonce_css(String::from(".probe { color: red; }"));
+
+    view! {
+        <span data-testid="nonce-rules-count">
+            {move || nonce_context.rules.get().len().to_string()}
+        </span>
+    }
+}
+
+#[leptos::component]
+fn FallbackProbe() -> impl IntoView {
+    let strategy_label = format!("{:?}", use_style_strategy());
+
+    view! { <span data-testid="fallback-style-strategy">{strategy_label}</span> }
+}
+
+fn text_for(container: &web_sys::HtmlElement, selector: &str) -> String {
+    container
+        .query_selector(selector)
+        .expect("selector should be valid")
+        .unwrap_or_else(|| panic!("{selector} should exist"))
+        .text_content()
+        .expect("element should have text content")
+}
+
+#[cfg(feature = "csr")]
+#[wasm_bindgen_test]
+async fn ars_provider_publishes_all_configured_fields_to_descendants_on_wasm() {
+    let container = container();
+
+    let mount_handle = mount_to(container.clone(), move || {
+        view! {
+            <ArsProvider
+                locale=Signal::stored(Locale::parse("es-ES").expect("locale should parse"))
+                direction=Signal::stored(Direction::Rtl)
+                color_mode=Signal::stored(ColorMode::Dark)
+                disabled=Signal::stored(true)
+                read_only=Signal::stored(true)
+                id_prefix=String::from("app-prefix")
+                portal_container_id=String::from("portal-root")
+                root_node_id=String::from("focus-root")
+                style_strategy=StyleStrategy::Cssom
+            >
+                <ConfigProbe />
+            </ArsProvider>
+        }
+    });
+
+    leptos::task::tick().await;
+
+    assert_eq!(text_for(&container, "[data-testid='locale']"), "es-ES");
+    assert_eq!(text_for(&container, "[data-testid='direction']"), "rtl");
+    assert_eq!(text_for(&container, "[data-testid='color-mode']"), "Dark");
+    assert_eq!(text_for(&container, "[data-testid='disabled']"), "true");
+    assert_eq!(text_for(&container, "[data-testid='read-only']"), "true");
+    assert_eq!(
+        text_for(&container, "[data-testid='id-prefix']"),
+        "app-prefix"
+    );
+    assert_eq!(
+        text_for(&container, "[data-testid='portal-container-id']"),
+        "portal-root"
+    );
+    assert_eq!(
+        text_for(&container, "[data-testid='root-node-id']"),
+        "focus-root"
+    );
+    assert_eq!(
+        text_for(&container, "[data-testid='style-strategy']"),
+        "Cssom"
+    );
+
+    let wrapper = container
+        .query_selector("[dir='rtl']")
+        .expect("selector should be valid")
+        .expect("RTL wrapper should exist");
+
+    assert_eq!(wrapper.get_attribute("dir").as_deref(), Some("rtl"));
+
+    drop(mount_handle);
+
+    container.remove();
+}
+
+#[cfg(feature = "csr")]
+#[wasm_bindgen_test]
+async fn ars_provider_with_nonce_strategy_auto_renders_style_tag_in_dom_on_wasm() {
+    let container = container();
+
+    let mount_handle = mount_to(container.clone(), move || {
+        view! {
+            <ArsProvider style_strategy=StyleStrategy::Nonce(String::from("dom-nonce"))>
+                <NonceProbe />
+            </ArsProvider>
+        }
+    });
+
+    leptos::task::tick().await;
+
+    assert_eq!(
+        text_for(&container, "[data-testid='nonce-rules-count']"),
+        "1",
+        "probe should have appended exactly one rule"
+    );
+
+    let style = container
+        .query_selector("style[nonce='dom-nonce']")
+        .expect("selector should be valid")
+        .expect("nonce-bearing style tag should be in the DOM");
+
+    let css = style
+        .text_content()
+        .expect("style tag should have CSS text");
+
+    assert!(
+        css.contains(".probe { color: red; }"),
+        "appended CSS rules should land in the nonce style tag: {css}"
+    );
+
+    drop(mount_handle);
+
+    container.remove();
+}
+
+#[cfg(feature = "csr")]
+#[wasm_bindgen_test]
+async fn use_style_strategy_falls_back_to_inline_without_provider_on_wasm() {
+    let container = container();
+
+    let mount_handle = mount_to(container.clone(), move || {
+        view! { <FallbackProbe /> }
+    });
+
+    leptos::task::tick().await;
+
+    assert_eq!(
+        text_for(&container, "[data-testid='fallback-style-strategy']"),
+        "Inline",
+        "use_style_strategy must default to Inline without ArsProvider in scope"
+    );
+
+    drop(mount_handle);
+
+    container.remove();
+}

--- a/examples/widgets-dioxus-css/src/main.rs
+++ b/examples/widgets-dioxus-css/src/main.rs
@@ -3,10 +3,14 @@ mod locale;
 mod messages;
 mod text;
 
-use ars_dioxus::{ArsProvider, prelude::t};
+use ars_dioxus::prelude::{ArsProvider, t};
 use dioxus::prelude::*;
 
-use crate::{categories::CategoryTabs, locale::{LocaleSwitcher, parse_locale}, text::WidgetsText};
+use crate::{
+    categories::CategoryTabs,
+    locale::{LocaleSwitcher, parse_locale},
+    text::WidgetsText,
+};
 
 fn main() {
     dioxus::launch(App);

--- a/examples/widgets-dioxus-tailwind/src/main.rs
+++ b/examples/widgets-dioxus-tailwind/src/main.rs
@@ -1,4 +1,4 @@
-use ars_dioxus::{ArsProvider, prelude::t};
+use ars_dioxus::prelude::{ArsProvider, t};
 use dioxus::prelude::*;
 
 mod categories;
@@ -6,7 +6,11 @@ mod locale;
 mod messages;
 mod text;
 
-use crate::{categories::CategoryTabs, locale::{LocaleSwitcher, parse_locale}, text::WidgetsText};
+use crate::{
+    categories::CategoryTabs,
+    locale::{LocaleSwitcher, parse_locale},
+    text::WidgetsText,
+};
 
 fn main() {
     dioxus::launch(App);

--- a/examples/widgets-dioxus/src/main.rs
+++ b/examples/widgets-dioxus/src/main.rs
@@ -3,10 +3,14 @@ mod locale;
 mod messages;
 mod text;
 
-use ars_dioxus::{ArsProvider, prelude::t};
+use ars_dioxus::prelude::{ArsProvider, t};
 use dioxus::prelude::*;
 
-use crate::{categories::CategoryTabs, locale::{LocaleSwitcher, parse_locale}, text::WidgetsText};
+use crate::{
+    categories::CategoryTabs,
+    locale::{LocaleSwitcher, parse_locale},
+    text::WidgetsText,
+};
 
 fn main() {
     dioxus::launch(App);

--- a/examples/widgets-leptos-css/src/main.rs
+++ b/examples/widgets-leptos-css/src/main.rs
@@ -1,4 +1,4 @@
-use ars_leptos::{ArsProvider, prelude::t};
+use ars_leptos::prelude::{ArsProvider, t};
 use leptos::{mount::mount_to_body, prelude::*};
 
 mod categories;
@@ -6,7 +6,11 @@ mod locale;
 mod messages;
 mod text;
 
-use crate::{categories::CategoryTabs, locale::{LocaleSwitcher, parse_locale}, text::WidgetsText};
+use crate::{
+    categories::CategoryTabs,
+    locale::{LocaleSwitcher, parse_locale},
+    text::WidgetsText,
+};
 
 fn main() {
     mount_to_body(App);

--- a/examples/widgets-leptos-tailwind/src/main.rs
+++ b/examples/widgets-leptos-tailwind/src/main.rs
@@ -3,10 +3,14 @@ mod locale;
 mod messages;
 mod text;
 
-use ars_leptos::{ArsProvider, prelude::t};
+use ars_leptos::prelude::{ArsProvider, t};
 use leptos::{mount::mount_to_body, prelude::*};
 
-use crate::{categories::CategoryTabs, locale::{LocaleSwitcher, parse_locale}, text::WidgetsText};
+use crate::{
+    categories::CategoryTabs,
+    locale::{LocaleSwitcher, parse_locale},
+    text::WidgetsText,
+};
 
 fn main() {
     mount_to_body(App);

--- a/examples/widgets-leptos/src/main.rs
+++ b/examples/widgets-leptos/src/main.rs
@@ -3,10 +3,14 @@ mod locale;
 mod messages;
 mod text;
 
-use ars_leptos::{ArsProvider, prelude::t};
+use ars_leptos::prelude::{ArsProvider, t};
 use leptos::{mount::mount_to_body, prelude::*};
 
-use crate::{categories::CategoryTabs, locale::{LocaleSwitcher, parse_locale}, text::WidgetsText};
+use crate::{
+    categories::CategoryTabs,
+    locale::{LocaleSwitcher, parse_locale},
+    text::WidgetsText,
+};
 
 fn main() {
     mount_to_body(App);

--- a/spec/dioxus-components/utility/ars-provider.md
+++ b/spec/dioxus-components/utility/ars-provider.md
@@ -198,9 +198,11 @@ ArsProvider is context-driven rather than event-driven.
 
 ## 22. Shared Adapter Helper Notes
 
-| Helper concept      | Required? | Responsibility                                  | Reused by                       | Notes                                   |
-| ------------------- | --------- | ----------------------------------------------- | ------------------------------- | --------------------------------------- |
-| `use_locale()` hook | required  | Read locale from ArsContext with en-US fallback | all locale-dependent components | Defined in `09-adapter-dioxus.md` §16.1 |
+| Helper concept              | Required? | Responsibility                                   | Reused by                          | Notes                                   |
+| --------------------------- | --------- | ------------------------------------------------ | ---------------------------------- | --------------------------------------- |
+| `use_locale()` hook         | required  | Read locale from ArsContext with en-US fallback  | all locale-dependent components    | Defined in `09-adapter-dioxus.md` §16.1 |
+| `use_direction()` hook      | required  | Read direction from ArsContext with Ltr fallback | all direction-dependent components | Parallel to `use_locale()`              |
+| `use_style_strategy()` hook | required  | Read style strategy from ArsContext              | all components using `attrs.rs`    | Returns `StyleStrategy::Inline` default |
 
 ## 23. Framework-Specific Behavior
 
@@ -322,6 +324,7 @@ Intentional deviations:
 - nonce collector publication for `ArsNonceStyle`
 - default fallback values when props are absent
 - `use_locale()` fallback without provider
+- `use_direction()` fallback without provider
 - `dir` attribute reactivity on locale change
 - SSR rendering on all Dioxus targets (web, desktop, mobile)
 - `style_strategy` defaults to `StyleStrategy::Inline` when absent
@@ -333,6 +336,7 @@ Intentional deviations:
 | ----------------------- | --------------------- | ------------------------------------------------------------------------------------ |
 | provider publication    | context registration  | Assert descendants observe the published ArsContext.                                 |
 | locale fallback         | context registration  | Assert `use_locale()` returns en-US without a provider.                              |
+| direction fallback      | context registration  | Assert `use_direction()` returns `Ltr` without a provider.                           |
 | dir attribute           | DOM assertion         | Assert `dir` attribute matches current direction.                                    |
 | SSR platform fallback   | context registration  | Verify context is published without platform lookup during SSR.                      |
 | style strategy default  | context registration  | Assert `use_style_strategy()` returns `Inline` without explicit prop.                |
@@ -346,6 +350,7 @@ Intentional deviations:
 - [ ] `<div dir>` wrapper renders and reactively updates.
 - [ ] Default fallback values match documented defaults (en-US, Ltr, System, false, false, Inline).
 - [ ] `use_locale()` works with and without provider.
+- [ ] `use_direction()` works with and without provider.
 - [ ] SSR renders without platform lookup.
 - [ ] `style_strategy` defaults to `StyleStrategy::Inline`.
 - [ ] `dioxus_platform` defaults via feature flag resolution (Web > Desktop > NullPlatform).

--- a/spec/leptos-components/utility/ars-provider.md
+++ b/spec/leptos-components/utility/ars-provider.md
@@ -264,6 +264,7 @@ Intentional deviations: none.
 - nonce collector publication for `ArsNonceStyle`
 - default fallback values when props are absent
 - `use_locale()` fallback without provider
+- `use_direction()` fallback without provider
 - `dir` attribute reactivity on locale change
 - SSR rendering
 - `use_style_strategy()` returns `StyleStrategy::Inline` by default
@@ -275,6 +276,7 @@ Intentional deviations: none.
 | ---------------------- | --------------------- | --------------------------------------------------------------------- |
 | provider publication   | context registration  | Assert descendants observe the published ArsContext.                  |
 | locale fallback        | context registration  | Assert `use_locale()` returns en-US without a provider.               |
+| direction fallback     | context registration  | Assert `use_direction()` returns `Ltr` without a provider.            |
 | dir attribute          | DOM assertion         | Assert `dir` attribute matches current direction.                     |
 | style strategy default | context registration  | Assert `use_style_strategy()` returns `Inline` without explicit prop. |
 | nonce collector        | context registration  | Assert `append_nonce_css()` collects rules from provider context.     |
@@ -286,6 +288,7 @@ Intentional deviations: none.
 - [ ] `<div dir>` wrapper renders and reactively updates.
 - [ ] Default fallback values match documented defaults (en-US, Ltr, System, false, false, Inline).
 - [ ] `use_locale()` works with and without provider.
+- [ ] `use_direction()` works with and without provider.
 - [ ] `use_style_strategy()` returns `StyleStrategy::Inline` by default.
 - [ ] SSR renders the wrapper with correct `dir`.
 - [ ] Context-registration test oracles are covered.


### PR DESCRIPTION
## Summary

- Add adapter-tier integration tests, prelude exposure, and a missing `use_direction()` helper required by Leptos spec §22 for the `ArsProvider` component shell in both `ars-leptos` and `ars-dioxus`.
- The provider component itself and ~40 inline unit/wasm tests already shipped via #190/#191/#193/#194, but the discrete adapter-component deliverable (dedicated `tests/ars_provider*.rs`, prelude export, full spec §28 oracle coverage) was never completed; #477 was closed prematurely as superseded.
- Each adapter now publishes `ArsProvider` (and Dioxus `ArsProviderProps`) plus `ars_core::ColorMode` through its prelude. The six widgets examples switched from `ars_*::{ArsProvider, prelude::t}` to `ars_*::prelude::{ArsProvider, t}` to validate and dogfood the new export path.

## What landed

- **New integration tests (4 files, 22 tests):**
  - `crates/ars-leptos/tests/ars_provider.rs` — 7 SSR oracles via `view!{}.to_html()` (default `dir="ltr"`, RTL locale inference, explicit direction override, `StyleStrategy::{Nonce,Inline,Cssom}` emission, wrapper attr hygiene).
  - `crates/ars-leptos/tests/ars_provider_wasm.rs` — 3 wasm tests via `mount_to` + real DOM probes (all-props round-trip dogfooding `use_direction()`, nonce `<style>` tag presence, `use_style_strategy()` fallback to Inline).
  - `crates/ars-dioxus/tests/ars_provider.rs` — 9 SSR oracles via `dioxus_ssr::render` (mirror Leptos coverage + feature-flag-agnostic `dioxus_platform` default fingerprint + `ArsProviderProps: Clone + PartialEq` smoke test).
  - `crates/ars-dioxus/tests/ars_provider_wasm.rs` — 3 wasm tests via `dioxus_web::launch::launch_virtual_dom` (real-DOM nonce `<style>`, `use_platform()` falls back to `WebPlatform` UUID outside provider, context-published `dioxus_platform` matches `default_dioxus_platform()` family).

- **`use_direction()` helper added to both adapters.** Documented as `required` in Leptos spec §22 but the implementation was missing on both sides; mirrored from `use_locale()` with `Direction::Ltr` fallback when no `ArsProvider` is in scope. Inline unit tests cover the fallback and the published-context paths.

- **Spec drift fixes** (caught by `post-implementation-audit`):
  - Dioxus spec §22 (`Shared Adapter Helper Notes`) now lists `use_direction()` and `use_style_strategy()` for parity with the Leptos spec.
  - Both adapter specs §28/§29/§30 gained `use_direction()` test scenarios, oracle row, and checklist item.

- **Preludes (symmetric):**
  - `ars-leptos::prelude` re-exports `ArsProvider` and `ars_core::ColorMode`.
  - `ars-dioxus::prelude` re-exports `ArsProvider`, `ArsProviderProps`, and `ars_core::ColorMode`.

- **Widgets examples** (`examples/widgets-{leptos,dioxus}{,-css,-tailwind}/src/main.rs`) now reach `ArsProvider` through the prelude — confirms the new exports flow end-to-end through the public consumption path.

## Test plan

- [x] `cargo test -p ars-leptos --features ssr --test ars_provider` — 7/7 pass.
- [x] `wasm-pack test --headless --chrome crates/ars-leptos --features csr --test ars_provider_wasm` — 3/3 pass.
- [x] `cargo test -p ars-dioxus --test ars_provider` — 9/9 pass under default and `--all-features`.
- [x] `wasm-pack test --headless --chrome crates/ars-dioxus --features web --test ars_provider_wasm` — 3/3 pass.
- [x] Inline `use_direction` tests pass for both adapters.
- [x] `cargo xci-fast` — all 10 gates green (fmt, check, clippy, unit, integration, adapter, spec-compile-snippets, error-variant-coverage, mutual-exclusion, snapshot-count).
- [x] `cargo xtask spec validate` — 340 files clean.
- [x] `cargo clippy -p ars-leptos -p ars-dioxus --all-features --tests -- -D warnings` clean.

## Spec parity notes (not changing the spec contract)

- Issue #347's "Tests to add first" boilerplate listed "ARIA attributes from core ConnectApi" and "Axe-core audit using `data-ars-scope` selector". Neither applies to `ArsProvider`: spec §1.2 documents it as a context-only provider with no `ConnectApi`/`Part`/`data-ars-scope`, and the `<div dir>` wrapper has no ARIA semantics (§3.1, §26). This PR delivers against the §28 test scenarios — the authoritative list.
- `ArsContext` deliberately stays out of the prelude (published context value, not a configuration input). Advanced users still reach it via `ars_{leptos,dioxus}::ArsContext`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)