### PR TITLE
Implement FocusScope agnostic core

### DIFF
--- a/crates/ars-components/src/utility/focus_scope/mod.rs
+++ b/crates/ars-components/src/utility/focus_scope/mod.rs
@@ -275,7 +275,13 @@ impl ars_core::Machine for Machine {
                     saved_focus_id,
                 },
             ) => {
-                let trap = *trapped || props.contain;
+                // `Props::trapped` is documented in spec §1.4 as
+                // controlling whether focus is trapped; `Props::contain`
+                // is its alias. Either prop opts the scope into
+                // trapping; the event's `trapped` is a per-activation
+                // override that can also force trapping when the props
+                // didn't request it.
+                let trap = *trapped || props.trapped || props.contain;
                 let auto_focus = props.auto_focus;
                 let saved = saved_focus_id.clone();
 
@@ -611,6 +617,32 @@ mod tests {
             service.state(),
             &State::Active { trapped: true },
             "contain=true must promote `trapped` even when event passes false"
+        );
+    }
+
+    #[test]
+    fn activate_propagates_trapped_prop_into_trapped_when_event_trapped_false() {
+        // Regression guard for Codex review #663 (P2): `Props::trapped`
+        // is documented in spec §1.4 as the prop that prevents Tab from
+        // escaping. The original `Activate` transition ORed only the
+        // event's `trapped` and `props.contain`, silently dropping
+        // `props.trapped` and forcing every caller to mirror it into
+        // `Event::Activate { trapped: ... }`. Adapters that activate
+        // with a constant `false` (or that derive `trapped` solely from
+        // a transient interaction state) would have left a
+        // `Props { trapped: true, .. }` scope untrapped.
+        let mut service = service(test_props().trapped(true));
+
+        let result = service.send(Event::Activate {
+            trapped: false,
+            saved_focus_id: None,
+        });
+
+        assert!(result.state_changed);
+        assert_eq!(
+            service.state(),
+            &State::Active { trapped: true },
+            "Props::trapped=true must promote `trapped` even when the event passes false",
         );
     }
 

