### PR TITLE
fix(ci): remediate nightly mutation and pagination failures

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -63,6 +63,21 @@ exclude_re = [
   # cargo-mutants reports the kill as a timeout instead of a caught failure.
   'replace \+= with \*= in contains_byte',
 
+  # Highlight's overlapping-match scanner is killed only by nontermination
+  # when the start/search cursor arithmetic is changed to non-advancing forms.
+  # The existing overlapping-match tests detect these mutants via cargo-mutants
+  # timeout, so exclude the timeout-only spellings without hiding survivors.
+  'highlight/mod\.rs:\d+:\d+: replace \+ with \* in push_contains_matches',
+  'highlight/mod\.rs:\d+:\d+: replace \+ with [-*] in push_contains_matches',
+  # Equality at this merge boundary is equivalent: assigning the same end back
+  # into the last merged range does not change the resulting chunks.
+  'highlight/mod\.rs:\d+:\d+: replace > with >= in merge_ranges',
+
+  # `step_change_plan` rejects `target == current` before checking whether a
+  # forward move requires validation, so `target > current` and
+  # `target >= current` agree for every reachable call at this guard.
+  'steps/mod\.rs:\d+:\d+: replace > with >= in step_change_plan',
+
   # Toast manager auto-id resolver chain (`resolve_or_generate_id`,
   # `make_auto_id`, `auto_id_collides`, `push_decimal`). Each of these
   # mutants either freezes the id counter, pins the candidate to a constant,
@@ -202,6 +217,45 @@ exclude_re = [
   # nontermination on existing slash / percent / scheme-prefix inputs, but
   # cargo-mutants reports them as timeouts. Excluding the timeout-only form
   # keeps the Nightly matrix focused on surviving behavior changes.
+  'download_trigger/mod\.rs:\d+:\d+: replace \+= with \*= in http_https_authority_rest',
+  'download_trigger/mod\.rs:\d+:\d+: replace \+= with [-*]= in percent_decode_host',
+  'download_trigger/mod\.rs:\d+:\d+: replace \+= with \*= in contains_scheme_separator_before_delim',
+  'download_trigger/mod\.rs:\d+:\d+: replace \+= with \*= in starts_with_ignore_case',
+  # The bitwise replacements are equivalent because the high-nibble and
+  # low-nibble / IPv4 component bit ranges do not overlap.
+  'download_trigger/mod\.rs:\d+:\d+: replace \| with \^ in percent_decode_host',
+  'download_trigger/mod\.rs:\d+:\d+: replace \| with \^ in parse_ipv4_address_relaxed',
+  # Empty strings and colon-containing strings already fail the downstream
+  # IPv4 parsers, so weakening this early guard does not change the result.
+  'download_trigger/mod\.rs:\d+:\d+: replace \|\| with && in parse_ipv4_address_relaxed',
+  # Raw "0" parses to the same numeric value as decimal or octal; the branch is
+  # only there to select radix for multi-byte leading-zero components.
+  'download_trigger/mod\.rs:\d+:\d+: replace > with >= in parse_ipv4_component_value',
+  # Once the explicit slash branch is preserved, weakening the later relative
+  # prefixes (`?`, `#`, `./`, `../`) is equivalent because the final
+  # no-scheme fallback still classifies them as relative.
+  'download_trigger/mod\.rs:\d+:\d+: replace \|\| with && in is_relative_reference',
+  # If URL delimiters are not detected early, the same delimiter byte remains
+  # in the would-be scheme prefix and fails `scheme_prefix_bytes_valid`, so the
+  # final scheme-separator result is unchanged.
+  'download_trigger/mod\.rs:\d+:\d+: replace \|\| with && in contains_scheme_separator_before_delim',
+  # `mailto:` and `tel:` share the same NoDownloadHint result, so requiring
+  # both prefixes cannot change observable policy for either scheme.
+  'download_trigger/mod\.rs:\d+:\d+: replace \|\| with && in classify_href',
+  # Equality at the oversized-panel viewport clamp boundary chooses the same
+  # coordinate from both branches.
+  'floating_panel/mod\.rs:\d+:\d+: replace < with <= in clamp_position',
+  # West/north resize positions are recomputed from the original right/bottom
+  # edge after size clamping, so these provisional assignments are overwritten
+  # before the rectangle is returned.
+  'floating_panel/mod\.rs:(662|669|679|686|691|693):\d+: replace \+ with [-*] in resize_rect',
+  # `State::Minimized` with `ctx.open == false` is unreachable: every close
+  # sync/reset transition also targets `State::Idle`, so weakening this restore
+  # guard cannot affect a reachable machine state.
+  'floating_panel/mod\.rs:1126:\d+: replace match guard ctx\.open with true in <impl ars_core::Machine for Machine>::transition',
+  # `State::Maximized` with `ctx.open == false` is likewise unreachable because
+  # every close sync/reset clears maximized state and targets `State::Idle`.
+  'floating_panel/mod\.rs:1146:\d+: replace match guard ctx\.open with true in <impl ars_core::Machine for Machine>::transition',
   'download_trigger\.rs:\d+:\d+: replace \+= with \*= in http_https_authority_rest',
   'download_trigger\.rs:\d+:\d+: replace \+= with [-*]= in percent_decode_host',
   'download_trigger\.rs:\d+:\d+: replace \+= with [-*]= in contains_scheme_separator_before_delim',

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -101,69 +101,90 @@ jobs:
           - name: components-shard-1
             package: ars-components
             shard: "0/12"
+            features: "ars-components/i18n"
           - name: components-shard-2
             package: ars-components
             shard: "1/12"
+            features: "ars-components/i18n"
           - name: components-shard-3
             package: ars-components
             shard: "2/12"
+            features: "ars-components/i18n"
           - name: components-shard-4
             package: ars-components
             shard: "3/12"
+            features: "ars-components/i18n"
           - name: components-shard-5
             package: ars-components
             shard: "4/12"
+            features: "ars-components/i18n"
           - name: components-shard-6
             package: ars-components
             shard: "5/12"
+            features: "ars-components/i18n"
           - name: components-shard-7
             package: ars-components
             shard: "6/12"
+            features: "ars-components/i18n"
           - name: components-shard-8
             package: ars-components
             shard: "7/12"
+            features: "ars-components/i18n"
           - name: components-shard-9
             package: ars-components
             shard: "8/12"
+            features: "ars-components/i18n"
           - name: components-shard-10
             package: ars-components
             shard: "9/12"
+            features: "ars-components/i18n"
           - name: components-shard-11
             package: ars-components
             shard: "10/12"
+            features: "ars-components/i18n"
           - name: components-shard-12
             package: ars-components
             shard: "11/12"
+            features: "ars-components/i18n"
           # ─── ars-collections (≈ 1,080 mutants, sharded 4-way) ──
           - name: collections-shard-1
             package: ars-collections
             shard: "0/4"
+            features: ""
           - name: collections-shard-2
             package: ars-collections
             shard: "1/4"
+            features: ""
           - name: collections-shard-3
             package: ars-collections
             shard: "2/4"
+            features: ""
           - name: collections-shard-4
             package: ars-collections
             shard: "3/4"
+            features: ""
           # ─── ars-core (≈ 700 mutants, sharded 2-way) ───────────
           - name: core-shard-1
             package: ars-core
             shard: "0/2"
+            features: ""
           - name: core-shard-2
             package: ars-core
             shard: "1/2"
+            features: ""
           # ─── Single-job runs (small enough for one runner) ─────
           - name: a11y
             package: ars-a11y
             shard: ""
+            features: ""
           - name: forms
             package: ars-forms
             shard: ""
+            features: ""
           - name: interactions
             package: ars-interactions
             shard: ""
+            features: ""
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -193,15 +214,20 @@ jobs:
         env:
           PACKAGE: ${{ matrix.package }}
           SHARD: ${{ matrix.shard }}
+          FEATURES: ${{ matrix.features }}
         # `SHARD` is empty for single-job entries and `k/n` for sharded
         # entries; the conditional keeps both shapes in one job template.
         # Both env vars are quoted to defend against accidental whitespace
         # from matrix overrides.
         run: |
+          args=(-p "$PACKAGE" --output mutants.out)
+          if [ -n "$FEATURES" ]; then
+            args+=(--features "$FEATURES")
+          fi
           if [ -n "$SHARD" ]; then
-            cargo mutants -p "$PACKAGE" --shard "$SHARD" --output mutants.out
+            cargo mutants "${args[@]}" --shard "$SHARD"
           else
-            cargo mutants -p "$PACKAGE" --output mutants.out
+            cargo mutants "${args[@]}"
           fi
       # Always upload, even on success — surviving "missed" entries on a
       # passing run are valuable feedback for follow-up tightening.

--- a/crates/ars-components/src/input/pin_input/mod.rs
+++ b/crates/ars-components/src/input/pin_input/mod.rs
@@ -1526,6 +1526,15 @@ mod tests {
     }
 
     #[test]
+    fn pin_input_zero_length_never_reports_complete() {
+        let svc = service(props().length(0));
+
+        assert_eq!(svc.state(), &State::Idle);
+        assert!(!svc.context().complete);
+        assert!(svc.context().value.get().is_empty());
+    }
+
+    #[test]
     fn pin_input_private_helpers_cover_next_empty_and_output_props() {
         let values = string_vec(&["1", "", "3", ""]);
 
@@ -1800,6 +1809,23 @@ mod tests {
         assert_eq!(svc.context().focused_index, Some(1));
         assert_eq!(result.pending_effects.len(), 1);
         assert_eq!(result.pending_effects[0].name, Effect::FocusCell);
+    }
+
+    #[test]
+    fn pin_input_delete_char_on_first_empty_cell_is_noop() {
+        let mut svc = service(props());
+
+        drop(svc.send(Event::Focus {
+            index: 0,
+            is_keyboard: false,
+        }));
+
+        let before = svc.context().clone();
+        let result = svc.send(Event::DeleteChar { index: 0 });
+
+        assert!(result.pending_effects.is_empty());
+        assert_eq!(svc.context(), &before);
+        assert_eq!(svc.state(), &State::Focused { index: 0 });
     }
 
     #[test]
@@ -2087,6 +2113,19 @@ mod tests {
         drop(svc.set_props(props().uncontrolled()));
 
         assert!(!svc.context().value.is_controlled());
+    }
+
+    #[test]
+    fn pin_input_set_value_keeps_zero_length_incomplete() {
+        let mut svc = service(props().length(0).value(Vec::new()));
+
+        assert_eq!(svc.state(), &State::Idle);
+        assert!(!svc.context().complete);
+
+        drop(svc.set_props(props().length(0).value(Vec::new())));
+
+        assert_eq!(svc.state(), &State::Idle);
+        assert!(!svc.context().complete);
     }
 
     #[test]

--- a/crates/ars-components/src/navigation/pagination/mod.rs
+++ b/crates/ars-components/src/navigation/pagination/mod.rs
@@ -375,13 +375,10 @@ impl ars_core::Machine for Machine {
     ) -> (Self::State, Self::Context) {
         let page_count = Context::compute_page_count(props.total_items, props.page_size);
 
-        let raw_initial_page = props.page.unwrap_or(props.default_page);
-        let initial_page = clamp_page(raw_initial_page, page_count);
+        let initial_page = clamp_page(props.page.unwrap_or(props.default_page), page_count);
 
         let page = if props.page.is_some() {
-            let mut page = Bindable::controlled(raw_initial_page);
-            page.set(initial_page);
-            page
+            Bindable::controlled(initial_page)
         } else {
             Bindable::uncontrolled(initial_page)
         };
@@ -443,6 +440,10 @@ impl ars_core::Machine for Machine {
                     ctx.page_size = new_size;
                     ctx.page_count = new_count;
 
+                    if ctx.page.is_controlled() {
+                        ctx.page.sync_controlled(Some(target));
+                    }
+
                     ctx.page.set(target);
                 });
 
@@ -459,11 +460,9 @@ impl ars_core::Machine for Machine {
                 let boundary_count = props.boundary_count;
 
                 let new_count = Context::compute_page_count(total_items, page_size);
-                let controlled = props.page;
-                let target = controlled.map_or_else(
-                    || clamp_page(current, new_count),
-                    |page| clamp_page(page, new_count),
-                );
+                let controlled = props.page.map(|page| clamp_page(page, new_count));
+                let target = controlled
+                    .map_or_else(|| clamp_page(current, new_count), core::convert::identity);
 
                 Some(TransitionPlan::context_only(move |ctx: &mut Context| {
                     ctx.page_size = page_size;
@@ -1081,7 +1080,7 @@ mod tests {
         let service = service(props().page(20));
 
         assert_eq!(service.context().page_count, 10);
-        assert_eq!(*service.context().page.get(), 20);
+        assert_eq!(*service.context().page.get(), 10);
         assert_eq!(service.context().current_page(), 10);
 
         let api = service.connect(&|_| {});
@@ -1099,7 +1098,7 @@ mod tests {
         ));
 
         assert_eq!(service.context().page_count, 5);
-        assert_eq!(*service.context().page.get(), 10);
+        assert_eq!(*service.context().page.get(), 5);
         assert_eq!(service.context().current_page(), 5);
         assert_eq!(result.pending_effects.len(), 1);
         assert_eq!(result.pending_effects[0].name, Effect::PageChange);
@@ -1119,7 +1118,7 @@ mod tests {
         drop(service.send(Event::SyncProps));
 
         assert_eq!(service.context().page_count, 3);
-        assert_eq!(*service.context().page.get(), 8);
+        assert_eq!(*service.context().page.get(), 3);
         assert_eq!(service.context().current_page(), 3);
 
         let api = service.connect(&|_| {});
@@ -1174,7 +1173,7 @@ mod tests {
         }
 
         assert_eq!(service.context().page_count, 5);
-        assert_eq!(*service.context().page.get(), 10);
+        assert_eq!(*service.context().page.get(), 5);
         assert_eq!(service.context().current_page(), 5);
 
         let expand = service.send(Event::SetPageSize(

--- a/crates/ars-components/src/navigation/pagination/mod.rs
+++ b/crates/ars-components/src/navigation/pagination/mod.rs
@@ -313,11 +313,17 @@ impl Context {
         total_items.div_ceil(size).max(1)
     }
 
+    /// Returns the effective one-based page clamped to the current page count.
+    #[must_use]
+    pub fn current_page(&self) -> u32 {
+        clamp_page(*self.page.get(), self.page_count)
+    }
+
     /// Generates the visible one-based page range. `None` represents an ellipsis.
     #[must_use]
     pub fn page_range(&self) -> Vec<Option<u32>> {
         page_range(
-            *self.page.get(),
+            self.current_page(),
             self.page_count,
             self.sibling_count,
             self.boundary_count,
@@ -369,10 +375,13 @@ impl ars_core::Machine for Machine {
     ) -> (Self::State, Self::Context) {
         let page_count = Context::compute_page_count(props.total_items, props.page_size);
 
-        let initial_page = clamp_page(props.page.unwrap_or(props.default_page), page_count);
+        let raw_initial_page = props.page.unwrap_or(props.default_page);
+        let initial_page = clamp_page(raw_initial_page, page_count);
 
         let page = if props.page.is_some() {
-            Bindable::controlled(initial_page)
+            let mut page = Bindable::controlled(raw_initial_page);
+            page.set(initial_page);
+            page
         } else {
             Bindable::uncontrolled(initial_page)
         };
@@ -399,7 +408,7 @@ impl ars_core::Machine for Machine {
         ctx: &Self::Context,
         props: &Self::Props,
     ) -> Option<TransitionPlan<Self>> {
-        let current = *ctx.page.get();
+        let current = ctx.current_page();
 
         match event {
             Event::GoToPage(page) => {
@@ -426,16 +435,13 @@ impl ars_core::Machine for Machine {
                 let new_size = *page_size;
 
                 let new_count = Context::compute_page_count(ctx.total_items, new_size);
-                let target = clamp_page(current, new_count);
+                let raw_current = props.page.unwrap_or(*ctx.page.get());
+                let target = clamp_page(raw_current, new_count);
                 let emit = target != current;
 
                 let mut plan = TransitionPlan::context_only(move |ctx: &mut Context| {
                     ctx.page_size = new_size;
                     ctx.page_count = new_count;
-
-                    if ctx.page.is_controlled() {
-                        ctx.page.sync_controlled(Some(target));
-                    }
 
                     ctx.page.set(target);
                 });
@@ -453,8 +459,11 @@ impl ars_core::Machine for Machine {
                 let boundary_count = props.boundary_count;
 
                 let new_count = Context::compute_page_count(total_items, page_size);
-                let controlled = props.page.map(|page| clamp_page(page, new_count));
-                let target = controlled.unwrap_or_else(|| clamp_page(current, new_count));
+                let controlled = props.page;
+                let target = controlled.map_or_else(
+                    || clamp_page(current, new_count),
+                    |page| clamp_page(page, new_count),
+                );
 
                 Some(TransitionPlan::context_only(move |ctx: &mut Context| {
                     ctx.page_size = page_size;
@@ -527,7 +536,7 @@ impl Api<'_> {
     /// Returns the current one-based page.
     #[must_use]
     pub fn current_page(&self) -> u32 {
-        *self.ctx.page.get()
+        self.ctx.current_page()
     }
 
     /// Returns the total page count.
@@ -722,7 +731,7 @@ fn clamp_page(page: u32, page_count: u32) -> u32 {
 }
 
 fn page_change_plan(ctx: &Context, _props: &Props, target: u32) -> Option<TransitionPlan<Machine>> {
-    if target == *ctx.page.get() {
+    if target == ctx.current_page() {
         return None;
     }
 
@@ -1072,7 +1081,8 @@ mod tests {
         let service = service(props().page(20));
 
         assert_eq!(service.context().page_count, 10);
-        assert_eq!(*service.context().page.get(), 10);
+        assert_eq!(*service.context().page.get(), 20);
+        assert_eq!(service.context().current_page(), 10);
 
         let api = service.connect(&|_| {});
 
@@ -1089,7 +1099,8 @@ mod tests {
         ));
 
         assert_eq!(service.context().page_count, 5);
-        assert_eq!(*service.context().page.get(), 5);
+        assert_eq!(*service.context().page.get(), 10);
+        assert_eq!(service.context().current_page(), 5);
         assert_eq!(result.pending_effects.len(), 1);
         assert_eq!(result.pending_effects[0].name, Effect::PageChange);
 
@@ -1108,7 +1119,8 @@ mod tests {
         drop(service.send(Event::SyncProps));
 
         assert_eq!(service.context().page_count, 3);
-        assert_eq!(*service.context().page.get(), 3);
+        assert_eq!(*service.context().page.get(), 8);
+        assert_eq!(service.context().current_page(), 3);
 
         let api = service.connect(&|_| {});
 
@@ -1138,6 +1150,45 @@ mod tests {
         }
 
         assert_eq!(lock(&pages).as_slice(), &[5]);
+    }
+
+    #[test]
+    fn controlled_set_page_size_preserves_parent_page_for_later_expansion() {
+        let pages = Arc::new(Mutex::new(Vec::new()));
+        let pages_clone = Arc::clone(&pages);
+
+        let mut service = service(
+            props()
+                .page(10)
+                .on_page_change(move |page| lock(&pages_clone).push(page)),
+        );
+
+        let shrink = service.send(Event::SetPageSize(
+            NonZeroU32::new(20).expect("non-zero page size"),
+        ));
+
+        let send: StrongSend<Event> = Arc::new(|_| {});
+
+        for effect in shrink.pending_effects {
+            drop(effect.run(service.context(), service.props(), Arc::clone(&send)));
+        }
+
+        assert_eq!(service.context().page_count, 5);
+        assert_eq!(*service.context().page.get(), 10);
+        assert_eq!(service.context().current_page(), 5);
+
+        let expand = service.send(Event::SetPageSize(
+            NonZeroU32::new(10).expect("non-zero page size"),
+        ));
+
+        for effect in expand.pending_effects {
+            drop(effect.run(service.context(), service.props(), Arc::clone(&send)));
+        }
+
+        assert_eq!(service.context().page_count, 10);
+        assert_eq!(*service.context().page.get(), 10);
+        assert_eq!(service.context().current_page(), 10);
+        assert_eq!(lock(&pages).as_slice(), &[5, 10]);
     }
 
     #[test]

--- a/crates/ars-components/src/navigation/pagination/mod.rs
+++ b/crates/ars-components/src/navigation/pagination/mod.rs
@@ -432,6 +432,11 @@ impl ars_core::Machine for Machine {
                 let mut plan = TransitionPlan::context_only(move |ctx: &mut Context| {
                     ctx.page_size = new_size;
                     ctx.page_count = new_count;
+
+                    if ctx.page.is_controlled() {
+                        ctx.page.sync_controlled(Some(target));
+                    }
+
                     ctx.page.set(target);
                 });
 
@@ -1063,7 +1068,20 @@ mod tests {
     }
 
     #[test]
-    fn controlled_set_page_size_preserves_controlled_page_until_sync() {
+    fn controlled_initial_page_is_clamped_to_page_count() {
+        let service = service(props().page(20));
+
+        assert_eq!(service.context().page_count, 10);
+        assert_eq!(*service.context().page.get(), 10);
+
+        let api = service.connect(&|_| {});
+
+        assert_eq!(api.current_page(), 10);
+        assert!(api.is_last_page());
+    }
+
+    #[test]
+    fn controlled_set_page_size_clamps_visible_page_when_page_count_shrinks() {
         let mut service = service(props().page(10));
 
         let result = service.send(Event::SetPageSize(
@@ -1071,9 +1089,55 @@ mod tests {
         ));
 
         assert_eq!(service.context().page_count, 5);
-        assert_eq!(*service.context().page.get(), 10);
+        assert_eq!(*service.context().page.get(), 5);
         assert_eq!(result.pending_effects.len(), 1);
         assert_eq!(result.pending_effects[0].name, Effect::PageChange);
+
+        let api = service.connect(&|_| {});
+
+        assert_eq!(api.current_page(), 5);
+        assert!(api.is_last_page());
+    }
+
+    #[test]
+    fn sync_props_clamps_controlled_page_to_new_page_count() {
+        let mut service = service(props().page(4));
+
+        service.set_props(props().page(8).total_items(25));
+
+        drop(service.send(Event::SyncProps));
+
+        assert_eq!(service.context().page_count, 3);
+        assert_eq!(*service.context().page.get(), 3);
+
+        let api = service.connect(&|_| {});
+
+        assert_eq!(api.current_page(), 3);
+        assert!(api.is_last_page());
+    }
+
+    #[test]
+    fn controlled_page_change_callback_keeps_requested_target_after_clamped_size_change() {
+        let pages = Arc::new(Mutex::new(Vec::new()));
+        let pages_clone = Arc::clone(&pages);
+
+        let mut service = service(
+            props()
+                .page(10)
+                .on_page_change(move |page| lock(&pages_clone).push(page)),
+        );
+
+        let result = service.send(Event::SetPageSize(
+            NonZeroU32::new(20).expect("non-zero page size"),
+        ));
+
+        let send: StrongSend<Event> = Arc::new(|_| {});
+
+        for effect in result.pending_effects {
+            drop(effect.run(service.context(), service.props(), Arc::clone(&send)));
+        }
+
+        assert_eq!(lock(&pages).as_slice(), &[5]);
     }
 
     #[test]

--- a/crates/ars-components/src/navigation/steps/mod.rs
+++ b/crates/ars-components/src/navigation/steps/mod.rs
@@ -1047,6 +1047,17 @@ mod tests {
     }
 
     #[test]
+    fn api_reports_last_step_only_at_or_beyond_final_index() {
+        let first = service(props().default_step(0));
+        let middle = service(props().default_step(2));
+        let last = service(props().default_step(3));
+
+        assert!(!first.connect(&|_| {}).is_last_step());
+        assert!(!middle.connect(&|_| {}).is_last_step());
+        assert!(last.connect(&|_| {}).is_last_step());
+    }
+
+    #[test]
     fn next_prev_and_direct_navigation_update_statuses() {
         let mut service = service(props().default_step(0));
 
@@ -1280,6 +1291,17 @@ mod tests {
 
         assert!(!result.context_changed);
         assert_eq!(*service.context().step.get(), 0);
+    }
+
+    #[test]
+    fn validation_blocks_completion_from_last_step() {
+        let mut service = service(props().default_step(3).is_step_valid(|_| false));
+
+        let result = service.send(Event::NextStep);
+
+        assert!(!result.context_changed);
+        assert!(result.pending_effects.is_empty());
+        assert_eq!(*service.context().step.get(), 3);
     }
 
     #[test]

--- a/crates/ars-components/src/overlay/floating_panel/mod.rs
+++ b/crates/ars-components/src/overlay/floating_panel/mod.rs
@@ -1879,6 +1879,134 @@ mod tests {
     }
 
     #[test]
+    fn resize_rect_covers_every_handle_and_aspect_ratio_axis() {
+        let props = Props {
+            min_size: (10.0, 10.0),
+            max_size: (1_000.0, 1_000.0),
+            initial_size: (400.0, 200.0),
+            lock_aspect_ratio: false,
+            ..test_props()
+        };
+
+        assert_eq!(
+            resize_rect(
+                (100.0, 100.0),
+                (400.0, 300.0),
+                ResizeHandle::E,
+                20.0,
+                7.0,
+                &props
+            ),
+            ((100.0, 100.0), (420.0, 300.0))
+        );
+        assert_eq!(
+            resize_rect(
+                (100.0, 100.0),
+                (400.0, 300.0),
+                ResizeHandle::W,
+                20.0,
+                7.0,
+                &props
+            ),
+            ((120.0, 100.0), (380.0, 300.0))
+        );
+        assert_eq!(
+            resize_rect(
+                (100.0, 100.0),
+                (400.0, 300.0),
+                ResizeHandle::S,
+                20.0,
+                7.0,
+                &props
+            ),
+            ((100.0, 100.0), (400.0, 307.0))
+        );
+        assert_eq!(
+            resize_rect(
+                (100.0, 100.0),
+                (400.0, 300.0),
+                ResizeHandle::N,
+                20.0,
+                7.0,
+                &props
+            ),
+            ((100.0, 107.0), (400.0, 293.0))
+        );
+        assert_eq!(
+            resize_rect(
+                (100.0, 100.0),
+                (400.0, 300.0),
+                ResizeHandle::SE,
+                20.0,
+                7.0,
+                &props
+            ),
+            ((100.0, 100.0), (420.0, 307.0))
+        );
+        assert_eq!(
+            resize_rect(
+                (100.0, 100.0),
+                (400.0, 300.0),
+                ResizeHandle::SW,
+                20.0,
+                7.0,
+                &props
+            ),
+            ((120.0, 100.0), (380.0, 307.0))
+        );
+        assert_eq!(
+            resize_rect(
+                (100.0, 100.0),
+                (400.0, 300.0),
+                ResizeHandle::NE,
+                20.0,
+                7.0,
+                &props
+            ),
+            ((100.0, 107.0), (420.0, 293.0))
+        );
+        assert_eq!(
+            resize_rect(
+                (100.0, 100.0),
+                (400.0, 300.0),
+                ResizeHandle::NW,
+                20.0,
+                7.0,
+                &props
+            ),
+            ((120.0, 107.0), (380.0, 293.0))
+        );
+
+        let aspect = Props {
+            lock_aspect_ratio: true,
+            ..props
+        };
+
+        assert_eq!(
+            resize_rect(
+                (0.0, 0.0),
+                (400.0, 200.0),
+                ResizeHandle::E,
+                100.0,
+                0.0,
+                &aspect
+            ),
+            ((0.0, 0.0), (500.0, 250.0))
+        );
+        assert_eq!(
+            resize_rect(
+                (0.0, 0.0),
+                (400.0, 200.0),
+                ResizeHandle::N,
+                0.0,
+                -50.0,
+                &aspect
+            ),
+            ((0.0, -50.0), (500.0, 250.0))
+        );
+    }
+
+    #[test]
     fn minimize_maximize_restore_and_close_track_stage() {
         let mut service =
             Service::<Machine>::new(test_props(), &Env::default(), &Messages::default());
@@ -2020,6 +2148,23 @@ mod tests {
         assert_eq!(service.context(), &before);
         assert!(!escape.state_changed);
         assert!(effect_names(&escape).is_empty());
+
+        let mut escape_disabled = Service::<Machine>::new(
+            Props {
+                close_on_escape: false,
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages::default(),
+        );
+
+        let before = escape_disabled.context().clone();
+
+        let escape = escape_disabled.send(Event::CloseOnEscape);
+
+        assert_eq!(escape_disabled.context(), &before);
+        assert!(!escape.state_changed);
+        assert!(effect_names(&escape).is_empty());
     }
 
     #[test]
@@ -2116,6 +2261,35 @@ mod tests {
     }
 
     #[test]
+    fn controlled_close_from_active_resize_returns_to_idle_without_closing() {
+        let mut service = Service::<Machine>::new(
+            Props {
+                open: Some(true),
+                close_on_escape: true,
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages::default(),
+        );
+
+        drop(service.send(Event::ResizeStart(ResizeHandle::SE)));
+
+        assert_eq!(
+            service.state(),
+            &State::Resizing {
+                handle: ResizeHandle::SE
+            }
+        );
+
+        let close = service.send(Event::CloseOnEscape);
+
+        assert_eq!(service.state(), &State::Idle);
+        assert!(service.context().open);
+        assert!(service.context().active_resize_handle.is_none());
+        assert_eq!(effect_names(&close), vec![Effect::OpenChange]);
+    }
+
+    #[test]
     fn maximize_from_minimized_uses_supplied_viewport_metrics() {
         let mut service =
             Service::<Machine>::new(test_props(), &Env::default(), &Messages::default());
@@ -2196,6 +2370,90 @@ mod tests {
         assert_eq!(service.context(), &before);
         assert!(!focus.state_changed);
         assert!(effect_names(&focus).is_empty());
+    }
+
+    #[test]
+    fn closed_or_disabled_stage_and_resize_events_are_ignored() {
+        let mut closed = Service::<Machine>::new(
+            Props {
+                default_open: false,
+                close_on_escape: false,
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages::default(),
+        );
+
+        assert!(
+            !closed
+                .send(Event::ResizeStart(ResizeHandle::SE))
+                .state_changed
+        );
+        assert!(!closed.send(Event::Minimize).state_changed);
+        assert!(
+            !closed
+                .send(Event::Maximize(MaximizeMetrics {
+                    viewport: ViewportRect {
+                        x: 0.0,
+                        y: 0.0,
+                        width: 800.0,
+                        height: 600.0,
+                    },
+                }))
+                .state_changed
+        );
+        assert!(!closed.send(Event::CloseOnEscape).state_changed);
+
+        let mut locked = Service::<Machine>::new(
+            Props {
+                resizable: false,
+                minimizable: false,
+                maximizable: false,
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages::default(),
+        );
+
+        assert!(
+            !locked
+                .send(Event::ResizeStart(ResizeHandle::SE))
+                .state_changed
+        );
+        assert!(!locked.send(Event::Minimize).state_changed);
+        assert!(
+            !locked
+                .send(Event::Maximize(MaximizeMetrics {
+                    viewport: ViewportRect {
+                        x: 0.0,
+                        y: 0.0,
+                        width: 800.0,
+                        height: 600.0,
+                    },
+                }))
+                .state_changed
+        );
+
+        let mut maximized = Service::<Machine>::new(
+            Props {
+                minimizable: false,
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages::default(),
+        );
+
+        drop(maximized.send(Event::Maximize(MaximizeMetrics {
+            viewport: ViewportRect {
+                x: 0.0,
+                y: 0.0,
+                width: 800.0,
+                height: 600.0,
+            },
+        })));
+
+        assert_eq!(maximized.state(), &State::Maximized);
+        assert!(!maximized.send(Event::Minimize).state_changed);
     }
 
     #[test]
@@ -2377,6 +2635,106 @@ mod tests {
         });
 
         assert!(sync.context_changed);
+    }
+
+    #[test]
+    fn viewport_clamp_preserves_edge_boundaries() {
+        let props = Props {
+            allow_overflow: false,
+            constrain_to_viewport: true,
+            viewport: ViewportRect {
+                x: 10.0,
+                y: 20.0,
+                width: 300.0,
+                height: 200.0,
+            },
+            ..test_props()
+        };
+
+        assert_eq!(
+            clamp_position((110.0, 70.0), (200.0, 150.0), &props),
+            (110.0, 70.0)
+        );
+        assert_eq!(
+            clamp_position((111.0, 71.0), (200.0, 150.0), &props),
+            (110.0, 70.0)
+        );
+        assert_eq!(
+            clamp_position((9.0, 19.0), (200.0, 150.0), &props),
+            (10.0, 20.0)
+        );
+    }
+
+    #[test]
+    fn props_changed_covers_every_sync_field() {
+        let base = test_props();
+
+        assert!(!props_changed(&base, &base));
+
+        let mut changed = base.clone();
+
+        changed.min_size = (201.0, 151.0);
+
+        assert!(props_changed(&base, &changed));
+
+        let mut changed = base.clone();
+
+        changed.max_size = (999.0, 799.0);
+
+        assert!(props_changed(&base, &changed));
+
+        let mut changed = base.clone();
+
+        changed.viewport = ViewportRect {
+            x: 0.0,
+            y: 0.0,
+            width: 640.0,
+            height: 480.0,
+        };
+
+        assert!(props_changed(&base, &changed));
+
+        let mut changed = base.clone();
+
+        changed.draggable = !base.draggable;
+
+        assert!(props_changed(&base, &changed));
+
+        let mut changed = base.clone();
+
+        changed.resizable = !base.resizable;
+
+        assert!(props_changed(&base, &changed));
+
+        let mut changed = base.clone();
+
+        changed.modal = !base.modal;
+
+        assert!(props_changed(&base, &changed));
+
+        let mut changed = base.clone();
+
+        changed.constrain_to_viewport = !base.constrain_to_viewport;
+
+        assert!(props_changed(&base, &changed));
+
+        let mut changed = base.clone();
+
+        changed.close_on_escape = !base.close_on_escape;
+
+        assert!(props_changed(&base, &changed));
+
+        let mut changed = base.clone();
+
+        changed.allow_overflow = !base.allow_overflow;
+
+        assert!(props_changed(&base, &changed));
+
+        let mut changed = base.clone();
+
+        changed.grid_size += 1.0;
+
+        assert!(props_changed(&base, &changed));
     }
 
     #[test]
@@ -2733,6 +3091,52 @@ mod tests {
     }
 
     #[test]
+    fn stage_trigger_restores_from_non_default_stages() {
+        let mut minimized =
+            Service::<Machine>::new(test_props(), &Env::default(), &Messages::default());
+
+        drop(minimized.send(Event::Minimize));
+
+        let minimized_events = RefCell::new(Vec::new());
+        let send = |event| minimized_events.borrow_mut().push(event);
+
+        minimized.connect(&send).on_stage_trigger_click();
+
+        assert_eq!(minimized_events.into_inner(), vec![Event::Restore]);
+
+        let mut maximized =
+            Service::<Machine>::new(test_props(), &Env::default(), &Messages::default());
+
+        drop(maximized.send(Event::Maximize(MaximizeMetrics {
+            viewport: ViewportRect {
+                x: 0.0,
+                y: 0.0,
+                width: 800.0,
+                height: 600.0,
+            },
+        })));
+
+        let maximized_events = RefCell::new(Vec::new());
+        let send = |event| maximized_events.borrow_mut().push(event);
+
+        maximized.connect(&send).on_stage_trigger_click();
+
+        assert_eq!(maximized_events.into_inner(), vec![Event::Restore]);
+    }
+
+    #[test]
+    fn bring_to_front_allocates_z_index_without_state_change() {
+        let mut service =
+            Service::<Machine>::new(test_props(), &Env::default(), &Messages::default());
+
+        let result = service.send(Event::BringToFront);
+
+        assert_eq!(service.state(), &State::Idle);
+        assert!(!result.state_changed);
+        assert_eq!(effect_names(&result), vec![Effect::AllocateZIndex]);
+    }
+
+    #[test]
     fn locked_aspect_ratio_resize_stays_within_constraints() {
         let mut service = Service::<Machine>::new(
             Props {
@@ -2769,6 +3173,7 @@ mod tests {
         let api = service.connect(&send);
 
         assert!(api.on_keydown(&shifted_keyboard_data(KeyboardKey::ArrowRight)));
+        assert!(api.on_keydown(&keyboard_data(KeyboardKey::ArrowLeft)));
         assert!(api.on_keydown(&keyboard_data(KeyboardKey::ArrowUp)));
         assert!(!api.on_keydown(&keyboard_data(KeyboardKey::Tab)));
 
@@ -2776,6 +3181,7 @@ mod tests {
             sent.into_inner(),
             vec![
                 Event::KeyboardMove { dx: 10.0, dy: 0.0 },
+                Event::KeyboardMove { dx: -1.0, dy: 0.0 },
                 Event::KeyboardMove { dx: 0.0, dy: -1.0 }
             ]
         );
@@ -2935,6 +3341,100 @@ mod tests {
         assert_eq!(
             resize.get(&HtmlAttr::Aria(AriaAttr::Label)),
             Some("Resize bottom-right")
+        );
+    }
+
+    #[test]
+    fn api_getters_and_part_attrs_reflect_context() {
+        let mut service = Service::<Machine>::new(
+            Props {
+                initial_position: (33.0, 44.0),
+                initial_size: (222.0, 111.0),
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages::default(),
+        );
+
+        let api = service.connect(&|_| {});
+
+        assert!(api.is_open());
+        assert!(!api.is_minimized());
+        assert!(!api.is_maximized());
+        assert_eq!(api.position(), (33.0, 44.0));
+        assert_eq!(api.size(), (222.0, 111.0));
+        assert_eq!(
+            api.part_attrs(Part::ResizeHandle {
+                handle: ResizeHandle::W
+            })
+            .get(&HtmlAttr::Data("ars-handle")),
+            Some("w")
+        );
+
+        drop(service.send(Event::Minimize));
+
+        let minimized = service.connect(&|_| {});
+
+        assert!(minimized.is_minimized());
+        assert!(!minimized.is_maximized());
+        assert_eq!(minimized.stage(), Stage::Minimized);
+
+        drop(service.send(Event::Restore));
+        drop(service.send(Event::Maximize(MaximizeMetrics {
+            viewport: ViewportRect {
+                x: 0.0,
+                y: 0.0,
+                width: 800.0,
+                height: 600.0,
+            },
+        })));
+
+        assert!(service.connect(&|_| {}).is_maximized());
+
+        drop(service.send(Event::Close));
+
+        assert!(!service.connect(&|_| {}).is_open());
+    }
+
+    #[test]
+    fn resize_handle_cursor_requires_resizable_non_maximized_panel() {
+        let disabled = Service::<Machine>::new(
+            Props {
+                resizable: false,
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages::default(),
+        );
+
+        assert!(
+            !disabled
+                .connect(&|_| {})
+                .resize_handle_attrs(ResizeHandle::E)
+                .styles()
+                .iter()
+                .any(|(property, _)| *property == CssProperty::Cursor)
+        );
+
+        let mut maximized =
+            Service::<Machine>::new(test_props(), &Env::default(), &Messages::default());
+
+        drop(maximized.send(Event::Maximize(MaximizeMetrics {
+            viewport: ViewportRect {
+                x: 0.0,
+                y: 0.0,
+                width: 800.0,
+                height: 600.0,
+            },
+        })));
+
+        assert!(
+            !maximized
+                .connect(&|_| {})
+                .resize_handle_attrs(ResizeHandle::E)
+                .styles()
+                .iter()
+                .any(|(property, _)| *property == CssProperty::Cursor)
         );
     }
 

--- a/crates/ars-components/src/overlay/hover_card/mod.rs
+++ b/crates/ars-components/src/overlay/hover_card/mod.rs
@@ -2016,6 +2016,7 @@ mod tests {
         let second_mount = service.send(Event::TitleMount);
 
         assert!(!second_mount.state_changed);
+        assert!(!second_mount.context_changed);
         assert!(service.context().has_title);
 
         drop(service.send(Event::TitleUnmount));
@@ -2023,6 +2024,7 @@ mod tests {
         let second_unmount = service.send(Event::TitleUnmount);
 
         assert!(!second_unmount.state_changed);
+        assert!(!second_unmount.context_changed);
         assert!(!service.context().has_title);
     }
 

--- a/crates/ars-components/src/utility/download_trigger/mod.rs
+++ b/crates/ars-components/src/utility/download_trigger/mod.rs
@@ -1679,6 +1679,10 @@ mod tests {
     #[test]
     fn relative_reference_scheme_scan_stops_at_url_delimiters() {
         assert!(contains_scheme_separator_before_delim(b"web+app.1:path"));
+        assert!(contains_scheme_separator_before_delim(b"a:path"));
+        assert!(contains_scheme_separator_before_delim(b"a+b:path"));
+        assert!(contains_scheme_separator_before_delim(b"a-b:path"));
+        assert!(contains_scheme_separator_before_delim(b"a.b:path"));
         assert!(!contains_scheme_separator_before_delim(b"/x:y"));
         assert!(!contains_scheme_separator_before_delim(b"?x:y"));
         assert!(!contains_scheme_separator_before_delim(b"#x:y"));
@@ -1690,6 +1694,7 @@ mod tests {
             b"not a scheme:path"
         ));
 
+        assert!(!is_relative_reference(""));
         assert!(is_relative_reference("./a:b"));
         assert!(is_relative_reference("../a:b"));
         assert!(is_relative_reference("/a:b"));
@@ -1723,6 +1728,8 @@ mod tests {
         assert_eq!(hex_value(b'g'), None);
 
         assert_eq!(percent_decode_host("exa%6Dple.com").as_ref(), "example.com");
+        assert_eq!(percent_decode_host("a%2Fb").as_ref(), "a/b");
+        assert_eq!(percent_decode_host("a%00b").as_ref(), "a\0b");
         assert_eq!(percent_decode_host("%").as_ref(), "%");
         assert_eq!(percent_decode_host("%6").as_ref(), "%6");
         assert_eq!(percent_decode_host("a%20b").as_ref(), "a b");
@@ -1797,14 +1804,30 @@ mod tests {
             Some(Ipv4Addr::new(127, 0, 0, 1))
         );
         assert_eq!(parse_ipv4_address_relaxed(""), None);
+        assert_eq!(parse_ipv4_address_relaxed("127:1"), None);
+        assert_eq!(
+            parse_ipv4_address_relaxed("1.2.3.255"),
+            Some(Ipv4Addr::new(1, 2, 3, 255))
+        );
+        assert_eq!(parse_ipv4_address_relaxed("1.2.3.256"), None);
         assert_eq!(parse_ipv4_address_relaxed("127.0.0.256"), None);
         assert_eq!(parse_ipv4_address_relaxed("1.2.65536"), None);
+        assert_eq!(
+            parse_ipv4_address_relaxed("1.2.65535"),
+            Some(Ipv4Addr::new(1, 2, 255, 255))
+        );
         assert_eq!(parse_ipv4_address_relaxed("1.16777216"), None);
+        assert_eq!(
+            parse_ipv4_address_relaxed("1.16777215"),
+            Some(Ipv4Addr::new(1, 255, 255, 255))
+        );
         assert_eq!(parse_ipv4_address_relaxed("127.0.0.0.1"), None);
         assert_eq!(parse_ipv4_address_relaxed("127:"), None);
 
         assert_eq!(parse_ipv4_component_value("010"), Some(8));
         assert_eq!(parse_ipv4_component_value("0X10"), Some(16));
+        assert_eq!(parse_ipv4_component_value("0x0"), Some(0));
+        assert_eq!(parse_ipv4_component_value("0"), Some(0));
         assert_eq!(parse_ipv4_component_value(""), None);
         assert_eq!(parse_ipv4_component_value("0x"), None);
     }
@@ -1825,6 +1848,22 @@ mod tests {
         );
         assert_eq!(
             classify_href("tel:+15551212", None),
+            DownloadPolicy::NoDownloadHint
+        );
+        assert_eq!(
+            classify_href("BLOB:https://example.com/id", None),
+            DownloadPolicy::Native
+        );
+        assert_eq!(
+            classify_href("DATA:text/plain,hello", None),
+            DownloadPolicy::Native
+        );
+        assert_eq!(
+            classify_href("MAILTO:user@example.com", None),
+            DownloadPolicy::NoDownloadHint
+        );
+        assert_eq!(
+            classify_href("TEL:+15551212", None),
             DownloadPolicy::NoDownloadHint
         );
 

--- a/crates/ars-components/src/utility/highlight/mod.rs
+++ b/crates/ars-components/src/utility/highlight/mod.rs
@@ -1500,6 +1500,24 @@ mod tests {
                 },
             ]
         );
+
+        assert_eq!(
+            build_chunks("0123", &[(1, 1), (1, 3), (3, 3)]),
+            vec![
+                HighlightChunk {
+                    text: "0",
+                    highlighted: false,
+                },
+                HighlightChunk {
+                    text: "12",
+                    highlighted: true,
+                },
+                HighlightChunk {
+                    text: "3",
+                    highlighted: false,
+                },
+            ]
+        );
     }
 
     // ── Snapshots ──────────────────────────────────────────────────

--- a/crates/ars-components/src/utility/swap/mod.rs
+++ b/crates/ars-components/src/utility/swap/mod.rs
@@ -750,6 +750,28 @@ mod tests {
     }
 
     #[test]
+    fn swap_set_props_syncs_disabled_without_checked_change() {
+        let mut service =
+            Service::<Machine>::new(test_props(), &Env::default(), &Messages::default());
+
+        let result = service.set_props(Props {
+            disabled: true,
+            ..test_props()
+        });
+
+        assert!(result.context_changed);
+        assert!(service.context().disabled);
+
+        let result = service.set_props(Props {
+            disabled: true,
+            ..test_props()
+        });
+
+        assert!(!result.context_changed);
+        assert!(service.context().disabled);
+    }
+
+    #[test]
     fn swap_disabled_blocks_value_events() {
         let mut service = Service::<Machine>::new(
             Props {
@@ -790,6 +812,23 @@ mod tests {
         }
 
         assert_eq!(*changes.lock().unwrap(), vec![true]);
+    }
+
+    #[test]
+    fn swap_api_reports_disabled_state() {
+        let enabled = Service::<Machine>::new(test_props(), &Env::default(), &Messages::default());
+
+        let disabled = Service::<Machine>::new(
+            Props {
+                disabled: true,
+                ..test_props()
+            },
+            &Env::default(),
+            &Messages::default(),
+        );
+
+        assert!(!enabled.connect(&|_| {}).is_disabled());
+        assert!(disabled.connect(&|_| {}).is_disabled());
     }
 
     #[test]

--- a/crates/ars-components/src/utility/toggle/mod.rs
+++ b/crates/ars-components/src/utility/toggle/mod.rs
@@ -581,6 +581,27 @@ mod tests {
     }
 
     #[test]
+    fn toggle_set_props_syncs_disabled_without_pressed_change() {
+        let mut service = Service::<Machine>::new(test_props(), &Env::default(), &Messages);
+
+        let result = service.set_props(Props {
+            disabled: true,
+            ..test_props()
+        });
+
+        assert!(result.context_changed);
+        assert!(service.context().disabled);
+
+        let result = service.set_props(Props {
+            disabled: true,
+            ..test_props()
+        });
+
+        assert!(!result.context_changed);
+        assert!(service.context().disabled);
+    }
+
+    #[test]
     fn toggle_disabled_blocks_value_events() {
         let mut service = Service::<Machine>::new(
             Props {

--- a/crates/ars-components/tests/proptest_state_machines/navigation.rs
+++ b/crates/ars-components/tests/proptest_state_machines/navigation.rs
@@ -717,7 +717,7 @@ fn arb_steps_props() -> impl Strategy<Value = steps::Props> {
 
 fn assert_pagination_invariants(service: &Service<pagination::Machine>) -> TestCaseResult {
     let ctx = service.context();
-    let page = ctx.current_page();
+    let page = *ctx.page.get();
 
     prop_assert!(page >= 1);
     prop_assert!(page <= ctx.page_count);

--- a/crates/ars-components/tests/proptest_state_machines/navigation.rs
+++ b/crates/ars-components/tests/proptest_state_machines/navigation.rs
@@ -717,7 +717,7 @@ fn arb_steps_props() -> impl Strategy<Value = steps::Props> {
 
 fn assert_pagination_invariants(service: &Service<pagination::Machine>) -> TestCaseResult {
     let ctx = service.context();
-    let page = *ctx.page.get();
+    let page = ctx.current_page();
 
     prop_assert!(page >= 1);
     prop_assert!(page <= ctx.page_count);

--- a/spec/components/navigation/pagination.md
+++ b/spec/components/navigation/pagination.md
@@ -21,6 +21,10 @@ with ellipsis for large page counts.
 `Pagination` is effectively stateless — its only meaningful state is the current page, tracked
 in context. A single `Idle` state is used.
 
+The effective current page is always clamped into `1..=page_count`, including controlled
+`page` props. `Context::page.get()` and `Api::current_page()` must not expose an out-of-range
+page when `page_count` changes.
+
 | State  | Description                                                 |
 | ------ | ----------------------------------------------------------- |
 | `Idle` | The only machine state; current page is in `Context::page`. |
@@ -195,11 +199,16 @@ impl ars_core::Machine for Machine {
     type Messages = Messages;
 
     fn init(props: &Self::Props, env: &Env, messages: &Self::Messages) -> (Self::State, Self::Context) {
-        let page = match props.page {
-            Some(p) => Bindable::controlled(p),
-            None    => Bindable::uncontrolled(props.default_page.max(1)),
-        };
         let page_count = Context::compute_page_count(props.total_items, props.page_size);
+        let initial_page = props
+            .page
+            .unwrap_or(props.default_page)
+            .max(1)
+            .min(page_count);
+        let page = match props.page {
+            Some(_) => Bindable::controlled(initial_page),
+            None    => Bindable::uncontrolled(initial_page),
+        };
         let ids = ComponentIds::from_id(&props.id);
         let locale = env.locale.clone();
         let messages = messages.clone();
@@ -267,6 +276,9 @@ impl ars_core::Machine for Machine {
                 Some(TransitionPlan::context_only(move |ctx| {
                     ctx.page_size  = new_size;
                     ctx.page_count = new_count;
+                    if ctx.page.is_controlled() {
+                        ctx.page.sync_controlled(Some(clamped));
+                    }
                     ctx.page.set(clamped);
                 }))
             }


### PR DESCRIPTION
## Summary

- Refreshed Nightly on current `main` with run `26244492008`, which confirmed the stale failures still applied: Extended Property Tests failed on pagination, and mutation shards failed for `ars-components`.
- Fixed controlled pagination so the exposed effective page stays clamped when `page_count` shrinks, and documented the controlled out-of-range contract in the pagination spec.
- Added focused regression and mutation-killing coverage across the remaining fresh survivor clusters: pagination, floating panel, pin input, steps, highlight, swap, toggle, hover card, and download trigger.
- Updated the Nightly mutation matrix so `ars-components` mutation shards run with `ars-components/i18n`, making i18n-gated highlight tests visible to mutation CI.
- Added narrow mutation skips only for equivalent or timeout-only mutants, with justifications in `.cargo/mutants.toml`.

## Fresh Nightly Signal

Manual Nightly refresh on current `main`:

- Run: https://github.com/fogodev/ars-ui/actions/runs/26244492008
- Failed signals still relevant:
  - `Extended Property Tests`: controlled pagination shrink case.
  - `mutation-testing`: `ars-components` shards `2`, `3`, `5`, `8`, `10`, `11`, and `12`.

## Verification

- `PROPTEST_CASES=10000 cargo test -p ars-components --features ars-components/i18n --test proptest_state_machines navigation::proptest_pagination_page_bounds_and_ranges_hold -- --ignored`
- Focused mutation reruns for changed clusters: pagination, pin input, steps, toggle, swap, highlight, hover card, floating panel, and download trigger.
- `cargo +nightly fmt --check`
- `cargo test -p ars-components --all-targets`
- `cargo clippy -p ars-components --all-targets --all-features -- -D warnings`
- `cargo xtask spec validate`
- `cargo test -p xtask --test spec_corpus_compile_snippets`
- `cargo llvm-cov test -p ars-components --features ars-components/i18n --lib` (`97.39%` line coverage)
- `.agents/skills/post-implementation-audit/SKILL.md` completed with no unresolved findings.
- `cargo xci-fast` passed all 10 gates.