### PR TITLE
Implement Calendar agnostic core (#280)

### DIFF
--- a/crates/ars-components/src/date_time/calendar/grid.rs
+++ b/crates/ars-components/src/date_time/calendar/grid.rs
@@ -1,0 +1,297 @@
+//! Grid math for the `Calendar` component.
+//!
+//! Pure functions over a small slice of the parent [`Context`] state: the
+//! visible month/year, the configured first-day-of-week, and the visible
+//! month count. The machine in [`super`] holds the full context and forwards
+//! the relevant fields here so this module stays free of the wider machine
+//! plumbing — useful both for unit testing the math in isolation and for
+//! keeping the §1.6 spec algorithm legible alongside the rest of the
+//! transitions.
+
+use alloc::vec::Vec;
+
+use ars_i18n::{CalendarDate, Weekday};
+
+/// Sunday-zero index for a weekday.
+///
+/// The spec's §1.6 grid algorithm uses modulo arithmetic that anchors at
+/// Sunday=0, but [`Weekday`] is iso-numbered (Monday=1..Sunday=7). The local
+/// helper isolates that conversion so every grid call site uses the same
+/// convention.
+#[must_use]
+pub(super) const fn weekday_sunday_zero(weekday: Weekday) -> u8 {
+    match weekday {
+        Weekday::Sunday => 0,
+        Weekday::Monday => 1,
+        Weekday::Tuesday => 2,
+        Weekday::Wednesday => 3,
+        Weekday::Thursday => 4,
+        Weekday::Friday => 5,
+        Weekday::Saturday => 6,
+    }
+}
+
+/// Returns `(month, year)` for the month at `offset` from the first visible
+/// month, normalising the result to the 1..=12 month range with a year
+/// adjustment.
+#[must_use]
+pub(super) const fn month_year_at_offset(
+    visible_month: u8,
+    visible_year: i32,
+    offset: usize,
+) -> (u8, i32) {
+    let raw_index = visible_month as i64 - 1 + offset as i64;
+
+    let normalised_month = raw_index.rem_euclid(12) as u8 + 1;
+    let year_delta = raw_index.div_euclid(12) as i32;
+
+    (normalised_month, visible_year + year_delta)
+}
+
+/// Advances `(month, year)` by `n` months (signed), normalising the month
+/// back into the 1..=12 range.
+#[must_use]
+pub(super) const fn advance_month(visible_month: u8, visible_year: i32, n: i32) -> (u8, i32) {
+    let raw_index = visible_month as i64 - 1 + n as i64;
+
+    let normalised_month = raw_index.rem_euclid(12) as u8 + 1;
+    let year_delta = raw_index.div_euclid(12) as i32;
+
+    (normalised_month, visible_year + year_delta)
+}
+
+/// Builds the 6-week grid for the month at the supplied offset.
+///
+/// Always returns exactly 6 rows of 7 dates each (42 cells), padded with
+/// leading days from the previous month and trailing days from the next.
+/// The leading-day count is derived from the difference between the first
+/// day of the target month and the configured `first_day_of_week`, modulo 7.
+///
+/// Date arithmetic at the start/end of the supported calendar range
+/// (`new_gregorian` reject) is treated as a no-op: the returned vector is
+/// empty in that case, signalling that the adapter should render an empty
+/// grid for the boundary month rather than panic.
+#[must_use]
+pub(super) fn weeks_for(
+    visible_month: u8,
+    visible_year: i32,
+    first_day_of_week: Weekday,
+    offset: usize,
+) -> Vec<[CalendarDate; 7]> {
+    let (target_month, target_year) = month_year_at_offset(visible_month, visible_year, offset);
+
+    let Ok(first_of_month) = CalendarDate::new_gregorian(target_year, target_month, 1) else {
+        return Vec::new();
+    };
+
+    let first_weekday_index = weekday_sunday_zero(first_of_month.weekday());
+    let start_index = weekday_sunday_zero(first_day_of_week);
+
+    let leading = i32::from((first_weekday_index + 7 - start_index) % 7);
+
+    let Ok(grid_start) = first_of_month.add_days(-leading) else {
+        return Vec::new();
+    };
+
+    let mut weeks: Vec<[CalendarDate; 7]> = Vec::with_capacity(6);
+
+    let mut current = grid_start;
+
+    for _ in 0..6 {
+        let Some(row) = build_week(&current) else {
+            return weeks;
+        };
+
+        weeks.push(row);
+
+        let Ok(next_week_start) = current.add_days(7) else {
+            return weeks;
+        };
+
+        current = next_week_start;
+    }
+
+    weeks
+}
+
+fn build_week(start: &CalendarDate) -> Option<[CalendarDate; 7]> {
+    let day0 = start.clone();
+    let day1 = start.add_days(1).ok()?;
+    let day2 = start.add_days(2).ok()?;
+    let day3 = start.add_days(3).ok()?;
+    let day4 = start.add_days(4).ok()?;
+    let day5 = start.add_days(5).ok()?;
+    let day6 = start.add_days(6).ok()?;
+
+    Some([day0, day1, day2, day3, day4, day5, day6])
+}
+
+/// Whether `date` belongs to a different `(month, year)` than the month at
+/// the given visible-month offset.
+#[must_use]
+pub(super) const fn is_outside_month_at_offset(
+    date: &CalendarDate,
+    visible_month: u8,
+    visible_year: i32,
+    offset: usize,
+) -> bool {
+    let (target_month, target_year) = month_year_at_offset(visible_month, visible_year, offset);
+
+    date.month() != target_month || date.year() != target_year
+}
+
+/// Whether `date` falls within any of the `visible_months` months starting
+/// at `(visible_month, visible_year)`.
+#[must_use]
+pub(super) fn is_in_visible_range(
+    date: &CalendarDate,
+    visible_month: u8,
+    visible_year: i32,
+    visible_months: usize,
+) -> bool {
+    (0..visible_months).any(|offset| {
+        let (month, year) = month_year_at_offset(visible_month, visible_year, offset);
+
+        date.month() == month && date.year() == year
+    })
+}
+
+/// Ordered weekday sequence starting at `first_day_of_week`, returned as
+/// `(weekday, sunday_zero_index)` pairs so callers can fetch labels from the
+/// `IntlBackend` without re-deriving the index.
+#[must_use]
+pub(super) fn ordered_weekdays(first_day_of_week: Weekday) -> [Weekday; 7] {
+    let start = weekday_sunday_zero(first_day_of_week);
+
+    let mut out = [Weekday::Sunday; 7];
+
+    for (i, slot) in out.iter_mut().enumerate() {
+        *slot = sunday_zero_to_weekday((start + i as u8) % 7);
+    }
+
+    out
+}
+
+const fn sunday_zero_to_weekday(index: u8) -> Weekday {
+    match index % 7 {
+        0 => Weekday::Sunday,
+        1 => Weekday::Monday,
+        2 => Weekday::Tuesday,
+        3 => Weekday::Wednesday,
+        4 => Weekday::Thursday,
+        5 => Weekday::Friday,
+        _ => Weekday::Saturday,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn month_year_offset_within_same_year() {
+        assert_eq!(month_year_at_offset(1, 2024, 0), (1, 2024));
+        assert_eq!(month_year_at_offset(1, 2024, 2), (3, 2024));
+        assert_eq!(month_year_at_offset(10, 2024, 1), (11, 2024));
+    }
+
+    #[test]
+    fn month_year_offset_wraps_into_next_year() {
+        assert_eq!(month_year_at_offset(11, 2024, 2), (1, 2025));
+        assert_eq!(month_year_at_offset(12, 2024, 1), (1, 2025));
+    }
+
+    #[test]
+    fn advance_month_handles_negative_into_prev_year() {
+        assert_eq!(advance_month(1, 2024, -1), (12, 2023));
+        assert_eq!(advance_month(3, 2024, -12), (3, 2023));
+        assert_eq!(advance_month(6, 2024, 12), (6, 2025));
+    }
+
+    #[test]
+    fn weeks_for_january_2024_sunday_start_has_leading_days_from_december() {
+        let weeks = weeks_for(1, 2024, Weekday::Sunday, 0);
+
+        assert_eq!(weeks.len(), 6);
+
+        // January 1, 2024 is a Monday, so with Sunday-start the first row
+        // starts on December 31, 2023.
+        let first = &weeks[0][0];
+
+        assert_eq!(first.year(), 2023);
+        assert_eq!(first.month(), 12);
+        assert_eq!(first.day(), 31);
+
+        // Second cell is January 1, 2024.
+        let second = &weeks[0][1];
+
+        assert_eq!(second.year(), 2024);
+        assert_eq!(second.month(), 1);
+        assert_eq!(second.day(), 1);
+    }
+
+    #[test]
+    fn weeks_for_january_2024_monday_start_first_cell_is_january_first() {
+        let weeks = weeks_for(1, 2024, Weekday::Monday, 0);
+
+        assert_eq!(weeks.len(), 6);
+
+        let first = &weeks[0][0];
+
+        assert_eq!(first.year(), 2024);
+        assert_eq!(first.month(), 1);
+        assert_eq!(first.day(), 1);
+    }
+
+    #[test]
+    fn ordered_weekdays_starts_at_configured_day() {
+        assert_eq!(
+            ordered_weekdays(Weekday::Sunday),
+            [
+                Weekday::Sunday,
+                Weekday::Monday,
+                Weekday::Tuesday,
+                Weekday::Wednesday,
+                Weekday::Thursday,
+                Weekday::Friday,
+                Weekday::Saturday,
+            ],
+        );
+        assert_eq!(
+            ordered_weekdays(Weekday::Monday),
+            [
+                Weekday::Monday,
+                Weekday::Tuesday,
+                Weekday::Wednesday,
+                Weekday::Thursday,
+                Weekday::Friday,
+                Weekday::Saturday,
+                Weekday::Sunday,
+            ],
+        );
+    }
+
+    #[test]
+    fn is_outside_month_detects_leading_and_trailing_days() {
+        let weeks = weeks_for(1, 2024, Weekday::Sunday, 0);
+
+        // First date is December 31, 2023, which is outside January 2024.
+        assert!(is_outside_month_at_offset(&weeks[0][0], 1, 2024, 0));
+        // January 1 is inside.
+        assert!(!is_outside_month_at_offset(&weeks[0][1], 1, 2024, 0));
+        // Last row generally contains February dates.
+        assert!(is_outside_month_at_offset(&weeks[5][6], 1, 2024, 0));
+    }
+
+    #[test]
+    fn is_in_visible_range_with_multiple_months() {
+        let jan = CalendarDate::new_gregorian(2024, 1, 15).unwrap();
+        let feb = CalendarDate::new_gregorian(2024, 2, 15).unwrap();
+        let mar = CalendarDate::new_gregorian(2024, 3, 15).unwrap();
+
+        assert!(is_in_visible_range(&jan, 1, 2024, 2));
+        assert!(is_in_visible_range(&feb, 1, 2024, 2));
+        assert!(!is_in_visible_range(&mar, 1, 2024, 2));
+        assert!(is_in_visible_range(&mar, 1, 2024, 3));
+    }
+}

--- a/crates/ars-components/src/date_time/calendar/grid.rs
+++ b/crates/ars-components/src/date_time/calendar/grid.rs
@@ -93,22 +93,28 @@ pub(super) fn weeks_for(
         return Vec::new();
     };
 
+    // The contract is "exactly 6 rows of 7 cells" or an empty vec on
+    // boundary failure. Partial vectors would break adapters and tests
+    // that assume the stable 6-row grid, so any arithmetic failure
+    // partway through bails out with an empty result.
     let mut weeks: Vec<[CalendarDate; 7]> = Vec::with_capacity(6);
 
     let mut current = grid_start;
 
-    for _ in 0..6 {
+    for i in 0..6 {
         let Some(row) = build_week(&current) else {
-            return weeks;
+            return Vec::new();
         };
 
         weeks.push(row);
 
-        let Ok(next_week_start) = current.add_days(7) else {
-            return weeks;
-        };
+        if i < 5 {
+            let Ok(next_week_start) = current.add_days(7) else {
+                return Vec::new();
+            };
 
-        current = next_week_start;
+            current = next_week_start;
+        }
     }
 
     weeks

--- a/crates/ars-components/src/date_time/calendar/mod.rs
+++ b/crates/ars-components/src/date_time/calendar/mod.rs
@@ -1114,18 +1114,21 @@ impl ars_core::Machine for Machine {
 
                 Some(
                     TransitionPlan::context_only(move |ctx: &mut Context| {
-                        // Move both visible_month and focused_date by the
-                        // same month delta so the roving-tabindex target
-                        // still has a rendered cell. The shifted date is
-                        // clamped into [min, max].
+                        // visible_month and focused_date must move
+                        // atomically. Compute the shifted date first and
+                        // only commit `visible_month` if the shift
+                        // succeeds — otherwise leave both untouched so
+                        // the roving target can never end up outside the
+                        // rendered grid.
                         let delta = i32::from(month) - i32::from(ctx.visible_month);
-                        ctx.visible_month = month;
-                        if let Ok(shifted) = ctx.focused_date.add(ars_i18n::DateDuration {
+                        let Ok(shifted) = ctx.focused_date.add(ars_i18n::DateDuration {
                             months: delta,
                             ..ars_i18n::DateDuration::default()
-                        }) {
-                            ctx.focused_date = ctx.clamp_date(shifted);
-                        }
+                        }) else {
+                            return;
+                        };
+                        ctx.visible_month = month;
+                        ctx.focused_date = ctx.clamp_date(shifted);
                     })
                     .with_effect(announce_month_effect()),
                 )
@@ -1135,14 +1138,24 @@ impl ars_core::Machine for Machine {
                 let year = *year;
                 Some(
                     TransitionPlan::context_only(move |ctx: &mut Context| {
-                        let delta_years = year - ctx.visible_year;
-                        ctx.visible_year = year;
-                        if let Ok(shifted) = ctx.focused_date.add(ars_i18n::DateDuration {
+                        // `i32 - i32` overflows on extreme inputs
+                        // (`SetYear { year: i32::MIN }` with positive
+                        // `visible_year`). Bail out via `checked_sub`
+                        // instead of panicking in debug or wrapping in
+                        // release.
+                        let Some(delta_years) = year.checked_sub(ctx.visible_year) else {
+                            return;
+                        };
+                        // visible_year and focused_date move atomically —
+                        // commit only after the shift succeeds.
+                        let Ok(shifted) = ctx.focused_date.add(ars_i18n::DateDuration {
                             years: delta_years,
                             ..ars_i18n::DateDuration::default()
-                        }) {
-                            ctx.focused_date = ctx.clamp_date(shifted);
-                        }
+                        }) else {
+                            return;
+                        };
+                        ctx.visible_year = year;
+                        ctx.focused_date = ctx.clamp_date(shifted);
                     })
                     .with_effect(announce_month_effect()),
                 )
@@ -1185,18 +1198,21 @@ fn sync_props_into_ctx(ctx: &mut Context, props: &Props) {
     ctx.today = props.today.clone();
 
     // `first_day_of_week` is the only field that can come from *either*
-    // props or the locale-derived default in `Env`. If props supplies an
-    // explicit override, honour it; otherwise leave the locale-derived
-    // value as-is (we cannot re-derive it from here because `Env` is not
-    // threaded through props updates).
-    if let Some(fdow) = props.first_day_of_week {
-        ctx.first_day_of_week = fdow;
-    }
+    // props or the locale-derived default. An explicit override always
+    // wins; clearing the override (`Some(_) → None`) restores the
+    // locale-derived value via the cached `intl_backend`, otherwise
+    // context would keep the stale weekday in violation of the Props
+    // contract.
+    ctx.first_day_of_week = props
+        .first_day_of_week
+        .unwrap_or_else(|| ctx.locale.first_day_of_week(&*ctx.intl_backend));
 
     // Re-clamp `focused_date` in case `min`/`max` tightened so the roving
-    // target never points at an out-of-range cell.
+    // target never points at an out-of-range cell, then drag the visible
+    // window along if the clamp moved focus into a different month.
     let clamped = ctx.clamp_date(ctx.focused_date.clone());
     ctx.focused_date = clamped;
+    ctx.sync_visible_to_focused();
 }
 
 fn step_for_page_behavior(ctx: &Context) -> i32 {

--- a/crates/ars-components/src/date_time/calendar/mod.rs
+++ b/crates/ars-components/src/date_time/calendar/mod.rs
@@ -924,17 +924,31 @@ pub enum Part {
     },
 
     /// A grid cell wrapping one date.
+    ///
+    /// `offset` is the multi-month grid index this cell belongs to
+    /// (0 for the first/only visible month, 1 for the second, …). It
+    /// drives the offset-aware `outside-month` check inside
+    /// [`Api::part_attrs`] so multi-month layouts don't mislabel later
+    /// grids' dates as outside-month.
     Cell {
         /// The date represented by this cell.
         #[part(default = default_calendar_date())]
         date: CalendarDate,
+        /// Zero-based offset of this cell's grid within the visible
+        /// month range. `0` is the default (single-month or first grid).
+        offset: usize,
     },
 
     /// The interactive trigger inside a cell (the actual `<button>`).
+    ///
+    /// `offset` carries the same multi-month grid index as [`Part::Cell`].
     CellTrigger {
         /// The date represented by this trigger.
         #[part(default = default_calendar_date())]
         date: CalendarDate,
+        /// Zero-based offset of this cell's grid within the visible
+        /// month range. `0` is the default (single-month or first grid).
+        offset: usize,
     },
 }
 
@@ -1098,13 +1112,13 @@ impl ars_core::Machine for Machine {
                 SelectionMode::Multiple => apply_toggle_multi(ctx, date.clone()),
             },
 
-            Event::NextMonth => Some(month_step_plan(step_for_page_behavior(ctx))),
+            Event::NextMonth => month_step_plan(ctx, step_for_page_behavior(ctx)),
 
-            Event::PrevMonth => Some(month_step_plan(-step_for_page_behavior(ctx))),
+            Event::PrevMonth => month_step_plan(ctx, -step_for_page_behavior(ctx)),
 
-            Event::NextYear => Some(month_step_plan(12)),
+            Event::NextYear => month_step_plan(ctx, 12),
 
-            Event::PrevYear => Some(month_step_plan(-12)),
+            Event::PrevYear => month_step_plan(ctx, -12),
 
             Event::SetMonth { month } => {
                 let month = *month;
@@ -1112,23 +1126,27 @@ impl ars_core::Machine for Machine {
                     return None;
                 }
 
+                // Pre-compute the focused-date shift so a boundary
+                // failure short-circuits the entire transition (no
+                // spurious `AnnounceMonth`). The `delta` here ranges
+                // over -11..=11 (u8 differences), no overflow risk.
+                let delta = i32::from(month) - i32::from(ctx.visible_month);
+                let shifted = ctx
+                    .focused_date
+                    .add(ars_i18n::DateDuration {
+                        months: delta,
+                        ..ars_i18n::DateDuration::default()
+                    })
+                    .ok()?;
                 Some(
                     TransitionPlan::context_only(move |ctx: &mut Context| {
-                        // visible_month and focused_date must move
-                        // atomically. Compute the shifted date first and
-                        // only commit `visible_month` if the shift
-                        // succeeds — otherwise leave both untouched so
-                        // the roving target can never end up outside the
-                        // rendered grid.
-                        let delta = i32::from(month) - i32::from(ctx.visible_month);
-                        let Ok(shifted) = ctx.focused_date.add(ars_i18n::DateDuration {
-                            months: delta,
-                            ..ars_i18n::DateDuration::default()
-                        }) else {
-                            return;
-                        };
                         ctx.visible_month = month;
                         ctx.focused_date = ctx.clamp_date(shifted);
+                        // If the clamp pushed focus into another month
+                        // (e.g., `SetMonth { month: 6 }` with `max = Jan 25`
+                        // clamps back to Jan 25), drag the visible window
+                        // along so the focused cell remains rendered.
+                        ctx.sync_visible_to_focused();
                     })
                     .with_effect(announce_month_effect()),
                 )
@@ -1136,26 +1154,24 @@ impl ars_core::Machine for Machine {
 
             Event::SetYear { year } => {
                 let year = *year;
+                // `i32 - i32` overflows on extreme inputs
+                // (`SetYear { year: i32::MIN }` with positive
+                // `visible_year`); bail out via `checked_sub`.
+                let delta_years = year.checked_sub(ctx.visible_year)?;
+                // Pre-compute the shift so boundary failure → no transition
+                // → no `AnnounceMonth`.
+                let shifted = ctx
+                    .focused_date
+                    .add(ars_i18n::DateDuration {
+                        years: delta_years,
+                        ..ars_i18n::DateDuration::default()
+                    })
+                    .ok()?;
                 Some(
                     TransitionPlan::context_only(move |ctx: &mut Context| {
-                        // `i32 - i32` overflows on extreme inputs
-                        // (`SetYear { year: i32::MIN }` with positive
-                        // `visible_year`). Bail out via `checked_sub`
-                        // instead of panicking in debug or wrapping in
-                        // release.
-                        let Some(delta_years) = year.checked_sub(ctx.visible_year) else {
-                            return;
-                        };
-                        // visible_year and focused_date move atomically —
-                        // commit only after the shift succeeds.
-                        let Ok(shifted) = ctx.focused_date.add(ars_i18n::DateDuration {
-                            years: delta_years,
-                            ..ars_i18n::DateDuration::default()
-                        }) else {
-                            return;
-                        };
                         ctx.visible_year = year;
                         ctx.focused_date = ctx.clamp_date(shifted);
+                        ctx.sync_visible_to_focused();
                     })
                     .with_effect(announce_month_effect()),
                 )
@@ -1222,23 +1238,32 @@ fn step_for_page_behavior(ctx: &Context) -> i32 {
     }
 }
 
-fn month_step_plan(step: i32) -> TransitionPlan<Machine> {
-    TransitionPlan::context_only(move |ctx: &mut Context| {
-        // `visible_month/year` and `focused_date` must advance atomically.
-        // If the focused-date shift fails near a representable calendar
-        // boundary, leave both untouched so the roving-tabindex target
-        // can never end up outside the rendered grid. The clamp keeps
-        // out-of-range targets snapped to `[min, max]`.
-        let Ok(shifted) = ctx.focused_date.add(ars_i18n::DateDuration {
+fn month_step_plan(ctx: &Context, step: i32) -> Option<TransitionPlan<Machine>> {
+    // Pre-compute the focused-date shift at plan-build time so a
+    // boundary failure short-circuits the whole transition (no spurious
+    // `AnnounceMonth` effect). Returning `None` here propagates as "no
+    // change" to the machine — visible_month, focused_date, AND the
+    // announce effect all stay put.
+    let shifted = ctx
+        .focused_date
+        .add(ars_i18n::DateDuration {
             months: step,
             ..ars_i18n::DateDuration::default()
-        }) else {
-            return;
-        };
-        ctx.advance_month(step);
-        ctx.focused_date = ctx.clamp_date(shifted);
-    })
-    .with_effect(announce_month_effect())
+        })
+        .ok()?;
+    Some(
+        TransitionPlan::context_only(move |ctx: &mut Context| {
+            ctx.advance_month(step);
+            ctx.focused_date = ctx.clamp_date(shifted);
+            // If the clamp pushed focus into a month different from the
+            // newly-advanced visible window (e.g., NextMonth when
+            // focused_date is at `max` already), pull visible back to
+            // wherever the clamped focus lives. Without this the
+            // roving-tabindex target would have no rendered cell.
+            ctx.sync_visible_to_focused();
+        })
+        .with_effect(announce_month_effect()),
+    )
 }
 
 fn announce_month_effect() -> ars_core::PendingEffect<Machine> {
@@ -1301,8 +1326,8 @@ fn apply_toggle_multi(ctx: &Context, date: CalendarDate) -> Option<TransitionPla
 fn handle_keydown(key: KeyboardKey, shift: bool, ctx: &Context) -> Option<TransitionPlan<Machine>> {
     if shift {
         match key {
-            KeyboardKey::PageUp => return Some(month_step_plan(-12)),
-            KeyboardKey::PageDown => return Some(month_step_plan(12)),
+            KeyboardKey::PageUp => return month_step_plan(ctx, -12),
+            KeyboardKey::PageDown => return month_step_plan(ctx, 12),
             _ => {}
         }
     }
@@ -1487,6 +1512,10 @@ impl<'a> Api<'a> {
             .set(HtmlAttr::Id, self.ctx.ids.part("prev-trigger"))
             .set(scope_attr, scope_val)
             .set(part_attr, part_val)
+            // `type="button"` keeps a click from submitting an enclosing
+            // <form>. Without it the browser default (`type="submit"`)
+            // turns prev/next paging into form submission.
+            .set(HtmlAttr::Type, "button")
             .set(HtmlAttr::Aria(AriaAttr::Label), label)
             .set(HtmlAttr::TabIndex, "-1");
 
@@ -1517,6 +1546,9 @@ impl<'a> Api<'a> {
             .set(HtmlAttr::Id, self.ctx.ids.part("next-trigger"))
             .set(scope_attr, scope_val)
             .set(part_attr, part_val)
+            // See `prev_trigger_attrs` — explicit `type="button"` prevents
+            // an enclosing <form> from auto-submitting on nav clicks.
+            .set(HtmlAttr::Type, "button")
             .set(HtmlAttr::Aria(AriaAttr::Label), label)
             .set(HtmlAttr::TabIndex, "-1");
 
@@ -1720,8 +1752,11 @@ impl<'a> Api<'a> {
     #[must_use]
     pub fn cell_attrs(&self, date: &CalendarDate) -> AttrMap {
         let mut attrs = AttrMap::new();
-        let [(scope_attr, scope_val), (part_attr, part_val)] =
-            Part::Cell { date: date.clone() }.data_attrs();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Cell {
+            date: date.clone(),
+            offset: 0,
+        }
+        .data_attrs();
 
         attrs
             .set(HtmlAttr::Role, "gridcell")
@@ -1750,8 +1785,11 @@ impl<'a> Api<'a> {
     #[must_use]
     pub fn cell_attrs_for(&self, date: &CalendarDate, offset: usize) -> AttrMap {
         let mut attrs = AttrMap::new();
-        let [(scope_attr, scope_val), (part_attr, part_val)] =
-            Part::Cell { date: date.clone() }.data_attrs();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Cell {
+            date: date.clone(),
+            offset,
+        }
+        .data_attrs();
 
         attrs
             .set(HtmlAttr::Role, "gridcell")
@@ -1791,10 +1829,18 @@ impl<'a> Api<'a> {
 
     fn cell_trigger_attrs_inner(&self, date: &CalendarDate, offset: Option<usize>) -> AttrMap {
         let mut attrs = AttrMap::new();
-        let [(scope_attr, scope_val), (part_attr, part_val)] =
-            Part::CellTrigger { date: date.clone() }.data_attrs();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::CellTrigger {
+            date: date.clone(),
+            offset: offset.unwrap_or(0),
+        }
+        .data_attrs();
 
-        attrs.set(scope_attr, scope_val).set(part_attr, part_val);
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            // `type="button"` keeps a click on a date inside a <form>
+            // from submitting; without it browsers default to submit.
+            .set(HtmlAttr::Type, "button");
 
         let disabled = self.is_disabled(date);
         let unavailable = self.is_unavailable(date);
@@ -2113,8 +2159,8 @@ impl ConnectApi for Api<'_> {
             Part::HeadRow => self.head_row_attrs(),
             Part::HeadCell { day } => self.head_cell_attrs(day),
             Part::Row { week_index } => self.row_attrs(week_index),
-            Part::Cell { date } => self.cell_attrs(&date),
-            Part::CellTrigger { date } => self.cell_trigger_attrs(&date),
+            Part::Cell { date, offset } => self.cell_attrs_for(&date, offset),
+            Part::CellTrigger { date, offset } => self.cell_trigger_attrs_for(&date, offset),
         }
     }
 }

--- a/crates/ars-components/src/date_time/calendar/mod.rs
+++ b/crates/ars-components/src/date_time/calendar/mod.rs
@@ -1017,6 +1017,15 @@ impl ars_core::Machine for Machine {
         ctx: &Self::Context,
         _props: &Self::Props,
     ) -> Option<TransitionPlan<Self>> {
+        // `FocusOut` must run even when the calendar is disabled — a
+        // calendar that becomes disabled while focused still needs its
+        // blur cleanup to land, otherwise it stays stuck in
+        // `State::Focused` with stale `data-ars-state="focused"`. All
+        // other events are gated by the disabled guard below.
+        if matches!(event, Event::FocusOut) {
+            return Some(TransitionPlan::to(State::Idle));
+        }
+
         if ctx.disabled {
             return None;
         }
@@ -1024,8 +1033,11 @@ impl ars_core::Machine for Machine {
         match event {
             Event::FocusIn => Some(TransitionPlan::to(State::Focused)),
 
-            Event::FocusOut => Some(TransitionPlan::to(State::Idle)),
-
+            // `FocusOut` is handled above the disabled guard so blur
+            // cleanup still runs when the context becomes disabled while
+            // focused. Control never reaches this arm — it exists purely
+            // to satisfy match exhaustiveness over `Event`.
+            Event::FocusOut => None,
             Event::FocusDate { date } => {
                 let clamped = ctx.clamp_date(date.clone());
                 Some(
@@ -1098,6 +1110,18 @@ fn step_for_page_behavior(ctx: &Context) -> i32 {
 fn month_step_plan(step: i32) -> TransitionPlan<Machine> {
     TransitionPlan::context_only(move |ctx: &mut Context| {
         ctx.advance_month(step);
+        // Keep `focused_date` aligned with the newly visible range so the
+        // roving-tabindex target still has a rendered cell. Without this,
+        // paging from Jan 15 → Feb leaves focused_date on Jan 15, which is
+        // not in February's 6-week grid, and no cell gets `tabindex="0"`.
+        // The shifted date is clamped into the configured `[min, max]`
+        // range so out-of-range targets snap back to the boundary.
+        if let Ok(shifted) = ctx.focused_date.add(ars_i18n::DateDuration {
+            months: step,
+            ..ars_i18n::DateDuration::default()
+        }) {
+            ctx.focused_date = ctx.clamp_date(shifted);
+        }
     })
     .with_effect(announce_month_effect())
 }
@@ -1637,6 +1661,20 @@ impl<'a> Api<'a> {
     /// Attributes for the interactive trigger inside a cell.
     #[must_use]
     pub fn cell_trigger_attrs(&self, date: &CalendarDate) -> AttrMap {
+        self.cell_trigger_attrs_inner(date, None)
+    }
+
+    /// Like [`Api::cell_trigger_attrs`] but checks "outside month" against
+    /// the month at the supplied offset rather than the first visible
+    /// month. Multi-month layouts use this so triggers in later grids do
+    /// not get flagged `data-ars-outside-month` just because they belong
+    /// to a different month than offset 0.
+    #[must_use]
+    pub fn cell_trigger_attrs_for(&self, date: &CalendarDate, offset: usize) -> AttrMap {
+        self.cell_trigger_attrs_inner(date, Some(offset))
+    }
+
+    fn cell_trigger_attrs_inner(&self, date: &CalendarDate, offset: Option<usize>) -> AttrMap {
         let mut attrs = AttrMap::new();
         let [(scope_attr, scope_val), (part_attr, part_val)] =
             Part::CellTrigger { date: date.clone() }.data_attrs();
@@ -1651,10 +1689,17 @@ impl<'a> Api<'a> {
 
         attrs.set(HtmlAttr::TabIndex, if is_focused { "0" } else { "-1" });
 
+        // `aria-disabled` announces the semantic restriction for both
+        // out-of-range (disabled) and unavailable dates. HTML `disabled`
+        // is **only** set for the disabled case because it removes the
+        // element from the browser focus model; unavailable dates must
+        // remain focusable per spec §3 even though they cannot be selected.
         if disabled || unavailable {
-            attrs
-                .set_bool(HtmlAttr::Disabled, true)
-                .set(HtmlAttr::Aria(AriaAttr::Disabled), "true");
+            attrs.set(HtmlAttr::Aria(AriaAttr::Disabled), "true");
+        }
+
+        if disabled {
+            attrs.set_bool(HtmlAttr::Disabled, true);
         }
 
         if selected {
@@ -1665,7 +1710,11 @@ impl<'a> Api<'a> {
             attrs.set_bool(HtmlAttr::Data("ars-today"), true);
         }
 
-        if self.ctx.is_outside_visible_month(date) {
+        let outside_month = match offset {
+            Some(o) => self.ctx.is_outside_month_at_offset(date, o),
+            None => self.ctx.is_outside_visible_month(date),
+        };
+        if outside_month {
             attrs.set_bool(HtmlAttr::Data("ars-outside-month"), true);
         }
 

--- a/crates/ars-components/src/date_time/calendar/mod.rs
+++ b/crates/ars-components/src/date_time/calendar/mod.rs
@@ -37,9 +37,11 @@ pub mod grid;
 mod tests;
 
 use alloc::{
+    boxed::Box,
     format,
     string::{String, ToString as _},
     sync::Arc,
+    vec,
     vec::Vec,
 };
 use core::{
@@ -146,6 +148,15 @@ pub enum Event {
         /// Whether the shift modifier was held.
         shift: bool,
     },
+
+    /// Synchronise context from a new props snapshot.
+    ///
+    /// Emitted automatically by [`Machine::on_props_changed`] when the
+    /// adapter pushes new props via `Service::set_props`. Updates the
+    /// `Bindable` controlled values, refreshes the cached `disabled`,
+    /// `readonly`, `min`/`max`, predicate, and layout fields, and
+    /// re-clamps `focused_date` into the (possibly tighter) range.
+    SyncProps(Box<Props>),
 }
 
 /// Typed identifier for every named effect intent the `calendar` machine emits.
@@ -961,7 +972,7 @@ impl ars_core::Machine for Machine {
             Bindable::uncontrolled(props.default_selected_dates.clone())
         };
 
-        let initial_date = match props.selection_mode {
+        let mut initial_date = match props.selection_mode {
             SelectionMode::Single => value.get().clone().unwrap_or_else(|| props.today.clone()),
             SelectionMode::Multiple => selected_dates
                 .get()
@@ -970,6 +981,21 @@ impl ars_core::Machine for Machine {
                 .cloned()
                 .unwrap_or_else(|| props.today.clone()),
         };
+
+        // Clamp the initial focused date into the configured [min, max]
+        // range so the roving-tabindex target on first mount is never on
+        // a disabled cell (which would also be HTML-disabled, removing
+        // any focusable day target from the grid).
+        if let Some(min) = &props.min
+            && initial_date.compare(min) == Ordering::Less
+        {
+            initial_date = min.clone();
+        }
+        if let Some(max) = &props.max
+            && initial_date.compare(max) == Ordering::Greater
+        {
+            initial_date = max.clone();
+        }
 
         let locale = env.locale.clone();
 
@@ -1011,6 +1037,18 @@ impl ars_core::Machine for Machine {
         (State::Idle, ctx)
     }
 
+    fn on_props_changed(old: &Self::Props, new: &Self::Props) -> Vec<Self::Event> {
+        debug_assert_eq!(
+            old.id, new.id,
+            "calendar::Props.id must remain stable after init",
+        );
+        if old == new {
+            Vec::new()
+        } else {
+            vec![Event::SyncProps(Box::new(new.clone()))]
+        }
+    }
+
     fn transition(
         _state: &Self::State,
         event: &Self::Event,
@@ -1020,10 +1058,17 @@ impl ars_core::Machine for Machine {
         // `FocusOut` must run even when the calendar is disabled — a
         // calendar that becomes disabled while focused still needs its
         // blur cleanup to land, otherwise it stays stuck in
-        // `State::Focused` with stale `data-ars-state="focused"`. All
-        // other events are gated by the disabled guard below.
+        // `State::Focused` with stale `data-ars-state="focused"`. `SyncProps`
+        // must also flow through so parent-driven changes that *take the
+        // calendar out of* the disabled state can actually land.
         if matches!(event, Event::FocusOut) {
             return Some(TransitionPlan::to(State::Idle));
+        }
+        if let Event::SyncProps(props) = event {
+            let props = props.as_ref().clone();
+            return Some(TransitionPlan::context_only(move |ctx: &mut Context| {
+                sync_props_into_ctx(ctx, &props);
+            }));
         }
 
         if ctx.disabled {
@@ -1033,11 +1078,10 @@ impl ars_core::Machine for Machine {
         match event {
             Event::FocusIn => Some(TransitionPlan::to(State::Focused)),
 
-            // `FocusOut` is handled above the disabled guard so blur
-            // cleanup still runs when the context becomes disabled while
-            // focused. Control never reaches this arm — it exists purely
+            // `FocusOut` and `SyncProps` are handled above the disabled
+            // guard. Control never reaches these arms — they exist purely
             // to satisfy match exhaustiveness over `Event`.
-            Event::FocusOut => None,
+            Event::FocusOut | Event::SyncProps(_) => None,
             Event::FocusDate { date } => {
                 let clamped = ctx.clamp_date(date.clone());
                 Some(
@@ -1070,7 +1114,18 @@ impl ars_core::Machine for Machine {
 
                 Some(
                     TransitionPlan::context_only(move |ctx: &mut Context| {
+                        // Move both visible_month and focused_date by the
+                        // same month delta so the roving-tabindex target
+                        // still has a rendered cell. The shifted date is
+                        // clamped into [min, max].
+                        let delta = i32::from(month) - i32::from(ctx.visible_month);
                         ctx.visible_month = month;
+                        if let Ok(shifted) = ctx.focused_date.add(ars_i18n::DateDuration {
+                            months: delta,
+                            ..ars_i18n::DateDuration::default()
+                        }) {
+                            ctx.focused_date = ctx.clamp_date(shifted);
+                        }
                     })
                     .with_effect(announce_month_effect()),
                 )
@@ -1080,7 +1135,14 @@ impl ars_core::Machine for Machine {
                 let year = *year;
                 Some(
                     TransitionPlan::context_only(move |ctx: &mut Context| {
+                        let delta_years = year - ctx.visible_year;
                         ctx.visible_year = year;
+                        if let Ok(shifted) = ctx.focused_date.add(ars_i18n::DateDuration {
+                            years: delta_years,
+                            ..ars_i18n::DateDuration::default()
+                        }) {
+                            ctx.focused_date = ctx.clamp_date(shifted);
+                        }
                     })
                     .with_effect(announce_month_effect()),
                 )
@@ -1100,6 +1162,43 @@ impl ars_core::Machine for Machine {
     }
 }
 
+fn sync_props_into_ctx(ctx: &mut Context, props: &Props) {
+    // Push controlled values through their `Bindable`s. `sync_controlled`
+    // accepts `Option<T>`: `Some(_)` keeps the calendar in controlled
+    // mode, `None` flips it back to uncontrolled (revealing the internal
+    // value).
+    ctx.value.sync_controlled(props.value.clone());
+    ctx.selected_dates
+        .sync_controlled(props.selected_dates.clone());
+
+    ctx.selection_mode = props.selection_mode;
+    ctx.max_selected = props.max_selected;
+    ctx.min = props.min.clone();
+    ctx.max = props.max.clone();
+    ctx.disabled = props.disabled;
+    ctx.readonly = props.readonly;
+    ctx.is_date_unavailable_fn = props.is_date_unavailable.clone();
+    ctx.show_week_numbers = props.show_week_numbers;
+    ctx.is_rtl = props.is_rtl;
+    ctx.visible_months = props.visible_months.max(1);
+    ctx.page_behavior = props.page_behavior;
+    ctx.today = props.today.clone();
+
+    // `first_day_of_week` is the only field that can come from *either*
+    // props or the locale-derived default in `Env`. If props supplies an
+    // explicit override, honour it; otherwise leave the locale-derived
+    // value as-is (we cannot re-derive it from here because `Env` is not
+    // threaded through props updates).
+    if let Some(fdow) = props.first_day_of_week {
+        ctx.first_day_of_week = fdow;
+    }
+
+    // Re-clamp `focused_date` in case `min`/`max` tightened so the roving
+    // target never points at an out-of-range cell.
+    let clamped = ctx.clamp_date(ctx.focused_date.clone());
+    ctx.focused_date = clamped;
+}
+
 fn step_for_page_behavior(ctx: &Context) -> i32 {
     match ctx.page_behavior {
         PageBehavior::Visible => i32::try_from(ctx.visible_months).unwrap_or(1).max(1),
@@ -1109,19 +1208,19 @@ fn step_for_page_behavior(ctx: &Context) -> i32 {
 
 fn month_step_plan(step: i32) -> TransitionPlan<Machine> {
     TransitionPlan::context_only(move |ctx: &mut Context| {
-        ctx.advance_month(step);
-        // Keep `focused_date` aligned with the newly visible range so the
-        // roving-tabindex target still has a rendered cell. Without this,
-        // paging from Jan 15 → Feb leaves focused_date on Jan 15, which is
-        // not in February's 6-week grid, and no cell gets `tabindex="0"`.
-        // The shifted date is clamped into the configured `[min, max]`
-        // range so out-of-range targets snap back to the boundary.
-        if let Ok(shifted) = ctx.focused_date.add(ars_i18n::DateDuration {
+        // `visible_month/year` and `focused_date` must advance atomically.
+        // If the focused-date shift fails near a representable calendar
+        // boundary, leave both untouched so the roving-tabindex target
+        // can never end up outside the rendered grid. The clamp keeps
+        // out-of-range targets snapped to `[min, max]`.
+        let Ok(shifted) = ctx.focused_date.add(ars_i18n::DateDuration {
             months: step,
             ..ars_i18n::DateDuration::default()
-        }) {
-            ctx.focused_date = ctx.clamp_date(shifted);
-        }
+        }) else {
+            return;
+        };
+        ctx.advance_month(step);
+        ctx.focused_date = ctx.clamp_date(shifted);
     })
     .with_effect(announce_month_effect())
 }
@@ -1781,9 +1880,14 @@ impl<'a> Api<'a> {
         self.ctx.is_outside_visible_month(date)
     }
 
-    /// Whether the prev-trigger should be disabled due to a `min` constraint.
+    /// Whether the prev-trigger should be disabled — either the calendar
+    /// is globally disabled or the visible range is already at `min`.
     #[must_use]
     pub fn is_prev_disabled(&self) -> bool {
+        if self.ctx.disabled {
+            return true;
+        }
+
         let Some(min) = &self.ctx.min else {
             return false;
         };
@@ -1797,11 +1901,16 @@ impl<'a> Api<'a> {
         !matches!(first_of_visible.compare(min), Ordering::Greater)
     }
 
-    /// Whether the next-trigger should be disabled due to a `max` constraint.
+    /// Whether the next-trigger should be disabled — either the calendar
+    /// is globally disabled or the visible range is already at `max`.
     /// Checks against the **last** visible month so multi-month layouts
     /// behave correctly.
     #[must_use]
     pub fn is_next_disabled(&self) -> bool {
+        if self.ctx.disabled {
+            return true;
+        }
+
         let Some(max) = &self.ctx.max else {
             return false;
         };

--- a/crates/ars-components/src/date_time/calendar/mod.rs
+++ b/crates/ars-components/src/date_time/calendar/mod.rs
@@ -1,0 +1,1918 @@
+//! `Calendar` component state machine and connect API.
+//!
+//! Framework-agnostic implementation of the grid-based date picker defined
+//! in `spec/components/date-time/calendar.md`. The machine owns visible
+//! month/year, focused-date roving tab state, single and multi-date
+//! selection, locale-aware weekday ordering, min/max constraints, and the
+//! screen-reader announcement intent emitted when the visible month
+//! changes.
+//!
+//! ## Spec-vs-implementation reconciliation
+//!
+//! The spec's §1.7 code examples use illustrative pseudo-Rust that
+//! pre-dates the current `ars-i18n::CalendarDate` API: it treats months and
+//! days as `NonZero<u8>`, calls `add_days` / `add_months` as infallible,
+//! and accesses month/day/year as fields. The real types return
+//! `Result<_, CalendarError>` and expose month/day/year as `u8` methods.
+//! The implementation here keeps the spec's semantics intact while using
+//! the real fallible API; cases where the spec implies an arithmetic
+//! result cannot fail (grid anchoring, focused-date navigation) propagate
+//! using `?`-style early returns that leave context unchanged rather than
+//! panic at calendar-system boundaries.
+//!
+//! ## Range-calendar drift in spec §1.8
+//!
+//! The spec's §1.8 connect API includes `on_cell_hover(date) ->
+//! Event::HoverDate { date }` and `on_grid_mouseleave() ->
+//! Event::HoverEnd`, but neither event appears in §1.2 and neither has a
+//! transition arm. Those entries belong to the future `RangeCalendar`
+//! component; this implementation omits them and the matching
+//! `Event::HoverDate` / `Event::HoverEnd` variants. The range-calendar
+//! delivery will reintroduce them alongside the rest of its hover/range
+//! preview state.
+
+pub mod grid;
+
+#[cfg(test)]
+mod tests;
+
+use alloc::{
+    format,
+    string::{String, ToString as _},
+    sync::Arc,
+    vec::Vec,
+};
+use core::{
+    cmp::Ordering,
+    fmt::{self, Debug},
+};
+
+use ars_core::{
+    AriaAttr, AttrMap, Bindable, Callback, ComponentIds, ComponentMessages, ComponentPart,
+    ConnectApi, Env, HtmlAttr, IntlBackend, KeyboardKey, Locale, MessageFn, TransitionPlan,
+};
+use ars_i18n::{CalendarDate, Weekday};
+
+use self::grid::{
+    advance_month as advance_month_pair, is_in_visible_range as grid_is_in_visible_range,
+    is_outside_month_at_offset as grid_is_outside_month_at_offset,
+    month_year_at_offset as grid_month_year_at_offset, ordered_weekdays as grid_ordered_weekdays,
+    weeks_for as grid_weeks_for,
+};
+
+// ────────────────────────────────────────────────────────────────────
+// State / Event / Effect
+// ────────────────────────────────────────────────────────────────────
+
+/// States for the `Calendar` component.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum State {
+    /// Calendar rendered but no cell has keyboard focus.
+    Idle,
+
+    /// A specific date cell holds keyboard focus within the grid.
+    Focused,
+}
+
+/// Events for the `Calendar` component.
+#[derive(Clone, Debug, PartialEq)]
+pub enum Event {
+    /// Move keyboard focus to a specific date (clamped to min/max).
+    FocusDate {
+        /// The date to focus on.
+        date: CalendarDate,
+    },
+
+    /// User selected a date via click or `Enter`/`Space` on the focused cell.
+    ///
+    /// In [`SelectionMode::Single`] this sets the value to that date. In
+    /// [`SelectionMode::Multiple`] it falls through to [`Event::ToggleDate`]
+    /// to keep one user-visible "select this date" event for adapters that
+    /// do not know the configured selection mode.
+    SelectDate {
+        /// The date that was selected.
+        date: CalendarDate,
+    },
+
+    /// Toggle the date in or out of the multi-selection set.
+    ///
+    /// Only meaningful when `selection_mode == Multiple`. A toggle that
+    /// would add a date when the set already holds `max_selected` entries
+    /// is silently dropped.
+    ToggleDate {
+        /// The date to toggle.
+        date: CalendarDate,
+    },
+
+    /// Navigate to the next month (advances by `page_behavior` step).
+    NextMonth,
+
+    /// Navigate to the previous month (retreats by `page_behavior` step).
+    PrevMonth,
+
+    /// Navigate forward by 12 months (one year).
+    NextYear,
+
+    /// Navigate backward by 12 months (one year).
+    PrevYear,
+
+    /// Jump to a specific month (1-based; out-of-range values are ignored).
+    SetMonth {
+        /// The 1-based month to display.
+        month: u8,
+    },
+
+    /// Jump to a specific year.
+    SetYear {
+        /// The year to display.
+        year: i32,
+    },
+
+    /// Grid received focus.
+    FocusIn,
+
+    /// Focus left the grid entirely.
+    FocusOut,
+
+    /// Keyboard event on the grid.
+    ///
+    /// The `shift` flag is folded into the event so the adapter does not
+    /// need a side-channel to communicate `Shift+PageUp` / `Shift+PageDown`
+    /// for year navigation.
+    KeyDown {
+        /// The key that was pressed.
+        key: KeyboardKey,
+
+        /// Whether the shift modifier was held.
+        shift: bool,
+    },
+}
+
+/// Typed identifier for every named effect intent the `calendar` machine emits.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Effect {
+    /// Announce the newly visible month (or month range) to assistive tech
+    /// via the adapter's platform announcer. Triggered by every
+    /// month/year navigation transition.
+    AnnounceMonth,
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Props sub-types
+// ────────────────────────────────────────────────────────────────────
+
+/// Controls how prev/next navigation advances when multiple months are visible.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum PageBehavior {
+    /// Prev/next advances by the full `visible_months` count.
+    #[default]
+    Visible,
+
+    /// Prev/next advances by exactly 1 month, regardless of `visible_months`.
+    Single,
+}
+
+/// Whether the calendar selects a single date or an unordered set of dates.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum SelectionMode {
+    /// Single-date selection — `value` holds the chosen date (or `None`).
+    #[default]
+    Single,
+
+    /// Multiple non-contiguous date selection — `selected_dates` holds the
+    /// chosen set, optionally capped by `max_selected`.
+    Multiple,
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Props
+// ────────────────────────────────────────────────────────────────────
+
+/// Ordered set of unique calendar dates, sorted by
+/// [`CalendarDate::compare`].
+///
+/// [`CalendarDate`] implements neither [`Ord`] nor [`PartialOrd`] (different
+/// calendar systems share the same `CalendarDate` value type, so global
+/// ordering is undefined), but it does expose a chronological
+/// [`compare`](CalendarDate::compare) method. `SelectedDates` is a thin
+/// newtype wrapper around `Vec<CalendarDate>` that maintains sorted order
+/// using that comparator, plays the role of `SelectedDates` for the
+/// multi-select variant, and stays usable without any extra trait impls on
+/// the foreign type.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct SelectedDates {
+    dates: Vec<CalendarDate>,
+}
+
+impl SelectedDates {
+    /// Creates an empty set.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self { dates: Vec::new() }
+    }
+
+    /// Returns the number of selected dates.
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.dates.len()
+    }
+
+    /// Whether the set is empty.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.dates.is_empty()
+    }
+
+    /// Iterates over the selected dates in chronological order.
+    pub fn iter(&self) -> core::slice::Iter<'_, CalendarDate> {
+        self.dates.iter()
+    }
+
+    /// Returns whether `date` is in the set.
+    #[must_use]
+    pub fn contains(&self, date: &CalendarDate) -> bool {
+        self.dates
+            .binary_search_by(|candidate| candidate.compare(date))
+            .is_ok()
+    }
+
+    /// Inserts `date` into the set, returning `true` if it was newly added.
+    pub fn insert(&mut self, date: CalendarDate) -> bool {
+        if let Err(idx) = self
+            .dates
+            .binary_search_by(|candidate| candidate.compare(&date))
+        {
+            self.dates.insert(idx, date);
+
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Removes `date` from the set, returning `true` if it was present.
+    pub fn remove(&mut self, date: &CalendarDate) -> bool {
+        if let Ok(idx) = self
+            .dates
+            .binary_search_by(|candidate| candidate.compare(date))
+        {
+            self.dates.remove(idx);
+
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Returns the underlying sorted slice.
+    #[must_use]
+    pub fn as_slice(&self) -> &[CalendarDate] {
+        &self.dates
+    }
+}
+
+impl FromIterator<CalendarDate> for SelectedDates {
+    fn from_iter<I: IntoIterator<Item = CalendarDate>>(iter: I) -> Self {
+        let mut set = Self::new();
+
+        for date in iter {
+            set.insert(date);
+        }
+
+        set
+    }
+}
+
+impl<'a> IntoIterator for &'a SelectedDates {
+    type Item = &'a CalendarDate;
+    type IntoIter = core::slice::Iter<'a, CalendarDate>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.dates.iter()
+    }
+}
+
+/// Predicate type for marking dates unavailable.
+///
+/// Unavailable dates remain focusable for keyboard navigation but cannot
+/// be selected. Wrapped in [`Callback`] so applications can supply
+/// closures with captured state (allowlists, computed holiday tables,
+/// etc.); the `Arc`-backed pointer equality keeps `Props` `Clone +
+/// PartialEq` without the function-pointer comparison foot-gun.
+pub type IsDateUnavailableFn = Callback<dyn for<'a> Fn(&'a CalendarDate) -> bool + Send + Sync>;
+
+/// Props for the `Calendar` component.
+#[derive(Clone, Debug, PartialEq, ars_core::HasId)]
+pub struct Props {
+    /// Component instance ID. The adapter supplies a hydration-stable
+    /// base; [`ComponentIds`] derives part IDs from it.
+    pub id: String,
+
+    /// Controlled single-date value. `None` means uncontrolled;
+    /// `Some(None)` means controlled-and-empty; `Some(Some(date))` means
+    /// controlled with a date.
+    pub value: Option<Option<CalendarDate>>,
+
+    /// Default date for uncontrolled single-select mode.
+    pub default_value: Option<CalendarDate>,
+
+    /// Controlled multi-selection set. `None` means uncontrolled.
+    pub selected_dates: Option<SelectedDates>,
+
+    /// Default selection set for uncontrolled multi-select mode.
+    pub default_selected_dates: SelectedDates,
+
+    /// Selection mode — single by default. Multi-select unlocks the
+    /// `selected_dates` set and the `ToggleDate` event.
+    pub selection_mode: SelectionMode,
+
+    /// Maximum number of dates that can be selected in `Multiple` mode.
+    /// `None` removes the cap. Excess toggles are silently dropped.
+    pub max_selected: Option<usize>,
+
+    /// Minimum selectable date.
+    pub min: Option<CalendarDate>,
+
+    /// Maximum selectable date.
+    pub max: Option<CalendarDate>,
+
+    /// Whether the entire calendar is non-interactive.
+    pub disabled: bool,
+
+    /// Whether the calendar allows navigation but blocks selection.
+    pub readonly: bool,
+
+    /// Predicate returning `true` for dates that should be marked
+    /// unavailable (focusable, but not selectable).
+    pub is_date_unavailable: Option<IsDateUnavailableFn>,
+
+    /// Explicit override of the locale's default first day of week.
+    /// `None` derives the value from the active [`IntlBackend`].
+    pub first_day_of_week: Option<Weekday>,
+
+    /// Whether the head row exposes ISO week numbers (rendered by the
+    /// adapter; the machine only forwards this flag to the connect API).
+    pub show_week_numbers: bool,
+
+    /// Right-to-left layout direction (mirrors the grid and swaps the
+    /// `ArrowLeft`/`ArrowRight` semantics).
+    pub is_rtl: bool,
+
+    /// Number of months to display side-by-side. Values below 1 are
+    /// clamped to 1 by [`Machine::init`].
+    pub visible_months: usize,
+
+    /// Controls navigation step size.
+    pub page_behavior: PageBehavior,
+
+    /// The "today" date, injected by the adapter for testability and SSR
+    /// determinism.
+    pub today: CalendarDate,
+}
+
+impl Default for Props {
+    fn default() -> Self {
+        Self {
+            id: String::new(),
+            value: None,
+            default_value: None,
+            selected_dates: None,
+            default_selected_dates: SelectedDates::new(),
+            selection_mode: SelectionMode::Single,
+            max_selected: None,
+            min: None,
+            max: None,
+            disabled: false,
+            readonly: false,
+            is_date_unavailable: None,
+            first_day_of_week: None,
+            show_week_numbers: false,
+            is_rtl: false,
+            visible_months: 1,
+            page_behavior: PageBehavior::Visible,
+            today: CalendarDate::new_gregorian(2025, 1, 1)
+                .expect("2025-01-01 is a valid Gregorian date"),
+        }
+    }
+}
+
+impl Props {
+    /// Creates a new `Props` with defaults plus the supplied ID.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets [`id`](Self::id).
+    #[must_use]
+    pub fn id(mut self, id: impl Into<String>) -> Self {
+        self.id = id.into();
+        self
+    }
+
+    /// Sets [`value`](Self::value) (controlled single-select value).
+    #[must_use]
+    pub fn value(mut self, value: Option<CalendarDate>) -> Self {
+        self.value = Some(value);
+        self
+    }
+
+    /// Sets [`default_value`](Self::default_value).
+    #[must_use]
+    pub fn default_value(mut self, value: Option<CalendarDate>) -> Self {
+        self.default_value = value;
+        self
+    }
+
+    /// Sets [`selected_dates`](Self::selected_dates) (controlled multi-select).
+    #[must_use]
+    pub fn selected_dates(mut self, dates: Option<SelectedDates>) -> Self {
+        self.selected_dates = dates;
+        self
+    }
+
+    /// Sets [`default_selected_dates`](Self::default_selected_dates).
+    #[must_use]
+    pub fn default_selected_dates(mut self, dates: SelectedDates) -> Self {
+        self.default_selected_dates = dates;
+        self
+    }
+
+    /// Sets [`selection_mode`](Self::selection_mode).
+    #[must_use]
+    pub const fn selection_mode(mut self, mode: SelectionMode) -> Self {
+        self.selection_mode = mode;
+        self
+    }
+
+    /// Sets [`max_selected`](Self::max_selected).
+    #[must_use]
+    pub const fn max_selected(mut self, max: Option<usize>) -> Self {
+        self.max_selected = max;
+        self
+    }
+
+    /// Sets [`min`](Self::min).
+    #[must_use]
+    pub fn min(mut self, date: Option<CalendarDate>) -> Self {
+        self.min = date;
+        self
+    }
+
+    /// Sets [`max`](Self::max).
+    #[must_use]
+    pub fn max(mut self, date: Option<CalendarDate>) -> Self {
+        self.max = date;
+        self
+    }
+
+    /// Sets [`disabled`](Self::disabled).
+    #[must_use]
+    pub const fn disabled(mut self, value: bool) -> Self {
+        self.disabled = value;
+        self
+    }
+
+    /// Sets [`readonly`](Self::readonly).
+    #[must_use]
+    pub const fn readonly(mut self, value: bool) -> Self {
+        self.readonly = value;
+        self
+    }
+
+    /// Sets [`is_date_unavailable`](Self::is_date_unavailable).
+    #[must_use]
+    pub fn is_date_unavailable(mut self, predicate: Option<IsDateUnavailableFn>) -> Self {
+        self.is_date_unavailable = predicate;
+        self
+    }
+
+    /// Sets [`first_day_of_week`](Self::first_day_of_week).
+    #[must_use]
+    pub const fn first_day_of_week(mut self, weekday: Option<Weekday>) -> Self {
+        self.first_day_of_week = weekday;
+        self
+    }
+
+    /// Sets [`show_week_numbers`](Self::show_week_numbers).
+    #[must_use]
+    pub const fn show_week_numbers(mut self, value: bool) -> Self {
+        self.show_week_numbers = value;
+        self
+    }
+
+    /// Sets [`is_rtl`](Self::is_rtl).
+    #[must_use]
+    pub const fn is_rtl(mut self, value: bool) -> Self {
+        self.is_rtl = value;
+        self
+    }
+
+    /// Sets [`visible_months`](Self::visible_months).
+    #[must_use]
+    pub const fn visible_months(mut self, count: usize) -> Self {
+        self.visible_months = count;
+        self
+    }
+
+    /// Sets [`page_behavior`](Self::page_behavior).
+    #[must_use]
+    pub const fn page_behavior(mut self, behavior: PageBehavior) -> Self {
+        self.page_behavior = behavior;
+        self
+    }
+
+    /// Sets [`today`](Self::today).
+    #[must_use]
+    pub fn today(mut self, date: CalendarDate) -> Self {
+        self.today = date;
+        self
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Messages
+// ────────────────────────────────────────────────────────────────────
+
+/// `MessageFn` carrying a locale-only label closure.
+pub type LocaleLabelFn = dyn Fn(&Locale) -> String + Send + Sync;
+
+/// `MessageFn` carrying a step-count plus locale label closure (used by the
+/// multi-month prev/next page labels).
+pub type PageLabelFn = dyn Fn(usize, &Locale) -> String + Send + Sync;
+
+/// Locale-specific labels for the `Calendar` component.
+///
+/// Month names, weekday abbreviations, and full weekday names are resolved
+/// from the active [`IntlBackend`] — they are not stored here.
+#[derive(Clone)]
+pub struct Messages {
+    /// Accessible label for the previous-month button (single-month nav).
+    pub prev_month_label: MessageFn<LocaleLabelFn>,
+
+    /// Accessible label for the next-month button (single-month nav).
+    pub next_month_label: MessageFn<LocaleLabelFn>,
+
+    /// Accessible label for the previous-page button when navigating
+    /// multiple months at once. The `usize` parameter is the step count.
+    pub prev_page_label: MessageFn<PageLabelFn>,
+
+    /// Accessible label for the next-page button when navigating multiple
+    /// months at once. The `usize` parameter is the step count.
+    pub next_page_label: MessageFn<PageLabelFn>,
+
+    /// Separator inserted between month names in a multi-month range
+    /// heading (e.g., `" – "`).
+    pub month_range_separator: MessageFn<LocaleLabelFn>,
+}
+
+impl Default for Messages {
+    fn default() -> Self {
+        Self {
+            prev_month_label: MessageFn::static_str("Previous month"),
+            next_month_label: MessageFn::static_str("Next month"),
+            prev_page_label: MessageFn::new(|count: usize, _locale: &Locale| {
+                format!("Previous {count} months")
+            }),
+            next_page_label: MessageFn::new(|count: usize, _locale: &Locale| {
+                format!("Next {count} months")
+            }),
+            month_range_separator: MessageFn::static_str(" \u{2013} "),
+        }
+    }
+}
+
+impl Debug for Messages {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Messages").finish_non_exhaustive()
+    }
+}
+
+impl PartialEq for Messages {
+    fn eq(&self, other: &Self) -> bool {
+        self.prev_month_label == other.prev_month_label
+            && self.next_month_label == other.next_month_label
+            && self.prev_page_label == other.prev_page_label
+            && self.next_page_label == other.next_page_label
+            && self.month_range_separator == other.month_range_separator
+    }
+}
+
+impl ComponentMessages for Messages {}
+
+// ────────────────────────────────────────────────────────────────────
+// Context
+// ────────────────────────────────────────────────────────────────────
+
+/// Context for the `Calendar` component.
+#[derive(Clone)]
+pub struct Context {
+    /// Selected date in single-select mode.
+    pub value: Bindable<Option<CalendarDate>>,
+
+    /// Selected date set in multi-select mode.
+    pub selected_dates: Bindable<SelectedDates>,
+
+    /// Active selection mode.
+    pub selection_mode: SelectionMode,
+
+    /// Maximum number of dates the multi-selection set may hold.
+    pub max_selected: Option<usize>,
+
+    /// The date that currently holds keyboard focus.
+    pub focused_date: CalendarDate,
+
+    /// The first visible month (1-based).
+    pub visible_month: u8,
+
+    /// The year of the first visible month.
+    pub visible_year: i32,
+
+    /// Number of months displayed side-by-side (>= 1).
+    pub visible_months: usize,
+
+    /// Navigation step size for prev/next.
+    pub page_behavior: PageBehavior,
+
+    /// Minimum selectable date.
+    pub min: Option<CalendarDate>,
+
+    /// Maximum selectable date.
+    pub max: Option<CalendarDate>,
+
+    /// Resolved first-day-of-week (locale default unless overridden).
+    pub first_day_of_week: Weekday,
+
+    /// Whether the calendar is rendered right-to-left.
+    pub is_rtl: bool,
+
+    /// Whether the calendar is globally disabled.
+    pub disabled: bool,
+
+    /// Whether the calendar is read-only (focus OK, selection blocked).
+    pub readonly: bool,
+
+    /// Whether the head row exposes ISO week numbers.
+    pub show_week_numbers: bool,
+
+    /// Date passed in as "today" by the adapter; used to mark today's
+    /// cell with `data-ars-today`.
+    pub today: CalendarDate,
+
+    /// Predicate marking dates as unavailable. Unavailable dates remain
+    /// focusable but are not selectable.
+    pub is_date_unavailable_fn: Option<IsDateUnavailableFn>,
+
+    /// Resolved locale (from `Env`).
+    pub locale: Locale,
+
+    /// Resolved translatable messages.
+    pub messages: Messages,
+
+    /// Backend used for locale-dependent labels.
+    pub intl_backend: Arc<dyn IntlBackend>,
+
+    /// Component part IDs derived from `props.id`.
+    pub ids: ComponentIds,
+}
+
+impl Debug for Context {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Context")
+            .field("value", &self.value)
+            .field("selected_dates", &self.selected_dates)
+            .field("selection_mode", &self.selection_mode)
+            .field("max_selected", &self.max_selected)
+            .field("focused_date", &self.focused_date)
+            .field("visible_month", &self.visible_month)
+            .field("visible_year", &self.visible_year)
+            .field("visible_months", &self.visible_months)
+            .field("page_behavior", &self.page_behavior)
+            .field("min", &self.min)
+            .field("max", &self.max)
+            .field("first_day_of_week", &self.first_day_of_week)
+            .field("is_rtl", &self.is_rtl)
+            .field("disabled", &self.disabled)
+            .field("readonly", &self.readonly)
+            .field("show_week_numbers", &self.show_week_numbers)
+            .field("today", &self.today)
+            .field(
+                "is_date_unavailable_fn",
+                &self.is_date_unavailable_fn.as_ref().map(|_| "<callback>"),
+            )
+            .field("locale", &self.locale)
+            .field("messages", &self.messages)
+            .field("intl_backend", &"<dyn IntlBackend>")
+            .field("ids", &self.ids)
+            .finish()
+    }
+}
+
+impl Context {
+    /// Whether `date` equals the currently selected single-select value.
+    #[must_use]
+    pub fn is_selected_single(&self, date: &CalendarDate) -> bool {
+        self.value.get().as_ref() == Some(date)
+    }
+
+    /// Whether `date` is in the multi-selection set.
+    #[must_use]
+    pub fn is_selected_multi(&self, date: &CalendarDate) -> bool {
+        self.selected_dates.get().contains(date)
+    }
+
+    /// Whether `date` is selected under the active selection mode.
+    #[must_use]
+    pub fn is_selected(&self, date: &CalendarDate) -> bool {
+        match self.selection_mode {
+            SelectionMode::Single => self.is_selected_single(date),
+            SelectionMode::Multiple => self.is_selected_multi(date),
+        }
+    }
+
+    /// Whether `date` is disabled (out of min/max or globally disabled).
+    #[must_use]
+    pub fn is_date_disabled(&self, date: &CalendarDate) -> bool {
+        if self.disabled {
+            return true;
+        }
+
+        if let Some(min) = &self.min
+            && date.compare(min) == Ordering::Less
+        {
+            return true;
+        }
+
+        if let Some(max) = &self.max
+            && date.compare(max) == Ordering::Greater
+        {
+            return true;
+        }
+
+        false
+    }
+
+    /// Whether the user's predicate marks `date` as unavailable.
+    #[must_use]
+    pub fn is_date_unavailable(&self, date: &CalendarDate) -> bool {
+        self.is_date_unavailable_fn
+            .as_ref()
+            .is_some_and(|predicate| predicate(date))
+    }
+
+    /// Clamps `date` into the configured `[min, max]` range.
+    #[must_use]
+    pub fn clamp_date(&self, date: CalendarDate) -> CalendarDate {
+        let mut clamped = date;
+
+        if let Some(min) = &self.min
+            && clamped.compare(min) == Ordering::Less
+        {
+            clamped = min.clone();
+        }
+
+        if let Some(max) = &self.max
+            && clamped.compare(max) == Ordering::Greater
+        {
+            clamped = max.clone();
+        }
+
+        clamped
+    }
+
+    /// If the focused date has moved outside the visible month range,
+    /// scrolls the visible months so the focused date is visible. No-op
+    /// when the focused date already lies within the visible range.
+    pub fn sync_visible_to_focused(&mut self) {
+        if !grid_is_in_visible_range(
+            &self.focused_date,
+            self.visible_month,
+            self.visible_year,
+            self.visible_months,
+        ) {
+            self.visible_month = self.focused_date.month();
+            self.visible_year = self.focused_date.year();
+        }
+    }
+
+    /// Returns `(month, year)` for the visible month at `offset` from the
+    /// first visible month.
+    #[must_use]
+    pub const fn month_year_at_offset(&self, offset: usize) -> (u8, i32) {
+        grid_month_year_at_offset(self.visible_month, self.visible_year, offset)
+    }
+
+    /// Whether `date` belongs to a month other than the month at the
+    /// given visible-month offset.
+    #[must_use]
+    pub const fn is_outside_month_at_offset(&self, date: &CalendarDate, offset: usize) -> bool {
+        grid_is_outside_month_at_offset(date, self.visible_month, self.visible_year, offset)
+    }
+
+    /// Whether `date`'s month/year matches the first visible month.
+    #[must_use]
+    pub const fn is_outside_visible_month(&self, date: &CalendarDate) -> bool {
+        date.month() != self.visible_month || date.year() != self.visible_year
+    }
+
+    /// Whether `date` falls within any of the visible months.
+    #[must_use]
+    pub fn is_in_visible_range(&self, date: &CalendarDate) -> bool {
+        grid_is_in_visible_range(
+            date,
+            self.visible_month,
+            self.visible_year,
+            self.visible_months,
+        )
+    }
+
+    /// Builds the 6-week grid for the first visible month.
+    #[must_use]
+    pub fn weeks(&self) -> Vec<[CalendarDate; 7]> {
+        self.weeks_for(0)
+    }
+
+    /// Builds the 6-week grid for the month at the supplied offset.
+    #[must_use]
+    pub fn weeks_for(&self, offset: usize) -> Vec<[CalendarDate; 7]> {
+        grid_weeks_for(
+            self.visible_month,
+            self.visible_year,
+            self.first_day_of_week,
+            offset,
+        )
+    }
+
+    /// Returns the ordered weekday list starting at `first_day_of_week`.
+    #[must_use]
+    pub fn ordered_weekdays(&self) -> [Weekday; 7] {
+        grid_ordered_weekdays(self.first_day_of_week)
+    }
+
+    /// Ordered `(weekday, short_label)` pairs for the head row.
+    #[must_use]
+    pub fn week_day_labels(&self) -> Vec<(Weekday, String)> {
+        self.ordered_weekdays()
+            .into_iter()
+            .map(|wd| (wd, self.intl_backend.weekday_short_label(wd, &self.locale)))
+            .collect()
+    }
+
+    /// Advances `(visible_month, visible_year)` by `n` whole months.
+    pub const fn advance_month(&mut self, n: i32) {
+        let (month, year) = advance_month_pair(self.visible_month, self.visible_year, n);
+
+        self.visible_month = month;
+        self.visible_year = year;
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Part / Machine
+// ────────────────────────────────────────────────────────────────────
+
+/// Parts of the `Calendar` anatomy. See spec §2.
+#[derive(ars_core::ComponentPart)]
+#[scope = "calendar"]
+pub enum Part {
+    /// The outer component root.
+    Root,
+
+    /// The header container holding the prev/heading/next controls.
+    Header,
+
+    /// The "previous month" button.
+    PrevTrigger,
+
+    /// The "next month" button.
+    NextTrigger,
+
+    /// The textual month/year heading.
+    Heading,
+
+    /// The grid wrapper element (a single `<table>` per visible month).
+    Grid,
+
+    /// Wrapper grouping multiple grids when `visible_months > 1`.
+    GridGroup,
+
+    /// The header row of weekday labels.
+    HeadRow,
+
+    /// Individual weekday header cell.
+    HeadCell {
+        /// The weekday this cell describes.
+        #[part(default = Weekday::Monday)]
+        day: Weekday,
+    },
+
+    /// A row of seven day cells (one week).
+    Row {
+        /// Zero-based index of this week within the grid (0..6).
+        week_index: usize,
+    },
+
+    /// A grid cell wrapping one date.
+    Cell {
+        /// The date represented by this cell.
+        #[part(default = default_calendar_date())]
+        date: CalendarDate,
+    },
+
+    /// The interactive trigger inside a cell (the actual `<button>`).
+    CellTrigger {
+        /// The date represented by this trigger.
+        #[part(default = default_calendar_date())]
+        date: CalendarDate,
+    },
+}
+
+fn default_calendar_date() -> CalendarDate {
+    CalendarDate::new_gregorian(1, 1, 1).expect("1-01-01 is a valid Gregorian date")
+}
+
+/// Machine for the `Calendar` component.
+#[derive(Debug)]
+pub struct Machine;
+
+impl ars_core::Machine for Machine {
+    type State = State;
+    type Event = Event;
+    type Context = Context;
+    type Props = Props;
+    type Messages = Messages;
+    type Effect = Effect;
+    type Api<'a> = Api<'a>;
+
+    fn init(
+        props: &Self::Props,
+        env: &Env,
+        messages: &Self::Messages,
+    ) -> (Self::State, Self::Context) {
+        let value = if let Some(controlled) = &props.value {
+            Bindable::controlled(controlled.clone())
+        } else {
+            Bindable::uncontrolled(props.default_value.clone())
+        };
+
+        let selected_dates = if let Some(set) = &props.selected_dates {
+            Bindable::controlled(set.clone())
+        } else {
+            Bindable::uncontrolled(props.default_selected_dates.clone())
+        };
+
+        let initial_date = match props.selection_mode {
+            SelectionMode::Single => value.get().clone().unwrap_or_else(|| props.today.clone()),
+            SelectionMode::Multiple => selected_dates
+                .get()
+                .iter()
+                .next()
+                .cloned()
+                .unwrap_or_else(|| props.today.clone()),
+        };
+
+        let locale = env.locale.clone();
+
+        let first_day_of_week = props
+            .first_day_of_week
+            .unwrap_or_else(|| locale.first_day_of_week(&*env.intl_backend));
+
+        let visible_months = props.visible_months.max(1);
+        let ids = ComponentIds::from_id(&props.id);
+        let focused_date = initial_date;
+        let visible_month = focused_date.month();
+        let visible_year = focused_date.year();
+
+        let ctx = Context {
+            value,
+            selected_dates,
+            selection_mode: props.selection_mode,
+            max_selected: props.max_selected,
+            focused_date,
+            visible_month,
+            visible_year,
+            visible_months,
+            page_behavior: props.page_behavior,
+            min: props.min.clone(),
+            max: props.max.clone(),
+            first_day_of_week,
+            is_rtl: props.is_rtl,
+            disabled: props.disabled,
+            readonly: props.readonly,
+            show_week_numbers: props.show_week_numbers,
+            today: props.today.clone(),
+            is_date_unavailable_fn: props.is_date_unavailable.clone(),
+            locale,
+            messages: messages.clone(),
+            intl_backend: Arc::clone(&env.intl_backend),
+            ids,
+        };
+
+        (State::Idle, ctx)
+    }
+
+    fn transition(
+        _state: &Self::State,
+        event: &Self::Event,
+        ctx: &Self::Context,
+        _props: &Self::Props,
+    ) -> Option<TransitionPlan<Self>> {
+        if ctx.disabled {
+            return None;
+        }
+
+        match event {
+            Event::FocusIn => Some(TransitionPlan::to(State::Focused)),
+
+            Event::FocusOut => Some(TransitionPlan::to(State::Idle)),
+
+            Event::FocusDate { date } => {
+                let clamped = ctx.clamp_date(date.clone());
+                Some(
+                    TransitionPlan::to(State::Focused).apply(move |ctx: &mut Context| {
+                        ctx.focused_date = clamped;
+
+                        ctx.sync_visible_to_focused();
+                    }),
+                )
+            }
+
+            Event::SelectDate { date } | Event::ToggleDate { date } => match ctx.selection_mode {
+                SelectionMode::Single => apply_select_single(ctx, date.clone()),
+                SelectionMode::Multiple => apply_toggle_multi(ctx, date.clone()),
+            },
+
+            Event::NextMonth => Some(month_step_plan(step_for_page_behavior(ctx))),
+
+            Event::PrevMonth => Some(month_step_plan(-step_for_page_behavior(ctx))),
+
+            Event::NextYear => Some(month_step_plan(12)),
+
+            Event::PrevYear => Some(month_step_plan(-12)),
+
+            Event::SetMonth { month } => {
+                let month = *month;
+                if !(1..=12).contains(&month) {
+                    return None;
+                }
+
+                Some(
+                    TransitionPlan::context_only(move |ctx: &mut Context| {
+                        ctx.visible_month = month;
+                    })
+                    .with_effect(announce_month_effect()),
+                )
+            }
+
+            Event::SetYear { year } => {
+                let year = *year;
+                Some(
+                    TransitionPlan::context_only(move |ctx: &mut Context| {
+                        ctx.visible_year = year;
+                    })
+                    .with_effect(announce_month_effect()),
+                )
+            }
+
+            Event::KeyDown { key, shift } => handle_keydown(*key, *shift, ctx),
+        }
+    }
+
+    fn connect<'a>(
+        state: &'a Self::State,
+        context: &'a Self::Context,
+        props: &'a Self::Props,
+        send: &'a dyn Fn(Self::Event),
+    ) -> Self::Api<'a> {
+        Api::new(state, context, props, send)
+    }
+}
+
+fn step_for_page_behavior(ctx: &Context) -> i32 {
+    match ctx.page_behavior {
+        PageBehavior::Visible => i32::try_from(ctx.visible_months).unwrap_or(1).max(1),
+        PageBehavior::Single => 1,
+    }
+}
+
+fn month_step_plan(step: i32) -> TransitionPlan<Machine> {
+    TransitionPlan::context_only(move |ctx: &mut Context| {
+        ctx.advance_month(step);
+    })
+    .with_effect(announce_month_effect())
+}
+
+fn announce_month_effect() -> ars_core::PendingEffect<Machine> {
+    ars_core::PendingEffect::named(Effect::AnnounceMonth)
+}
+
+fn apply_select_single(ctx: &Context, date: CalendarDate) -> Option<TransitionPlan<Machine>> {
+    if ctx.readonly {
+        return None;
+    }
+
+    if ctx.is_date_disabled(&date) || ctx.is_date_unavailable(&date) {
+        return None;
+    }
+
+    Some(
+        TransitionPlan::to(State::Focused).apply(move |ctx: &mut Context| {
+            ctx.value.set(Some(date.clone()));
+            ctx.focused_date = date;
+        }),
+    )
+}
+
+fn apply_toggle_multi(ctx: &Context, date: CalendarDate) -> Option<TransitionPlan<Machine>> {
+    if ctx.readonly {
+        return None;
+    }
+
+    if ctx.is_date_disabled(&date) || ctx.is_date_unavailable(&date) {
+        return None;
+    }
+
+    let already_selected = ctx.selected_dates.get().contains(&date);
+    let max_selected = ctx.max_selected;
+
+    let at_cap =
+        !already_selected && max_selected.is_some_and(|cap| ctx.selected_dates.get().len() >= cap);
+
+    if at_cap {
+        // Excess toggles are silently dropped per spec §5.4.
+        return None;
+    }
+
+    Some(
+        TransitionPlan::to(State::Focused).apply(move |ctx: &mut Context| {
+            let mut next = ctx.selected_dates.get().clone();
+
+            if already_selected {
+                next.remove(&date);
+            } else {
+                next.insert(date.clone());
+            }
+
+            ctx.selected_dates.set(next);
+            ctx.focused_date = date;
+        }),
+    )
+}
+
+fn handle_keydown(key: KeyboardKey, shift: bool, ctx: &Context) -> Option<TransitionPlan<Machine>> {
+    if shift {
+        match key {
+            KeyboardKey::PageUp => return Some(month_step_plan(-12)),
+            KeyboardKey::PageDown => return Some(month_step_plan(12)),
+            _ => {}
+        }
+    }
+
+    let focused = ctx.focused_date.clone();
+
+    let (prev_day_key, next_day_key) = if ctx.is_rtl {
+        (KeyboardKey::ArrowRight, KeyboardKey::ArrowLeft)
+    } else {
+        (KeyboardKey::ArrowLeft, KeyboardKey::ArrowRight)
+    };
+
+    let new_focus: Option<CalendarDate> = if key == prev_day_key {
+        focused.add_days(-1).ok()
+    } else if key == next_day_key {
+        focused.add_days(1).ok()
+    } else {
+        match key {
+            KeyboardKey::ArrowUp => focused.add_days(-7).ok(),
+
+            KeyboardKey::ArrowDown => focused.add_days(7).ok(),
+
+            KeyboardKey::Home => {
+                let wd = grid::weekday_sunday_zero(focused.weekday());
+                let start = grid::weekday_sunday_zero(ctx.first_day_of_week);
+                let offset = i32::from((wd + 7 - start) % 7);
+
+                focused.add_days(-offset).ok()
+            }
+
+            KeyboardKey::End => {
+                let wd = grid::weekday_sunday_zero(focused.weekday());
+                let start = grid::weekday_sunday_zero(ctx.first_day_of_week);
+                let offset = i32::from((wd + 7 - start) % 7);
+
+                focused.add_days(6 - offset).ok()
+            }
+
+            KeyboardKey::PageUp => focused
+                .add(ars_i18n::DateDuration {
+                    months: -1,
+                    ..ars_i18n::DateDuration::default()
+                })
+                .ok(),
+
+            KeyboardKey::PageDown => focused
+                .add(ars_i18n::DateDuration {
+                    months: 1,
+                    ..ars_i18n::DateDuration::default()
+                })
+                .ok(),
+
+            _ => None,
+        }
+    };
+
+    if let Some(date) = new_focus {
+        let clamped = ctx.clamp_date(date);
+
+        return Some(
+            TransitionPlan::to(State::Focused).apply(move |ctx: &mut Context| {
+                ctx.focused_date = clamped;
+
+                ctx.sync_visible_to_focused();
+            }),
+        );
+    }
+
+    match key {
+        KeyboardKey::Enter | KeyboardKey::Space => {
+            let date = focused;
+
+            let select_event = match ctx.selection_mode {
+                SelectionMode::Single => Event::SelectDate { date },
+                SelectionMode::Multiple => Event::ToggleDate { date },
+            };
+
+            Some(TransitionPlan::context_only(|_ctx: &mut Context| {}).then(select_event))
+        }
+
+        _ => None,
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Api
+// ────────────────────────────────────────────────────────────────────
+
+/// API for the `Calendar` component.
+pub struct Api<'a> {
+    state: &'a State,
+    ctx: &'a Context,
+    props: &'a Props,
+    send: &'a dyn Fn(Event),
+}
+
+impl Debug for Api<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Api")
+            .field("state", self.state)
+            .field("ctx", self.ctx)
+            .field("props", self.props)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<'a> Api<'a> {
+    /// Creates a new `Calendar` connect API from machine state.
+    #[must_use]
+    pub const fn new(
+        state: &'a State,
+        ctx: &'a Context,
+        props: &'a Props,
+        send: &'a dyn Fn(Event),
+    ) -> Self {
+        Self {
+            state,
+            ctx,
+            props,
+            send,
+        }
+    }
+
+    // ── Root / structural attributes ─────────────────────────────────────
+
+    /// Returns attributes for the outer root element.
+    #[must_use]
+    pub fn root_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Root.data_attrs();
+
+        attrs
+            .set(HtmlAttr::Id, self.ctx.ids.id())
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Data("ars-state"), self.state_name());
+
+        if self.ctx.disabled {
+            attrs.set_bool(HtmlAttr::Data("ars-disabled"), true);
+        }
+
+        if self.ctx.readonly {
+            attrs.set_bool(HtmlAttr::Data("ars-readonly"), true);
+        }
+
+        if self.ctx.is_rtl {
+            attrs.set(HtmlAttr::Dir, "rtl");
+        }
+
+        attrs
+    }
+
+    /// Returns attributes for the header container.
+    #[must_use]
+    pub fn header_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Header.data_attrs();
+
+        attrs
+            .set(HtmlAttr::Id, self.ctx.ids.part("header"))
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val);
+
+        attrs
+    }
+
+    /// Returns attributes for the previous-month / previous-page button.
+    #[must_use]
+    pub fn prev_trigger_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::PrevTrigger.data_attrs();
+
+        let step = self.nav_step_size();
+
+        let label = if step > 1 {
+            (self.ctx.messages.prev_page_label)(step, &self.ctx.locale)
+        } else {
+            (self.ctx.messages.prev_month_label)(&self.ctx.locale)
+        };
+
+        attrs
+            .set(HtmlAttr::Id, self.ctx.ids.part("prev-trigger"))
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Aria(AriaAttr::Label), label)
+            .set(HtmlAttr::TabIndex, "-1");
+
+        if self.is_prev_disabled() {
+            attrs
+                .set_bool(HtmlAttr::Disabled, true)
+                .set(HtmlAttr::Aria(AriaAttr::Disabled), "true");
+        }
+
+        attrs
+    }
+
+    /// Returns attributes for the next-month / next-page button.
+    #[must_use]
+    pub fn next_trigger_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::NextTrigger.data_attrs();
+
+        let step = self.nav_step_size();
+
+        let label = if step > 1 {
+            (self.ctx.messages.next_page_label)(step, &self.ctx.locale)
+        } else {
+            (self.ctx.messages.next_month_label)(&self.ctx.locale)
+        };
+
+        attrs
+            .set(HtmlAttr::Id, self.ctx.ids.part("next-trigger"))
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Aria(AriaAttr::Label), label)
+            .set(HtmlAttr::TabIndex, "-1");
+
+        if self.is_next_disabled() {
+            attrs
+                .set_bool(HtmlAttr::Disabled, true)
+                .set(HtmlAttr::Aria(AriaAttr::Disabled), "true");
+        }
+
+        attrs
+    }
+
+    /// Returns attributes for the main month/year heading. The heading
+    /// is the `aria-live="polite"` announcer for month navigation.
+    #[must_use]
+    pub fn heading_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Heading.data_attrs();
+
+        attrs
+            .set(HtmlAttr::Id, self.ctx.ids.part("heading"))
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Aria(AriaAttr::Live), "polite")
+            .set(HtmlAttr::Aria(AriaAttr::Atomic), "true");
+
+        attrs
+    }
+
+    /// Formatted month/year string for the main heading. Multi-month
+    /// configurations render the full range via [`Api::range_heading_text`];
+    /// this method always describes the first visible month only.
+    #[must_use]
+    pub fn heading_text(&self) -> String {
+        format!(
+            "{} {}",
+            self.ctx
+                .intl_backend
+                .month_long_name(self.ctx.visible_month, &self.ctx.locale),
+            self.ctx.visible_year,
+        )
+    }
+
+    /// Attributes for the grid wrapper of the first visible month.
+    #[must_use]
+    pub fn grid_attrs(&self) -> AttrMap {
+        self.grid_attrs_with_ids(self.ctx.ids.part("grid"), self.ctx.ids.part("heading"))
+    }
+
+    /// Attributes for the grid of the month at the supplied offset.
+    /// Multi-month layouts use the per-grid heading id rather than the
+    /// shared live-region heading.
+    #[must_use]
+    pub fn grid_attrs_for(&self, offset: usize) -> AttrMap {
+        let grid_id = self.ctx.ids.item("grid", &offset);
+        let heading_id = self.ctx.ids.item("heading", &offset);
+
+        self.grid_attrs_with_ids(grid_id, heading_id)
+    }
+
+    fn grid_attrs_with_ids(&self, grid_id: String, heading_id: String) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Grid.data_attrs();
+
+        attrs
+            .set(HtmlAttr::Id, grid_id)
+            .set(HtmlAttr::Role, "grid")
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Aria(AriaAttr::LabelledBy), heading_id);
+
+        if matches!(self.ctx.selection_mode, SelectionMode::Multiple) {
+            attrs.set(HtmlAttr::Aria(AriaAttr::MultiSelectable), "true");
+        }
+
+        if self.ctx.readonly {
+            attrs.set(HtmlAttr::Aria(AriaAttr::ReadOnly), "true");
+        }
+
+        if self.ctx.disabled {
+            attrs.set(HtmlAttr::Aria(AriaAttr::Disabled), "true");
+        }
+
+        attrs
+    }
+
+    /// Attributes for the multi-grid wrapper. Only meaningful when
+    /// `visible_months > 1`; single-month layouts skip rendering the
+    /// wrapper entirely and use [`Api::grid_attrs`] directly.
+    #[must_use]
+    pub fn grid_group_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::GridGroup.data_attrs();
+
+        attrs
+            .set(HtmlAttr::Id, format!("{}-grid-group", self.ctx.ids.id()))
+            .set(HtmlAttr::Role, "group")
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Aria(AriaAttr::Label), self.range_heading_text());
+
+        attrs
+    }
+
+    /// Heading attributes for a per-grid (offset > 0) heading. Per-grid
+    /// headings are visually hidden and intentionally have no `aria-live`
+    /// — only the main [`Api::heading_attrs`] heading announces month
+    /// changes to avoid duplicate announcements.
+    #[must_use]
+    pub fn heading_attrs_for(&self, offset: usize) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Heading.data_attrs();
+
+        attrs
+            .set(HtmlAttr::Id, self.ctx.ids.item("heading", &offset))
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val);
+
+        attrs
+    }
+
+    /// Heading text for the month at the supplied offset.
+    #[must_use]
+    pub fn heading_text_for(&self, offset: usize) -> String {
+        let (month, year) = self.ctx.month_year_at_offset(offset);
+
+        format!(
+            "{} {}",
+            self.ctx
+                .intl_backend
+                .month_long_name(month, &self.ctx.locale),
+            year,
+        )
+    }
+
+    /// Heading text that spans every visible month. Equivalent to
+    /// [`Api::heading_text`] when `visible_months <= 1`.
+    #[must_use]
+    pub fn range_heading_text(&self) -> String {
+        if self.ctx.visible_months <= 1 {
+            return self.heading_text();
+        }
+
+        let first = self.heading_text_for(0);
+        let last = self.heading_text_for(self.ctx.visible_months - 1);
+
+        let sep = (self.ctx.messages.month_range_separator)(&self.ctx.locale);
+
+        format!("{first}{sep}{last}")
+    }
+
+    /// Attributes for the head row (weekday labels).
+    #[must_use]
+    pub fn head_row_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::HeadRow.data_attrs();
+
+        attrs.set(scope_attr, scope_val).set(part_attr, part_val);
+
+        attrs
+    }
+
+    /// Attributes for a single weekday header cell.
+    #[must_use]
+    pub fn head_cell_attrs(&self, weekday: Weekday) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] =
+            Part::HeadCell { day: weekday }.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Scope, "col")
+            .set(
+                HtmlAttr::Abbr,
+                self.ctx
+                    .intl_backend
+                    .weekday_long_label(weekday, &self.ctx.locale),
+            );
+
+        attrs
+    }
+
+    /// Attributes for a body row, including the `data-ars-week-index`
+    /// hook adapters use for keyed reconciliation.
+    #[must_use]
+    pub fn row_attrs(&self, week_index: usize) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] =
+            Part::Row { week_index }.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Data("ars-week-index"), week_index.to_string());
+
+        attrs
+    }
+
+    /// Attributes for a cell wrapper around a date trigger.
+    #[must_use]
+    pub fn cell_attrs(&self, date: &CalendarDate) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] =
+            Part::Cell { date: date.clone() }.data_attrs();
+
+        attrs
+            .set(HtmlAttr::Role, "gridcell")
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val);
+
+        if self.is_selected(date) {
+            attrs.set(HtmlAttr::Aria(AriaAttr::Selected), "true");
+        }
+
+        if self.ctx.is_outside_visible_month(date) {
+            attrs.set_bool(HtmlAttr::Data("ars-outside-month"), true);
+        }
+
+        if self.is_disabled(date) {
+            attrs.set(HtmlAttr::Aria(AriaAttr::Disabled), "true");
+        }
+
+        attrs
+    }
+
+    /// Like [`Api::cell_attrs`] but checks "outside month" against the
+    /// month at the supplied offset rather than the first visible month.
+    /// Multi-month layouts use this so cells render the correct
+    /// outside-month flag for each grid.
+    #[must_use]
+    pub fn cell_attrs_for(&self, date: &CalendarDate, offset: usize) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] =
+            Part::Cell { date: date.clone() }.data_attrs();
+
+        attrs
+            .set(HtmlAttr::Role, "gridcell")
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val);
+
+        if self.is_selected(date) {
+            attrs.set(HtmlAttr::Aria(AriaAttr::Selected), "true");
+        }
+
+        if self.ctx.is_outside_month_at_offset(date, offset) {
+            attrs.set_bool(HtmlAttr::Data("ars-outside-month"), true);
+        }
+
+        if self.is_disabled(date) {
+            attrs.set(HtmlAttr::Aria(AriaAttr::Disabled), "true");
+        }
+
+        attrs
+    }
+
+    /// Attributes for the interactive trigger inside a cell.
+    #[must_use]
+    pub fn cell_trigger_attrs(&self, date: &CalendarDate) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] =
+            Part::CellTrigger { date: date.clone() }.data_attrs();
+
+        attrs.set(scope_attr, scope_val).set(part_attr, part_val);
+
+        let disabled = self.is_disabled(date);
+        let unavailable = self.is_unavailable(date);
+        let is_focused = &self.ctx.focused_date == date;
+        let is_today = self.is_today(date);
+        let selected = self.is_selected(date);
+
+        attrs.set(HtmlAttr::TabIndex, if is_focused { "0" } else { "-1" });
+
+        if disabled || unavailable {
+            attrs
+                .set_bool(HtmlAttr::Disabled, true)
+                .set(HtmlAttr::Aria(AriaAttr::Disabled), "true");
+        }
+
+        if selected {
+            attrs.set(HtmlAttr::Aria(AriaAttr::Selected), "true");
+        }
+
+        if is_today {
+            attrs.set_bool(HtmlAttr::Data("ars-today"), true);
+        }
+
+        if self.ctx.is_outside_visible_month(date) {
+            attrs.set_bool(HtmlAttr::Data("ars-outside-month"), true);
+        }
+
+        if unavailable {
+            attrs.set_bool(HtmlAttr::Data("ars-unavailable"), true);
+        }
+
+        let base_label = format!(
+            "{} {}, {}, {}",
+            self.ctx
+                .intl_backend
+                .month_long_name(date.month(), &self.ctx.locale),
+            date.day(),
+            date.year(),
+            self.ctx
+                .intl_backend
+                .weekday_long_label(date.weekday(), &self.ctx.locale),
+        );
+
+        let label = if unavailable {
+            format!("{base_label} (unavailable)")
+        } else if disabled {
+            format!("{base_label} (disabled)")
+        } else {
+            base_label
+        };
+
+        attrs.set(HtmlAttr::Aria(AriaAttr::Label), label);
+
+        attrs
+    }
+
+    // ── Computed state accessors ─────────────────────────────────────
+
+    /// Whether `date` is the currently selected single-select value or
+    /// is in the multi-select set, depending on `selection_mode`.
+    #[must_use]
+    pub fn is_selected(&self, date: &CalendarDate) -> bool {
+        self.ctx.is_selected(date)
+    }
+
+    /// Whether `date` equals the configured `today`.
+    #[must_use]
+    pub fn is_today(&self, date: &CalendarDate) -> bool {
+        date == &self.ctx.today
+    }
+
+    /// Whether `date` is disabled (outside min/max or globally disabled).
+    #[must_use]
+    pub fn is_disabled(&self, date: &CalendarDate) -> bool {
+        self.ctx.is_date_disabled(date)
+    }
+
+    /// Whether `date` is marked unavailable by the user predicate.
+    #[must_use]
+    pub fn is_unavailable(&self, date: &CalendarDate) -> bool {
+        self.ctx.is_date_unavailable(date)
+    }
+
+    /// Whether `date` belongs to a different month than the first visible
+    /// month.
+    #[must_use]
+    pub const fn is_outside_visible_month(&self, date: &CalendarDate) -> bool {
+        self.ctx.is_outside_visible_month(date)
+    }
+
+    /// Whether the prev-trigger should be disabled due to a `min` constraint.
+    #[must_use]
+    pub fn is_prev_disabled(&self) -> bool {
+        let Some(min) = &self.ctx.min else {
+            return false;
+        };
+
+        let Ok(first_of_visible) =
+            CalendarDate::new_gregorian(self.ctx.visible_year, self.ctx.visible_month, 1)
+        else {
+            return false;
+        };
+
+        !matches!(first_of_visible.compare(min), Ordering::Greater)
+    }
+
+    /// Whether the next-trigger should be disabled due to a `max` constraint.
+    /// Checks against the **last** visible month so multi-month layouts
+    /// behave correctly.
+    #[must_use]
+    pub fn is_next_disabled(&self) -> bool {
+        let Some(max) = &self.ctx.max else {
+            return false;
+        };
+
+        let last_offset = self.ctx.visible_months.saturating_sub(1);
+
+        let (month, year) = self.ctx.month_year_at_offset(last_offset);
+
+        let Ok(first_of_last) = CalendarDate::new_gregorian(year, month, 1) else {
+            return false;
+        };
+
+        let days_in_month = first_of_last.days_in_month();
+
+        let Ok(last_of_last) = CalendarDate::new_gregorian(year, month, days_in_month) else {
+            return false;
+        };
+
+        !matches!(last_of_last.compare(max), Ordering::Less)
+    }
+
+    /// Returns the configured "today" date.
+    #[must_use]
+    pub const fn today(&self) -> &CalendarDate {
+        &self.ctx.today
+    }
+
+    /// Returns the currently focused date.
+    #[must_use]
+    pub const fn focused_date(&self) -> &CalendarDate {
+        &self.ctx.focused_date
+    }
+
+    /// Whether the calendar grid currently has focus.
+    #[must_use]
+    pub const fn is_focused(&self) -> bool {
+        matches!(self.state, State::Focused)
+    }
+
+    /// Number of months visible side-by-side (>= 1).
+    #[must_use]
+    pub const fn visible_month_count(&self) -> usize {
+        self.ctx.visible_months
+    }
+
+    /// Iterator of month offsets `0..visible_months` for multi-month
+    /// rendering.
+    #[must_use]
+    pub const fn month_offsets(&self) -> core::ops::Range<usize> {
+        0..self.ctx.visible_months
+    }
+
+    /// Whether week numbers should be rendered.
+    #[must_use]
+    pub const fn show_week_numbers(&self) -> bool {
+        self.ctx.show_week_numbers
+    }
+
+    /// Active selection mode.
+    #[must_use]
+    pub const fn selection_mode(&self) -> SelectionMode {
+        self.ctx.selection_mode
+    }
+
+    /// 6-week grid for the first visible month.
+    #[must_use]
+    pub fn weeks(&self) -> Vec<[CalendarDate; 7]> {
+        self.ctx.weeks()
+    }
+
+    /// 6-week grid for the month at the supplied offset.
+    #[must_use]
+    pub fn weeks_for(&self, offset: usize) -> Vec<[CalendarDate; 7]> {
+        self.ctx.weeks_for(offset)
+    }
+
+    /// Ordered `(weekday, short-label)` pairs for the head row.
+    #[must_use]
+    pub fn week_day_labels(&self) -> Vec<(Weekday, String)> {
+        self.ctx.week_day_labels()
+    }
+
+    // ── Event handlers ───────────────────────────────────────────────
+
+    /// Handle a click on a date cell.
+    pub fn on_cell_click(&self, date: CalendarDate) {
+        let event = match self.ctx.selection_mode {
+            SelectionMode::Single => Event::SelectDate { date },
+            SelectionMode::Multiple => Event::ToggleDate { date },
+        };
+
+        (self.send)(event);
+    }
+
+    /// Handle focus entering the grid.
+    pub fn on_grid_focusin(&self) {
+        (self.send)(Event::FocusIn);
+    }
+
+    /// Handle focus leaving the grid. The adapter passes
+    /// `focus_leaving_grid = true` only when focus moves outside the grid
+    /// element, so the machine stays focused when arrow keys move between
+    /// cells.
+    pub fn on_grid_focusout(&self, focus_leaving_grid: bool) {
+        if focus_leaving_grid {
+            (self.send)(Event::FocusOut);
+        }
+    }
+
+    /// Handle a keydown on the grid. The adapter folds the shift modifier
+    /// into the call so the machine can map `Shift+PageUp` / `Shift+PageDown`
+    /// to year navigation in a single transition.
+    pub fn on_grid_keydown(&self, key: KeyboardKey, shift: bool) {
+        (self.send)(Event::KeyDown { key, shift });
+    }
+
+    /// Handle a click on the previous-month button.
+    pub fn on_prev_click(&self) {
+        (self.send)(Event::PrevMonth);
+    }
+
+    /// Handle a click on the next-month button.
+    pub fn on_next_click(&self) {
+        (self.send)(Event::NextMonth);
+    }
+
+    // ── Internal helpers ─────────────────────────────────────────────
+
+    const fn nav_step_size(&self) -> usize {
+        match self.ctx.page_behavior {
+            PageBehavior::Visible => self.ctx.visible_months,
+            PageBehavior::Single => 1,
+        }
+    }
+
+    const fn state_name(&self) -> &'static str {
+        match self.state {
+            State::Idle => "idle",
+            State::Focused => "focused",
+        }
+    }
+}
+
+impl ConnectApi for Api<'_> {
+    type Part = Part;
+
+    fn part_attrs(&self, part: Part) -> AttrMap {
+        match part {
+            Part::Root => self.root_attrs(),
+            Part::Header => self.header_attrs(),
+            Part::PrevTrigger => self.prev_trigger_attrs(),
+            Part::NextTrigger => self.next_trigger_attrs(),
+            Part::Heading => self.heading_attrs(),
+            Part::Grid => self.grid_attrs(),
+            Part::GridGroup => self.grid_group_attrs(),
+            Part::HeadRow => self.head_row_attrs(),
+            Part::HeadCell { day } => self.head_cell_attrs(day),
+            Part::Row { week_index } => self.row_attrs(week_index),
+            Part::Cell { date } => self.cell_attrs(&date),
+            Part::CellTrigger { date } => self.cell_trigger_attrs(&date),
+        }
+    }
+}

--- a/crates/ars-components/src/date_time/calendar/mod.rs
+++ b/crates/ars-components/src/date_time/calendar/mod.rs
@@ -1881,7 +1881,13 @@ impl<'a> Api<'a> {
     }
 
     /// Whether the prev-trigger should be disabled — either the calendar
-    /// is globally disabled or the visible range is already at `min`.
+    /// is globally disabled or stepping back by `page_behavior`'s step
+    /// would yield a visible range with no selectable dates ≥ `min`.
+    ///
+    /// The check honours [`PageBehavior::Single`] vs [`PageBehavior::Visible`]:
+    /// with multi-month + `Single`, paging back by one month may still
+    /// produce a range that contains selectable dates even if the current
+    /// first visible month already starts at-or-before `min`.
     #[must_use]
     pub fn is_prev_disabled(&self) -> bool {
         if self.ctx.disabled {
@@ -1892,19 +1898,40 @@ impl<'a> Api<'a> {
             return false;
         };
 
-        let Ok(first_of_visible) =
-            CalendarDate::new_gregorian(self.ctx.visible_year, self.ctx.visible_month, 1)
+        // Compute the LAST visible month after pressing prev. If even its
+        // last day is below `min`, the next page back has no selectable
+        // dates and prev is disabled.
+        let step = self.nav_step_size();
+        let (new_first_month, new_first_year) = advance_month_pair(
+            self.ctx.visible_month,
+            self.ctx.visible_year,
+            -i32::try_from(step).unwrap_or(1),
+        );
+        let last_offset = self.ctx.visible_months.saturating_sub(1);
+        let (new_last_month, new_last_year) =
+            grid_month_year_at_offset(new_first_month, new_first_year, last_offset);
+
+        let Ok(first_of_new_last) = CalendarDate::new_gregorian(new_last_year, new_last_month, 1)
+        else {
+            return false;
+        };
+        let days_in_month = first_of_new_last.days_in_month();
+        let Ok(last_of_new_last) =
+            CalendarDate::new_gregorian(new_last_year, new_last_month, days_in_month)
         else {
             return false;
         };
 
-        !matches!(first_of_visible.compare(min), Ordering::Greater)
+        matches!(last_of_new_last.compare(min), Ordering::Less)
     }
 
     /// Whether the next-trigger should be disabled — either the calendar
-    /// is globally disabled or the visible range is already at `max`.
-    /// Checks against the **last** visible month so multi-month layouts
-    /// behave correctly.
+    /// is globally disabled or stepping forward by `page_behavior`'s step
+    /// would yield a visible range with no selectable dates ≤ `max`.
+    ///
+    /// Symmetric to [`Api::is_prev_disabled`]: the check honours
+    /// [`PageBehavior::Single`] vs [`PageBehavior::Visible`] so multi-month
+    /// + single-step paging doesn't disable too early.
     #[must_use]
     pub fn is_next_disabled(&self) -> bool {
         if self.ctx.disabled {
@@ -1915,21 +1942,22 @@ impl<'a> Api<'a> {
             return false;
         };
 
-        let last_offset = self.ctx.visible_months.saturating_sub(1);
-
-        let (month, year) = self.ctx.month_year_at_offset(last_offset);
-
-        let Ok(first_of_last) = CalendarDate::new_gregorian(year, month, 1) else {
+        // Compute the FIRST visible month after pressing next. If its
+        // first day is already above `max`, the next page forward has no
+        // selectable dates and next is disabled.
+        let step = self.nav_step_size();
+        let (new_first_month, new_first_year) = advance_month_pair(
+            self.ctx.visible_month,
+            self.ctx.visible_year,
+            i32::try_from(step).unwrap_or(1),
+        );
+        let Ok(first_of_new_first) =
+            CalendarDate::new_gregorian(new_first_year, new_first_month, 1)
+        else {
             return false;
         };
 
-        let days_in_month = first_of_last.days_in_month();
-
-        let Ok(last_of_last) = CalendarDate::new_gregorian(year, month, days_in_month) else {
-            return false;
-        };
-
-        !matches!(last_of_last.compare(max), Ordering::Less)
+        matches!(first_of_new_first.compare(max), Ordering::Greater)
     }
 
     /// Returns the configured "today" date.

--- a/crates/ars-components/src/date_time/calendar/mod.rs
+++ b/crates/ars-components/src/date_time/calendar/mod.rs
@@ -575,6 +575,20 @@ pub struct Messages {
     /// Separator inserted between month names in a multi-month range
     /// heading (e.g., `" – "`).
     pub month_range_separator: MessageFn<LocaleLabelFn>,
+
+    /// Suffix appended to a date cell's `aria-label` when the date is
+    /// marked **unavailable** by the user predicate (focusable but not
+    /// selectable). The full label reads
+    /// `"{month} {day}, {year}, {weekday} {unavailable_suffix}"` with a
+    /// leading space inserted automatically — supply the parenthesised
+    /// or bracketed phrase verbatim (default: `"(unavailable)"`).
+    pub unavailable_suffix: MessageFn<LocaleLabelFn>,
+
+    /// Suffix appended to a date cell's `aria-label` when the date is
+    /// **disabled** by the configured `min`/`max` range. See
+    /// [`Messages::unavailable_suffix`] for the formatting contract
+    /// (default: `"(disabled)"`).
+    pub disabled_suffix: MessageFn<LocaleLabelFn>,
 }
 
 impl Default for Messages {
@@ -589,6 +603,8 @@ impl Default for Messages {
                 format!("Next {count} months")
             }),
             month_range_separator: MessageFn::static_str(" \u{2013} "),
+            unavailable_suffix: MessageFn::static_str("(unavailable)"),
+            disabled_suffix: MessageFn::static_str("(disabled)"),
         }
     }
 }
@@ -606,6 +622,8 @@ impl PartialEq for Messages {
             && self.prev_page_label == other.prev_page_label
             && self.next_page_label == other.next_page_label
             && self.month_range_separator == other.month_range_separator
+            && self.unavailable_suffix == other.unavailable_suffix
+            && self.disabled_suffix == other.disabled_suffix
     }
 }
 
@@ -1895,10 +1913,15 @@ impl<'a> Api<'a> {
                 .weekday_long_label(date.weekday(), &self.ctx.locale),
         );
 
+        // Status suffix flows through `Messages` so it can be localized
+        // (e.g., German `(nicht verfügbar)`); the leading space joins the
+        // base label and the suffix automatically.
         let label = if unavailable {
-            format!("{base_label} (unavailable)")
+            let suffix = (self.ctx.messages.unavailable_suffix)(&self.ctx.locale);
+            format!("{base_label} {suffix}")
         } else if disabled {
-            format!("{base_label} (disabled)")
+            let suffix = (self.ctx.messages.disabled_suffix)(&self.ctx.locale);
+            format!("{base_label} {suffix}")
         } else {
             base_label
         };
@@ -1956,13 +1979,10 @@ impl<'a> Api<'a> {
             return true;
         }
 
-        let Some(min) = &self.ctx.min else {
-            return false;
-        };
-
-        // Compute the LAST visible month after pressing prev. If even its
-        // last day is below `min`, the next page back has no selectable
-        // dates and prev is disabled.
+        // Compute the LAST visible month after pressing prev. If the
+        // arithmetic fails (calendar boundary), `month_step_plan` will
+        // drop the click — so we must surface that as a disabled
+        // control rather than leaving a clickable no-op.
         let step = self.nav_step_size();
         let (new_first_month, new_first_year) = advance_month_pair(
             self.ctx.visible_month,
@@ -1975,15 +1995,20 @@ impl<'a> Api<'a> {
 
         let Ok(first_of_new_last) = CalendarDate::new_gregorian(new_last_year, new_last_month, 1)
         else {
-            return false;
+            return true;
         };
         let days_in_month = first_of_new_last.days_in_month();
         let Ok(last_of_new_last) =
             CalendarDate::new_gregorian(new_last_year, new_last_month, days_in_month)
         else {
-            return false;
+            return true;
         };
 
+        // Past the representable range, also check the min constraint:
+        // if the post-step page is entirely below `min`, disable.
+        let Some(min) = &self.ctx.min else {
+            return false;
+        };
         matches!(last_of_new_last.compare(min), Ordering::Less)
     }
 
@@ -2000,13 +2025,10 @@ impl<'a> Api<'a> {
             return true;
         }
 
-        let Some(max) = &self.ctx.max else {
-            return false;
-        };
-
-        // Compute the FIRST visible month after pressing next. If its
-        // first day is already above `max`, the next page forward has no
-        // selectable dates and next is disabled.
+        // Compute the FIRST visible month after pressing next. If the
+        // arithmetic fails (calendar boundary), `month_step_plan` will
+        // drop the click — so surface that as disabled rather than a
+        // clickable no-op.
         let step = self.nav_step_size();
         let (new_first_month, new_first_year) = advance_month_pair(
             self.ctx.visible_month,
@@ -2016,9 +2038,13 @@ impl<'a> Api<'a> {
         let Ok(first_of_new_first) =
             CalendarDate::new_gregorian(new_first_year, new_first_month, 1)
         else {
-            return false;
+            return true;
         };
 
+        // Past representable range, also check the max constraint.
+        let Some(max) = &self.ctx.max else {
+            return false;
+        };
         matches!(first_of_new_first.compare(max), Ordering::Greater)
     }
 

--- a/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__cell_disabled_by_min.snap
+++ b/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__cell_disabled_by_min.snap
@@ -1,0 +1,39 @@
+---
+source: crates/ars-components/src/date_time/calendar/tests.rs
+expression: "snapshot_attrs(&api.cell_attrs(&date(2024, 1, 5)))"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "cell",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "calendar",
+            ),
+        ),
+        (
+            Aria(
+                Disabled,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "gridcell",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__cell_outside_month.snap
+++ b/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__cell_outside_month.snap
@@ -1,0 +1,39 @@
+---
+source: crates/ars-components/src/date_time/calendar/tests.rs
+expression: "snapshot_attrs(&api.cell_attrs(&date(2023, 12, 31)))"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-outside-month",
+            ),
+            Bool(
+                true,
+            ),
+        ),
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "cell",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "calendar",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "gridcell",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__cell_selected.snap
+++ b/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__cell_selected.snap
@@ -1,0 +1,39 @@
+---
+source: crates/ars-components/src/date_time/calendar/tests.rs
+expression: snapshot_attrs(&api.cell_attrs(&chosen))
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "cell",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "calendar",
+            ),
+        ),
+        (
+            Aria(
+                Selected,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "gridcell",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__cell_trigger_disabled_and_unavailable.snap
+++ b/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__cell_trigger_disabled_and_unavailable.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ars-components/src/date_time/calendar/tests.rs
+assertion_line: 1226
 expression: "snapshot_attrs(&api.cell_trigger_attrs(&date(2024, 1, 5)))"
 ---
 AttrMap {
@@ -54,6 +55,12 @@ AttrMap {
             Disabled,
             Bool(
                 true,
+            ),
+        ),
+        (
+            Type,
+            String(
+                "button",
             ),
         ),
     ],

--- a/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__cell_trigger_disabled_and_unavailable.snap
+++ b/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__cell_trigger_disabled_and_unavailable.snap
@@ -1,0 +1,61 @@
+---
+source: crates/ars-components/src/date_time/calendar/tests.rs
+expression: "snapshot_attrs(&api.cell_trigger_attrs(&date(2024, 1, 5)))"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "cell-trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "calendar",
+            ),
+        ),
+        (
+            Data(
+                "ars-unavailable",
+            ),
+            Bool(
+                true,
+            ),
+        ),
+        (
+            Aria(
+                Disabled,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "January 5, 2024, Friday (unavailable)",
+            ),
+        ),
+        (
+            TabIndex,
+            String(
+                "-1",
+            ),
+        ),
+        (
+            Disabled,
+            Bool(
+                true,
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__cell_trigger_focused.snap
+++ b/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__cell_trigger_focused.snap
@@ -1,0 +1,47 @@
+---
+source: crates/ars-components/src/date_time/calendar/tests.rs
+expression: snapshot_attrs(&trigger)
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "cell-trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "calendar",
+            ),
+        ),
+        (
+            Data(
+                "ars-today",
+            ),
+            Bool(
+                true,
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "January 15, 2024, Monday",
+            ),
+        ),
+        (
+            TabIndex,
+            String(
+                "0",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__cell_trigger_focused.snap
+++ b/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__cell_trigger_focused.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ars-components/src/date_time/calendar/tests.rs
+assertion_line: 1181
 expression: snapshot_attrs(&trigger)
 ---
 AttrMap {
@@ -40,6 +41,12 @@ AttrMap {
             TabIndex,
             String(
                 "0",
+            ),
+        ),
+        (
+            Type,
+            String(
+                "button",
             ),
         ),
     ],

--- a/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__cell_trigger_selected.snap
+++ b/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__cell_trigger_selected.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ars-components/src/date_time/calendar/tests.rs
+assertion_line: 1207
 expression: "snapshot_attrs(&api.cell_trigger_attrs(&date(2024, 1, 20)))"
 ---
 AttrMap {
@@ -40,6 +41,12 @@ AttrMap {
             TabIndex,
             String(
                 "0",
+            ),
+        ),
+        (
+            Type,
+            String(
+                "button",
             ),
         ),
     ],

--- a/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__cell_trigger_selected.snap
+++ b/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__cell_trigger_selected.snap
@@ -1,0 +1,47 @@
+---
+source: crates/ars-components/src/date_time/calendar/tests.rs
+expression: "snapshot_attrs(&api.cell_trigger_attrs(&date(2024, 1, 20)))"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "cell-trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "calendar",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "January 20, 2024, Saturday",
+            ),
+        ),
+        (
+            Aria(
+                Selected,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            TabIndex,
+            String(
+                "0",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__cell_trigger_today.snap
+++ b/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__cell_trigger_today.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ars-components/src/date_time/calendar/tests.rs
+assertion_line: 1238
 expression: "snapshot_attrs(&api.cell_trigger_attrs(&date(2024, 1, 15)))"
 ---
 AttrMap {
@@ -40,6 +41,12 @@ AttrMap {
             TabIndex,
             String(
                 "0",
+            ),
+        ),
+        (
+            Type,
+            String(
+                "button",
             ),
         ),
     ],

--- a/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__cell_trigger_today.snap
+++ b/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__cell_trigger_today.snap
@@ -1,0 +1,47 @@
+---
+source: crates/ars-components/src/date_time/calendar/tests.rs
+expression: "snapshot_attrs(&api.cell_trigger_attrs(&date(2024, 1, 15)))"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "cell-trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "calendar",
+            ),
+        ),
+        (
+            Data(
+                "ars-today",
+            ),
+            Bool(
+                true,
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "January 15, 2024, Monday",
+            ),
+        ),
+        (
+            TabIndex,
+            String(
+                "0",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__cell_trigger_unfocused.snap
+++ b/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__cell_trigger_unfocused.snap
@@ -1,0 +1,39 @@
+---
+source: crates/ars-components/src/date_time/calendar/tests.rs
+expression: "snapshot_attrs(&api.cell_trigger_attrs(&date(2024, 1, 20)))"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "cell-trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "calendar",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "January 20, 2024, Saturday",
+            ),
+        ),
+        (
+            TabIndex,
+            String(
+                "-1",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__cell_trigger_unfocused.snap
+++ b/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__cell_trigger_unfocused.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ars-components/src/date_time/calendar/tests.rs
+assertion_line: 1190
 expression: "snapshot_attrs(&api.cell_trigger_attrs(&date(2024, 1, 20)))"
 ---
 AttrMap {
@@ -32,6 +33,12 @@ AttrMap {
             TabIndex,
             String(
                 "-1",
+            ),
+        ),
+        (
+            Type,
+            String(
+                "button",
             ),
         ),
     ],

--- a/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__grid_group_multi_month.snap
+++ b/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__grid_group_multi_month.snap
@@ -1,0 +1,45 @@
+---
+source: crates/ars-components/src/date_time/calendar/tests.rs
+expression: snapshot_attrs(&api.grid_group_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "grid-group",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "calendar",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "January 2024 – February 2024",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "cal-grid-group",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "group",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__grid_multi_select.snap
+++ b/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__grid_multi_select.snap
@@ -1,0 +1,53 @@
+---
+source: crates/ars-components/src/date_time/calendar/tests.rs
+expression: snapshot_attrs(&api.grid_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "grid",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "calendar",
+            ),
+        ),
+        (
+            Aria(
+                LabelledBy,
+            ),
+            String(
+                "cal-heading",
+            ),
+        ),
+        (
+            Aria(
+                MultiSelectable,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "cal-grid",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "grid",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__grid_single_select.snap
+++ b/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__grid_single_select.snap
@@ -1,0 +1,45 @@
+---
+source: crates/ars-components/src/date_time/calendar/tests.rs
+expression: snapshot_attrs(&api.grid_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "grid",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "calendar",
+            ),
+        ),
+        (
+            Aria(
+                LabelledBy,
+            ),
+            String(
+                "cal-heading",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "cal-grid",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "grid",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__head_cell_monday.snap
+++ b/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__head_cell_monday.snap
@@ -1,0 +1,37 @@
+---
+source: crates/ars-components/src/date_time/calendar/tests.rs
+expression: "snapshot_attrs(&api.head_cell_attrs(Weekday::Monday))"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "head-cell",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "calendar",
+            ),
+        ),
+        (
+            Abbr,
+            String(
+                "Monday",
+            ),
+        ),
+        (
+            Scope,
+            String(
+                "col",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__head_cell_sunday.snap
+++ b/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__head_cell_sunday.snap
@@ -1,0 +1,37 @@
+---
+source: crates/ars-components/src/date_time/calendar/tests.rs
+expression: "snapshot_attrs(&api.head_cell_attrs(Weekday::Sunday))"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "head-cell",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "calendar",
+            ),
+        ),
+        (
+            Abbr,
+            String(
+                "Sunday",
+            ),
+        ),
+        (
+            Scope,
+            String(
+                "col",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__head_row.snap
+++ b/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__head_row.snap
@@ -1,0 +1,25 @@
+---
+source: crates/ars-components/src/date_time/calendar/tests.rs
+expression: snapshot_attrs(&api.head_row_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "head-row",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "calendar",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__header.snap
+++ b/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__header.snap
@@ -1,0 +1,31 @@
+---
+source: crates/ars-components/src/date_time/calendar/tests.rs
+expression: snapshot_attrs(&api.header_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "header",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "calendar",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "cal-header",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__heading.snap
+++ b/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__heading.snap
@@ -1,0 +1,47 @@
+---
+source: crates/ars-components/src/date_time/calendar/tests.rs
+expression: snapshot_attrs(&api.heading_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "heading",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "calendar",
+            ),
+        ),
+        (
+            Aria(
+                Atomic,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Aria(
+                Live,
+            ),
+            String(
+                "polite",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "cal-heading",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__next_trigger_default.snap
+++ b/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__next_trigger_default.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ars-components/src/date_time/calendar/tests.rs
+assertion_line: 1006
 expression: snapshot_attrs(&api.next_trigger_attrs())
 ---
 AttrMap {
@@ -38,6 +39,12 @@ AttrMap {
             TabIndex,
             String(
                 "-1",
+            ),
+        ),
+        (
+            Type,
+            String(
+                "button",
             ),
         ),
     ],

--- a/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__next_trigger_default.snap
+++ b/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__next_trigger_default.snap
@@ -1,0 +1,45 @@
+---
+source: crates/ars-components/src/date_time/calendar/tests.rs
+expression: snapshot_attrs(&api.next_trigger_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "next-trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "calendar",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Next month",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "cal-next-trigger",
+            ),
+        ),
+        (
+            TabIndex,
+            String(
+                "-1",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__next_trigger_disabled_by_max.snap
+++ b/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__next_trigger_disabled_by_max.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ars-components/src/date_time/calendar/tests.rs
+assertion_line: 1030
 expression: snapshot_attrs(&api.next_trigger_attrs())
 ---
 AttrMap {
@@ -52,6 +53,12 @@ AttrMap {
             Disabled,
             Bool(
                 true,
+            ),
+        ),
+        (
+            Type,
+            String(
+                "button",
             ),
         ),
     ],

--- a/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__next_trigger_disabled_by_max.snap
+++ b/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__next_trigger_disabled_by_max.snap
@@ -1,0 +1,59 @@
+---
+source: crates/ars-components/src/date_time/calendar/tests.rs
+expression: snapshot_attrs(&api.next_trigger_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "next-trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "calendar",
+            ),
+        ),
+        (
+            Aria(
+                Disabled,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Next month",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "cal-next-trigger",
+            ),
+        ),
+        (
+            TabIndex,
+            String(
+                "-1",
+            ),
+        ),
+        (
+            Disabled,
+            Bool(
+                true,
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__next_trigger_multi_month_visible_step.snap
+++ b/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__next_trigger_multi_month_visible_step.snap
@@ -1,0 +1,45 @@
+---
+source: crates/ars-components/src/date_time/calendar/tests.rs
+expression: snapshot_attrs(&api.next_trigger_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "next-trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "calendar",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Next 2 months",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "cal-next-trigger",
+            ),
+        ),
+        (
+            TabIndex,
+            String(
+                "-1",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__next_trigger_multi_month_visible_step.snap
+++ b/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__next_trigger_multi_month_visible_step.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ars-components/src/date_time/calendar/tests.rs
+assertion_line: 1051
 expression: snapshot_attrs(&api.next_trigger_attrs())
 ---
 AttrMap {
@@ -38,6 +39,12 @@ AttrMap {
             TabIndex,
             String(
                 "-1",
+            ),
+        ),
+        (
+            Type,
+            String(
+                "button",
             ),
         ),
     ],

--- a/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__prev_trigger_default.snap
+++ b/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__prev_trigger_default.snap
@@ -1,0 +1,45 @@
+---
+source: crates/ars-components/src/date_time/calendar/tests.rs
+expression: snapshot_attrs(&api.prev_trigger_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "prev-trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "calendar",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Previous month",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "cal-prev-trigger",
+            ),
+        ),
+        (
+            TabIndex,
+            String(
+                "-1",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__prev_trigger_default.snap
+++ b/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__prev_trigger_default.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ars-components/src/date_time/calendar/tests.rs
+assertion_line: 994
 expression: snapshot_attrs(&api.prev_trigger_attrs())
 ---
 AttrMap {
@@ -38,6 +39,12 @@ AttrMap {
             TabIndex,
             String(
                 "-1",
+            ),
+        ),
+        (
+            Type,
+            String(
+                "button",
             ),
         ),
     ],

--- a/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__prev_trigger_disabled_by_min.snap
+++ b/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__prev_trigger_disabled_by_min.snap
@@ -1,0 +1,59 @@
+---
+source: crates/ars-components/src/date_time/calendar/tests.rs
+expression: snapshot_attrs(&api.prev_trigger_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "prev-trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "calendar",
+            ),
+        ),
+        (
+            Aria(
+                Disabled,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Previous month",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "cal-prev-trigger",
+            ),
+        ),
+        (
+            TabIndex,
+            String(
+                "-1",
+            ),
+        ),
+        (
+            Disabled,
+            Bool(
+                true,
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__prev_trigger_disabled_by_min.snap
+++ b/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__prev_trigger_disabled_by_min.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ars-components/src/date_time/calendar/tests.rs
+assertion_line: 1018
 expression: snapshot_attrs(&api.prev_trigger_attrs())
 ---
 AttrMap {
@@ -52,6 +53,12 @@ AttrMap {
             Disabled,
             Bool(
                 true,
+            ),
+        ),
+        (
+            Type,
+            String(
+                "button",
             ),
         ),
     ],

--- a/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__prev_trigger_multi_month_visible_step.snap
+++ b/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__prev_trigger_multi_month_visible_step.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ars-components/src/date_time/calendar/tests.rs
+assertion_line: 1047
 expression: snapshot_attrs(&api.prev_trigger_attrs())
 ---
 AttrMap {
@@ -38,6 +39,12 @@ AttrMap {
             TabIndex,
             String(
                 "-1",
+            ),
+        ),
+        (
+            Type,
+            String(
+                "button",
             ),
         ),
     ],

--- a/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__prev_trigger_multi_month_visible_step.snap
+++ b/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__prev_trigger_multi_month_visible_step.snap
@@ -1,0 +1,45 @@
+---
+source: crates/ars-components/src/date_time/calendar/tests.rs
+expression: snapshot_attrs(&api.prev_trigger_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "prev-trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "calendar",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Previous 2 months",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "cal-prev-trigger",
+            ),
+        ),
+        (
+            TabIndex,
+            String(
+                "-1",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__root_disabled_readonly_rtl.snap
+++ b/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__root_disabled_readonly_rtl.snap
@@ -1,0 +1,61 @@
+---
+source: crates/ars-components/src/date_time/calendar/tests.rs
+expression: snapshot_attrs(&api.root_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-disabled",
+            ),
+            Bool(
+                true,
+            ),
+        ),
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-readonly",
+            ),
+            Bool(
+                true,
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "calendar",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "idle",
+            ),
+        ),
+        (
+            Dir,
+            String(
+                "rtl",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "cal",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__root_focused.snap
+++ b/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__root_focused.snap
@@ -1,0 +1,39 @@
+---
+source: crates/ars-components/src/date_time/calendar/tests.rs
+expression: snapshot_attrs(&api.root_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "calendar",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "focused",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "cal",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__root_idle.snap
+++ b/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__root_idle.snap
@@ -1,0 +1,39 @@
+---
+source: crates/ars-components/src/date_time/calendar/tests.rs
+expression: snapshot_attrs(&api.root_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "calendar",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "idle",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "cal",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__row.snap
+++ b/crates/ars-components/src/date_time/calendar/snapshots/ars_components__date_time__calendar__tests__row.snap
@@ -1,0 +1,33 @@
+---
+source: crates/ars-components/src/date_time/calendar/tests.rs
+expression: snapshot_attrs(&api.row_attrs(0))
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "row",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "calendar",
+            ),
+        ),
+        (
+            Data(
+                "ars-week-index",
+            ),
+            String(
+                "0",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/calendar/tests.rs
+++ b/crates/ars-components/src/date_time/calendar/tests.rs
@@ -1,0 +1,1665 @@
+//! Unit and snapshot tests for the `Calendar` component.
+//!
+//! Test names that begin with `snapshot_` use `insta::assert_snapshot!` and
+//! commit golden output under `snapshots/`. Every other test is a pure
+//! state-machine assertion that does not depend on `.snap` files.
+
+use alloc::{format, string::String, sync::Arc, vec::Vec};
+
+use ars_core::{AttrMap, Callback, ComponentPart, Env, HtmlAttr, KeyboardKey, Service};
+use ars_i18n::{
+    CalendarDate, Locale, StubIntlBackend,
+    locales::{ar_sa, de_de, en_gb, en_us, fa},
+};
+use insta::assert_snapshot;
+
+use super::*;
+
+// ────────────────────────────────────────────────────────────────────
+// Helpers
+// ────────────────────────────────────────────────────────────────────
+
+fn date(year: i32, month: u8, day: u8) -> CalendarDate {
+    CalendarDate::new_gregorian(year, month, day).expect("valid test date")
+}
+
+fn props() -> Props {
+    Props::new().id("cal").today(date(2024, 1, 15))
+}
+
+fn env(locale: Locale) -> Env {
+    Env::new(locale, Arc::new(StubIntlBackend))
+}
+
+fn service() -> Service<Machine> {
+    Service::<Machine>::new(props(), &env(en_us()), &Messages::default())
+}
+
+fn service_with(props: Props, locale: Locale) -> Service<Machine> {
+    Service::<Machine>::new(props, &env(locale), &Messages::default())
+}
+
+fn snapshot_attrs(attrs: &AttrMap) -> String {
+    format!("{attrs:#?}")
+}
+
+fn attr(attrs: &AttrMap, key: HtmlAttr) -> Option<String> {
+    attrs.get(&key).map(ToString::to_string)
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Initial state
+// ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn initial_state_is_idle() {
+    let svc = service();
+
+    assert_eq!(*svc.state(), State::Idle);
+}
+
+#[test]
+fn initial_focused_date_falls_back_to_today() {
+    let svc = service();
+
+    assert_eq!(svc.context().focused_date, date(2024, 1, 15));
+}
+
+#[test]
+fn initial_focused_date_prefers_controlled_value() {
+    let props = props().value(Some(date(2023, 7, 4)));
+
+    let svc = service_with(props, en_us());
+
+    assert_eq!(svc.context().focused_date, date(2023, 7, 4));
+    assert_eq!(svc.context().visible_month, 7);
+    assert_eq!(svc.context().visible_year, 2023);
+}
+
+#[test]
+fn focus_in_transitions_to_focused() {
+    let mut svc = service();
+
+    drop(svc.send(Event::FocusIn));
+
+    assert_eq!(*svc.state(), State::Focused);
+}
+
+#[test]
+fn focus_out_returns_to_idle() {
+    let mut svc = service();
+
+    drop(svc.send(Event::FocusIn));
+    drop(svc.send(Event::FocusOut));
+
+    assert_eq!(*svc.state(), State::Idle);
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Anatomy / connect
+// ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn grid_has_role_grid() {
+    let svc = service();
+
+    let api = svc.connect(&|_| {});
+
+    assert_eq!(
+        attr(&api.grid_attrs(), HtmlAttr::Role).as_deref(),
+        Some("grid")
+    );
+}
+
+#[test]
+fn cells_have_role_gridcell_with_aria_selected_when_selected() {
+    let chosen = date(2024, 1, 10);
+
+    let props = props().value(Some(chosen.clone()));
+
+    let svc = service_with(props, en_us());
+
+    let api = svc.connect(&|_| {});
+
+    let cell = api.cell_attrs(&chosen);
+
+    assert_eq!(attr(&cell, HtmlAttr::Role).as_deref(), Some("gridcell"));
+    assert_eq!(
+        attr(&cell, HtmlAttr::Aria(AriaAttr::Selected)).as_deref(),
+        Some("true"),
+    );
+
+    // A non-selected cell should not carry aria-selected.
+    let other = date(2024, 1, 11);
+
+    let cell = api.cell_attrs(&other);
+
+    assert!(cell.get(&HtmlAttr::Aria(AriaAttr::Selected)).is_none());
+}
+
+#[test]
+fn cell_trigger_aria_label_includes_full_date_and_weekday() {
+    let svc = service();
+
+    let api = svc.connect(&|_| {});
+
+    let trigger = api.cell_trigger_attrs(&date(2024, 1, 15));
+
+    let label = attr(&trigger, HtmlAttr::Aria(AriaAttr::Label)).unwrap_or_default();
+
+    assert!(
+        label.contains("January"),
+        "label {label:?} should contain month name"
+    );
+    assert!(
+        label.contains("15"),
+        "label {label:?} should contain day number"
+    );
+    assert!(
+        label.contains("2024"),
+        "label {label:?} should contain year"
+    );
+    assert!(
+        label.contains("Monday"),
+        "label {label:?} should contain weekday"
+    );
+}
+
+#[test]
+fn prev_next_triggers_have_aria_labels_from_messages() {
+    let svc = service();
+
+    let api = svc.connect(&|_| {});
+
+    assert_eq!(
+        attr(&api.prev_trigger_attrs(), HtmlAttr::Aria(AriaAttr::Label)).as_deref(),
+        Some("Previous month"),
+    );
+    assert_eq!(
+        attr(&api.next_trigger_attrs(), HtmlAttr::Aria(AriaAttr::Label)).as_deref(),
+        Some("Next month"),
+    );
+}
+
+#[test]
+fn prev_next_triggers_use_plural_labels_when_multi_month_visible_step() {
+    let props = props()
+        .visible_months(3)
+        .page_behavior(PageBehavior::Visible);
+
+    let svc = service_with(props, en_us());
+
+    let api = svc.connect(&|_| {});
+
+    assert_eq!(
+        attr(&api.prev_trigger_attrs(), HtmlAttr::Aria(AriaAttr::Label)).as_deref(),
+        Some("Previous 3 months"),
+    );
+    assert_eq!(
+        attr(&api.next_trigger_attrs(), HtmlAttr::Aria(AriaAttr::Label)).as_deref(),
+        Some("Next 3 months"),
+    );
+}
+
+#[test]
+fn head_cells_use_scope_col_with_abbr_full_name() {
+    let svc = service();
+
+    let api = svc.connect(&|_| {});
+
+    let cell = api.head_cell_attrs(Weekday::Monday);
+
+    assert_eq!(attr(&cell, HtmlAttr::Scope).as_deref(), Some("col"));
+    assert_eq!(attr(&cell, HtmlAttr::Abbr).as_deref(), Some("Monday"));
+}
+
+#[test]
+fn heading_has_aria_live_polite_and_atomic_true() {
+    let svc = service();
+
+    let api = svc.connect(&|_| {});
+
+    let h = api.heading_attrs();
+
+    assert_eq!(
+        attr(&h, HtmlAttr::Aria(AriaAttr::Live)).as_deref(),
+        Some("polite"),
+    );
+    assert_eq!(
+        attr(&h, HtmlAttr::Aria(AriaAttr::Atomic)).as_deref(),
+        Some("true"),
+    );
+}
+
+// ────────────────────────────────────────────────────────────────────
+// i18n
+// ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn week_day_labels_start_sunday_for_en_us() {
+    let svc = service();
+
+    let labels = svc.context().week_day_labels();
+
+    assert_eq!(labels.first().map(|(wd, _)| *wd), Some(Weekday::Sunday));
+    assert_eq!(labels.first().map(|(_, label)| label.as_str()), Some("Su"));
+}
+
+#[test]
+fn week_day_labels_start_monday_for_en_gb() {
+    let svc = service_with(props(), en_gb());
+
+    let labels = svc.context().week_day_labels();
+
+    assert_eq!(labels.first().map(|(wd, _)| *wd), Some(Weekday::Monday));
+}
+
+#[test]
+fn first_day_of_week_prop_overrides_locale() {
+    let svc = service_with(props().first_day_of_week(Some(Weekday::Wednesday)), en_us());
+
+    let labels = svc.context().week_day_labels();
+
+    assert_eq!(labels.first().map(|(wd, _)| *wd), Some(Weekday::Wednesday));
+}
+
+#[test]
+fn first_day_of_week_defaults_to_saturday_for_ar_sa() {
+    let svc = service_with(props(), ar_sa());
+
+    assert_eq!(svc.context().first_day_of_week, Weekday::Saturday);
+}
+
+#[test]
+fn first_day_of_week_defaults_to_monday_for_de_de() {
+    let svc = service_with(props(), de_de());
+
+    assert_eq!(svc.context().first_day_of_week, Weekday::Monday);
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Navigation
+// ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn next_month_advances_visible_month() {
+    let mut svc = service();
+
+    assert_eq!(svc.context().visible_month, 1);
+
+    drop(svc.send(Event::NextMonth));
+
+    assert_eq!(svc.context().visible_month, 2);
+}
+
+#[test]
+fn prev_month_retreats_visible_month() {
+    let mut svc = service();
+
+    drop(svc.send(Event::PrevMonth));
+
+    assert_eq!(svc.context().visible_month, 12);
+    assert_eq!(svc.context().visible_year, 2023);
+}
+
+#[test]
+fn next_year_advances_by_twelve_months() {
+    let mut svc = service();
+
+    drop(svc.send(Event::NextYear));
+
+    assert_eq!(svc.context().visible_year, 2025);
+    assert_eq!(svc.context().visible_month, 1);
+}
+
+#[test]
+fn prev_year_retreats_by_twelve_months() {
+    let mut svc = service();
+
+    drop(svc.send(Event::PrevYear));
+
+    assert_eq!(svc.context().visible_year, 2023);
+    assert_eq!(svc.context().visible_month, 1);
+}
+
+#[test]
+fn page_behavior_visible_advances_by_visible_months_count() {
+    let mut svc = service_with(
+        props()
+            .visible_months(3)
+            .page_behavior(PageBehavior::Visible),
+        en_us(),
+    );
+
+    drop(svc.send(Event::NextMonth));
+
+    assert_eq!(svc.context().visible_month, 4);
+}
+
+#[test]
+fn page_behavior_single_advances_by_one_month_even_when_multi_visible() {
+    let mut svc = service_with(
+        props()
+            .visible_months(3)
+            .page_behavior(PageBehavior::Single),
+        en_us(),
+    );
+
+    drop(svc.send(Event::NextMonth));
+
+    assert_eq!(svc.context().visible_month, 2);
+}
+
+#[test]
+fn set_month_clamps_to_1_through_12() {
+    let mut svc = service();
+
+    drop(svc.send(Event::SetMonth { month: 0 }));
+
+    assert_eq!(svc.context().visible_month, 1);
+
+    drop(svc.send(Event::SetMonth { month: 13 }));
+
+    assert_eq!(svc.context().visible_month, 1);
+
+    drop(svc.send(Event::SetMonth { month: 7 }));
+
+    assert_eq!(svc.context().visible_month, 7);
+}
+
+#[test]
+fn navigation_emits_announce_month_effect() {
+    let mut svc = service();
+
+    let result = svc.send(Event::NextMonth);
+
+    assert!(
+        result
+            .pending_effects
+            .iter()
+            .any(|e| e.name == Effect::AnnounceMonth),
+        "next-month should queue AnnounceMonth effect",
+    );
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Keyboard
+// ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn arrow_right_moves_focused_date_by_one_day() {
+    let mut svc = service();
+
+    drop(svc.send(Event::FocusIn));
+
+    let before = svc.context().focused_date.clone();
+
+    drop(svc.send(Event::KeyDown {
+        key: KeyboardKey::ArrowRight,
+        shift: false,
+    }));
+
+    assert_eq!(svc.context().focused_date, before.add_days(1).unwrap(),);
+}
+
+#[test]
+fn arrow_left_moves_focused_date_back_one_day() {
+    let mut svc = service();
+
+    drop(svc.send(Event::FocusIn));
+
+    let before = svc.context().focused_date.clone();
+
+    drop(svc.send(Event::KeyDown {
+        key: KeyboardKey::ArrowLeft,
+        shift: false,
+    }));
+
+    assert_eq!(svc.context().focused_date, before.add_days(-1).unwrap());
+}
+
+#[test]
+fn arrow_down_moves_focused_date_by_one_week() {
+    let mut svc = service();
+
+    drop(svc.send(Event::FocusIn));
+
+    let before = svc.context().focused_date.clone();
+
+    drop(svc.send(Event::KeyDown {
+        key: KeyboardKey::ArrowDown,
+        shift: false,
+    }));
+
+    assert_eq!(svc.context().focused_date, before.add_days(7).unwrap());
+}
+
+#[test]
+fn arrow_keys_swap_in_rtl_locale() {
+    let mut svc = service_with(props().is_rtl(true), fa());
+
+    drop(svc.send(Event::FocusIn));
+
+    let before = svc.context().focused_date.clone();
+
+    drop(svc.send(Event::KeyDown {
+        key: KeyboardKey::ArrowLeft,
+        shift: false,
+    }));
+
+    // RTL: ArrowLeft means "next day".
+    assert_eq!(svc.context().focused_date, before.add_days(1).unwrap());
+}
+
+#[test]
+fn enter_selects_focused_date() {
+    let mut svc = service();
+
+    drop(svc.send(Event::FocusIn));
+
+    let target = svc.context().focused_date.clone();
+
+    drop(svc.send(Event::KeyDown {
+        key: KeyboardKey::Enter,
+        shift: false,
+    }));
+
+    assert_eq!(*svc.context().value.get(), Some(target));
+}
+
+#[test]
+fn space_selects_focused_date() {
+    let mut svc = service();
+
+    drop(svc.send(Event::FocusIn));
+
+    let target = svc.context().focused_date.clone();
+
+    drop(svc.send(Event::KeyDown {
+        key: KeyboardKey::Space,
+        shift: false,
+    }));
+
+    assert_eq!(*svc.context().value.get(), Some(target));
+}
+
+#[test]
+fn page_up_changes_month_back() {
+    let mut svc = service();
+
+    drop(svc.send(Event::FocusIn));
+    drop(svc.send(Event::KeyDown {
+        key: KeyboardKey::PageUp,
+        shift: false,
+    }));
+
+    // Focused date moves back one month; visible month follows via sync.
+    assert_eq!(svc.context().focused_date, date(2023, 12, 15));
+    assert_eq!(svc.context().visible_month, 12);
+    assert_eq!(svc.context().visible_year, 2023);
+}
+
+#[test]
+fn page_down_changes_month_forward() {
+    let mut svc = service();
+
+    drop(svc.send(Event::FocusIn));
+    drop(svc.send(Event::KeyDown {
+        key: KeyboardKey::PageDown,
+        shift: false,
+    }));
+
+    assert_eq!(svc.context().focused_date, date(2024, 2, 15));
+    assert_eq!(svc.context().visible_month, 2);
+}
+
+#[test]
+fn shift_page_down_navigates_year_forward() {
+    let mut svc = service();
+
+    drop(svc.send(Event::FocusIn));
+
+    let before_year = svc.context().visible_year;
+
+    drop(svc.send(Event::KeyDown {
+        key: KeyboardKey::PageDown,
+        shift: true,
+    }));
+
+    assert_eq!(svc.context().visible_year, before_year + 1);
+}
+
+#[test]
+fn shift_page_up_navigates_year_back() {
+    let mut svc = service();
+
+    drop(svc.send(Event::FocusIn));
+
+    let before_year = svc.context().visible_year;
+
+    drop(svc.send(Event::KeyDown {
+        key: KeyboardKey::PageUp,
+        shift: true,
+    }));
+
+    assert_eq!(svc.context().visible_year, before_year - 1);
+}
+
+#[test]
+fn home_moves_focus_to_start_of_current_week() {
+    // Today is Jan 15, 2024 (Monday). With Sunday-start, "Home" should
+    // go to Jan 14 (Sunday).
+    let mut svc = service();
+
+    drop(svc.send(Event::FocusIn));
+    drop(svc.send(Event::KeyDown {
+        key: KeyboardKey::Home,
+        shift: false,
+    }));
+
+    assert_eq!(svc.context().focused_date, date(2024, 1, 14));
+}
+
+#[test]
+fn end_moves_focus_to_end_of_current_week() {
+    // Sunday-start, Jan 15 is Monday → end of week is Jan 20 (Saturday).
+    let mut svc = service();
+
+    drop(svc.send(Event::FocusIn));
+    drop(svc.send(Event::KeyDown {
+        key: KeyboardKey::End,
+        shift: false,
+    }));
+
+    assert_eq!(svc.context().focused_date, date(2024, 1, 20));
+}
+
+#[test]
+fn arrow_into_next_month_auto_scrolls_visible_month() {
+    // Jan 31 + 1 day → Feb 1; the calendar should follow.
+    let mut svc = service_with(props().today(date(2024, 1, 31)), en_us());
+
+    drop(svc.send(Event::FocusIn));
+    drop(svc.send(Event::KeyDown {
+        key: KeyboardKey::ArrowRight,
+        shift: false,
+    }));
+
+    assert_eq!(svc.context().focused_date, date(2024, 2, 1));
+    assert_eq!(svc.context().visible_month, 2);
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Constraints
+// ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn min_max_disable_out_of_range_cells_with_aria_disabled() {
+    let svc = service_with(
+        props()
+            .min(Some(date(2024, 1, 10)))
+            .max(Some(date(2024, 1, 20))),
+        en_us(),
+    );
+
+    let api = svc.connect(&|_| {});
+
+    let outside = api.cell_attrs(&date(2024, 1, 5));
+
+    assert_eq!(
+        attr(&outside, HtmlAttr::Aria(AriaAttr::Disabled)).as_deref(),
+        Some("true"),
+    );
+
+    let inside = api.cell_attrs(&date(2024, 1, 15));
+
+    assert!(inside.get(&HtmlAttr::Aria(AriaAttr::Disabled)).is_none());
+}
+
+#[test]
+fn focus_date_clamps_to_min_max() {
+    let mut svc = service_with(
+        props()
+            .min(Some(date(2024, 1, 10)))
+            .max(Some(date(2024, 1, 20))),
+        en_us(),
+    );
+
+    drop(svc.send(Event::FocusDate {
+        date: date(2024, 1, 1),
+    }));
+
+    assert_eq!(svc.context().focused_date, date(2024, 1, 10));
+}
+
+#[test]
+fn prev_disabled_when_first_visible_month_at_or_before_min() {
+    // visible_month = 1 (Jan 2024); min = Feb 1 2024 → prev should be disabled
+    // because the first of the visible month (Jan 1) is <= min.
+    let svc = service_with(props().min(Some(date(2024, 2, 1))), en_us());
+
+    let api = svc.connect(&|_| {});
+
+    assert!(api.is_prev_disabled());
+}
+
+#[test]
+fn next_disabled_when_last_visible_month_at_or_after_max() {
+    let svc = service_with(props().max(Some(date(2024, 1, 25))), en_us());
+
+    let api = svc.connect(&|_| {});
+
+    assert!(api.is_next_disabled());
+}
+
+#[test]
+fn disabled_calendar_blocks_select_event() {
+    let mut svc = service_with(props().disabled(true), en_us());
+
+    drop(svc.send(Event::SelectDate {
+        date: date(2024, 1, 20),
+    }));
+
+    assert_eq!(*svc.context().value.get(), None);
+}
+
+#[test]
+fn readonly_allows_focus_but_blocks_select() {
+    let mut svc = service_with(props().readonly(true), en_us());
+
+    drop(svc.send(Event::FocusIn));
+
+    assert_eq!(*svc.state(), State::Focused);
+
+    drop(svc.send(Event::SelectDate {
+        date: date(2024, 1, 20),
+    }));
+
+    assert_eq!(*svc.context().value.get(), None);
+}
+
+#[test]
+fn unavailable_predicate_marks_cells_with_data_ars_unavailable_and_aria_disabled() {
+    let is_unavailable = Callback::new_ref(|date: &CalendarDate| date.day() == 12);
+
+    let svc = service_with(props().is_date_unavailable(Some(is_unavailable)), en_us());
+
+    let api = svc.connect(&|_| {});
+
+    let trigger = api.cell_trigger_attrs(&date(2024, 1, 12));
+
+    assert_eq!(
+        attr(&trigger, HtmlAttr::Data("ars-unavailable")).as_deref(),
+        Some("true"),
+    );
+    assert_eq!(
+        attr(&trigger, HtmlAttr::Aria(AriaAttr::Disabled)).as_deref(),
+        Some("true"),
+    );
+
+    let label = attr(&trigger, HtmlAttr::Aria(AriaAttr::Label)).unwrap_or_default();
+
+    assert!(label.ends_with("(unavailable)"), "label was {label:?}");
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Today
+// ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn today_cell_has_data_ars_today_attribute() {
+    let svc = service();
+
+    let api = svc.connect(&|_| {});
+
+    let trigger = api.cell_trigger_attrs(&date(2024, 1, 15));
+
+    assert_eq!(
+        attr(&trigger, HtmlAttr::Data("ars-today")).as_deref(),
+        Some("true"),
+    );
+
+    let other = api.cell_trigger_attrs(&date(2024, 1, 16));
+
+    assert!(other.get(&HtmlAttr::Data("ars-today")).is_none());
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Multi-select (§5)
+// ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn selection_mode_multiple_uses_toggle_date() {
+    let mut svc = service_with(props().selection_mode(SelectionMode::Multiple), en_us());
+
+    drop(svc.send(Event::SelectDate {
+        date: date(2024, 1, 10),
+    }));
+
+    assert!(
+        svc.context()
+            .selected_dates
+            .get()
+            .contains(&date(2024, 1, 10))
+    );
+}
+
+#[test]
+fn toggle_date_adds_then_removes() {
+    let mut svc = service_with(props().selection_mode(SelectionMode::Multiple), en_us());
+
+    drop(svc.send(Event::ToggleDate {
+        date: date(2024, 1, 10),
+    }));
+    drop(svc.send(Event::ToggleDate {
+        date: date(2024, 1, 12),
+    }));
+
+    assert_eq!(svc.context().selected_dates.get().len(), 2);
+    drop(svc.send(Event::ToggleDate {
+        date: date(2024, 1, 10),
+    }));
+
+    assert_eq!(svc.context().selected_dates.get().len(), 1);
+    assert!(
+        !svc.context()
+            .selected_dates
+            .get()
+            .contains(&date(2024, 1, 10))
+    );
+}
+
+#[test]
+fn max_selected_blocks_excess_toggles_silently() {
+    let mut svc = service_with(
+        props()
+            .selection_mode(SelectionMode::Multiple)
+            .max_selected(Some(2)),
+        en_us(),
+    );
+
+    drop(svc.send(Event::ToggleDate {
+        date: date(2024, 1, 10),
+    }));
+    drop(svc.send(Event::ToggleDate {
+        date: date(2024, 1, 11),
+    }));
+    drop(svc.send(Event::ToggleDate {
+        date: date(2024, 1, 12),
+    }));
+
+    let set = svc.context().selected_dates.get();
+
+    assert_eq!(set.len(), 2);
+    assert!(!set.contains(&date(2024, 1, 12)));
+}
+
+#[test]
+fn multi_select_grid_has_aria_multiselectable_true() {
+    let svc = service_with(props().selection_mode(SelectionMode::Multiple), en_us());
+
+    let api = svc.connect(&|_| {});
+
+    assert_eq!(
+        attr(&api.grid_attrs(), HtmlAttr::Aria(AriaAttr::MultiSelectable)).as_deref(),
+        Some("true"),
+    );
+}
+
+#[test]
+fn single_select_grid_does_not_have_aria_multiselectable() {
+    let svc = service();
+
+    let api = svc.connect(&|_| {});
+
+    assert!(
+        api.grid_attrs()
+            .get(&HtmlAttr::Aria(AriaAttr::MultiSelectable))
+            .is_none()
+    );
+}
+
+#[test]
+fn multi_select_cell_aria_selected_reflects_set_membership() {
+    let svc = service_with(
+        props()
+            .selection_mode(SelectionMode::Multiple)
+            .default_selected_dates(SelectedDates::from_iter([date(2024, 1, 11)])),
+        en_us(),
+    );
+
+    let api = svc.connect(&|_| {});
+
+    let selected = api.cell_attrs(&date(2024, 1, 11));
+
+    assert_eq!(
+        attr(&selected, HtmlAttr::Aria(AriaAttr::Selected)).as_deref(),
+        Some("true"),
+    );
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Multi-month layout
+// ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn weeks_for_returns_correct_month_per_offset() {
+    let svc = service_with(props().visible_months(2), en_us());
+
+    let weeks0 = svc.context().weeks_for(0);
+    let weeks1 = svc.context().weeks_for(1);
+
+    assert_eq!(weeks0[2][3].month(), 1);
+    assert_eq!(weeks1[2][3].month(), 2);
+}
+
+#[test]
+fn sync_visible_does_not_scroll_when_focus_stays_in_range() {
+    let mut svc = service_with(props().visible_months(2), en_us());
+
+    drop(svc.send(Event::FocusDate {
+        date: date(2024, 2, 10),
+    }));
+
+    assert_eq!(svc.context().visible_month, 1);
+}
+
+#[test]
+fn range_heading_text_uses_separator_for_multi_month() {
+    let svc = service_with(props().visible_months(2), en_us());
+
+    let api = svc.connect(&|_| {});
+
+    let heading = api.range_heading_text();
+
+    assert!(
+        heading.contains('\u{2013}'),
+        "expected en-dash in {heading:?}"
+    );
+    assert!(
+        heading.contains("January"),
+        "first month label missing: {heading:?}"
+    );
+    assert!(
+        heading.contains("February"),
+        "last month label missing: {heading:?}"
+    );
+}
+
+#[test]
+fn grid_group_only_makes_sense_for_multi_month() {
+    let svc = service_with(props().visible_months(2), en_us());
+
+    let api = svc.connect(&|_| {});
+
+    let group = api.grid_group_attrs();
+
+    assert_eq!(attr(&group, HtmlAttr::Role).as_deref(), Some("group"));
+}
+
+#[test]
+fn cell_attrs_for_offset_marks_outside_for_other_grids_month() {
+    let svc = service_with(props().visible_months(2), en_us());
+
+    let api = svc.connect(&|_| {});
+
+    // From the perspective of offset=1 (February), Jan 15 is outside.
+    let cell = api.cell_attrs_for(&date(2024, 1, 15), 1);
+
+    assert_eq!(
+        attr(&cell, HtmlAttr::Data("ars-outside-month")).as_deref(),
+        Some("true"),
+    );
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Spec-conformance: Part enum order matches the anatomy table.
+// ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn part_anatomy_matches_spec() {
+    assert_eq!(Part::scope(), "calendar");
+
+    let names: Vec<&'static str> = Part::all().iter().map(ComponentPart::name).collect();
+
+    let expected: &[&'static str] = &[
+        "root",
+        "header",
+        "prev-trigger",
+        "next-trigger",
+        "heading",
+        "grid",
+        "grid-group",
+        "head-row",
+        "head-cell",
+        "row",
+        "cell",
+        "cell-trigger",
+    ];
+
+    assert_eq!(names.as_slice(), expected);
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Snapshot tests
+// ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn snapshot_root_idle() {
+    let svc = service();
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!("root_idle", snapshot_attrs(&api.root_attrs()));
+}
+
+#[test]
+fn snapshot_root_disabled_readonly_rtl() {
+    let svc = service_with(props().disabled(true).readonly(true).is_rtl(true), en_us());
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!(
+        "root_disabled_readonly_rtl",
+        snapshot_attrs(&api.root_attrs()),
+    );
+}
+
+#[test]
+fn snapshot_root_focused() {
+    let mut svc = service();
+
+    drop(svc.send(Event::FocusIn));
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!("root_focused", snapshot_attrs(&api.root_attrs()));
+}
+
+#[test]
+fn snapshot_header() {
+    let svc = service();
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!("header", snapshot_attrs(&api.header_attrs()));
+}
+
+#[test]
+fn snapshot_prev_trigger_default() {
+    let svc = service();
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!(
+        "prev_trigger_default",
+        snapshot_attrs(&api.prev_trigger_attrs())
+    );
+}
+
+#[test]
+fn snapshot_next_trigger_default() {
+    let svc = service();
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!(
+        "next_trigger_default",
+        snapshot_attrs(&api.next_trigger_attrs())
+    );
+}
+
+#[test]
+fn snapshot_prev_trigger_disabled_by_min() {
+    let svc = service_with(props().min(Some(date(2024, 2, 1))), en_us());
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!(
+        "prev_trigger_disabled_by_min",
+        snapshot_attrs(&api.prev_trigger_attrs()),
+    );
+}
+
+#[test]
+fn snapshot_next_trigger_disabled_by_max() {
+    let svc = service_with(props().max(Some(date(2024, 1, 25))), en_us());
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!(
+        "next_trigger_disabled_by_max",
+        snapshot_attrs(&api.next_trigger_attrs()),
+    );
+}
+
+#[test]
+fn snapshot_prev_next_trigger_multi_month_visible_step() {
+    let svc = service_with(
+        props()
+            .visible_months(2)
+            .page_behavior(PageBehavior::Visible),
+        en_us(),
+    );
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!(
+        "prev_trigger_multi_month_visible_step",
+        snapshot_attrs(&api.prev_trigger_attrs()),
+    );
+    assert_snapshot!(
+        "next_trigger_multi_month_visible_step",
+        snapshot_attrs(&api.next_trigger_attrs()),
+    );
+}
+
+#[test]
+fn snapshot_heading() {
+    let svc = service();
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!("heading", snapshot_attrs(&api.heading_attrs()));
+}
+
+#[test]
+fn snapshot_grid_single_select() {
+    let svc = service();
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!("grid_single_select", snapshot_attrs(&api.grid_attrs()));
+}
+
+#[test]
+fn snapshot_grid_multi_select() {
+    let svc = service_with(props().selection_mode(SelectionMode::Multiple), en_us());
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!("grid_multi_select", snapshot_attrs(&api.grid_attrs()));
+}
+
+#[test]
+fn snapshot_grid_group_multi_month() {
+    let svc = service_with(props().visible_months(2), en_us());
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!(
+        "grid_group_multi_month",
+        snapshot_attrs(&api.grid_group_attrs())
+    );
+}
+
+#[test]
+fn snapshot_head_row() {
+    let svc = service();
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!("head_row", snapshot_attrs(&api.head_row_attrs()));
+}
+
+#[test]
+fn snapshot_head_cell_sunday() {
+    let svc = service();
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!(
+        "head_cell_sunday",
+        snapshot_attrs(&api.head_cell_attrs(Weekday::Sunday))
+    );
+}
+
+#[test]
+fn snapshot_head_cell_monday() {
+    let svc = service();
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!(
+        "head_cell_monday",
+        snapshot_attrs(&api.head_cell_attrs(Weekday::Monday))
+    );
+}
+
+#[test]
+fn snapshot_row() {
+    let svc = service();
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!("row", snapshot_attrs(&api.row_attrs(0)));
+}
+
+#[test]
+fn snapshot_cell_selected() {
+    let chosen = date(2024, 1, 15);
+
+    let svc = service_with(props().value(Some(chosen.clone())), en_us());
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!("cell_selected", snapshot_attrs(&api.cell_attrs(&chosen)));
+}
+
+#[test]
+fn snapshot_cell_outside_month() {
+    let svc = service();
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!(
+        "cell_outside_month",
+        snapshot_attrs(&api.cell_attrs(&date(2023, 12, 31))),
+    );
+}
+
+#[test]
+fn snapshot_cell_disabled_by_min() {
+    let svc = service_with(props().min(Some(date(2024, 1, 20))), en_us());
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!(
+        "cell_disabled_by_min",
+        snapshot_attrs(&api.cell_attrs(&date(2024, 1, 5))),
+    );
+}
+
+#[test]
+fn snapshot_cell_trigger_focused() {
+    let svc = service();
+
+    let api = svc.connect(&|_| {});
+
+    let trigger = api.cell_trigger_attrs(&date(2024, 1, 15));
+
+    assert_snapshot!("cell_trigger_focused", snapshot_attrs(&trigger));
+}
+
+#[test]
+fn snapshot_cell_trigger_unfocused() {
+    let svc = service();
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!(
+        "cell_trigger_unfocused",
+        snapshot_attrs(&api.cell_trigger_attrs(&date(2024, 1, 20))),
+    );
+}
+
+#[test]
+fn snapshot_cell_trigger_selected() {
+    let svc = service_with(
+        props()
+            .value(Some(date(2024, 1, 20)))
+            .today(date(2024, 1, 15)),
+        en_us(),
+    );
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!(
+        "cell_trigger_selected",
+        snapshot_attrs(&api.cell_trigger_attrs(&date(2024, 1, 20))),
+    );
+}
+
+#[test]
+fn snapshot_cell_trigger_disabled_and_unavailable() {
+    let predicate = Callback::new_ref(|d: &CalendarDate| d.day() == 5);
+
+    let svc = service_with(
+        props()
+            .min(Some(date(2024, 1, 10)))
+            .is_date_unavailable(Some(predicate)),
+        en_us(),
+    );
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!(
+        "cell_trigger_disabled_and_unavailable",
+        snapshot_attrs(&api.cell_trigger_attrs(&date(2024, 1, 5))),
+    );
+}
+
+#[test]
+fn snapshot_cell_trigger_today() {
+    let svc = service();
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!(
+        "cell_trigger_today",
+        snapshot_attrs(&api.cell_trigger_attrs(&date(2024, 1, 15))),
+    );
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Additional coverage — SelectedDates, Props builder, transitions
+// ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn selected_dates_set_semantics() {
+    let mut set = SelectedDates::new();
+
+    assert!(set.is_empty());
+    assert_eq!(set.len(), 0);
+    assert!(set.insert(date(2024, 1, 10)));
+    assert!(!set.insert(date(2024, 1, 10)));
+    assert!(set.insert(date(2024, 1, 12)));
+    assert!(set.contains(&date(2024, 1, 10)));
+    assert!(!set.is_empty());
+    assert_eq!(set.len(), 2);
+
+    let slice = set.as_slice();
+
+    assert_eq!(slice.len(), 2);
+    assert!(set.remove(&date(2024, 1, 10)));
+    assert!(!set.remove(&date(2024, 1, 10)));
+
+    let collected: Vec<&CalendarDate> = (&set).into_iter().collect();
+
+    assert_eq!(collected.len(), 1);
+
+    let collected: SelectedDates = [date(2024, 2, 1), date(2024, 2, 2)].into_iter().collect();
+
+    assert_eq!(collected.len(), 2);
+}
+
+#[test]
+fn props_equality_handles_callback_pointer_identity() {
+    let base = props();
+    let same = props();
+
+    assert_eq!(base, same);
+
+    let cb_a = Callback::new_ref(|_: &CalendarDate| false);
+    let cb_b = Callback::new_ref(|_: &CalendarDate| true);
+
+    let with_a = props().is_date_unavailable(Some(cb_a.clone()));
+    let with_b = props().is_date_unavailable(Some(cb_b));
+
+    assert_ne!(with_a, with_b);
+
+    // Same callback instance compares equal even when cloned (Arc::ptr_eq).
+    let with_a_again = props().is_date_unavailable(Some(cb_a));
+
+    assert_eq!(with_a, with_a_again);
+}
+
+#[test]
+fn props_builders_round_trip_all_fields() {
+    let configured = Props::new()
+        .id("cal-2")
+        .value(Some(date(2024, 6, 1)))
+        .default_value(Some(date(2024, 6, 15)))
+        .selected_dates(Some(SelectedDates::from_iter([date(2024, 6, 5)])))
+        .default_selected_dates(SelectedDates::from_iter([date(2024, 6, 6)]))
+        .selection_mode(SelectionMode::Multiple)
+        .max_selected(Some(4))
+        .min(Some(date(2024, 1, 1)))
+        .max(Some(date(2024, 12, 31)))
+        .disabled(false)
+        .readonly(false)
+        .first_day_of_week(Some(Weekday::Tuesday))
+        .show_week_numbers(true)
+        .is_rtl(true)
+        .visible_months(2)
+        .page_behavior(PageBehavior::Single)
+        .today(date(2024, 6, 10));
+
+    assert_eq!(configured.id, "cal-2");
+    assert_eq!(configured.value, Some(Some(date(2024, 6, 1))));
+    assert_eq!(configured.default_value, Some(date(2024, 6, 15)));
+    assert_eq!(configured.selection_mode, SelectionMode::Multiple);
+    assert_eq!(configured.max_selected, Some(4));
+    assert_eq!(configured.first_day_of_week, Some(Weekday::Tuesday));
+    assert!(configured.show_week_numbers);
+    assert!(configured.is_rtl);
+    assert_eq!(configured.visible_months, 2);
+    assert_eq!(configured.page_behavior, PageBehavior::Single);
+    assert_eq!(configured.today, date(2024, 6, 10));
+}
+
+#[test]
+fn props_debug_renders() {
+    let formatted = format!("{:?}", props());
+
+    assert!(formatted.contains("Props"));
+}
+
+#[test]
+fn context_debug_renders() {
+    let svc = service();
+
+    let formatted = format!("{:?}", svc.context());
+
+    assert!(formatted.contains("Context"));
+    assert!(formatted.contains("focused_date"));
+}
+
+#[test]
+fn messages_debug_renders() {
+    let formatted = format!("{:?}", Messages::default());
+
+    assert!(formatted.contains("Messages"));
+}
+
+#[test]
+fn messages_clone_and_equality() {
+    let messages = Messages::default();
+
+    let cloned = messages.clone();
+
+    assert_eq!(messages, cloned);
+}
+
+#[test]
+fn api_debug_renders() {
+    let svc = service();
+
+    let api = svc.connect(&|_| {});
+
+    let formatted = format!("{api:?}");
+
+    assert!(formatted.contains("Api"));
+}
+
+#[test]
+fn focus_date_clamps_to_max() {
+    let mut svc = service_with(
+        props()
+            .min(Some(date(2024, 1, 10)))
+            .max(Some(date(2024, 1, 20))),
+        en_us(),
+    );
+
+    drop(svc.send(Event::FocusDate {
+        date: date(2024, 1, 31),
+    }));
+
+    assert_eq!(svc.context().focused_date, date(2024, 1, 20));
+}
+
+#[test]
+fn set_year_advances_context() {
+    let mut svc = service();
+
+    let result = svc.send(Event::SetYear { year: 2030 });
+
+    assert_eq!(svc.context().visible_year, 2030);
+    assert!(
+        result
+            .pending_effects
+            .iter()
+            .any(|e| e.name == Effect::AnnounceMonth)
+    );
+}
+
+#[test]
+fn readonly_blocks_multi_toggle() {
+    let mut svc = service_with(
+        props()
+            .selection_mode(SelectionMode::Multiple)
+            .readonly(true),
+        en_us(),
+    );
+
+    drop(svc.send(Event::ToggleDate {
+        date: date(2024, 1, 10),
+    }));
+
+    assert!(svc.context().selected_dates.get().is_empty());
+}
+
+#[test]
+fn select_date_skips_disabled_and_unavailable_dates() {
+    let never_available = Callback::new_ref(|_: &CalendarDate| true);
+
+    let mut svc = service_with(props().is_date_unavailable(Some(never_available)), en_us());
+
+    drop(svc.send(Event::SelectDate {
+        date: date(2024, 1, 10),
+    }));
+
+    assert_eq!(*svc.context().value.get(), None);
+
+    let mut svc2 = service_with(props().min(Some(date(2024, 1, 20))), en_us());
+
+    drop(svc2.send(Event::SelectDate {
+        date: date(2024, 1, 5),
+    }));
+
+    assert_eq!(*svc2.context().value.get(), None);
+}
+
+#[test]
+fn keydown_enter_in_multi_mode_uses_toggle_event() {
+    let mut svc = service_with(props().selection_mode(SelectionMode::Multiple), en_us());
+
+    drop(svc.send(Event::FocusIn));
+    drop(svc.send(Event::KeyDown {
+        key: KeyboardKey::Enter,
+        shift: false,
+    }));
+
+    let focused = svc.context().focused_date.clone();
+
+    assert!(svc.context().selected_dates.get().contains(&focused));
+}
+
+#[test]
+fn keydown_unhandled_key_is_noop() {
+    let mut svc = service();
+
+    drop(svc.send(Event::FocusIn));
+
+    let before = svc.context().focused_date.clone();
+
+    let result = svc.send(Event::KeyDown {
+        key: KeyboardKey::Escape,
+        shift: false,
+    });
+
+    assert_eq!(svc.context().focused_date, before);
+    assert!(!result.state_changed);
+    assert!(!result.context_changed);
+}
+
+#[test]
+fn controlled_multi_select_uses_controlled_bindable() {
+    let svc = service_with(
+        props()
+            .selection_mode(SelectionMode::Multiple)
+            .selected_dates(Some(SelectedDates::from_iter([date(2024, 1, 11)]))),
+        en_us(),
+    );
+
+    assert!(svc.context().selected_dates.is_controlled());
+    assert!(
+        svc.context()
+            .selected_dates
+            .get()
+            .contains(&date(2024, 1, 11))
+    );
+}
+
+#[test]
+fn controlled_single_select_uses_controlled_bindable() {
+    let svc = service_with(props().value(Some(date(2024, 7, 4))), en_us());
+
+    assert!(svc.context().value.is_controlled());
+}
+
+#[test]
+fn visible_months_zero_clamped_to_one_in_init() {
+    let svc = service_with(props().visible_months(0), en_us());
+
+    assert_eq!(svc.context().visible_months, 1);
+}
+
+#[test]
+fn weeks_helper_returns_six_rows() {
+    let svc = service();
+
+    assert_eq!(svc.context().weeks().len(), 6);
+}
+
+#[test]
+fn is_in_visible_range_helper_reports_first_visible_month() {
+    let svc = service();
+
+    assert!(
+        svc.context()
+            .is_in_visible_range(&svc.context().focused_date)
+    );
+}
+
+#[test]
+fn heading_text_single_month_uses_long_month_name() {
+    let svc = service();
+
+    let api = svc.connect(&|_| {});
+
+    let heading = api.heading_text();
+
+    assert_eq!(heading, "January 2024");
+}
+
+#[test]
+fn grid_attrs_for_uses_offset_specific_ids() {
+    let svc = service_with(props().visible_months(2), en_us());
+
+    let api = svc.connect(&|_| {});
+
+    let g0 = api.grid_attrs_for(0);
+    let g1 = api.grid_attrs_for(1);
+
+    assert_eq!(attr(&g0, HtmlAttr::Id).as_deref(), Some("cal-grid-0"));
+    assert_eq!(attr(&g1, HtmlAttr::Id).as_deref(), Some("cal-grid-1"));
+}
+
+#[test]
+fn heading_attrs_for_omits_aria_live() {
+    let svc = service_with(props().visible_months(2), en_us());
+
+    let api = svc.connect(&|_| {});
+
+    let h = api.heading_attrs_for(1);
+
+    assert!(h.get(&HtmlAttr::Aria(AriaAttr::Live)).is_none());
+    assert!(
+        attr(&h, HtmlAttr::Id)
+            .as_deref()
+            .is_some_and(|id| id.ends_with("-heading-1"))
+    );
+}
+
+#[test]
+fn grid_attrs_readonly_and_disabled_paths() {
+    let svc_readonly = service_with(props().readonly(true), en_us());
+
+    let api = svc_readonly.connect(&|_| {});
+
+    assert_eq!(
+        attr(&api.grid_attrs(), HtmlAttr::Aria(AriaAttr::ReadOnly)).as_deref(),
+        Some("true"),
+    );
+
+    let svc_disabled = service_with(props().disabled(true), en_us());
+
+    let api = svc_disabled.connect(&|_| {});
+
+    assert_eq!(
+        attr(&api.grid_attrs(), HtmlAttr::Aria(AriaAttr::Disabled)).as_deref(),
+        Some("true"),
+    );
+}
+
+#[test]
+fn api_view_helpers_expose_visible_layout() {
+    let svc = service_with(props().visible_months(3).show_week_numbers(true), en_us());
+
+    let api = svc.connect(&|_| {});
+
+    assert_eq!(api.visible_month_count(), 3);
+    assert_eq!(api.month_offsets(), 0..3);
+    assert!(api.show_week_numbers());
+    assert_eq!(api.selection_mode(), SelectionMode::Single);
+    assert!(!api.is_focused());
+    assert_eq!(api.weeks_for(1).len(), 6);
+    assert_eq!(api.weeks().len(), 6);
+    assert_eq!(api.week_day_labels().len(), 7);
+    assert_eq!(api.today(), &date(2024, 1, 15));
+    assert!(!api.is_outside_visible_month(&date(2024, 1, 10)));
+}
+
+#[test]
+fn api_send_helpers_route_events_to_machine() {
+    use core::cell::RefCell;
+    let captured: RefCell<Vec<Event>> = RefCell::new(Vec::new());
+    let send = |event: Event| captured.borrow_mut().push(event);
+
+    let svc = service_with(props().selection_mode(SelectionMode::Multiple), en_us());
+
+    let api = svc.connect(&send);
+
+    api.on_cell_click(date(2024, 1, 10));
+    api.on_grid_focusin();
+    api.on_grid_focusout(true);
+    api.on_grid_focusout(false);
+    api.on_grid_keydown(KeyboardKey::ArrowRight, true);
+    api.on_prev_click();
+    api.on_next_click();
+
+    let events = captured.borrow();
+
+    assert!(matches!(events[0], Event::ToggleDate { .. }));
+    assert!(matches!(events[1], Event::FocusIn));
+    assert!(matches!(events[2], Event::FocusOut));
+    assert!(matches!(
+        events[3],
+        Event::KeyDown {
+            key: KeyboardKey::ArrowRight,
+            shift: true
+        }
+    ));
+    assert!(matches!(events[4], Event::PrevMonth));
+    assert!(matches!(events[5], Event::NextMonth));
+    assert_eq!(events.len(), 6);
+}
+
+#[test]
+fn api_on_cell_click_uses_select_in_single_mode() {
+    use core::cell::RefCell;
+    let captured: RefCell<Vec<Event>> = RefCell::new(Vec::new());
+    let send = |event: Event| captured.borrow_mut().push(event);
+
+    let svc = service();
+
+    let api = svc.connect(&send);
+
+    api.on_cell_click(date(2024, 1, 10));
+    assert!(matches!(
+        captured.borrow().first(),
+        Some(Event::SelectDate { .. })
+    ));
+}
+
+#[test]
+fn disabled_calendar_blocks_navigation_too() {
+    let mut svc = service_with(props().disabled(true), en_us());
+
+    let before_month = svc.context().visible_month;
+
+    drop(svc.send(Event::NextMonth));
+
+    assert_eq!(svc.context().visible_month, before_month);
+}

--- a/crates/ars-components/src/date_time/calendar/tests.rs
+++ b/crates/ars-components/src/date_time/calendar/tests.rs
@@ -2076,3 +2076,88 @@ fn month_step_plan_keeps_visible_and_focused_in_sync_at_boundary() {
         svc.context().visible_year,
     );
 }
+
+// ────────────────────────────────────────────────────────────────────
+// Codex review regressions, pass 3 (PR #688)
+// ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn prev_disabled_considers_page_behavior_single_in_multi_month() {
+    // Codex N7 (P2): with visible_months=3 and PageBehavior::Single, the
+    // calendar shows Mar-Apr-May. If `min = Mar 15`, paging back by one
+    // month (Single) yields Feb-Mar-Apr — which still contains
+    // selectable dates (≥ Mar 15 in April). prev must NOT be disabled.
+    let svc = service_with(
+        props()
+            .today(date(2024, 3, 15))
+            .visible_months(3)
+            .page_behavior(PageBehavior::Single)
+            .min(Some(date(2024, 3, 15))),
+        en_us(),
+    );
+    let api = svc.connect(&|_| {});
+
+    assert!(
+        !api.is_prev_disabled(),
+        "prev must not be disabled when the next page back still has selectable dates",
+    );
+}
+
+#[test]
+fn prev_disabled_when_full_prev_page_below_min() {
+    // Conversely, prev IS disabled when the whole prev page would be
+    // entirely below min — visible Jan 2024, min = Jan 15, paging back
+    // (Single) → Dec 2023 which is fully below min.
+    let svc = service_with(
+        props()
+            .today(date(2024, 1, 15))
+            .min(Some(date(2024, 1, 15))),
+        en_us(),
+    );
+    let api = svc.connect(&|_| {});
+
+    assert!(
+        api.is_prev_disabled(),
+        "prev must be disabled when stepping back yields no selectable dates",
+    );
+}
+
+#[test]
+fn next_disabled_considers_page_behavior_single_in_multi_month() {
+    // Codex N8 (P2): symmetric case for next. visible Jan-Feb-Mar with
+    // PageBehavior::Single and max = Mar 15. Paging forward by one
+    // month (Single) yields Feb-Mar-Apr — Feb still has selectable
+    // dates (≤ Mar 15 in February). next must NOT be disabled.
+    let svc = service_with(
+        props()
+            .today(date(2024, 1, 15))
+            .visible_months(3)
+            .page_behavior(PageBehavior::Single)
+            .max(Some(date(2024, 3, 15))),
+        en_us(),
+    );
+    let api = svc.connect(&|_| {});
+
+    assert!(
+        !api.is_next_disabled(),
+        "next must not be disabled when the next page forward still has selectable dates",
+    );
+}
+
+#[test]
+fn next_disabled_when_full_next_page_above_max() {
+    // visible Jan 2024 with max = Jan 25, paging forward (Single) → Feb 2024
+    // which is fully above max. next IS disabled.
+    let svc = service_with(
+        props()
+            .today(date(2024, 1, 15))
+            .max(Some(date(2024, 1, 25))),
+        en_us(),
+    );
+    let api = svc.connect(&|_| {});
+
+    assert!(
+        api.is_next_disabled(),
+        "next must be disabled when the next page forward yields no selectable dates",
+    );
+}

--- a/crates/ars-components/src/date_time/calendar/tests.rs
+++ b/crates/ars-components/src/date_time/calendar/tests.rs
@@ -8,7 +8,7 @@ use alloc::{format, string::String, sync::Arc, vec::Vec};
 
 use ars_core::{AttrMap, Callback, ComponentPart, Env, HtmlAttr, KeyboardKey, Service};
 use ars_i18n::{
-    CalendarDate, Locale, StubIntlBackend,
+    CalendarDate, DateDuration, Locale, StubIntlBackend,
     locales::{ar_sa, de_de, en_gb, en_us, fa},
 };
 use insta::assert_snapshot;
@@ -1662,4 +1662,241 @@ fn disabled_calendar_blocks_navigation_too() {
     drop(svc.send(Event::NextMonth));
 
     assert_eq!(svc.context().visible_month, before_month);
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Codex review regressions (PR #688)
+// ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn unavailable_cell_trigger_stays_focusable_and_not_html_disabled() {
+    // Codex T1 (P1): unavailable cells must remain focusable per spec §3.
+    // HTML `disabled` removes the element from the focus model, so we only
+    // surface `aria-disabled` + the data hook for unavailable-but-not-disabled
+    // dates; HTML `disabled` is reserved for the min/max-disabled case.
+    let predicate = Callback::new_ref(|d: &CalendarDate| d.day() == 12);
+    let svc = service_with(props().is_date_unavailable(Some(predicate)), en_us());
+    let api = svc.connect(&|_| {});
+
+    let trigger = api.cell_trigger_attrs(&date(2024, 1, 12));
+
+    // aria-disabled is set (semantic restriction is announced).
+    assert_eq!(
+        attr(&trigger, HtmlAttr::Aria(AriaAttr::Disabled)).as_deref(),
+        Some("true"),
+    );
+    // HTML `disabled` is NOT set — the cell must remain in the focus model.
+    assert!(
+        trigger.get(&HtmlAttr::Disabled).is_none(),
+        "unavailable cell triggers must remain focusable; HTML disabled removes them from tab order",
+    );
+}
+
+#[test]
+fn min_max_disabled_cell_trigger_is_html_disabled() {
+    // Sanity check the other branch: dates outside min/max keep both
+    // `aria-disabled` and HTML `disabled` set.
+    let svc = service_with(props().min(Some(date(2024, 1, 10))), en_us());
+    let api = svc.connect(&|_| {});
+
+    let trigger = api.cell_trigger_attrs(&date(2024, 1, 5));
+
+    assert_eq!(
+        attr(&trigger, HtmlAttr::Aria(AriaAttr::Disabled)).as_deref(),
+        Some("true"),
+    );
+    assert_eq!(
+        trigger.get(&HtmlAttr::Disabled).map(ToString::to_string),
+        Some(String::from("true")),
+    );
+}
+
+#[test]
+fn cell_trigger_attrs_for_offset_marks_outside_for_other_grids_month() {
+    // Codex T2 (P2): cell_trigger_attrs_for(offset) checks against the grid's
+    // own month, not the first visible month.
+    let svc = service_with(props().visible_months(2), en_us());
+    let api = svc.connect(&|_| {});
+
+    // From offset=1 (February), Jan 15 is outside-month.
+    let trigger = api.cell_trigger_attrs_for(&date(2024, 1, 15), 1);
+    assert_eq!(
+        attr(&trigger, HtmlAttr::Data("ars-outside-month")).as_deref(),
+        Some("true"),
+    );
+
+    // From offset=0 (January), Jan 15 is inside.
+    let trigger = api.cell_trigger_attrs_for(&date(2024, 1, 15), 0);
+    assert!(trigger.get(&HtmlAttr::Data("ars-outside-month")).is_none());
+
+    // Feb 15 from offset=1 (Feb's grid) — should NOT be outside-month
+    // (which is the regression the bare cell_trigger_attrs has).
+    let trigger = api.cell_trigger_attrs_for(&date(2024, 2, 15), 1);
+    assert!(
+        trigger.get(&HtmlAttr::Data("ars-outside-month")).is_none(),
+        "Feb 15 in Feb's grid must not be flagged outside-month",
+    );
+}
+
+#[test]
+fn next_month_advances_focused_date() {
+    // Codex T4 (P1): paging keeps focused_date in the visible range so the
+    // roving tab target remains rendered.
+    let mut svc = service();
+    let before = svc.context().focused_date.clone();
+
+    drop(svc.send(Event::NextMonth));
+
+    let expected = before
+        .add(DateDuration {
+            months: 1,
+            ..DateDuration::default()
+        })
+        .expect("Jan 15 + 1 month is valid");
+    assert_eq!(svc.context().focused_date, expected);
+    assert!(
+        svc.context()
+            .is_in_visible_range(&svc.context().focused_date),
+        "focused_date must land in the new visible range",
+    );
+}
+
+#[test]
+fn prev_month_retreats_focused_date() {
+    let mut svc = service();
+    let before = svc.context().focused_date.clone();
+
+    drop(svc.send(Event::PrevMonth));
+
+    let expected = before
+        .add(DateDuration {
+            months: -1,
+            ..DateDuration::default()
+        })
+        .expect("Jan 15 - 1 month is valid");
+    assert_eq!(svc.context().focused_date, expected);
+}
+
+#[test]
+fn next_year_advances_focused_date_by_twelve_months() {
+    // Codex T4 (P1) — year paging.
+    let mut svc = service();
+    let before = svc.context().focused_date.clone();
+
+    drop(svc.send(Event::NextYear));
+
+    let expected = before
+        .add(DateDuration {
+            months: 12,
+            ..DateDuration::default()
+        })
+        .expect("Jan 15 + 12 months is valid");
+    assert_eq!(svc.context().focused_date, expected);
+}
+
+#[test]
+fn prev_year_retreats_focused_date_by_twelve_months() {
+    let mut svc = service();
+    let before = svc.context().focused_date.clone();
+
+    drop(svc.send(Event::PrevYear));
+
+    let expected = before
+        .add(DateDuration {
+            months: -12,
+            ..DateDuration::default()
+        })
+        .expect("Jan 15 - 12 months is valid");
+    assert_eq!(svc.context().focused_date, expected);
+}
+
+#[test]
+fn shift_page_down_advances_focused_date_by_one_year() {
+    // Codex T3 (P2): keyboard year nav also moves focused_date, matching
+    // spec §3.2 ("Shift+PageDown: same day, next year").
+    let mut svc = service();
+    drop(svc.send(Event::FocusIn));
+    let before = svc.context().focused_date.clone();
+
+    drop(svc.send(Event::KeyDown {
+        key: KeyboardKey::PageDown,
+        shift: true,
+    }));
+
+    let expected = before
+        .add(DateDuration {
+            months: 12,
+            ..DateDuration::default()
+        })
+        .expect("Jan 15 + 12 months is valid");
+    assert_eq!(svc.context().focused_date, expected);
+}
+
+#[test]
+fn shift_page_up_retreats_focused_date_by_one_year() {
+    let mut svc = service();
+    drop(svc.send(Event::FocusIn));
+    let before = svc.context().focused_date.clone();
+
+    drop(svc.send(Event::KeyDown {
+        key: KeyboardKey::PageUp,
+        shift: true,
+    }));
+
+    let expected = before
+        .add(DateDuration {
+            months: -12,
+            ..DateDuration::default()
+        })
+        .expect("Jan 15 - 12 months is valid");
+    assert_eq!(svc.context().focused_date, expected);
+}
+
+#[test]
+fn paging_clamps_focused_date_into_min_max_range() {
+    // When paging pushes focused_date past max (or min), clamp it back into
+    // the configured range — the roving tab target must remain selectable.
+    let mut svc = service_with(
+        props()
+            .today(date(2024, 1, 15))
+            .max(Some(date(2024, 1, 31))),
+        en_us(),
+    );
+
+    drop(svc.send(Event::NextMonth));
+
+    // Without clamping, focused_date would be Feb 15 (out of range). With
+    // clamping, it lands on Jan 31 — the maximum allowed date.
+    assert_eq!(svc.context().focused_date, date(2024, 1, 31));
+}
+
+#[test]
+fn focus_out_processes_even_when_context_becomes_disabled() {
+    // Codex T5 (P2): the disabled guard must not swallow FocusOut, otherwise
+    // a calendar that becomes disabled mid-focus stays stuck in State::Focused.
+    let mut svc = service();
+    drop(svc.send(Event::FocusIn));
+    assert_eq!(*svc.state(), State::Focused);
+
+    // Simulate the parent flipping `disabled` to true while focused (e.g.,
+    // a controlled prop change). The real plumbing for prop propagation is
+    // adapter-side; here we mutate the live context directly.
+    svc.context_mut().disabled = true;
+
+    drop(svc.send(Event::FocusOut));
+
+    assert_eq!(
+        *svc.state(),
+        State::Idle,
+        "FocusOut must process even when ctx.disabled is true; otherwise the calendar stays stuck in Focused",
+    );
+}
+
+#[test]
+fn focus_in_still_blocked_when_disabled() {
+    // The disabled guard still gates interaction events including FocusIn —
+    // a disabled calendar should not be enterable via focus.
+    let mut svc = service_with(props().disabled(true), en_us());
+    drop(svc.send(Event::FocusIn));
+    assert_eq!(*svc.state(), State::Idle);
 }

--- a/crates/ars-components/src/date_time/calendar/tests.rs
+++ b/crates/ars-components/src/date_time/calendar/tests.rs
@@ -2241,3 +2241,107 @@ fn set_year_is_atomic_with_focused_date() {
     assert_eq!(svc.context().visible_year, 2030);
     assert_eq!(svc.context().focused_date.year(), 2030);
 }
+
+// ────────────────────────────────────────────────────────────────────
+// Codex review regressions, pass 5 (PR #688)
+// ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn paging_pulls_visible_back_when_clamp_moves_focus_to_other_month() {
+    // Codex N14 (P1): with focus Jan 15 and max=Jan 25, pressing NextMonth
+    // tries to shift to Feb 15, clamps back to Jan 25 (the max). visible_month
+    // must follow the clamp — both should land on January.
+    let mut svc = service_with(
+        props()
+            .today(date(2024, 1, 15))
+            .max(Some(date(2024, 1, 25))),
+        en_us(),
+    );
+    drop(svc.send(Event::NextMonth));
+
+    assert_eq!(svc.context().focused_date, date(2024, 1, 25));
+    assert_eq!(
+        svc.context().visible_month,
+        svc.context().focused_date.month(),
+        "visible_month must follow clamped focused_date",
+    );
+}
+
+#[test]
+fn set_month_pulls_visible_back_when_clamp_moves_focus() {
+    // Codex N14 (P1): SetMonth follows the same rule.
+    let mut svc = service_with(
+        props()
+            .today(date(2024, 1, 15))
+            .max(Some(date(2024, 1, 25))),
+        en_us(),
+    );
+    drop(svc.send(Event::SetMonth { month: 6 }));
+
+    assert_eq!(
+        svc.context().visible_month,
+        svc.context().focused_date.month(),
+    );
+}
+
+#[test]
+fn set_year_pulls_visible_back_when_clamp_moves_focus() {
+    let mut svc = service_with(
+        props()
+            .today(date(2024, 1, 15))
+            .max(Some(date(2024, 12, 31))),
+        en_us(),
+    );
+    drop(svc.send(Event::SetYear { year: 2030 }));
+
+    assert_eq!(
+        svc.context().visible_year,
+        svc.context().focused_date.year(),
+    );
+}
+
+#[test]
+fn cell_trigger_carries_button_type() {
+    // Codex N15 (P1): cell trigger must declare `type="button"` so a
+    // calendar inside a <form> doesn't accidentally submit when a date is
+    // clicked.
+    let svc = service();
+    let api = svc.connect(&|_| {});
+    let trigger = api.cell_trigger_attrs(&date(2024, 1, 15));
+    assert_eq!(attr(&trigger, HtmlAttr::Type).as_deref(), Some("button"));
+}
+
+#[test]
+fn prev_next_triggers_carry_button_type() {
+    let svc = service();
+    let api = svc.connect(&|_| {});
+    assert_eq!(
+        attr(&api.prev_trigger_attrs(), HtmlAttr::Type).as_deref(),
+        Some("button"),
+    );
+    assert_eq!(
+        attr(&api.next_trigger_attrs(), HtmlAttr::Type).as_deref(),
+        Some("button"),
+    );
+}
+
+#[test]
+fn announce_month_effect_skipped_on_boundary_failure() {
+    // Codex N17 (P2): when month_step_plan can't shift focused_date (e.g.,
+    // calendar boundary), it must return None so AnnounceMonth doesn't
+    // fire a spurious live-region announcement.
+    //
+    // We can't deterministically hit a Gregorian calendar boundary in a
+    // portable test, but we can pin the happy-path invariant that
+    // AnnounceMonth fires when the shift succeeds.
+    let mut svc = service();
+    let result = svc.send(Event::NextMonth);
+    assert!(
+        result
+            .pending_effects
+            .iter()
+            .any(|e| e.name == Effect::AnnounceMonth),
+        "happy-path NextMonth must still fire AnnounceMonth",
+    );
+    assert!(result.context_changed);
+}

--- a/crates/ars-components/src/date_time/calendar/tests.rs
+++ b/crates/ars-components/src/date_time/calendar/tests.rs
@@ -2345,3 +2345,67 @@ fn announce_month_effect_skipped_on_boundary_failure() {
     );
     assert!(result.context_changed);
 }
+
+// ────────────────────────────────────────────────────────────────────
+// Codex review regressions, pass 6 (PR #688)
+// ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn unavailable_suffix_label_uses_messages_default() {
+    // Codex N20 (P2): the "(unavailable)" suffix in the cell aria-label
+    // must come from `Messages` so it can be localized. The default value
+    // matches what was previously hard-coded, so existing snapshots stay
+    // the same.
+    let predicate = Callback::new_ref(|d: &CalendarDate| d.day() == 12);
+    let svc = service_with(props().is_date_unavailable(Some(predicate)), en_us());
+    let api = svc.connect(&|_| {});
+    let trigger = api.cell_trigger_attrs(&date(2024, 1, 12));
+    let label = attr(&trigger, HtmlAttr::Aria(AriaAttr::Label)).unwrap_or_default();
+    assert!(
+        label.ends_with("(unavailable)"),
+        "default Messages must keep the existing English suffix; got {label:?}",
+    );
+}
+
+#[test]
+fn unavailable_suffix_label_routes_through_messages_override() {
+    // Localised Messages must reach the aria-label so a German consumer
+    // can replace `(unavailable)` with `(nicht verfügbar)`.
+    let predicate = Callback::new_ref(|d: &CalendarDate| d.day() == 12);
+    let messages = Messages {
+        unavailable_suffix: MessageFn::static_str("(nicht verfügbar)"),
+        ..Messages::default()
+    };
+    let svc = Service::<Machine>::new(
+        props().is_date_unavailable(Some(predicate)),
+        &env(en_us()),
+        &messages,
+    );
+    let api = svc.connect(&|_| {});
+    let trigger = api.cell_trigger_attrs(&date(2024, 1, 12));
+    let label = attr(&trigger, HtmlAttr::Aria(AriaAttr::Label)).unwrap_or_default();
+    assert!(
+        label.ends_with("(nicht verfügbar)"),
+        "localized suffix must flow through; got {label:?}",
+    );
+}
+
+#[test]
+fn disabled_suffix_label_routes_through_messages_override() {
+    let messages = Messages {
+        disabled_suffix: MessageFn::static_str("(deaktiviert)"),
+        ..Messages::default()
+    };
+    let svc = Service::<Machine>::new(
+        props().min(Some(date(2024, 1, 20))),
+        &env(en_us()),
+        &messages,
+    );
+    let api = svc.connect(&|_| {});
+    let trigger = api.cell_trigger_attrs(&date(2024, 1, 5));
+    let label = attr(&trigger, HtmlAttr::Aria(AriaAttr::Label)).unwrap_or_default();
+    assert!(
+        label.ends_with("(deaktiviert)"),
+        "localized disabled suffix must flow through; got {label:?}",
+    );
+}

--- a/crates/ars-components/src/date_time/calendar/tests.rs
+++ b/crates/ars-components/src/date_time/calendar/tests.rs
@@ -1900,3 +1900,179 @@ fn focus_in_still_blocked_when_disabled() {
     drop(svc.send(Event::FocusIn));
     assert_eq!(*svc.state(), State::Idle);
 }
+
+// ────────────────────────────────────────────────────────────────────
+// Codex review regressions, pass 2 (PR #688)
+// ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn initial_focused_date_is_clamped_into_min_max_range() {
+    // Codex N1 (P1): the initial focused_date must respect min/max so the
+    // roving tab target never lands on a disabled cell.
+    let svc = service_with(
+        props()
+            .today(date(2024, 1, 1))
+            .min(Some(date(2024, 1, 10)))
+            .max(Some(date(2024, 1, 25))),
+        en_us(),
+    );
+    assert_eq!(svc.context().focused_date, date(2024, 1, 10));
+
+    // Symmetric: today above max → clamped down to max.
+    let svc = service_with(
+        props()
+            .today(date(2024, 1, 31))
+            .min(Some(date(2024, 1, 10)))
+            .max(Some(date(2024, 1, 25))),
+        en_us(),
+    );
+    assert_eq!(svc.context().focused_date, date(2024, 1, 25));
+}
+
+#[test]
+fn sync_props_propagates_controlled_value_changes() {
+    // Codex N2 (P1): `set_props` must surface parent prop changes —
+    // controlled value, disabled, min/max, etc. — into the live context.
+    let mut svc = service_with(props().value(Some(date(2024, 1, 10))), en_us());
+    assert_eq!(*svc.context().value.get(), Some(date(2024, 1, 10)));
+
+    // Parent flips the controlled value.
+    drop(svc.set_props(props().value(Some(date(2024, 1, 20)))));
+    assert_eq!(
+        *svc.context().value.get(),
+        Some(date(2024, 1, 20)),
+        "controlled value change must flow through set_props",
+    );
+}
+
+#[test]
+fn sync_props_propagates_disabled_and_readonly() {
+    let mut svc = service();
+    assert!(!svc.context().disabled);
+    assert!(!svc.context().readonly);
+
+    drop(svc.set_props(props().disabled(true).readonly(true)));
+
+    assert!(
+        svc.context().disabled,
+        "disabled must propagate via set_props"
+    );
+    assert!(
+        svc.context().readonly,
+        "readonly must propagate via set_props"
+    );
+}
+
+#[test]
+fn sync_props_propagates_min_max() {
+    let mut svc = service();
+    assert!(svc.context().min.is_none());
+
+    drop(
+        svc.set_props(
+            props()
+                .min(Some(date(2024, 1, 10)))
+                .max(Some(date(2024, 1, 25))),
+        ),
+    );
+
+    assert_eq!(svc.context().min, Some(date(2024, 1, 10)));
+    assert_eq!(svc.context().max, Some(date(2024, 1, 25)));
+}
+
+#[test]
+fn set_month_advances_focused_date() {
+    // Codex N3 (P2): SetMonth/SetYear must keep focused_date in range.
+    let mut svc = service();
+    let before = svc.context().focused_date.clone();
+
+    drop(svc.send(Event::SetMonth { month: 6 }));
+
+    assert_eq!(svc.context().visible_month, 6);
+    // Focused date follows the visible month: same day, new month.
+    assert_eq!(svc.context().focused_date.month(), 6);
+    assert_eq!(svc.context().focused_date.day(), before.day());
+}
+
+#[test]
+fn set_year_advances_focused_date() {
+    let mut svc = service();
+    let before_day = svc.context().focused_date.day();
+    let before_month = svc.context().focused_date.month();
+
+    drop(svc.send(Event::SetYear { year: 2030 }));
+
+    assert_eq!(svc.context().visible_year, 2030);
+    assert_eq!(svc.context().focused_date.year(), 2030);
+    assert_eq!(svc.context().focused_date.month(), before_month);
+    assert_eq!(svc.context().focused_date.day(), before_day);
+}
+
+#[test]
+fn prev_next_triggers_disabled_when_calendar_disabled() {
+    // Codex N4 (P2): a globally-disabled calendar must mark its prev/next
+    // triggers as HTML-disabled too, otherwise the buttons appear active
+    // while the machine drops their events.
+    let svc = service_with(props().disabled(true), en_us());
+    let api = svc.connect(&|_| {});
+
+    let prev = api.prev_trigger_attrs();
+    let next = api.next_trigger_attrs();
+
+    assert_eq!(
+        prev.get(&HtmlAttr::Disabled).map(ToString::to_string),
+        Some(String::from("true")),
+        "prev trigger must be HTML-disabled when ctx.disabled is true",
+    );
+    assert_eq!(
+        attr(&prev, HtmlAttr::Aria(AriaAttr::Disabled)).as_deref(),
+        Some("true"),
+    );
+    assert_eq!(
+        next.get(&HtmlAttr::Disabled).map(ToString::to_string),
+        Some(String::from("true")),
+    );
+    assert_eq!(
+        attr(&next, HtmlAttr::Aria(AriaAttr::Disabled)).as_deref(),
+        Some("true"),
+    );
+}
+
+#[test]
+fn weeks_for_returns_six_rows_or_empty_never_partial() {
+    // Codex N5 (P2): the contract is "exactly 6 rows or empty on boundary
+    // failure", never a partially-built vector. Confirm the happy path
+    // produces 6 rows; boundary behaviour is exercised in grid.rs unit
+    // tests where we can drive `add_days` failure deterministically.
+    let svc = service();
+    let weeks = svc.context().weeks();
+    assert!(
+        weeks.is_empty() || weeks.len() == 6,
+        "weeks() must return either 0 or 6 rows, got {}",
+        weeks.len(),
+    );
+    assert_eq!(weeks.len(), 6); // happy path
+}
+
+#[test]
+fn month_step_plan_keeps_visible_and_focused_in_sync_at_boundary() {
+    // Codex N6 (P2): if the focused-date shift fails near a representable
+    // boundary, visible_month must NOT advance either — they move
+    // atomically.
+    //
+    // We can't easily hit the calendar boundary in a portable test (the
+    // overflow point depends on the ICU calendar engine), but we can pin
+    // the happy-path invariant: after paging, focused_date.month() must
+    // equal visible_month (within the same calendar year wrap).
+    let mut svc = service();
+    drop(svc.send(Event::NextMonth));
+    assert_eq!(
+        svc.context().focused_date.month(),
+        svc.context().visible_month,
+        "focused_date.month() must track visible_month after paging",
+    );
+    assert_eq!(
+        svc.context().focused_date.year(),
+        svc.context().visible_year,
+    );
+}

--- a/crates/ars-components/src/date_time/calendar/tests.rs
+++ b/crates/ars-components/src/date_time/calendar/tests.rs
@@ -2161,3 +2161,83 @@ fn next_disabled_when_full_next_page_above_max() {
         "next must be disabled when the next page forward yields no selectable dates",
     );
 }
+
+// ────────────────────────────────────────────────────────────────────
+// Codex review regressions, pass 4 (PR #688)
+// ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn sync_props_keeps_focused_date_in_visible_range() {
+    // Codex N9 (P1): after `sync_props_into_ctx` clamps focused_date, the
+    // visible month/year window must follow, otherwise the focused cell
+    // is no longer rendered.
+    let mut svc = service_with(props().today(date(2024, 1, 15)), en_us());
+    assert_eq!(svc.context().visible_month, 1);
+
+    // Parent installs a new min in July — clamping pushes focused_date
+    // to Jul 1, and the visible window must follow.
+    drop(svc.set_props(props().today(date(2024, 1, 15)).min(Some(date(2024, 7, 1)))));
+
+    assert_eq!(svc.context().focused_date, date(2024, 7, 1));
+    assert!(
+        svc.context()
+            .is_in_visible_range(&svc.context().focused_date),
+        "visible window must follow the clamped focused_date",
+    );
+}
+
+#[test]
+fn sync_props_clears_first_day_of_week_override() {
+    // Codex N10 (P2): when the parent flips `first_day_of_week` Some→None
+    // the override clears and context returns to the locale-derived value.
+    let mut svc = service_with(props().first_day_of_week(Some(Weekday::Wednesday)), en_us());
+    assert_eq!(svc.context().first_day_of_week, Weekday::Wednesday);
+
+    // Parent removes the override.
+    drop(svc.set_props(props().first_day_of_week(None)));
+
+    // en_us locale default is Sunday — context must return to it.
+    assert_eq!(
+        svc.context().first_day_of_week,
+        Weekday::Sunday,
+        "clearing the override must restore the locale default",
+    );
+}
+
+#[test]
+fn set_year_handles_extreme_year_without_overflow() {
+    // Codex N11 (P2): `SetYear { year: i32::MIN }` would overflow the
+    // delta computation against a positive current visible_year. The
+    // transition must drop the event safely instead of panicking in
+    // debug or wrapping in release.
+    let mut svc = service();
+    let visible_before = svc.context().visible_year;
+    let focused_before = svc.context().focused_date.clone();
+
+    drop(svc.send(Event::SetYear { year: i32::MIN }));
+
+    // The event is dropped (no overflow). Visible year and focused date
+    // remain unchanged.
+    assert_eq!(svc.context().visible_year, visible_before);
+    assert_eq!(svc.context().focused_date, focused_before);
+}
+
+#[test]
+fn set_month_is_atomic_with_focused_date() {
+    // Codex N12 (P2): SetMonth must commit `visible_month` only after
+    // the focused-date shift succeeds. Happy-path invariant: after
+    // SetMonth, focused_date.month() always equals visible_month.
+    let mut svc = service();
+    drop(svc.send(Event::SetMonth { month: 7 }));
+    assert_eq!(svc.context().visible_month, 7);
+    assert_eq!(svc.context().focused_date.month(), 7);
+}
+
+#[test]
+fn set_year_is_atomic_with_focused_date() {
+    // Codex N13 (P2): SetYear same atomicity rule.
+    let mut svc = service();
+    drop(svc.send(Event::SetYear { year: 2030 }));
+    assert_eq!(svc.context().visible_year, 2030);
+    assert_eq!(svc.context().focused_date.year(), 2030);
+}

--- a/crates/ars-components/src/date_time/mod.rs
+++ b/crates/ars-components/src/date_time/mod.rs
@@ -1,5 +1,8 @@
 //! Date and time component machines.
 
+/// Calendar machine.
+pub mod calendar;
+
 /// DateField machine.
 pub mod date_field;
 

--- a/crates/ars-components/tests/proptest_state_machines/date_time.rs
+++ b/crates/ars-components/tests/proptest_state_machines/date_time.rs
@@ -1,9 +1,10 @@
 use ars_components::date_time::{
+    calendar::{self, PageBehavior, SelectionMode},
     date_field::{self, DateSegmentKind},
     time_field,
 };
-use ars_core::{Env, Service};
-use ars_i18n::{CalendarDate, HourCycle, Time};
+use ars_core::{Env, KeyboardKey, Service};
+use ars_i18n::{CalendarDate, HourCycle, Time, Weekday};
 use proptest::prelude::*;
 
 #[derive(Clone, Debug)]
@@ -302,5 +303,237 @@ proptest! {
                 );
             }
         }
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Calendar
+// ────────────────────────────────────────────────────────────────────
+
+#[derive(Clone, Debug)]
+enum CalendarAction {
+    Send(calendar::Event),
+    SetDisabled(bool),
+    SetReadonly(bool),
+    SetMin(Option<CalendarDate>),
+    SetMax(Option<CalendarDate>),
+}
+
+fn calendar_props() -> calendar::Props {
+    calendar::Props::new().id("cal").today(date(2024, 1, 15))
+}
+
+fn calendar_props_multi() -> calendar::Props {
+    calendar_props().selection_mode(SelectionMode::Multiple)
+}
+
+fn arb_calendar_date() -> impl Strategy<Value = CalendarDate> {
+    (1900i32..=2100, 1u8..=12, 1u8..=28).prop_map(|(y, m, d)| date(y, m, d))
+}
+
+fn arb_calendar_key() -> impl Strategy<Value = KeyboardKey> {
+    prop_oneof![
+        Just(KeyboardKey::ArrowLeft),
+        Just(KeyboardKey::ArrowRight),
+        Just(KeyboardKey::ArrowUp),
+        Just(KeyboardKey::ArrowDown),
+        Just(KeyboardKey::Home),
+        Just(KeyboardKey::End),
+        Just(KeyboardKey::PageUp),
+        Just(KeyboardKey::PageDown),
+        Just(KeyboardKey::Enter),
+        Just(KeyboardKey::Space),
+    ]
+}
+
+fn arb_calendar_event() -> impl Strategy<Value = calendar::Event> {
+    prop_oneof![
+        arb_calendar_date().prop_map(|date| calendar::Event::FocusDate { date }),
+        arb_calendar_date().prop_map(|date| calendar::Event::SelectDate { date }),
+        arb_calendar_date().prop_map(|date| calendar::Event::ToggleDate { date }),
+        Just(calendar::Event::NextMonth),
+        Just(calendar::Event::PrevMonth),
+        Just(calendar::Event::NextYear),
+        Just(calendar::Event::PrevYear),
+        (1u8..=12).prop_map(|month| calendar::Event::SetMonth { month }),
+        (1900i32..=2100).prop_map(|year| calendar::Event::SetYear { year }),
+        Just(calendar::Event::FocusIn),
+        Just(calendar::Event::FocusOut),
+        (arb_calendar_key(), any::<bool>())
+            .prop_map(|(key, shift)| calendar::Event::KeyDown { key, shift }),
+    ]
+}
+
+fn arb_calendar_action() -> impl Strategy<Value = CalendarAction> {
+    prop_oneof![
+        arb_calendar_event().prop_map(CalendarAction::Send),
+        any::<bool>().prop_map(CalendarAction::SetDisabled),
+        any::<bool>().prop_map(CalendarAction::SetReadonly),
+        prop::option::of(arb_calendar_date()).prop_map(CalendarAction::SetMin),
+        prop::option::of(arb_calendar_date()).prop_map(CalendarAction::SetMax),
+    ]
+}
+
+fn apply_calendar_action(
+    service: &mut Service<calendar::Machine>,
+    action: CalendarAction,
+    base_props: &calendar::Props,
+) {
+    match action {
+        CalendarAction::Send(event) => {
+            drop(service.send(event));
+        }
+
+        CalendarAction::SetDisabled(value) => {
+            drop(service.set_props(base_props.clone().disabled(value)));
+        }
+
+        CalendarAction::SetReadonly(value) => {
+            drop(service.set_props(base_props.clone().readonly(value)));
+        }
+
+        CalendarAction::SetMin(value) => {
+            drop(service.set_props(base_props.clone().min(value)));
+        }
+
+        CalendarAction::SetMax(value) => {
+            drop(service.set_props(base_props.clone().max(value)));
+        }
+    }
+}
+
+fn assert_calendar_invariants(service: &Service<calendar::Machine>) {
+    let ctx = service.context();
+
+    assert!(ctx.visible_month >= 1, "visible_month must be 1-based");
+    assert!(ctx.visible_month <= 12, "visible_month must be 1..=12");
+    assert!(ctx.visible_months >= 1, "visible_months must be >= 1");
+    assert!(
+        matches!(
+            ctx.first_day_of_week,
+            Weekday::Sunday
+                | Weekday::Monday
+                | Weekday::Tuesday
+                | Weekday::Wednesday
+                | Weekday::Thursday
+                | Weekday::Friday
+                | Weekday::Saturday,
+        ),
+        "first_day_of_week must be a valid weekday",
+    );
+
+    if let Some(min) = &ctx.min {
+        assert!(
+            !matches!(ctx.focused_date.compare(min), core::cmp::Ordering::Less),
+            "focused_date must be >= min",
+        );
+    }
+
+    if let Some(max) = &ctx.max {
+        assert!(
+            !matches!(ctx.focused_date.compare(max), core::cmp::Ordering::Greater),
+            "focused_date must be <= max",
+        );
+    }
+
+    if let Some(cap) = ctx.max_selected {
+        assert!(
+            ctx.selected_dates.get().len() <= cap,
+            "selected_dates exceeded max_selected cap",
+        );
+    }
+
+    let weeks = ctx.weeks();
+
+    if !weeks.is_empty() {
+        assert_eq!(weeks.len(), 6, "grid must always render 6 weeks");
+        for row in &weeks {
+            assert_eq!(row.len(), 7, "every row must contain 7 days");
+        }
+    }
+
+    assert!(matches!(
+        service.state(),
+        calendar::State::Idle | calendar::State::Focused,
+    ));
+}
+
+proptest! {
+    #![proptest_config(super::common::proptest_config())]
+
+    #[test]
+    #[ignore = "proptest — nightly extended-proptest job"]
+    fn proptest_calendar_single_select_preserves_invariants(
+        actions in prop::collection::vec(arb_calendar_action(), 0..64),
+    ) {
+        let base = calendar_props();
+
+        let mut service = Service::<calendar::Machine>::new(
+            base.clone(),
+            &Env::default(),
+            &calendar::Messages::default(),
+        );
+
+        for action in actions {
+            apply_calendar_action(&mut service, action, &base);
+
+            assert_calendar_invariants(&service);
+        }
+    }
+
+    #[test]
+    #[ignore = "proptest — nightly extended-proptest job"]
+    fn proptest_calendar_multi_select_preserves_invariants(
+        actions in prop::collection::vec(arb_calendar_action(), 0..64),
+        max_selected in prop::option::of(1usize..=8),
+    ) {
+        let base = calendar_props_multi().max_selected(max_selected);
+
+        let mut service = Service::<calendar::Machine>::new(
+            base.clone(),
+            &Env::default(),
+            &calendar::Messages::default(),
+        );
+
+        for action in actions {
+            apply_calendar_action(&mut service, action, &base);
+
+            assert_calendar_invariants(&service);
+        }
+    }
+
+    #[test]
+    #[ignore = "proptest — nightly extended-proptest job"]
+    fn proptest_calendar_page_behavior_advances_one_or_visible_months(
+        visible in 1usize..=4,
+        behavior in prop_oneof![Just(PageBehavior::Visible), Just(PageBehavior::Single)],
+        steps in 0u8..=20,
+    ) {
+        let base = calendar_props().visible_months(visible).page_behavior(behavior);
+
+        let mut service = Service::<calendar::Machine>::new(
+            base.clone(),
+            &Env::default(),
+            &calendar::Messages::default(),
+        );
+
+        let start_month = i32::from(service.context().visible_month);
+        let start_year = service.context().visible_year;
+
+        for _ in 0..steps {
+            drop(service.send(calendar::Event::NextMonth));
+        }
+
+        let step = match behavior {
+            PageBehavior::Visible => i32::try_from(visible).unwrap_or(1),
+            PageBehavior::Single => 1,
+        };
+
+        let expected_total = start_month - 1 + step * i32::from(steps);
+        let expected_month = expected_total.rem_euclid(12) + 1;
+        let expected_year = start_year + expected_total.div_euclid(12);
+
+        prop_assert_eq!(service.context().visible_month, expected_month as u8);
+        prop_assert_eq!(service.context().visible_year, expected_year);
     }
 }

--- a/crates/ars-components/tests/spec_conformance/date_time.rs
+++ b/crates/ars-components/tests/spec_conformance/date_time.rs
@@ -2,9 +2,56 @@
 //!
 //! Asserts each date-time component's `Part` enum matches the spec anatomy.
 
-use ars_components::date_time::{date_field::DateSegmentKind, time_field};
+use ars_components::date_time::{calendar, date_field::DateSegmentKind, time_field};
+use ars_i18n::{CalendarDate, Weekday};
 
 use super::helper::assert_anatomy;
+
+fn calendar_date_default_for_part_all() -> CalendarDate {
+    // Mirrors the `#[part(default = ...)]` value on `calendar::Part::Cell`
+    // and `::CellTrigger`. `Part::all()` constructs these variants with the
+    // declared defaults, and the spec-conformance helper compares
+    // `Part::all()[i]` against the supplied expected parts via `PartialEq`,
+    // so the test must use the same date the derive emits.
+    CalendarDate::new_gregorian(1, 1, 1).expect("0001-01-01 is a valid Gregorian date")
+}
+
+#[test]
+fn calendar_anatomy_matches_spec() {
+    let example = calendar_date_default_for_part_all();
+    assert_anatomy(
+        "calendar",
+        &[
+            (calendar::Part::Root, "root"),
+            (calendar::Part::Header, "header"),
+            (calendar::Part::PrevTrigger, "prev-trigger"),
+            (calendar::Part::NextTrigger, "next-trigger"),
+            (calendar::Part::Heading, "heading"),
+            (calendar::Part::Grid, "grid"),
+            (calendar::Part::GridGroup, "grid-group"),
+            (calendar::Part::HeadRow, "head-row"),
+            (
+                calendar::Part::HeadCell {
+                    day: Weekday::Monday,
+                },
+                "head-cell",
+            ),
+            (calendar::Part::Row { week_index: 0 }, "row"),
+            (
+                calendar::Part::Cell {
+                    date: example.clone(),
+                },
+                "cell",
+            ),
+            (
+                calendar::Part::CellTrigger {
+                    date: example.clone(),
+                },
+                "cell-trigger",
+            ),
+        ],
+    );
+}
 
 #[test]
 fn time_field_anatomy_matches_spec() {

--- a/crates/ars-components/tests/spec_conformance/date_time.rs
+++ b/crates/ars-components/tests/spec_conformance/date_time.rs
@@ -40,12 +40,14 @@ fn calendar_anatomy_matches_spec() {
             (
                 calendar::Part::Cell {
                     date: example.clone(),
+                    offset: 0,
                 },
                 "cell",
             ),
             (
                 calendar::Part::CellTrigger {
                     date: example.clone(),
+                    offset: 0,
                 },
                 "cell-trigger",
             ),

--- a/crates/ars-core/src/callback.rs
+++ b/crates/ars-core/src/callback.rs
@@ -86,6 +86,27 @@ impl<F: Fn(Args) -> Out + Send + Sync + 'static, Args: 'static, Out: 'static> Fr
     }
 }
 
+// ── Constructors for Callback<dyn for<'a> Fn(&'a T) -> Out + Send + Sync> ─
+// The generic `Callback::new` requires `Args: 'static`, which excludes
+// `&T` (since the reference itself is not `'static`). This sibling
+// constructor accepts a higher-ranked closure over a reference argument
+// so predicate-style Props fields (e.g. `Calendar::is_date_unavailable`)
+// can still use `Callback` without falling back to raw `fn` pointers.
+
+/// Constructor for `Callback<dyn for<'a> Fn(&'a T) -> Out + Send + Sync>`.
+impl<T: ?Sized + 'static, Out: 'static> Callback<dyn for<'a> Fn(&'a T) -> Out + Send + Sync> {
+    /// Creates a new callback wrapping a higher-ranked closure over a
+    /// reference argument.
+    ///
+    /// Use when the closure signature is `Fn(&T) -> Out` (predicates,
+    /// transformers, key extractors) — the regular [`Callback::new`]
+    /// constructor cannot satisfy the implicit HRTB lifetime because its
+    /// `Args: 'static` bound excludes reference types.
+    pub fn new_ref(f: impl for<'a> Fn(&'a T) -> Out + Send + Sync + 'static) -> Self {
+        Self(Arc::new(f))
+    }
+}
+
 // ── Constructors for Callback<dyn Fn() + Send + Sync> (zero-argument) ─
 // `dyn Fn() + Send + Sync` and `dyn Fn(Args) -> Out + Send + Sync` are
 // distinct trait objects in Rust, so the generic `Callback::new` cannot
@@ -119,7 +140,7 @@ pub fn callback<Args: 'static, Out: 'static>(
 
 #[cfg(test)]
 mod tests {
-    use alloc::format;
+    use alloc::{format, string::String};
 
     use super::*;
 
@@ -190,6 +211,29 @@ mod tests {
         let cb: Callback<dyn Fn(i32) -> i32 + Send + Sync> = Callback::from(|value| value + 2);
 
         assert_eq!(cb(40), 42);
+    }
+
+    #[test]
+    fn callback_new_ref_invokes_higher_ranked_closure() {
+        let cb: Callback<dyn for<'a> Fn(&'a str) -> usize + Send + Sync> =
+            Callback::new_ref(|s: &str| s.len());
+
+        assert_eq!(cb("hello"), 5);
+
+        let owned = String::from("world!");
+
+        assert_eq!(cb(&owned), 6);
+    }
+
+    #[test]
+    fn callback_new_ref_supports_captured_state() {
+        let allowed = alloc::vec![1, 2, 3];
+
+        let cb: Callback<dyn for<'a> Fn(&'a i32) -> bool + Send + Sync> =
+            Callback::new_ref(move |value: &i32| allowed.contains(value));
+
+        assert!(cb(&2));
+        assert!(!cb(&5));
     }
 
     #[test]

--- a/spec/components/date-time/calendar.md
+++ b/spec/components/date-time/calendar.md
@@ -659,45 +659,43 @@ impl ars_core::Machine for Machine {
             }
 
             // ── Month / year navigation ──────────────────────────────────
-            Event::NextMonth => Some(month_step_plan(step_for_page_behavior(ctx))),
-            Event::PrevMonth => Some(month_step_plan(-step_for_page_behavior(ctx))),
-            Event::NextYear  => Some(month_step_plan(12)),
-            Event::PrevYear  => Some(month_step_plan(-12)),
+            Event::NextMonth => month_step_plan(ctx, step_for_page_behavior(ctx)),
+            Event::PrevMonth => month_step_plan(ctx, -step_for_page_behavior(ctx)),
+            Event::NextYear  => month_step_plan(ctx, 12),
+            Event::PrevYear  => month_step_plan(ctx, -12),
 
             Event::SetMonth { month } => {
                 let month = *month;
                 if !(1..=12).contains(&month) { return None; }
+                // Pre-compute the focused-date shift; on failure the
+                // whole transition (and `AnnounceMonth`) is dropped.
+                let delta = i32::from(month) - i32::from(ctx.visible_month);
+                let shifted = ctx.focused_date.add(DateDuration {
+                    months: delta,
+                    ..DateDuration::default()
+                }).ok()?;
                 Some(TransitionPlan::context_only(move |ctx| {
-                    // visible_month and focused_date move atomically:
-                    // compute the shifted date first and only commit
-                    // `visible_month` if the shift succeeds, otherwise
-                    // leave both untouched. Out-of-range targets clamp
-                    // back to [min, max].
-                    let delta = i32::from(month) - i32::from(ctx.visible_month);
-                    let Ok(shifted) = ctx.focused_date.add(DateDuration {
-                        months: delta,
-                        ..DateDuration::default()
-                    }) else { return; };
                     ctx.visible_month = month;
                     ctx.focused_date = ctx.clamp_date(shifted);
+                    // If the clamp moved focus into another month, pull
+                    // visible_month along so the focused cell renders.
+                    ctx.sync_visible_to_focused();
                 }).with_effect(announce_month_effect()))
             }
 
             Event::SetYear { year } => {
                 let year = *year;
+                // `i32 - i32` overflows on extreme inputs; drop event on
+                // overflow.
+                let delta_years = year.checked_sub(ctx.visible_year)?;
+                let shifted = ctx.focused_date.add(DateDuration {
+                    years: delta_years,
+                    ..DateDuration::default()
+                }).ok()?;
                 Some(TransitionPlan::context_only(move |ctx| {
-                    // `i32 - i32` overflows on extreme inputs
-                    // (`SetYear { year: i32::MIN }` with positive
-                    // `visible_year`); use `checked_sub` and drop the
-                    // event on overflow.
-                    let Some(delta_years) = year.checked_sub(ctx.visible_year) else { return; };
-                    // visible_year and focused_date move atomically.
-                    let Ok(shifted) = ctx.focused_date.add(DateDuration {
-                        years: delta_years,
-                        ..DateDuration::default()
-                    }) else { return; };
                     ctx.visible_year = year;
                     ctx.focused_date = ctx.clamp_date(shifted);
+                    ctx.sync_visible_to_focused();
                 }).with_effect(announce_month_effect()))
             }
 
@@ -723,23 +721,29 @@ fn step_for_page_behavior(ctx: &Context) -> i32 {
     }
 }
 
-fn month_step_plan(step: i32) -> TransitionPlan<Machine> {
-    TransitionPlan::context_only(move |ctx: &mut Context| {
-        // `visible_month/year` and `focused_date` must advance atomically.
-        // If the focused-date shift fails near a representable calendar
-        // boundary, leave both untouched so the roving-tabindex target
-        // can never end up outside the rendered grid. The clamp keeps
-        // out-of-range targets snapped to `[min, max]`.
-        let Ok(shifted) = ctx.focused_date.add(DateDuration {
-            months: step,
-            ..DateDuration::default()
-        }) else {
-            return;
-        };
-        ctx.advance_month(step);
-        ctx.focused_date = ctx.clamp_date(shifted);
-    })
-    .with_effect(announce_month_effect())
+fn month_step_plan(ctx: &Context, step: i32) -> Option<TransitionPlan<Machine>> {
+    // Pre-compute the focused-date shift at plan-build time so a
+    // boundary failure short-circuits the whole transition (no spurious
+    // `AnnounceMonth` effect). Returning `None` propagates as "no
+    // change" — visible_month, focused_date, AND announce effect all
+    // stay put.
+    let shifted = ctx.focused_date.add(DateDuration {
+        months: step,
+        ..DateDuration::default()
+    }).ok()?;
+    Some(
+        TransitionPlan::context_only(move |ctx: &mut Context| {
+            ctx.advance_month(step);
+            ctx.focused_date = ctx.clamp_date(shifted);
+            // If the clamp pushed focus into a different month than the
+            // newly-advanced visible window (e.g., NextMonth when focus
+            // is already at `max`), pull visible back to wherever the
+            // clamped focus lives. Without this the roving target has no
+            // rendered cell.
+            ctx.sync_visible_to_focused();
+        })
+        .with_effect(announce_month_effect()),
+    )
 }
 
 fn sync_props_into_ctx(ctx: &mut Context, props: &Props) {
@@ -818,8 +822,8 @@ fn handle_keydown(key: KeyboardKey, shift: bool, ctx: &Context)
 {
     if shift {
         match key {
-            KeyboardKey::PageUp   => return Some(month_step_plan(-12)),
-            KeyboardKey::PageDown => return Some(month_step_plan(12)),
+            KeyboardKey::PageUp   => return month_step_plan(ctx, -12),
+            KeyboardKey::PageDown => return month_step_plan(ctx, 12),
             _ => {}
         }
     }
@@ -899,8 +903,12 @@ pub enum Part {
     HeadRow,
     HeadCell { day: Weekday },
     Row { week_index: usize },
-    Cell { date: CalendarDate },
-    CellTrigger { date: CalendarDate },
+    /// `offset` carries the multi-month grid index (0 for single-month
+    /// or the first visible grid) so `ConnectApi::part_attrs` dispatches
+    /// to the offset-aware helpers and later grids are not mislabelled
+    /// as outside-month.
+    Cell { date: CalendarDate, offset: usize },
+    CellTrigger { date: CalendarDate, offset: usize },
 }
 
 /// API for the Calendar component.
@@ -967,6 +975,10 @@ impl<'a> Api<'a> {
         };
         attrs.set(HtmlAttr::Aria(AriaAttr::Label), label);
         attrs.set(HtmlAttr::TabIndex, "-1");
+        // `type="button"` keeps a click from auto-submitting an
+        // enclosing <form>. Browser default for untyped buttons is
+        // `submit`, which would turn paging into form submission.
+        attrs.set(HtmlAttr::Type, "button");
         if self.is_prev_disabled() {
             attrs.set_bool(HtmlAttr::Disabled, true);
             attrs.set(HtmlAttr::Aria(AriaAttr::Disabled), "true");
@@ -993,6 +1005,9 @@ impl<'a> Api<'a> {
         };
         attrs.set(HtmlAttr::Aria(AriaAttr::Label), label);
         attrs.set(HtmlAttr::TabIndex, "-1");
+        // See `prev_trigger_attrs` — explicit `type="button"` prevents
+        // form auto-submission on next clicks.
+        attrs.set(HtmlAttr::Type, "button");
         if self.is_next_disabled() {
             attrs.set_bool(HtmlAttr::Disabled, true);
             attrs.set(HtmlAttr::Aria(AriaAttr::Disabled), "true");
@@ -1166,7 +1181,8 @@ impl<'a> Api<'a> {
     pub fn cell_attrs(&self, date: &CalendarDate) -> AttrMap {
         let mut attrs = AttrMap::new();
         attrs.set(HtmlAttr::Role, "gridcell");
-        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Cell { date: date.clone() }.data_attrs();
+        let [(scope_attr, scope_val), (part_attr, part_val)] =
+            Part::Cell { date: date.clone(), offset: 0 }.data_attrs();
         attrs.set(scope_attr, scope_val);
         attrs.set(part_attr, part_val);
 
@@ -1199,9 +1215,15 @@ impl<'a> Api<'a> {
 
     fn cell_trigger_attrs_inner(&self, date: &CalendarDate, offset: Option<usize>) -> AttrMap {
         let mut attrs = AttrMap::new();
-        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::CellTrigger { date: date.clone() }.data_attrs();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::CellTrigger {
+            date: date.clone(),
+            offset: offset.unwrap_or(0),
+        }.data_attrs();
         attrs.set(scope_attr, scope_val);
         attrs.set(part_attr, part_val);
+        // `type="button"` prevents an enclosing <form> from submitting
+        // on date clicks (browser default for untyped buttons is submit).
+        attrs.set(HtmlAttr::Type, "button");
 
         let disabled = self.is_disabled(date);
         let unavailable = self.is_unavailable(date);
@@ -1415,8 +1437,8 @@ impl ConnectApi for Api<'_> {
             Part::HeadRow => self.head_row_attrs(),
             Part::HeadCell { day } => self.head_cell_attrs(day),
             Part::Row { week_index } => self.row_attrs(*week_index),
-            Part::Cell { date } => self.cell_attrs(date),
-            Part::CellTrigger { date } => self.cell_trigger_attrs(date),
+            Part::Cell { date, offset } => self.cell_attrs_for(date, *offset),
+            Part::CellTrigger { date, offset } => self.cell_trigger_attrs_for(date, *offset),
         }
     }
 }

--- a/spec/components/date-time/calendar.md
+++ b/spec/components/date-time/calendar.md
@@ -1324,33 +1324,43 @@ impl<'a> Api<'a> {
     }
 
     /// Whether the prev button should be disabled — either the calendar
-    /// is globally disabled or the visible range is already at `min`.
+    /// is globally disabled, or pressing prev (stepping by the active
+    /// `page_behavior`) would yield a visible range with **no** dates
+    /// ≥ `min`. The check looks at the LAST month of the post-step range
+    /// so multi-month + `PageBehavior::Single` doesn't disable too early.
     pub fn is_prev_disabled(&self) -> bool {
         if self.ctx.disabled { return true; }
         let Some(min) = &self.ctx.min else { return false; };
-        let Ok(first_of_visible) =
-            CalendarDate::new_gregorian(self.ctx.visible_year, self.ctx.visible_month, 1)
+        let step = self.nav_step_size();
+        let (new_first_m, new_first_y) = advance_month(
+            self.ctx.visible_month, self.ctx.visible_year, -(step as i32),
+        );
+        let last_offset = self.ctx.visible_months.saturating_sub(1);
+        let (new_last_m, new_last_y) = month_year_at_offset(new_first_m, new_first_y, last_offset);
+        let Ok(first_of_new_last) = CalendarDate::new_gregorian(new_last_y, new_last_m, 1)
         else { return false; };
-        !matches!(first_of_visible.compare(min), Ordering::Greater)
+        let Ok(last_of_new_last) =
+            CalendarDate::new_gregorian(new_last_y, new_last_m, first_of_new_last.days_in_month())
+        else { return false; };
+        matches!(last_of_new_last.compare(min), Ordering::Less)
     }
 
     /// Whether the next button should be disabled — either the calendar
-    /// is globally disabled or the visible range is already at `max`.
-    /// Checks against the **last** visible month so multi-month layouts
-    /// behave correctly.
+    /// is globally disabled, or pressing next (stepping by the active
+    /// `page_behavior`) would yield a visible range with **no** dates
+    /// ≤ `max`. Symmetric to `is_prev_disabled`: checks the FIRST month
+    /// of the post-step range so multi-month + `PageBehavior::Single`
+    /// doesn't disable too early.
     pub fn is_next_disabled(&self) -> bool {
         if self.ctx.disabled { return true; }
         let Some(max) = &self.ctx.max else { return false; };
-        let last_offset = self.ctx.visible_months.saturating_sub(1);
-        let (month, year) = self.ctx.month_year_at_offset(last_offset);
-        let Ok(first_of_last) = CalendarDate::new_gregorian(year, month, 1) else {
-            return false;
-        };
-        let days_in_month = first_of_last.days_in_month();
-        let Ok(last_of_last) = CalendarDate::new_gregorian(year, month, days_in_month) else {
-            return false;
-        };
-        !matches!(last_of_last.compare(max), Ordering::Less)
+        let step = self.nav_step_size();
+        let (new_first_m, new_first_y) = advance_month(
+            self.ctx.visible_month, self.ctx.visible_year, step as i32,
+        );
+        let Ok(first_of_new_first) = CalendarDate::new_gregorian(new_first_y, new_first_m, 1)
+        else { return false; };
+        matches!(first_of_new_first.compare(max), Ordering::Greater)
     }
 
     /// The grid data: weeks and day labels.

--- a/spec/components/date-time/calendar.md
+++ b/spec/components/date-time/calendar.md
@@ -668,32 +668,36 @@ impl ars_core::Machine for Machine {
                 let month = *month;
                 if !(1..=12).contains(&month) { return None; }
                 Some(TransitionPlan::context_only(move |ctx| {
-                    // Move both visible_month and focused_date by the
-                    // same delta so the roving-tabindex target still has
-                    // a rendered cell. Out-of-range targets clamp back
-                    // to [min, max].
+                    // visible_month and focused_date move atomically:
+                    // compute the shifted date first and only commit
+                    // `visible_month` if the shift succeeds, otherwise
+                    // leave both untouched. Out-of-range targets clamp
+                    // back to [min, max].
                     let delta = i32::from(month) - i32::from(ctx.visible_month);
-                    ctx.visible_month = month;
-                    if let Ok(shifted) = ctx.focused_date.add(DateDuration {
+                    let Ok(shifted) = ctx.focused_date.add(DateDuration {
                         months: delta,
                         ..DateDuration::default()
-                    }) {
-                        ctx.focused_date = ctx.clamp_date(shifted);
-                    }
+                    }) else { return; };
+                    ctx.visible_month = month;
+                    ctx.focused_date = ctx.clamp_date(shifted);
                 }).with_effect(announce_month_effect()))
             }
 
             Event::SetYear { year } => {
                 let year = *year;
                 Some(TransitionPlan::context_only(move |ctx| {
-                    let delta_years = year - ctx.visible_year;
-                    ctx.visible_year = year;
-                    if let Ok(shifted) = ctx.focused_date.add(DateDuration {
+                    // `i32 - i32` overflows on extreme inputs
+                    // (`SetYear { year: i32::MIN }` with positive
+                    // `visible_year`); use `checked_sub` and drop the
+                    // event on overflow.
+                    let Some(delta_years) = year.checked_sub(ctx.visible_year) else { return; };
+                    // visible_year and focused_date move atomically.
+                    let Ok(shifted) = ctx.focused_date.add(DateDuration {
                         years: delta_years,
                         ..DateDuration::default()
-                    }) {
-                        ctx.focused_date = ctx.clamp_date(shifted);
-                    }
+                    }) else { return; };
+                    ctx.visible_year = year;
+                    ctx.focused_date = ctx.clamp_date(shifted);
                 }).with_effect(announce_month_effect()))
             }
 
@@ -755,13 +759,18 @@ fn sync_props_into_ctx(ctx: &mut Context, props: &Props) {
     ctx.page_behavior = props.page_behavior;
     ctx.today = props.today.clone();
 
-    if let Some(fdow) = props.first_day_of_week {
-        ctx.first_day_of_week = fdow;
-    }
+    // `first_day_of_week` accepts an explicit override; clearing it
+    // (`Some(_) → None`) restores the locale-derived value via the
+    // cached `intl_backend` rather than retaining the stale override.
+    ctx.first_day_of_week = props
+        .first_day_of_week
+        .unwrap_or_else(|| ctx.locale.first_day_of_week(&*ctx.intl_backend));
 
-    // Re-clamp `focused_date` in case `min`/`max` tightened.
+    // Re-clamp `focused_date` in case `min`/`max` tightened, then drag
+    // the visible window along so the focused cell remains rendered.
     let clamped = ctx.clamp_date(ctx.focused_date.clone());
     ctx.focused_date = clamped;
+    ctx.sync_visible_to_focused();
 }
 
 fn announce_month_effect() -> ars_core::PendingEffect<Machine> {

--- a/spec/components/date-time/calendar.md
+++ b/spec/components/date-time/calendar.md
@@ -572,12 +572,23 @@ impl ars_core::Machine for Machine {
         ctx: &Self::Context,
         _props: &Self::Props,
     ) -> Option<TransitionPlan<Self>> {
+        // `FocusOut` must run even when the calendar is disabled — a
+        // calendar that becomes disabled while focused still needs its blur
+        // cleanup to land, otherwise it stays stuck in `State::Focused`
+        // with stale `data-ars-state="focused"`. All other events are gated
+        // by the disabled guard below.
+        if matches!(event, Event::FocusOut) {
+            return Some(TransitionPlan::to(State::Idle));
+        }
+
         if ctx.disabled { return None; }
 
         match event {
             // ── Focus management ─────────────────────────────────────────
             Event::FocusIn  => Some(TransitionPlan::to(State::Focused)),
-            Event::FocusOut => Some(TransitionPlan::to(State::Idle)),
+            // `FocusOut` handled above the disabled guard; this arm exists
+            // only to satisfy match exhaustiveness over `Event`.
+            Event::FocusOut => None,
 
             Event::FocusDate { date } => {
                 let clamped = ctx.clamp_date(date.clone());
@@ -643,8 +654,22 @@ fn step_for_page_behavior(ctx: &Context) -> i32 {
 }
 
 fn month_step_plan(step: i32) -> TransitionPlan<Machine> {
-    TransitionPlan::context_only(move |ctx: &mut Context| { ctx.advance_month(step); })
-        .with_effect(announce_month_effect())
+    TransitionPlan::context_only(move |ctx: &mut Context| {
+        ctx.advance_month(step);
+        // Keep `focused_date` aligned with the newly visible range so the
+        // roving-tabindex target still has a rendered cell. Without this,
+        // paging from Jan 15 → Feb leaves focused_date on Jan 15, which is
+        // not in February's 6-week grid, and no cell gets `tabindex="0"`.
+        // The shifted date is clamped into the configured `[min, max]`
+        // range so out-of-range targets snap back to the boundary.
+        if let Ok(shifted) = ctx.focused_date.add(DateDuration {
+            months: step,
+            ..DateDuration::default()
+        }) {
+            ctx.focused_date = ctx.clamp_date(shifted);
+        }
+    })
+    .with_effect(announce_month_effect())
 }
 
 fn announce_month_effect() -> ars_core::PendingEffect<Machine> {
@@ -1059,6 +1084,19 @@ impl<'a> Api<'a> {
 
     /// Attributes for the cell trigger element.
     pub fn cell_trigger_attrs(&self, date: &CalendarDate) -> AttrMap {
+        self.cell_trigger_attrs_inner(date, None)
+    }
+
+    /// Like [`Api::cell_trigger_attrs`] but checks "outside month" against
+    /// the month at the supplied offset rather than the first visible
+    /// month. Multi-month layouts use this so triggers in later grids do
+    /// not get flagged `data-ars-outside-month` just because they belong
+    /// to a different month than offset 0.
+    pub fn cell_trigger_attrs_for(&self, date: &CalendarDate, offset: usize) -> AttrMap {
+        self.cell_trigger_attrs_inner(date, Some(offset))
+    }
+
+    fn cell_trigger_attrs_inner(&self, date: &CalendarDate, offset: Option<usize>) -> AttrMap {
         let mut attrs = AttrMap::new();
         let [(scope_attr, scope_val), (part_attr, part_val)] = Part::CellTrigger { date: date.clone() }.data_attrs();
         attrs.set(scope_attr, scope_val);
@@ -1073,9 +1111,16 @@ impl<'a> Api<'a> {
         // tabindex: only the focused cell or the first selectable cell is tabbable.
         attrs.set(HtmlAttr::TabIndex, if is_focused { "0" } else { "-1" });
 
+        // `aria-disabled` announces the semantic restriction for both
+        // out-of-range (disabled) and unavailable dates. HTML `disabled`
+        // is **only** set for the disabled case because it removes the
+        // element from the browser focus model; unavailable dates must
+        // remain focusable per spec §3 even though they cannot be selected.
         if disabled || unavailable {
-            attrs.set_bool(HtmlAttr::Disabled, true);
             attrs.set(HtmlAttr::Aria(AriaAttr::Disabled), "true");
+        }
+        if disabled {
+            attrs.set_bool(HtmlAttr::Disabled, true);
         }
         if selected {
             attrs.set(HtmlAttr::Aria(AriaAttr::Selected), "true");
@@ -1083,7 +1128,11 @@ impl<'a> Api<'a> {
         if is_today {
             attrs.set_bool(HtmlAttr::Data("ars-today"), true);
         }
-        if self.ctx.is_outside_visible_month(date) {
+        let outside_month = match offset {
+            Some(o) => self.ctx.is_outside_month_at_offset(date, o),
+            None    => self.ctx.is_outside_visible_month(date),
+        };
+        if outside_month {
             attrs.set_bool(HtmlAttr::Data("ars-outside-month"), true);
         }
         if unavailable {

--- a/spec/components/date-time/calendar.md
+++ b/spec/components/date-time/calendar.md
@@ -38,32 +38,46 @@ pub enum State {
 /// Events for the Calendar component.
 #[derive(Clone, Debug, PartialEq)]
 pub enum Event {
-    /// Move keyboard focus to a specific date.
+    /// Move keyboard focus to a specific date (clamped to min/max).
     FocusDate {
         /// The date to focus on.
         date: CalendarDate,
     },
-    /// User selected a date (click or Enter/Space on focused cell).
+    /// User selected a date via click or `Enter`/`Space` on the focused cell.
+    ///
+    /// In [`SelectionMode::Single`] this sets the value. In
+    /// [`SelectionMode::Multiple`] it falls through to [`Event::ToggleDate`] so
+    /// adapters that do not know the active mode can emit one canonical
+    /// "select this date" event.
     SelectDate {
         /// The date to select.
         date: CalendarDate,
     },
-    /// Navigate to the next month.
+    /// Toggle the date in or out of the multi-selection set.
+    ///
+    /// Only meaningful when `selection_mode == Multiple`. A toggle that
+    /// would add a date when `selected_dates.len() >= max_selected` is
+    /// silently dropped.
+    ToggleDate {
+        /// The date to toggle.
+        date: CalendarDate,
+    },
+    /// Navigate to the next month (advances by `page_behavior` step).
     NextMonth,
-    /// Navigate to the previous month.
+    /// Navigate to the previous month (retreats by `page_behavior` step).
     PrevMonth,
-    /// Navigate to the next year.
+    /// Navigate forward by 12 months (one year).
     NextYear,
-    /// Navigate to the previous year.
+    /// Navigate backward by 12 months (one year).
     PrevYear,
-    /// Jump to a specific month (1-based).
+    /// Jump to a specific month (1-based; out-of-range values are ignored).
     SetMonth {
-        /// The month to jump to.
+        /// The 1-based month to display.
         month: u8,
     },
     /// Jump to a specific year.
     SetYear {
-        /// The year to jump to.
+        /// The year to display.
         year: i32,
     },
     /// Grid received focus.
@@ -71,111 +85,135 @@ pub enum Event {
     /// Focus left the grid entirely.
     FocusOut,
     /// Keyboard event on the grid.
+    ///
+    /// The `shift` flag is folded into the event so adapters do not need a
+    /// side-channel to communicate `Shift+PageUp` / `Shift+PageDown` for
+    /// year navigation — the machine maps those to `PrevYear`/`NextYear`
+    /// inside its transition function.
     KeyDown {
         /// The key that was pressed.
         key: KeyboardKey,
+        /// Whether the shift modifier was held.
+        shift: bool,
     },
 }
 ```
 
 ### 1.3 Context
 
+[`CalendarDate`] implements neither `Ord` nor `PartialOrd` — different
+calendar systems share the same value type so global ordering is undefined,
+but it does expose chronological [`CalendarDate::compare`](https://docs.rs/ars-i18n).
+Both `is_date_disabled` and `clamp_date` compare via `compare(...)` rather
+than `<`/`>`, and the multi-select set lives in a [`SelectedDates`] newtype
+(§1.4) that keeps a sorted `Vec<CalendarDate>` instead of a `BTreeSet`.
+
 ```rust
 /// Context for the Calendar component.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 pub struct Context {
     /// Selected date (single-select mode).
     pub value: Bindable<Option<CalendarDate>>,
+    /// Selected date set (multi-select mode).
+    pub selected_dates: Bindable<SelectedDates>,
+    /// Active selection mode.
+    pub selection_mode: SelectionMode,
+    /// Cap on `selected_dates.len()` in multi-select mode.
+    pub max_selected: Option<usize>,
     /// The date that currently holds keyboard focus within the grid.
     pub focused_date: CalendarDate,
-    /// The month currently displayed (1-based).
+    /// The first visible month (1-based).
     pub visible_month: u8,
-    /// The year currently displayed.
+    /// The year of the first visible month.
     pub visible_year: i32,
+    /// Number of months displayed side-by-side (>= 1).
+    pub visible_months: usize,
+    /// Navigation step size for prev/next.
+    pub page_behavior: PageBehavior,
     /// Minimum selectable date.
     pub min: Option<CalendarDate>,
     /// Maximum selectable date.
     pub max: Option<CalendarDate>,
-    /// Locale for week start, month/day names.
+    /// Resolved first day of week (locale default unless overridden by Props).
+    pub first_day_of_week: Weekday,
+    /// Whether the calendar is rendered right-to-left.
+    pub is_rtl: bool,
+    /// Whether the calendar is globally disabled.
+    pub disabled: bool,
+    /// Whether the calendar is read-only (focus OK, selection blocked).
+    pub readonly: bool,
+    /// Whether the head row exposes ISO week numbers.
+    pub show_week_numbers: bool,
+    /// Date passed in as "today" by the adapter; used to mark today's cell
+    /// with `data-ars-today`.
+    pub today: CalendarDate,
+    /// User-supplied predicate marking dates unavailable. Unavailable dates
+    /// remain focusable but are not selectable. Evaluated lazily — there is
+    /// no pre-computed static cache.
+    pub is_date_unavailable_fn: Option<fn(&CalendarDate) -> bool>,
+    /// Resolved locale (from `Env`).
     pub locale: Locale,
     /// Resolved translatable messages.
     pub messages: Messages,
-    /// Intl backend for locale-dependent formatting (month/weekday names, etc.).
+    /// Backend used for locale-dependent labels and digits.
     pub intl_backend: Arc<dyn IntlBackend>,
-    /// Override for first day of week (falls back to locale default).
-    pub first_day_of_week: Weekday,
-    /// Right-to-left layout.
-    pub is_rtl: bool,
-    /// Disabled state — ignores all interactive events.
-    pub disabled: bool,
-    /// Read-only state — can focus/navigate but not select.
-    pub readonly: bool,
-    /// Static list of unavailable dates (pre-computed from Props.is_date_unavailable
-    /// for the currently visible month range). Refreshed on month navigation.
-    pub unavailable_dates: Vec<CalendarDate>,
-    /// Reference to the user-provided predicate from Props.is_date_unavailable.
-    /// Used by `is_date_unavailable()` for dynamic evaluation beyond the static list.
-    pub is_date_unavailable_fn: Option<fn(&CalendarDate) -> bool>,
-    /// Component IDs.
+    /// Derived part IDs (`ids.part("heading")`, `ids.part("grid")`, …).
     pub ids: ComponentIds,
-    /// Number of months displayed side-by-side.
-    pub visible_months: usize,
-    /// Navigation step size.
-    pub page_behavior: PageBehavior,
-    /// Whether to display ISO week numbers.
-    pub show_week_numbers: bool,
 }
 
 impl Context {
-    /// Whether the given date is the currently selected value.
+    /// Whether `date` is selected under the active selection mode.
     pub fn is_selected(&self, date: &CalendarDate) -> bool {
-        self.value.get().as_ref() == Some(date)
+        match self.selection_mode {
+            SelectionMode::Single => self.value.get().as_ref() == Some(date),
+            SelectionMode::Multiple => self.selected_dates.get().contains(date),
+        }
     }
 
     /// Whether a date is disabled (outside min/max or globally disabled).
     pub fn is_date_disabled(&self, date: &CalendarDate) -> bool {
         if self.disabled { return true; }
-        if let Some(ref min) = self.min {
-            if date < min { return true; }
-        }
-        if let Some(ref max) = self.max {
-            if date > max { return true; }
-        }
-        false
-    }
-
-    /// Whether a date is marked unavailable by the user-provided predicate.
-    /// Checks both the static `unavailable_dates` list and the dynamic
-    /// `is_date_unavailable_fn` callback from Props. Unavailable dates are
-    /// focusable (for keyboard navigation) but not selectable.
-    pub fn is_date_unavailable(&self, date: &CalendarDate) -> bool {
-        if self.unavailable_dates.contains(date) {
+        if let Some(min) = &self.min
+            && date.compare(min) == Ordering::Less
+        {
             return true;
         }
-        if let Some(ref predicate) = self.is_date_unavailable_fn {
-            return predicate(date);
+        if let Some(max) = &self.max
+            && date.compare(max) == Ordering::Greater
+        {
+            return true;
         }
         false
     }
 
-    /// Clamp a date into the min/max range.
+    /// Whether the user predicate marks `date` as unavailable.
+    pub fn is_date_unavailable(&self, date: &CalendarDate) -> bool {
+        self.is_date_unavailable_fn
+            .is_some_and(|predicate| predicate(date))
+    }
+
+    /// Clamp `date` into the configured `[min, max]` range.
     pub fn clamp_date(&self, date: CalendarDate) -> CalendarDate {
-        let date = match &self.min {
-            Some(min) if date < *min => min.clone(),
-            _ => date,
-        };
-        match &self.max {
-            Some(max) if date > *max => max.clone(),
-            _ => date,
+        let mut clamped = date;
+        if let Some(min) = &self.min
+            && clamped.compare(min) == Ordering::Less
+        {
+            clamped = min.clone();
         }
+        if let Some(max) = &self.max
+            && clamped.compare(max) == Ordering::Greater
+        {
+            clamped = max.clone();
+        }
+        clamped
     }
 
     /// Ensure the focused date's month is visible.
     /// Only scrolls when the focused date falls outside all visible months.
     pub fn sync_visible_to_focused(&mut self) {
         if !self.is_in_visible_range(&self.focused_date) {
-            self.visible_month = self.focused_date.month.get();
-            self.visible_year = self.focused_date.year;
+            self.visible_month = self.focused_date.month();
+            self.visible_year = self.focused_date.year();
         }
     }
 }
@@ -183,7 +221,58 @@ impl Context {
 
 ### 1.4 Props
 
+Multi-select Props (`selection_mode`, `max_selected`, `selected_dates`,
+`default_selected_dates`) live directly on `Props`, not in a §5 extension —
+the machine is a single unified type that switches behaviour on
+`selection_mode` rather than two parallel `Machine` types.
+
 ```rust
+/// Ordered set of unique calendar dates, sorted by `CalendarDate::compare`.
+///
+/// `CalendarDate` implements neither `Ord` nor `PartialOrd`, so `BTreeSet`
+/// is unavailable. `SelectedDates` is a thin newtype around
+/// `Vec<CalendarDate>` that maintains chronological order through binary
+/// search with the type's `compare` method.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct SelectedDates {
+    dates: Vec<CalendarDate>,
+}
+
+impl SelectedDates {
+    pub const fn new() -> Self;
+    pub const fn len(&self) -> usize;
+    pub const fn is_empty(&self) -> bool;
+    pub fn iter(&self) -> core::slice::Iter<'_, CalendarDate>;
+    pub fn contains(&self, date: &CalendarDate) -> bool;
+    pub fn insert(&mut self, date: CalendarDate) -> bool;
+    pub fn remove(&mut self, date: &CalendarDate) -> bool;
+    pub fn as_slice(&self) -> &[CalendarDate];
+}
+
+impl FromIterator<CalendarDate> for SelectedDates { /* … */ }
+impl<'a> IntoIterator for &'a SelectedDates { /* … */ }
+
+/// Whether the calendar selects a single date or an unordered set of dates.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum SelectionMode {
+    #[default]
+    Single,
+    Multiple,
+}
+
+/// Predicate type for marking dates unavailable.
+///
+/// Wrapped in [`Callback`] so applications can supply closures with
+/// captured state (allowlists, computed holiday tables, etc.). `Callback`
+/// is `Arc`-backed and compares by pointer identity, so `Props` derives
+/// `Clone + PartialEq` cleanly. Construct via
+/// [`Callback::new_ref`](ars_core::Callback::new_ref), which accepts a
+/// higher-ranked closure over a reference argument — the generic
+/// [`Callback::new`](ars_core::Callback::new) constructor cannot satisfy
+/// the implicit HRTB lifetime because its `Args: 'static` bound excludes
+/// reference types.
+pub type IsDateUnavailableFn = Callback<dyn for<'a> Fn(&'a CalendarDate) -> bool + Send + Sync>;
+
 /// Props for the Calendar component.
 #[derive(Clone, Debug, PartialEq, HasId)]
 pub struct Props {
@@ -191,8 +280,18 @@ pub struct Props {
     pub id: String,
     /// Controlled single-date value.
     pub value: Option<Option<CalendarDate>>,
-    /// Default date for uncontrolled mode.
+    /// Default date for uncontrolled single-select mode.
     pub default_value: Option<CalendarDate>,
+    /// Controlled multi-selection set.
+    pub selected_dates: Option<SelectedDates>,
+    /// Default selection set for uncontrolled multi-select mode.
+    pub default_selected_dates: SelectedDates,
+    /// Selection mode — single by default. Multi-select unlocks
+    /// `selected_dates` and the `ToggleDate` event.
+    pub selection_mode: SelectionMode,
+    /// Maximum number of dates that can be selected in `Multiple` mode.
+    /// `None` removes the cap; excess toggles are silently dropped.
+    pub max_selected: Option<usize>,
     /// Minimum selectable date.
     pub min: Option<CalendarDate>,
     /// Maximum selectable date.
@@ -203,7 +302,7 @@ pub struct Props {
     pub readonly: bool,
     /// Predicate returning true for dates that should be marked unavailable.
     /// Unavailable dates are focusable but not selectable.
-    pub is_date_unavailable: Option<fn(&CalendarDate) -> bool>,
+    pub is_date_unavailable: Option<IsDateUnavailableFn>,
     /// Explicit override of the locale's default first day of week.
     /// When `Some`, overrides the locale default. When `None`, derives from
     /// `ars_i18n::Locale` via `WeekInfo::first_day`.
@@ -219,7 +318,8 @@ pub struct Props {
     pub show_week_numbers: bool,
     /// Right-to-left layout direction.
     pub is_rtl: bool,
-    /// Number of months to display side-by-side. Default: 1.
+    /// Number of months to display side-by-side. Values below 1 are
+    /// clamped to 1 by `Machine::init`. Default: 1.
     pub visible_months: usize,
     /// Controls navigation step size. Default: `PageBehavior::Visible`.
     pub page_behavior: PageBehavior,
@@ -233,6 +333,10 @@ impl Default for Props {
             id: String::new(),
             value: None,
             default_value: None,
+            selected_dates: None,
+            default_selected_dates: SelectedDates::new(),
+            selection_mode: SelectionMode::Single,
+            max_selected: None,
             min: None,
             max: None,
             disabled: false,
@@ -243,7 +347,8 @@ impl Default for Props {
             is_rtl: false,
             visible_months: 1,
             page_behavior: PageBehavior::Visible,
-            today: CalendarDate::new_gregorian(2025, nzu8(1), nzu8(1)),
+            today: CalendarDate::new_gregorian(2025, 1, 1)
+                .expect("2025-01-01 is a valid Gregorian date"),
         }
     }
 }
@@ -260,9 +365,22 @@ fn is_date_unavailable(ctx: &Context, date: &CalendarDate) -> bool { ctx.is_date
 
 ### 1.6 Grid Computation
 
+All `CalendarDate` arithmetic in this section uses the real `ars-i18n` API:
+`new_gregorian(year, month, day)` takes plain `u8`s and returns
+`Result<CalendarDate, CalendarError>`; `add_days(i32)` / `add(DateDuration)`
+also return `Result`. Grid anchoring calls cannot fail by construction —
+the spec uses `.expect("…")` with explicit reasons where overflow is
+impossible. Adapters propagate other failures by treating the grid as
+empty for that boundary month rather than panicking.
+
+`Weekday` is the ISO-numbered enum from `ars-i18n` (Monday=1..Sunday=7) and
+cannot be cast to `u8` directly. The grid module exposes a local
+`weekday_sunday_zero(wd) -> u8` helper that maps to the Sunday-zero
+convention the modulo arithmetic below requires.
+
 ```rust
 /// Controls how prev/next navigation advances when multiple months are visible.
-#[derive(Clone, Debug, PartialEq, Eq, Default)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum PageBehavior {
     /// Prev/next advances by the full `visible_months` count.
     #[default]
@@ -279,13 +397,9 @@ impl Context {
 
     /// Ordered day-of-week labels starting from the configured first day.
     pub fn week_day_labels(&self) -> Vec<(Weekday, String)> {
-        let start = self.first_day_of_week as u8;
-        (0..7)
-            .map(|i| {
-                let wd = Weekday::from_u8((start + i) % 7);
-                let label = wd.short_label(&*self.intl_backend, &self.locale);
-                (wd, label)
-            })
+        ordered_weekdays(self.first_day_of_week)
+            .into_iter()
+            .map(|wd| (wd, self.intl_backend.weekday_short_label(wd, &self.locale)))
             .collect()
     }
 
@@ -297,124 +411,163 @@ impl Context {
     /// Build the grid of weeks for the month at the given offset
     /// from the first visible month. Offset 0 = first visible month.
     pub fn weeks_for(&self, offset: usize) -> Vec<[CalendarDate; 7]> {
-        let anchor = CalendarDate::new_gregorian(self.visible_year, NonZero::new(self.visible_month).expect("visible_month is 1-based"), nzu8(1));
-        let target = anchor.add_months(offset as i32);
-        let first_of_month = CalendarDate::new_gregorian(target.year, target.month, nzu8(1));
-        let first_weekday = first_of_month.weekday() as u8;
-        let start_offset = ((first_weekday + 7 - self.first_day_of_week as u8) % 7) as i32;
-        let grid_start = first_of_month.add_days(-start_offset);
+        let (target_month, target_year) =
+            month_year_at_offset(self.visible_month, self.visible_year, offset);
 
-        let mut weeks = Vec::new();
-        let mut current = grid_start.clone();
+        let Ok(first_of_month) = CalendarDate::new_gregorian(target_year, target_month, 1) else {
+            return Vec::new();
+        };
+
+        let first_weekday_index = weekday_sunday_zero(first_of_month.weekday());
+        let start_index = weekday_sunday_zero(self.first_day_of_week);
+        let leading = i32::from((first_weekday_index + 7 - start_index) % 7);
+
+        let Ok(grid_start) = first_of_month.add_days(-leading) else {
+            return Vec::new();
+        };
+
+        let mut weeks: Vec<[CalendarDate; 7]> = Vec::with_capacity(6);
+        let mut current = grid_start;
         // Always render 6 weeks (42 days) for consistent grid height.
         for _ in 0..6 {
-            let mut week = [current.clone(); 7];
-            for d in 0..7 {
-                week[d] = current.add_days(d as i32);
-            }
-            weeks.push(week);
-            current = current.add_days(7);
+            let Some(row) = build_week(&current) else { return weeks; };
+            weeks.push(row);
+            let Ok(next_week_start) = current.add_days(7) else { return weeks; };
+            current = next_week_start;
         }
         weeks
     }
 
-    /// Returns (month, year) for the month at the given offset.
+    /// Returns (month, year) for the month at the given offset, normalised
+    /// into the 1..=12 month range with a year adjustment.
     pub fn month_year_at_offset(&self, offset: usize) -> (u8, i32) {
-        let anchor = CalendarDate::new_gregorian(self.visible_year, NonZero::new(self.visible_month).expect("visible_month is 1-based"), nzu8(1));
-        let target = anchor.add_months(offset as i32);
-        (target.month.get(), target.year)
+        month_year_at_offset(self.visible_month, self.visible_year, offset)
     }
 
     /// Whether a date is outside the month at the specified offset.
     pub fn is_outside_month_at_offset(&self, date: &CalendarDate, offset: usize) -> bool {
         let (month, year) = self.month_year_at_offset(offset);
-        date.month.get() != month || date.year != year
+        date.month() != month || date.year() != year
     }
 
     /// Whether the date's month falls within any of the visible months.
     pub fn is_in_visible_range(&self, date: &CalendarDate) -> bool {
-        for offset in 0..self.visible_months {
+        (0..self.visible_months).any(|offset| {
             let (month, year) = self.month_year_at_offset(offset);
-            if date.month.get() == month && date.year == year {
-                return true;
-            }
-        }
-        false
+            date.month() == month && date.year() == year
+        })
     }
 
     /// Navigate the visible month/year forward by `n` months.
     pub fn advance_month(&mut self, n: i32) {
-        let anchor = CalendarDate::new_gregorian(self.visible_year, NonZero::new(self.visible_month).expect("visible_month is 1-based"), nzu8(1));
-        let next = anchor.add_months(n);
-        self.visible_month = next.month.get().clamp(1, 12);
-        self.visible_year = next.year;
+        let (month, year) = advance_month(self.visible_month, self.visible_year, n);
+        self.visible_month = month;
+        self.visible_year = year;
     }
 
     /// Whether the given date is outside the currently visible month.
     pub fn is_outside_visible_month(&self, date: &CalendarDate) -> bool {
-        date.month.get() != self.visible_month || date.year != self.visible_year
+        date.month() != self.visible_month || date.year() != self.visible_year
     }
 }
+
+/// Sunday-zero index for a weekday (Sunday=0..Saturday=6).
+const fn weekday_sunday_zero(weekday: Weekday) -> u8 { /* … */ }
+
+/// `(month, year)` at the given offset from `(visible_month, visible_year)`,
+/// normalised into the 1..=12 month range with a year adjustment.
+const fn month_year_at_offset(visible_month: u8, visible_year: i32, offset: usize) -> (u8, i32) {
+    let raw_index = visible_month as i64 - 1 + offset as i64;
+    let normalised_month = raw_index.rem_euclid(12) as u8 + 1;
+    let year_delta = raw_index.div_euclid(12) as i32;
+    (normalised_month, visible_year + year_delta)
+}
+
+/// `advance_month` shares the same modulo arithmetic — see
+/// `month_year_at_offset`; signed `n` advances or retreats by `|n|` months.
+const fn advance_month(visible_month: u8, visible_year: i32, n: i32) -> (u8, i32);
 ```
 
 ### 1.7 Full Machine Implementation
 
+The named-effect intent for month/year navigation is a typed enum, not a
+bare `&'static str`. The setup closure is a no-op marker
+([`PendingEffect::named`]); the adapter resolves the announce intent based
+on the typed name and calls into its platform announce path — core code
+never reaches for a framework hook like `use_platform_effects()`.
+
 ```rust
+/// Typed identifier for every named effect intent the `calendar` machine emits.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Effect {
+    /// Announce the newly visible month (or month range) to assistive tech
+    /// via the adapter's platform announcer. Triggered by every
+    /// month/year navigation transition.
+    AnnounceMonth,
+}
+
 pub struct Machine;
 
 impl ars_core::Machine for Machine {
-    type State   = State;
-    type Event   = Event;
-    type Context = Context;
-    type Props   = Props;
+    type State    = State;
+    type Event    = Event;
+    type Context  = Context;
+    type Props    = Props;
     type Messages = Messages;
-    type Api<'a> = Api<'a>;
+    type Effect   = Effect;
+    type Api<'a>  = Api<'a>;
 
     fn init(props: &Self::Props, env: &Env, messages: &Self::Messages) -> (Self::State, Self::Context) {
-        let initial_date = props.value.flatten();
-        let focused = initial_date
-            .clone()
-            .unwrap_or_else(|| props.today.clone());
+        let value = match &props.value {
+            Some(controlled) => Bindable::controlled(controlled.clone()),
+            None             => Bindable::uncontrolled(props.default_value.clone()),
+        };
+        let selected_dates = match &props.selected_dates {
+            Some(set) => Bindable::controlled(set.clone()),
+            None      => Bindable::uncontrolled(props.default_selected_dates.clone()),
+        };
 
-        let value = match props.value {
-            Some(v) => Bindable::controlled(v),
-            None    => Bindable::uncontrolled(props.default_value.clone()),
+        let initial_date = match props.selection_mode {
+            SelectionMode::Single   => value.get().clone().unwrap_or_else(|| props.today.clone()),
+            SelectionMode::Multiple => selected_dates.get().iter().next().cloned()
+                .unwrap_or_else(|| props.today.clone()),
         };
 
         let locale = env.locale.clone();
-        let messages = messages.clone();
-
         let first_day = props
             .first_day_of_week
-            .unwrap_or_else(|| locale.first_day_of_week());
+            .unwrap_or_else(|| locale.first_day_of_week(&*env.intl_backend));
 
         let ctx = Context {
             value,
-            focused_date: focused.clone(),
-            visible_month: focused.month.get(),
-            visible_year: focused.year,
+            selected_dates,
+            selection_mode: props.selection_mode,
+            max_selected: props.max_selected,
+            focused_date: initial_date.clone(),
+            visible_month: initial_date.month(),
+            visible_year: initial_date.year(),
+            visible_months: props.visible_months.max(1),
+            page_behavior: props.page_behavior,
             min: props.min.clone(),
             max: props.max.clone(),
-            locale,
-            messages,
-            intl_backend: env.intl_backend.clone(),
             first_day_of_week: first_day,
             is_rtl: props.is_rtl,
             disabled: props.disabled,
             readonly: props.readonly,
-            unavailable_dates: Vec::new(),
-            is_date_unavailable_fn: props.is_date_unavailable,
-            ids: ComponentIds::from_id(&props.id),
-            visible_months: props.visible_months.max(1),
-            page_behavior: props.page_behavior.clone(),
             show_week_numbers: props.show_week_numbers,
+            today: props.today.clone(),
+            is_date_unavailable_fn: props.is_date_unavailable,
+            locale,
+            messages: messages.clone(),
+            intl_backend: Arc::clone(&env.intl_backend),
+            ids: ComponentIds::from_id(&props.id),
         };
 
         (State::Idle, ctx)
     }
 
     fn transition(
-        state: &Self::State,
+        _state: &Self::State,
         event: &Self::Event,
         ctx: &Self::Context,
         _props: &Self::Props,
@@ -423,115 +576,52 @@ impl ars_core::Machine for Machine {
 
         match event {
             // ── Focus management ─────────────────────────────────────────
-            Event::FocusIn => {
-                Some(TransitionPlan::to(State::Focused))
-            }
-
-            Event::FocusOut => {
-                Some(TransitionPlan::to(State::Idle))
-            }
+            Event::FocusIn  => Some(TransitionPlan::to(State::Focused)),
+            Event::FocusOut => Some(TransitionPlan::to(State::Idle)),
 
             Event::FocusDate { date } => {
-                let date = ctx.clamp_date(date.clone());
-                Some(TransitionPlan::to(State::Focused)
-                    .apply(move |ctx| {
-                        ctx.focused_date = date;
-                        ctx.sync_visible_to_focused();
-                    }))
+                let clamped = ctx.clamp_date(date.clone());
+                Some(TransitionPlan::to(State::Focused).apply(move |ctx| {
+                    ctx.focused_date = clamped;
+                    ctx.sync_visible_to_focused();
+                }))
             }
 
             // ── Date selection ────────────────────────────────────────────
-            Event::SelectDate { date } => {
-                if ctx.readonly { return None; }
-                if ctx.is_date_disabled(date) || ctx.is_date_unavailable(date) {
-                    return None;
+            // `SelectDate` and `ToggleDate` both route through the active
+            // selection mode: Single uses `apply_select_single`, Multiple
+            // uses `apply_toggle_multi`. Read the spec wording in §1.2 for
+            // why they share an arm.
+            Event::SelectDate { date } | Event::ToggleDate { date } => {
+                match ctx.selection_mode {
+                    SelectionMode::Single   => apply_select_single(ctx, date.clone()),
+                    SelectionMode::Multiple => apply_toggle_multi(ctx, date.clone()),
                 }
-                let date = date.clone();
-                Some(TransitionPlan::to(State::Focused)
-                    .apply(move |ctx| {
-                        ctx.value.set(Some(date.clone()));
-                        ctx.focused_date = date;
-                    }))
             }
+
             // ── Month / year navigation ──────────────────────────────────
-            Event::NextMonth => {
-                Some(TransitionPlan::context_only(|ctx| {
-                    let step = match ctx.page_behavior {
-                        PageBehavior::Visible => ctx.visible_months as i32,
-                        PageBehavior::Single  => 1,
-                    };
-                    ctx.advance_month(step);
-                }).with_effect(PendingEffect::new("announce-month", |ctx, _props, _send| {
-                    let platform = use_platform_effects();
-                    let label = if ctx.visible_months > 1 {
-                        let first = format!("{} {}", month_long_name(&*ctx.intl_backend, ctx.visible_month, &ctx.locale), ctx.visible_year);
-                        let (lm, ly) = ctx.month_year_at_offset(ctx.visible_months - 1);
-                        let sep = (ctx.messages.month_range_separator)(&ctx.locale);
-                        format!("{}{}{} {}", first, sep, month_long_name(&*ctx.intl_backend, lm, &ctx.locale), ly)
-                    } else {
-                        format!("{} {}", month_long_name(&*ctx.intl_backend, ctx.visible_month, &ctx.locale), ctx.visible_year)
-                    };
-                    platform.announce(&label);
-                    no_cleanup()
-                })))
-            }
-
-            Event::PrevMonth => {
-                Some(TransitionPlan::context_only(|ctx| {
-                    let step = match ctx.page_behavior {
-                        PageBehavior::Visible => ctx.visible_months as i32,
-                        PageBehavior::Single  => 1,
-                    };
-                    ctx.advance_month(-step);
-                }).with_effect(PendingEffect::new("announce-month", |ctx, _props, _send| {
-                    let platform = use_platform_effects();
-                    let label = if ctx.visible_months > 1 {
-                        let first = format!("{} {}", month_long_name(&*ctx.intl_backend, ctx.visible_month, &ctx.locale), ctx.visible_year);
-                        let (lm, ly) = ctx.month_year_at_offset(ctx.visible_months - 1);
-                        let sep = (ctx.messages.month_range_separator)(&ctx.locale);
-                        format!("{}{}{} {}", first, sep, month_long_name(&*ctx.intl_backend, lm, &ctx.locale), ly)
-                    } else {
-                        format!("{} {}", month_long_name(&*ctx.intl_backend, ctx.visible_month, &ctx.locale), ctx.visible_year)
-                    };
-                    platform.announce(&label);
-                    no_cleanup()
-                })))
-            }
-
-            Event::NextYear => {
-                Some(TransitionPlan::context_only(|ctx| {
-                    ctx.advance_month(12);
-                }))
-            }
-
-            Event::PrevYear => {
-                Some(TransitionPlan::context_only(|ctx| {
-                    ctx.advance_month(-12);
-                }))
-            }
+            Event::NextMonth => Some(month_step_plan(step_for_page_behavior(ctx))),
+            Event::PrevMonth => Some(month_step_plan(-step_for_page_behavior(ctx))),
+            Event::NextYear  => Some(month_step_plan(12)),
+            Event::PrevYear  => Some(month_step_plan(-12)),
 
             Event::SetMonth { month } => {
                 let month = *month;
                 if !(1..=12).contains(&month) { return None; }
                 Some(TransitionPlan::context_only(move |ctx| {
                     ctx.visible_month = month;
-                }))
+                }).with_effect(announce_month_effect()))
             }
 
             Event::SetYear { year } => {
                 let year = *year;
                 Some(TransitionPlan::context_only(move |ctx| {
                     ctx.visible_year = year;
-                }))
+                }).with_effect(announce_month_effect()))
             }
 
             // ── Keyboard navigation ──────────────────────────────────────
-            Event::KeyDown { ref key } => {
-                Self::handle_keydown(state, &KeyboardEventData { key: *key }, ctx)
-            }
-
-            // Catch-all for guarded match arms.
-            _ => None,
+            Event::KeyDown { key, shift } => handle_keydown(*key, *shift, ctx),
         }
     }
 
@@ -541,80 +631,128 @@ impl ars_core::Machine for Machine {
         props: &'a Self::Props,
         send: &'a dyn Fn(Event),
     ) -> Self::Api<'a> {
-        Api { state, ctx, props, send }
+        Api::new(state, ctx, props, send)
     }
 }
 
-impl Machine {
-    /// Keyboard navigation within the calendar grid.
-    /// Follows WAI-ARIA Grid pattern with RTL awareness.
-    fn handle_keydown(
-        state: &State,
-        data: &KeyboardEventData,
-        ctx: &Context,
-    ) -> Option<TransitionPlan<Self>> {
-        // Only handle keys when the grid is focused.
-        if *state != State::Focused { return None; }
+fn step_for_page_behavior(ctx: &Context) -> i32 {
+    match ctx.page_behavior {
+        PageBehavior::Visible => i32::try_from(ctx.visible_months).unwrap_or(1).max(1),
+        PageBehavior::Single  => 1,
+    }
+}
 
-        let focused = ctx.focused_date.clone();
-        // RTL-aware directional keys: in RTL, Left means "next" and Right means "prev".
-        let (prev_day_key, next_day_key) = if ctx.is_rtl {
-            (KeyboardKey::ArrowRight, KeyboardKey::ArrowLeft)
-        } else {
-            (KeyboardKey::ArrowLeft, KeyboardKey::ArrowRight)
-        };
+fn month_step_plan(step: i32) -> TransitionPlan<Machine> {
+    TransitionPlan::context_only(move |ctx: &mut Context| { ctx.advance_month(step); })
+        .with_effect(announce_month_effect())
+}
 
-        let new_focus = match data.key {
-            k if k == prev_day_key => Some(focused.add_days(-1)),
-            k if k == next_day_key => Some(focused.add_days(1)),
-            KeyboardKey::ArrowUp              => Some(focused.add_days(-7)),
-            KeyboardKey::ArrowDown            => Some(focused.add_days(7)),
-            KeyboardKey::Home                 => {
+fn announce_month_effect() -> ars_core::PendingEffect<Machine> {
+    ars_core::PendingEffect::named(Effect::AnnounceMonth)
+}
+
+fn apply_select_single(ctx: &Context, date: CalendarDate)
+    -> Option<TransitionPlan<Machine>>
+{
+    if ctx.readonly { return None; }
+    if ctx.is_date_disabled(&date) || ctx.is_date_unavailable(&date) { return None; }
+    Some(TransitionPlan::to(State::Focused).apply(move |ctx: &mut Context| {
+        ctx.value.set(Some(date.clone()));
+        ctx.focused_date = date;
+    }))
+}
+
+fn apply_toggle_multi(ctx: &Context, date: CalendarDate)
+    -> Option<TransitionPlan<Machine>>
+{
+    if ctx.readonly { return None; }
+    if ctx.is_date_disabled(&date) || ctx.is_date_unavailable(&date) { return None; }
+    let already_selected = ctx.selected_dates.get().contains(&date);
+    let at_cap = !already_selected && ctx.max_selected
+        .is_some_and(|cap| ctx.selected_dates.get().len() >= cap);
+    if at_cap { return None; } // §5.4 silent drop
+    Some(TransitionPlan::to(State::Focused).apply(move |ctx: &mut Context| {
+        let mut next = ctx.selected_dates.get().clone();
+        if already_selected { next.remove(&date); } else { next.insert(date.clone()); }
+        ctx.selected_dates.set(next);
+        ctx.focused_date = date;
+    }))
+}
+
+/// Keyboard navigation within the calendar grid.
+/// Follows WAI-ARIA Grid pattern with RTL awareness.
+///
+/// `Shift+PageUp` / `Shift+PageDown` are handled here directly because
+/// `Event::KeyDown` carries the `shift` flag — adapters do not need a
+/// side-channel mapping. The `Enter`/`Space` arm fans out to
+/// `Event::SelectDate` (Single) or `Event::ToggleDate` (Multiple) so the
+/// active selection mode determines the follow-up behavior.
+fn handle_keydown(key: KeyboardKey, shift: bool, ctx: &Context)
+    -> Option<TransitionPlan<Machine>>
+{
+    if shift {
+        match key {
+            KeyboardKey::PageUp   => return Some(month_step_plan(-12)),
+            KeyboardKey::PageDown => return Some(month_step_plan(12)),
+            _ => {}
+        }
+    }
+
+    let focused = ctx.focused_date.clone();
+    // RTL-aware directional keys: in RTL, Left means "next" and Right means "prev".
+    let (prev_day_key, next_day_key) = if ctx.is_rtl {
+        (KeyboardKey::ArrowRight, KeyboardKey::ArrowLeft)
+    } else {
+        (KeyboardKey::ArrowLeft, KeyboardKey::ArrowRight)
+    };
+
+    let new_focus: Option<CalendarDate> = if key == prev_day_key {
+        focused.add_days(-1).ok()
+    } else if key == next_day_key {
+        focused.add_days(1).ok()
+    } else {
+        match key {
+            KeyboardKey::ArrowUp   => focused.add_days(-7).ok(),
+            KeyboardKey::ArrowDown => focused.add_days(7).ok(),
+            KeyboardKey::Home => {
                 // Move to start of current week.
-                let wd = focused.weekday() as u8;
-                let start = ctx.first_day_of_week as u8;
-                let offset = ((wd + 7 - start) % 7) as i32;
-                Some(focused.add_days(-offset))
+                let wd = weekday_sunday_zero(focused.weekday());
+                let start = weekday_sunday_zero(ctx.first_day_of_week);
+                let offset = i32::from((wd + 7 - start) % 7);
+                focused.add_days(-offset).ok()
             }
             KeyboardKey::End => {
                 // Move to end of current week.
-                let wd = focused.weekday() as u8;
-                let start = ctx.first_day_of_week as u8;
-                let offset = ((wd + 7 - start) % 7) as i32;
-                Some(focused.add_days(6 - offset))
+                let wd = weekday_sunday_zero(focused.weekday());
+                let start = weekday_sunday_zero(ctx.first_day_of_week);
+                let offset = i32::from((wd + 7 - start) % 7);
+                focused.add_days(6 - offset).ok()
             }
-            KeyboardKey::PageUp  => Some(focused.add_months(-1)),
-            KeyboardKey::PageDown => Some(focused.add_months(1)),
+            KeyboardKey::PageUp   => focused.add(DateDuration { months: -1, ..Default::default() }).ok(),
+            KeyboardKey::PageDown => focused.add(DateDuration { months:  1, ..Default::default() }).ok(),
             _ => None,
-        };
-
-        // Shift+PageUp/PageDown for year navigation is handled separately
-        // because the key enum itself doesn't encode the shift modifier.
-        // Adapters call `on_grid_keydown(data, shift)` which maps:
-        //   Shift+PageUp   -> Event::PrevYear
-        //   Shift+PageDown -> Event::NextYear
-
-        match new_focus {
-            Some(date) => {
-                let clamped = ctx.clamp_date(date);
-                Some(TransitionPlan::to(State::Focused)
-                    .apply(move |ctx| {
-                        ctx.focused_date = clamped;
-                        ctx.sync_visible_to_focused();
-                    }))
-            }
-            None => {
-                // Enter / Space selects the focused date.
-                match data.key {
-                    KeyboardKey::Enter | KeyboardKey::Space => {
-                        let date = focused;
-                        Some(TransitionPlan::context_only(|_ctx| {})
-                            .then(Event::SelectDate { date }))
-                    }
-                    _ => None,
-                }
-            }
         }
+    };
+
+    if let Some(date) = new_focus {
+        let clamped = ctx.clamp_date(date);
+        return Some(TransitionPlan::to(State::Focused).apply(move |ctx: &mut Context| {
+            ctx.focused_date = clamped;
+            ctx.sync_visible_to_focused();
+        }));
+    }
+
+    // Enter / Space selects (Single) or toggles (Multiple) the focused date.
+    match key {
+        KeyboardKey::Enter | KeyboardKey::Space => {
+            let date = focused;
+            let select_event = match ctx.selection_mode {
+                SelectionMode::Single   => Event::SelectDate { date },
+                SelectionMode::Multiple => Event::ToggleDate { date },
+            };
+            Some(TransitionPlan::context_only(|_ctx: &mut Context| {}).then(select_event))
+        }
+        _ => None,
     }
 }
 ```
@@ -736,10 +874,11 @@ impl<'a> Api<'a> {
         attrs
     }
 
-    /// Attributes for the heading text element.
-    pub fn heading_text_attrs(&self) -> AttrMap {
+    /// Attributes for the main heading element. The heading is the
+    /// `aria-live="polite"` announcer for month navigation.
+    pub fn heading_attrs(&self) -> AttrMap {
         let mut attrs = AttrMap::new();
-        attrs.set(HtmlAttr::Id, &self.ctx.heading_id);
+        attrs.set(HtmlAttr::Id, self.ctx.ids.part("heading"));
         let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Heading.data_attrs();
         attrs.set(scope_attr, scope_val);
         attrs.set(part_attr, part_val);
@@ -750,20 +889,24 @@ impl<'a> Api<'a> {
 
     /// Formatted heading text: e.g. "January 2024".
     pub fn heading_text(&self) -> String {
-        let month_name = month_long_name(&*self.ctx.intl_backend, self.ctx.visible_month, &self.ctx.locale);
+        let month_name = self.ctx.intl_backend.month_long_name(self.ctx.visible_month, &self.ctx.locale);
         format!("{} {}", month_name, self.ctx.visible_year)
     }
 
-    /// Attributes for the grid element.
+    /// Attributes for the grid element (first visible month).
     pub fn grid_attrs(&self) -> AttrMap {
+        self.grid_attrs_with_ids(self.ctx.ids.part("grid"), self.ctx.ids.part("heading"))
+    }
+
+    fn grid_attrs_with_ids(&self, grid_id: String, heading_id: String) -> AttrMap {
         let mut attrs = AttrMap::new();
-        attrs.set(HtmlAttr::Id, &self.ctx.grid_id);
-        attrs.set(HtmlAttr::Role, "grid");
         let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Grid.data_attrs();
+        attrs.set(HtmlAttr::Id, grid_id);
+        attrs.set(HtmlAttr::Role, "grid");
         attrs.set(scope_attr, scope_val);
         attrs.set(part_attr, part_val);
-        attrs.set(HtmlAttr::Aria(AriaAttr::LabelledBy), &self.ctx.heading_id);
-        if self.ctx.is_range {
+        attrs.set(HtmlAttr::Aria(AriaAttr::LabelledBy), heading_id);
+        if matches!(self.ctx.selection_mode, SelectionMode::Multiple) {
             attrs.set(HtmlAttr::Aria(AriaAttr::MultiSelectable), "true");
         }
         if self.ctx.readonly {
@@ -787,39 +930,31 @@ impl<'a> Api<'a> {
         0..self.ctx.visible_months
     }
 
-    /// Grid attributes for the month at the given offset.
+    /// Grid attributes for the month at the given offset. Multi-month
+    /// layouts use the per-grid heading id rather than the shared live
+    /// region.
     pub fn grid_attrs_for(&self, offset: usize) -> AttrMap {
-        let mut attrs = AttrMap::new();
-        let grid_id = format!("{}-grid-{}", self.ctx.id, offset);
-        let heading_id = format!("{}-heading-{}", self.ctx.id, offset);
-        attrs.set(HtmlAttr::Id, grid_id);
-        attrs.set(HtmlAttr::Role, "grid");
-        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Grid.data_attrs();
-        attrs.set(scope_attr, scope_val);
-        attrs.set(part_attr, part_val);
-        attrs.set(HtmlAttr::Aria(AriaAttr::LabelledBy),  heading_id);
-        if self.ctx.is_range {
-            attrs.set(HtmlAttr::Aria(AriaAttr::MultiSelectable), "true");
-        }
-        if self.ctx.readonly { attrs.set(HtmlAttr::Aria(AriaAttr::ReadOnly), "true"); }
-        if self.ctx.disabled { attrs.set(HtmlAttr::Aria(AriaAttr::Disabled), "true"); }
-        attrs
+        let grid_id    = format!("{}-grid-{}",    self.ctx.ids.id(), offset);
+        let heading_id = format!("{}-heading-{}", self.ctx.ids.id(), offset);
+        self.grid_attrs_with_ids(grid_id, heading_id)
     }
 
     /// Heading text for the month at the given offset.
     pub fn heading_text_for(&self, offset: usize) -> String {
         let (month, year) = self.ctx.month_year_at_offset(offset);
-        format!("{} {}", month_long_name(&*self.ctx.intl_backend, month, &self.ctx.locale), year)
+        format!("{} {}", self.ctx.intl_backend.month_long_name(month, &self.ctx.locale), year)
     }
 
-    /// Heading text attributes for a per-grid heading.
-    pub fn heading_text_attrs_for(&self, offset: usize) -> AttrMap {
+    /// Heading attributes for a per-grid heading. Per-grid headings are
+    /// visually hidden and intentionally have no `aria-live` — only the
+    /// main `heading_attrs` heading announces month changes to avoid
+    /// duplicate announcements.
+    pub fn heading_attrs_for(&self, offset: usize) -> AttrMap {
         let mut attrs = AttrMap::new();
-        attrs.set(HtmlAttr::Id, format!("{}-heading-{}", self.ctx.id, offset));
+        attrs.set(HtmlAttr::Id, format!("{}-heading-{}", self.ctx.ids.id(), offset));
         let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Heading.data_attrs();
         attrs.set(scope_attr, scope_val);
         attrs.set(part_attr, part_val);
-        // No aria-live on per-grid headings; only the main heading has it.
         attrs
     }
 
@@ -844,10 +979,10 @@ impl<'a> Api<'a> {
     }
 
     /// Attributes for the grid group container (role="group").
-    /// Only rendered when visible_months > 1.
+    /// Only meaningful when `visible_months > 1`.
     pub fn grid_group_attrs(&self) -> AttrMap {
         let mut attrs = AttrMap::new();
-        attrs.set(HtmlAttr::Id, format!("{}-grid-group", self.ctx.id));
+        attrs.set(HtmlAttr::Id, format!("{}-grid-group", self.ctx.ids.id()));
         attrs.set(HtmlAttr::Role, "group");
         let [(scope_attr, scope_val), (part_attr, part_val)] = Part::GridGroup.data_attrs();
         attrs.set(scope_attr, scope_val);
@@ -886,7 +1021,7 @@ impl<'a> Api<'a> {
         attrs.set(scope_attr, scope_val);
         attrs.set(part_attr, part_val);
         attrs.set(HtmlAttr::Scope, "col");
-        attrs.set(HtmlAttr::Abbr, weekday.long_label(&*self.ctx.intl_backend, &self.ctx.locale));
+        attrs.set(HtmlAttr::Abbr, self.ctx.intl_backend.weekday_long_label(weekday, &self.ctx.locale));
         attrs
     }
 
@@ -932,7 +1067,7 @@ impl<'a> Api<'a> {
         let disabled = self.is_disabled(date);
         let unavailable = self.is_unavailable(date);
         let is_focused = self.ctx.focused_date == *date;
-        let is_today = *date == self.props.today;
+        let is_today = *date == self.ctx.today;
         let selected = self.is_selected(date);
 
         // tabindex: only the focused cell or the first selectable cell is tabbable.
@@ -959,11 +1094,11 @@ impl<'a> Api<'a> {
         // Unavailable and disabled dates append a suffix so screen readers announce
         // the restriction without requiring the user to attempt selection.
         let base_label = format!(
-            "{} {} {}, {}",
-            month_long_name(&*self.ctx.intl_backend, date.month.get(), &self.ctx.locale),
-            date.day.get(),
-            date.year,
-            date.weekday().long_label(&*self.ctx.intl_backend, &self.ctx.locale),
+            "{} {}, {}, {}",
+            self.ctx.intl_backend.month_long_name(date.month(), &self.ctx.locale),
+            date.day(),
+            date.year(),
+            self.ctx.intl_backend.weekday_long_label(date.weekday(), &self.ctx.locale),
         );
         let label = if unavailable {
             format!("{} (unavailable)", base_label)
@@ -979,19 +1114,14 @@ impl<'a> Api<'a> {
 
     // ── Typed handler methods ────────────────────────────────────────────
 
-    /// Handle click on a day cell.
+    /// Handle click on a day cell. Routes to `SelectDate` in Single mode
+    /// and `ToggleDate` in Multiple mode.
     pub fn on_cell_click(&self, date: CalendarDate) {
-        (self.send)(Event::SelectDate { date });
-    }
-
-    /// Handle hover over a day cell (for range preview).
-    pub fn on_cell_hover(&self, date: CalendarDate) {
-        (self.send)(Event::HoverDate { date });
-    }
-
-    /// Handle mouse leaving the grid.
-    pub fn on_grid_mouseleave(&self) {
-        (self.send)(Event::HoverEnd);
+        let event = match self.ctx.selection_mode {
+            SelectionMode::Single   => Event::SelectDate { date },
+            SelectionMode::Multiple => Event::ToggleDate { date },
+        };
+        (self.send)(event);
     }
 
     /// Handle focus entering the grid.
@@ -1006,13 +1136,13 @@ impl<'a> Api<'a> {
         }
     }
 
-    /// Handle keydown on the grid. Shift modifier handled here for year nav.
+    /// Handle keydown on the grid. The adapter folds the `shift` modifier
+    /// into the call so the machine can map `Shift+PageUp` /
+    /// `Shift+PageDown` to year navigation inside its single transition
+    /// arm. There is no side-channel dispatch — `Event::KeyDown` carries
+    /// `shift` directly.
     pub fn on_grid_keydown(&self, key: KeyboardKey, shift: bool) {
-        match (key, shift) {
-            (KeyboardKey::PageUp, true)  => (self.send)(Event::PrevYear),
-            (KeyboardKey::PageDown, true) => (self.send)(Event::NextYear),
-            _ => (self.send)(Event::KeyDown { key }),
-        }
+        (self.send)(Event::KeyDown { key, shift });
     }
 
     /// Handle click on the previous month button.
@@ -1034,7 +1164,7 @@ impl<'a> Api<'a> {
 
     /// Whether a date is today.
     pub fn is_today(&self, date: &CalendarDate) -> bool {
-        *date == self.props.today
+        *date == self.ctx.today
     }
 
     /// Whether a date is disabled (out of min/max range or globally disabled).
@@ -1054,32 +1184,28 @@ impl<'a> Api<'a> {
 
     /// Whether the prev button should be disabled (min constraint).
     pub fn is_prev_disabled(&self) -> bool {
-        if let Some(ref min) = self.ctx.min {
-            let first_of_visible = CalendarDate::new_gregorian(
-                self.ctx.visible_year,
-                NonZero::new(self.ctx.visible_month).expect("visible_month is 1-based"),
-                nzu8(1),
-            );
-            first_of_visible <= *min
-        } else {
-            false
-        }
+        let Some(min) = &self.ctx.min else { return false; };
+        let Ok(first_of_visible) =
+            CalendarDate::new_gregorian(self.ctx.visible_year, self.ctx.visible_month, 1)
+        else { return false; };
+        !matches!(first_of_visible.compare(min), Ordering::Greater)
     }
 
     /// Whether the next button should be disabled (max constraint).
-    /// Checks against the **last** visible month instead of the first.
+    /// Checks against the **last** visible month so multi-month layouts
+    /// behave correctly.
     pub fn is_next_disabled(&self) -> bool {
-        if let Some(ref max) = self.ctx.max {
-            let last_offset = self.ctx.visible_months.saturating_sub(1);
-            let (month, year) = self.ctx.month_year_at_offset(last_offset);
-            let first_of_last = CalendarDate::new_gregorian(year, NonZero::new(month).expect("month is 1-based"), nzu8(1));
-            let last_of_last = CalendarDate::new_gregorian(
-                year, NonZero::new(month).expect("month is 1-based"), NonZero::new(first_of_last.days_in_month()).expect("days_in_month is >= 1"),
-            );
-            last_of_last >= *max
-        } else {
-            false
-        }
+        let Some(max) = &self.ctx.max else { return false; };
+        let last_offset = self.ctx.visible_months.saturating_sub(1);
+        let (month, year) = self.ctx.month_year_at_offset(last_offset);
+        let Ok(first_of_last) = CalendarDate::new_gregorian(year, month, 1) else {
+            return false;
+        };
+        let days_in_month = first_of_last.days_in_month();
+        let Ok(last_of_last) = CalendarDate::new_gregorian(year, month, days_in_month) else {
+            return false;
+        };
+        !matches!(last_of_last.compare(max), Ordering::Less)
     }
 
     /// The grid data: weeks and day labels.
@@ -1119,7 +1245,7 @@ impl ConnectApi for Api<'_> {
             Part::Header => self.header_attrs(),
             Part::PrevTrigger => self.prev_trigger_attrs(),
             Part::NextTrigger => self.next_trigger_attrs(),
-            Part::Heading => self.heading_text_attrs(),
+            Part::Heading => self.heading_attrs(),
             Part::Grid => self.grid_attrs(),
             Part::GridGroup => self.grid_group_attrs(),
             Part::HeadRow => self.head_row_attrs(),
@@ -1253,24 +1379,33 @@ When `visible_months == 1`, anatomy is identical to the single-month tree above 
 ```rust
 // ars-i18n/src/calendar/i18n.rs
 
+/// `MessageFn` carrying a locale-only label closure.
+pub type LocaleLabelFn = dyn Fn(&Locale) -> String + Send + Sync;
+
+/// `MessageFn` carrying a step-count plus locale label closure (used by the
+/// multi-month prev/next page labels).
+pub type PageLabelFn = dyn Fn(usize, &Locale) -> String + Send + Sync;
+
 /// Locale-specific labels for the Calendar component.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct Messages {
     /// Accessible label for the previous month navigation button.
-    pub prev_month_label: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
+    pub prev_month_label: MessageFn<LocaleLabelFn>,
     /// Accessible label for the next month navigation button.
-    pub next_month_label: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
+    pub next_month_label: MessageFn<LocaleLabelFn>,
     /// Label for prev button when navigating multiple months.
     /// The `usize` parameter is the step count.
-    pub prev_page_label: MessageFn<dyn Fn(usize, &Locale) -> String + Send + Sync>,
+    pub prev_page_label: MessageFn<PageLabelFn>,
     /// Label for next button when navigating multiple months.
     /// The `usize` parameter is the step count.
-    pub next_page_label: MessageFn<dyn Fn(usize, &Locale) -> String + Send + Sync>,
+    pub next_page_label: MessageFn<PageLabelFn>,
     /// Separator between month names in multi-month range heading (e.g., " – ").
-    pub month_range_separator: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
+    pub month_range_separator: MessageFn<LocaleLabelFn>,
 }
-// Month names, weekday names, and abbreviations are resolved from the IntlBackend
-// (via `month_long_name()`, `wd.short_label()`, etc.) — not stored in Messages.
+// Month names, weekday names, and abbreviations are resolved from the
+// `IntlBackend` via `intl_backend.month_long_name(month, &locale)`,
+// `intl_backend.weekday_short_label(wd, &locale)`, and
+// `intl_backend.weekday_long_label(wd, &locale)` — not stored in Messages.
 
 impl Default for Messages {
     fn default() -> Self {
@@ -1315,57 +1450,49 @@ The `first_day_of_week` prop overrides the locale default when provided.
 
 ## 5. Variant: Multiple Selection
 
-Calendar supports multiple non-contiguous date selection in addition to the default single-date mode.
+Calendar supports multiple non-contiguous date selection alongside the
+default single-date mode. The Props, Context, and Event surface for
+multi-select live directly in §1.2-§1.4 (not as "additional"
+declarations) — the machine is one unified type that switches behaviour
+on `selection_mode` rather than two parallel `Machine` types.
 
-### 5.1 Additional Props
+### 5.1 Active surface
 
-```rust,no_check
-/// Added to Props.
-pub selection_mode: CalendarSelectionMode,
-/// Maximum number of dates that can be selected.
-pub max_selected: Option<usize>,
+The unified surface relevant to multi-select:
 
-#[derive(Clone, Debug, PartialEq, Default)]
-pub enum CalendarSelectionMode {
-    /// Select a single date (default behavior).
-    #[default]
-    Single,
-    /// Select multiple non-contiguous dates.
-    Multiple,
-}
-```
+- [`SelectionMode { Single, Multiple }`](#14-props) on `Props` and
+  `Context`.
+- `Props.selected_dates: Option<SelectedDates>` (controlled) and
+  `Props.default_selected_dates: SelectedDates` (uncontrolled), backing
+  `Context.selected_dates: Bindable<SelectedDates>`.
+- `Props.max_selected: Option<usize>` and `Context.max_selected`.
+- [`Event::ToggleDate { date }`](#12-events) struct variant. `SelectDate`
+  is accepted in `Multiple` mode and routes to the same toggle handler so
+  adapters that do not know the active mode can emit one canonical
+  "select this date" event.
 
-### 5.2 Additional Context
+### 5.2 Behavior
 
-```rust,no_check
-/// Extended CalendarContext for multi-selection.
-/// When selection_mode is Multiple:
-pub selected_dates: BTreeSet<CalendarDate>,
-```
+| Action     | Click                 |
+| ---------- | --------------------- |
+| `Multiple` | Toggle date selection |
 
-### 5.3 Additional Events
+When `max_selected` is set, the `ToggleDate` transition guards against
+`selected_dates.len() >= max_selected`. Toggles that would add a date
+beyond the cap are silently dropped; toggles that remove an already-selected
+date always succeed.
 
-```rust,no_check
-/// Added to Calendar Event enum.
-/// Toggle a date in/out of the selection set.
-ToggleDate(CalendarDate),
-```
+### 5.3 Keyboard
 
-### 5.4 Behavior
+| Key               | Behavior                                |
+| ----------------- | --------------------------------------- |
+| `Space` / `Enter` | Toggle focused date in/out of selection |
 
-| Action   | Click                 | Shift+Click                                 |
-| -------- | --------------------- | ------------------------------------------- |
-| Multiple | Toggle date selection | Select range from last-clicked to this date |
-
-When `max_selected` is set, the `ToggleDate` transition guards against `selected_dates.len() >= max_selected`. Excess selections are silently prevented.
-
-### 5.5 Keyboard
-
-| Key           | Behavior                                  |
-| ------------- | ----------------------------------------- |
-| Space / Enter | Toggle focused date in/out of selection   |
-| Shift+Space   | Select range from anchor to focused       |
-| Ctrl+A        | Select all visible dates in current month |
+Advanced multi-select keyboard operations (`Shift+Click`,
+`Shift+Space` range fill from an anchor, `Ctrl+A` select-all visible)
+are not part of this implementation. They require an "anchor" concept
+not currently in the spec or machine state, and are tracked as a
+follow-up that will refine §5 once a concrete anchor design lands.
 
 ## 6. Library Parity
 
@@ -1451,270 +1578,86 @@ When `max_selected` is set, the `ToggleDate` transition guards against `selected
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ars_core::service::Service;
+    use ars_core::Service;
 
-    fn make_service() -> Service<Machine> {
-        Service::new(Props {
-            id: "test-cal".into(),
-            value: None,
-            default_value: None,
-            min: None,
-            max: None,
-            disabled: false,
-            readonly: false,
-            is_date_unavailable: None,
-            first_day_of_week: None,
-            is_range: false,
-            is_rtl: false,
-            visible_months: 1,
-            page_behavior: PageBehavior::Visible,
-            today: CalendarDate::new_gregorian(2024, nzu8(1), nzu8(15)),
-        }, Env::default(), Default::default())
+    fn date(year: i32, month: u8, day: u8) -> CalendarDate {
+        CalendarDate::new_gregorian(year, month, day).expect("valid test date")
+    }
+
+    fn props() -> Props {
+        Props::new().id("cal").today(date(2024, 1, 15))
+    }
+
+    fn service() -> Service<Machine> {
+        Service::<Machine>::new(props(), &Env::default(), &Messages::default())
     }
 
     #[test]
     fn initial_state_is_idle() {
-        let svc = make_service();
-        assert_eq!(*svc.state(), State::Idle);
+        assert_eq!(*service().state(), State::Idle);
     }
 
     #[test]
     fn focus_in_transitions_to_focused() {
-        let mut svc = make_service();
-        svc.send(Event::FocusIn);
+        let mut svc = service();
+        drop(svc.send(Event::FocusIn));
         assert_eq!(*svc.state(), State::Focused);
     }
 
     #[test]
     fn arrow_right_advances_focused_date() {
-        let mut svc = make_service();
-        svc.send(Event::FocusIn);
+        let mut svc = service();
+        drop(svc.send(Event::FocusIn));
         let before = svc.context().focused_date.clone();
-        svc.send(Event::KeyDown { key: KeyboardKey::ArrowRight });
-        assert_eq!(svc.context().focused_date, before.add_days(1));
-    }
-
-    #[test]
-    fn arrow_up_moves_back_one_week() {
-        let mut svc = make_service();
-        svc.send(Event::FocusIn);
-        let before = svc.context().focused_date.clone();
-        svc.send(Event::KeyDown { key: KeyboardKey::ArrowUp });
-        assert_eq!(svc.context().focused_date, before.add_days(-7));
+        drop(svc.send(Event::KeyDown { key: KeyboardKey::ArrowRight, shift: false }));
+        assert_eq!(svc.context().focused_date, before.add_days(1).unwrap());
     }
 
     #[test]
     fn select_date_updates_value() {
-        let mut svc = make_service();
-        let date = CalendarDate::new_gregorian(2024, nzu8(1), nzu8(20));
-        svc.send(Event::SelectDate { date: date.clone() });
-        assert_eq!(*svc.context().value.get(), Some(date));
+        let mut svc = service();
+        let d = date(2024, 1, 20);
+        drop(svc.send(Event::SelectDate { date: d.clone() }));
+        assert_eq!(*svc.context().value.get(), Some(d));
     }
 
     #[test]
-    fn next_month_advances_visible_month() {
-        let mut svc = make_service();
-        assert_eq!(svc.context().visible_month, 1);
-        svc.send(Event::NextMonth);
-        assert_eq!(svc.context().visible_month, 2);
+    fn shift_page_down_advances_one_year() {
+        let mut svc = service();
+        drop(svc.send(Event::FocusIn));
+        let before = svc.context().visible_year;
+        drop(svc.send(Event::KeyDown { key: KeyboardKey::PageDown, shift: true }));
+        assert_eq!(svc.context().visible_year, before + 1);
     }
 
     #[test]
-    fn prev_month_goes_back() {
-        let mut svc = make_service();
-        assert_eq!(svc.context().visible_month, 1);
-        svc.send(Event::PrevMonth);
-        assert_eq!(svc.context().visible_month, 12);
-        assert_eq!(svc.context().visible_year, 2023);
-    }
-
-    #[test]
-    fn disabled_calendar_ignores_events() {
-        let mut svc = Service::new(Props {
-            disabled: true,
-            ..make_service().props().clone()
-        }, Env::default(), Default::default());
-        svc.send(Event::SelectDate {
-            date: CalendarDate::new_gregorian(2024, nzu8(1), nzu8(20)),
-        });
-        assert_eq!(*svc.context().value.get(), None);
-    }
-
-    #[test]
-    fn range_mode_first_click_sets_start() {
-        let mut svc = Service::new(Props {
-            is_range: true,
-            ..make_service().props().clone()
-        }, Env::default(), Default::default());
-        let date = CalendarDate::new_gregorian(2024, nzu8(1), nzu8(10));
-        svc.send(Event::SelectDate { date: date.clone() });
-        assert_eq!(svc.context().range_start, Some(date));
-        assert_eq!(svc.context().range_end, None);
-    }
-
-    #[test]
-    fn range_mode_second_click_completes_range() {
-        let mut svc = Service::new(Props {
-            is_range: true,
-            ..make_service().props().clone()
-        }, Env::default(), Default::default());
-        let start = CalendarDate::new_gregorian(2024, nzu8(1), nzu8(10));
-        let end = CalendarDate::new_gregorian(2024, nzu8(1), nzu8(20));
-        svc.send(Event::SelectDate { date: start.clone() });
-        svc.send(Event::SelectDate { date: end.clone() });
-        assert_eq!(svc.context().range_start, Some(start));
-        assert_eq!(svc.context().range_end, Some(end));
-    }
-
-    #[test]
-    fn range_mode_swaps_if_end_before_start() {
-        let mut svc = Service::new(Props {
-            is_range: true,
-            ..make_service().props().clone()
-        }, Env::default(), Default::default());
-        let later = CalendarDate::new_gregorian(2024, nzu8(1), nzu8(20));
-        let earlier = CalendarDate::new_gregorian(2024, nzu8(1), nzu8(5));
-        svc.send(Event::SelectDate { date: later.clone() });
-        svc.send(Event::SelectDate { date: earlier.clone() });
-        assert_eq!(svc.context().range_start, Some(earlier));
-        assert_eq!(svc.context().range_end, Some(later));
-    }
-
-    #[test]
-    fn min_max_clamps_focused_date() {
-        let mut svc = Service::new(Props {
-            min: Some(CalendarDate::new_gregorian(2024, nzu8(1), nzu8(10))),
-            max: Some(CalendarDate::new_gregorian(2024, nzu8(1), nzu8(25))),
-            ..make_service().props().clone()
-        }, Env::default(), Default::default());
-        svc.send(Event::FocusDate {
-            date: CalendarDate::new_gregorian(2024, nzu8(1), nzu8(1)),
-        });
-        assert_eq!(
-            svc.context().focused_date,
-            CalendarDate::new_gregorian(2024, nzu8(1), nzu8(10)),
+    fn multi_select_toggle_round_trip() {
+        let mut svc = Service::<Machine>::new(
+            props().selection_mode(SelectionMode::Multiple),
+            &Env::default(),
+            &Messages::default(),
         );
+        drop(svc.send(Event::ToggleDate { date: date(2024, 1, 10) }));
+        assert!(svc.context().selected_dates.get().contains(&date(2024, 1, 10)));
+        drop(svc.send(Event::ToggleDate { date: date(2024, 1, 10) }));
+        assert!(!svc.context().selected_dates.get().contains(&date(2024, 1, 10)));
     }
 
     #[test]
-    fn rtl_arrow_keys_reversed() {
-        let mut svc = Service::new(Props {
-            is_rtl: true,
-            ..make_service().props().clone()
-        }, Env::default(), Default::default());
-        svc.send(Event::FocusIn);
-        let before = svc.context().focused_date.clone();
-        // In RTL, ArrowLeft should advance (next day).
-        svc.send(Event::KeyDown { key: KeyboardKey::ArrowLeft });
-        assert_eq!(svc.context().focused_date, before.add_days(1));
-    }
-
-    // ── Multi-month tests ───────────────────────────────────────────
-
-    fn make_multi_month_service(months: usize, behavior: PageBehavior) -> Service<Machine> {
-        Service::new(Props {
-            visible_months: months,
-            page_behavior: behavior,
-            ..make_service().props().clone()
-        }, Env::default(), Default::default())
-    }
-
-    #[test]
-    fn multi_month_weeks_for_returns_correct_months() {
-        let svc = make_multi_month_service(2, PageBehavior::Visible);
-        let weeks0 = svc.context().weeks_for(0);
-        let weeks1 = svc.context().weeks_for(1);
-        // First grid should contain January dates, second should contain February.
-        // Check a mid-month date in each grid.
-        assert_eq!(weeks0[2][3].month.get(), 1); // mid-January
-        assert_eq!(weeks1[2][3].month.get(), 2); // mid-February
-    }
-
-    #[test]
-    fn next_month_advances_by_visible_months_in_visible_mode() {
-        let mut svc = make_multi_month_service(3, PageBehavior::Visible);
-        assert_eq!(svc.context().visible_month, 1);
-        svc.send(Event::NextMonth);
-        // Should jump +3: January → April.
-        assert_eq!(svc.context().visible_month, 4);
-    }
-
-    #[test]
-    fn next_month_advances_by_1_in_single_mode() {
-        let mut svc = make_multi_month_service(3, PageBehavior::Single);
-        assert_eq!(svc.context().visible_month, 1);
-        svc.send(Event::NextMonth);
-        // Should jump +1: January → February.
-        assert_eq!(svc.context().visible_month, 2);
-    }
-
-    #[test]
-    fn prev_month_steps_back_by_visible_months() {
-        let mut svc = make_multi_month_service(2, PageBehavior::Visible);
-        // Advance to March first.
-        svc.send(Event::NextMonth); // Jan → Mar (step 2)
-        assert_eq!(svc.context().visible_month, 3);
-        svc.send(Event::PrevMonth); // Mar → Jan (step -2)
-        assert_eq!(svc.context().visible_month, 1);
-    }
-
-    #[test]
-    fn sync_visible_does_not_scroll_when_focus_in_range() {
-        let mut svc = make_multi_month_service(2, PageBehavior::Visible);
-        // visible_month = 1 (Jan), visible_months = 2, so Jan+Feb visible.
-        // Focus on a Feb date — should NOT scroll.
-        let feb_date = CalendarDate::new_gregorian(2024, nzu8(2), nzu8(10));
-        svc.send(Event::FocusDate { date: feb_date });
-        assert_eq!(svc.context().visible_month, 1); // Still January
-    }
-
-    #[test]
-    fn sync_visible_scrolls_when_focus_leaves_range() {
-        let mut svc = make_multi_month_service(2, PageBehavior::Visible);
-        // visible range is Jan+Feb. Focus on March — should scroll.
-        let mar_date = CalendarDate::new_gregorian(2024, nzu8(3), nzu8(5));
-        svc.send(Event::FocusDate { date: mar_date });
-        assert_eq!(svc.context().visible_month, 3); // Scrolled to March
-    }
-
-    #[test]
-    fn is_in_visible_range_checks_all_months() {
-        let svc = make_multi_month_service(3, PageBehavior::Visible);
-        let jan = CalendarDate::new_gregorian(2024, nzu8(1), nzu8(15));
-        let feb = CalendarDate::new_gregorian(2024, nzu8(2), nzu8(15));
-        let mar = CalendarDate::new_gregorian(2024, nzu8(3), nzu8(15));
-        let apr = CalendarDate::new_gregorian(2024, nzu8(4), nzu8(1));
-        assert!(svc.context().is_in_visible_range(&jan));
-        assert!(svc.context().is_in_visible_range(&feb));
-        assert!(svc.context().is_in_visible_range(&mar));
-        assert!(!svc.context().is_in_visible_range(&apr));
-    }
-
-    #[test]
-    fn month_year_at_offset_wraps_year() {
-        let mut svc = make_multi_month_service(3, PageBehavior::Visible);
-        // Set visible to November 2024.
-        svc.send(Event::SetMonth { month: 11 });
-        let (m, y) = svc.context().month_year_at_offset(2);
-        assert_eq!(m, 1);    // January
-        assert_eq!(y, 2025); // Next year
+    fn next_month_emits_announce_month_effect() {
+        let mut svc = service();
+        let result = svc.send(Event::NextMonth);
+        assert!(result.pending_effects.iter().any(|e| e.name == Effect::AnnounceMonth));
     }
 
     #[test]
     fn is_next_disabled_checks_last_visible_month() {
-        let svc = Service::new(Props {
-            visible_months: 2,
-            page_behavior: PageBehavior::Visible,
-            max: Some(CalendarDate::new_gregorian(2024, nzu8(2), nzu8(28))),
-            ..make_service().props().clone()
-        }, Env::default(), Default::default());
-        let api = Machine::connect(
-            svc.state(), svc.context(), svc.props(), &|_| {},
+        let svc = Service::<Machine>::new(
+            props().visible_months(2).max(Some(date(2024, 1, 25))),
+            &Env::default(),
+            &Messages::default(),
         );
-        // visible_month=1 (Jan), visible_months=2 → last visible is Feb.
-        // max = Feb 28. Last day of Feb = Feb 29 (2024 is a leap year) ≥ Feb 28.
-        // But Feb 28 is the max and the last of the last visible month
-        // includes Feb 29 which is ≥ max, so next should be disabled.
+        let api = svc.connect(&|_| {});
         assert!(api.is_next_disabled());
     }
 }

--- a/spec/components/date-time/calendar.md
+++ b/spec/components/date-time/calendar.md
@@ -1272,10 +1272,15 @@ impl<'a> Api<'a> {
             date.year(),
             self.ctx.intl_backend.weekday_long_label(date.weekday(), &self.ctx.locale),
         );
+        // Status suffix flows through `Messages` so it can be localized
+        // (e.g., German `(nicht verfügbar)`); a single space joins base
+        // and suffix automatically.
         let label = if unavailable {
-            format!("{} (unavailable)", base_label)
+            let suffix = (self.ctx.messages.unavailable_suffix)(&self.ctx.locale);
+            format!("{base_label} {suffix}")
         } else if disabled {
-            format!("{} (disabled)", base_label)
+            let suffix = (self.ctx.messages.disabled_suffix)(&self.ctx.locale);
+            format!("{base_label} {suffix}")
         } else {
             base_label
         };
@@ -1355,42 +1360,47 @@ impl<'a> Api<'a> {
     }
 
     /// Whether the prev button should be disabled — either the calendar
-    /// is globally disabled, or pressing prev (stepping by the active
-    /// `page_behavior`) would yield a visible range with **no** dates
-    /// ≥ `min`. The check looks at the LAST month of the post-step range
-    /// so multi-month + `PageBehavior::Single` doesn't disable too early.
+    /// is globally disabled, the post-step range is unrepresentable
+    /// (calendar boundary), or stepping by the active `page_behavior`
+    /// would yield a visible range with **no** dates ≥ `min`. The check
+    /// looks at the LAST month of the post-step range so multi-month +
+    /// `PageBehavior::Single` doesn't disable too early.
     pub fn is_prev_disabled(&self) -> bool {
         if self.ctx.disabled { return true; }
-        let Some(min) = &self.ctx.min else { return false; };
         let step = self.nav_step_size();
         let (new_first_m, new_first_y) = advance_month(
             self.ctx.visible_month, self.ctx.visible_year, -(step as i32),
         );
         let last_offset = self.ctx.visible_months.saturating_sub(1);
         let (new_last_m, new_last_y) = month_year_at_offset(new_first_m, new_first_y, last_offset);
+        // Construction failure means the post-step range is past the
+        // representable calendar limit — paging would be a no-op, so
+        // surface as disabled rather than leaving a clickable no-op.
         let Ok(first_of_new_last) = CalendarDate::new_gregorian(new_last_y, new_last_m, 1)
-        else { return false; };
+        else { return true; };
         let Ok(last_of_new_last) =
             CalendarDate::new_gregorian(new_last_y, new_last_m, first_of_new_last.days_in_month())
-        else { return false; };
+        else { return true; };
+        // Past representability, also apply the min constraint.
+        let Some(min) = &self.ctx.min else { return false; };
         matches!(last_of_new_last.compare(min), Ordering::Less)
     }
 
     /// Whether the next button should be disabled — either the calendar
-    /// is globally disabled, or pressing next (stepping by the active
-    /// `page_behavior`) would yield a visible range with **no** dates
-    /// ≤ `max`. Symmetric to `is_prev_disabled`: checks the FIRST month
-    /// of the post-step range so multi-month + `PageBehavior::Single`
-    /// doesn't disable too early.
+    /// is globally disabled, the post-step range is unrepresentable
+    /// (calendar boundary), or stepping by the active `page_behavior`
+    /// would yield a visible range with **no** dates ≤ `max`. Symmetric
+    /// to `is_prev_disabled`.
     pub fn is_next_disabled(&self) -> bool {
         if self.ctx.disabled { return true; }
-        let Some(max) = &self.ctx.max else { return false; };
         let step = self.nav_step_size();
         let (new_first_m, new_first_y) = advance_month(
             self.ctx.visible_month, self.ctx.visible_year, step as i32,
         );
+        // Construction failure → calendar boundary → disable.
         let Ok(first_of_new_first) = CalendarDate::new_gregorian(new_first_y, new_first_m, 1)
-        else { return false; };
+        else { return true; };
+        let Some(max) = &self.ctx.max else { return false; };
         matches!(first_of_new_first.compare(max), Ordering::Greater)
     }
 
@@ -1587,6 +1597,13 @@ pub struct Messages {
     pub next_page_label: MessageFn<PageLabelFn>,
     /// Separator between month names in multi-month range heading (e.g., " – ").
     pub month_range_separator: MessageFn<LocaleLabelFn>,
+    /// Suffix appended to a date cell's `aria-label` when the date is
+    /// marked **unavailable** (default `"(unavailable)"`). Localizable so
+    /// non-English consumers don't end up with mixed-language labels.
+    pub unavailable_suffix: MessageFn<LocaleLabelFn>,
+    /// Suffix appended to a date cell's `aria-label` when the date is
+    /// **disabled** by `min`/`max` (default `"(disabled)"`).
+    pub disabled_suffix: MessageFn<LocaleLabelFn>,
 }
 // Month names, weekday names, and abbreviations are resolved from the
 // `IntlBackend` via `intl_backend.month_long_name(month, &locale)`,
@@ -1601,6 +1618,8 @@ impl Default for Messages {
             prev_page_label: MessageFn::new(|count, _locale| format!("Previous {} months", count)),
             next_page_label: MessageFn::new(|count, _locale| format!("Next {} months", count)),
             month_range_separator: MessageFn::static_str(" \u{2013} "),
+            unavailable_suffix: MessageFn::static_str("(unavailable)"),
+            disabled_suffix: MessageFn::static_str("(disabled)"),
         }
     }
 }

--- a/spec/components/date-time/calendar.md
+++ b/spec/components/date-time/calendar.md
@@ -96,6 +96,15 @@ pub enum Event {
         /// Whether the shift modifier was held.
         shift: bool,
     },
+
+    /// Synchronise context from a new props snapshot.
+    ///
+    /// Emitted automatically by [`Machine::on_props_changed`] when the
+    /// adapter pushes new props via `Service::set_props`. Updates the
+    /// `Bindable` controlled values, refreshes the cached `disabled`,
+    /// `readonly`, `min`/`max`, predicate, and layout fields, and
+    /// re-clamps `focused_date` into the (possibly tighter) range.
+    SyncProps(Box<Props>),
 }
 ```
 
@@ -426,14 +435,19 @@ impl Context {
             return Vec::new();
         };
 
+        // The contract is "exactly 6 rows of 7 cells" or an empty vec on
+        // boundary failure. Partial vectors would break adapters that
+        // assume a stable 6-row grid, so any arithmetic failure partway
+        // through bails out with an empty result.
         let mut weeks: Vec<[CalendarDate; 7]> = Vec::with_capacity(6);
         let mut current = grid_start;
-        // Always render 6 weeks (42 days) for consistent grid height.
-        for _ in 0..6 {
-            let Some(row) = build_week(&current) else { return weeks; };
+        for i in 0..6 {
+            let Some(row) = build_week(&current) else { return Vec::new(); };
             weeks.push(row);
-            let Ok(next_week_start) = current.add_days(7) else { return weeks; };
-            current = next_week_start;
+            if i < 5 {
+                let Ok(next_week_start) = current.add_days(7) else { return Vec::new(); };
+                current = next_week_start;
+            }
         }
         weeks
     }
@@ -527,11 +541,24 @@ impl ars_core::Machine for Machine {
             None      => Bindable::uncontrolled(props.default_selected_dates.clone()),
         };
 
-        let initial_date = match props.selection_mode {
+        let mut initial_date = match props.selection_mode {
             SelectionMode::Single   => value.get().clone().unwrap_or_else(|| props.today.clone()),
             SelectionMode::Multiple => selected_dates.get().iter().next().cloned()
                 .unwrap_or_else(|| props.today.clone()),
         };
+
+        // Clamp the initial focused date into [min, max] so the roving
+        // tabindex target never starts on a disabled cell.
+        if let Some(min) = &props.min
+            && initial_date.compare(min) == Ordering::Less
+        {
+            initial_date = min.clone();
+        }
+        if let Some(max) = &props.max
+            && initial_date.compare(max) == Ordering::Greater
+        {
+            initial_date = max.clone();
+        }
 
         let locale = env.locale.clone();
         let first_day = props
@@ -566,19 +593,40 @@ impl ars_core::Machine for Machine {
         (State::Idle, ctx)
     }
 
+    /// Surface parent prop changes to the live machine via a `SyncProps`
+    /// event. Without this, controlled `value`/`selected_dates` updates,
+    /// `disabled`/`readonly` flips, and `min`/`max` tightening from
+    /// `Service::set_props` would be ignored after mount.
+    fn on_props_changed(old: &Self::Props, new: &Self::Props) -> Vec<Self::Event> {
+        debug_assert_eq!(
+            old.id, new.id,
+            "calendar::Props.id must remain stable after init",
+        );
+        if old == new {
+            Vec::new()
+        } else {
+            vec![Event::SyncProps(Box::new(new.clone()))]
+        }
+    }
+
     fn transition(
         _state: &Self::State,
         event: &Self::Event,
         ctx: &Self::Context,
         _props: &Self::Props,
     ) -> Option<TransitionPlan<Self>> {
-        // `FocusOut` must run even when the calendar is disabled — a
-        // calendar that becomes disabled while focused still needs its blur
-        // cleanup to land, otherwise it stays stuck in `State::Focused`
-        // with stale `data-ars-state="focused"`. All other events are gated
-        // by the disabled guard below.
+        // `FocusOut` and `SyncProps` must run even when the calendar is
+        // disabled. FocusOut needs to land blur cleanup; SyncProps needs
+        // to land parent-driven changes that may *flip* the calendar out
+        // of the disabled state. All other events are gated below.
         if matches!(event, Event::FocusOut) {
             return Some(TransitionPlan::to(State::Idle));
+        }
+        if let Event::SyncProps(props) = event {
+            let props = props.as_ref().clone();
+            return Some(TransitionPlan::context_only(move |ctx: &mut Context| {
+                sync_props_into_ctx(ctx, &props);
+            }));
         }
 
         if ctx.disabled { return None; }
@@ -586,9 +634,9 @@ impl ars_core::Machine for Machine {
         match event {
             // ── Focus management ─────────────────────────────────────────
             Event::FocusIn  => Some(TransitionPlan::to(State::Focused)),
-            // `FocusOut` handled above the disabled guard; this arm exists
-            // only to satisfy match exhaustiveness over `Event`.
-            Event::FocusOut => None,
+            // `FocusOut` and `SyncProps` handled above the disabled guard;
+            // these arms exist only to satisfy match exhaustiveness.
+            Event::FocusOut | Event::SyncProps(_) => None,
 
             Event::FocusDate { date } => {
                 let clamped = ctx.clamp_date(date.clone());
@@ -620,14 +668,32 @@ impl ars_core::Machine for Machine {
                 let month = *month;
                 if !(1..=12).contains(&month) { return None; }
                 Some(TransitionPlan::context_only(move |ctx| {
+                    // Move both visible_month and focused_date by the
+                    // same delta so the roving-tabindex target still has
+                    // a rendered cell. Out-of-range targets clamp back
+                    // to [min, max].
+                    let delta = i32::from(month) - i32::from(ctx.visible_month);
                     ctx.visible_month = month;
+                    if let Ok(shifted) = ctx.focused_date.add(DateDuration {
+                        months: delta,
+                        ..DateDuration::default()
+                    }) {
+                        ctx.focused_date = ctx.clamp_date(shifted);
+                    }
                 }).with_effect(announce_month_effect()))
             }
 
             Event::SetYear { year } => {
                 let year = *year;
                 Some(TransitionPlan::context_only(move |ctx| {
+                    let delta_years = year - ctx.visible_year;
                     ctx.visible_year = year;
+                    if let Ok(shifted) = ctx.focused_date.add(DateDuration {
+                        years: delta_years,
+                        ..DateDuration::default()
+                    }) {
+                        ctx.focused_date = ctx.clamp_date(shifted);
+                    }
                 }).with_effect(announce_month_effect()))
             }
 
@@ -655,21 +721,47 @@ fn step_for_page_behavior(ctx: &Context) -> i32 {
 
 fn month_step_plan(step: i32) -> TransitionPlan<Machine> {
     TransitionPlan::context_only(move |ctx: &mut Context| {
-        ctx.advance_month(step);
-        // Keep `focused_date` aligned with the newly visible range so the
-        // roving-tabindex target still has a rendered cell. Without this,
-        // paging from Jan 15 → Feb leaves focused_date on Jan 15, which is
-        // not in February's 6-week grid, and no cell gets `tabindex="0"`.
-        // The shifted date is clamped into the configured `[min, max]`
-        // range so out-of-range targets snap back to the boundary.
-        if let Ok(shifted) = ctx.focused_date.add(DateDuration {
+        // `visible_month/year` and `focused_date` must advance atomically.
+        // If the focused-date shift fails near a representable calendar
+        // boundary, leave both untouched so the roving-tabindex target
+        // can never end up outside the rendered grid. The clamp keeps
+        // out-of-range targets snapped to `[min, max]`.
+        let Ok(shifted) = ctx.focused_date.add(DateDuration {
             months: step,
             ..DateDuration::default()
-        }) {
-            ctx.focused_date = ctx.clamp_date(shifted);
-        }
+        }) else {
+            return;
+        };
+        ctx.advance_month(step);
+        ctx.focused_date = ctx.clamp_date(shifted);
     })
     .with_effect(announce_month_effect())
+}
+
+fn sync_props_into_ctx(ctx: &mut Context, props: &Props) {
+    ctx.value.sync_controlled(props.value.clone());
+    ctx.selected_dates.sync_controlled(props.selected_dates.clone());
+
+    ctx.selection_mode = props.selection_mode;
+    ctx.max_selected = props.max_selected;
+    ctx.min = props.min.clone();
+    ctx.max = props.max.clone();
+    ctx.disabled = props.disabled;
+    ctx.readonly = props.readonly;
+    ctx.is_date_unavailable_fn = props.is_date_unavailable.clone();
+    ctx.show_week_numbers = props.show_week_numbers;
+    ctx.is_rtl = props.is_rtl;
+    ctx.visible_months = props.visible_months.max(1);
+    ctx.page_behavior = props.page_behavior;
+    ctx.today = props.today.clone();
+
+    if let Some(fdow) = props.first_day_of_week {
+        ctx.first_day_of_week = fdow;
+    }
+
+    // Re-clamp `focused_date` in case `min`/`max` tightened.
+    let clamped = ctx.clamp_date(ctx.focused_date.clone());
+    ctx.focused_date = clamped;
 }
 
 fn announce_month_effect() -> ars_core::PendingEffect<Machine> {
@@ -1231,8 +1323,10 @@ impl<'a> Api<'a> {
         self.ctx.is_outside_visible_month(date)
     }
 
-    /// Whether the prev button should be disabled (min constraint).
+    /// Whether the prev button should be disabled — either the calendar
+    /// is globally disabled or the visible range is already at `min`.
     pub fn is_prev_disabled(&self) -> bool {
+        if self.ctx.disabled { return true; }
         let Some(min) = &self.ctx.min else { return false; };
         let Ok(first_of_visible) =
             CalendarDate::new_gregorian(self.ctx.visible_year, self.ctx.visible_month, 1)
@@ -1240,10 +1334,12 @@ impl<'a> Api<'a> {
         !matches!(first_of_visible.compare(min), Ordering::Greater)
     }
 
-    /// Whether the next button should be disabled (max constraint).
+    /// Whether the next button should be disabled — either the calendar
+    /// is globally disabled or the visible range is already at `max`.
     /// Checks against the **last** visible month so multi-month layouts
     /// behave correctly.
     pub fn is_next_disabled(&self) -> bool {
+        if self.ctx.disabled { return true; }
         let Some(max) = &self.ctx.max else { return false; };
         let last_offset = self.ctx.visible_months.saturating_sub(1);
         let (month, year) = self.ctx.month_year_at_offset(last_offset);


### PR DESCRIPTION
## Summary

- Implements the framework-agnostic `Calendar` state machine, grid math,
  connect API, and §1.4 unified multi-select Props in
  `ars-components::date_time::calendar` (118 unit + snapshot tests, 3
  nightly proptests, calendar anatomy spec-conformance entry, 27
  committed `.snap` fixtures).
- Adds `Callback::new_ref` to `ars-core` — a sibling constructor for
  higher-ranked closures over reference arguments
  (`for<'a> Fn(&'a T) -> Out`). Lets `Calendar::is_date_unavailable` (and
  any future predicate-style Props) use `Callback` with full closure
  support instead of falling back to raw `fn` pointers.
- Ports the §1-§5 spec at `spec/components/date-time/calendar.md` to
  match the implementation end-to-end: typed `Effect::AnnounceMonth`
  enum, `Event::KeyDown { key, shift }`, `Event::ToggleDate { date }`
  struct variant, `SelectedDates` newtype replacing
  `BTreeSet<CalendarDate>`, multi-select Props in §1.4 (not §5.1
  "additional"), real `CalendarDate` API form (`u8` + `Result` returns +
  `.compare()`), `Context::ids: ComponentIds` replacing string id
  fields, and range-calendar drift (`HoverDate`/`HoverEnd`/`is_range`)
  removed for the future `RangeCalendar` to reintroduce.

## Scope notes

- §5.5 advanced multi-select keyboard operations (`Shift+Space` range
  from anchor, `Ctrl+A` select-all) are **out of scope** for this PR —
  the spec does not yet define the "anchor" state these operations
  require. Tracked as a follow-up.
- Adapter implementations (Leptos #281-adjacent, Dioxus #282-adjacent)
  are out of scope. The agnostic core is what #280 delivers.

## Test plan

- [x] `cargo test -p ars-components --lib date_time::calendar` (118 passed)
- [x] `cargo test -p ars-core --lib callback` (10 passed, 2 new for `new_ref`)
- [x] `cargo test -p ars-components --test spec_conformance date_time` (calendar anatomy)
- [x] `cargo test -p ars-components --test proptest_state_machines -- --ignored proptest_calendar` (3 passed @ PROPTEST_CASES=100)
- [x] `cargo clippy -p ars-components --lib --tests --no-deps -- -D warnings`
- [x] `cargo clippy -p ars-core --lib --tests --no-deps -- -D warnings`
- [x] `cargo xtask spec validate` (340 files validated)
- [x] `cargo xci-fast` (all 10 steps passed)
- [x] Coverage ≥95% line / ≥95% branch on `calendar/mod.rs` and `calendar/grid.rs`
- [x] Mutation testing: 0 missed across partial runs on `calendar/mod.rs` and `calendar/grid.rs`

Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)