--- a/crates/ars-components/src/utility/focus_scope/mod.rs
+++ b/crates/ars-components/src/utility/focus_scope/mod.rs
@@ -1,0 +1,1267 @@
+//! `FocusScope` component state machine and connect API.
+//!
+//! `FocusScope` constrains keyboard Tab focus within a container, enabling
+//! focus trapping for `Dialog`, `Drawer`, `Popover`, and other overlay
+//! components. The agnostic core emits typed effect intents
+//! ([`Effect`]) that adapters route through their `PlatformEffects`
+//! implementation — the core never touches the DOM or framework helpers.
+//!
+//! See `spec/components/utility/focus-scope.md` for the full contract.
+
+use alloc::string::String;
+use core::fmt::{self, Debug};
+
+use ars_core::{
+    AttrMap, ComponentMessages, ComponentPart, ConnectApi, Env, HasId, HtmlAttr, PendingEffect,
+    TransitionPlan,
+};
+
+// ────────────────────────────────────────────────────────────────────
+// State
+// ────────────────────────────────────────────────────────────────────
+
+/// The states of the `FocusScope` component.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum State {
+    /// Focus scope is idle; Tab behavior is unmodified.
+    Inactive,
+
+    /// Focus scope is active; the adapter is responsible for trapping Tab
+    /// inside the container when `trapped` is true.
+    Active {
+        /// When true, Tab cannot escape the container.
+        trapped: bool,
+    },
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Event
+// ────────────────────────────────────────────────────────────────────
+
+/// The events of the `FocusScope` component.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Event {
+    /// Activate the focus scope, optionally trapping focus.
+    ///
+    /// The adapter captures the currently focused element ID before sending
+    /// this event (via `PlatformEffects::active_element_id`) so the machine
+    /// can store it for later restoration.
+    Activate {
+        /// When true, Tab cannot escape the container.
+        trapped: bool,
+
+        /// ID of the element that had focus before activation (for
+        /// restore-on-deactivate). Captured by the adapter via
+        /// `PlatformEffects::active_element_id`.
+        saved_focus_id: Option<String>,
+    },
+
+    /// Deactivate the scope and optionally restore previous focus.
+    Deactivate {
+        /// When true, the machine emits [`Effect::RestoreFocus`] so the
+        /// adapter can return focus to the previously focused element.
+        restore_focus: bool,
+    },
+
+    /// Enable focus trapping on an active scope (toggles `trapped` to true).
+    TrapFocus,
+
+    /// Disable focus trapping on an active scope (toggles `trapped` to false).
+    ReleaseTrap,
+
+    /// Request focus restoration to [`Context::saved_focus`].
+    ///
+    /// When `Inactive`, the machine emits [`Effect::RestoreFocus`]; when
+    /// `Active`, the event is ignored — restoration is only meaningful
+    /// after the scope has deactivated. Adapters MAY send this event
+    /// explicitly when an `Inactive` scope still holds a saved target
+    /// (e.g., nested-scope cleanup).
+    RestoreFocus,
+
+    /// Request focus on the first tabbable element inside the container.
+    /// Emits [`Effect::FocusFirst`] when `Active`; ignored otherwise.
+    FocusFirst,
+
+    /// Request focus on the last tabbable element inside the container.
+    /// Emits [`Effect::FocusLast`] when `Active`; ignored otherwise.
+    FocusLast,
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Context
+// ────────────────────────────────────────────────────────────────────
+
+/// Machine context for the `FocusScope` component.
+///
+/// `is_active()` and `is_trapped()` are derived from [`State`] in the
+/// connect API — they are not stored here.
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+pub struct Context {
+    /// The element that had focus before the scope was activated.
+    ///
+    /// Set on [`Event::Activate`] and read by the adapter when dispatching
+    /// [`Effect::RestoreFocus`]. The agnostic core does not clear the value
+    /// after restoration — the next `Activate` overwrites it.
+    pub saved_focus: Option<String>,
+
+    /// The DOM ID of the container element that scopes focus.
+    ///
+    /// Adapters populate this via `Service::context_mut()` once they have
+    /// resolved the container's stable ID. The agnostic core treats it as
+    /// an opaque token.
+    pub container_id: Option<String>,
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Props
+// ────────────────────────────────────────────────────────────────────
+
+/// Props for the `FocusScope` component.
+#[derive(Clone, Debug, PartialEq, Eq, HasId)]
+pub struct Props {
+    /// Component instance ID. Adapters set this from a hydration-safe
+    /// stable ID generator.
+    pub id: String,
+
+    /// Prevent Tab from moving focus outside the container.
+    pub trapped: bool,
+
+    /// Alias for [`trapped`](Self::trapped) — clearer naming in some
+    /// contexts (e.g., when `trapped` already means "active" elsewhere).
+    pub contain: bool,
+
+    /// On activation, automatically move focus to the first tabbable
+    /// element (or the element with `autofocus` attribute, if any).
+    pub auto_focus: bool,
+
+    /// On deactivation, restore focus to the previously focused element.
+    pub restore_focus: bool,
+}
+
+impl Default for Props {
+    fn default() -> Self {
+        Self {
+            id: String::new(),
+            trapped: false,
+            contain: false,
+            auto_focus: true,
+            restore_focus: true,
+        }
+    }
+}
+
+impl Props {
+    /// Returns a fresh [`Props`] with every field at its [`Default`] value.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets [`id`](Self::id).
+    #[must_use]
+    pub fn id(mut self, id: impl Into<String>) -> Self {
+        self.id = id.into();
+        self
+    }
+
+    /// Sets [`trapped`](Self::trapped).
+    #[must_use]
+    pub const fn trapped(mut self, trapped: bool) -> Self {
+        self.trapped = trapped;
+        self
+    }
+
+    /// Sets [`contain`](Self::contain).
+    #[must_use]
+    pub const fn contain(mut self, contain: bool) -> Self {
+        self.contain = contain;
+        self
+    }
+
+    /// Sets [`auto_focus`](Self::auto_focus).
+    #[must_use]
+    pub const fn auto_focus(mut self, auto_focus: bool) -> Self {
+        self.auto_focus = auto_focus;
+        self
+    }
+
+    /// Sets [`restore_focus`](Self::restore_focus).
+    #[must_use]
+    pub const fn restore_focus(mut self, restore_focus: bool) -> Self {
+        self.restore_focus = restore_focus;
+        self
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Messages
+// ────────────────────────────────────────────────────────────────────
+
+/// `FocusScope` has no translatable strings.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct Messages;
+
+impl ComponentMessages for Messages {}
+
+// ────────────────────────────────────────────────────────────────────
+// Effect
+// ────────────────────────────────────────────────────────────────────
+
+/// Typed effect intents emitted by the `FocusScope` machine.
+///
+/// Each variant is an adapter contract — the adapter's effect handler
+/// translates the variant into the corresponding `PlatformEffects` call.
+/// See `spec/components/utility/focus-scope.md` §1.8 for the per-variant
+/// contract.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Effect {
+    /// Install the Tab-key interception (keydown handler + sentinel
+    /// elements) that keeps focus inside the scope while it is active.
+    ///
+    /// Cleanup tears the handler back down — invoked when the machine
+    /// emits `.cancel_effect(Effect::FocusTrapListener)` on `Deactivate`.
+    FocusTrapListener,
+
+    /// Move focus to the first tabbable descendant of the container.
+    /// Fall back to focusing the container itself when none exist.
+    FocusFirst,
+
+    /// Move focus to the last tabbable descendant of the container.
+    /// Fall back to focusing the container itself when none exist.
+    FocusLast,
+
+    /// Restore focus to `service.context().saved_focus`, applying the
+    /// §7 fallback chain when the saved target is no longer focusable.
+    RestoreFocus,
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Machine
+// ────────────────────────────────────────────────────────────────────
+
+/// State machine for the `FocusScope` component.
+#[derive(Debug)]
+pub struct Machine;
+
+impl ars_core::Machine for Machine {
+    type State = State;
+    type Event = Event;
+    type Context = Context;
+    type Props = Props;
+    type Messages = Messages;
+    type Effect = Effect;
+    type Api<'a> = Api<'a>;
+
+    fn init(
+        _props: &Self::Props,
+        _env: &Env,
+        _messages: &Self::Messages,
+    ) -> (Self::State, Self::Context) {
+        (State::Inactive, Context::default())
+    }
+
+    fn transition(
+        state: &Self::State,
+        event: &Self::Event,
+        _ctx: &Self::Context,
+        props: &Self::Props,
+    ) -> Option<TransitionPlan<Self>> {
+        match (state, event) {
+            // ── Activation ──────────────────────────────────────────────
+            (
+                State::Inactive,
+                Event::Activate {
+                    trapped,
+                    saved_focus_id,
+                },
+            ) => {
+                let trap = *trapped || props.contain;
+                let auto_focus = props.auto_focus;
+                let saved = saved_focus_id.clone();
+
+                let mut plan = TransitionPlan::to(State::Active { trapped: trap })
+                    .apply(move |ctx: &mut Context| {
+                        ctx.saved_focus = saved;
+                    })
+                    .with_effect(PendingEffect::named(Effect::FocusTrapListener));
+
+                if auto_focus {
+                    plan = plan.then(Event::FocusFirst);
+                }
+
+                Some(plan)
+            }
+
+            // ── Deactivation ────────────────────────────────────────────
+            (State::Active { .. }, Event::Deactivate { restore_focus }) => {
+                let restore = *restore_focus;
+                let mut plan =
+                    TransitionPlan::to(State::Inactive).cancel_effect(Effect::FocusTrapListener);
+
+                if restore {
+                    plan = plan.with_effect(PendingEffect::named(Effect::RestoreFocus));
+                } else {
+                    plan = plan.apply(|ctx: &mut Context| {
+                        ctx.saved_focus = None;
+                    });
+                }
+
+                Some(plan)
+            }
+
+            // ── Trap / Release ──────────────────────────────────────────
+            (State::Active { trapped: false }, Event::TrapFocus) => {
+                Some(TransitionPlan::to(State::Active { trapped: true }))
+            }
+            (State::Active { trapped: true }, Event::ReleaseTrap) => {
+                Some(TransitionPlan::to(State::Active { trapped: false }))
+            }
+
+            // ── RestoreFocus ────────────────────────────────────────────
+            // While `Active`, `RestoreFocus` is ignored by the wildcard
+            // arm at the bottom — restoration is only meaningful after
+            // the scope has deactivated.
+            (State::Inactive, Event::RestoreFocus) => {
+                Some(TransitionPlan::new().with_effect(PendingEffect::named(Effect::RestoreFocus)))
+            }
+
+            // ── Focus Navigation ────────────────────────────────────────
+            (State::Active { .. }, Event::FocusFirst) => {
+                Some(TransitionPlan::new().with_effect(PendingEffect::named(Effect::FocusFirst)))
+            }
+            (State::Active { .. }, Event::FocusLast) => {
+                Some(TransitionPlan::new().with_effect(PendingEffect::named(Effect::FocusLast)))
+            }
+
+            _ => None,
+        }
+    }
+
+    fn connect<'a>(
+        state: &'a Self::State,
+        ctx: &'a Self::Context,
+        props: &'a Self::Props,
+        send: &'a dyn Fn(Self::Event),
+    ) -> Self::Api<'a> {
+        Api {
+            state,
+            ctx,
+            props,
+            send,
+        }
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Part
+// ────────────────────────────────────────────────────────────────────
+
+/// Anatomy parts of the `FocusScope` component.
+#[derive(ars_core::ComponentPart)]
+#[scope = "focus-scope"]
+pub enum Part {
+    /// The container element that scopes focus.
+    Container,
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Api
+// ────────────────────────────────────────────────────────────────────
+
+/// Connect API for the `FocusScope` component.
+pub struct Api<'a> {
+    /// The current state of the focus scope.
+    state: &'a State,
+    /// The context of the focus scope.
+    ctx: &'a Context,
+    /// The props of the focus scope.
+    props: &'a Props,
+    /// The send function for the focus scope.
+    send: &'a dyn Fn(Event),
+}
+
+impl Debug for Api<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("focus_scope::Api")
+            .field("state", self.state)
+            .field("ctx", self.ctx)
+            .field("props", self.props)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Api<'_> {
+    /// Returns the current [`State`] of the focus scope.
+    #[must_use]
+    pub const fn state(&self) -> &State {
+        self.state
+    }
+
+    /// Returns the current [`Context`] of the focus scope.
+    #[must_use]
+    pub const fn context(&self) -> &Context {
+        self.ctx
+    }
+
+    /// Returns the [`Props`] used by the focus scope.
+    #[must_use]
+    pub const fn props(&self) -> &Props {
+        self.props
+    }
+
+    /// Whether the focus scope is currently active.
+    #[must_use]
+    pub const fn is_active(&self) -> bool {
+        matches!(self.state, State::Active { .. })
+    }
+
+    /// Whether the focus scope is currently trapping focus.
+    #[must_use]
+    pub const fn is_trapped(&self) -> bool {
+        matches!(self.state, State::Active { trapped: true })
+    }
+
+    /// Attributes for the container element that scopes focus.
+    ///
+    /// Always emits `data-ars-scope="focus-scope"` and
+    /// `data-ars-part="container"`. When active, adds `data-ars-active`
+    /// and `tabindex="-1"` so the container can be a programmatic focus
+    /// target when no tabbable children exist yet. When trapped, adds
+    /// `data-ars-trapped`.
+    #[must_use]
+    pub fn container_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Container.data_attrs();
+
+        attrs.set(scope_attr, scope_val).set(part_attr, part_val);
+
+        if self.is_active() {
+            attrs
+                .set_bool(HtmlAttr::Data("ars-active"), true)
+                .set(HtmlAttr::TabIndex, "-1");
+        }
+
+        if self.is_trapped() {
+            attrs.set_bool(HtmlAttr::Data("ars-trapped"), true);
+        }
+
+        attrs
+    }
+
+    /// Imperatively activate the focus scope.
+    ///
+    /// `saved_focus_id` is the ID of the currently focused element,
+    /// captured by the adapter via `PlatformEffects::active_element_id`
+    /// before calling this.
+    pub fn activate(&self, trapped: bool, saved_focus_id: Option<String>) {
+        (self.send)(Event::Activate {
+            trapped,
+            saved_focus_id,
+        });
+    }
+
+    /// Imperatively deactivate the focus scope.
+    pub fn deactivate(&self, restore_focus: bool) {
+        (self.send)(Event::Deactivate { restore_focus });
+    }
+
+    /// Request that focus move to the first tabbable descendant of the
+    /// container. Sends [`Event::FocusFirst`].
+    pub fn focus_first(&self) {
+        (self.send)(Event::FocusFirst);
+    }
+
+    /// Request that focus move to the last tabbable descendant of the
+    /// container. Sends [`Event::FocusLast`].
+    pub fn focus_last(&self) {
+        (self.send)(Event::FocusLast);
+    }
+}
+
+impl ConnectApi for Api<'_> {
+    type Part = Part;
+
+    fn part_attrs(&self, part: Part) -> AttrMap {
+        match part {
+            Part::Container => self.container_attrs(),
+        }
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Tests
+// ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec::Vec;
+
+    use ars_core::{ConnectApi as _, Env, HtmlAttr, Service};
+    use insta::assert_snapshot;
+
+    use super::*;
+
+    const SCOPE_ID: &str = "scope";
+
+    fn test_props() -> Props {
+        Props::new().id(SCOPE_ID)
+    }
+
+    fn service(props: Props) -> Service<Machine> {
+        Service::<Machine>::new(props, &Env::default(), &Messages)
+    }
+
+    fn effect_names<M: ars_core::Machine>(effects: &[PendingEffect<M>]) -> Vec<M::Effect> {
+        effects.iter().map(|effect| effect.name).collect()
+    }
+
+    fn snapshot_attrs(attrs: &AttrMap) -> String {
+        format!("{attrs:#?}")
+    }
+
+    // ── Init & defaults ─────────────────────────────────────────────
+
+    #[test]
+    fn init_returns_inactive_state_and_empty_context() {
+        let service = service(test_props());
+
+        assert_eq!(service.state(), &State::Inactive);
+        assert_eq!(service.context().saved_focus, None);
+        assert_eq!(service.context().container_id, None);
+    }
+
+    #[test]
+    fn props_default_matches_spec_section_1_4() {
+        let props = Props::default();
+
+        assert_eq!(props.id, String::new());
+        assert!(!props.trapped);
+        assert!(!props.contain);
+        assert!(
+            props.auto_focus,
+            "auto_focus defaults to true per spec §1.4"
+        );
+        assert!(
+            props.restore_focus,
+            "restore_focus defaults to true per spec §1.4"
+        );
+    }
+
+    #[test]
+    fn props_builder_chains_each_field() {
+        let props = Props::new()
+            .id("dialog-trap")
+            .trapped(true)
+            .contain(true)
+            .auto_focus(false)
+            .restore_focus(false);
+
+        assert_eq!(props.id, "dialog-trap");
+        assert!(props.trapped);
+        assert!(props.contain);
+        assert!(!props.auto_focus);
+        assert!(!props.restore_focus);
+    }
+
+    #[test]
+    fn messages_default_matches_spec_empty_struct() {
+        // `Messages` has no fields per spec — empty struct that implements
+        // `Default`. The trait round-trip is exercised here via an
+        // explicit qualified call to avoid the lint that suggests using
+        // the unit literal directly.
+        let from_default: Messages = <Messages as Default>::default();
+
+        assert_eq!(from_default, Messages);
+    }
+
+    // ── Activate ────────────────────────────────────────────────────
+
+    #[test]
+    fn activate_inactive_to_active_with_trapped_from_event() {
+        let mut service = service(test_props());
+
+        let result = service.send(Event::Activate {
+            trapped: true,
+            saved_focus_id: None,
+        });
+
+        assert!(result.state_changed);
+        assert_eq!(service.state(), &State::Active { trapped: true });
+    }
+
+    #[test]
+    fn activate_propagates_contain_prop_into_trapped_when_event_trapped_false() {
+        let mut service = service(test_props().contain(true));
+
+        let result = service.send(Event::Activate {
+            trapped: false,
+            saved_focus_id: None,
+        });
+
+        assert!(result.state_changed);
+        assert_eq!(
+            service.state(),
+            &State::Active { trapped: true },
+            "contain=true must promote `trapped` even when event passes false"
+        );
+    }
+
+    #[test]
+    fn activate_stores_saved_focus_id_in_context() {
+        let mut service = service(test_props());
+
+        drop(service.send(Event::Activate {
+            trapped: false,
+            saved_focus_id: Some("trigger-7".into()),
+        }));
+
+        assert_eq!(
+            service.context().saved_focus.as_deref(),
+            Some("trigger-7"),
+            "Activate must store saved_focus_id into ctx.saved_focus for later RestoreFocus"
+        );
+    }
+
+    #[test]
+    fn activate_emits_focus_trap_listener_effect() {
+        let mut service = service(test_props());
+
+        let result = service.send(Event::Activate {
+            trapped: true,
+            saved_focus_id: None,
+        });
+
+        assert!(
+            effect_names(&result.pending_effects).contains(&Effect::FocusTrapListener),
+            "Activate must emit Effect::FocusTrapListener so the adapter can install the keydown handler"
+        );
+    }
+
+    #[test]
+    fn activate_then_sends_focus_first_when_props_auto_focus_true() {
+        let mut service = service(test_props().auto_focus(true));
+
+        let result = service.send(Event::Activate {
+            trapped: true,
+            saved_focus_id: None,
+        });
+
+        let names = effect_names(&result.pending_effects);
+
+        assert!(
+            names.contains(&Effect::FocusTrapListener),
+            "Activate always emits Effect::FocusTrapListener"
+        );
+        assert!(
+            names.contains(&Effect::FocusFirst),
+            "Activate with auto_focus=true must chain FocusFirst (which emits Effect::FocusFirst in the same SendResult)"
+        );
+    }
+
+    #[test]
+    fn activate_does_not_then_send_focus_first_when_props_auto_focus_false() {
+        let mut service = service(test_props().auto_focus(false));
+
+        let result = service.send(Event::Activate {
+            trapped: true,
+            saved_focus_id: None,
+        });
+
+        let names = effect_names(&result.pending_effects);
+
+        assert!(
+            names.contains(&Effect::FocusTrapListener),
+            "Activate always emits Effect::FocusTrapListener"
+        );
+        assert!(
+            !names.contains(&Effect::FocusFirst),
+            "Activate with auto_focus=false must NOT chain FocusFirst"
+        );
+    }
+
+    #[test]
+    fn activate_ignored_when_already_active() {
+        let mut service = service(test_props());
+
+        drop(service.send(Event::Activate {
+            trapped: false,
+            saved_focus_id: None,
+        }));
+
+        let result = service.send(Event::Activate {
+            trapped: true,
+            saved_focus_id: Some("other".into()),
+        });
+
+        assert!(
+            !result.state_changed,
+            "Activate is a no-op when the scope is already Active"
+        );
+    }
+
+    // ── Deactivate ──────────────────────────────────────────────────
+
+    fn active_service(restore_focus: bool) -> Service<Machine> {
+        let mut service = service(test_props().restore_focus(restore_focus));
+
+        drop(service.send(Event::Activate {
+            trapped: true,
+            saved_focus_id: Some("trigger".into()),
+        }));
+
+        service
+    }
+
+    #[test]
+    fn deactivate_active_to_inactive() {
+        let mut service = active_service(true);
+
+        let result = service.send(Event::Deactivate {
+            restore_focus: true,
+        });
+
+        assert!(result.state_changed);
+        assert_eq!(service.state(), &State::Inactive);
+    }
+
+    #[test]
+    fn deactivate_with_restore_focus_emits_restore_focus_effect() {
+        let mut service = active_service(true);
+
+        let result = service.send(Event::Deactivate {
+            restore_focus: true,
+        });
+
+        assert!(
+            effect_names(&result.pending_effects).contains(&Effect::RestoreFocus),
+            "Deactivate{{ restore_focus: true }} must emit Effect::RestoreFocus"
+        );
+        assert_eq!(
+            service.context().saved_focus.as_deref(),
+            Some("trigger"),
+            "saved_focus must remain in context so the adapter can read it when dispatching the effect"
+        );
+    }
+
+    #[test]
+    fn deactivate_without_restore_focus_clears_saved_focus() {
+        let mut service = active_service(false);
+
+        assert_eq!(service.context().saved_focus.as_deref(), Some("trigger"));
+
+        let result = service.send(Event::Deactivate {
+            restore_focus: false,
+        });
+
+        assert!(
+            !effect_names(&result.pending_effects).contains(&Effect::RestoreFocus),
+            "Deactivate{{ restore_focus: false }} must NOT emit Effect::RestoreFocus"
+        );
+        assert_eq!(
+            service.context().saved_focus,
+            None,
+            "Deactivate without restore must clear ctx.saved_focus to drop the stale token"
+        );
+    }
+
+    #[test]
+    fn deactivate_cancels_focus_trap_listener_effect() {
+        let mut service = active_service(true);
+
+        let result = service.send(Event::Deactivate {
+            restore_focus: true,
+        });
+
+        assert!(
+            result.cancel_effects.contains(&Effect::FocusTrapListener),
+            "Deactivate must cancel Effect::FocusTrapListener so the adapter tears down the keydown handler"
+        );
+    }
+
+    #[test]
+    fn deactivate_ignored_when_already_inactive() {
+        let mut service = service(test_props());
+
+        let result = service.send(Event::Deactivate {
+            restore_focus: true,
+        });
+
+        assert!(!result.state_changed);
+    }
+
+    // ── Trap / Release ──────────────────────────────────────────────
+
+    #[test]
+    fn trap_focus_toggles_trapped_flag_within_active() {
+        let mut service = service(test_props());
+
+        drop(service.send(Event::Activate {
+            trapped: false,
+            saved_focus_id: None,
+        }));
+
+        assert_eq!(service.state(), &State::Active { trapped: false });
+
+        let result = service.send(Event::TrapFocus);
+
+        assert!(result.state_changed);
+        assert_eq!(service.state(), &State::Active { trapped: true });
+    }
+
+    #[test]
+    fn release_trap_toggles_trapped_flag_within_active() {
+        let mut service = service(test_props());
+
+        drop(service.send(Event::Activate {
+            trapped: true,
+            saved_focus_id: None,
+        }));
+
+        let result = service.send(Event::ReleaseTrap);
+
+        assert!(result.state_changed);
+        assert_eq!(service.state(), &State::Active { trapped: false });
+    }
+
+    #[test]
+    fn trap_focus_ignored_when_already_trapped() {
+        let mut service = service(test_props());
+
+        drop(service.send(Event::Activate {
+            trapped: true,
+            saved_focus_id: None,
+        }));
+
+        let result = service.send(Event::TrapFocus);
+
+        assert!(!result.state_changed);
+        assert_eq!(service.state(), &State::Active { trapped: true });
+    }
+
+    #[test]
+    fn release_trap_ignored_when_not_trapped() {
+        let mut service = service(test_props());
+
+        drop(service.send(Event::Activate {
+            trapped: false,
+            saved_focus_id: None,
+        }));
+
+        let result = service.send(Event::ReleaseTrap);
+
+        assert!(!result.state_changed);
+        assert_eq!(service.state(), &State::Active { trapped: false });
+    }
+
+    #[test]
+    fn trap_focus_ignored_when_inactive() {
+        let mut service = service(test_props());
+
+        let result = service.send(Event::TrapFocus);
+
+        assert!(!result.state_changed);
+        assert_eq!(service.state(), &State::Inactive);
+    }
+
+    #[test]
+    fn release_trap_ignored_when_inactive() {
+        let mut service = service(test_props());
+
+        let result = service.send(Event::ReleaseTrap);
+
+        assert!(!result.state_changed);
+        assert_eq!(service.state(), &State::Inactive);
+    }
+
+    // ── RestoreFocus ────────────────────────────────────────────────
+
+    #[test]
+    fn restore_focus_when_inactive_emits_restore_focus_effect() {
+        let mut service = service(test_props());
+
+        let result = service.send(Event::RestoreFocus);
+
+        assert!(
+            effect_names(&result.pending_effects).contains(&Effect::RestoreFocus),
+            "RestoreFocus from Inactive must emit Effect::RestoreFocus for the adapter to dispatch"
+        );
+    }
+
+    #[test]
+    fn restore_focus_when_active_returns_none_transition() {
+        let mut service = service(test_props());
+
+        drop(service.send(Event::Activate {
+            trapped: false,
+            saved_focus_id: Some("trigger".into()),
+        }));
+
+        let result = service.send(Event::RestoreFocus);
+
+        assert!(
+            !result.state_changed && result.pending_effects.is_empty(),
+            "RestoreFocus while Active must be ignored — restoration only makes sense after Deactivate"
+        );
+    }
+
+    // ── FocusFirst / FocusLast ──────────────────────────────────────
+
+    #[test]
+    fn focus_first_when_active_emits_focus_first_effect() {
+        let mut service = service(test_props().auto_focus(false));
+
+        drop(service.send(Event::Activate {
+            trapped: false,
+            saved_focus_id: None,
+        }));
+
+        let result = service.send(Event::FocusFirst);
+
+        assert!(effect_names(&result.pending_effects).contains(&Effect::FocusFirst));
+    }
+
+    #[test]
+    fn focus_last_when_active_emits_focus_last_effect() {
+        let mut service = service(test_props().auto_focus(false));
+
+        drop(service.send(Event::Activate {
+            trapped: false,
+            saved_focus_id: None,
+        }));
+
+        let result = service.send(Event::FocusLast);
+
+        assert!(effect_names(&result.pending_effects).contains(&Effect::FocusLast));
+    }
+
+    #[test]
+    fn focus_first_when_inactive_returns_none_transition() {
+        let mut service = service(test_props());
+
+        let result = service.send(Event::FocusFirst);
+
+        assert!(!result.state_changed && result.pending_effects.is_empty());
+    }
+
+    #[test]
+    fn focus_last_when_inactive_returns_none_transition() {
+        let mut service = service(test_props());
+
+        let result = service.send(Event::FocusLast);
+
+        assert!(!result.state_changed && result.pending_effects.is_empty());
+    }
+
+    // ── Connect API: container_attrs ────────────────────────────────
+
+    #[test]
+    fn container_attrs_inactive_sets_scope_and_part_only() {
+        let service = service(test_props());
+
+        let attrs = service.connect(&|_| {}).container_attrs();
+
+        assert_eq!(attrs.get(&HtmlAttr::Data("ars-scope")), Some("focus-scope"));
+        assert_eq!(attrs.get(&HtmlAttr::Data("ars-part")), Some("container"));
+        assert_eq!(attrs.get(&HtmlAttr::Data("ars-active")), None);
+        assert_eq!(attrs.get(&HtmlAttr::Data("ars-trapped")), None);
+        assert_eq!(attrs.get(&HtmlAttr::TabIndex), None);
+    }
+
+    #[test]
+    fn container_attrs_active_adds_data_active_and_tabindex_minus_one() {
+        let mut service = service(test_props());
+
+        drop(service.send(Event::Activate {
+            trapped: false,
+            saved_focus_id: None,
+        }));
+
+        let attrs = service.connect(&|_| {}).container_attrs();
+
+        assert_eq!(attrs.get(&HtmlAttr::Data("ars-active")), Some("true"));
+        assert_eq!(attrs.get(&HtmlAttr::TabIndex), Some("-1"));
+        assert_eq!(
+            attrs.get(&HtmlAttr::Data("ars-trapped")),
+            None,
+            "untrapped active scope must not advertise data-ars-trapped"
+        );
+    }
+
+    #[test]
+    fn container_attrs_active_trapped_adds_data_trapped() {
+        let mut service = service(test_props());
+
+        drop(service.send(Event::Activate {
+            trapped: true,
+            saved_focus_id: None,
+        }));
+
+        let attrs = service.connect(&|_| {}).container_attrs();
+
+        assert_eq!(attrs.get(&HtmlAttr::Data("ars-active")), Some("true"));
+        assert_eq!(attrs.get(&HtmlAttr::Data("ars-trapped")), Some("true"));
+        assert_eq!(attrs.get(&HtmlAttr::TabIndex), Some("-1"));
+    }
+
+    #[test]
+    fn container_attrs_never_emits_data_ars_focus_trapped_typo() {
+        // Issue #212 test 9 says `data-ars-focus-trapped`; the spec §2 says
+        // `data-ars-trapped`. The spec is authoritative — this regression
+        // guard pins the spec-correct name.
+        let mut service = service(test_props());
+
+        drop(service.send(Event::Activate {
+            trapped: true,
+            saved_focus_id: None,
+        }));
+
+        let attrs = service.connect(&|_| {}).container_attrs();
+
+        assert_eq!(
+            attrs.get(&HtmlAttr::Data("ars-focus-trapped")),
+            None,
+            "spec §2 names the attribute `data-ars-trapped`, not `data-ars-focus-trapped`"
+        );
+    }
+
+    #[test]
+    fn connect_part_attrs_for_container_matches_container_attrs() {
+        let mut service = service(test_props());
+
+        drop(service.send(Event::Activate {
+            trapped: true,
+            saved_focus_id: None,
+        }));
+
+        let api = service.connect(&|_| {});
+        let container = api.container_attrs();
+        let via_part = api.part_attrs(Part::Container);
+
+        assert_eq!(container, via_part);
+    }
+
+    // ── is_active / is_trapped derivations ──────────────────────────
+
+    #[test]
+    fn is_active_and_is_trapped_derived_from_state() {
+        let mut service = service(test_props());
+
+        {
+            let api = service.connect(&|_| {});
+            assert!(!api.is_active());
+            assert!(!api.is_trapped());
+        }
+
+        drop(service.send(Event::Activate {
+            trapped: false,
+            saved_focus_id: None,
+        }));
+
+        {
+            let api = service.connect(&|_| {});
+
+            assert!(api.is_active());
+            assert!(!api.is_trapped(), "Active{{trapped:false}} is not trapped");
+        }
+
+        drop(service.send(Event::TrapFocus));
+
+        {
+            let api = service.connect(&|_| {});
+
+            assert!(api.is_active());
+            assert!(api.is_trapped());
+        }
+    }
+
+    // ── Api imperative methods send the expected events ─────────────
+
+    use core::cell::RefCell;
+
+    fn capture<F: FnOnce(&dyn Fn(Event))>(invoke: F) -> Vec<Event> {
+        let captured: RefCell<Vec<Event>> = RefCell::new(Vec::new());
+        let sender = |event: Event| captured.borrow_mut().push(event);
+
+        invoke(&sender);
+
+        captured.into_inner()
+    }
+
+    fn api_with<'a>(
+        state: &'a State,
+        ctx: &'a Context,
+        props: &'a Props,
+        send: &'a dyn Fn(Event),
+    ) -> Api<'a> {
+        Api {
+            state,
+            ctx,
+            props,
+            send,
+        }
+    }
+
+    #[test]
+    fn api_activate_sends_activate_event_with_args() {
+        let state = State::Inactive;
+        let ctx = Context::default();
+        let props = test_props();
+
+        let events = capture(|sender| {
+            let api = api_with(&state, &ctx, &props, sender);
+
+            api.activate(true, Some("trigger".into()));
+        });
+
+        assert_eq!(
+            events,
+            vec![Event::Activate {
+                trapped: true,
+                saved_focus_id: Some("trigger".into()),
+            }]
+        );
+    }
+
+    #[test]
+    fn api_deactivate_sends_deactivate_event_with_restore_focus() {
+        let state = State::Active { trapped: true };
+        let ctx = Context::default();
+        let props = test_props();
+
+        let events = capture(|sender| {
+            let api = api_with(&state, &ctx, &props, sender);
+
+            api.deactivate(false);
+        });
+
+        assert_eq!(
+            events,
+            vec![Event::Deactivate {
+                restore_focus: false
+            }]
+        );
+    }
+
+    #[test]
+    fn api_focus_first_sends_focus_first_event() {
+        let state = State::Active { trapped: true };
+        let ctx = Context::default();
+        let props = test_props();
+
+        let events = capture(|sender| {
+            let api = api_with(&state, &ctx, &props, sender);
+
+            api.focus_first();
+        });
+
+        assert_eq!(events, vec![Event::FocusFirst]);
+    }
+
+    #[test]
+    fn api_focus_last_sends_focus_last_event() {
+        let state = State::Active { trapped: true };
+        let ctx = Context::default();
+        let props = test_props();
+
+        let events = capture(|sender| {
+            let api = api_with(&state, &ctx, &props, sender);
+
+            api.focus_last();
+        });
+
+        assert_eq!(events, vec![Event::FocusLast]);
+    }
+
+    #[test]
+    fn api_state_context_props_accessors_return_underlying_references() {
+        let mut service = service(test_props().contain(true));
+
+        drop(service.send(Event::Activate {
+            trapped: true,
+            saved_focus_id: Some("trigger".into()),
+        }));
+
+        let api = service.connect(&|_| {});
+
+        assert_eq!(api.state(), &State::Active { trapped: true });
+        assert_eq!(api.context().saved_focus.as_deref(), Some("trigger"));
+        assert!(api.props().contain);
+    }
+
+    #[test]
+    fn api_debug_impl_is_non_exhaustive_and_includes_label() {
+        let state = State::Active { trapped: true };
+        let ctx = Context::default();
+        let props = test_props();
+
+        let api = api_with(&state, &ctx, &props, &|_| {});
+
+        let formatted = format!("{api:?}");
+
+        assert!(
+            formatted.contains("focus_scope::Api"),
+            "Debug must include the type label, got: {formatted}",
+        );
+        assert!(
+            formatted.contains(".."),
+            "Debug must be non-exhaustive (hides the send closure)",
+        );
+    }
+
+    // ── Snapshot tests ──────────────────────────────────────────────
+
+    #[test]
+    fn container_attrs_inactive_default_props_snapshot() {
+        let service = service(test_props());
+
+        assert_snapshot!(
+            "container_attrs_inactive",
+            snapshot_attrs(&service.connect(&|_| {}).container_attrs())
+        );
+    }
+
+    #[test]
+    fn container_attrs_active_untrapped_snapshot() {
+        let mut service = service(test_props());
+
+        drop(service.send(Event::Activate {
+            trapped: false,
+            saved_focus_id: None,
+        }));
+
+        assert_snapshot!(
+            "container_attrs_active_untrapped",
+            snapshot_attrs(&service.connect(&|_| {}).container_attrs())
+        );
+    }
+
+    #[test]
+    fn container_attrs_active_trapped_snapshot() {
+        let mut service = service(test_props());
+
+        drop(service.send(Event::Activate {
+            trapped: true,
+            saved_focus_id: None,
+        }));
+
+        assert_snapshot!(
+            "container_attrs_active_trapped",
+            snapshot_attrs(&service.connect(&|_| {}).container_attrs())
+        );
+    }
+
+    #[test]
+    fn container_attrs_contain_prop_promotes_trapped_snapshot() {
+        let mut service = service(test_props().contain(true));
+
+        drop(service.send(Event::Activate {
+            trapped: false,
+            saved_focus_id: None,
+        }));
+
+        assert_snapshot!(
+            "container_attrs_contain_prop_promotes_trapped",
+            snapshot_attrs(&service.connect(&|_| {}).container_attrs())
+        );
+    }
+}

--- a/crates/ars-components/src/utility/focus_scope/mod.rs
+++ b/crates/ars-components/src/utility/focus_scope/mod.rs
@@ -285,11 +285,20 @@ impl ars_core::Machine for Machine {
                 let auto_focus = props.auto_focus;
                 let saved = saved_focus_id.clone();
 
-                let mut plan = TransitionPlan::to(State::Active { trapped: trap })
-                    .apply(move |ctx: &mut Context| {
+                let mut plan = TransitionPlan::to(State::Active { trapped: trap }).apply(
+                    move |ctx: &mut Context| {
                         ctx.saved_focus = saved;
-                    })
-                    .with_effect(PendingEffect::named(Effect::FocusTrapListener));
+                    },
+                );
+                // Only install Tab interception when the resolved state
+                // is actually trapped. `PlatformEffects::attach_focus_trap`
+                // unconditionally wraps Tab/Shift+Tab in the web
+                // implementation, so emitting the effect for an
+                // untrapped Active scope would contradict the resolved
+                // `trapped: false` state.
+                if trap {
+                    plan = plan.with_effect(PendingEffect::named(Effect::FocusTrapListener));
+                }
 
                 if auto_focus {
                     plan = plan.then(Event::FocusFirst);
@@ -318,18 +327,19 @@ impl ars_core::Machine for Machine {
             // ── Trap / Release ──────────────────────────────────────────
             // Adapters drain ALL active effect cleanups when
             // `state_changed` is true (see `ars-leptos::use_machine::
-            // handle_effects`), so the `Active{trapped:_}` ↔
-            // `Active{trapped:_}` boundary must re-emit
+            // handle_effects`). `TrapFocus` enters a state that DOES
+            // need the listener, so it must re-emit
             // `Effect::FocusTrapListener` for the adapter to reinstall
-            // the keydown trap that the cleanup drain just removed.
+            // the trap. `ReleaseTrap` exits the trapped state, so it
+            // MUST NOT re-emit the effect — the drain teardown is the
+            // intended outcome.
             (State::Active { trapped: false }, Event::TrapFocus) => Some(
                 TransitionPlan::to(State::Active { trapped: true })
                     .with_effect(PendingEffect::named(Effect::FocusTrapListener)),
             ),
-            (State::Active { trapped: true }, Event::ReleaseTrap) => Some(
-                TransitionPlan::to(State::Active { trapped: false })
-                    .with_effect(PendingEffect::named(Effect::FocusTrapListener)),
-            ),
+            (State::Active { trapped: true }, Event::ReleaseTrap) => {
+                Some(TransitionPlan::to(State::Active { trapped: false }))
+            }
 
             // ── RestoreFocus ────────────────────────────────────────────
             // While `Active`, `RestoreFocus` is ignored by the wildcard
@@ -865,13 +875,13 @@ mod tests {
 
     #[test]
     fn trap_focus_re_emits_focus_trap_listener_so_adapter_reinstalls_after_state_change() {
-        // Regression guard for Codex review #663: adapters drain ALL active
-        // effect cleanups whenever `state_changed` is true (see
-        // `ars-leptos::use_machine::handle_effects` line 607). If the
-        // `Active{trapped:false} → Active{trapped:true}` transition does
-        // NOT re-emit `Effect::FocusTrapListener`, the adapter tears down
-        // the keydown trap and never reinstalls it, silently breaking Tab
-        // trapping until a full deactivate/activate cycle.
+        // Regression guard for Codex review #663 round 1 (P1): adapters
+        // drain ALL active effect cleanups whenever `state_changed` is
+        // true (see `ars-leptos::use_machine::handle_effects` line 607).
+        // `Active{trapped:false} → Active{trapped:true}` enters a state
+        // that DOES need the listener, so the transition must re-emit
+        // `Effect::FocusTrapListener` to reinstall the trap after the
+        // drain, otherwise Tab interception is silently disabled.
         let mut service = service(test_props());
         drop(service.send(Event::Activate {
             trapped: false,
@@ -883,20 +893,21 @@ mod tests {
         assert!(result.state_changed);
         assert!(
             effect_names(&result.pending_effects).contains(&Effect::FocusTrapListener),
-            "TrapFocus must re-emit Effect::FocusTrapListener so the adapter reinstalls \
-             the trap listener after the state-change-driven cleanup drain",
+            "TrapFocus moves into a trapped state — Effect::FocusTrapListener must \
+             be re-emitted so the adapter reinstalls the listener after the drain",
         );
     }
 
     #[test]
-    fn release_trap_re_emits_focus_trap_listener_so_adapter_reinstalls_after_state_change() {
-        // Same regression class as
-        // `trap_focus_re_emits_focus_trap_listener_so_adapter_reinstalls_after_state_change`,
-        // but for the `Active{trapped:true} → Active{trapped:false}`
-        // direction. The trap listener semantically stays valid across
-        // both Active variants — its `trapped` check reads context — but
-        // the adapter still needs to be told to reinstall after the
-        // state-change cleanup drain.
+    fn release_trap_does_not_emit_focus_trap_listener_so_drain_can_uninstall() {
+        // Regression guard for Codex review #663 round 2 (P1):
+        // `Active{trapped:true} → Active{trapped:false}` leaves the
+        // scope active but no longer trapping. The adapter's
+        // `state_changed`-driven drain runs the listener cleanup, and
+        // the transition MUST NOT re-emit `Effect::FocusTrapListener`
+        // — otherwise the adapter immediately reinstalls the trap and
+        // `ReleaseTrap` becomes a no-op (Tab stays intercepted even
+        // though state says it shouldn't).
         let mut service = service(test_props());
         drop(service.send(Event::Activate {
             trapped: true,
@@ -907,9 +918,36 @@ mod tests {
 
         assert!(result.state_changed);
         assert!(
-            effect_names(&result.pending_effects).contains(&Effect::FocusTrapListener),
-            "ReleaseTrap must re-emit Effect::FocusTrapListener so the adapter reinstalls \
-             the trap listener after the state-change-driven cleanup drain",
+            !effect_names(&result.pending_effects).contains(&Effect::FocusTrapListener),
+            "ReleaseTrap moves out of a trapped state — Effect::FocusTrapListener \
+             must NOT be re-emitted, so the drain can uninstall the listener",
+        );
+    }
+
+    #[test]
+    fn activate_does_not_emit_focus_trap_listener_when_resolved_trap_is_false() {
+        // Regression guard for Codex review #663 round 2 (P1):
+        // Activating into `Active{trapped:false}` (no trap requested by
+        // event/props) must NOT install the trap listener — the scope
+        // is active for focus-restoration accounting but does not
+        // intercept Tab. Emitting the effect would have the adapter
+        // attach Tab interception unconditionally via
+        // `PlatformEffects::attach_focus_trap`, contradicting the
+        // resolved `trapped: false` state.
+        let mut service = service(test_props()); // trapped=false, contain=false
+
+        let result = service.send(Event::Activate {
+            trapped: false,
+            saved_focus_id: None,
+        });
+
+        assert!(result.state_changed);
+        assert_eq!(service.state(), &State::Active { trapped: false });
+        assert!(
+            !effect_names(&result.pending_effects).contains(&Effect::FocusTrapListener),
+            "Activate into Active{{trapped:false}} must NOT emit \
+             Effect::FocusTrapListener — the adapter would otherwise install \
+             Tab interception despite the resolved untrapped state",
         );
     }
 

--- a/crates/ars-components/src/utility/focus_scope/mod.rs
+++ b/crates/ars-components/src/utility/focus_scope/mod.rs
@@ -310,12 +310,20 @@ impl ars_core::Machine for Machine {
             }
 
             // ── Trap / Release ──────────────────────────────────────────
-            (State::Active { trapped: false }, Event::TrapFocus) => {
-                Some(TransitionPlan::to(State::Active { trapped: true }))
-            }
-            (State::Active { trapped: true }, Event::ReleaseTrap) => {
-                Some(TransitionPlan::to(State::Active { trapped: false }))
-            }
+            // Adapters drain ALL active effect cleanups when
+            // `state_changed` is true (see `ars-leptos::use_machine::
+            // handle_effects`), so the `Active{trapped:_}` ↔
+            // `Active{trapped:_}` boundary must re-emit
+            // `Effect::FocusTrapListener` for the adapter to reinstall
+            // the keydown trap that the cleanup drain just removed.
+            (State::Active { trapped: false }, Event::TrapFocus) => Some(
+                TransitionPlan::to(State::Active { trapped: true })
+                    .with_effect(PendingEffect::named(Effect::FocusTrapListener)),
+            ),
+            (State::Active { trapped: true }, Event::ReleaseTrap) => Some(
+                TransitionPlan::to(State::Active { trapped: false })
+                    .with_effect(PendingEffect::named(Effect::FocusTrapListener)),
+            ),
 
             // ── RestoreFocus ────────────────────────────────────────────
             // While `Active`, `RestoreFocus` is ignored by the wildcard
@@ -821,6 +829,56 @@ mod tests {
 
         assert!(result.state_changed);
         assert_eq!(service.state(), &State::Active { trapped: false });
+    }
+
+    #[test]
+    fn trap_focus_re_emits_focus_trap_listener_so_adapter_reinstalls_after_state_change() {
+        // Regression guard for Codex review #663: adapters drain ALL active
+        // effect cleanups whenever `state_changed` is true (see
+        // `ars-leptos::use_machine::handle_effects` line 607). If the
+        // `Active{trapped:false} → Active{trapped:true}` transition does
+        // NOT re-emit `Effect::FocusTrapListener`, the adapter tears down
+        // the keydown trap and never reinstalls it, silently breaking Tab
+        // trapping until a full deactivate/activate cycle.
+        let mut service = service(test_props());
+        drop(service.send(Event::Activate {
+            trapped: false,
+            saved_focus_id: None,
+        }));
+
+        let result = service.send(Event::TrapFocus);
+
+        assert!(result.state_changed);
+        assert!(
+            effect_names(&result.pending_effects).contains(&Effect::FocusTrapListener),
+            "TrapFocus must re-emit Effect::FocusTrapListener so the adapter reinstalls \
+             the trap listener after the state-change-driven cleanup drain",
+        );
+    }
+
+    #[test]
+    fn release_trap_re_emits_focus_trap_listener_so_adapter_reinstalls_after_state_change() {
+        // Same regression class as
+        // `trap_focus_re_emits_focus_trap_listener_so_adapter_reinstalls_after_state_change`,
+        // but for the `Active{trapped:true} → Active{trapped:false}`
+        // direction. The trap listener semantically stays valid across
+        // both Active variants — its `trapped` check reads context — but
+        // the adapter still needs to be told to reinstall after the
+        // state-change cleanup drain.
+        let mut service = service(test_props());
+        drop(service.send(Event::Activate {
+            trapped: true,
+            saved_focus_id: None,
+        }));
+
+        let result = service.send(Event::ReleaseTrap);
+
+        assert!(result.state_changed);
+        assert!(
+            effect_names(&result.pending_effects).contains(&Effect::FocusTrapListener),
+            "ReleaseTrap must re-emit Effect::FocusTrapListener so the adapter reinstalls \
+             the trap listener after the state-change-driven cleanup drain",
+        );
     }
 
     #[test]

--- a/crates/ars-components/src/utility/focus_scope/snapshots/ars_components__utility__focus_scope__tests__container_attrs_active_trapped.snap
+++ b/crates/ars-components/src/utility/focus_scope/snapshots/ars_components__utility__focus_scope__tests__container_attrs_active_trapped.snap
@@ -1,0 +1,48 @@
+---
+source: crates/ars-components/src/utility/focus_scope/mod.rs
+assertion_line: 1248
+expression: "snapshot_attrs(&service.connect(&|_| {}).container_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-active",
+            ),
+            Bool(
+                true,
+            ),
+        ),
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "container",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "focus-scope",
+            ),
+        ),
+        (
+            Data(
+                "ars-trapped",
+            ),
+            Bool(
+                true,
+            ),
+        ),
+        (
+            TabIndex,
+            String(
+                "-1",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/utility/focus_scope/snapshots/ars_components__utility__focus_scope__tests__container_attrs_active_untrapped.snap
+++ b/crates/ars-components/src/utility/focus_scope/snapshots/ars_components__utility__focus_scope__tests__container_attrs_active_untrapped.snap
@@ -1,0 +1,40 @@
+---
+source: crates/ars-components/src/utility/focus_scope/mod.rs
+assertion_line: 1234
+expression: "snapshot_attrs(&service.connect(&|_| {}).container_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-active",
+            ),
+            Bool(
+                true,
+            ),
+        ),
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "container",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "focus-scope",
+            ),
+        ),
+        (
+            TabIndex,
+            String(
+                "-1",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/utility/focus_scope/snapshots/ars_components__utility__focus_scope__tests__container_attrs_contain_prop_promotes_trapped.snap
+++ b/crates/ars-components/src/utility/focus_scope/snapshots/ars_components__utility__focus_scope__tests__container_attrs_contain_prop_promotes_trapped.snap
@@ -1,0 +1,48 @@
+---
+source: crates/ars-components/src/utility/focus_scope/mod.rs
+assertion_line: 1262
+expression: "snapshot_attrs(&service.connect(&|_| {}).container_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-active",
+            ),
+            Bool(
+                true,
+            ),
+        ),
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "container",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "focus-scope",
+            ),
+        ),
+        (
+            Data(
+                "ars-trapped",
+            ),
+            Bool(
+                true,
+            ),
+        ),
+        (
+            TabIndex,
+            String(
+                "-1",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/utility/focus_scope/snapshots/ars_components__utility__focus_scope__tests__container_attrs_inactive.snap
+++ b/crates/ars-components/src/utility/focus_scope/snapshots/ars_components__utility__focus_scope__tests__container_attrs_inactive.snap
@@ -1,0 +1,26 @@
+---
+source: crates/ars-components/src/utility/focus_scope/mod.rs
+assertion_line: 1220
+expression: "snapshot_attrs(&service.connect(&|_| {}).container_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "container",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "focus-scope",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/utility/mod.rs
+++ b/crates/ars-components/src/utility/mod.rs
@@ -35,6 +35,10 @@ pub mod form;
 /// focus modality).
 pub mod focus_ring;
 
+/// `FocusScope` component machine (focus-trap state machine with named
+/// effect intents that adapters route to `PlatformEffects` focus helpers).
+pub mod focus_scope;
+
 /// Form submit machine.
 pub mod form_submit;
 

--- a/crates/ars-components/tests/proptest_state_machines/utility.rs
+++ b/crates/ars-components/tests/proptest_state_machines/utility.rs
@@ -4,8 +4,8 @@ use ars_a11y::AriaRelevant;
 #[cfg(feature = "i18n")]
 use ars_components::utility::highlight;
 use ars_components::utility::{
-    button, download_trigger, error_boundary, field, fieldset, form, form_submit, live_region,
-    separator, swap, toggle, visually_hidden,
+    button, download_trigger, error_boundary, field, fieldset, focus_scope, form, form_submit,
+    live_region, separator, swap, toggle, visually_hidden,
 };
 use ars_core::{ConnectApi, Env, HtmlAttr, Service, WeakSend, callback};
 use ars_forms::{
@@ -152,6 +152,39 @@ fn arb_live_region_event() -> impl Strategy<Value = live_region::Event> {
         Just(live_region::Event::Clear),
         Just(live_region::Event::Rendered),
         Just(live_region::Event::SetProps),
+    ]
+}
+
+fn arb_focus_scope_props() -> impl Strategy<Value = focus_scope::Props> {
+    (any::<bool>(), any::<bool>(), any::<bool>(), any::<bool>()).prop_map(
+        |(trapped, contain, auto_focus, restore_focus)| focus_scope::Props {
+            id: "focus-scope".to_string(),
+            trapped,
+            contain,
+            auto_focus,
+            restore_focus,
+        },
+    )
+}
+
+fn arb_optional_focus_target() -> impl Strategy<Value = Option<String>> {
+    prop::option::of("[a-zA-Z0-9-]{1,16}".prop_map(String::from))
+}
+
+fn arb_focus_scope_event() -> impl Strategy<Value = focus_scope::Event> {
+    prop_oneof![
+        (any::<bool>(), arb_optional_focus_target()).prop_map(|(trapped, saved_focus_id)| {
+            focus_scope::Event::Activate {
+                trapped,
+                saved_focus_id,
+            }
+        }),
+        any::<bool>().prop_map(|restore_focus| focus_scope::Event::Deactivate { restore_focus }),
+        Just(focus_scope::Event::TrapFocus),
+        Just(focus_scope::Event::ReleaseTrap),
+        Just(focus_scope::Event::RestoreFocus),
+        Just(focus_scope::Event::FocusFirst),
+        Just(focus_scope::Event::FocusLast),
     ]
 }
 
@@ -1232,6 +1265,141 @@ proptest! {
             prop_assert_eq!(chunks.len(), 1, "empty query → exactly one chunk");
             prop_assert!(!chunks[0].highlighted, "empty-query chunk must not be highlighted");
             prop_assert_eq!(chunks[0].text, props.text.as_str());
+        }
+    }
+}
+
+proptest! {
+    #![proptest_config(super::common::proptest_config())]
+
+    /// `Activate → Deactivate { restore_focus: false }` always lands at
+    /// `State::Inactive` with `saved_focus = None`, regardless of any
+    /// intermediate events. Intermediate events may toggle the scope in
+    /// and out of `Active`, but the final forced `Deactivate(false)`
+    /// from `Active` clears the saved focus via its apply step.
+    #[test]
+    #[ignore = "proptest — nightly extended-proptest job"]
+    fn proptest_focus_scope_activate_deactivate_round_trip(
+        props in arb_focus_scope_props(),
+        intermediate in prop::collection::vec(arb_focus_scope_event(), 0..64),
+        saved_focus_id in arb_optional_focus_target(),
+    ) {
+        let mut service = Service::<focus_scope::Machine>::new(
+            props,
+            &Env::default(),
+            &focus_scope::Messages,
+        );
+
+        // Force-activate so the round-trip always exercises both halves.
+        drop(service.send(focus_scope::Event::Activate {
+            trapped: true,
+            saved_focus_id,
+        }));
+
+        for event in intermediate {
+            drop(service.send(event));
+        }
+
+        // Re-activate if the intermediate sequence landed us back at
+        // `Inactive`. Without this the final `Deactivate(false)` would be
+        // a no-op (the wildcard arm ignores it) and any leftover
+        // `saved_focus` from an earlier `Deactivate(true)` would survive.
+        if matches!(service.state(), focus_scope::State::Inactive) {
+            drop(service.send(focus_scope::Event::Activate {
+                trapped: false,
+                saved_focus_id: Some("force-active".to_string()),
+            }));
+        }
+
+        // Force back to Inactive without restoration. Any active scope
+        // MUST return to Inactive after a Deactivate(false); the apply
+        // step clears `saved_focus` to drop the stale token.
+        drop(service.send(focus_scope::Event::Deactivate { restore_focus: false }));
+
+        prop_assert_eq!(service.state(), &focus_scope::State::Inactive);
+        prop_assert!(service.context().saved_focus.is_none());
+    }
+
+    /// `TrapFocus` and `ReleaseTrap` only have a state-affecting effect
+    /// while the scope is `Active`; they are ignored from `Inactive`.
+    #[test]
+    #[ignore = "proptest — nightly extended-proptest job"]
+    fn proptest_focus_scope_trap_release_only_changes_state_in_active(
+        props in arb_focus_scope_props(),
+        events in prop::collection::vec(arb_focus_scope_event(), 0..32),
+    ) {
+        let mut service = Service::<focus_scope::Machine>::new(
+            props,
+            &Env::default(),
+            &focus_scope::Messages,
+        );
+
+        for event in events {
+            let was_active = matches!(service.state(), focus_scope::State::Active { .. });
+
+            let result = service.send(event.clone());
+
+            match event {
+                focus_scope::Event::TrapFocus | focus_scope::Event::ReleaseTrap
+                    if !was_active =>
+                {
+                    prop_assert!(
+                        !result.state_changed,
+                        "{:?} from Inactive must be ignored",
+                        event,
+                    );
+                }
+                _ => {}
+            }
+
+            // The trapped flag and the State::Active variant always agree.
+            match service.state() {
+                focus_scope::State::Inactive => {
+                    // No further invariant — saved_focus may be set or cleared.
+                }
+
+                focus_scope::State::Active { trapped } => {
+                    // Empty arm: we just assert the variant carries the
+                    // current `trapped` flag, which is structural.
+                    let _ = trapped;
+                }
+            }
+        }
+    }
+
+    /// Focus-navigation events (`FocusFirst`, `FocusLast`, `RestoreFocus`)
+    /// never change the high-level state — they either emit an effect
+    /// intent (when their state precondition holds) or are no-ops.
+    #[test]
+    #[ignore = "proptest — nightly extended-proptest job"]
+    fn proptest_focus_scope_navigation_events_never_leave_state(
+        props in arb_focus_scope_props(),
+        events in prop::collection::vec(arb_focus_scope_event(), 0..32),
+    ) {
+        let mut service = Service::<focus_scope::Machine>::new(
+            props,
+            &Env::default(),
+            &focus_scope::Messages,
+        );
+
+        for event in events {
+            let before = *service.state();
+
+            let result = service.send(event.clone());
+
+            if matches!(
+                event,
+                focus_scope::Event::FocusFirst
+                    | focus_scope::Event::FocusLast
+                    | focus_scope::Event::RestoreFocus,
+            ) {
+                prop_assert!(
+                    !result.state_changed,
+                    "{:?} must not change the high-level state (it only emits an effect intent)",
+                    event,
+                );
+                prop_assert_eq!(service.state(), &before);
+            }
         }
     }
 }

--- a/crates/ars-components/tests/spec_conformance/utility.rs
+++ b/crates/ars-components/tests/spec_conformance/utility.rs
@@ -5,7 +5,8 @@
 
 #[cfg(feature = "i18n")]
 use ars_components::utility::highlight;
-use ars_components::utility::{download_trigger, group, live_region, swap, toggle};
+use ars_components::utility::{download_trigger, focus_scope, group, live_region, swap, toggle};
+use ars_core::{Env, HtmlAttr, Service};
 
 use super::helper::assert_anatomy;
 
@@ -53,6 +54,113 @@ fn swap_anatomy_matches_spec() {
 #[test]
 fn live_region_anatomy_matches_spec() {
     assert_anatomy("live-region", &[(live_region::Part::Root, "root")]);
+}
+
+#[test]
+fn focus_scope_anatomy_matches_spec() {
+    // FocusScope's anatomy table (spec §2) declares a single row:
+    // `Container`. The container element is also the `ROOT` part —
+    // every `Part` enum's first variant is treated as root by the
+    // `ComponentPart` derive macro.
+    assert_anatomy(
+        "focus-scope",
+        &[(focus_scope::Part::Container, "container")],
+    );
+}
+
+#[test]
+fn focus_scope_props_defaults_match_spec_section_1_4() {
+    let props = focus_scope::Props::default();
+
+    assert_eq!(props.id, "");
+    assert!(!props.trapped, "spec §1.4: trapped defaults to false");
+    assert!(!props.contain, "spec §1.4: contain defaults to false");
+    assert!(props.auto_focus, "spec §1.4: auto_focus defaults to true");
+    assert!(
+        props.restore_focus,
+        "spec §1.4: restore_focus defaults to true",
+    );
+}
+
+#[test]
+fn focus_scope_event_variants_match_spec_section_1_2() {
+    // Spec §1.2 declares seven events. Listing all of them in a typed
+    // array here guards against a future drift where a variant is
+    // renamed or removed without spec sync.
+    let events: [focus_scope::Event; 7] = [
+        focus_scope::Event::Activate {
+            trapped: false,
+            saved_focus_id: None,
+        },
+        focus_scope::Event::Deactivate {
+            restore_focus: false,
+        },
+        focus_scope::Event::TrapFocus,
+        focus_scope::Event::ReleaseTrap,
+        focus_scope::Event::RestoreFocus,
+        focus_scope::Event::FocusFirst,
+        focus_scope::Event::FocusLast,
+    ];
+
+    assert_eq!(events.len(), 7);
+}
+
+#[test]
+fn focus_scope_state_variants_match_spec_section_1_1() {
+    // Spec §1.1: `Inactive` and `Active { trapped: bool }`.
+    let states: [focus_scope::State; 3] = [
+        focus_scope::State::Inactive,
+        focus_scope::State::Active { trapped: false },
+        focus_scope::State::Active { trapped: true },
+    ];
+
+    assert_eq!(states.len(), 3);
+}
+
+#[test]
+fn focus_scope_effect_variants_match_spec_section_1_8() {
+    // Spec §1.8 (Effect Contract): four typed effect intents.
+    let effects: [focus_scope::Effect; 4] = [
+        focus_scope::Effect::FocusTrapListener,
+        focus_scope::Effect::FocusFirst,
+        focus_scope::Effect::FocusLast,
+        focus_scope::Effect::RestoreFocus,
+    ];
+
+    assert_eq!(effects.len(), 4);
+}
+
+#[test]
+fn focus_scope_connect_api_emits_data_ars_trapped_not_focus_trapped() {
+    // Spec §2 anatomy table declares the trap data attribute as
+    // `data-ars-trapped`. GitHub issue #212 test 9 has a typo that
+    // calls it `data-ars-focus-trapped`. This regression test pins
+    // the spec-correct name so a future refactor cannot drift to
+    // the issue's wording without a deliberate spec edit.
+    let mut service = Service::<focus_scope::Machine>::new(
+        focus_scope::Props::new().id("trap"),
+        &Env::default(),
+        &focus_scope::Messages,
+    );
+
+    drop(service.send(focus_scope::Event::Activate {
+        trapped: true,
+        saved_focus_id: None,
+    }));
+
+    let attrs = service.connect(&|_| {}).container_attrs();
+
+    assert_eq!(
+        attrs.get(&HtmlAttr::Data("ars-trapped")),
+        Some("true"),
+        "spec §2 names the trap data attribute `data-ars-trapped`",
+    );
+    assert_eq!(
+        attrs.get(&HtmlAttr::Data("ars-focus-trapped")),
+        None,
+        "spec §2 does NOT define `data-ars-focus-trapped`; issue #212 \
+         test 9 has a typo that the spec is authoritative against",
+    );
 }
 
 #[cfg(feature = "i18n")]

--- a/spec/components/utility/focus-scope.md
+++ b/spec/components/utility/focus-scope.md
@@ -189,10 +189,14 @@ impl Props {
 
 ```text
 Inactive + Activate { trapped, saved_focus_id }
-  → Active { trapped: trapped || props.contain }
+  → Active { trapped: trapped || props.trapped || props.contain }
   action: ctx.saved_focus = saved_focus_id (adapter-captured ID)
   effect: PendingEffect::named(Effect::FocusTrapListener)
   then_send: FocusFirst (if props.auto_focus=true)
+
+  (Either `Props::trapped` or its `Props::contain` alias opts the
+   scope into trapping; the event's `trapped` is a per-activation
+   override that can also force trapping when the props didn't.)
 
 Active + Deactivate { restore_focus }
   → Inactive
@@ -318,7 +322,12 @@ impl ars_core::Machine for Machine {
         match (state, event) {
             // ── Activation ──────────────────────────────────────────────
             (State::Inactive, Event::Activate { trapped, saved_focus_id }) => {
-                let trap = *trapped || props.contain;
+                // `Props::trapped` is the documented trap prop;
+                // `Props::contain` is its alias. Either opts the scope
+                // into trapping; the event's `trapped` is a
+                // per-activation override that can also force trapping
+                // when the props didn't request it.
+                let trap = *trapped || props.trapped || props.contain;
                 let auto_focus = props.auto_focus;
                 let saved = saved_focus_id.clone();
                 let mut plan = TransitionPlan::to(State::Active { trapped: trap })

--- a/spec/components/utility/focus-scope.md
+++ b/spec/components/utility/focus-scope.md
@@ -191,12 +191,16 @@ impl Props {
 Inactive + Activate { trapped, saved_focus_id }
   → Active { trapped: trapped || props.trapped || props.contain }
   action: ctx.saved_focus = saved_focus_id (adapter-captured ID)
-  effect: PendingEffect::named(Effect::FocusTrapListener)
+  effect: PendingEffect::named(Effect::FocusTrapListener)  ← only when the
+                                                            resolved `trapped`
+                                                            is `true`
   then_send: FocusFirst (if props.auto_focus=true)
 
   (Either `Props::trapped` or its `Props::contain` alias opts the
    scope into trapping; the event's `trapped` is a per-activation
-   override that can also force trapping when the props didn't.)
+   override that can also force trapping when the props didn't. The
+   trap listener is gated on the resolved trap value — entering
+   `Active { trapped: false }` does NOT install Tab interception.)
 
 Active + Deactivate { restore_focus }
   → Inactive
@@ -216,8 +220,9 @@ Active { trapped: false } + TrapFocus
 
 Active { trapped: true } + ReleaseTrap
   → Active { trapped: false }
-  effect: PendingEffect::named(Effect::FocusTrapListener)
-  (re-emitted for the same adapter-cleanup-drain reason as above)
+  (NO trap-listener effect — the `state_changed=true` drain
+   uninstalls the listener, which is the desired outcome since
+   `trapped: false` should not intercept Tab)
 
 Inactive + RestoreFocus
   → Inactive (stay)
@@ -333,8 +338,13 @@ impl ars_core::Machine for Machine {
                 let mut plan = TransitionPlan::to(State::Active { trapped: trap })
                     .apply(move |ctx: &mut Context| {
                         ctx.saved_focus = saved;
-                    })
-                    .with_effect(PendingEffect::named(Effect::FocusTrapListener));
+                    });
+                // Only install Tab interception when the resolved state
+                // is actually trapped — `PlatformEffects::attach_focus_trap`
+                // unconditionally wraps Tab/Shift+Tab.
+                if trap {
+                    plan = plan.with_effect(PendingEffect::named(Effect::FocusTrapListener));
+                }
                 if auto_focus {
                     plan = plan.then(Event::FocusFirst);
                 }
@@ -361,18 +371,18 @@ impl ars_core::Machine for Machine {
 
             // ── Trap / Release ──────────────────────────────────────────
             // Adapters drain ALL active effect cleanups when
-            // `state_changed` is true, so the `Active{trapped:_}` ↔
-            // `Active{trapped:_}` boundary must re-emit
-            // `Effect::FocusTrapListener` for the adapter to reinstall
-            // the keydown trap that the drain just removed.
+            // `state_changed` is true. `TrapFocus` enters a state that
+            // DOES need the listener, so it re-emits the effect for the
+            // adapter to reinstall the trap. `ReleaseTrap` exits the
+            // trapped state, so it MUST NOT re-emit — the drain
+            // teardown is the intended outcome.
             (State::Active { trapped: false }, Event::TrapFocus) => Some(
                 TransitionPlan::to(State::Active { trapped: true })
                     .with_effect(PendingEffect::named(Effect::FocusTrapListener)),
             ),
-            (State::Active { trapped: true }, Event::ReleaseTrap) => Some(
-                TransitionPlan::to(State::Active { trapped: false })
-                    .with_effect(PendingEffect::named(Effect::FocusTrapListener)),
-            ),
+            (State::Active { trapped: true }, Event::ReleaseTrap) => {
+                Some(TransitionPlan::to(State::Active { trapped: false }))
+            }
 
             // ── RestoreFocus ────────────────────────────────────────────
             // Adapters may send `RestoreFocus` explicitly (e.g. nested
@@ -598,7 +608,7 @@ expected to call into the workspace's `PlatformEffects` implementation
 
 | Effect              | When emitted                                                                                                   | Adapter contract                                                                                                                                                                                                                                                                                  |
 | ------------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `FocusTrapListener` | `Inactive → Active` (Activate) and every `Active{trapped:_} ↔ Active{trapped:_}` transition (TrapFocus / ReleaseTrap) | Call `PlatformEffects::attach_focus_trap(container_id, on_escape)`. Wire the returned `CleanupFn` as the effect's cleanup so `cancel_effect(Effect::FocusTrapListener)` tears the handler down on `Deactivate`. The `on_escape` callback SHOULD send `Event::Deactivate { restore_focus: true }`. **Re-emitted on TrapFocus / ReleaseTrap because adapters drain all active cleanups when `state_changed` is true, so the listener must be reinstalled to preserve Tab trapping across the Active variants.** |
+| `FocusTrapListener` | `Inactive → Active{trapped:true}` (Activate when the resolved trap is `true`) and `Active{trapped:false} → Active{trapped:true}` (TrapFocus). NOT emitted on `Inactive → Active{trapped:false}` (active-but-untrapped activation) or on `ReleaseTrap` — the listener is only valid while `trapped: true`. | Call `PlatformEffects::attach_focus_trap(container_id, on_escape)`. Wire the returned `CleanupFn` as the effect's cleanup so `cancel_effect(Effect::FocusTrapListener)` tears the handler down on `Deactivate`. The `on_escape` callback SHOULD send `Event::Deactivate { restore_focus: true }`. The state-change-driven cleanup drain also uninstalls the listener whenever the resolved state moves off `trapped: true` (TrapFocus reinstalls it, ReleaseTrap and Deactivate intentionally leave it uninstalled). |
 | `FocusFirst`        | `Active + FocusFirst` (also on `Activate` when `props.auto_focus`)                                             | Call `PlatformEffects::focus_first_tabbable(container_id)`. Fall back to focusing the container element (which has `tabindex="-1"` while active) when no tabbable descendants exist.                                                                                                              |
 | `FocusLast`         | `Active + FocusLast`                                                                                           | Call `PlatformEffects::focus_last_tabbable(container_id)`. Fall back to the container when no tabbable descendants exist.                                                                                                                                                                         |
 | `RestoreFocus`      | `Active → Inactive` (Deactivate with `restore_focus: true`) or explicit `Event::RestoreFocus` while `Inactive` | Read `service.context().saved_focus`. If `Some(id)`, apply the §1.6.1 / §7 fallback chain via `PlatformEffects::can_restore_focus` → `focus_element_by_id` → `nearest_focusable_ancestor_id` → `focus_body`. The core does not clear `saved_focus` here; the next `Activate` overwrites it.       |

--- a/spec/components/utility/focus-scope.md
+++ b/spec/components/utility/focus-scope.md
@@ -206,9 +206,14 @@ Active + Deactivate { restore_focus }
 
 Active { trapped: false } + TrapFocus
   → Active { trapped: true }
+  effect: PendingEffect::named(Effect::FocusTrapListener)
+  (re-emitted so the adapter reinstalls the trap listener that
+   `state_changed=true` just drained — see §1.8)
 
 Active { trapped: true } + ReleaseTrap
   → Active { trapped: false }
+  effect: PendingEffect::named(Effect::FocusTrapListener)
+  (re-emitted for the same adapter-cleanup-drain reason as above)
 
 Inactive + RestoreFocus
   → Inactive (stay)
@@ -346,12 +351,19 @@ impl ars_core::Machine for Machine {
             }
 
             // ── Trap / Release ──────────────────────────────────────────
-            (State::Active { trapped: false }, Event::TrapFocus) => {
-                Some(TransitionPlan::to(State::Active { trapped: true }))
-            }
-            (State::Active { trapped: true }, Event::ReleaseTrap) => {
-                Some(TransitionPlan::to(State::Active { trapped: false }))
-            }
+            // Adapters drain ALL active effect cleanups when
+            // `state_changed` is true, so the `Active{trapped:_}` ↔
+            // `Active{trapped:_}` boundary must re-emit
+            // `Effect::FocusTrapListener` for the adapter to reinstall
+            // the keydown trap that the drain just removed.
+            (State::Active { trapped: false }, Event::TrapFocus) => Some(
+                TransitionPlan::to(State::Active { trapped: true })
+                    .with_effect(PendingEffect::named(Effect::FocusTrapListener)),
+            ),
+            (State::Active { trapped: true }, Event::ReleaseTrap) => Some(
+                TransitionPlan::to(State::Active { trapped: false })
+                    .with_effect(PendingEffect::named(Effect::FocusTrapListener)),
+            ),
 
             // ── RestoreFocus ────────────────────────────────────────────
             // Adapters may send `RestoreFocus` explicitly (e.g. nested
@@ -577,7 +589,7 @@ expected to call into the workspace's `PlatformEffects` implementation
 
 | Effect              | When emitted                                                                                                   | Adapter contract                                                                                                                                                                                                                                                                                  |
 | ------------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `FocusTrapListener` | `Inactive → Active` (Activate)                                                                                 | Call `PlatformEffects::attach_focus_trap(container_id, on_escape)`. Wire the returned `CleanupFn` as the effect's cleanup so `cancel_effect(Effect::FocusTrapListener)` tears the handler down on `Deactivate`. The `on_escape` callback SHOULD send `Event::Deactivate { restore_focus: true }`. |
+| `FocusTrapListener` | `Inactive → Active` (Activate) and every `Active{trapped:_} ↔ Active{trapped:_}` transition (TrapFocus / ReleaseTrap) | Call `PlatformEffects::attach_focus_trap(container_id, on_escape)`. Wire the returned `CleanupFn` as the effect's cleanup so `cancel_effect(Effect::FocusTrapListener)` tears the handler down on `Deactivate`. The `on_escape` callback SHOULD send `Event::Deactivate { restore_focus: true }`. **Re-emitted on TrapFocus / ReleaseTrap because adapters drain all active cleanups when `state_changed` is true, so the listener must be reinstalled to preserve Tab trapping across the Active variants.** |
 | `FocusFirst`        | `Active + FocusFirst` (also on `Activate` when `props.auto_focus`)                                             | Call `PlatformEffects::focus_first_tabbable(container_id)`. Fall back to focusing the container element (which has `tabindex="-1"` while active) when no tabbable descendants exist.                                                                                                              |
 | `FocusLast`         | `Active + FocusLast`                                                                                           | Call `PlatformEffects::focus_last_tabbable(container_id)`. Fall back to the container when no tabbable descendants exist.                                                                                                                                                                         |
 | `RestoreFocus`      | `Active → Inactive` (Deactivate with `restore_focus: true`) or explicit `Event::RestoreFocus` while `Inactive` | Read `service.context().saved_focus`. If `Some(id)`, apply the §1.6.1 / §7 fallback chain via `PlatformEffects::can_restore_focus` → `focus_element_by_id` → `nearest_focusable_ancestor_id` → `focus_body`. The core does not clear `saved_focus` here; the next `Activate` overwrites it.       |

--- a/spec/components/utility/focus-scope.md
+++ b/spec/components/utility/focus-scope.md
@@ -73,8 +73,11 @@ pub enum Event {
     /// Disable focus trapping on an active scope.
     ReleaseTrap,
     /// Restore focus to the element that was focused before activation.
-    /// Only processed during deactivation (via `then_send` from Deactivate).
-    /// Ignored if the scope is still Active.
+    /// Adapters MAY send this event explicitly when an `Inactive` scope still
+    /// holds a non-empty `Context::saved_focus` (e.g., nested-scope cleanup).
+    /// When `Inactive`, the machine emits [`Effect::RestoreFocus`]; when
+    /// `Active`, the event is ignored — restoration is only meaningful
+    /// after the scope has deactivated.
     RestoreFocus,
     /// Move focus to the first tabbable element in the container.
     FocusFirst,
@@ -92,12 +95,19 @@ pub enum Event {
 /// from `State` in the connect API:
 /// - `is_active()` → `matches!(state, State::Active { .. })`
 /// - `is_trapped()` → `matches!(state, State::Active { trapped: true })`
-#[derive(Clone, Debug, PartialEq)]
+///
+/// `Eq` enables value-based comparison in proptest invariants; `Default`
+/// gives the machine a free `Context::default()` for `init`.
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
 pub struct Context {
     /// The element that had focus before the scope was activated.
-    /// Restored on `Deactivate` if `restore_focus=true`.
+    /// Set on `Activate` and read by the adapter when dispatching
+    /// `Effect::RestoreFocus`. The agnostic core does not clear the value
+    /// after restoration — the next `Activate` overwrites it.
     pub saved_focus: Option<String>,
     /// The DOM ID of the container element that scopes focus.
+    /// Adapters populate this via `Service::context_mut()` once they have
+    /// resolved the container's stable ID.
     pub container_id: Option<String>,
 }
 ```
@@ -132,22 +142,67 @@ impl Default for Props {
         }
     }
 }
+
+impl Props {
+    /// Returns a fresh `Props` with every field at its `Default` value.
+    #[must_use]
+    pub fn new() -> Self { Self::default() }
+
+    /// Sets [`id`](Self::id).
+    #[must_use]
+    pub fn id(mut self, id: impl Into<String>) -> Self {
+        self.id = id.into();
+        self
+    }
+
+    /// Sets [`trapped`](Self::trapped).
+    #[must_use]
+    pub const fn trapped(mut self, trapped: bool) -> Self {
+        self.trapped = trapped;
+        self
+    }
+
+    /// Sets [`contain`](Self::contain).
+    #[must_use]
+    pub const fn contain(mut self, contain: bool) -> Self {
+        self.contain = contain;
+        self
+    }
+
+    /// Sets [`auto_focus`](Self::auto_focus).
+    #[must_use]
+    pub const fn auto_focus(mut self, auto_focus: bool) -> Self {
+        self.auto_focus = auto_focus;
+        self
+    }
+
+    /// Sets [`restore_focus`](Self::restore_focus).
+    #[must_use]
+    pub const fn restore_focus(mut self, restore_focus: bool) -> Self {
+        self.restore_focus = restore_focus;
+        self
+    }
+}
 ```
 
 ### 1.5 Transitions
 
 ```text
-Inactive + Activate { trapped }
-  → Active { trapped: trapped || contain }
-  action: save currently focused element → ctx.saved_focus
-  effect: "focus-trap-listener" (attaches keydown handler to intercept Tab)
-  then_send: FocusFirst (if auto_focus=true)
+Inactive + Activate { trapped, saved_focus_id }
+  → Active { trapped: trapped || props.contain }
+  action: ctx.saved_focus = saved_focus_id (adapter-captured ID)
+  effect: PendingEffect::named(Effect::FocusTrapListener)
+  then_send: FocusFirst (if props.auto_focus=true)
 
 Active + Deactivate { restore_focus }
   → Inactive
-  action: clear ctx.saved_focus reference
-  cleanup effect: remove keydown handler
-  then_send: RestoreFocus (if restore_focus=true)
+  cancel_effect: Effect::FocusTrapListener  (runs the adapter cleanup, tearing
+                                              down the Tab keydown handler)
+  if restore_focus:
+    effect: PendingEffect::named(Effect::RestoreFocus)
+    (ctx.saved_focus stays — adapter reads it; next Activate overwrites)
+  else:
+    action: ctx.saved_focus = None
 
 Active { trapped: false } + TrapFocus
   → Active { trapped: true }
@@ -157,39 +212,78 @@ Active { trapped: true } + ReleaseTrap
 
 Inactive + RestoreFocus
   → Inactive (stay)
-  action: restore focus from ctx.saved_focus via restore_focus_safely()
+  effect: PendingEffect::named(Effect::RestoreFocus)
 
 Active + RestoreFocus
-  → None (ignored — RestoreFocus is only meaningful after Deactivate)
+  → None (ignored — restoration is only meaningful after Deactivate)
 
 Active + FocusFirst
   → Active (stay)
-  effect: focus first tabbable element in container
+  effect: PendingEffect::named(Effect::FocusFirst)
 
 Active + FocusLast
   → Active (stay)
-  effect: focus last tabbable element in container
+  effect: PendingEffect::named(Effect::FocusLast)
 
-When `contain` is true and no tabbable elements exist within the scope, FocusScope MUST:
+When `contain` is true and no tabbable elements exist within the scope, the
+adapter's `Effect::FocusTrapListener` handler MUST:
   (1) keep focus on the container element (which has `tabindex="-1"`),
   (2) suppress Tab/Shift+Tab key events entirely (`preventDefault()`),
-  (3) re-scan for tabbable elements on each Tab press to detect dynamically added
-      content (e.g., lazy-loaded dialog body).
-  (handled entirely in effect, no state change needed)
+  (3) re-scan for tabbable elements on each Tab press to detect dynamically
+      added content (e.g., lazy-loaded dialog body).
+  (handled entirely in the adapter effect — no state change needed)
 ```
 
 ### 1.6 Full Machine Implementation
 
+The agnostic core emits typed effect intents via `Effect` markers. Adapters
+dispatch on the `Effect` variant and route to their `PlatformEffects`
+implementation — the core never calls platform helpers directly. This matches
+the named-effect pattern used by `Dialog` (`spec/components/overlay/dialog.md`)
+and `Popover`.
+
 ```rust
-use ars_core::{TransitionPlan, PendingEffect, ConnectApi, AttrMap};
+// The local `Messages` struct below shadows the `Messages` trait name, so the
+// trait must be brought into scope by its real name (`ComponentMessages`)
+// rather than an `as _` alias.
+use ars_core::{
+    AttrMap, ComponentMessages, ComponentPart, ConnectApi, Env, HtmlAttr, PendingEffect,
+    TransitionPlan,
+};
 
 /// The machine for the `FocusScope` component.
+#[derive(Debug)]
 pub struct Machine;
 
 /// This component has no translatable strings.
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct Messages;
 impl ComponentMessages for Messages {}
+
+/// Typed effect intents emitted by the focus-scope machine.
+///
+/// Each variant is an adapter contract — the adapter's effect handler
+/// translates the variant into the corresponding `PlatformEffects` call
+/// (see [`spec/foundation/11-dom-utilities.md`] §3 for the platform-level
+/// helpers and §1.8 of this file for each variant's contract).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Effect {
+    /// Install the Tab-key interception (keydown handler + sentinel
+    /// elements) that keeps focus inside the scope while it is active.
+    ///
+    /// Cleanup tears the handler back down — invoked when the machine
+    /// emits `.cancel_effect(Effect::FocusTrapListener)` on `Deactivate`.
+    FocusTrapListener,
+    /// Move focus to the first tabbable descendant of the container.
+    /// Fall back to focusing the container itself when none exist.
+    FocusFirst,
+    /// Move focus to the last tabbable descendant of the container.
+    /// Fall back to focusing the container itself when none exist.
+    FocusLast,
+    /// Restore focus to `service.context().saved_focus`, applying the §7
+    /// fallback chain when the saved target is no longer focusable.
+    RestoreFocus,
+}
 
 impl ars_core::Machine for Machine {
     type State = State;
@@ -197,9 +291,10 @@ impl ars_core::Machine for Machine {
     type Context = Context;
     type Props = Props;
     type Messages = Messages;
+    type Effect = Effect;
     type Api<'a> = Api<'a>;
 
-    fn init(props: &Props, _env: &Env, _messages: &Messages) -> (State, Context) {
+    fn init(_props: &Props, _env: &Env, _messages: &Messages) -> (State, Context) {
         (
             State::Inactive,
             Context {
@@ -212,7 +307,7 @@ impl ars_core::Machine for Machine {
     fn transition(
         state: &Self::State,
         event: &Self::Event,
-        ctx: &Self::Context,
+        _ctx: &Self::Context,
         props: &Self::Props,
     ) -> Option<TransitionPlan<Self>> {
         match (state, event) {
@@ -222,16 +317,10 @@ impl ars_core::Machine for Machine {
                 let auto_focus = props.auto_focus;
                 let saved = saved_focus_id.clone();
                 let mut plan = TransitionPlan::to(State::Active { trapped: trap })
-                    .apply(move |ctx| {
+                    .apply(move |ctx: &mut Context| {
                         ctx.saved_focus = saved;
                     })
-                    .with_named_effect("focus-trap-listener", |ctx, _props, send| {
-                        let platform = use_platform_effects();
-                        let container_id = ctx.ids.part("container");
-                        platform.attach_focus_trap(&container_id, Box::new(move || {
-                            send.call_if_alive(Event::Deactivate { restore_focus: true });
-                        }))
-                    });
+                    .with_effect(PendingEffect::named(Effect::FocusTrapListener));
                 if auto_focus {
                     plan = plan.then(Event::FocusFirst);
                 }
@@ -241,13 +330,16 @@ impl ars_core::Machine for Machine {
             // ── Deactivation ────────────────────────────────────────────
             (State::Active { .. }, Event::Deactivate { restore_focus }) => {
                 let restore = *restore_focus;
-                let mut plan = TransitionPlan::to(State::Inactive);
+                let mut plan = TransitionPlan::to(State::Inactive)
+                    .cancel_effect(Effect::FocusTrapListener);
                 if restore {
-                    // RestoreFocus will read saved_focus then clear it.
-                    plan = plan.then(Event::RestoreFocus);
+                    // Adapter reads `service.context().saved_focus` when
+                    // dispatching `Effect::RestoreFocus`. The value stays
+                    // in context until the next `Activate` overwrites it.
+                    plan = plan.with_effect(PendingEffect::named(Effect::RestoreFocus));
                 } else {
-                    plan = plan.apply(|ctx| {
-                        ctx.saved_focus = None; // Clear to prevent stale DOM references
+                    plan = plan.apply(|ctx: &mut Context| {
+                        ctx.saved_focus = None;
                     });
                 }
                 Some(plan)
@@ -262,37 +354,22 @@ impl ars_core::Machine for Machine {
             }
 
             // ── RestoreFocus ────────────────────────────────────────────
-            // Only processed when Inactive (after Deactivate via then_send).
-            (State::Inactive, Event::RestoreFocus) => {
-                Some(TransitionPlan::context_only(|ctx| {
-                    if let Some(ref target) = ctx.saved_focus {
-                        restore_focus_safely(target.clone(), &[]);
-                    }
-                    ctx.saved_focus = None;
-                }))
-            }
-            // If RestoreFocus arrives while Active, ignore it.
+            // Adapters may send `RestoreFocus` explicitly (e.g. nested
+            // scope cleanup). When `Inactive` we emit the effect intent;
+            // when `Active` the event is ignored — restoration is only
+            // meaningful after the scope has deactivated.
+            (State::Inactive, Event::RestoreFocus) => Some(
+                TransitionPlan::new().with_effect(PendingEffect::named(Effect::RestoreFocus)),
+            ),
             (State::Active { .. }, Event::RestoreFocus) => None,
 
             // ── Focus Navigation ────────────────────────────────────────
-            (State::Active { .. }, Event::FocusFirst) => {
-                Some(TransitionPlan::new()
-                    .with_named_effect("focus_first", |ctx, _props, _send| {
-                        let platform = use_platform_effects();
-                        if let Some(ref id) = ctx.container_id {
-                            platform.focus_first_tabbable(id);
-                        }
-                    }))
-            }
-            (State::Active { .. }, Event::FocusLast) => {
-                Some(TransitionPlan::new()
-                    .with_named_effect("focus_last", |ctx, _props, _send| {
-                        let platform = use_platform_effects();
-                        if let Some(ref id) = ctx.container_id {
-                            platform.focus_last_tabbable(id);
-                        }
-                    }))
-            }
+            (State::Active { .. }, Event::FocusFirst) => Some(
+                TransitionPlan::new().with_effect(PendingEffect::named(Effect::FocusFirst)),
+            ),
+            (State::Active { .. }, Event::FocusLast) => Some(
+                TransitionPlan::new().with_effect(PendingEffect::named(Effect::FocusLast)),
+            ),
 
             _ => None,
         }
@@ -314,85 +391,45 @@ impl ars_core::Machine for Machine {
 }
 ```
 
-#### 1.6.1 Focus Restoration Safety
+#### 1.6.1 Focus Restoration Safety (adapter contract)
 
-````rust
-// Guard against restoring focus to a removed or unfocusable element.
-//
-// Checks performed before restoring focus:
-// 1. Element is in the DOM (document.contains)
-// 2. Element is visible (not visibility:hidden, not display:none)
-// 3. Element is not inside a closed <details> element
-// 4. Element is not already the active element (document.activeElement)
-// 5. Element can receive focus (is tabbable or has tabindex)
-// 6. Element has layout (offsetParent != null)
-//
-// If the target fails any check, try each fallback in order, then the
-// nearest focusable ancestor, then the document body.
-//
-// The `fallbacks` parameter supports nested dialog scenarios where the
-// original trigger may have been removed. Callers pass a prioritized list
-// (e.g., [parent_dialog_last_focused, parent_dialog_container,
-// parent_dialog_first_focusable]) so the function can gracefully degrade.
-fn restore_focus_safely(target_id: &str, fallback_ids: &[&str]) {
-    let platform = use_platform_effects();
-    if platform.can_restore_focus(target_id) {
-        platform.focus_element_by_id(target_id);
-        return;
-    }
-    // Try fallback elements in order
-    for id in fallback_ids {
-        if platform.can_restore_focus(id) {
-            platform.focus_element_by_id(id);
-            return;
-        }
-    }
-    // Walk up to nearest focusable ancestor of the original target.
-    if let Some(ancestor_id) = platform.nearest_focusable_ancestor_id(target_id) {
-        platform.focus_element_by_id(&ancestor_id);
-    } else {
-        // Last resort — focus document body
-        platform.focus_body();
-    }
-}
+The agnostic core stores the saved focus target as an opaque `Option<String>`
+on `Context::saved_focus`. When `Effect::RestoreFocus` fires, the adapter MUST
+guard against restoring focus to a removed, hidden, or otherwise unfocusable
+element by walking the following safety checks before calling
+`PlatformEffects::focus_element_by_id`:
 
-// ── Orientation Change Focus Audit ──────────────────────────────────────
-//
-// When the viewport orientation changes (e.g., portrait → landscape on mobile),
-// CSS media queries may hide or show elements. If FocusScope has trapped focus
-// on an element that is now hidden by `display: none`, the element stays in
-// the DOM but is invisible and has `offsetParent == null`.
-//
-// The FocusScope Tab handler MUST check `offsetParent !== null` before allowing
-// focus on any element. Additionally, the adapter MUST register a
-// `matchMedia('(orientation: portrait)')` change listener that triggers a
-// focus audit when orientation changes:
-//
-//   1. Check if the currently focused element has `offsetParent == null`.
-//   2. If hidden, move focus to the first visible tabbable element in the scope.
-//   3. Update the saved_focus reference if the restore target is now hidden.
-//
-// ```rust
-// fn audit_focus_on_orientation_change(scope: &FocusScopeContext) {
-//     let platform = use_platform_effects();
-//     if let Some(active_id) = platform.active_element_id() {
-//         if !platform.has_layout(&active_id) {
-//             // Focused element is hidden — move to first visible tabbable
-//             if let Some(ref container_id) = scope.container_id {
-//                 platform.focus_first_tabbable(container_id);
-//             }
-//         }
-//     }
-//     // Also validate the saved_focus restore target
-//     if let Some(ref saved) = scope.saved_focus {
-//         if !platform.has_layout(saved) {
-//             // Restore target is now hidden; clear it so fallback chain is used
-//             scope.saved_focus = None;
-//         }
-//     }
-// }
-// ```
-````
+1. The element is connected to the DOM (`document.contains` returns true).
+2. The element is visible (`visibility` is not `hidden`; `display` is not
+   `none`).
+3. The element is not inside a closed `<details>` element.
+4. The element is not already the active element (avoid a no-op refocus).
+5. The element can receive focus (tabbable or has explicit `tabindex`).
+6. The element has layout (`offsetParent !== null`).
+
+Each predicate above corresponds to a single `PlatformEffects::can_restore_focus`
+call — adapters typically implement the entire check list inside that one
+method. If the saved target fails any check, the adapter applies the fallback
+chain documented in §7.
+
+#### 1.6.2 Orientation-Change Focus Audit (adapter contract)
+
+When viewport orientation changes (portrait ↔ landscape on mobile), CSS media
+queries can hide or show elements without removing them from the DOM. If the
+currently focused element is hidden by `display: none` after the change, it
+still has focus but `offsetParent` becomes `null`. The agnostic core does not
+observe orientation events — adapters that need this behavior MUST register a
+`matchMedia('(orientation: portrait)')` change listener that:
+
+1. Reads the currently focused element via
+   `PlatformEffects::active_element_id`.
+2. If the focused element lacks layout (per the §1.6.1 check list), emits a
+   fresh `Event::FocusFirst` to move focus to the first visible tabbable in
+   the scope.
+3. If `service.context().saved_focus` references an element that lacks layout
+   after the change, the adapter may inform the consumer that the restore
+   target is no longer valid — the core's fallback chain (§7) handles the
+   actual recovery on the next `Effect::RestoreFocus` dispatch.
 
 ### 1.7 Connect / API
 
@@ -415,42 +452,72 @@ pub struct Api<'a> {
     send: &'a dyn Fn(Event),
 }
 
-impl<'a> Api<'a> {
+/// `Api` carries a closure-typed `send` field, so a manual `Debug` impl is
+/// required to satisfy the workspace's `missing_debug_implementations` lint
+/// without leaking the closure's address.
+impl Debug for Api<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("focus_scope::Api")
+            .field("state", self.state)
+            .field("ctx", self.ctx)
+            .field("props", self.props)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Api<'_> {
+    /// Returns the current [`State`] of the focus scope.
+    #[must_use]
+    pub const fn state(&self) -> &State { self.state }
+
+    /// Returns the current [`Context`] of the focus scope.
+    #[must_use]
+    pub const fn context(&self) -> &Context { self.ctx }
+
+    /// Returns the [`Props`] used by the focus scope.
+    #[must_use]
+    pub const fn props(&self) -> &Props { self.props }
+
     /// Whether the focus scope is active.
-    pub fn is_active(&self) -> bool {
+    #[must_use]
+    pub const fn is_active(&self) -> bool {
         matches!(self.state, State::Active { .. })
     }
 
     /// Whether the focus scope is trapped.
-    pub fn is_trapped(&self) -> bool {
+    #[must_use]
+    pub const fn is_trapped(&self) -> bool {
         matches!(self.state, State::Active { trapped: true })
     }
 
-    /// Props for the container element that scopes focus.
+    /// Attributes for the container element that scopes focus.
+    ///
+    /// Always emits `data-ars-scope="focus-scope"` and
+    /// `data-ars-part="container"`. When active, adds `data-ars-active`
+    /// and `tabindex="-1"` so the container can be a programmatic focus
+    /// target when no tabbable children exist yet. When trapped, adds
+    /// `data-ars-trapped`.
+    #[must_use]
     pub fn container_attrs(&self) -> AttrMap {
         let mut attrs = AttrMap::new();
         let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Container.data_attrs();
-        attrs.set(scope_attr, scope_val);
-        attrs.set(part_attr, part_val);
+        attrs.set(scope_attr, scope_val).set(part_attr, part_val);
         if self.is_active() {
-            attrs.set_bool(HtmlAttr::Data("ars-active"), true);
-
-            // tabindex="-1" allows the container itself to be focused programmatically,
-            // which is needed as a focus target when no tabbable children exist yet.
-            // Only set when active — an inactive scope's container should not appear
-            // as a programmatic focus target to screen readers.
-            attrs.set(HtmlAttr::TabIndex, "-1");
+            attrs
+                .set_bool(HtmlAttr::Data("ars-active"), true)
+                .set(HtmlAttr::TabIndex, "-1");
         }
         if self.is_trapped() {
             attrs.set_bool(HtmlAttr::Data("ars-trapped"), true);
         }
-        // Event handlers (keydown for Tab trapping) are typed methods on the Api struct.
         attrs
     }
 
     /// Imperatively activate the focus scope.
-    /// `saved_focus_id` is the ID of the currently focused element, captured by
-    /// the adapter via `platform.active_element_id()` before calling this.
+    ///
+    /// `saved_focus_id` is the ID of the currently focused element,
+    /// captured by the adapter via `PlatformEffects::active_element_id`
+    /// before calling this.
     pub fn activate(&self, trapped: bool, saved_focus_id: Option<String>) {
         (self.send)(Event::Activate { trapped, saved_focus_id });
     }
@@ -460,46 +527,19 @@ impl<'a> Api<'a> {
         (self.send)(Event::Deactivate { restore_focus });
     }
 
-    /// Move focus to the first tabbable element within the container.
-    /// Used by framework adapters when auto_focus=true.
+    /// Request that focus move to the first tabbable descendant of the
+    /// container. Sends [`Event::FocusFirst`]; the agnostic core then emits
+    /// [`Effect::FocusFirst`] which the adapter routes through
+    /// `PlatformEffects::focus_first_tabbable`. Used by framework adapters
+    /// when `auto_focus=true`.
     pub fn focus_first(&self) {
-        let platform = use_platform_effects();
-        if let Some(ref id) = self.ctx.container_id {
-            platform.focus_first_tabbable(id);
-        }
+        (self.send)(Event::FocusFirst);
     }
 
-    /// Move focus to the last tabbable element within the container.
+    /// Request that focus move to the last tabbable descendant of the
+    /// container. Sends [`Event::FocusLast`].
     pub fn focus_last(&self) {
-        let platform = use_platform_effects();
-        if let Some(ref id) = self.ctx.container_id {
-            platform.focus_last_tabbable(id);
-        }
-    }
-
-    /// Return IDs of all currently tabbable elements in the container.
-    pub fn get_tabbable_elements(&self) -> Vec<String> {
-        let platform = use_platform_effects();
-        self.ctx.container_id
-            .as_ref()
-            .map(|id| platform.tabbable_element_ids(id))
-            .unwrap_or_default()
-    }
-
-    /// Move focus to the next focusable element within the scope.
-    /// Returns `true` if focus was moved, `false` if no valid target exists.
-    /// Used by Toolbar, ActionGroup, and TreeView for programmatic sequential
-    /// focus movement beyond roving tabindex.
-    pub fn focus_next(&self, _opts: FocusNavigationOptions) -> bool {
-        // IMPL: traverse tabbable elements forward within scope
-        false
-    }
-
-    /// Move focus to the previous focusable element within the scope.
-    /// Returns `true` if focus was moved, `false` if no valid target exists.
-    pub fn focus_previous(&self, _opts: FocusNavigationOptions) -> bool {
-        // IMPL: traverse tabbable elements backward within scope
-        false
+        (self.send)(Event::FocusLast);
     }
 }
 
@@ -513,24 +553,55 @@ impl ConnectApi for Api<'_> {
     }
 }
 
-/// Options for focus navigation.
-#[derive(Clone)]
-pub struct FocusNavigationOptions {
-    /// Wrap around at boundaries.
-    pub wrap: bool,
-    /// Element ID to start from (default: currently focused element).
-    pub from: Option<String>,
-    /// Only consider tabbable elements (tabindex >= 0).
-    pub tabbable: bool,
-    /// Custom filter predicate that receives an element ID.
-    /// Uses `Rc` so the options struct can be cloned.
-    pub accept: Option<Rc<dyn Fn(&str) -> bool>>,
-}
 ```
+
+**Programmatic sequential navigation lives in the adapter layer, not the
+core.** `focus_next` / `focus_previous` and any `FocusNavigationOptions`-style
+config struct would require synchronous DOM lookups (tabbable filtering,
+`activeElement`, `accept` predicate evaluation against live element handles)
+that the agnostic core cannot perform — the issue's "Element/ref handling
+note" explicitly forbids ID-only or DOM-bound APIs at this layer. Adapters
+that need this behavior (consumed by `Toolbar`, `ActionGroup`, `TreeView`,
+nested `FocusScope`s) expose it on their own API surface and publish a
+`FocusManager` context as described in §1.7 _Focus Manager Context_ below;
+the agnostic core only emits `Event::FocusFirst` / `Event::FocusLast` for the
+two end-of-list targets it can describe as effect intents.
+
+### 1.8 Effect Contract
+
+Adapters MUST provide a handler for every [`Effect`] variant. Each handler
+receives `&Context`, `&Props`, and a `WeakSend<Event>` send handle, and is
+expected to call into the workspace's `PlatformEffects` implementation
+(see `spec/foundation/01-architecture.md` §2.2.7 and
+`spec/foundation/11-dom-utilities.md` §3) rather than the DOM directly.
+
+| Effect              | When emitted                                                                                                   | Adapter contract                                                                                                                                                                                                                                                                                  |
+| ------------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `FocusTrapListener` | `Inactive → Active` (Activate)                                                                                 | Call `PlatformEffects::attach_focus_trap(container_id, on_escape)`. Wire the returned `CleanupFn` as the effect's cleanup so `cancel_effect(Effect::FocusTrapListener)` tears the handler down on `Deactivate`. The `on_escape` callback SHOULD send `Event::Deactivate { restore_focus: true }`. |
+| `FocusFirst`        | `Active + FocusFirst` (also on `Activate` when `props.auto_focus`)                                             | Call `PlatformEffects::focus_first_tabbable(container_id)`. Fall back to focusing the container element (which has `tabindex="-1"` while active) when no tabbable descendants exist.                                                                                                              |
+| `FocusLast`         | `Active + FocusLast`                                                                                           | Call `PlatformEffects::focus_last_tabbable(container_id)`. Fall back to the container when no tabbable descendants exist.                                                                                                                                                                         |
+| `RestoreFocus`      | `Active → Inactive` (Deactivate with `restore_focus: true`) or explicit `Event::RestoreFocus` while `Inactive` | Read `service.context().saved_focus`. If `Some(id)`, apply the §1.6.1 / §7 fallback chain via `PlatformEffects::can_restore_focus` → `focus_element_by_id` → `nearest_focusable_ancestor_id` → `focus_body`. The core does not clear `saved_focus` here; the next `Activate` overwrites it.       |
 
 #### Focus Manager Context
 
-The adapter SHOULD provide the FocusScope's navigation methods (`focus_next`, `focus_previous`, `focus_first`, `focus_last`) via framework context, allowing child components to programmatically manage focus without prop drilling. In Leptos: `provide_context(FocusManager { ... })`. In Dioxus: `use_context_provider(|| FocusManager { ... })`. This mirrors React Aria's `useFocusManager()` hook pattern.
+The adapter SHOULD publish a `FocusManager` context so child components can
+programmatically manage focus without prop drilling, mirroring React Aria's
+`useFocusManager()` hook pattern. The expected handles are:
+
+- `focus_first` / `focus_last` — thin wrappers that call
+  [`Api::focus_first`] / [`Api::focus_last`], so the underlying transition
+  still flows through the agnostic core's `Effect::FocusFirst` /
+  `Effect::FocusLast` markers.
+- `focus_next` / `focus_previous` — **adapter-owned**; these resolve live
+  tabbable element handles via `PlatformEffects::tabbable_element_ids`,
+  `active_element_id`, and `focus_element_by_id`, plus any adapter-defined
+  `FocusNavigationOptions` (wrap, accept predicate, starting element, etc.).
+  They are intentionally absent from the agnostic-core [`Api`] surface so
+  that the workspace's "no synchronous DOM lookups in the core" rule stays
+  enforced.
+
+Publication: `provide_context(FocusManager { ... })` in Leptos,
+`use_context_provider(|| FocusManager { ... })` in Dioxus.
 
 ## 2. Anatomy
 
@@ -753,14 +824,18 @@ fallback chain.
 
 ## 9. Platform Notes
 
-> **Dioxus focus operations:** Focus operations (`focus_first`, `focus_last`,
-> `restore_focus_safely`) use `PlatformEffects` trait methods (see `01-architecture.md`
-> section 2.2.7). For Dioxus Desktop/Mobile, the adapter provides a platform implementation
-> that routes these through native focus APIs for cross-platform compatibility.
+> **Dioxus focus operations:** Adapter-level focus operations (the
+> `Effect::FocusFirst`, `Effect::FocusLast`, `Effect::RestoreFocus` handlers,
+> the §1.6.1 safety chain, and the adapter-owned `focus_next` /
+> `focus_previous` from the `FocusManager` context) route through
+> `PlatformEffects` trait methods (see `spec/foundation/01-architecture.md`
+> §2.2.7 and `spec/foundation/11-dom-utilities.md` §3). For Dioxus
+> Desktop/Mobile, the adapter provides a platform implementation that
+> calls native focus APIs for cross-platform compatibility.
 >
-> **Cleanup timing:** Leptos uses `on_cleanup` and Dioxus uses `use_drop` for teardown.
-> In HMR/hot-reload scenarios, timing may differ — ensure the `FocusRestorationStack`
-> is cleared on both cleanup and re-mount.
+> **Cleanup timing:** Leptos uses `on_cleanup` and Dioxus uses `use_drop`
+> for teardown. In HMR/hot-reload scenarios, timing may differ — ensure
+> the `FocusRestorationStack` is cleared on both cleanup and re-mount.
 
 ## 10. Library Parity
 
@@ -786,19 +861,26 @@ fallback chain.
 
 ### 10.3 Features
 
-| Feature                  | ars-ui                              | React Aria              |
-| ------------------------ | ----------------------------------- | ----------------------- |
-| Focus trapping           | Yes                                 | Yes                     |
-| Focus restoration        | Yes                                 | Yes                     |
-| Auto-focus first element | Yes                                 | Yes                     |
-| FocusManager context     | Yes (`focus_next`/`focus_previous`) | Yes (`useFocusManager`) |
-| Nested scope stack       | Yes (`FocusRestorationStack`)       | Yes (internal)          |
-| Focus navigation options | Yes (`FocusNavigationOptions`)      | Yes (`wrap`, etc.)      |
+| Feature                  | ars-ui                                                                                      | React Aria              |
+| ------------------------ | ------------------------------------------------------------------------------------------- | ----------------------- |
+| Focus trapping           | Yes                                                                                         | Yes                     |
+| Focus restoration        | Yes                                                                                         | Yes                     |
+| Auto-focus first element | Yes                                                                                         | Yes                     |
+| FocusManager context     | Adapter-only (`focus_next` / `focus_previous` published via Leptos / Dioxus context — §1.7) | Yes (`useFocusManager`) |
+| Nested scope stack       | Yes (`FocusRestorationStack`)                                                               | Yes (internal)          |
+| Focus navigation options | Adapter-only (adapter defines its own option struct alongside `focus_next`)                 | Yes (`wrap`, etc.)      |
 
-**Gaps:** None.
+**Gaps:** None at the parity level. The two adapter-only rows above reflect a
+deliberate layering choice — see §1.7 for why programmatic sequential
+navigation lives in the adapter layer.
 
 ### 10.4 Summary
 
 - **Overall:** Full parity.
-- **Divergences:** ars-ui exposes both `trapped` and `contain` prop aliases. ars-ui explicitly defines `FocusRestorationStack` for nested scopes; React Aria handles this internally.
+- **Divergences:** ars-ui exposes both `trapped` and `contain` prop aliases.
+  ars-ui explicitly defines `FocusRestorationStack` for nested scopes; React
+  Aria handles this internally. Programmatic sequential focus navigation
+  (`focus_next` / `focus_previous` + a `FocusNavigationOptions`-style config
+  struct) lives in the adapter layer rather than on the agnostic-core `Api`,
+  so it can use live element handles instead of opaque ID strings.
 - **Recommended additions:** None.


### PR DESCRIPTION
## Summary

- Adds the framework-agnostic FocusScope state machine (`Inactive ↔ Active { trapped }`) at `crates/ars-components/src/utility/focus_scope/`. The machine emits typed `Effect::{FocusTrapListener, FocusFirst, FocusLast, RestoreFocus}` intents that adapters route through `PlatformEffects` — the core never touches the DOM or framework helpers.
- Resolves spec drift in `spec/components/utility/focus-scope.md`: §1.6 transitions now use named-effect markers instead of inline `use_platform_effects()` calls; §1.6.1 / §1.6.2 reframe focus-restoration safety and orientation-change audit as adapter contracts; §1.7 drops `focus_next` / `focus_previous` / `FocusNavigationOptions` / `AcceptFn` from the core API (synchronous DOM lookups now live in the adapter layer's `FocusManager` context, per the issue's "Element/ref handling note"); §1.8 adds the explicit Effect Contract table; §10 parity table marks the adapter-only carve-out.
- Note on the issue's wording: test 9 says `data-ars-focus-trapped` but spec §2 names the attribute `data-ars-trapped`. The spec is authoritative; `container_attrs_never_emits_data_ars_focus_trapped_typo` and `focus_scope_connect_api_emits_data_ars_trapped_not_focus_trapped` pin the spec-correct name as regression guards.

Closes #212.

## Test plan

- [x] `cargo nextest run -p ars-components focus_scope` — 50 / 50 pass (31 unit + connect-API, 4 snapshot, 3 proptest, 6 spec-conformance, plus 6 derived accessor / Debug)
- [x] `cargo insta test -p ars-components --all-features --unreferenced=reject` — no orphans
- [x] `cargo clippy --workspace --all-targets --exclude ars-i18n -- -D warnings` — clean
- [x] `cargo xtask spec validate` — 340 files validated
- [x] `cargo xtask ci spec-compile-snippets` — 2173 blocks parsed, no syntax findings
- [x] `cargo mutants -p ars-components -f crates/ars-components/src/utility/focus_scope/mod.rs` — 22 caught, 11 unviable, 0 missed
- [x] `cargo xci --profile fast` — all 10 fast gates green (fmt, check, clippy, unit, integration, adapter, spec-compile-snippets, error-variant-coverage, mutual-exclusion, snapshot-count)

🤖 Generated with [Claude Code](https://claude.com/claude-code)