### PR TITLE
Implement FileUpload agnostic core (#301)

### DIFF
--- a/crates/ars-components/src/specialized/file_upload/mod.rs
+++ b/crates/ars-components/src/specialized/file_upload/mod.rs
@@ -650,6 +650,85 @@ impl ars_core::Machine for Machine {
         ctx: &Self::Context,
         props: &Self::Props,
     ) -> Option<TransitionPlan<Self>> {
+        match event {
+            Event::SetFiles(files) => {
+                let files = files.clone();
+                return Some(TransitionPlan::context_only(
+                    move |context: &mut Context| {
+                        if let Some(files) = files {
+                            context.files.set(files.clone());
+                            context.files.sync_controlled(Some(files));
+                        } else {
+                            context.files.sync_controlled(None);
+                        }
+                    },
+                ));
+            }
+
+            Event::SetProps => {
+                return Some(TransitionPlan::context_only({
+                    let disabled = props.disabled;
+                    let readonly = props.readonly;
+                    let required = props.required;
+                    let multiple = props.multiple;
+                    let accept = props.accept.clone();
+                    let max_file_size = props.max_file_size;
+                    let min_file_size = props.min_file_size;
+                    let max_files = props.max_files;
+                    let auto_upload = props.auto_upload;
+                    let directory = props.directory;
+
+                    move |context: &mut Context| {
+                        context.disabled = disabled;
+                        context.readonly = readonly;
+                        context.required = required;
+                        context.multiple = multiple;
+                        context.accept = accept;
+                        context.max_file_size = max_file_size;
+                        context.min_file_size = min_file_size;
+                        context.max_files = max_files;
+                        context.auto_upload = auto_upload;
+                        context.directory = directory;
+                    }
+                }));
+            }
+
+            Event::UploadProgress { file_id, progress } if matches!(state, State::Uploading) => {
+                let file_id = file_id.clone();
+                let progress = clamp_upload_fraction(*progress);
+                return Some(TransitionPlan::context_only(
+                    move |context: &mut Context| {
+                        update_file_progress(context, &file_id, progress);
+                    },
+                ));
+            }
+
+            Event::UploadComplete { file_id } if matches!(state, State::Uploading) => {
+                let file_id = file_id.clone();
+                let still_uploading = upload_complete_updates(ctx, &file_id);
+                return Some(upload_finish_plan(
+                    still_uploading,
+                    move |context: &mut Context| {
+                        apply_upload_complete(context, &file_id);
+                    },
+                ));
+            }
+
+            Event::UploadError { file_id, error } if matches!(state, State::Uploading) => {
+                let file_id = file_id.clone();
+                let error = error.clone();
+                let still_uploading = upload_error_updates(ctx, &file_id);
+                return Some(upload_finish_plan(
+                    still_uploading,
+                    move |context: &mut Context| {
+                        apply_upload_error(context, &file_id, &error);
+                    },
+                ));
+            }
+
+            _ => {}
+        }
+
         if ctx.disabled || ctx.readonly {
             return match event {
                 Event::Focus { part } => {
@@ -738,37 +817,14 @@ impl ars_core::Machine for Machine {
                 )
             }
 
-            (State::Uploading, Event::UploadProgress { file_id, progress }) => {
-                let file_id = file_id.clone();
-                let progress = *progress;
-                Some(TransitionPlan::context_only(
-                    move |context: &mut Context| {
-                        update_file_progress(context, &file_id, progress);
-                    },
-                ))
-            }
+            (State::Uploading, Event::StartUpload) => {
+                if !has_pending_files(ctx, props) {
+                    return None;
+                }
 
-            (State::Uploading, Event::UploadComplete { file_id }) => {
-                let file_id = file_id.clone();
-                let still_uploading = upload_complete_updates(ctx, &file_id);
-                Some(upload_finish_plan(
-                    still_uploading,
-                    move |context: &mut Context| {
-                        apply_upload_complete(context, &file_id);
-                    },
-                ))
-            }
-
-            (State::Uploading, Event::UploadError { file_id, error }) => {
-                let file_id = file_id.clone();
-                let error = error.clone();
-                let still_uploading = upload_error_updates(ctx, &file_id);
-                Some(upload_finish_plan(
-                    still_uploading,
-                    move |context: &mut Context| {
-                        apply_upload_error(context, &file_id, &error);
-                    },
-                ))
+                Some(TransitionPlan::context_only(|context: &mut Context| {
+                    mark_pending_as_uploading(context);
+                }))
             }
 
             (_, Event::RemoveFile { file_id }) => {
@@ -829,46 +885,6 @@ impl ars_core::Machine for Machine {
                     context.focused_part = None;
                 }))
             }
-
-            (_, Event::SetFiles(files)) => {
-                let files = files.clone();
-                Some(TransitionPlan::context_only(
-                    move |context: &mut Context| {
-                        if let Some(files) = files {
-                            context.files.set(files.clone());
-                            context.files.sync_controlled(Some(files));
-                        } else {
-                            context.files.sync_controlled(None);
-                        }
-                    },
-                ))
-            }
-
-            (_, Event::SetProps) => Some(TransitionPlan::context_only({
-                let disabled = props.disabled;
-                let readonly = props.readonly;
-                let required = props.required;
-                let multiple = props.multiple;
-                let accept = props.accept.clone();
-                let max_file_size = props.max_file_size;
-                let min_file_size = props.min_file_size;
-                let max_files = props.max_files;
-                let auto_upload = props.auto_upload;
-                let directory = props.directory;
-
-                move |context: &mut Context| {
-                    context.disabled = disabled;
-                    context.readonly = readonly;
-                    context.required = required;
-                    context.multiple = multiple;
-                    context.accept = accept;
-                    context.max_file_size = max_file_size;
-                    context.min_file_size = min_file_size;
-                    context.max_files = max_files;
-                    context.auto_upload = auto_upload;
-                    context.directory = directory;
-                }
-            })),
 
             _ => None,
         }
@@ -1132,7 +1148,7 @@ impl Api<'_> {
             attrs.set_bool(HtmlAttr::Data("ars-dragging"), true);
         }
 
-        if self.ctx.disabled {
+        if self.ctx.disabled || self.ctx.readonly {
             attrs.set(HtmlAttr::Aria(AriaAttr::Disabled), "true");
         }
 
@@ -1148,12 +1164,13 @@ impl Api<'_> {
         attrs
             .set(scope_attr, scope_val)
             .set(part_attr, part_val)
+            .set(HtmlAttr::Type, "button")
             .set(
                 HtmlAttr::Aria(AriaAttr::Label),
                 (self.ctx.messages.trigger_label)(&self.ctx.locale),
             );
 
-        if self.ctx.disabled {
+        if self.ctx.disabled || self.ctx.readonly {
             attrs
                 .set_bool(HtmlAttr::Disabled, true)
                 .set(HtmlAttr::Aria(AriaAttr::Disabled), "true");
@@ -1515,7 +1532,16 @@ fn mark_pending_as_uploading(context: &mut Context) {
     context.files.set(updated);
 }
 
+fn clamp_upload_fraction(progress: f64) -> f64 {
+    if progress.is_nan() {
+        0.0
+    } else {
+        progress.clamp(0.0, 1.0)
+    }
+}
+
 fn update_file_progress(context: &mut Context, file_id: &str, progress: f64) {
+    let progress = clamp_upload_fraction(progress);
     let files = context.files.get().clone();
 
     let updated = files
@@ -1567,7 +1593,7 @@ fn projected_files_after_complete(ctx: &Context, file_id: &str) -> Vec<Item> {
         .clone()
         .into_iter()
         .map(|mut file| {
-            if file.id == file_id {
+            if file.id == file_id && file.status == Status::Uploading {
                 file.status = Status::Complete;
                 file.progress = 1.0;
             }
@@ -1583,7 +1609,7 @@ fn projected_files_after_error(ctx: &Context, file_id: &str, error: &str) -> Vec
         .clone()
         .into_iter()
         .map(|mut file| {
-            if file.id == file_id {
+            if file.id == file_id && file.status == Status::Uploading {
                 file.status = Status::Failed(error.to_string());
                 file.error = Some(error.to_string());
             }
@@ -1666,6 +1692,19 @@ fn validate_files(raw: &[RawFile], ctx: &Context) -> (Vec<Item>, Vec<Rejection>)
     let current_count = ctx.files.get().len();
 
     for file in raw {
+        if !ctx.multiple {
+            if current_count >= 1 || !accepted.is_empty() {
+                rejected.push(Rejection {
+                    name: file.name.clone(),
+                    size: file.size,
+                    mime_type: file.mime_type.clone(),
+                    reason: RejectionReason::TooMany,
+                });
+
+                continue;
+            }
+        }
+
         if let Some(max) = ctx.max_files
             && current_count + accepted.len() >= max
         {

--- a/crates/ars-components/src/specialized/file_upload/mod.rs
+++ b/crates/ars-components/src/specialized/file_upload/mod.rs
@@ -646,11 +646,19 @@ pub enum Effect {
     /// [`Messages::drop_zone_left`].
     AnnounceDropzoneLeft,
 
-    /// Adapter announces (polite) that files were added, via
-    /// [`Messages::files_added`] with `count`.
+    /// Adapter announces that files were added, via [`Messages::files_added`]
+    /// with `count`.
+    ///
+    /// `from_drop` selects the live region per the spec: a drop is announced in
+    /// the **assertive** drag-and-drop region (§4.2), a picker selection in the
+    /// **polite** region (§3.3).
     AnnounceFilesAdded {
         /// Number of files accepted in this selection/drop.
         count: usize,
+
+        /// Whether the files arrived via drag-and-drop (assertive) rather than
+        /// the file picker (polite).
+        from_drop: bool,
     },
 
     /// Adapter announces (polite) that files were rejected, via
@@ -849,9 +857,13 @@ impl ars_core::Machine for Machine {
                     .iter()
                     .any(|file| file.id == file_id && file.status == Status::Uploading);
                 let still_uploading = upload_complete_updates(ctx, &file_id);
-                let plan = upload_finish_plan(still_uploading, move |context: &mut Context| {
-                    apply_upload_complete(context, &file_id);
-                });
+                let plan = upload_finish_plan(
+                    still_uploading,
+                    ctx.dragging,
+                    move |context: &mut Context| {
+                        apply_upload_complete(context, &file_id);
+                    },
+                );
                 return Some(if did_complete {
                     plan.with_effect(PendingEffect::named(Effect::AnnounceUploadComplete))
                 } else {
@@ -865,6 +877,7 @@ impl ars_core::Machine for Machine {
                 let still_uploading = upload_error_updates(ctx, &file_id);
                 return Some(upload_finish_plan(
                     still_uploading,
+                    ctx.dragging,
                     move |context: &mut Context| {
                         apply_upload_error(context, &file_id, &error);
                     },
@@ -936,6 +949,7 @@ impl ars_core::Machine for Machine {
                 Some(State::Idle),
                 raw_files,
                 ctx.auto_upload,
+                true,
                 ctx,
                 |context: &mut Context| {
                     context.dragging = false;
@@ -981,6 +995,7 @@ impl ars_core::Machine for Machine {
                 None,
                 raw_files,
                 ctx.auto_upload,
+                true,
                 ctx,
                 |context: &mut Context| {
                     context.dragging = false;
@@ -995,6 +1010,7 @@ impl ars_core::Machine for Machine {
                     None,
                     raw_files,
                     auto_upload,
+                    false,
                     ctx,
                     |_| {},
                 ))
@@ -1025,21 +1041,18 @@ impl ars_core::Machine for Machine {
             (_, Event::RemoveFile { file_id }) => {
                 let file_id = file_id.clone();
                 let still_uploading = remove_file_updates(ctx, &file_id);
-                let proposed: Vec<Item> = ctx
-                    .files
-                    .get()
-                    .iter()
-                    .filter(|file| file.id != file_id)
-                    .cloned()
-                    .collect();
-                let changed = proposed.len() != ctx.files.get().len();
-                let plan =
-                    file_queue_plan(*state, still_uploading, move |context: &mut Context| {
+                let changed = ctx.files.get().iter().any(|file| file.id == file_id);
+                let plan = file_queue_plan(
+                    *state,
+                    still_uploading,
+                    ctx.dragging,
+                    move |context: &mut Context| {
                         remove_file_by_id(context, &file_id);
-                    });
+                    },
+                );
 
                 Some(if changed {
-                    plan.with_effect(files_change_effect(proposed))
+                    plan.with_effect(files_change_effect())
                 } else {
                     plan
                 })
@@ -1053,7 +1066,7 @@ impl ars_core::Machine for Machine {
                 });
 
                 Some(if had_files {
-                    plan.with_effect(files_change_effect(Vec::new()))
+                    plan.with_effect(files_change_effect())
                 } else {
                     plan
                 })
@@ -1081,6 +1094,7 @@ impl ars_core::Machine for Machine {
                 Some(file_queue_plan(
                     *state,
                     still_uploading,
+                    ctx.dragging,
                     move |context: &mut Context| {
                         cancel_file_by_id(context, &file_id);
                     },
@@ -1735,20 +1749,29 @@ fn format_file_size_with_locale(bytes: u64, locale: &Locale) -> String {
 
 /// Effect that invokes [`Props::on_files_change`] with the updated queue, so a
 /// controlled parent can sync its `files` prop after a set change.
-fn files_change_effect(files: Vec<Item>) -> PendingEffect<Machine> {
-    PendingEffect::new(Effect::FilesChanged, move |_ctx, props: &Props, _send| {
-        if let Some(callback) = &props.on_files_change {
-            callback(files);
-        }
+fn files_change_effect() -> PendingEffect<Machine> {
+    // Read the queue from the context snapshot the adapter passes at run time,
+    // which is taken *after* the event queue fully drains. This way an
+    // `auto_upload` selection reports the post-`StartUpload` queue (files marked
+    // `Uploading`) rather than the intermediate `Pending` snapshot, so a
+    // controlled parent writes back the correct state.
+    PendingEffect::new(
+        Effect::FilesChanged,
+        |ctx: &Context, props: &Props, _send| {
+            if let Some(callback) = &props.on_files_change {
+                callback(ctx.files.get().clone());
+            }
 
-        no_cleanup()
-    })
+            no_cleanup()
+        },
+    )
 }
 
 fn apply_selected_files_plan(
     transition_to: Option<State>,
     raw: &[RawFile],
     auto_upload: bool,
+    from_drop: bool,
     ctx: &Context,
     before: impl FnOnce(&mut Context) + 'static,
 ) -> TransitionPlan<Machine> {
@@ -1762,11 +1785,9 @@ fn apply_selected_files_plan(
     let rejected_count = rejected.len();
 
     // `before` only touches drag state, so the queue is unchanged between here
-    // and `apply`; compute the full proposed list once for both the write and
-    // the `FilesChanged` callback.
+    // and `apply`; build the full proposed list once.
     let mut proposed = ctx.files.get().clone();
     proposed.extend(accepted);
-    let files_changed = (accepted_count > 0).then(|| proposed.clone());
 
     let mut plan = if let Some(state) = transition_to {
         TransitionPlan::to(state)
@@ -1786,6 +1807,7 @@ fn apply_selected_files_plan(
     if accepted_count > 0 {
         plan = plan.with_effect(PendingEffect::named(Effect::AnnounceFilesAdded {
             count: accepted_count,
+            from_drop,
         }));
     }
 
@@ -1795,8 +1817,8 @@ fn apply_selected_files_plan(
         }));
     }
 
-    if let Some(files) = files_changed {
-        plan = plan.with_effect(files_change_effect(files));
+    if accepted_count > 0 {
+        plan = plan.with_effect(files_change_effect());
     }
 
     if auto_upload {
@@ -1809,10 +1831,11 @@ fn apply_selected_files_plan(
 fn file_queue_plan(
     state: State,
     still_uploading: bool,
+    dragging: bool,
     apply: impl FnOnce(&mut Context) + 'static,
 ) -> TransitionPlan<Machine> {
     if matches!(state, State::Uploading) && !still_uploading {
-        TransitionPlan::to(State::Idle).apply(apply)
+        TransitionPlan::to(finished_uploading_state(dragging)).apply(apply)
     } else {
         TransitionPlan::context_only(apply)
     }
@@ -1820,12 +1843,27 @@ fn file_queue_plan(
 
 fn upload_finish_plan(
     still_uploading: bool,
+    dragging: bool,
     apply: impl FnOnce(&mut Context) + 'static,
 ) -> TransitionPlan<Machine> {
     if still_uploading {
         TransitionPlan::context_only(apply)
     } else {
-        TransitionPlan::to(State::Idle).apply(apply)
+        TransitionPlan::to(finished_uploading_state(dragging)).apply(apply)
+    }
+}
+
+/// The resting state to enter when the last active upload finishes.
+///
+/// If a drag is still in progress, return to [`State::DragOver`] (preserving the
+/// drag flags) so the `DragOver` drag-leave/drop path can clear them — otherwise
+/// a `DragLeave` would be ignored by the `Idle` table and leave `data-ars-dragging`
+/// stuck. With no drag in progress, settle in [`State::Idle`].
+const fn finished_uploading_state(dragging: bool) -> State {
+    if dragging {
+        State::DragOver
+    } else {
+        State::Idle
     }
 }
 

--- a/crates/ars-components/src/specialized/file_upload/mod.rs
+++ b/crates/ars-components/src/specialized/file_upload/mod.rs
@@ -281,8 +281,21 @@ pub struct Context {
     /// Whether the dropzone is a directory upload.
     pub directory: bool,
 
+    /// Camera selection for mobile capture (`"user"` front, `"environment"` rear).
+    pub capture: Option<String>,
+
+    /// Name for form submission.
+    pub name: Option<String>,
+
     /// Drag-over nesting counter (for nested elements).
     pub drag_counter: u32,
+
+    /// Monotonic counter for the next generated file id.
+    ///
+    /// Only ever increases, so ids are never reused after files are removed —
+    /// preventing late async upload events from being applied to a different
+    /// file that happened to reuse an earlier id.
+    pub next_file_id: u64,
 
     /// Focused part.
     pub focused_part: Option<&'static str>,
@@ -617,6 +630,8 @@ impl ars_core::Machine for Machine {
 
         let ids = ComponentIds::from_id(&props.id);
 
+        let next_file_id = next_id_after(files.get());
+
         (
             State::Idle,
             Context {
@@ -633,7 +648,10 @@ impl ars_core::Machine for Machine {
                 max_files: props.max_files,
                 auto_upload: props.auto_upload,
                 directory: props.directory,
+                capture: props.capture.clone(),
+                name: props.name.clone(),
                 drag_counter: 0,
+                next_file_id,
                 focused_part: None,
                 locale: env.locale.clone(),
                 messages: messages.clone(),
@@ -655,20 +673,41 @@ impl ars_core::Machine for Machine {
         match event {
             Event::SetFiles(files) => {
                 let files = files.clone();
-                return Some(TransitionPlan::context_only(
-                    move |context: &mut Context| {
-                        if let Some(files) = files {
-                            context.files.set(files.clone());
-                            context.files.sync_controlled(Some(files));
-                        } else {
-                            context.files.sync_controlled(None);
-                        }
-                    },
-                ));
+
+                // An externally replaced queue must reconcile the machine state:
+                // a controlled parent can drop the last uploading file (or add a
+                // new uploading one), and the state must follow so `is_uploading`
+                // and `data-ars-state` stay truthful.
+                let target = files
+                    .as_deref()
+                    .and_then(|files| reconciled_state(*state, files));
+
+                let apply = move |context: &mut Context| {
+                    if let Some(files) = files {
+                        context.next_file_id = context.next_file_id.max(next_id_after(&files));
+                        context.files.set(files.clone());
+                        context.files.sync_controlled(Some(files));
+                    } else {
+                        context.files.sync_controlled(None);
+                    }
+                };
+
+                return Some(match target {
+                    Some(state) => TransitionPlan::to(state).apply(apply),
+                    None => TransitionPlan::context_only(apply),
+                });
             }
 
             Event::SetProps => {
-                return Some(TransitionPlan::context_only({
+                // Becoming disabled/read-only while a drag is in progress would
+                // otherwise trap the machine: the guard below swallows the
+                // `DragLeave`/`Drop` that would normally clear `dragging`, so the
+                // dropzone would stay stuck in its drag-over UI/ARIA state. Reset
+                // to `Idle` and clear the drag flags as part of the sync.
+                let reset_drag =
+                    (props.disabled || props.readonly) && matches!(state, State::DragOver);
+
+                let apply = {
                     let disabled = props.disabled;
                     let readonly = props.readonly;
                     let required = props.required;
@@ -679,6 +718,8 @@ impl ars_core::Machine for Machine {
                     let max_files = props.max_files;
                     let auto_upload = props.auto_upload;
                     let directory = props.directory;
+                    let capture = props.capture.clone();
+                    let name = props.name.clone();
 
                     move |context: &mut Context| {
                         context.disabled = disabled;
@@ -691,8 +732,21 @@ impl ars_core::Machine for Machine {
                         context.max_files = max_files;
                         context.auto_upload = auto_upload;
                         context.directory = directory;
+                        context.capture = capture;
+                        context.name = name;
+
+                        if reset_drag {
+                            context.dragging = false;
+                            context.drag_counter = 0;
+                        }
                     }
-                }));
+                };
+
+                return Some(if reset_drag {
+                    TransitionPlan::to(State::Idle).apply(apply)
+                } else {
+                    TransitionPlan::context_only(apply)
+                });
             }
 
             Event::UploadProgress { file_id, progress } if matches!(state, State::Uploading) => {
@@ -914,6 +968,8 @@ impl ars_core::Machine for Machine {
             || old.max_files != new.max_files
             || old.auto_upload != new.auto_upload
             || old.directory != new.directory
+            || old.capture != new.capture
+            || old.name != new.name
         {
             events.push(Event::SetProps);
         }
@@ -1306,11 +1362,11 @@ impl Api<'_> {
             attrs.set(HtmlAttr::WebkitDirectory, "");
         }
 
-        if let Some(ref capture) = self.props.capture {
+        if let Some(ref capture) = self.ctx.capture {
             attrs.set(HtmlAttr::Capture, capture);
         }
 
-        if let Some(ref name) = self.props.name {
+        if let Some(ref name) = self.ctx.name {
             attrs.set(HtmlAttr::Name, name);
         }
 
@@ -1502,8 +1558,11 @@ fn apply_selected_files_plan(
     plan = plan.apply(move |context: &mut Context| {
         before(context);
 
-        let (accepted, rejected) = validate_files(&raw, context);
+        let mut next_file_id = context.next_file_id;
 
+        let (accepted, rejected) = validate_files(&raw, context, &mut next_file_id);
+
+        context.next_file_id = next_file_id;
         context.rejected_files = rejected;
 
         let mut current = context.files.get().clone();
@@ -1575,7 +1634,10 @@ fn update_file_progress(context: &mut Context, file_id: &str, progress: f64) {
     let updated = files
         .into_iter()
         .map(|mut file| {
-            if file.id == file_id {
+            // Only the actively uploading file accepts progress: a late callback
+            // for a file that was already cancelled/failed/completed must not
+            // mutate its terminal progress.
+            if file.id == file_id && file.status == Status::Uploading {
                 file.progress = progress;
             }
             file
@@ -1713,7 +1775,14 @@ fn cancel_file_by_id(context: &mut Context, file_id: &str) {
 }
 
 /// Validate raw files against context constraints.
-fn validate_files(raw: &[RawFile], ctx: &Context) -> (Vec<Item>, Vec<Rejection>) {
+///
+/// `next_file_id` is the machine's monotonic id counter; each accepted file
+/// consumes the next value and advances it so ids are never reused.
+fn validate_files(
+    raw: &[RawFile],
+    ctx: &Context,
+    next_file_id: &mut u64,
+) -> (Vec<Item>, Vec<Rejection>) {
     let mut accepted = Vec::new();
     let mut rejected = Vec::new();
 
@@ -1782,7 +1851,7 @@ fn validate_files(raw: &[RawFile], ctx: &Context) -> (Vec<Item>, Vec<Rejection>)
         }
 
         accepted.push(Item {
-            id: generate_file_id(ctx, &accepted),
+            id: generate_file_id(next_file_id),
             name: file.name.clone(),
             size: file.size,
             mime_type: file.mime_type.clone(),
@@ -1795,17 +1864,43 @@ fn validate_files(raw: &[RawFile], ctx: &Context) -> (Vec<Item>, Vec<Rejection>)
     (accepted, rejected)
 }
 
-fn generate_file_id(ctx: &Context, pending_accepted: &[Item]) -> String {
-    let max_existing = ctx
-        .files
-        .get()
+/// Consumes the next monotonic file id and advances the counter.
+fn generate_file_id(next_file_id: &mut u64) -> String {
+    let id = *next_file_id;
+
+    *next_file_id = next_file_id.saturating_add(1);
+
+    format!("file-{id}")
+}
+
+/// The next monotonic id that sits strictly above every `file-N` id in `files`.
+///
+/// Used to seed [`Context::next_file_id`] at init and to advance it past
+/// externally supplied ids on [`Event::SetFiles`].
+fn next_id_after(files: &[Item]) -> u64 {
+    files
         .iter()
-        .chain(pending_accepted.iter())
         .filter_map(|file| file.id.strip_prefix("file-")?.parse::<u64>().ok())
         .max()
-        .unwrap_or(0);
+        .unwrap_or(0)
+        .saturating_add(1)
+}
 
-    format!("file-{}", max_existing.saturating_add(1))
+/// Reconciles the machine state with an externally replaced file set.
+///
+/// `State::Uploading` must hold exactly when at least one file is uploading, so
+/// a controlled queue replacement that adds or removes the last uploading file
+/// drives the resting state between [`State::Idle`] and [`State::Uploading`].
+/// Returns `None` when no state change is required (including while in
+/// [`State::DragOver`], whose transient drag lifecycle is left untouched).
+fn reconciled_state(current: State, files: &[Item]) -> Option<State> {
+    let any_uploading = files.iter().any(|file| file.status == Status::Uploading);
+
+    match (current, any_uploading) {
+        (State::Uploading, false) => Some(State::Idle),
+        (State::Idle, true) => Some(State::Uploading),
+        _ => None,
+    }
 }
 
 fn mime_matches(mime: &str, name: &str, patterns: &[String]) -> bool {

--- a/crates/ars-components/src/specialized/file_upload/mod.rs
+++ b/crates/ars-components/src/specialized/file_upload/mod.rs
@@ -375,11 +375,12 @@ pub struct Props {
     /// Name for form submission.
     pub name: Option<String>,
 
-    /// Invoked with the updated queue when the file set changes.
+    /// Invoked with the updated working queue when the file set changes
+    /// (selection, drop, removal, clear).
     ///
-    /// Required for controlled mode (`files: Some(...)`): the parent uses it to
-    /// sync its controlled `files` prop after a selection, drop, removal, or
-    /// clear. Fired via [`Effect::FilesChanged`].
+    /// An **observation** hook: the component owns its working queue, and this
+    /// lets the parent mirror it into its own state (e.g. to persist or to seed
+    /// the controlled `files` prop). Fired via [`Effect::FilesChanged`].
     pub on_files_change: Option<Callback<dyn Fn(Vec<Item>) + Send + Sync>>,
 
     /// Component instance ID.
@@ -671,11 +672,11 @@ pub enum Effect {
     /// Adapter announces (polite) that an upload completed.
     AnnounceUploadComplete,
 
-    /// Adapter invokes [`Props::on_files_change`] with the updated queue.
+    /// Adapter invokes [`Props::on_files_change`] with the updated working queue.
     ///
     /// Emitted whenever the file *set* changes (selection, drop, removal, clear)
-    /// so a controlled parent can sync its `files` prop. The new queue rides in
-    /// the effect's setup closure, not in this `Copy` marker.
+    /// so the parent can observe it. The queue is read from the run-time context
+    /// snapshot when the effect runs, not carried in this `Copy` marker.
     FilesChanged,
 
     /// Adapter opens the native file picker via the hidden input.
@@ -1876,13 +1877,18 @@ const fn finished_uploading_state(dragging: bool) -> State {
     }
 }
 
-/// Writes the queue, mirroring it into the controlled value when controlled.
+/// Writes the working upload queue.
 ///
-/// In controlled mode `Bindable::get` returns the parent's value, so a bare
-/// `set` (internal-only) would leave [`Api::files`] showing the stale list. This
-/// optimistically syncs the controlled value too, so the queue is visible
-/// immediately; the parent then confirms it via [`Event::SetFiles`] (driven by
-/// the [`Effect::FilesChanged`] callback on set changes).
+/// `FileUpload` **owns its working queue** (the in-flight upload list): `Api::files`
+/// and every lifecycle operation read it, in both controlled and uncontrolled
+/// mode — like `react-dropzone` and similar libraries. The controlled `files`
+/// prop is a *seed/sync* source (applied at `init` and on [`Event::SetFiles`]),
+/// and [`Props::on_files_change`] lets the parent observe changes; the parent
+/// does not veto an in-flight queue mid-edit.
+///
+/// To keep `Bindable::get` returning the working queue in controlled mode (where
+/// it would otherwise return the parent's seed value), this mirrors the queue
+/// into the controlled slot as well.
 fn commit_files(context: &mut Context, files: Vec<Item>) {
     if context.files.is_controlled() {
         context.files.sync_controlled(Some(files.clone()));

--- a/crates/ars-components/src/specialized/file_upload/mod.rs
+++ b/crates/ars-components/src/specialized/file_upload/mod.rs
@@ -224,6 +224,14 @@ pub enum Event {
 
     /// Synchronize output-affecting props stored in context.
     SetProps,
+
+    /// Reconcile the machine state with the currently visible file queue.
+    ///
+    /// Chained after [`Event::SetFiles`] so the resting state (`Idle` vs
+    /// `Uploading`) tracks the queue revealed by the sync — whether that is a
+    /// freshly controlled value or the internal value exposed when control is
+    /// released.
+    ReconcileState,
 }
 
 /// Raw file data from the browser File API, prior to validation.
@@ -599,10 +607,37 @@ impl Default for Messages {
 impl ComponentMessages for Messages {}
 
 /// Typed effect intents emitted by the file upload machine.
+///
+/// Announcement variants drive the accessible live regions described in the
+/// spec (§3.3, §4.2). On each, the adapter resolves the user-facing text from
+/// the corresponding [`Messages`] field — using the carried `count` for the
+/// pluralized add/reject messages — and writes it to the live region.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum Effect {
-    /// Adapter announces that the dropzone is active.
+    /// Adapter announces (assertive) that the dropzone became active, via
+    /// [`Messages::dropzone_active`].
     AnnounceDropzoneActive,
+
+    /// Adapter announces (assertive) that the dropzone is no longer active, via
+    /// [`Messages::drop_zone_left`].
+    AnnounceDropzoneLeft,
+
+    /// Adapter announces (polite) that files were added, via
+    /// [`Messages::files_added`] with `count`.
+    AnnounceFilesAdded {
+        /// Number of files accepted in this selection/drop.
+        count: usize,
+    },
+
+    /// Adapter announces (polite) that files were rejected, via
+    /// [`Messages::rejection_message`] with `count`.
+    AnnounceFilesRejected {
+        /// Number of files rejected in this selection/drop.
+        count: usize,
+    },
+
+    /// Adapter announces (polite) that an upload completed.
+    AnnounceUploadComplete,
 
     /// Adapter opens the native file picker via the hidden input.
     OpenFilePicker,
@@ -674,14 +709,6 @@ impl ars_core::Machine for Machine {
             Event::SetFiles(files) => {
                 let files = files.clone();
 
-                // An externally replaced queue must reconcile the machine state:
-                // a controlled parent can drop the last uploading file (or add a
-                // new uploading one), and the state must follow so `is_uploading`
-                // and `data-ars-state` stay truthful.
-                let target = files
-                    .as_deref()
-                    .and_then(|files| reconciled_state(*state, files));
-
                 let apply = move |context: &mut Context| {
                     if let Some(files) = files {
                         context.next_file_id = context.next_file_id.max(next_id_after(&files));
@@ -692,10 +719,19 @@ impl ars_core::Machine for Machine {
                     }
                 };
 
-                return Some(match target {
-                    Some(state) => TransitionPlan::to(state).apply(apply),
-                    None => TransitionPlan::context_only(apply),
-                });
+                // Reconcile after the sync lands: chaining `ReconcileState` lets
+                // the same path handle both a freshly controlled value and the
+                // internal value revealed when control is released (`None`), which
+                // is not visible until `sync_controlled` runs.
+                return Some(TransitionPlan::context_only(apply).then(Event::ReconcileState));
+            }
+
+            Event::ReconcileState => {
+                // `State::Uploading` must hold exactly when at least one file is
+                // uploading. Drive the resting state between `Idle` and
+                // `Uploading` to match the currently visible queue; `DragOver`'s
+                // transient drag lifecycle is left untouched.
+                return reconciled_state(*state, ctx.files.get()).map(TransitionPlan::to);
             }
 
             Event::SetProps => {
@@ -761,13 +797,23 @@ impl ars_core::Machine for Machine {
 
             Event::UploadComplete { file_id } if matches!(state, State::Uploading) => {
                 let file_id = file_id.clone();
+                // Only announce when this event actually completes a file that
+                // was still uploading (a late duplicate for a terminal file is a
+                // no-op and must stay silent).
+                let did_complete = ctx
+                    .files
+                    .get()
+                    .iter()
+                    .any(|file| file.id == file_id && file.status == Status::Uploading);
                 let still_uploading = upload_complete_updates(ctx, &file_id);
-                return Some(upload_finish_plan(
-                    still_uploading,
-                    move |context: &mut Context| {
-                        apply_upload_complete(context, &file_id);
-                    },
-                ));
+                let plan = upload_finish_plan(still_uploading, move |context: &mut Context| {
+                    apply_upload_complete(context, &file_id);
+                });
+                return Some(if did_complete {
+                    plan.with_effect(PendingEffect::named(Effect::AnnounceUploadComplete))
+                } else {
+                    plan
+                });
             }
 
             Event::UploadError { file_id, error } if matches!(state, State::Uploading) => {
@@ -827,10 +873,12 @@ impl ars_core::Machine for Machine {
 
                 if new_counter == 0 {
                     Some(
-                        TransitionPlan::to(State::Idle).apply(|context: &mut Context| {
-                            context.drag_counter = 0;
-                            context.dragging = false;
-                        }),
+                        TransitionPlan::to(State::Idle)
+                            .apply(|context: &mut Context| {
+                                context.drag_counter = 0;
+                                context.dragging = false;
+                            })
+                            .with_effect(PendingEffect::named(Effect::AnnounceDropzoneLeft)),
                     )
                 } else {
                     Some(TransitionPlan::context_only(
@@ -841,24 +889,27 @@ impl ars_core::Machine for Machine {
                 }
             }
 
-            (State::DragOver, Event::Drop(raw_files)) => {
-                let raw = raw_files.clone();
-                Some(apply_selected_files_plan(
-                    Some(State::Idle),
-                    raw,
-                    ctx.auto_upload,
-                    |context: &mut Context| {
-                        context.dragging = false;
-                        context.drag_counter = 0;
-                    },
-                ))
-            }
+            (State::DragOver, Event::Drop(raw_files)) => Some(apply_selected_files_plan(
+                Some(State::Idle),
+                raw_files,
+                ctx.auto_upload,
+                ctx,
+                |context: &mut Context| {
+                    context.dragging = false;
+                    context.drag_counter = 0;
+                },
+            )),
 
             (State::Idle, Event::FilesSelected(raw_files))
             | (State::Uploading, Event::FilesSelected(raw_files)) => {
-                let raw = raw_files.clone();
                 let auto_upload = ctx.auto_upload;
-                Some(apply_selected_files_plan(None, raw, auto_upload, |_| {}))
+                Some(apply_selected_files_plan(
+                    None,
+                    raw_files,
+                    auto_upload,
+                    ctx,
+                    |_| {},
+                ))
             }
 
             (State::Idle, Event::StartUpload) => {
@@ -1321,6 +1372,15 @@ impl Api<'_> {
             );
         }
 
+        // The transition guard ignores `RemoveFile` while disabled/read-only, so
+        // the delete control must read as inert too — matching the trigger and
+        // hidden input — rather than a focusable button that silently does nothing.
+        if self.ctx.disabled || self.ctx.readonly {
+            attrs
+                .set_bool(HtmlAttr::Disabled, true)
+                .set(HtmlAttr::Aria(AriaAttr::Disabled), "true");
+        }
+
         attrs
     }
 
@@ -1452,6 +1512,17 @@ impl Api<'_> {
         }
     }
 
+    /// Dispatches keyboard intent on the file item at `index`.
+    ///
+    /// Per the spec keyboard contract, <kbd>Delete</kbd>/<kbd>Backspace</kbd> on
+    /// a focused file item removes that file. The adapter passes the item's index
+    /// so the core can resolve the file id without tracking per-item focus.
+    pub fn on_item_keydown(&self, index: usize, data: &KeyboardEventData) {
+        if matches!(data.key, KeyboardKey::Delete | KeyboardKey::Backspace) {
+            self.on_item_delete_trigger_click(index);
+        }
+    }
+
     const fn state_token(&self) -> &'static str {
         match self.state {
             State::Idle => "idle",
@@ -1545,10 +1616,20 @@ fn format_file_size_with_locale(bytes: u64, locale: &Locale) -> String {
 
 fn apply_selected_files_plan(
     transition_to: Option<State>,
-    raw: Vec<RawFile>,
+    raw: &[RawFile],
     auto_upload: bool,
+    ctx: &Context,
     before: impl FnOnce(&mut Context) + 'static,
 ) -> TransitionPlan<Machine> {
+    // Validate up front (the `before` hook only touches drag state, never the
+    // fields validation reads) so the accepted/rejected counts are known when
+    // the announcement effects are attached — effects are fixed before `apply`
+    // runs.
+    let mut next_file_id = ctx.next_file_id;
+    let (accepted, rejected) = validate_files(raw, ctx, &mut next_file_id);
+    let accepted_count = accepted.len();
+    let rejected_count = rejected.len();
+
     let mut plan = if let Some(state) = transition_to {
         TransitionPlan::to(state)
     } else {
@@ -1557,10 +1638,6 @@ fn apply_selected_files_plan(
 
     plan = plan.apply(move |context: &mut Context| {
         before(context);
-
-        let mut next_file_id = context.next_file_id;
-
-        let (accepted, rejected) = validate_files(&raw, context, &mut next_file_id);
 
         context.next_file_id = next_file_id;
         context.rejected_files = rejected;
@@ -1571,6 +1648,18 @@ fn apply_selected_files_plan(
 
         context.files.set(current);
     });
+
+    if accepted_count > 0 {
+        plan = plan.with_effect(PendingEffect::named(Effect::AnnounceFilesAdded {
+            count: accepted_count,
+        }));
+    }
+
+    if rejected_count > 0 {
+        plan = plan.with_effect(PendingEffect::named(Effect::AnnounceFilesRejected {
+            count: rejected_count,
+        }));
+    }
 
     if auto_upload {
         plan = plan.then(Event::StartUpload);
@@ -1886,13 +1975,13 @@ fn next_id_after(files: &[Item]) -> u64 {
         .saturating_add(1)
 }
 
-/// Reconciles the machine state with an externally replaced file set.
+/// Reconciles the machine state with the currently visible file set.
 ///
 /// `State::Uploading` must hold exactly when at least one file is uploading, so
-/// a controlled queue replacement that adds or removes the last uploading file
-/// drives the resting state between [`State::Idle`] and [`State::Uploading`].
-/// Returns `None` when no state change is required (including while in
-/// [`State::DragOver`], whose transient drag lifecycle is left untouched).
+/// when [`Event::ReconcileState`] runs after a [`Event::SetFiles`] sync it drives
+/// the resting state between [`State::Idle`] and [`State::Uploading`] to match
+/// the visible queue. Returns `None` when no state change is required (including
+/// while in [`State::DragOver`], whose transient drag lifecycle is left untouched).
 fn reconciled_state(current: State, files: &[Item]) -> Option<State> {
     let any_uploading = files.iter().any(|file| file.status == Status::Uploading);
 
@@ -1932,11 +2021,17 @@ fn normalize_mime_type(mime_type: &str) -> String {
 }
 
 fn file_name_has_extension(name: &str, extension: &str) -> bool {
-    let Some(actual_extension) = name.rsplit_once('.').map(|(_, ext)| ext) else {
+    if extension.is_empty() {
         return false;
-    };
+    }
 
-    !actual_extension.is_empty() && actual_extension.eq_ignore_ascii_case(extension)
+    // Match the full dotted suffix so compound extensions (e.g. `.tar.gz`) match
+    // `archive.tar.gz`, not just the segment after the final dot. Browser
+    // `accept` extension tokens are matched case-insensitively against the
+    // filename suffix.
+    let suffix = format!(".{}", extension.to_ascii_lowercase());
+
+    name.to_ascii_lowercase().ends_with(&suffix)
 }
 
 #[cfg(test)]

--- a/crates/ars-components/src/specialized/file_upload/mod.rs
+++ b/crates/ars-components/src/specialized/file_upload/mod.rs
@@ -86,14 +86,22 @@ pub enum RejectionReason {
     /// File type not in the accepted list.
     InvalidType,
 
-    /// File exceeds the maximum size.
-    TooLarge,
+    /// File exceeds the maximum size, carrying the limit that was in effect at
+    /// rejection time so the message stays accurate if the prop later changes.
+    TooLarge {
+        /// The `max_file_size` (bytes) that the file exceeded.
+        max: u64,
+    },
 
     /// Adding this file would exceed the maximum count.
     TooMany,
 
-    /// File is smaller than the minimum size.
-    TooSmall,
+    /// File is smaller than the minimum size, carrying the limit in effect at
+    /// rejection time.
+    TooSmall {
+        /// The `min_file_size` (bytes) that the file fell below.
+        min: u64,
+    },
 
     /// Custom validation failed.
     CustomValidation(String),
@@ -1063,10 +1071,15 @@ impl ars_core::Machine for Machine {
 
             (_, Event::ClearFiles) => {
                 let had_files = !ctx.files.get().is_empty();
-                let plan = TransitionPlan::to(State::Idle).apply(|context: &mut Context| {
-                    commit_files(context, Vec::new());
-                    context.rejected_files.clear();
-                });
+                // Drag-aware (like the upload-finish paths): clearing mid-drag
+                // settles in DragOver so the drag-leave path clears the flags,
+                // rather than stranding `data-ars-dragging` in Idle.
+                let plan = TransitionPlan::to(finished_uploading_state(ctx.dragging)).apply(
+                    |context: &mut Context| {
+                        commit_files(context, Vec::new());
+                        context.rejected_files.clear();
+                    },
+                );
 
                 Some(if had_files {
                     plan.with_effect(files_change_effect())
@@ -1588,16 +1601,18 @@ impl Api<'_> {
     #[must_use]
     pub fn validation_error_text(&self, rejection: &Rejection) -> String {
         match &rejection.reason {
-            RejectionReason::TooLarge => {
-                (self.ctx.messages.too_large)(self.ctx.max_file_size.unwrap_or(0), &self.ctx.locale)
+            // Use the limit captured at rejection time, not the current prop
+            // (which may have been changed or cleared since).
+            RejectionReason::TooLarge { max } => {
+                (self.ctx.messages.too_large)(*max, &self.ctx.locale)
             }
 
             RejectionReason::InvalidType => (self.ctx.messages.wrong_type)(&self.ctx.locale),
 
             RejectionReason::TooMany => (self.ctx.messages.too_many_files)(&self.ctx.locale),
 
-            RejectionReason::TooSmall => {
-                (self.ctx.messages.too_small)(self.ctx.min_file_size.unwrap_or(0), &self.ctx.locale)
+            RejectionReason::TooSmall { min } => {
+                (self.ctx.messages.too_small)(*min, &self.ctx.locale)
             }
 
             RejectionReason::CustomValidation(message) => message.clone(),
@@ -1831,7 +1846,10 @@ fn apply_selected_files_plan(
         plan = plan.with_effect(files_change_effect());
     }
 
-    if auto_upload {
+    // Auto-upload is tied to a real accepted selection/drop: a zero-accept result
+    // (all rejected, or an empty/cancelled picker) must not start unrelated
+    // pending files already in the queue.
+    if auto_upload && accepted_count > 0 {
         plan = plan.then(Event::StartUpload);
     }
 
@@ -2127,7 +2145,7 @@ fn validate_files(
                 name: file.name.clone(),
                 size: file.size,
                 mime_type: file.mime_type.clone(),
-                reason: RejectionReason::TooLarge,
+                reason: RejectionReason::TooLarge { max: max_size },
             });
 
             continue;
@@ -2140,7 +2158,7 @@ fn validate_files(
                 name: file.name.clone(),
                 size: file.size,
                 mime_type: file.mime_type.clone(),
-                reason: RejectionReason::TooSmall,
+                reason: RejectionReason::TooSmall { min: min_size },
             });
 
             continue;

--- a/crates/ars-components/src/specialized/file_upload/mod.rs
+++ b/crates/ars-components/src/specialized/file_upload/mod.rs
@@ -4,8 +4,8 @@ use alloc::{format, string::String, vec::Vec};
 use core::fmt::{self, Debug, Display};
 
 use ars_core::{
-    AriaAttr, AttrMap, Bindable, ComponentIds, ComponentMessages, ComponentPart, ConnectApi, Env,
-    HasId, HtmlAttr, Locale, MessageFn, PendingEffect, TransitionPlan,
+    AriaAttr, AttrMap, Bindable, Callback, ComponentIds, ComponentMessages, ComponentPart,
+    ConnectApi, Env, HasId, HtmlAttr, Locale, MessageFn, PendingEffect, TransitionPlan, no_cleanup,
 };
 use ars_interactions::{KeyboardEventData, KeyboardKey};
 
@@ -375,6 +375,13 @@ pub struct Props {
     /// Name for form submission.
     pub name: Option<String>,
 
+    /// Invoked with the updated queue when the file set changes.
+    ///
+    /// Required for controlled mode (`files: Some(...)`): the parent uses it to
+    /// sync its controlled `files` prop after a selection, drop, removal, or
+    /// clear. Fired via [`Effect::FilesChanged`].
+    pub on_files_change: Option<Callback<dyn Fn(Vec<Item>) + Send + Sync>>,
+
     /// Component instance ID.
     pub id: String,
 }
@@ -518,6 +525,23 @@ impl Props {
         self.name = Some(name.into());
         self
     }
+
+    /// Sets [`on_files_change`](Self::on_files_change).
+    #[must_use]
+    pub fn on_files_change(
+        mut self,
+        callback: impl Into<Callback<dyn Fn(Vec<Item>) + Send + Sync>>,
+    ) -> Self {
+        self.on_files_change = Some(callback.into());
+        self
+    }
+
+    /// Clears [`on_files_change`](Self::on_files_change).
+    #[must_use]
+    pub fn clear_on_files_change(mut self) -> Self {
+        self.on_files_change = None;
+        self
+    }
 }
 
 type LocaleMessageFn = dyn Fn(&Locale) -> String + Send + Sync;
@@ -639,6 +663,13 @@ pub enum Effect {
     /// Adapter announces (polite) that an upload completed.
     AnnounceUploadComplete,
 
+    /// Adapter invokes [`Props::on_files_change`] with the updated queue.
+    ///
+    /// Emitted whenever the file *set* changes (selection, drop, removal, clear)
+    /// so a controlled parent can sync its `files` prop. The new queue rides in
+    /// the effect's setup closure, not in this `Copy` marker.
+    FilesChanged,
+
     /// Adapter opens the native file picker via the hidden input.
     OpenFilePicker,
 }
@@ -667,8 +698,14 @@ impl ars_core::Machine for Machine {
 
         let next_file_id = next_id_after(files.get());
 
+        // Honor the `State::Uploading` invariant from the start: a queue seeded
+        // (controlled or default) with an uploading item must boot in `Uploading`,
+        // not `Idle`, so progress/complete/error events are not dropped by the
+        // `State::Uploading` guards before any prop sync runs.
+        let initial_state = reconciled_state(State::Idle, files.get()).unwrap_or(State::Idle);
+
         (
-            State::Idle,
+            initial_state,
             Context {
                 files,
                 rejected_files: Vec::new(),
@@ -900,6 +937,51 @@ impl ars_core::Machine for Machine {
                 },
             )),
 
+            // Drag-and-drop stays available during an active upload, mirroring
+            // `FilesSelected` (which is handled in `Uploading`). Drag is tracked via
+            // the `dragging`/`drag_counter` context flags without leaving the
+            // `Uploading` state, so the queue and `data-ars-state` stay truthful.
+            (State::Uploading, Event::DragEnter) => {
+                let first = ctx.drag_counter == 0;
+                let plan = TransitionPlan::context_only(move |context: &mut Context| {
+                    context.drag_counter = context.drag_counter.saturating_add(1);
+                    context.dragging = true;
+                });
+
+                Some(if first {
+                    plan.with_effect(PendingEffect::named(Effect::AnnounceDropzoneActive))
+                } else {
+                    plan
+                })
+            }
+
+            (State::Uploading, Event::DragLeave) => {
+                let new_counter = ctx.drag_counter.saturating_sub(1);
+                let plan = TransitionPlan::context_only(move |context: &mut Context| {
+                    context.drag_counter = new_counter;
+                    if new_counter == 0 {
+                        context.dragging = false;
+                    }
+                });
+
+                Some(if new_counter == 0 {
+                    plan.with_effect(PendingEffect::named(Effect::AnnounceDropzoneLeft))
+                } else {
+                    plan
+                })
+            }
+
+            (State::Uploading, Event::Drop(raw_files)) => Some(apply_selected_files_plan(
+                None,
+                raw_files,
+                ctx.auto_upload,
+                ctx,
+                |context: &mut Context| {
+                    context.dragging = false;
+                    context.drag_counter = 0;
+                },
+            )),
+
             (State::Idle, Event::FilesSelected(raw_files))
             | (State::Uploading, Event::FilesSelected(raw_files)) => {
                 let auto_upload = ctx.auto_upload;
@@ -937,29 +1019,54 @@ impl ars_core::Machine for Machine {
             (_, Event::RemoveFile { file_id }) => {
                 let file_id = file_id.clone();
                 let still_uploading = remove_file_updates(ctx, &file_id);
-                Some(file_queue_plan(
-                    *state,
-                    still_uploading,
-                    move |context: &mut Context| {
+                let proposed: Vec<Item> = ctx
+                    .files
+                    .get()
+                    .iter()
+                    .filter(|file| file.id != file_id)
+                    .cloned()
+                    .collect();
+                let changed = proposed.len() != ctx.files.get().len();
+                let plan =
+                    file_queue_plan(*state, still_uploading, move |context: &mut Context| {
                         remove_file_by_id(context, &file_id);
-                    },
-                ))
+                    });
+
+                Some(if changed {
+                    plan.with_effect(files_change_effect(proposed))
+                } else {
+                    plan
+                })
             }
 
-            (_, Event::ClearFiles) => Some(TransitionPlan::to(State::Idle).apply(
-                |context: &mut Context| {
-                    context.files.set(Vec::new());
+            (_, Event::ClearFiles) => {
+                let had_files = !ctx.files.get().is_empty();
+                let plan = TransitionPlan::to(State::Idle).apply(|context: &mut Context| {
+                    commit_files(context, Vec::new());
                     context.rejected_files.clear();
-                },
-            )),
+                });
+
+                Some(if had_files {
+                    plan.with_effect(files_change_effect(Vec::new()))
+                } else {
+                    plan
+                })
+            }
 
             (_, Event::RetryFile { file_id }) => {
                 let file_id = file_id.clone();
-                Some(TransitionPlan::context_only(
-                    move |context: &mut Context| {
-                        retry_file_by_id(context, &file_id);
-                    },
-                ))
+                let plan = TransitionPlan::context_only(move |context: &mut Context| {
+                    retry_file_by_id(context, &file_id);
+                });
+
+                // Mirror `FilesSelected`: when `auto_upload` is set, retrying a
+                // failed file re-queues it as `Pending` and immediately resumes
+                // uploading, so the retry control is not a silent no-op.
+                Some(if ctx.auto_upload {
+                    plan.then(Event::StartUpload)
+                } else {
+                    plan
+                })
             }
 
             (_, Event::CancelFile { file_id }) => {
@@ -1410,7 +1517,9 @@ impl Api<'_> {
             .set(HtmlAttr::TabIndex, "-1")
             .set(HtmlAttr::Class, "ars-sr-input");
 
-        if self.ctx.multiple {
+        // Directory uploads inherently select multiple files, so reflect that on
+        // the native input too.
+        if self.ctx.multiple || self.ctx.directory {
             attrs.set_bool(HtmlAttr::Multiple, true);
         }
 
@@ -1614,6 +1723,18 @@ fn format_file_size_with_locale(bytes: u64, locale: &Locale) -> String {
     format!("{number} {suffix}")
 }
 
+/// Effect that invokes [`Props::on_files_change`] with the updated queue, so a
+/// controlled parent can sync its `files` prop after a set change.
+fn files_change_effect(files: Vec<Item>) -> PendingEffect<Machine> {
+    PendingEffect::new(Effect::FilesChanged, move |_ctx, props: &Props, _send| {
+        if let Some(callback) = &props.on_files_change {
+            callback(files);
+        }
+
+        no_cleanup()
+    })
+}
+
 fn apply_selected_files_plan(
     transition_to: Option<State>,
     raw: &[RawFile],
@@ -1630,6 +1751,13 @@ fn apply_selected_files_plan(
     let accepted_count = accepted.len();
     let rejected_count = rejected.len();
 
+    // `before` only touches drag state, so the queue is unchanged between here
+    // and `apply`; compute the full proposed list once for both the write and
+    // the `FilesChanged` callback.
+    let mut proposed = ctx.files.get().clone();
+    proposed.extend(accepted);
+    let files_changed = (accepted_count > 0).then(|| proposed.clone());
+
     let mut plan = if let Some(state) = transition_to {
         TransitionPlan::to(state)
     } else {
@@ -1642,11 +1770,7 @@ fn apply_selected_files_plan(
         context.next_file_id = next_file_id;
         context.rejected_files = rejected;
 
-        let mut current = context.files.get().clone();
-
-        current.extend(accepted);
-
-        context.files.set(current);
+        commit_files(context, proposed);
     });
 
     if accepted_count > 0 {
@@ -1659,6 +1783,10 @@ fn apply_selected_files_plan(
         plan = plan.with_effect(PendingEffect::named(Effect::AnnounceFilesRejected {
             count: rejected_count,
         }));
+    }
+
+    if let Some(files) = files_changed {
+        plan = plan.with_effect(files_change_effect(files));
     }
 
     if auto_upload {
@@ -1691,6 +1819,21 @@ fn upload_finish_plan(
     }
 }
 
+/// Writes the queue, mirroring it into the controlled value when controlled.
+///
+/// In controlled mode `Bindable::get` returns the parent's value, so a bare
+/// `set` (internal-only) would leave [`Api::files`] showing the stale list. This
+/// optimistically syncs the controlled value too, so the queue is visible
+/// immediately; the parent then confirms it via [`Event::SetFiles`] (driven by
+/// the [`Effect::FilesChanged`] callback on set changes).
+fn commit_files(context: &mut Context, files: Vec<Item>) {
+    if context.files.is_controlled() {
+        context.files.sync_controlled(Some(files.clone()));
+    }
+
+    context.files.set(files);
+}
+
 fn mark_pending_as_uploading(context: &mut Context) {
     let files = context.files.get().clone();
 
@@ -1704,7 +1847,7 @@ fn mark_pending_as_uploading(context: &mut Context) {
         })
         .collect();
 
-    context.files.set(updated);
+    commit_files(context, updated);
 }
 
 #[expect(clippy::missing_const_for_fn, reason = "f64::is_nan is not const")]
@@ -1733,7 +1876,7 @@ fn update_file_progress(context: &mut Context, file_id: &str, progress: f64) {
         })
         .collect();
 
-    context.files.set(updated);
+    commit_files(context, updated);
 }
 
 fn upload_complete_updates(ctx: &Context, file_id: &str) -> bool {
@@ -1814,15 +1957,13 @@ fn projected_files_after_cancel(ctx: &Context, file_id: &str) -> Vec<Item> {
 }
 
 fn apply_upload_complete(context: &mut Context, file_id: &str) {
-    context
-        .files
-        .set(projected_files_after_complete(context, file_id));
+    let updated = projected_files_after_complete(context, file_id);
+    commit_files(context, updated);
 }
 
 fn apply_upload_error(context: &mut Context, file_id: &str, error: &str) {
-    context
-        .files
-        .set(projected_files_after_error(context, file_id, error));
+    let updated = projected_files_after_error(context, file_id, error);
+    commit_files(context, updated);
 }
 
 fn remove_file_by_id(context: &mut Context, file_id: &str) {
@@ -1834,7 +1975,7 @@ fn remove_file_by_id(context: &mut Context, file_id: &str) {
         .cloned()
         .collect();
 
-    context.files.set(updated);
+    commit_files(context, updated);
 }
 
 fn retry_file_by_id(context: &mut Context, file_id: &str) {
@@ -1854,13 +1995,12 @@ fn retry_file_by_id(context: &mut Context, file_id: &str) {
         })
         .collect();
 
-    context.files.set(updated);
+    commit_files(context, updated);
 }
 
 fn cancel_file_by_id(context: &mut Context, file_id: &str) {
-    context
-        .files
-        .set(projected_files_after_cancel(context, file_id));
+    let updated = projected_files_after_cancel(context, file_id);
+    commit_files(context, updated);
 }
 
 /// Validate raw files against context constraints.
@@ -1877,8 +2017,12 @@ fn validate_files(
 
     let current_count = ctx.files.get().len();
 
+    // A directory upload imports a folder's contents, so it accepts many files
+    // regardless of `multiple`; only `max_files` constrains it.
+    let single_file = !ctx.multiple && !ctx.directory;
+
     for file in raw {
-        if !ctx.multiple && (current_count >= 1 || !accepted.is_empty()) {
+        if single_file && (current_count >= 1 || !accepted.is_empty()) {
             rejected.push(Rejection {
                 name: file.name.clone(),
                 size: file.size,

--- a/crates/ars-components/src/specialized/file_upload/mod.rs
+++ b/crates/ars-components/src/specialized/file_upload/mod.rs
@@ -765,9 +765,9 @@ impl ars_core::Machine for Machine {
 
             Event::ReconcileState => {
                 // `State::Uploading` must hold exactly when at least one file is
-                // uploading. Drive the resting state between `Idle` and
-                // `Uploading` to match the currently visible queue; `DragOver`'s
-                // transient drag lifecycle is left untouched.
+                // uploading. Drive the resting state to match the currently
+                // visible queue (including entering `Uploading` from `DragOver`
+                // when a controlled upload begins mid-drag).
                 return reconciled_state(*state, ctx.files.get()).map(TransitionPlan::to);
             }
 
@@ -775,10 +775,16 @@ impl ars_core::Machine for Machine {
                 // Becoming disabled/read-only while a drag is in progress would
                 // otherwise trap the machine: the guard below swallows the
                 // `DragLeave`/`Drop` that would normally clear `dragging`, so the
-                // dropzone would stay stuck in its drag-over UI/ARIA state. Reset
-                // to `Idle` and clear the drag flags as part of the sync.
-                let reset_drag =
-                    (props.disabled || props.readonly) && matches!(state, State::DragOver);
+                // dropzone would stay stuck in its drag UI/ARIA state. Clear the
+                // drag flags as part of the sync — from `DragOver` that also means
+                // returning to `Idle`; while `Uploading` (a drag started via the
+                // uploading drag-enter path) the upload must continue, so only the
+                // flags are cleared.
+                let becoming_inert = props.disabled || props.readonly;
+                let reset_to_idle = becoming_inert && matches!(state, State::DragOver);
+                let clear_upload_drag =
+                    becoming_inert && matches!(state, State::Uploading) && ctx.dragging;
+                let clear_drag = reset_to_idle || clear_upload_drag;
 
                 let apply = {
                     let disabled = props.disabled;
@@ -808,14 +814,14 @@ impl ars_core::Machine for Machine {
                         context.capture = capture;
                         context.name = name;
 
-                        if reset_drag {
+                        if clear_drag {
                             context.dragging = false;
                             context.drag_counter = 0;
                         }
                     }
                 };
 
-                return Some(if reset_drag {
+                return Some(if reset_to_idle {
                     TransitionPlan::to(State::Idle).apply(apply)
                 } else {
                     TransitionPlan::context_only(apply)
@@ -1425,6 +1431,10 @@ impl Api<'_> {
         if let Some(file) = self.ctx.files.get().get(index) {
             attrs
                 .set(HtmlAttr::Role, "listitem")
+                // Keyboard-focusable so the spec's Tab-to-item / Delete-Backspace
+                // removal flow (`on_item_keydown`) is reachable — a plain listitem
+                // is skipped by sequential focus.
+                .set(HtmlAttr::TabIndex, "0")
                 .set(HtmlAttr::Data("ars-state"), item_status_token(&file.status))
                 .set(HtmlAttr::Data("ars-file-id"), &file.id)
                 .set(
@@ -2131,7 +2141,11 @@ fn reconciled_state(current: State, files: &[Item]) -> Option<State> {
 
     match (current, any_uploading) {
         (State::Uploading, false) => Some(State::Idle),
-        (State::Idle, true) => Some(State::Uploading),
+        // A controlled queue can begin an upload while a drag is in progress.
+        // Enter `Uploading` (keeping the drag flags) so progress/complete/error
+        // events are processed and the `Uploading` drag-leave path can later
+        // clear `dragging` — instead of stranding the upload behind `DragOver`.
+        (State::Idle | State::DragOver, true) => Some(State::Uploading),
         _ => None,
     }
 }

--- a/crates/ars-components/src/specialized/file_upload/mod.rs
+++ b/crates/ars-components/src/specialized/file_upload/mod.rs
@@ -710,7 +710,8 @@ impl ars_core::Machine for Machine {
         // (controlled or default) with an uploading item must boot in `Uploading`,
         // not `Idle`, so progress/complete/error events are not dropped by the
         // `State::Uploading` guards before any prop sync runs.
-        let initial_state = reconciled_state(State::Idle, files.get()).unwrap_or(State::Idle);
+        let initial_state =
+            reconciled_state(State::Idle, files.get(), false).unwrap_or(State::Idle);
 
         (
             initial_state,
@@ -776,7 +777,8 @@ impl ars_core::Machine for Machine {
                 // uploading. Drive the resting state to match the currently
                 // visible queue (including entering `Uploading` from `DragOver`
                 // when a controlled upload begins mid-drag).
-                return reconciled_state(*state, ctx.files.get()).map(TransitionPlan::to);
+                return reconciled_state(*state, ctx.files.get(), ctx.dragging)
+                    .map(TransitionPlan::to);
             }
 
             Event::SetProps => {
@@ -1073,6 +1075,13 @@ impl ars_core::Machine for Machine {
             }
 
             (_, Event::RetryFile { file_id }) => {
+                // Only re-queueing an actually-failed file should resume uploading.
+                // Otherwise a stale/duplicate retry would chain `StartUpload` and
+                // move unrelated `Pending` files to `Uploading`.
+                let will_retry =
+                    ctx.files.get().iter().any(|file| {
+                        &file.id == file_id && matches!(file.status, Status::Failed(_))
+                    });
                 let file_id = file_id.clone();
                 let plan = TransitionPlan::context_only(move |context: &mut Context| {
                     retry_file_by_id(context, &file_id);
@@ -1081,7 +1090,7 @@ impl ars_core::Machine for Machine {
                 // Mirror `FilesSelected`: when `auto_upload` is set, retrying a
                 // failed file re-queues it as `Pending` and immediately resumes
                 // uploading, so the retry control is not a silent no-op.
-                Some(if ctx.auto_upload {
+                Some(if ctx.auto_upload && will_retry {
                     plan.then(Event::StartUpload)
                 } else {
                     plan
@@ -2174,11 +2183,14 @@ fn next_id_after(files: &[Item]) -> u64 {
 /// the resting state between [`State::Idle`] and [`State::Uploading`] to match
 /// the visible queue. Returns `None` when no state change is required (including
 /// while in [`State::DragOver`], whose transient drag lifecycle is left untouched).
-fn reconciled_state(current: State, files: &[Item]) -> Option<State> {
+fn reconciled_state(current: State, files: &[Item], dragging: bool) -> Option<State> {
     let any_uploading = files.iter().any(|file| file.status == Status::Uploading);
 
     match (current, any_uploading) {
-        (State::Uploading, false) => Some(State::Idle),
+        // Leaving Uploading is drag-aware (same as `upload_finish_plan`): a drop
+        // still in progress settles in `DragOver` so the drag-leave path clears
+        // the flags rather than stranding `data-ars-dragging`; otherwise `Idle`.
+        (State::Uploading, false) => Some(finished_uploading_state(dragging)),
         // A controlled queue can begin an upload while a drag is in progress.
         // Enter `Uploading` (keeping the drag flags) so progress/complete/error
         // events are processed and the `Uploading` drag-leave path can later

--- a/crates/ars-components/src/specialized/file_upload/mod.rs
+++ b/crates/ars-components/src/specialized/file_upload/mod.rs
@@ -70,11 +70,13 @@ impl Progress {
     /// Progress as a fraction in `[0.0, 1.0]`.
     #[must_use]
     pub fn fraction(&self) -> f64 {
-        if self.bytes_total == 0 {
+        let raw = if self.bytes_total == 0 {
             0.0
         } else {
             self.bytes_sent as f64 / self.bytes_total as f64
-        }
+        };
+
+        clamp_upload_fraction(raw)
     }
 }
 
@@ -1251,7 +1253,10 @@ impl Api<'_> {
         let [(scope_attr, scope_val), (part_attr, part_val)] =
             Part::ItemDeleteTrigger { index }.data_attrs();
 
-        attrs.set(scope_attr, scope_val).set(part_attr, part_val);
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Type, "button");
 
         if let Some(file) = self.ctx.files.get().get(index) {
             attrs.set(
@@ -1309,11 +1314,11 @@ impl Api<'_> {
             attrs.set(HtmlAttr::Name, name);
         }
 
-        if self.ctx.required {
+        if self.ctx.required && self.ctx.files.get().is_empty() {
             attrs.set_bool(HtmlAttr::Required, true);
         }
 
-        if self.ctx.disabled {
+        if self.ctx.disabled || self.ctx.readonly {
             attrs.set_bool(HtmlAttr::Disabled, true);
         }
 
@@ -1447,17 +1452,39 @@ const fn item_status_token(status: &Status) -> &'static str {
     }
 }
 
-fn format_file_size_with_locale(bytes: u64, _locale: &Locale) -> String {
-    const KB: u64 = 1_024;
-    const MB: u64 = KB * 1_024;
+fn format_file_size_with_locale(bytes: u64, locale: &Locale) -> String {
+    use alloc::format;
 
-    if bytes >= MB {
-        format!("{} MB", bytes / MB)
-    } else if bytes >= KB {
-        format!("{} KB", bytes / KB)
+    use ars_i18n::number::{FormatOptions, Formatter};
+
+    const KB: f64 = 1_024.0;
+    const MB: f64 = KB * 1_024.0;
+    let bytes_f = bytes as f64;
+
+    let (value, suffix) = if bytes_f >= MB {
+        (bytes_f / MB, "MB")
+    } else if bytes_f >= KB {
+        (bytes_f / KB, "KB")
     } else {
-        format!("{bytes} bytes")
-    }
+        (bytes_f, "bytes")
+    };
+
+    let max_fraction_digits = if suffix == "bytes" || value.fract() == 0.0 {
+        0
+    } else {
+        1
+    };
+
+    let number = Formatter::new(
+        locale,
+        FormatOptions {
+            max_fraction_digits,
+            ..FormatOptions::default()
+        },
+    )
+    .format(value);
+
+    format!("{number} {suffix}")
 }
 
 fn apply_selected_files_plan(
@@ -1532,6 +1559,7 @@ fn mark_pending_as_uploading(context: &mut Context) {
     context.files.set(updated);
 }
 
+#[expect(clippy::missing_const_for_fn, reason = "f64::is_nan is not const")]
 fn clamp_upload_fraction(progress: f64) -> f64 {
     if progress.is_nan() {
         0.0
@@ -1692,17 +1720,15 @@ fn validate_files(raw: &[RawFile], ctx: &Context) -> (Vec<Item>, Vec<Rejection>)
     let current_count = ctx.files.get().len();
 
     for file in raw {
-        if !ctx.multiple {
-            if current_count >= 1 || !accepted.is_empty() {
-                rejected.push(Rejection {
-                    name: file.name.clone(),
-                    size: file.size,
-                    mime_type: file.mime_type.clone(),
-                    reason: RejectionReason::TooMany,
-                });
+        if !ctx.multiple && (current_count >= 1 || !accepted.is_empty()) {
+            rejected.push(Rejection {
+                name: file.name.clone(),
+                size: file.size,
+                mime_type: file.mime_type.clone(),
+                reason: RejectionReason::TooMany,
+            });
 
-                continue;
-            }
+            continue;
         }
 
         if let Some(max) = ctx.max_files
@@ -1786,12 +1812,14 @@ fn mime_matches(mime: &str, name: &str, patterns: &[String]) -> bool {
     let normalized = normalize_mime_type(mime);
 
     patterns.iter().any(|pattern| {
-        if pattern.ends_with("/*") {
-            let prefix = &pattern[..pattern.len() - 1];
+        let pattern = pattern.trim();
 
-            normalized.starts_with(prefix)
+        if pattern.ends_with("/*") {
+            let prefix = normalize_mime_type(&pattern[..pattern.len() - 1]);
+
+            normalized.starts_with(&prefix)
         } else if let Some(extension) = pattern.strip_prefix('.') {
-            normalized == *pattern || file_name_has_extension(name, extension)
+            normalized == normalize_mime_type(pattern) || file_name_has_extension(name, extension)
         } else {
             normalized == normalize_mime_type(pattern)
         }

--- a/crates/ars-components/src/specialized/file_upload/mod.rs
+++ b/crates/ars-components/src/specialized/file_upload/mod.rs
@@ -1,0 +1,1781 @@
+//! File upload component state machine and connect API.
+
+use alloc::{format, string::String, vec::Vec};
+use core::fmt::{self, Debug, Display};
+
+use ars_core::{
+    AriaAttr, AttrMap, Bindable, ComponentIds, ComponentMessages, ComponentPart, ConnectApi, Env,
+    HasId, HtmlAttr, Locale, MessageFn, PendingEffect, TransitionPlan,
+};
+use ars_interactions::{KeyboardEventData, KeyboardKey};
+
+/// Represents a single file in the upload queue.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Item {
+    /// Unique identifier for this file item.
+    pub id: String,
+
+    /// Original file name.
+    pub name: String,
+
+    /// File size in bytes.
+    pub size: u64,
+
+    /// MIME type (e.g., `"image/png"`).
+    pub mime_type: String,
+
+    /// Current upload status.
+    pub status: Status,
+
+    /// Upload progress as a fraction in `[0.0, 1.0]`.
+    pub progress: f64,
+
+    /// Error message if status is [`Status::Failed`].
+    pub error: Option<String>,
+}
+
+/// Upload status for a single file.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Status {
+    /// File is queued but not yet uploading.
+    Pending,
+
+    /// File is currently being uploaded.
+    Uploading,
+
+    /// Upload completed successfully.
+    Complete,
+
+    /// Upload failed with an error message.
+    Failed(String),
+
+    /// Upload was cancelled by the user.
+    Cancelled,
+}
+
+/// Granular upload progress information for a single file.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Progress {
+    /// Index of the file in the upload queue.
+    pub file_index: usize,
+
+    /// Number of bytes sent so far.
+    pub bytes_sent: usize,
+
+    /// Total number of bytes to send.
+    pub bytes_total: usize,
+}
+
+impl Progress {
+    /// Progress as a fraction in `[0.0, 1.0]`.
+    #[must_use]
+    pub fn fraction(&self) -> f64 {
+        if self.bytes_total == 0 {
+            0.0
+        } else {
+            self.bytes_sent as f64 / self.bytes_total as f64
+        }
+    }
+}
+
+/// Reasons a file can be rejected before upload.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RejectionReason {
+    /// File type not in the accepted list.
+    InvalidType,
+
+    /// File exceeds the maximum size.
+    TooLarge,
+
+    /// Adding this file would exceed the maximum count.
+    TooMany,
+
+    /// File is smaller than the minimum size.
+    TooSmall,
+
+    /// Custom validation failed.
+    CustomValidation(String),
+}
+
+/// A file that was rejected during selection.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Rejection {
+    /// Original file name.
+    pub name: String,
+
+    /// File size in bytes.
+    pub size: u64,
+
+    /// MIME type.
+    pub mime_type: String,
+
+    /// Reason for rejection.
+    pub reason: RejectionReason,
+}
+
+/// The states for the `FileUpload` component.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum State {
+    /// Default state, waiting for user interaction.
+    Idle,
+
+    /// A file is being dragged over the dropzone.
+    DragOver,
+
+    /// One or more files are actively uploading.
+    Uploading,
+}
+
+impl Display for State {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Idle => "idle",
+            Self::DragOver => "drag-over",
+            Self::Uploading => "uploading",
+        })
+    }
+}
+
+/// The events for the `FileUpload` component.
+#[derive(Clone, Debug, PartialEq)]
+pub enum Event {
+    /// Files were dragged into the dropzone boundary.
+    DragEnter,
+
+    /// Files are being dragged over the dropzone.
+    DragOver,
+
+    /// Files left the dropzone boundary.
+    DragLeave,
+
+    /// Files were dropped onto the dropzone.
+    Drop(Vec<RawFile>),
+
+    /// User selected files via the native file input.
+    FilesSelected(Vec<RawFile>),
+
+    /// Begin uploading all pending files.
+    StartUpload,
+
+    /// Upload progress for a specific file.
+    UploadProgress {
+        /// The id of the file.
+        file_id: String,
+
+        /// The progress of the file.
+        progress: f64,
+    },
+
+    /// Upload completed for a specific file.
+    UploadComplete {
+        /// The id of the file.
+        file_id: String,
+    },
+
+    /// Upload failed for a specific file.
+    UploadError {
+        /// The id of the file.
+        file_id: String,
+
+        /// The error message.
+        error: String,
+    },
+
+    /// Remove a file from the list.
+    RemoveFile {
+        /// The id of the file.
+        file_id: String,
+    },
+
+    /// Clear all files.
+    ClearFiles,
+
+    /// Retry a failed upload.
+    RetryFile {
+        /// The id of the file.
+        file_id: String,
+    },
+
+    /// Cancel an in-progress upload.
+    CancelFile {
+        /// The id of the file.
+        file_id: String,
+    },
+
+    /// Open the native file picker.
+    OpenFilePicker,
+
+    /// Focus entered a part.
+    Focus {
+        /// The part that was focused.
+        part: &'static str,
+    },
+
+    /// Focus left a part.
+    Blur {
+        /// The part that was blurred.
+        part: &'static str,
+    },
+
+    /// Synchronize the externally controlled file list prop.
+    SetFiles(Option<Vec<Item>>),
+
+    /// Synchronize output-affecting props stored in context.
+    SetProps,
+}
+
+/// Raw file data from the browser File API, prior to validation.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RawFile {
+    /// The name of the file.
+    pub name: String,
+
+    /// The size of the file in bytes.
+    pub size: u64,
+
+    /// The MIME type of the file.
+    pub mime_type: String,
+}
+
+/// The context for the `FileUpload` component.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Context {
+    /// Currently accepted files.
+    pub files: Bindable<Vec<Item>>,
+
+    /// Files that were rejected during the most recent selection.
+    pub rejected_files: Vec<Rejection>,
+
+    /// Whether a drag is currently over the dropzone.
+    pub dragging: bool,
+
+    /// Component disabled state.
+    pub disabled: bool,
+
+    /// Read-only state (shows files but prevents adding/removing).
+    pub readonly: bool,
+
+    /// Whether a file is required.
+    pub required: bool,
+
+    /// Whether multiple files can be selected.
+    pub multiple: bool,
+
+    /// Accepted MIME types (e.g., `["image/*", "application/pdf"]`).
+    pub accept: Vec<String>,
+
+    /// Maximum file size in bytes.
+    pub max_file_size: Option<u64>,
+
+    /// Minimum file size in bytes.
+    pub min_file_size: Option<u64>,
+
+    /// Maximum number of files.
+    pub max_files: Option<usize>,
+
+    /// Whether to auto-start upload on file selection.
+    pub auto_upload: bool,
+
+    /// Whether the dropzone is a directory upload.
+    pub directory: bool,
+
+    /// Drag-over nesting counter (for nested elements).
+    pub drag_counter: u32,
+
+    /// Focused part.
+    pub focused_part: Option<&'static str>,
+
+    /// Locale for internationalized messages.
+    pub locale: Locale,
+
+    /// Resolved translatable messages.
+    pub messages: Messages,
+
+    /// Component instance base id.
+    pub id: String,
+
+    /// The id of the dropzone.
+    pub dropzone_id: String,
+
+    /// The id of the input.
+    pub input_id: String,
+
+    /// The id of the label.
+    pub label_id: String,
+
+    /// The id of the file list.
+    pub file_list_id: String,
+}
+
+/// The props for the `FileUpload` component.
+#[derive(Clone, Debug, Default, PartialEq, HasId)]
+pub struct Props {
+    /// Controlled file list.
+    pub files: Option<Vec<Item>>,
+
+    /// Default files for uncontrolled mode.
+    pub default_files: Vec<Item>,
+
+    /// Disabled state.
+    pub disabled: bool,
+
+    /// Read-only state (shows files but prevents adding/removing).
+    pub readonly: bool,
+
+    /// Whether a file is required.
+    pub required: bool,
+
+    /// Allow multiple files.
+    pub multiple: bool,
+
+    /// Camera selection for mobile (`"user"` front, `"environment"` rear).
+    pub capture: Option<String>,
+
+    /// Accepted MIME types.
+    pub accept: Vec<String>,
+
+    /// Maximum file size in bytes.
+    pub max_file_size: Option<u64>,
+
+    /// Minimum file size in bytes.
+    pub min_file_size: Option<u64>,
+
+    /// Maximum number of files.
+    pub max_files: Option<usize>,
+
+    /// Auto-start upload after selection.
+    pub auto_upload: bool,
+
+    /// Allow directory upload.
+    pub directory: bool,
+
+    /// Name for form submission.
+    pub name: Option<String>,
+
+    /// Component instance ID.
+    pub id: String,
+}
+
+impl Props {
+    /// Returns a fresh [`Props`] with every field at its [`Default`] value.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets [`id`](Self::id).
+    #[must_use]
+    pub fn id(mut self, id: impl Into<String>) -> Self {
+        self.id = id.into();
+        self
+    }
+
+    /// Sets controlled [`files`](Self::files).
+    #[must_use]
+    pub fn files(mut self, files: Vec<Item>) -> Self {
+        self.files = Some(files);
+        self
+    }
+
+    /// Clears controlled [`files`](Self::files), switching to uncontrolled mode.
+    #[must_use]
+    pub fn uncontrolled(mut self) -> Self {
+        self.files = None;
+        self
+    }
+
+    /// Sets [`default_files`](Self::default_files).
+    #[must_use]
+    pub fn default_files(mut self, files: Vec<Item>) -> Self {
+        self.default_files = files;
+        self
+    }
+
+    /// Sets [`disabled`](Self::disabled).
+    #[must_use]
+    pub const fn disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
+    }
+
+    /// Sets [`readonly`](Self::readonly).
+    #[must_use]
+    pub const fn readonly(mut self, readonly: bool) -> Self {
+        self.readonly = readonly;
+        self
+    }
+
+    /// Sets [`required`](Self::required).
+    #[must_use]
+    pub const fn required(mut self, required: bool) -> Self {
+        self.required = required;
+        self
+    }
+
+    /// Sets [`multiple`](Self::multiple).
+    #[must_use]
+    pub const fn multiple(mut self, multiple: bool) -> Self {
+        self.multiple = multiple;
+        self
+    }
+
+    /// Sets [`capture`](Self::capture).
+    #[must_use]
+    pub fn capture(mut self, capture: impl Into<String>) -> Self {
+        self.capture = Some(capture.into());
+        self
+    }
+
+    /// Sets [`accept`](Self::accept).
+    #[must_use]
+    pub fn accept(mut self, accept: Vec<String>) -> Self {
+        self.accept = accept;
+        self
+    }
+
+    /// Sets [`max_file_size`](Self::max_file_size).
+    #[must_use]
+    pub const fn max_file_size(mut self, max_file_size: u64) -> Self {
+        self.max_file_size = Some(max_file_size);
+        self
+    }
+
+    /// Clears [`max_file_size`](Self::max_file_size).
+    #[must_use]
+    pub const fn clear_max_file_size(mut self) -> Self {
+        self.max_file_size = None;
+        self
+    }
+
+    /// Sets [`min_file_size`](Self::min_file_size).
+    #[must_use]
+    pub const fn min_file_size(mut self, min_file_size: u64) -> Self {
+        self.min_file_size = Some(min_file_size);
+        self
+    }
+
+    /// Clears [`min_file_size`](Self::min_file_size).
+    #[must_use]
+    pub const fn clear_min_file_size(mut self) -> Self {
+        self.min_file_size = None;
+        self
+    }
+
+    /// Sets [`max_files`](Self::max_files).
+    #[must_use]
+    pub const fn max_files(mut self, max_files: usize) -> Self {
+        self.max_files = Some(max_files);
+        self
+    }
+
+    /// Clears [`max_files`](Self::max_files).
+    #[must_use]
+    pub const fn clear_max_files(mut self) -> Self {
+        self.max_files = None;
+        self
+    }
+
+    /// Sets [`auto_upload`](Self::auto_upload).
+    #[must_use]
+    pub const fn auto_upload(mut self, auto_upload: bool) -> Self {
+        self.auto_upload = auto_upload;
+        self
+    }
+
+    /// Sets [`directory`](Self::directory).
+    #[must_use]
+    pub const fn directory(mut self, directory: bool) -> Self {
+        self.directory = directory;
+        self
+    }
+
+    /// Sets [`name`](Self::name).
+    #[must_use]
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.name = Some(name.into());
+        self
+    }
+}
+
+type LocaleMessageFn = dyn Fn(&Locale) -> String + Send + Sync;
+type RemoveLabelMessageFn = dyn Fn(&str, &Locale) -> String + Send + Sync;
+type RejectionCountMessageFn = dyn Fn(usize, &Locale) -> String + Send + Sync;
+type FileSizeMessageFn = dyn Fn(u64, &Locale) -> String + Send + Sync;
+
+/// Messages for the `FileUpload` component.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Messages {
+    /// Accessible label for the upload root.
+    pub dropzone_label: MessageFn<LocaleMessageFn>,
+
+    /// Announcement when the dropzone becomes active.
+    pub dropzone_active: MessageFn<LocaleMessageFn>,
+
+    /// Announcement when the dropzone is no longer active.
+    pub drop_zone_left: MessageFn<LocaleMessageFn>,
+
+    /// Announcement when files were added via drop or selection.
+    pub files_added: MessageFn<RejectionCountMessageFn>,
+
+    /// Label for the browse trigger button.
+    pub trigger_label: MessageFn<LocaleMessageFn>,
+
+    /// Label for the file list container.
+    pub file_list_label: MessageFn<LocaleMessageFn>,
+
+    /// Label for a remove-file button.
+    pub remove_label: MessageFn<RemoveLabelMessageFn>,
+
+    /// Summary message when files were rejected.
+    pub rejection_message: MessageFn<RejectionCountMessageFn>,
+
+    /// Human-readable file size text.
+    pub file_size: MessageFn<FileSizeMessageFn>,
+
+    /// Error text when a file is too large.
+    pub too_large: MessageFn<FileSizeMessageFn>,
+
+    /// Error text when a file type is invalid.
+    pub wrong_type: MessageFn<LocaleMessageFn>,
+
+    /// Error text when too many files were selected.
+    pub too_many_files: MessageFn<LocaleMessageFn>,
+
+    /// Error text when a file is too small.
+    pub too_small: MessageFn<FileSizeMessageFn>,
+}
+
+impl Default for Messages {
+    fn default() -> Self {
+        Self {
+            dropzone_label: MessageFn::static_str("Drag and drop files here, or click to browse"),
+            dropzone_active: MessageFn::static_str("Drop files to upload"),
+            drop_zone_left: MessageFn::static_str("Drop zone is no longer active"),
+            files_added: MessageFn::new(|count: usize, _locale: &Locale| {
+                format!("{count} files added")
+            }),
+            trigger_label: MessageFn::static_str("Choose files to upload"),
+            file_list_label: MessageFn::static_str("Uploaded files"),
+            remove_label: MessageFn::new(|name: &str, _locale: &Locale| format!("Remove {name}")),
+            rejection_message: MessageFn::new(|count: usize, _locale: &Locale| {
+                format!("{count} files rejected")
+            }),
+            file_size: MessageFn::new(|bytes: u64, locale: &Locale| {
+                format_file_size_with_locale(bytes, locale)
+            }),
+            too_large: MessageFn::new(|max: u64, locale: &Locale| {
+                format!(
+                    "File exceeds maximum size of {}",
+                    format_file_size_with_locale(max, locale)
+                )
+            }),
+            wrong_type: MessageFn::static_str("File type not accepted"),
+            too_many_files: MessageFn::static_str("Too many files selected"),
+            too_small: MessageFn::new(|min: u64, locale: &Locale| {
+                format!(
+                    "File below minimum size of {}",
+                    format_file_size_with_locale(min, locale)
+                )
+            }),
+        }
+    }
+}
+
+impl ComponentMessages for Messages {}
+
+/// Typed effect intents emitted by the file upload machine.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Effect {
+    /// Adapter announces that the dropzone is active.
+    AnnounceDropzoneActive,
+
+    /// Adapter opens the native file picker via the hidden input.
+    OpenFilePicker,
+}
+
+/// The machine for the `FileUpload` component.
+#[derive(Debug)]
+pub struct Machine;
+
+impl ars_core::Machine for Machine {
+    type State = State;
+    type Event = Event;
+    type Context = Context;
+    type Props = Props;
+    type Messages = Messages;
+    type Effect = Effect;
+    type Api<'a> = Api<'a>;
+
+    fn init(props: &Self::Props, env: &Env, messages: &Self::Messages) -> (State, Context) {
+        let files = if let Some(files) = &props.files {
+            Bindable::controlled(files.clone())
+        } else {
+            Bindable::uncontrolled(props.default_files.clone())
+        };
+
+        let ids = ComponentIds::from_id(&props.id);
+
+        (
+            State::Idle,
+            Context {
+                files,
+                rejected_files: Vec::new(),
+                dragging: false,
+                disabled: props.disabled,
+                readonly: props.readonly,
+                required: props.required,
+                multiple: props.multiple,
+                accept: props.accept.clone(),
+                max_file_size: props.max_file_size,
+                min_file_size: props.min_file_size,
+                max_files: props.max_files,
+                auto_upload: props.auto_upload,
+                directory: props.directory,
+                drag_counter: 0,
+                focused_part: None,
+                locale: env.locale.clone(),
+                messages: messages.clone(),
+                id: ids.id().to_string(),
+                dropzone_id: ids.part("dropzone"),
+                input_id: ids.part("input"),
+                label_id: ids.part("label"),
+                file_list_id: ids.part("file-list"),
+            },
+        )
+    }
+
+    fn transition(
+        state: &Self::State,
+        event: &Self::Event,
+        ctx: &Self::Context,
+        props: &Self::Props,
+    ) -> Option<TransitionPlan<Self>> {
+        if ctx.disabled || ctx.readonly {
+            return match event {
+                Event::Focus { part } => {
+                    let part = *part;
+                    Some(TransitionPlan::context_only(
+                        move |context: &mut Context| {
+                            context.focused_part = Some(part);
+                        },
+                    ))
+                }
+
+                Event::Blur { .. } => {
+                    Some(TransitionPlan::context_only(|context: &mut Context| {
+                        context.focused_part = None;
+                    }))
+                }
+
+                _ => None,
+            };
+        }
+
+        match (state, event) {
+            (State::Idle, Event::DragEnter) => Some(
+                TransitionPlan::to(State::DragOver)
+                    .apply(|context: &mut Context| {
+                        context.dragging = true;
+                        context.drag_counter = 1;
+                    })
+                    .with_effect(PendingEffect::named(Effect::AnnounceDropzoneActive)),
+            ),
+
+            (State::DragOver, Event::DragEnter) => {
+                Some(TransitionPlan::context_only(|context: &mut Context| {
+                    context.drag_counter += 1;
+                }))
+            }
+
+            (State::DragOver, Event::DragLeave) => {
+                let new_counter = ctx.drag_counter.saturating_sub(1);
+
+                if new_counter == 0 {
+                    Some(
+                        TransitionPlan::to(State::Idle).apply(|context: &mut Context| {
+                            context.drag_counter = 0;
+                            context.dragging = false;
+                        }),
+                    )
+                } else {
+                    Some(TransitionPlan::context_only(
+                        move |context: &mut Context| {
+                            context.drag_counter = new_counter;
+                        },
+                    ))
+                }
+            }
+
+            (State::DragOver, Event::Drop(raw_files)) => {
+                let raw = raw_files.clone();
+                Some(apply_selected_files_plan(
+                    Some(State::Idle),
+                    raw,
+                    ctx.auto_upload,
+                    |context: &mut Context| {
+                        context.dragging = false;
+                        context.drag_counter = 0;
+                    },
+                ))
+            }
+
+            (State::Idle, Event::FilesSelected(raw_files))
+            | (State::Uploading, Event::FilesSelected(raw_files)) => {
+                let raw = raw_files.clone();
+                let auto_upload = ctx.auto_upload;
+                Some(apply_selected_files_plan(None, raw, auto_upload, |_| {}))
+            }
+
+            (State::Idle, Event::StartUpload) => {
+                if !has_pending_files(ctx, props) {
+                    return None;
+                }
+
+                Some(
+                    TransitionPlan::to(State::Uploading).apply(|context: &mut Context| {
+                        mark_pending_as_uploading(context);
+                    }),
+                )
+            }
+
+            (State::Uploading, Event::UploadProgress { file_id, progress }) => {
+                let file_id = file_id.clone();
+                let progress = *progress;
+                Some(TransitionPlan::context_only(
+                    move |context: &mut Context| {
+                        update_file_progress(context, &file_id, progress);
+                    },
+                ))
+            }
+
+            (State::Uploading, Event::UploadComplete { file_id }) => {
+                let file_id = file_id.clone();
+                let still_uploading = upload_complete_updates(ctx, &file_id);
+                Some(upload_finish_plan(
+                    still_uploading,
+                    move |context: &mut Context| {
+                        apply_upload_complete(context, &file_id);
+                    },
+                ))
+            }
+
+            (State::Uploading, Event::UploadError { file_id, error }) => {
+                let file_id = file_id.clone();
+                let error = error.clone();
+                let still_uploading = upload_error_updates(ctx, &file_id);
+                Some(upload_finish_plan(
+                    still_uploading,
+                    move |context: &mut Context| {
+                        apply_upload_error(context, &file_id, &error);
+                    },
+                ))
+            }
+
+            (_, Event::RemoveFile { file_id }) => {
+                let file_id = file_id.clone();
+                let still_uploading = remove_file_updates(ctx, &file_id);
+                Some(file_queue_plan(
+                    *state,
+                    still_uploading,
+                    move |context: &mut Context| {
+                        remove_file_by_id(context, &file_id);
+                    },
+                ))
+            }
+
+            (_, Event::ClearFiles) => Some(TransitionPlan::to(State::Idle).apply(
+                |context: &mut Context| {
+                    context.files.set(Vec::new());
+                    context.rejected_files.clear();
+                },
+            )),
+
+            (_, Event::RetryFile { file_id }) => {
+                let file_id = file_id.clone();
+                Some(TransitionPlan::context_only(
+                    move |context: &mut Context| {
+                        retry_file_by_id(context, &file_id);
+                    },
+                ))
+            }
+
+            (_, Event::CancelFile { file_id }) => {
+                let file_id = file_id.clone();
+                let still_uploading = cancel_file_updates(ctx, &file_id);
+                Some(file_queue_plan(
+                    *state,
+                    still_uploading,
+                    move |context: &mut Context| {
+                        cancel_file_by_id(context, &file_id);
+                    },
+                ))
+            }
+
+            (_, Event::OpenFilePicker) => Some(
+                TransitionPlan::new().with_effect(PendingEffect::named(Effect::OpenFilePicker)),
+            ),
+
+            (_, Event::Focus { part }) => {
+                let part = *part;
+                Some(TransitionPlan::context_only(
+                    move |context: &mut Context| {
+                        context.focused_part = Some(part);
+                    },
+                ))
+            }
+
+            (_, Event::Blur { .. }) => {
+                Some(TransitionPlan::context_only(|context: &mut Context| {
+                    context.focused_part = None;
+                }))
+            }
+
+            (_, Event::SetFiles(files)) => {
+                let files = files.clone();
+                Some(TransitionPlan::context_only(
+                    move |context: &mut Context| {
+                        if let Some(files) = files {
+                            context.files.set(files.clone());
+                            context.files.sync_controlled(Some(files));
+                        } else {
+                            context.files.sync_controlled(None);
+                        }
+                    },
+                ))
+            }
+
+            (_, Event::SetProps) => Some(TransitionPlan::context_only({
+                let disabled = props.disabled;
+                let readonly = props.readonly;
+                let required = props.required;
+                let multiple = props.multiple;
+                let accept = props.accept.clone();
+                let max_file_size = props.max_file_size;
+                let min_file_size = props.min_file_size;
+                let max_files = props.max_files;
+                let auto_upload = props.auto_upload;
+                let directory = props.directory;
+
+                move |context: &mut Context| {
+                    context.disabled = disabled;
+                    context.readonly = readonly;
+                    context.required = required;
+                    context.multiple = multiple;
+                    context.accept = accept;
+                    context.max_file_size = max_file_size;
+                    context.min_file_size = min_file_size;
+                    context.max_files = max_files;
+                    context.auto_upload = auto_upload;
+                    context.directory = directory;
+                }
+            })),
+
+            _ => None,
+        }
+    }
+
+    fn on_props_changed(old: &Self::Props, new: &Self::Props) -> Vec<Self::Event> {
+        assert_eq!(
+            old.id, new.id,
+            "file_upload::Props.id must remain stable after init"
+        );
+
+        let mut events = Vec::new();
+
+        if old.files != new.files {
+            events.push(Event::SetFiles(new.files.clone()));
+        }
+
+        if old.disabled != new.disabled
+            || old.readonly != new.readonly
+            || old.required != new.required
+            || old.multiple != new.multiple
+            || old.accept != new.accept
+            || old.max_file_size != new.max_file_size
+            || old.min_file_size != new.min_file_size
+            || old.max_files != new.max_files
+            || old.auto_upload != new.auto_upload
+            || old.directory != new.directory
+        {
+            events.push(Event::SetProps);
+        }
+
+        events
+    }
+
+    fn connect<'a>(
+        state: &'a Self::State,
+        ctx: &'a Self::Context,
+        props: &'a Self::Props,
+        send: &'a dyn Fn(Self::Event),
+    ) -> Self::Api<'a> {
+        Api {
+            state,
+            ctx,
+            props,
+            send,
+        }
+    }
+}
+
+/// DOM parts of the `FileUpload` component.
+#[derive(ComponentPart)]
+#[scope = "file-upload"]
+pub enum Part {
+    /// Root wrapper element.
+    Root,
+
+    /// Label describing the upload area.
+    Label,
+
+    /// Drag-and-drop target area.
+    Dropzone,
+
+    /// Button that opens the native file picker.
+    Trigger,
+
+    /// Container for file items.
+    ItemGroup,
+
+    /// A single file item.
+    Item {
+        /// Index of the file in the list.
+        index: usize,
+    },
+
+    /// File name display for an item.
+    ItemName {
+        /// Index of the file in the list.
+        index: usize,
+    },
+
+    /// File size text for an item.
+    ItemSizeText {
+        /// Index of the file in the list.
+        index: usize,
+    },
+
+    /// Remove button for an item.
+    ItemDeleteTrigger {
+        /// Index of the file in the list.
+        index: usize,
+    },
+
+    /// Upload progress indicator for an item.
+    ItemProgress {
+        /// Index of the file in the list.
+        index: usize,
+    },
+
+    /// Hidden native file input.
+    HiddenInput,
+}
+
+/// API for the `FileUpload` component.
+pub struct Api<'a> {
+    state: &'a State,
+    ctx: &'a Context,
+    props: &'a Props,
+    send: &'a dyn Fn(Event),
+}
+
+impl Debug for Api<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("file_upload::Api")
+            .field("state", self.state)
+            .field("ctx", self.ctx)
+            .field("props", self.props)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Api<'_> {
+    /// Whether the component is currently dragging.
+    #[must_use]
+    pub const fn is_dragging(&self) -> bool {
+        self.ctx.dragging
+    }
+
+    /// Whether the component is currently uploading.
+    #[must_use]
+    pub const fn is_uploading(&self) -> bool {
+        matches!(self.state, State::Uploading)
+    }
+
+    /// Returns the accepted files in the queue.
+    #[must_use]
+    pub fn files(&self) -> &[Item] {
+        self.ctx.files.get()
+    }
+
+    /// Returns files rejected during the most recent selection.
+    #[must_use]
+    pub fn rejected_files(&self) -> &[Rejection] {
+        &self.ctx.rejected_files
+    }
+
+    /// Whether the maximum number of files has been reached.
+    #[must_use]
+    pub fn is_max_files_reached(&self) -> bool {
+        is_max_files_reached(self.ctx, self.props)
+    }
+
+    /// Human-readable rejection announcement for screen readers.
+    #[must_use]
+    pub fn rejection_message(&self) -> Option<String> {
+        if self.ctx.rejected_files.is_empty() {
+            None
+        } else {
+            Some((self.ctx.messages.rejection_message)(
+                self.ctx.rejected_files.len(),
+                &self.ctx.locale,
+            ))
+        }
+    }
+
+    /// Opens the native file picker.
+    pub fn open_file_picker(&self) {
+        (self.send)(Event::OpenFilePicker);
+    }
+
+    /// Starts uploading all pending files.
+    pub fn start_upload(&self) {
+        (self.send)(Event::StartUpload);
+    }
+
+    /// Clears all files from the queue.
+    pub fn clear_files(&self) {
+        (self.send)(Event::ClearFiles);
+    }
+
+    /// Removes a file by id.
+    pub fn remove_file(&self, file_id: &str) {
+        (self.send)(Event::RemoveFile {
+            file_id: file_id.to_string(),
+        });
+    }
+
+    /// Retries a failed upload for the given file id.
+    pub fn retry_file(&self, file_id: &str) {
+        (self.send)(Event::RetryFile {
+            file_id: file_id.to_string(),
+        });
+    }
+
+    /// Cancels an in-progress upload for the given file id.
+    pub fn cancel_file(&self, file_id: &str) {
+        (self.send)(Event::CancelFile {
+            file_id: file_id.to_string(),
+        });
+    }
+
+    /// Root element attributes.
+    #[must_use]
+    pub fn root_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Root.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(
+                HtmlAttr::Aria(AriaAttr::Label),
+                (self.ctx.messages.dropzone_label)(&self.ctx.locale),
+            );
+
+        if self.ctx.disabled {
+            attrs.set_bool(HtmlAttr::Data("ars-disabled"), true);
+        }
+
+        if self.ctx.readonly {
+            attrs.set_bool(HtmlAttr::Data("ars-readonly"), true);
+        }
+
+        if self.is_dragging() {
+            attrs.set_bool(HtmlAttr::Data("ars-dragging"), true);
+        }
+
+        attrs
+    }
+
+    /// Label element attributes.
+    #[must_use]
+    pub fn label_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Label.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Id, &self.ctx.label_id)
+            .set(HtmlAttr::For, &self.ctx.input_id);
+
+        attrs
+    }
+
+    /// Dropzone element attributes.
+    #[must_use]
+    pub fn dropzone_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Dropzone.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Id, &self.ctx.dropzone_id)
+            .set(HtmlAttr::Role, "button")
+            .set(HtmlAttr::TabIndex, "0")
+            .set(HtmlAttr::Data("ars-state"), self.state_token())
+            .set(HtmlAttr::Aria(AriaAttr::LabelledBy), &self.ctx.label_id);
+
+        if self.is_dragging() {
+            attrs.set_bool(HtmlAttr::Data("ars-dragging"), true);
+        }
+
+        if self.ctx.disabled {
+            attrs.set(HtmlAttr::Aria(AriaAttr::Disabled), "true");
+        }
+
+        attrs
+    }
+
+    /// Trigger button attributes.
+    #[must_use]
+    pub fn trigger_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Trigger.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(
+                HtmlAttr::Aria(AriaAttr::Label),
+                (self.ctx.messages.trigger_label)(&self.ctx.locale),
+            );
+
+        if self.ctx.disabled {
+            attrs
+                .set_bool(HtmlAttr::Disabled, true)
+                .set(HtmlAttr::Aria(AriaAttr::Disabled), "true");
+        }
+
+        attrs
+    }
+
+    /// File list container attributes.
+    #[must_use]
+    pub fn item_group_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::ItemGroup.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Id, &self.ctx.file_list_id)
+            .set(HtmlAttr::Role, "list")
+            .set(
+                HtmlAttr::Aria(AriaAttr::Label),
+                (self.ctx.messages.file_list_label)(&self.ctx.locale),
+            );
+
+        attrs
+    }
+
+    /// File item attributes at the given index.
+    #[must_use]
+    pub fn item_attrs(&self, index: usize) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Item { index }.data_attrs();
+
+        attrs.set(scope_attr, scope_val).set(part_attr, part_val);
+
+        if let Some(file) = self.ctx.files.get().get(index) {
+            attrs
+                .set(HtmlAttr::Role, "listitem")
+                .set(HtmlAttr::Data("ars-state"), item_status_token(&file.status))
+                .set(HtmlAttr::Data("ars-file-id"), &file.id)
+                .set(
+                    HtmlAttr::Aria(AriaAttr::Description),
+                    (self.ctx.messages.file_size)(file.size, &self.ctx.locale),
+                );
+        }
+
+        attrs
+    }
+
+    /// File item name attributes at the given index.
+    #[must_use]
+    pub fn item_name_attrs(&self, index: usize) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] =
+            Part::ItemName { index }.data_attrs();
+
+        attrs.set(scope_attr, scope_val).set(part_attr, part_val);
+
+        attrs
+    }
+
+    /// File item size text attributes at the given index.
+    #[must_use]
+    pub fn item_size_text_attrs(&self, index: usize) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] =
+            Part::ItemSizeText { index }.data_attrs();
+
+        attrs.set(scope_attr, scope_val).set(part_attr, part_val);
+
+        attrs
+    }
+
+    /// File item delete trigger attributes at the given index.
+    #[must_use]
+    pub fn item_delete_trigger_attrs(&self, index: usize) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] =
+            Part::ItemDeleteTrigger { index }.data_attrs();
+
+        attrs.set(scope_attr, scope_val).set(part_attr, part_val);
+
+        if let Some(file) = self.ctx.files.get().get(index) {
+            attrs.set(
+                HtmlAttr::Aria(AriaAttr::Label),
+                (self.ctx.messages.remove_label)(&file.name, &self.ctx.locale),
+            );
+        }
+
+        attrs
+    }
+
+    /// File item progress indicator attributes at the given index.
+    #[must_use]
+    pub fn item_progress_attrs(&self, index: usize) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] =
+            Part::ItemProgress { index }.data_attrs();
+
+        attrs.set(scope_attr, scope_val).set(part_attr, part_val);
+
+        attrs
+    }
+
+    /// Hidden file input attributes.
+    #[must_use]
+    pub fn hidden_input_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::HiddenInput.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Id, &self.ctx.input_id)
+            .set(HtmlAttr::Type, "file")
+            .set(HtmlAttr::TabIndex, "-1")
+            .set(HtmlAttr::Class, "ars-sr-input");
+
+        if self.ctx.multiple {
+            attrs.set_bool(HtmlAttr::Multiple, true);
+        }
+
+        if !self.ctx.accept.is_empty() {
+            attrs.set(HtmlAttr::Accept, self.ctx.accept.join(","));
+        }
+
+        if self.ctx.directory {
+            attrs.set(HtmlAttr::WebkitDirectory, "");
+        }
+
+        if let Some(ref capture) = self.props.capture {
+            attrs.set(HtmlAttr::Capture, capture);
+        }
+
+        if let Some(ref name) = self.props.name {
+            attrs.set(HtmlAttr::Name, name);
+        }
+
+        if self.ctx.required {
+            attrs.set_bool(HtmlAttr::Required, true);
+        }
+
+        if self.ctx.disabled {
+            attrs.set_bool(HtmlAttr::Disabled, true);
+        }
+
+        attrs
+    }
+
+    /// Returns a human-readable validation error string for the given rejection.
+    #[must_use]
+    pub fn validation_error_text(&self, rejection: &Rejection) -> String {
+        match &rejection.reason {
+            RejectionReason::TooLarge => {
+                (self.ctx.messages.too_large)(self.ctx.max_file_size.unwrap_or(0), &self.ctx.locale)
+            }
+
+            RejectionReason::InvalidType => (self.ctx.messages.wrong_type)(&self.ctx.locale),
+
+            RejectionReason::TooMany => (self.ctx.messages.too_many_files)(&self.ctx.locale),
+
+            RejectionReason::TooSmall => {
+                (self.ctx.messages.too_small)(self.ctx.min_file_size.unwrap_or(0), &self.ctx.locale)
+            }
+
+            RejectionReason::CustomValidation(message) => message.clone(),
+        }
+    }
+
+    /// Dispatches drag-enter intent.
+    pub fn on_dropzone_drag_enter(&self) {
+        (self.send)(Event::DragEnter);
+    }
+
+    /// Dispatches drag-over intent.
+    pub fn on_dropzone_drag_over(&self) {
+        (self.send)(Event::DragOver);
+    }
+
+    /// Dispatches drag-leave intent.
+    pub fn on_dropzone_drag_leave(&self) {
+        (self.send)(Event::DragLeave);
+    }
+
+    /// Dispatches drop intent with raw file metadata.
+    pub fn on_dropzone_drop(&self, files: Vec<RawFile>) {
+        (self.send)(Event::Drop(files));
+    }
+
+    /// Dispatches click intent to open the file picker.
+    pub fn on_dropzone_click(&self) {
+        (self.send)(Event::OpenFilePicker);
+    }
+
+    /// Dispatches keyboard intent on the dropzone.
+    pub fn on_dropzone_keydown(&self, data: &KeyboardEventData) {
+        if matches!(data.key, KeyboardKey::Enter | KeyboardKey::Space) {
+            (self.send)(Event::OpenFilePicker);
+        }
+    }
+
+    /// Dispatches trigger click intent to open the file picker.
+    pub fn on_trigger_click(&self) {
+        (self.send)(Event::OpenFilePicker);
+    }
+
+    /// Dispatches hidden-input change intent with selected files.
+    pub fn on_hidden_input_change(&self, files: Vec<RawFile>) {
+        (self.send)(Event::FilesSelected(files));
+    }
+
+    /// Dispatches remove intent for the file at `index`.
+    pub fn on_item_delete_trigger_click(&self, index: usize) {
+        if let Some(file) = self.ctx.files.get().get(index) {
+            (self.send)(Event::RemoveFile {
+                file_id: file.id.clone(),
+            });
+        }
+    }
+
+    const fn state_token(&self) -> &'static str {
+        match self.state {
+            State::Idle => "idle",
+            State::DragOver => "drag-over",
+            State::Uploading => "uploading",
+        }
+    }
+}
+
+impl ConnectApi for Api<'_> {
+    type Part = Part;
+
+    fn part_attrs(&self, part: Part) -> AttrMap {
+        match part {
+            Part::Root => self.root_attrs(),
+            Part::Label => self.label_attrs(),
+            Part::Dropzone => self.dropzone_attrs(),
+            Part::Trigger => self.trigger_attrs(),
+            Part::ItemGroup => self.item_group_attrs(),
+            Part::Item { index } => self.item_attrs(index),
+            Part::ItemName { index } => self.item_name_attrs(index),
+            Part::ItemSizeText { index } => self.item_size_text_attrs(index),
+            Part::ItemDeleteTrigger { index } => self.item_delete_trigger_attrs(index),
+            Part::ItemProgress { index } => self.item_progress_attrs(index),
+            Part::HiddenInput => self.hidden_input_attrs(),
+        }
+    }
+}
+
+/// Whether the maximum number of files has been reached.
+fn is_max_files_reached(ctx: &Context, _props: &Props) -> bool {
+    if let Some(max) = ctx.max_files {
+        ctx.files.get().len() >= max
+    } else {
+        false
+    }
+}
+
+/// Whether there are any pending files.
+fn has_pending_files(ctx: &Context, _props: &Props) -> bool {
+    ctx.files
+        .get()
+        .iter()
+        .any(|file| file.status == Status::Pending)
+}
+
+const fn item_status_token(status: &Status) -> &'static str {
+    match status {
+        Status::Pending => "pending",
+        Status::Uploading => "uploading",
+        Status::Complete => "complete",
+        Status::Failed(_) => "error",
+        Status::Cancelled => "cancelled",
+    }
+}
+
+fn format_file_size_with_locale(bytes: u64, _locale: &Locale) -> String {
+    const KB: u64 = 1_024;
+    const MB: u64 = KB * 1_024;
+
+    if bytes >= MB {
+        format!("{} MB", bytes / MB)
+    } else if bytes >= KB {
+        format!("{} KB", bytes / KB)
+    } else {
+        format!("{bytes} bytes")
+    }
+}
+
+fn apply_selected_files_plan(
+    transition_to: Option<State>,
+    raw: Vec<RawFile>,
+    auto_upload: bool,
+    before: impl FnOnce(&mut Context) + 'static,
+) -> TransitionPlan<Machine> {
+    let mut plan = if let Some(state) = transition_to {
+        TransitionPlan::to(state)
+    } else {
+        TransitionPlan::new()
+    };
+
+    plan = plan.apply(move |context: &mut Context| {
+        before(context);
+
+        let (accepted, rejected) = validate_files(&raw, context);
+
+        context.rejected_files = rejected;
+
+        let mut current = context.files.get().clone();
+
+        current.extend(accepted);
+
+        context.files.set(current);
+    });
+
+    if auto_upload {
+        plan = plan.then(Event::StartUpload);
+    }
+
+    plan
+}
+
+fn file_queue_plan(
+    state: State,
+    still_uploading: bool,
+    apply: impl FnOnce(&mut Context) + 'static,
+) -> TransitionPlan<Machine> {
+    if matches!(state, State::Uploading) && !still_uploading {
+        TransitionPlan::to(State::Idle).apply(apply)
+    } else {
+        TransitionPlan::context_only(apply)
+    }
+}
+
+fn upload_finish_plan(
+    still_uploading: bool,
+    apply: impl FnOnce(&mut Context) + 'static,
+) -> TransitionPlan<Machine> {
+    if still_uploading {
+        TransitionPlan::context_only(apply)
+    } else {
+        TransitionPlan::to(State::Idle).apply(apply)
+    }
+}
+
+fn mark_pending_as_uploading(context: &mut Context) {
+    let files = context.files.get().clone();
+
+    let updated = files
+        .into_iter()
+        .map(|mut file| {
+            if file.status == Status::Pending {
+                file.status = Status::Uploading;
+            }
+            file
+        })
+        .collect();
+
+    context.files.set(updated);
+}
+
+fn update_file_progress(context: &mut Context, file_id: &str, progress: f64) {
+    let files = context.files.get().clone();
+
+    let updated = files
+        .into_iter()
+        .map(|mut file| {
+            if file.id == file_id {
+                file.progress = progress;
+            }
+            file
+        })
+        .collect();
+
+    context.files.set(updated);
+}
+
+fn upload_complete_updates(ctx: &Context, file_id: &str) -> bool {
+    let files = projected_files_after_complete(ctx, file_id);
+
+    files.iter().any(|file| file.status == Status::Uploading)
+}
+
+fn upload_error_updates(ctx: &Context, file_id: &str) -> bool {
+    let files = projected_files_after_error(ctx, file_id, "");
+
+    files.iter().any(|file| file.status == Status::Uploading)
+}
+
+fn remove_file_updates(ctx: &Context, file_id: &str) -> bool {
+    let files = ctx
+        .files
+        .get()
+        .iter()
+        .filter(|file| file.id != file_id)
+        .cloned()
+        .collect::<Vec<_>>();
+
+    files.iter().any(|file| file.status == Status::Uploading)
+}
+
+fn cancel_file_updates(ctx: &Context, file_id: &str) -> bool {
+    let files = projected_files_after_cancel(ctx, file_id);
+
+    files.iter().any(|file| file.status == Status::Uploading)
+}
+
+fn projected_files_after_complete(ctx: &Context, file_id: &str) -> Vec<Item> {
+    ctx.files
+        .get()
+        .clone()
+        .into_iter()
+        .map(|mut file| {
+            if file.id == file_id {
+                file.status = Status::Complete;
+                file.progress = 1.0;
+            }
+
+            file
+        })
+        .collect()
+}
+
+fn projected_files_after_error(ctx: &Context, file_id: &str, error: &str) -> Vec<Item> {
+    ctx.files
+        .get()
+        .clone()
+        .into_iter()
+        .map(|mut file| {
+            if file.id == file_id {
+                file.status = Status::Failed(error.to_string());
+                file.error = Some(error.to_string());
+            }
+
+            file
+        })
+        .collect()
+}
+
+fn projected_files_after_cancel(ctx: &Context, file_id: &str) -> Vec<Item> {
+    ctx.files
+        .get()
+        .clone()
+        .into_iter()
+        .map(|mut file| {
+            if file.id == file_id && file.status == Status::Uploading {
+                file.status = Status::Cancelled;
+            }
+
+            file
+        })
+        .collect()
+}
+
+fn apply_upload_complete(context: &mut Context, file_id: &str) {
+    context
+        .files
+        .set(projected_files_after_complete(context, file_id));
+}
+
+fn apply_upload_error(context: &mut Context, file_id: &str, error: &str) {
+    context
+        .files
+        .set(projected_files_after_error(context, file_id, error));
+}
+
+fn remove_file_by_id(context: &mut Context, file_id: &str) {
+    let updated = context
+        .files
+        .get()
+        .iter()
+        .filter(|file| file.id != file_id)
+        .cloned()
+        .collect();
+
+    context.files.set(updated);
+}
+
+fn retry_file_by_id(context: &mut Context, file_id: &str) {
+    let updated = context
+        .files
+        .get()
+        .clone()
+        .into_iter()
+        .map(|mut file| {
+            if file.id == file_id && matches!(file.status, Status::Failed(_)) {
+                file.status = Status::Pending;
+                file.progress = 0.0;
+                file.error = None;
+            }
+
+            file
+        })
+        .collect();
+
+    context.files.set(updated);
+}
+
+fn cancel_file_by_id(context: &mut Context, file_id: &str) {
+    context
+        .files
+        .set(projected_files_after_cancel(context, file_id));
+}
+
+/// Validate raw files against context constraints.
+fn validate_files(raw: &[RawFile], ctx: &Context) -> (Vec<Item>, Vec<Rejection>) {
+    let mut accepted = Vec::new();
+    let mut rejected = Vec::new();
+
+    let current_count = ctx.files.get().len();
+
+    for file in raw {
+        if let Some(max) = ctx.max_files
+            && current_count + accepted.len() >= max
+        {
+            rejected.push(Rejection {
+                name: file.name.clone(),
+                size: file.size,
+                mime_type: file.mime_type.clone(),
+                reason: RejectionReason::TooMany,
+            });
+
+            continue;
+        }
+
+        if !ctx.accept.is_empty() && !mime_matches(&file.mime_type, &file.name, &ctx.accept) {
+            rejected.push(Rejection {
+                name: file.name.clone(),
+                size: file.size,
+                mime_type: file.mime_type.clone(),
+                reason: RejectionReason::InvalidType,
+            });
+
+            continue;
+        }
+
+        if let Some(max_size) = ctx.max_file_size
+            && file.size > max_size
+        {
+            rejected.push(Rejection {
+                name: file.name.clone(),
+                size: file.size,
+                mime_type: file.mime_type.clone(),
+                reason: RejectionReason::TooLarge,
+            });
+
+            continue;
+        }
+
+        if let Some(min_size) = ctx.min_file_size
+            && file.size < min_size
+        {
+            rejected.push(Rejection {
+                name: file.name.clone(),
+                size: file.size,
+                mime_type: file.mime_type.clone(),
+                reason: RejectionReason::TooSmall,
+            });
+
+            continue;
+        }
+
+        accepted.push(Item {
+            id: generate_file_id(ctx, &accepted),
+            name: file.name.clone(),
+            size: file.size,
+            mime_type: file.mime_type.clone(),
+            status: Status::Pending,
+            progress: 0.0,
+            error: None,
+        });
+    }
+
+    (accepted, rejected)
+}
+
+fn generate_file_id(ctx: &Context, pending_accepted: &[Item]) -> String {
+    let max_existing = ctx
+        .files
+        .get()
+        .iter()
+        .chain(pending_accepted.iter())
+        .filter_map(|file| file.id.strip_prefix("file-")?.parse::<u64>().ok())
+        .max()
+        .unwrap_or(0);
+
+    format!("file-{}", max_existing.saturating_add(1))
+}
+
+fn mime_matches(mime: &str, name: &str, patterns: &[String]) -> bool {
+    let normalized = normalize_mime_type(mime);
+
+    patterns.iter().any(|pattern| {
+        if pattern.ends_with("/*") {
+            let prefix = &pattern[..pattern.len() - 1];
+
+            normalized.starts_with(prefix)
+        } else if let Some(extension) = pattern.strip_prefix('.') {
+            normalized == *pattern || file_name_has_extension(name, extension)
+        } else {
+            normalized == normalize_mime_type(pattern)
+        }
+    })
+}
+
+fn normalize_mime_type(mime_type: &str) -> String {
+    let normalized = mime_type.trim().to_ascii_lowercase();
+
+    if normalized == "image/jpg" {
+        "image/jpeg".to_owned()
+    } else {
+        normalized
+    }
+}
+
+fn file_name_has_extension(name: &str, extension: &str) -> bool {
+    let Some(actual_extension) = name.rsplit_once('.').map(|(_, ext)| ext) else {
+        return false;
+    };
+
+    !actual_extension.is_empty() && actual_extension.eq_ignore_ascii_case(extension)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_dropzone_disabled_snapshot.snap
+++ b/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_dropzone_disabled_snapshot.snap
@@ -1,0 +1,67 @@
+---
+source: crates/ars-components/src/specialized/file_upload/tests.rs
+expression: "snapshot_attrs(&api_with_context(ctx, State::Idle).dropzone_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "dropzone",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "file-upload",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "idle",
+            ),
+        ),
+        (
+            Aria(
+                Disabled,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Aria(
+                LabelledBy,
+            ),
+            String(
+                "upload-label",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "upload-dropzone",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "button",
+            ),
+        ),
+        (
+            TabIndex,
+            String(
+                "0",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_dropzone_drag_over_snapshot.snap
+++ b/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_dropzone_drag_over_snapshot.snap
@@ -1,0 +1,59 @@
+---
+source: crates/ars-components/src/specialized/file_upload/tests.rs
+expression: "snapshot_attrs(&api_for_state(State::DragOver).dropzone_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "dropzone",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "file-upload",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "drag-over",
+            ),
+        ),
+        (
+            Aria(
+                LabelledBy,
+            ),
+            String(
+                "upload-label",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "upload-dropzone",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "button",
+            ),
+        ),
+        (
+            TabIndex,
+            String(
+                "0",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_dropzone_idle_snapshot.snap
+++ b/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_dropzone_idle_snapshot.snap
@@ -1,0 +1,59 @@
+---
+source: crates/ars-components/src/specialized/file_upload/tests.rs
+expression: "snapshot_attrs(&api_for_state(State::Idle).dropzone_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "dropzone",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "file-upload",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "idle",
+            ),
+        ),
+        (
+            Aria(
+                LabelledBy,
+            ),
+            String(
+                "upload-label",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "upload-dropzone",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "button",
+            ),
+        ),
+        (
+            TabIndex,
+            String(
+                "0",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_dropzone_readonly_snapshot.snap
+++ b/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_dropzone_readonly_snapshot.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ars-components/src/specialized/file_upload/tests.rs
-expression: "snapshot_attrs(&api_with_context(ctx, State::Idle).trigger_attrs())"
+expression: "snapshot_attrs(&api_with_context(ctx, State::Idle).dropzone_attrs())"
 ---
 AttrMap {
     attrs: [
@@ -9,7 +9,7 @@ AttrMap {
                 "ars-part",
             ),
             String(
-                "trigger",
+                "dropzone",
             ),
         ),
         (
@@ -18,6 +18,14 @@ AttrMap {
             ),
             String(
                 "file-upload",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "idle",
             ),
         ),
         (
@@ -30,22 +38,28 @@ AttrMap {
         ),
         (
             Aria(
-                Label,
+                LabelledBy,
             ),
             String(
-                "Choose files to upload",
+                "upload-label",
             ),
         ),
         (
-            Disabled,
-            Bool(
-                true,
+            Id,
+            String(
+                "upload-dropzone",
             ),
         ),
         (
-            Type,
+            Role,
             String(
                 "button",
+            ),
+        ),
+        (
+            TabIndex,
+            String(
+                "0",
             ),
         ),
     ],

--- a/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_dropzone_uploading_snapshot.snap
+++ b/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_dropzone_uploading_snapshot.snap
@@ -1,0 +1,59 @@
+---
+source: crates/ars-components/src/specialized/file_upload/tests.rs
+expression: "snapshot_attrs(&api_for_state(State::Uploading).dropzone_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "dropzone",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "file-upload",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "uploading",
+            ),
+        ),
+        (
+            Aria(
+                LabelledBy,
+            ),
+            String(
+                "upload-label",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "upload-dropzone",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "button",
+            ),
+        ),
+        (
+            TabIndex,
+            String(
+                "0",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_hidden_input_accept_snapshot.snap
+++ b/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_hidden_input_accept_snapshot.snap
@@ -1,0 +1,55 @@
+---
+source: crates/ars-components/src/specialized/file_upload/tests.rs
+expression: "snapshot_attrs(&api_with_context(ctx, State::Idle).hidden_input_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "hidden-input",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "file-upload",
+            ),
+        ),
+        (
+            Class,
+            String(
+                "ars-sr-input",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "upload-input",
+            ),
+        ),
+        (
+            TabIndex,
+            String(
+                "-1",
+            ),
+        ),
+        (
+            Accept,
+            String(
+                "image/*",
+            ),
+        ),
+        (
+            Type,
+            String(
+                "file",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_hidden_input_capture_snapshot.snap
+++ b/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_hidden_input_capture_snapshot.snap
@@ -1,0 +1,55 @@
+---
+source: crates/ars-components/src/specialized/file_upload/tests.rs
+expression: "snapshot_attrs(&api_with_props(props, ctx, State::Idle).hidden_input_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "hidden-input",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "file-upload",
+            ),
+        ),
+        (
+            Class,
+            String(
+                "ars-sr-input",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "upload-input",
+            ),
+        ),
+        (
+            TabIndex,
+            String(
+                "-1",
+            ),
+        ),
+        (
+            Capture,
+            String(
+                "user",
+            ),
+        ),
+        (
+            Type,
+            String(
+                "file",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_hidden_input_default_snapshot.snap
+++ b/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_hidden_input_default_snapshot.snap
@@ -1,0 +1,49 @@
+---
+source: crates/ars-components/src/specialized/file_upload/tests.rs
+expression: "snapshot_attrs(&api_for_state(State::Idle).hidden_input_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "hidden-input",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "file-upload",
+            ),
+        ),
+        (
+            Class,
+            String(
+                "ars-sr-input",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "upload-input",
+            ),
+        ),
+        (
+            TabIndex,
+            String(
+                "-1",
+            ),
+        ),
+        (
+            Type,
+            String(
+                "file",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_hidden_input_directory_snapshot.snap
+++ b/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_hidden_input_directory_snapshot.snap
@@ -1,0 +1,55 @@
+---
+source: crates/ars-components/src/specialized/file_upload/tests.rs
+expression: "snapshot_attrs(&api_with_context(ctx, State::Idle).hidden_input_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "hidden-input",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "file-upload",
+            ),
+        ),
+        (
+            Class,
+            String(
+                "ars-sr-input",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "upload-input",
+            ),
+        ),
+        (
+            TabIndex,
+            String(
+                "-1",
+            ),
+        ),
+        (
+            Type,
+            String(
+                "file",
+            ),
+        ),
+        (
+            WebkitDirectory,
+            String(
+                "",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_hidden_input_directory_snapshot.snap
+++ b/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_hidden_input_directory_snapshot.snap
@@ -39,6 +39,12 @@ AttrMap {
             ),
         ),
         (
+            Multiple,
+            Bool(
+                true,
+            ),
+        ),
+        (
             Type,
             String(
                 "file",

--- a/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_hidden_input_disabled_snapshot.snap
+++ b/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_hidden_input_disabled_snapshot.snap
@@ -1,0 +1,55 @@
+---
+source: crates/ars-components/src/specialized/file_upload/tests.rs
+expression: "snapshot_attrs(&api_with_context(ctx, State::Idle).hidden_input_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "hidden-input",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "file-upload",
+            ),
+        ),
+        (
+            Class,
+            String(
+                "ars-sr-input",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "upload-input",
+            ),
+        ),
+        (
+            TabIndex,
+            String(
+                "-1",
+            ),
+        ),
+        (
+            Disabled,
+            Bool(
+                true,
+            ),
+        ),
+        (
+            Type,
+            String(
+                "file",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_hidden_input_multiple_snapshot.snap
+++ b/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_hidden_input_multiple_snapshot.snap
@@ -1,0 +1,55 @@
+---
+source: crates/ars-components/src/specialized/file_upload/tests.rs
+expression: "snapshot_attrs(&api_with_context(ctx, State::Idle).hidden_input_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "hidden-input",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "file-upload",
+            ),
+        ),
+        (
+            Class,
+            String(
+                "ars-sr-input",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "upload-input",
+            ),
+        ),
+        (
+            TabIndex,
+            String(
+                "-1",
+            ),
+        ),
+        (
+            Multiple,
+            Bool(
+                true,
+            ),
+        ),
+        (
+            Type,
+            String(
+                "file",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_hidden_input_name_snapshot.snap
+++ b/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_hidden_input_name_snapshot.snap
@@ -1,0 +1,55 @@
+---
+source: crates/ars-components/src/specialized/file_upload/tests.rs
+expression: "snapshot_attrs(&api_with_props(props, ctx, State::Idle).hidden_input_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "hidden-input",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "file-upload",
+            ),
+        ),
+        (
+            Class,
+            String(
+                "ars-sr-input",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "upload-input",
+            ),
+        ),
+        (
+            TabIndex,
+            String(
+                "-1",
+            ),
+        ),
+        (
+            Name,
+            String(
+                "attachments",
+            ),
+        ),
+        (
+            Type,
+            String(
+                "file",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_hidden_input_required_snapshot.snap
+++ b/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_hidden_input_required_snapshot.snap
@@ -1,0 +1,55 @@
+---
+source: crates/ars-components/src/specialized/file_upload/tests.rs
+expression: "snapshot_attrs(&api_with_props(props, ctx, State::Idle).hidden_input_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "hidden-input",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "file-upload",
+            ),
+        ),
+        (
+            Class,
+            String(
+                "ars-sr-input",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "upload-input",
+            ),
+        ),
+        (
+            TabIndex,
+            String(
+                "-1",
+            ),
+        ),
+        (
+            Required,
+            Bool(
+                true,
+            ),
+        ),
+        (
+            Type,
+            String(
+                "file",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_item_cancelled_snapshot.snap
+++ b/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_item_cancelled_snapshot.snap
@@ -50,6 +50,12 @@ AttrMap {
                 "listitem",
             ),
         ),
+        (
+            TabIndex,
+            String(
+                "0",
+            ),
+        ),
     ],
     styles: [],
 }

--- a/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_item_cancelled_snapshot.snap
+++ b/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_item_cancelled_snapshot.snap
@@ -1,0 +1,55 @@
+---
+source: crates/ars-components/src/specialized/file_upload/tests.rs
+expression: "snapshot_attrs(&api_with_files(vec![item(\"file-1\", \"photo.png\",\nStatus::Cancelled)]).item_attrs(0))"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-file-id",
+            ),
+            String(
+                "file-1",
+            ),
+        ),
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "item",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "file-upload",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "cancelled",
+            ),
+        ),
+        (
+            Aria(
+                Description,
+            ),
+            String(
+                "1 KB",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "listitem",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_item_complete_snapshot.snap
+++ b/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_item_complete_snapshot.snap
@@ -50,6 +50,12 @@ AttrMap {
                 "listitem",
             ),
         ),
+        (
+            TabIndex,
+            String(
+                "0",
+            ),
+        ),
     ],
     styles: [],
 }

--- a/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_item_complete_snapshot.snap
+++ b/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_item_complete_snapshot.snap
@@ -1,0 +1,55 @@
+---
+source: crates/ars-components/src/specialized/file_upload/tests.rs
+expression: "snapshot_attrs(&api_with_files(vec![item(\"file-1\", \"photo.png\",\nStatus::Complete)]).item_attrs(0))"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-file-id",
+            ),
+            String(
+                "file-1",
+            ),
+        ),
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "item",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "file-upload",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "complete",
+            ),
+        ),
+        (
+            Aria(
+                Description,
+            ),
+            String(
+                "1 KB",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "listitem",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_item_delete_trigger_snapshot.snap
+++ b/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_item_delete_trigger_snapshot.snap
@@ -1,0 +1,33 @@
+---
+source: crates/ars-components/src/specialized/file_upload/tests.rs
+expression: "snapshot_attrs(&api_with_files(vec![item(\"file-1\", \"photo.png\",\nStatus::Pending)]).item_delete_trigger_attrs(0))"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "item-delete-trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "file-upload",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Remove photo.png",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_item_delete_trigger_snapshot.snap
+++ b/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_item_delete_trigger_snapshot.snap
@@ -28,6 +28,12 @@ AttrMap {
                 "Remove photo.png",
             ),
         ),
+        (
+            Type,
+            String(
+                "button",
+            ),
+        ),
     ],
     styles: [],
 }

--- a/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_item_error_snapshot.snap
+++ b/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_item_error_snapshot.snap
@@ -50,6 +50,12 @@ AttrMap {
                 "listitem",
             ),
         ),
+        (
+            TabIndex,
+            String(
+                "0",
+            ),
+        ),
     ],
     styles: [],
 }

--- a/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_item_error_snapshot.snap
+++ b/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_item_error_snapshot.snap
@@ -1,0 +1,55 @@
+---
+source: crates/ars-components/src/specialized/file_upload/tests.rs
+expression: "snapshot_attrs(&api_with_files(vec![item(\"file-1\", \"photo.png\",\nStatus::Failed(\"network\".into()))]).item_attrs(0))"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-file-id",
+            ),
+            String(
+                "file-1",
+            ),
+        ),
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "item",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "file-upload",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "error",
+            ),
+        ),
+        (
+            Aria(
+                Description,
+            ),
+            String(
+                "1 KB",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "listitem",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_item_group_with_files_snapshot.snap
+++ b/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_item_group_with_files_snapshot.snap
@@ -1,0 +1,45 @@
+---
+source: crates/ars-components/src/specialized/file_upload/tests.rs
+expression: "snapshot_attrs(&api_with_files(vec![item(\"file-1\", \"photo.png\",\nStatus::Pending)]).item_group_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "item-group",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "file-upload",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Uploaded files",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "upload-file-list",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "list",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_item_pending_snapshot.snap
+++ b/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_item_pending_snapshot.snap
@@ -1,0 +1,55 @@
+---
+source: crates/ars-components/src/specialized/file_upload/tests.rs
+expression: "snapshot_attrs(&api_with_files(vec![item(\"file-1\", \"photo.png\",\nStatus::Pending)]).item_attrs(0))"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-file-id",
+            ),
+            String(
+                "file-1",
+            ),
+        ),
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "item",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "file-upload",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "pending",
+            ),
+        ),
+        (
+            Aria(
+                Description,
+            ),
+            String(
+                "1 KB",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "listitem",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_item_pending_snapshot.snap
+++ b/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_item_pending_snapshot.snap
@@ -50,6 +50,12 @@ AttrMap {
                 "listitem",
             ),
         ),
+        (
+            TabIndex,
+            String(
+                "0",
+            ),
+        ),
     ],
     styles: [],
 }

--- a/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_item_uploading_snapshot.snap
+++ b/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_item_uploading_snapshot.snap
@@ -1,0 +1,55 @@
+---
+source: crates/ars-components/src/specialized/file_upload/tests.rs
+expression: "snapshot_attrs(&api_with_files(vec![item(\"file-1\", \"photo.png\",\nStatus::Uploading)]).item_attrs(0))"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-file-id",
+            ),
+            String(
+                "file-1",
+            ),
+        ),
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "item",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "file-upload",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "uploading",
+            ),
+        ),
+        (
+            Aria(
+                Description,
+            ),
+            String(
+                "1 KB",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "listitem",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_item_uploading_snapshot.snap
+++ b/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_item_uploading_snapshot.snap
@@ -50,6 +50,12 @@ AttrMap {
                 "listitem",
             ),
         ),
+        (
+            TabIndex,
+            String(
+                "0",
+            ),
+        ),
     ],
     styles: [],
 }

--- a/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_label_snapshot.snap
+++ b/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_label_snapshot.snap
@@ -1,0 +1,37 @@
+---
+source: crates/ars-components/src/specialized/file_upload/tests.rs
+expression: "snapshot_attrs(&api_for_state(State::Idle).label_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "label",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "file-upload",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "upload-label",
+            ),
+        ),
+        (
+            For,
+            String(
+                "upload-input",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_root_disabled_snapshot.snap
+++ b/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_root_disabled_snapshot.snap
@@ -1,0 +1,41 @@
+---
+source: crates/ars-components/src/specialized/file_upload/tests.rs
+expression: "snapshot_attrs(&api_with_context(ctx, State::Idle).root_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-disabled",
+            ),
+            Bool(
+                true,
+            ),
+        ),
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "file-upload",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Drag and drop files here, or click to browse",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_root_dragging_snapshot.snap
+++ b/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_root_dragging_snapshot.snap
@@ -1,0 +1,41 @@
+---
+source: crates/ars-components/src/specialized/file_upload/tests.rs
+expression: "snapshot_attrs(&api_with_context(ctx, State::DragOver).root_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-dragging",
+            ),
+            Bool(
+                true,
+            ),
+        ),
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "file-upload",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Drag and drop files here, or click to browse",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_root_idle_snapshot.snap
+++ b/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_root_idle_snapshot.snap
@@ -1,0 +1,33 @@
+---
+source: crates/ars-components/src/specialized/file_upload/tests.rs
+expression: "snapshot_attrs(&api_for_state(State::Idle).root_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "file-upload",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Drag and drop files here, or click to browse",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_root_readonly_snapshot.snap
+++ b/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_root_readonly_snapshot.snap
@@ -1,0 +1,41 @@
+---
+source: crates/ars-components/src/specialized/file_upload/tests.rs
+expression: "snapshot_attrs(&api_with_context(ctx, State::Idle).root_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-readonly",
+            ),
+            Bool(
+                true,
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "file-upload",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Drag and drop files here, or click to browse",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_trigger_disabled_snapshot.snap
+++ b/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_trigger_disabled_snapshot.snap
@@ -1,0 +1,47 @@
+---
+source: crates/ars-components/src/specialized/file_upload/tests.rs
+expression: "snapshot_attrs(&api_with_context(ctx, State::Idle).trigger_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "file-upload",
+            ),
+        ),
+        (
+            Aria(
+                Disabled,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Choose files to upload",
+            ),
+        ),
+        (
+            Disabled,
+            Bool(
+                true,
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_trigger_enabled_snapshot.snap
+++ b/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_trigger_enabled_snapshot.snap
@@ -28,6 +28,12 @@ AttrMap {
                 "Choose files to upload",
             ),
         ),
+        (
+            Type,
+            String(
+                "button",
+            ),
+        ),
     ],
     styles: [],
 }

--- a/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_trigger_enabled_snapshot.snap
+++ b/crates/ars-components/src/specialized/file_upload/snapshots/ars_components__specialized__file_upload__tests__file_upload_trigger_enabled_snapshot.snap
@@ -1,0 +1,33 @@
+---
+source: crates/ars-components/src/specialized/file_upload/tests.rs
+expression: "snapshot_attrs(&api_for_state(State::Idle).trigger_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "file-upload",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Choose files to upload",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/specialized/file_upload/tests.rs
+++ b/crates/ars-components/src/specialized/file_upload/tests.rs
@@ -6,7 +6,7 @@ use alloc::{
 };
 use std::sync::Mutex;
 
-use ars_core::{AriaAttr, AttrMap, Env, HtmlAttr, Machine as _, Service};
+use ars_core::{AriaAttr, AttrMap, Env, HtmlAttr, Machine as _, Service, StrongSend};
 use ars_interactions::{KeyboardEventData, KeyboardKey};
 use insta::assert_snapshot;
 
@@ -994,11 +994,8 @@ fn file_upload_set_files_reconciles_idle_to_uploading_when_files_uploading() {
 }
 
 #[test]
-fn file_upload_set_files_none_reconciles_state_to_visible_queue() {
-    // `init` always starts in `Idle`, so a queue seeded with an uploading file is
-    // momentarily inconsistent. A `SetFiles(None)` sync must reconcile the state
-    // against the now-visible (internal) queue — not silently stay in `Idle`.
-    let mut service = Service::<Machine>::new(
+fn file_upload_init_starts_uploading_when_seeded_with_uploading_file() {
+    let service = Service::<Machine>::new(
         Props::new()
             .id("upload")
             .default_files(vec![item("file-1", "a.png", Status::Uploading)]),
@@ -1006,12 +1003,138 @@ fn file_upload_set_files_none_reconciles_state_to_visible_queue() {
         &Messages::default(),
     );
 
+    assert_eq!(service.state(), &State::Uploading);
+    assert!(service.connect(&|_| {}).is_uploading());
+}
+
+#[test]
+fn file_upload_init_stays_idle_without_uploading_files() {
+    let service = Service::<Machine>::new(
+        Props::new()
+            .id("upload")
+            .default_files(vec![item("file-1", "a.png", Status::Pending)]),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    assert_eq!(service.state(), &State::Idle);
+}
+
+#[test]
+fn file_upload_directory_accepts_multiple_files_without_multiple_prop() {
+    let mut service = Service::<Machine>::new(
+        Props::new().id("upload").directory(true),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    drop(service.send(Event::FilesSelected(vec![
+        raw_file("a.png", 10, "image/png"),
+        raw_file("b.png", 10, "image/png"),
+    ])));
+
+    assert_eq!(
+        service.context().files.get().len(),
+        2,
+        "directory upload accepts all files regardless of the multiple prop"
+    );
+    assert!(service.context().rejected_files.is_empty());
+}
+
+#[test]
+fn file_upload_hidden_input_directory_marks_multiple() {
+    let props = Props::new().id("upload").directory(true);
+    let (_, ctx) = Machine::init(&props, &Env::default(), &Messages::default());
+    let attrs = api_with_props(props, ctx, State::Idle).hidden_input_attrs();
+
+    assert_eq!(attrs.get(&HtmlAttr::Multiple), Some("true"));
+}
+
+#[test]
+fn file_upload_drag_enter_during_upload_keeps_uploading_state() {
+    let mut service = uploading_service("file-1");
+    assert_eq!(service.state(), &State::Uploading);
+
+    let result = service.send(Event::DragEnter);
+
+    assert_eq!(service.state(), &State::Uploading);
+    assert!(service.context().dragging);
+    assert!(
+        result
+            .pending_effects
+            .iter()
+            .any(|effect| effect.name == Effect::AnnounceDropzoneActive)
+    );
+}
+
+#[test]
+fn file_upload_drag_leave_during_upload_clears_dragging_and_stays_uploading() {
+    let mut service = uploading_service("file-1");
+    drop(service.send(Event::DragEnter));
+    assert!(service.context().dragging);
+
+    let result = service.send(Event::DragLeave);
+
+    assert_eq!(service.state(), &State::Uploading);
+    assert!(!service.context().dragging);
+    assert!(
+        result
+            .pending_effects
+            .iter()
+            .any(|effect| effect.name == Effect::AnnounceDropzoneLeft)
+    );
+}
+
+#[test]
+fn file_upload_drop_during_upload_appends_files_and_stays_uploading() {
+    let mut service = Service::<Machine>::new(
+        Props::new()
+            .id("upload")
+            .multiple(true)
+            .default_files(vec![item("file-1", "a.png", Status::Pending)]),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    drop(service.send(Event::StartUpload));
+    drop(service.send(Event::DragEnter));
+    let result = service.send(Event::Drop(vec![raw_file("b.png", 10, "image/png")]));
+
+    assert_eq!(service.state(), &State::Uploading);
+    assert_eq!(service.context().files.get().len(), 2);
+    assert!(!service.context().dragging);
+    assert!(
+        result
+            .pending_effects
+            .iter()
+            .any(|effect| effect.name == Effect::AnnounceFilesAdded { count: 1 })
+    );
+}
+
+#[test]
+fn file_upload_retry_with_auto_upload_resumes_uploading() {
+    let mut service = Service::<Machine>::new(
+        Props::new()
+            .id("upload")
+            .auto_upload(true)
+            .default_files(vec![Item {
+                status: Status::Failed("err".into()),
+                error: Some("err".into()),
+                ..item("file-1", "a.png", Status::Failed("err".into()))
+            }]),
+        &Env::default(),
+        &Messages::default(),
+    );
+
     assert_eq!(service.state(), &State::Idle);
 
-    let result = service.send(Event::SetFiles(None));
+    let result = service.send(Event::RetryFile {
+        file_id: "file-1".into(),
+    });
 
     assert!(result.state_changed);
     assert_eq!(service.state(), &State::Uploading);
+    assert_eq!(service.context().files.get()[0].status, Status::Uploading);
 }
 
 #[test]
@@ -1415,6 +1538,552 @@ fn file_upload_upload_complete_announces_completion() {
             .iter()
             .any(|effect| effect.name == Effect::AnnounceUploadComplete),
         "completing an upload must announce completion"
+    );
+}
+
+#[test]
+fn file_upload_controlled_selection_surfaces_files_and_fires_callback() {
+    let changed = Arc::new(Mutex::new(Vec::<Vec<Item>>::new()));
+    let captured = Arc::clone(&changed);
+
+    let mut service = Service::<Machine>::new(
+        Props::new()
+            .id("upload")
+            .multiple(true)
+            .files(vec![item("file-1", "a.png", Status::Complete)])
+            .on_files_change(move |files: Vec<Item>| {
+                captured.lock().unwrap().push(files);
+            }),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    let result = service.send(Event::FilesSelected(vec![raw_file(
+        "b.png",
+        10,
+        "image/png",
+    )]));
+
+    // Controlled mode still surfaces the new file via the API (optimistic sync)...
+    assert_eq!(service.context().files.get().len(), 2);
+    // ...and emits the FilesChanged effect so the parent can sync its prop.
+    assert!(
+        result
+            .pending_effects
+            .iter()
+            .any(|effect| effect.name == Effect::FilesChanged)
+    );
+
+    // The effect's setup closure invokes on_files_change with the new queue.
+    let send: StrongSend<Event> = Arc::new(|_| {});
+    for effect in result.pending_effects {
+        if effect.name == Effect::FilesChanged {
+            drop(effect.run(service.context(), service.props(), Arc::clone(&send)));
+        }
+    }
+
+    let recorded = changed.lock().unwrap();
+    assert_eq!(recorded.len(), 1);
+    assert_eq!(recorded[0].len(), 2);
+    assert_eq!(recorded[0][1].name, "b.png");
+}
+
+#[test]
+fn file_upload_remove_fires_files_change_effect() {
+    let mut service = Service::<Machine>::new(
+        Props::new()
+            .id("upload")
+            .default_files(vec![item("file-1", "a.png", Status::Pending)]),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    let result = service.send(Event::RemoveFile {
+        file_id: "file-1".into(),
+    });
+
+    assert!(service.context().files.get().is_empty());
+    assert!(
+        result
+            .pending_effects
+            .iter()
+            .any(|effect| effect.name == Effect::FilesChanged)
+    );
+}
+
+#[test]
+fn file_upload_clear_fires_files_change_effect() {
+    let mut service = Service::<Machine>::new(
+        Props::new()
+            .id("upload")
+            .default_files(vec![item("file-1", "a.png", Status::Pending)]),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    let result = service.send(Event::ClearFiles);
+
+    assert!(
+        result
+            .pending_effects
+            .iter()
+            .any(|effect| effect.name == Effect::FilesChanged)
+    );
+}
+
+#[test]
+fn file_upload_nested_drag_during_upload_tracks_counter_without_extra_announcements() {
+    let mut service = uploading_service("file-1");
+
+    drop(service.send(Event::DragEnter));
+    let result = service.send(Event::DragEnter);
+    assert_eq!(service.state(), &State::Uploading);
+    assert_eq!(service.context().drag_counter, 2);
+    assert!(service.context().dragging);
+    // A nested enter must not re-announce the active dropzone.
+    assert!(
+        !result
+            .pending_effects
+            .iter()
+            .any(|effect| effect.name == Effect::AnnounceDropzoneActive)
+    );
+
+    let result = service.send(Event::DragLeave);
+    assert_eq!(service.context().drag_counter, 1);
+    assert!(service.context().dragging);
+    assert!(
+        !result
+            .pending_effects
+            .iter()
+            .any(|effect| effect.name == Effect::AnnounceDropzoneLeft)
+    );
+}
+
+#[test]
+fn file_upload_remove_nonexistent_file_is_noop() {
+    let mut service = Service::<Machine>::new(
+        Props::new()
+            .id("upload")
+            .default_files(vec![item("file-1", "a.png", Status::Pending)]),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    let result = service.send(Event::RemoveFile {
+        file_id: "missing".into(),
+    });
+
+    assert_eq!(service.context().files.get().len(), 1);
+    assert!(
+        !result
+            .pending_effects
+            .iter()
+            .any(|effect| effect.name == Effect::FilesChanged)
+    );
+}
+
+#[test]
+fn file_upload_clear_empty_queue_emits_no_files_change() {
+    let mut service = Service::<Machine>::new(test_props(), &Env::default(), &Messages::default());
+
+    let result = service.send(Event::ClearFiles);
+
+    assert!(
+        !result
+            .pending_effects
+            .iter()
+            .any(|effect| effect.name == Effect::FilesChanged)
+    );
+}
+
+#[test]
+fn file_upload_files_change_effect_is_noop_without_callback() {
+    let mut service = Service::<Machine>::new(
+        Props::new()
+            .id("upload")
+            .default_files(vec![item("file-1", "a.png", Status::Pending)]),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    let result = service.send(Event::RemoveFile {
+        file_id: "file-1".into(),
+    });
+
+    // Running the FilesChanged effect without an on_files_change callback is a
+    // harmless no-op.
+    let send: StrongSend<Event> = Arc::new(|_| {});
+    for effect in result.pending_effects {
+        if effect.name == Effect::FilesChanged {
+            drop(effect.run(service.context(), service.props(), Arc::clone(&send)));
+        }
+    }
+
+    assert!(service.context().files.get().is_empty());
+}
+
+#[test]
+fn file_upload_complete_and_error_ignore_non_uploading_files_while_uploading() {
+    let mut service = Service::<Machine>::new(
+        Props::new().id("upload").multiple(true).default_files(vec![
+            item("file-1", "a.png", Status::Pending),
+            item("file-2", "b.png", Status::Pending),
+        ]),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    drop(service.send(Event::StartUpload));
+    drop(service.send(Event::CancelFile {
+        file_id: "file-1".into(),
+    }));
+    assert_eq!(service.state(), &State::Uploading);
+
+    // A late completion for the cancelled file must be ignored (no announce).
+    let complete = service.send(Event::UploadComplete {
+        file_id: "file-1".into(),
+    });
+    assert!(
+        !complete
+            .pending_effects
+            .iter()
+            .any(|effect| effect.name == Effect::AnnounceUploadComplete)
+    );
+
+    // A late error for the cancelled file must also be ignored.
+    drop(service.send(Event::UploadError {
+        file_id: "file-1".into(),
+        error: "late".into(),
+    }));
+
+    let file_1 = service
+        .context()
+        .files
+        .get()
+        .iter()
+        .find(|file| file.id == "file-1")
+        .expect("file-1 present")
+        .clone();
+    assert_eq!(file_1.status, Status::Cancelled);
+}
+
+#[test]
+fn file_upload_retry_non_failed_file_is_noop() {
+    let mut service = Service::<Machine>::new(
+        Props::new()
+            .id("upload")
+            .default_files(vec![item("file-1", "a.png", Status::Pending)]),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    drop(service.send(Event::RetryFile {
+        file_id: "file-1".into(),
+    }));
+
+    assert_eq!(service.context().files.get()[0].status, Status::Pending);
+}
+
+#[test]
+fn file_upload_single_mode_rejects_second_file_in_same_selection() {
+    let mut service = Service::<Machine>::new(test_props(), &Env::default(), &Messages::default());
+
+    drop(service.send(Event::FilesSelected(vec![
+        raw_file("a.png", 10, "image/png"),
+        raw_file("b.png", 10, "image/png"),
+    ])));
+
+    assert_eq!(service.context().files.get().len(), 1);
+    assert_eq!(
+        service.context().rejected_files[0].reason,
+        RejectionReason::TooMany
+    );
+}
+
+#[test]
+fn file_upload_start_upload_without_pending_files_is_noop() {
+    let mut idle = Service::<Machine>::new(test_props(), &Env::default(), &Messages::default());
+    let result = idle.send(Event::StartUpload);
+    assert!(!result.state_changed);
+    assert_eq!(idle.state(), &State::Idle);
+
+    let mut uploading = uploading_service("file-1");
+    let result = uploading.send(Event::StartUpload);
+    assert!(!result.state_changed);
+    assert_eq!(uploading.state(), &State::Uploading);
+}
+
+#[test]
+fn file_upload_on_props_changed_detects_each_output_prop() {
+    let base = test_props();
+
+    let cases = [
+        Props {
+            multiple: true,
+            ..base.clone()
+        },
+        Props {
+            accept: vec!["image/*".into()],
+            ..base.clone()
+        },
+        Props {
+            max_file_size: Some(1),
+            ..base.clone()
+        },
+        Props {
+            min_file_size: Some(1),
+            ..base.clone()
+        },
+        Props {
+            max_files: Some(1),
+            ..base.clone()
+        },
+        Props {
+            auto_upload: true,
+            ..base.clone()
+        },
+        Props {
+            directory: true,
+            ..base.clone()
+        },
+    ];
+
+    for new in cases {
+        assert_eq!(
+            Machine::on_props_changed(&base, &new),
+            vec![Event::SetProps]
+        );
+    }
+}
+
+#[test]
+fn file_upload_item_attrs_out_of_bounds_index_is_minimal() {
+    let api = api_for_state(State::Idle);
+
+    // No file at the index: the optional-file branches take their `None` path.
+    assert_eq!(api.item_attrs(0).get(&HtmlAttr::Role), None);
+    assert_eq!(
+        api.item_delete_trigger_attrs(0)
+            .get(&HtmlAttr::Aria(AriaAttr::Label)),
+        None
+    );
+}
+
+#[test]
+fn file_upload_file_size_message_formats_each_unit() {
+    let (_, ctx) = Machine::init(&test_props(), &Env::default(), &Messages::default());
+    let format = |bytes| (ctx.messages.file_size)(bytes, &ctx.locale);
+
+    assert!(format(500).contains("bytes"));
+    assert!(format(2_048).contains("KB"));
+    assert!(format(1_536).contains("KB")); // 1.5 KB (fractional)
+    assert!(format(3_145_728).contains("MB"));
+}
+
+#[test]
+fn file_upload_accept_normalizes_jpg_alias_to_jpeg() {
+    let mut service = Service::<Machine>::new(
+        Props::new().id("upload").accept(vec!["image/jpeg".into()]),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    drop(service.send(Event::FilesSelected(vec![raw_file(
+        "photo.jpg",
+        10,
+        "image/jpg",
+    )])));
+
+    assert_eq!(
+        service.context().files.get().len(),
+        1,
+        "image/jpg must normalize to image/jpeg and match"
+    );
+}
+
+#[test]
+fn file_upload_accept_extension_pattern_matches_equal_mime() {
+    // A dotted accept token also matches a file whose reported MIME equals the
+    // token verbatim (the exact-match arm of the extension branch).
+    let mut service = Service::<Machine>::new(
+        Props::new().id("upload").accept(vec![".png".into()]),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    drop(service.send(Event::FilesSelected(vec![raw_file("blob", 10, ".png")])));
+
+    assert_eq!(service.context().files.get().len(), 1);
+}
+
+#[test]
+fn file_upload_accept_dot_only_pattern_rejects() {
+    let mut service = Service::<Machine>::new(
+        Props::new().id("upload").accept(vec![".".into()]),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    drop(service.send(Event::FilesSelected(vec![raw_file(
+        "a.png",
+        10,
+        "image/png",
+    )])));
+
+    assert!(service.context().files.get().is_empty());
+}
+
+#[test]
+fn file_upload_trigger_readonly_sets_disabled() {
+    let props = Props::new().id("upload").readonly(true);
+    let (_, ctx) = Machine::init(&props, &Env::default(), &Messages::default());
+    let attrs = api_with_props(props, ctx, State::Idle).trigger_attrs();
+
+    assert_eq!(attrs.get(&HtmlAttr::Disabled), Some("true"));
+}
+
+#[test]
+fn file_upload_dropzone_attrs_reflect_dragging_flag() {
+    let mut ctx = Machine::init(&test_props(), &Env::default(), &Messages::default()).1;
+    ctx.dragging = true;
+
+    let attrs = api_with_context(ctx, State::DragOver).dropzone_attrs();
+
+    assert_eq!(attrs.get(&HtmlAttr::Data("ars-dragging")), Some("true"));
+}
+
+#[test]
+fn file_upload_item_handlers_out_of_bounds_are_noop() {
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let captured = Arc::clone(&events);
+    let send_event = move |event| captured.lock().unwrap().push(event);
+
+    let service = Service::<Machine>::new(test_props(), &Env::default(), &Messages::default());
+    let api = service.connect(&send_event);
+    api.on_item_delete_trigger_click(5);
+    api.on_item_keydown(5, &key_event(KeyboardKey::Delete));
+
+    assert!(events.lock().unwrap().is_empty());
+}
+
+#[test]
+fn file_upload_is_max_files_reached_false_without_limit() {
+    let service = Service::<Machine>::new(
+        Props::new()
+            .id("upload")
+            .default_files(vec![item("file-1", "a.png", Status::Pending)]),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    assert!(!service.connect(&|_| {}).is_max_files_reached());
+}
+
+#[test]
+fn file_upload_cancel_non_uploading_file_while_uploading_is_ignored() {
+    let mut service = Service::<Machine>::new(
+        Props::new().id("upload").multiple(true).default_files(vec![
+            item("file-1", "a.png", Status::Pending),
+            item("file-2", "b.png", Status::Pending),
+        ]),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    drop(service.send(Event::StartUpload));
+    drop(service.send(Event::UploadComplete {
+        file_id: "file-1".into(),
+    }));
+    assert_eq!(service.state(), &State::Uploading);
+
+    // Cancelling the already-complete file leaves it Complete.
+    drop(service.send(Event::CancelFile {
+        file_id: "file-1".into(),
+    }));
+
+    assert_eq!(
+        service
+            .context()
+            .files
+            .get()
+            .iter()
+            .find(|file| file.id == "file-1")
+            .expect("file-1 present")
+            .status,
+        Status::Complete
+    );
+}
+
+#[test]
+fn file_upload_retry_ignores_non_matching_files() {
+    let mut service = Service::<Machine>::new(
+        Props::new().id("upload").default_files(vec![
+            Item {
+                status: Status::Failed("e".into()),
+                error: Some("e".into()),
+                ..item("file-1", "a.png", Status::Failed("e".into()))
+            },
+            item("file-2", "b.png", Status::Pending),
+        ]),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    drop(service.send(Event::RetryFile {
+        file_id: "file-1".into(),
+    }));
+
+    let files = service.context().files.get();
+    assert_eq!(
+        files.iter().find(|f| f.id == "file-1").unwrap().status,
+        Status::Pending
+    );
+    assert_eq!(
+        files.iter().find(|f| f.id == "file-2").unwrap().status,
+        Status::Pending
+    );
+}
+
+#[test]
+fn file_upload_accepts_file_within_all_limits() {
+    let mut service = Service::<Machine>::new(
+        Props::new()
+            .id("upload")
+            .max_files(5)
+            .max_file_size(1_000)
+            .min_file_size(10),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    drop(service.send(Event::FilesSelected(vec![raw_file(
+        "a.png",
+        100,
+        "image/png",
+    )])));
+
+    assert_eq!(service.context().files.get().len(), 1);
+    assert!(service.context().rejected_files.is_empty());
+}
+
+#[test]
+fn file_upload_max_files_accepts_up_to_limit_then_rejects_in_same_selection() {
+    let mut service = Service::<Machine>::new(
+        Props::new().id("upload").multiple(true).max_files(2),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    drop(service.send(Event::FilesSelected(vec![
+        raw_file("a.png", 10, "image/png"),
+        raw_file("b.png", 10, "image/png"),
+        raw_file("c.png", 10, "image/png"),
+    ])));
+
+    assert_eq!(service.context().files.get().len(), 2);
+    assert_eq!(
+        service.context().rejected_files[0].reason,
+        RejectionReason::TooMany
     );
 }
 

--- a/crates/ars-components/src/specialized/file_upload/tests.rs
+++ b/crates/ars-components/src/specialized/file_upload/tests.rs
@@ -1565,9 +1565,10 @@ fn file_upload_controlled_selection_surfaces_files_and_fires_callback() {
         "image/png",
     )]));
 
-    // Controlled mode still surfaces the new file via the API (optimistic sync)...
+    // The component owns the working queue, so api.files() reflects the new file
+    // in controlled mode too...
     assert_eq!(service.context().files.get().len(), 2);
-    // ...and emits the FilesChanged effect so the parent can sync its prop.
+    // ...and emits FilesChanged so the parent can observe/mirror the change.
     assert!(
         result
             .pending_effects

--- a/crates/ars-components/src/specialized/file_upload/tests.rs
+++ b/crates/ars-components/src/specialized/file_upload/tests.rs
@@ -1192,6 +1192,56 @@ fn file_upload_hidden_input_capture_snapshot() {
 }
 
 #[test]
+fn file_upload_hidden_input_readonly_is_disabled() {
+    let props = Props::new().id("upload").readonly(true);
+    let (_, ctx) = Machine::init(&props, &Env::default(), &Messages::default());
+    let attrs = api_with_props(props, ctx, State::Idle).hidden_input_attrs();
+
+    assert_eq!(attrs.get(&HtmlAttr::Disabled), Some("true"));
+}
+
+#[test]
+fn file_upload_hidden_input_required_only_when_queue_empty() {
+    let props = Props::new()
+        .id("upload")
+        .required(true)
+        .default_files(vec![item("file-1", "a.png", Status::Pending)]);
+    let (_, ctx) = Machine::init(&props, &Env::default(), &Messages::default());
+    let attrs = api_with_props(props, ctx, State::Idle).hidden_input_attrs();
+
+    assert_eq!(attrs.get(&HtmlAttr::Required), None);
+}
+
+#[test]
+fn file_upload_progress_fraction_clamps_above_one() {
+    let fraction = Progress {
+        file_index: 0,
+        bytes_sent: 200,
+        bytes_total: 100,
+    }
+    .fraction();
+
+    assert!((fraction - 1.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn file_upload_accept_wildcard_is_case_insensitive() {
+    let mut service = Service::<Machine>::new(
+        Props::new().id("upload").accept(vec!["Image/*".into()]),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    drop(service.send(Event::FilesSelected(vec![raw_file(
+        "photo.png",
+        100,
+        "image/png",
+    )])));
+
+    assert_eq!(service.context().files.get().len(), 1);
+}
+
+#[test]
 fn file_upload_hidden_input_required_snapshot() {
     let props = Props::new().id("upload").required(true);
 

--- a/crates/ars-components/src/specialized/file_upload/tests.rs
+++ b/crates/ars-components/src/specialized/file_upload/tests.rs
@@ -857,6 +857,262 @@ fn file_upload_complete_ignores_cancelled_file() {
 }
 
 #[test]
+fn file_upload_on_props_changed_emits_set_props_for_capture_and_name() {
+    let base = test_props();
+
+    assert_eq!(
+        Machine::on_props_changed(
+            &base,
+            &Props {
+                capture: Some("user".into()),
+                ..base.clone()
+            },
+        ),
+        vec![Event::SetProps]
+    );
+
+    assert_eq!(
+        Machine::on_props_changed(
+            &base,
+            &Props {
+                name: Some("attachments".into()),
+                ..base.clone()
+            },
+        ),
+        vec![Event::SetProps]
+    );
+}
+
+#[test]
+fn file_upload_set_props_syncs_capture_and_name_into_context() {
+    let mut service = Service::<Machine>::new(test_props(), &Env::default(), &Messages::default());
+
+    assert_eq!(service.context().capture, None);
+    assert_eq!(service.context().name, None);
+
+    let result = service.set_props(Props {
+        capture: Some("environment".into()),
+        name: Some("avatar".into()),
+        ..service.props().clone()
+    });
+
+    assert!(result.context_changed);
+    assert_eq!(service.context().capture.as_deref(), Some("environment"));
+    assert_eq!(service.context().name.as_deref(), Some("avatar"));
+
+    let attrs = service.connect(&|_| {}).hidden_input_attrs();
+    assert_eq!(attrs.get(&HtmlAttr::Capture), Some("environment"));
+    assert_eq!(attrs.get(&HtmlAttr::Name), Some("avatar"));
+}
+
+#[test]
+fn file_upload_disabling_during_drag_over_resets_to_idle() {
+    let mut service = Service::<Machine>::new(test_props(), &Env::default(), &Messages::default());
+
+    drop(service.send(Event::DragEnter));
+    assert_eq!(service.state(), &State::DragOver);
+    assert!(service.context().dragging);
+
+    let result = service.set_props(Props {
+        disabled: true,
+        ..service.props().clone()
+    });
+
+    assert!(result.state_changed);
+    assert_eq!(service.state(), &State::Idle);
+    assert!(!service.context().dragging);
+    assert_eq!(service.context().drag_counter, 0);
+}
+
+#[test]
+fn file_upload_readonly_during_drag_over_resets_to_idle() {
+    let mut service = Service::<Machine>::new(test_props(), &Env::default(), &Messages::default());
+
+    drop(service.send(Event::DragEnter));
+    assert_eq!(service.state(), &State::DragOver);
+
+    let result = service.set_props(Props {
+        readonly: true,
+        ..service.props().clone()
+    });
+
+    assert!(result.state_changed);
+    assert_eq!(service.state(), &State::Idle);
+    assert!(!service.context().dragging);
+    assert_eq!(service.context().drag_counter, 0);
+}
+
+#[test]
+fn file_upload_set_files_reconciles_uploading_to_idle_when_no_uploading_files() {
+    let mut service = uploading_service("file-1");
+    assert_eq!(service.state(), &State::Uploading);
+
+    let result = service.send(Event::SetFiles(Some(vec![item(
+        "file-1",
+        "doc.txt",
+        Status::Complete,
+    )])));
+
+    assert!(result.state_changed);
+    assert_eq!(service.state(), &State::Idle);
+}
+
+#[test]
+fn file_upload_set_files_reconciles_idle_to_uploading_when_files_uploading() {
+    let mut service = Service::<Machine>::new(
+        Props::new()
+            .id("upload")
+            .files(vec![item("file-1", "a.png", Status::Pending)]),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    assert_eq!(service.state(), &State::Idle);
+
+    let result = service.send(Event::SetFiles(Some(vec![item(
+        "file-1",
+        "a.png",
+        Status::Uploading,
+    )])));
+
+    assert!(result.state_changed);
+    assert_eq!(service.state(), &State::Uploading);
+}
+
+#[test]
+fn file_upload_generated_ids_do_not_reuse_after_removal() {
+    let mut service = Service::<Machine>::new(
+        Props::new().id("upload").multiple(true),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    drop(service.send(Event::FilesSelected(vec![raw_file(
+        "a.png",
+        10,
+        "image/png",
+    )])));
+    let first_id = service.context().files.get()[0].id.clone();
+
+    drop(service.send(Event::RemoveFile {
+        file_id: first_id.clone(),
+    }));
+    assert!(service.context().files.get().is_empty());
+
+    drop(service.send(Event::FilesSelected(vec![raw_file(
+        "b.png",
+        10,
+        "image/png",
+    )])));
+    let second_id = service.context().files.get()[0].id.clone();
+
+    assert_ne!(
+        first_id, second_id,
+        "generated file id must not be reused after the previous file was removed"
+    );
+}
+
+#[test]
+fn file_upload_generated_ids_avoid_collision_with_controlled_ids() {
+    let mut service = Service::<Machine>::new(
+        Props::new().id("upload").multiple(true),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    // Parent supplies a file in the "file-N" id namespace, then relinquishes
+    // control so the queue becomes uncontrolled again.
+    drop(service.send(Event::SetFiles(Some(vec![item(
+        "file-1",
+        "external.png",
+        Status::Complete,
+    )]))));
+    drop(service.send(Event::SetFiles(None)));
+
+    // User adds a file; the generated id must not collide with the supplied one
+    // because the monotonic counter was advanced past it on SetFiles.
+    drop(service.send(Event::FilesSelected(vec![raw_file(
+        "new.png",
+        10,
+        "image/png",
+    )])));
+
+    let ids: Vec<String> = service
+        .context()
+        .files
+        .get()
+        .iter()
+        .map(|file| file.id.clone())
+        .collect();
+
+    let mut unique = ids.clone();
+    unique.sort();
+    unique.dedup();
+
+    assert_eq!(
+        ids.len(),
+        unique.len(),
+        "generated id collided with an externally supplied id: {ids:?}"
+    );
+}
+
+#[test]
+fn file_upload_progress_ignored_for_non_uploading_file() {
+    let mut service = Service::<Machine>::new(
+        Props::new().id("upload").multiple(true).default_files(vec![
+            item("file-1", "a.png", Status::Pending),
+            item("file-2", "b.png", Status::Pending),
+        ]),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    drop(service.send(Event::StartUpload));
+
+    // Cancel file-1 while file-2 keeps uploading (machine stays in Uploading).
+    drop(service.send(Event::CancelFile {
+        file_id: "file-1".into(),
+    }));
+    assert_eq!(service.state(), &State::Uploading);
+
+    // A late progress callback for the cancelled file must be ignored.
+    drop(service.send(Event::UploadProgress {
+        file_id: "file-1".into(),
+        progress: 0.7,
+    }));
+
+    let cancelled = service
+        .context()
+        .files
+        .get()
+        .iter()
+        .find(|file| file.id == "file-1")
+        .expect("cancelled file remains in the queue")
+        .clone();
+
+    assert_eq!(cancelled.status, Status::Cancelled);
+    assert!(
+        cancelled.progress.abs() < f64::EPSILON,
+        "progress for a non-uploading file must not advance"
+    );
+
+    // The still-uploading file continues to accept progress.
+    drop(service.send(Event::UploadProgress {
+        file_id: "file-2".into(),
+        progress: 0.4,
+    }));
+    let uploading = service
+        .context()
+        .files
+        .get()
+        .iter()
+        .find(|file| file.id == "file-2")
+        .expect("uploading file remains in the queue")
+        .clone();
+    assert!((uploading.progress - 0.4).abs() < f64::EPSILON);
+}
+
+#[test]
 fn file_upload_open_file_picker_emits_effect() {
     let mut service = Service::<Machine>::new(test_props(), &Env::default(), &Messages::default());
 

--- a/crates/ars-components/src/specialized/file_upload/tests.rs
+++ b/crates/ars-components/src/specialized/file_upload/tests.rs
@@ -2088,6 +2088,98 @@ fn file_upload_max_files_accepts_up_to_limit_then_rejects_in_same_selection() {
 }
 
 #[test]
+fn file_upload_reconcile_enters_uploading_from_drag_over() {
+    let mut service = Service::<Machine>::new(
+        Props::new().id("upload").multiple(true).files(vec![item(
+            "file-1",
+            "a.png",
+            Status::Pending,
+        )]),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    drop(service.send(Event::DragEnter));
+    assert_eq!(service.state(), &State::DragOver);
+    assert!(service.context().dragging);
+
+    // Controlled queue begins uploading mid-drag: enter Uploading, keep dragging.
+    let result = service.send(Event::SetFiles(Some(vec![item(
+        "file-1",
+        "a.png",
+        Status::Uploading,
+    )])));
+    assert!(result.state_changed);
+    assert_eq!(service.state(), &State::Uploading);
+    assert!(service.context().dragging);
+
+    // The Uploading drag-leave path then clears the drag without ending the upload.
+    drop(service.send(Event::DragLeave));
+    assert_eq!(service.state(), &State::Uploading);
+    assert!(!service.context().dragging);
+}
+
+#[test]
+fn file_upload_disabling_during_upload_drag_clears_drag_but_keeps_uploading() {
+    let mut service = uploading_service("file-1");
+
+    drop(service.send(Event::DragEnter));
+    assert!(service.context().dragging);
+
+    let result = service.set_props(Props {
+        disabled: true,
+        ..service.props().clone()
+    });
+
+    assert_eq!(service.state(), &State::Uploading);
+    assert!(!service.context().dragging);
+    assert_eq!(service.context().drag_counter, 0);
+    assert!(result.context_changed);
+}
+
+#[test]
+fn file_upload_item_is_keyboard_focusable() {
+    let api = api_with_files(vec![item("file-1", "a.png", Status::Pending)]);
+
+    assert_eq!(api.item_attrs(0).get(&HtmlAttr::TabIndex), Some("0"));
+}
+
+#[test]
+fn file_upload_open_file_picker_blocked_while_inert() {
+    let disabled = Props::new().id("upload").disabled(true);
+    let readonly = Props::new().id("upload").readonly(true);
+
+    for props in [disabled, readonly] {
+        let mut service = Service::<Machine>::new(props, &Env::default(), &Messages::default());
+        let result = service.send(Event::OpenFilePicker);
+
+        assert!(
+            result.pending_effects.is_empty(),
+            "the file picker must not open while the component is disabled or read-only"
+        );
+    }
+}
+
+#[test]
+fn file_upload_rejection_message_reflects_rejection_state() {
+    // No rejections: None.
+    assert!(api_for_state(State::Idle).rejection_message().is_none());
+
+    // With rejections: a screen-reader summary.
+    let mut service = Service::<Machine>::new(
+        Props::new().id("upload").max_file_size(50),
+        &Env::default(),
+        &Messages::default(),
+    );
+    drop(service.send(Event::FilesSelected(vec![raw_file(
+        "big.png",
+        100,
+        "image/png",
+    )])));
+    assert!(service.connect(&|_| {}).rejection_message().is_some());
+}
+
+#[test]
 fn file_upload_open_file_picker_emits_effect() {
     let mut service = Service::<Machine>::new(test_props(), &Env::default(), &Messages::default());
 

--- a/crates/ars-components/src/specialized/file_upload/tests.rs
+++ b/crates/ars-components/src/specialized/file_upload/tests.rs
@@ -43,6 +43,20 @@ fn snapshot_attrs(attrs: &AttrMap) -> String {
     format!("{attrs:#?}")
 }
 
+fn key_event(key: KeyboardKey) -> KeyboardEventData {
+    KeyboardEventData {
+        key,
+        character: None,
+        code: String::new(),
+        repeat: false,
+        shift_key: false,
+        ctrl_key: false,
+        alt_key: false,
+        meta_key: false,
+        is_composing: false,
+    }
+}
+
 fn api_for_state(state: State) -> super::Api<'static> {
     let props = Box::leak(Box::new(test_props()));
 
@@ -980,6 +994,27 @@ fn file_upload_set_files_reconciles_idle_to_uploading_when_files_uploading() {
 }
 
 #[test]
+fn file_upload_set_files_none_reconciles_state_to_visible_queue() {
+    // `init` always starts in `Idle`, so a queue seeded with an uploading file is
+    // momentarily inconsistent. A `SetFiles(None)` sync must reconcile the state
+    // against the now-visible (internal) queue — not silently stay in `Idle`.
+    let mut service = Service::<Machine>::new(
+        Props::new()
+            .id("upload")
+            .default_files(vec![item("file-1", "a.png", Status::Uploading)]),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    assert_eq!(service.state(), &State::Idle);
+
+    let result = service.send(Event::SetFiles(None));
+
+    assert!(result.state_changed);
+    assert_eq!(service.state(), &State::Uploading);
+}
+
+#[test]
 fn file_upload_generated_ids_do_not_reuse_after_removal() {
     let mut service = Service::<Machine>::new(
         Props::new().id("upload").multiple(true),
@@ -1110,6 +1145,277 @@ fn file_upload_progress_ignored_for_non_uploading_file() {
         .expect("uploading file remains in the queue")
         .clone();
     assert!((uploading.progress - 0.4).abs() < f64::EPSILON);
+}
+
+#[test]
+fn file_upload_item_delete_trigger_disabled_when_inert() {
+    let readonly = Props::new()
+        .id("upload")
+        .readonly(true)
+        .default_files(vec![item("file-1", "a.png", Status::Pending)]);
+    let disabled = Props::new()
+        .id("upload")
+        .disabled(true)
+        .default_files(vec![item("file-1", "a.png", Status::Pending)]);
+
+    for props in [readonly, disabled] {
+        let (_, ctx) = Machine::init(&props, &Env::default(), &Messages::default());
+        let attrs = api_with_props(props, ctx, State::Idle).item_delete_trigger_attrs(0);
+
+        assert_eq!(
+            attrs.get(&HtmlAttr::Disabled),
+            Some("true"),
+            "delete trigger must be disabled when the component is inert"
+        );
+        assert_eq!(
+            attrs.get(&HtmlAttr::Aria(AriaAttr::Disabled)),
+            Some("true"),
+            "delete trigger must be aria-disabled when the component is inert"
+        );
+    }
+}
+
+#[test]
+fn file_upload_item_delete_trigger_enabled_by_default() {
+    let props =
+        Props::new()
+            .id("upload")
+            .default_files(vec![item("file-1", "a.png", Status::Pending)]);
+    let (_, ctx) = Machine::init(&props, &Env::default(), &Messages::default());
+    let attrs = api_with_props(props, ctx, State::Idle).item_delete_trigger_attrs(0);
+
+    assert_eq!(attrs.get(&HtmlAttr::Disabled), None);
+    assert_eq!(attrs.get(&HtmlAttr::Aria(AriaAttr::Disabled)), None);
+}
+
+#[test]
+fn file_upload_item_keydown_delete_removes_focused_file() {
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let captured = Arc::clone(&events);
+    let send_event = move |event| captured.lock().unwrap().push(event);
+
+    let service = Service::<Machine>::new(
+        Props::new().id("upload").multiple(true).default_files(vec![
+            item("file-1", "a.png", Status::Pending),
+            item("file-2", "b.png", Status::Pending),
+        ]),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    service
+        .connect(&send_event)
+        .on_item_keydown(1, &key_event(KeyboardKey::Delete));
+
+    assert_eq!(
+        *events.lock().unwrap(),
+        vec![Event::RemoveFile {
+            file_id: "file-2".into()
+        }]
+    );
+}
+
+#[test]
+fn file_upload_item_keydown_backspace_removes_focused_file() {
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let captured = Arc::clone(&events);
+    let send_event = move |event| captured.lock().unwrap().push(event);
+
+    let service = Service::<Machine>::new(
+        Props::new().id("upload").multiple(true).default_files(vec![
+            item("file-1", "a.png", Status::Pending),
+            item("file-2", "b.png", Status::Pending),
+        ]),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    service
+        .connect(&send_event)
+        .on_item_keydown(0, &key_event(KeyboardKey::Backspace));
+
+    assert_eq!(
+        *events.lock().unwrap(),
+        vec![Event::RemoveFile {
+            file_id: "file-1".into()
+        }]
+    );
+}
+
+#[test]
+fn file_upload_item_keydown_other_key_is_ignored() {
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let captured = Arc::clone(&events);
+    let send_event = move |event| captured.lock().unwrap().push(event);
+
+    let service = Service::<Machine>::new(
+        Props::new()
+            .id("upload")
+            .default_files(vec![item("file-1", "a.png", Status::Pending)]),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    service
+        .connect(&send_event)
+        .on_item_keydown(0, &key_event(KeyboardKey::Enter));
+
+    assert!(events.lock().unwrap().is_empty());
+}
+
+#[test]
+fn file_upload_accept_compound_extension_matches() {
+    let mut service = Service::<Machine>::new(
+        Props::new().id("upload").accept(vec![".tar.gz".into()]),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    drop(service.send(Event::FilesSelected(vec![raw_file(
+        "archive.tar.gz",
+        100,
+        "application/gzip",
+    )])));
+
+    assert_eq!(
+        service.context().files.get().len(),
+        1,
+        "a compound extension like .tar.gz must match archive.tar.gz"
+    );
+}
+
+#[test]
+fn file_upload_accept_compound_extension_rejects_mismatch() {
+    let mut service = Service::<Machine>::new(
+        Props::new().id("upload").accept(vec![".tar.gz".into()]),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    drop(service.send(Event::FilesSelected(vec![raw_file(
+        "photo.png",
+        100,
+        "image/png",
+    )])));
+
+    assert!(service.context().files.get().is_empty());
+}
+
+#[test]
+fn file_upload_drag_leave_to_idle_announces_dropzone_left() {
+    let mut service = Service::<Machine>::new(test_props(), &Env::default(), &Messages::default());
+
+    drop(service.send(Event::DragEnter));
+    let result = service.send(Event::DragLeave);
+
+    assert_eq!(service.state(), &State::Idle);
+    assert!(
+        result
+            .pending_effects
+            .iter()
+            .any(|effect| effect.name == Effect::AnnounceDropzoneLeft),
+        "leaving the dropzone must emit AnnounceDropzoneLeft"
+    );
+}
+
+#[test]
+fn file_upload_nested_drag_leave_does_not_announce_dropzone_left() {
+    let mut service = Service::<Machine>::new(test_props(), &Env::default(), &Messages::default());
+
+    drop(service.send(Event::DragEnter));
+    drop(service.send(Event::DragEnter));
+    let result = service.send(Event::DragLeave);
+
+    assert_eq!(service.state(), &State::DragOver);
+    assert!(
+        !result
+            .pending_effects
+            .iter()
+            .any(|effect| effect.name == Effect::AnnounceDropzoneLeft),
+        "a nested drag-leave that stays in DragOver must not announce"
+    );
+}
+
+#[test]
+fn file_upload_files_selected_announces_files_added() {
+    let mut service = Service::<Machine>::new(test_props(), &Env::default(), &Messages::default());
+
+    let result = service.send(Event::FilesSelected(vec![raw_file(
+        "a.png",
+        10,
+        "image/png",
+    )]));
+
+    assert!(
+        result
+            .pending_effects
+            .iter()
+            .any(|effect| effect.name == Effect::AnnounceFilesAdded { count: 1 }),
+        "selecting files must announce the added count"
+    );
+}
+
+#[test]
+fn file_upload_drop_announces_files_added() {
+    let mut service = Service::<Machine>::new(test_props(), &Env::default(), &Messages::default());
+
+    drop(service.send(Event::DragEnter));
+    let result = service.send(Event::Drop(vec![raw_file("a.png", 10, "image/png")]));
+
+    assert!(
+        result
+            .pending_effects
+            .iter()
+            .any(|effect| effect.name == Effect::AnnounceFilesAdded { count: 1 }),
+        "dropping files must announce the added count"
+    );
+}
+
+#[test]
+fn file_upload_rejected_files_announce_rejection_not_addition() {
+    let mut service = Service::<Machine>::new(
+        Props::new().id("upload").max_file_size(50),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    let result = service.send(Event::FilesSelected(vec![raw_file(
+        "big.png",
+        100,
+        "image/png",
+    )]));
+
+    assert!(
+        result
+            .pending_effects
+            .iter()
+            .any(|effect| effect.name == Effect::AnnounceFilesRejected { count: 1 }),
+        "rejected files must announce the rejected count"
+    );
+    assert!(
+        !result
+            .pending_effects
+            .iter()
+            .any(|effect| matches!(effect.name, Effect::AnnounceFilesAdded { .. })),
+        "no files were accepted, so no addition should be announced"
+    );
+}
+
+#[test]
+fn file_upload_upload_complete_announces_completion() {
+    let mut service = uploading_service("file-1");
+
+    let result = service.send(Event::UploadComplete {
+        file_id: "file-1".into(),
+    });
+
+    assert!(
+        result
+            .pending_effects
+            .iter()
+            .any(|effect| effect.name == Effect::AnnounceUploadComplete),
+        "completing an upload must announce completion"
+    );
 }
 
 #[test]

--- a/crates/ars-components/src/specialized/file_upload/tests.rs
+++ b/crates/ars-components/src/specialized/file_upload/tests.rs
@@ -731,6 +731,132 @@ fn file_upload_readonly_allows_focus_only() {
 }
 
 #[test]
+fn file_upload_disabled_accepts_set_props_to_clear_disabled() {
+    let mut service = Service::<Machine>::new(
+        Props::new().id("upload").disabled(true),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    let result = service.set_props(Props {
+        disabled: false,
+        ..service.props().clone()
+    });
+
+    assert!(result.context_changed);
+    assert!(!service.context().disabled);
+
+    drop(service.send(Event::FilesSelected(vec![raw_file(
+        "a.png",
+        100,
+        "image/png",
+    )])));
+
+    assert_eq!(service.context().files.get().len(), 1);
+}
+
+#[test]
+fn file_upload_disabled_applies_upload_progress_while_uploading() {
+    let mut service = uploading_service("file-1");
+
+    drop(service.set_props(Props {
+        disabled: true,
+        ..service.props().clone()
+    }));
+
+    drop(service.send(Event::UploadProgress {
+        file_id: "file-1".into(),
+        progress: 0.25,
+    }));
+
+    assert!((service.context().files.get()[0].progress - 0.25).abs() < f64::EPSILON);
+}
+
+#[test]
+fn file_upload_uploading_auto_upload_starts_new_pending_files() {
+    let mut service = Service::<Machine>::new(
+        Props::new()
+            .id("upload")
+            .multiple(true)
+            .auto_upload(true)
+            .default_files(vec![item("file-1", "first.png", Status::Pending)]),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    drop(service.send(Event::StartUpload));
+
+    drop(service.send(Event::FilesSelected(vec![raw_file(
+        "second.png",
+        100,
+        "image/png",
+    )])));
+
+    let files = service.context().files.get();
+    assert_eq!(files.len(), 2);
+    assert_eq!(files[1].status, Status::Uploading);
+}
+
+#[test]
+fn file_upload_non_multiple_rejects_second_file() {
+    let mut service = Service::<Machine>::new(
+        Props::new().id("upload").multiple(false),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    drop(service.send(Event::FilesSelected(vec![raw_file(
+        "first.png",
+        100,
+        "image/png",
+    )])));
+
+    drop(service.send(Event::FilesSelected(vec![raw_file(
+        "second.png",
+        100,
+        "image/png",
+    )])));
+
+    assert_eq!(service.context().files.get().len(), 1);
+    assert_eq!(
+        service.context().rejected_files[0].reason,
+        RejectionReason::TooMany
+    );
+}
+
+#[test]
+fn file_upload_upload_progress_clamps_invalid_fraction() {
+    let mut service = uploading_service("file-1");
+
+    drop(service.send(Event::UploadProgress {
+        file_id: "file-1".into(),
+        progress: 2.0,
+    }));
+    assert!((service.context().files.get()[0].progress - 1.0).abs() < f64::EPSILON);
+
+    drop(service.send(Event::UploadProgress {
+        file_id: "file-1".into(),
+        progress: f64::NAN,
+    }));
+    assert!((service.context().files.get()[0].progress - 0.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn file_upload_complete_ignores_cancelled_file() {
+    let mut service = uploading_service("file-1");
+
+    drop(service.send(Event::CancelFile {
+        file_id: "file-1".into(),
+    }));
+
+    drop(service.send(Event::UploadComplete {
+        file_id: "file-1".into(),
+    }));
+
+    assert_eq!(service.context().files.get()[0].status, Status::Cancelled);
+}
+
+#[test]
 fn file_upload_open_file_picker_emits_effect() {
     let mut service = Service::<Machine>::new(test_props(), &Env::default(), &Messages::default());
 
@@ -861,6 +987,17 @@ fn file_upload_dropzone_disabled_sets_aria_disabled() {
 }
 
 #[test]
+fn file_upload_dropzone_readonly_sets_aria_disabled() {
+    let mut ctx = Machine::init(&test_props(), &Env::default(), &Messages::default()).1;
+
+    ctx.readonly = true;
+
+    let attrs = api_with_context(ctx, State::Idle).dropzone_attrs();
+
+    assert_eq!(attrs.get(&HtmlAttr::Aria(AriaAttr::Disabled)), Some("true"));
+}
+
+#[test]
 fn file_upload_messages_include_drag_and_drop_announcement_defaults() {
     let messages = Messages::default();
 
@@ -959,6 +1096,17 @@ fn file_upload_dropzone_disabled_snapshot() {
     let mut ctx = Machine::init(&test_props(), &Env::default(), &Messages::default()).1;
 
     ctx.disabled = true;
+
+    assert_snapshot!(snapshot_attrs(
+        &api_with_context(ctx, State::Idle).dropzone_attrs()
+    ));
+}
+
+#[test]
+fn file_upload_dropzone_readonly_snapshot() {
+    let mut ctx = Machine::init(&test_props(), &Env::default(), &Messages::default()).1;
+
+    ctx.readonly = true;
 
     assert_snapshot!(snapshot_attrs(
         &api_with_context(ctx, State::Idle).dropzone_attrs()

--- a/crates/ars-components/src/specialized/file_upload/tests.rs
+++ b/crates/ars-components/src/specialized/file_upload/tests.rs
@@ -1103,12 +1103,11 @@ fn file_upload_drop_during_upload_appends_files_and_stays_uploading() {
     assert_eq!(service.state(), &State::Uploading);
     assert_eq!(service.context().files.get().len(), 2);
     assert!(!service.context().dragging);
-    assert!(
-        result
-            .pending_effects
-            .iter()
-            .any(|effect| effect.name == Effect::AnnounceFilesAdded { count: 1 })
-    );
+    assert!(result.pending_effects.iter().any(|effect| effect.name
+        == Effect::AnnounceFilesAdded {
+            count: 1,
+            from_drop: true
+        }));
 }
 
 #[test]
@@ -1470,11 +1469,12 @@ fn file_upload_files_selected_announces_files_added() {
     )]));
 
     assert!(
-        result
-            .pending_effects
-            .iter()
-            .any(|effect| effect.name == Effect::AnnounceFilesAdded { count: 1 }),
-        "selecting files must announce the added count"
+        result.pending_effects.iter().any(|effect| effect.name
+            == Effect::AnnounceFilesAdded {
+                count: 1,
+                from_drop: false
+            }),
+        "selecting files must announce the added count (polite, not from drop)"
     );
 }
 
@@ -1486,11 +1486,12 @@ fn file_upload_drop_announces_files_added() {
     let result = service.send(Event::Drop(vec![raw_file("a.png", 10, "image/png")]));
 
     assert!(
-        result
-            .pending_effects
-            .iter()
-            .any(|effect| effect.name == Effect::AnnounceFilesAdded { count: 1 }),
-        "dropping files must announce the added count"
+        result.pending_effects.iter().any(|effect| effect.name
+            == Effect::AnnounceFilesAdded {
+                count: 1,
+                from_drop: true
+            }),
+        "dropping files must announce the added count (assertive, from drop)"
     );
 }
 
@@ -2177,6 +2178,67 @@ fn file_upload_rejection_message_reflects_rejection_state() {
         "image/png",
     )])));
     assert!(service.connect(&|_| {}).rejection_message().is_some());
+}
+
+#[test]
+fn file_upload_controlled_auto_upload_callback_reports_uploading_queue() {
+    let changed = Arc::new(Mutex::new(Vec::<Vec<Item>>::new()));
+    let captured = Arc::clone(&changed);
+
+    let mut service = Service::<Machine>::new(
+        Props::new()
+            .id("upload")
+            .auto_upload(true)
+            .files(Vec::new())
+            .on_files_change(move |files: Vec<Item>| {
+                captured.lock().unwrap().push(files);
+            }),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    let result = service.send(Event::FilesSelected(vec![raw_file(
+        "a.png",
+        10,
+        "image/png",
+    )]));
+    assert_eq!(service.state(), &State::Uploading);
+
+    // The FilesChanged callback must report the post-StartUpload queue (Uploading),
+    // not the intermediate Pending snapshot — otherwise the parent writes back a
+    // stale queue that reverts the machine to Idle.
+    let send: StrongSend<Event> = Arc::new(|_| {});
+    for effect in result.pending_effects {
+        if effect.name == Effect::FilesChanged {
+            drop(effect.run(service.context(), service.props(), Arc::clone(&send)));
+        }
+    }
+
+    let recorded = changed.lock().unwrap();
+    let last = recorded.last().expect("on_files_change fired");
+    assert_eq!(last[0].status, Status::Uploading);
+}
+
+#[test]
+fn file_upload_upload_complete_while_dragging_returns_to_drag_over() {
+    let mut service = uploading_service("file-1");
+
+    drop(service.send(Event::DragEnter));
+    assert!(service.context().dragging);
+
+    // Last upload finishes while a drag is active: settle in DragOver (keeping
+    // the drag flags) so the drag-leave path can clear them — not Idle, which
+    // would swallow the DragLeave and strand `data-ars-dragging`.
+    let result = service.send(Event::UploadComplete {
+        file_id: "file-1".into(),
+    });
+    assert!(result.state_changed);
+    assert_eq!(service.state(), &State::DragOver);
+    assert!(service.context().dragging);
+
+    drop(service.send(Event::DragLeave));
+    assert_eq!(service.state(), &State::Idle);
+    assert!(!service.context().dragging);
 }
 
 #[test]

--- a/crates/ars-components/src/specialized/file_upload/tests.rs
+++ b/crates/ars-components/src/specialized/file_upload/tests.rs
@@ -2242,6 +2242,95 @@ fn file_upload_upload_complete_while_dragging_returns_to_drag_over() {
 }
 
 #[test]
+fn file_upload_controlled_finish_while_dragging_returns_to_drag_over() {
+    let mut service = Service::<Machine>::new(
+        Props::new().id("upload").multiple(true).files(vec![item(
+            "file-1",
+            "a.png",
+            Status::Uploading,
+        )]),
+        &Env::default(),
+        &Messages::default(),
+    );
+    assert_eq!(service.state(), &State::Uploading);
+
+    drop(service.send(Event::DragEnter));
+    assert!(service.context().dragging);
+
+    // Controlled parent replaces the queue with no uploading items mid-drag:
+    // settle in DragOver (drag flags preserved), not Idle (which would strand
+    // the drag).
+    let result = service.send(Event::SetFiles(Some(vec![item(
+        "file-1",
+        "a.png",
+        Status::Complete,
+    )])));
+    assert!(result.state_changed);
+    assert_eq!(service.state(), &State::DragOver);
+    assert!(service.context().dragging);
+
+    drop(service.send(Event::DragLeave));
+    assert_eq!(service.state(), &State::Idle);
+    assert!(!service.context().dragging);
+}
+
+#[test]
+fn file_upload_retry_targets_specific_failed_file_after_a_mismatch() {
+    // The first file does not match the retried id, exercising the id-comparison
+    // branch in the will_retry scan before reaching the matching failed file.
+    let mut service = Service::<Machine>::new(
+        Props::new().id("upload").default_files(vec![
+            item("file-1", "a.png", Status::Pending),
+            Item {
+                status: Status::Failed("e".into()),
+                error: Some("e".into()),
+                ..item("file-2", "b.png", Status::Failed("e".into()))
+            },
+        ]),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    drop(service.send(Event::RetryFile {
+        file_id: "file-2".into(),
+    }));
+
+    assert_eq!(
+        service
+            .context()
+            .files
+            .get()
+            .iter()
+            .find(|f| f.id == "file-2")
+            .unwrap()
+            .status,
+        Status::Pending
+    );
+}
+
+#[test]
+fn file_upload_retry_non_failed_file_does_not_auto_start() {
+    let mut service = Service::<Machine>::new(
+        Props::new()
+            .id("upload")
+            .auto_upload(true)
+            .default_files(vec![item("file-1", "a.png", Status::Pending)]),
+        &Env::default(),
+        &Messages::default(),
+    );
+    assert_eq!(service.state(), &State::Idle);
+
+    // Retrying a file that is not failed must not chain StartUpload, which would
+    // otherwise start unrelated pending files.
+    drop(service.send(Event::RetryFile {
+        file_id: "file-1".into(),
+    }));
+
+    assert_eq!(service.state(), &State::Idle);
+    assert_eq!(service.context().files.get()[0].status, Status::Pending);
+}
+
+#[test]
 fn file_upload_open_file_picker_emits_effect() {
     let mut service = Service::<Machine>::new(test_props(), &Env::default(), &Messages::default());
 

--- a/crates/ars-components/src/specialized/file_upload/tests.rs
+++ b/crates/ars-components/src/specialized/file_upload/tests.rs
@@ -1,0 +1,1121 @@
+use alloc::{
+    string::{String, ToString},
+    sync::Arc,
+    vec,
+    vec::Vec,
+};
+use std::sync::Mutex;
+
+use ars_core::{AriaAttr, AttrMap, Env, HtmlAttr, Machine as _, Service};
+use ars_interactions::{KeyboardEventData, KeyboardKey};
+use insta::assert_snapshot;
+
+use super::{
+    Effect, Event, Item, Machine, Messages, Progress, Props, RawFile, RejectionReason, State,
+    Status,
+};
+
+fn test_props() -> Props {
+    Props::new().id("upload")
+}
+
+fn raw_file(name: &str, size: u64, mime_type: &str) -> RawFile {
+    RawFile {
+        name: name.to_string(),
+        size,
+        mime_type: mime_type.to_string(),
+    }
+}
+
+fn item(id: &str, name: &str, status: Status) -> Item {
+    Item {
+        id: id.to_string(),
+        name: name.to_string(),
+        size: 1_024,
+        mime_type: "image/png".to_string(),
+        status,
+        progress: 0.0,
+        error: None,
+    }
+}
+
+fn snapshot_attrs(attrs: &AttrMap) -> String {
+    format!("{attrs:#?}")
+}
+
+fn api_for_state(state: State) -> super::Api<'static> {
+    let props = Box::leak(Box::new(test_props()));
+
+    let messages = Messages::default();
+
+    let (_, mut ctx) = Machine::init(props, &Env::default(), &messages);
+
+    ctx.messages = messages;
+
+    let ctx = Box::leak(Box::new(ctx));
+    let state = Box::leak(Box::new(state));
+    let send = Box::leak(Box::new(|_: Event| {}));
+
+    super::Api {
+        state,
+        ctx,
+        props,
+        send,
+    }
+}
+
+fn api_with_files(files: Vec<Item>) -> super::Api<'static> {
+    let props = Box::leak(Box::new(
+        Props::new().id("upload").default_files(files.clone()),
+    ));
+
+    let messages = Messages::default();
+
+    let (_, mut ctx) = Machine::init(props, &Env::default(), &messages);
+
+    ctx.files.set(files);
+    ctx.messages = messages;
+
+    let ctx = Box::leak(Box::new(ctx));
+    let state = Box::leak(Box::new(State::Idle));
+    let send = Box::leak(Box::new(|_: Event| {}));
+
+    super::Api {
+        state,
+        ctx,
+        props,
+        send,
+    }
+}
+
+fn uploading_service(file_id: &str) -> Service<Machine> {
+    let mut service = Service::<Machine>::new(
+        Props::new()
+            .id("upload")
+            .default_files(vec![item(file_id, "doc.txt", Status::Pending)]),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    drop(service.send(Event::StartUpload));
+
+    service
+}
+
+fn api_with_context(ctx: super::Context, state: State) -> super::Api<'static> {
+    api_with_props(test_props(), ctx, state)
+}
+
+fn api_with_props(props: Props, ctx: super::Context, state: State) -> super::Api<'static> {
+    let props = Box::leak(Box::new(props));
+    let ctx = Box::leak(Box::new(ctx));
+    let state = Box::leak(Box::new(state));
+    let send = Box::leak(Box::new(|_: Event| {}));
+
+    super::Api {
+        state,
+        ctx,
+        props,
+        send,
+    }
+}
+
+#[test]
+fn file_upload_progress_fraction_handles_zero_total_and_partial_bytes() {
+    assert!(
+        (Progress {
+            file_index: 0,
+            bytes_sent: 0,
+            bytes_total: 0,
+        }
+        .fraction()
+            - 0.0)
+            .abs()
+            < f64::EPSILON
+    );
+
+    assert!(
+        (Progress {
+            file_index: 0,
+            bytes_sent: 50,
+            bytes_total: 100,
+        }
+        .fraction()
+            - 0.5)
+            .abs()
+            < f64::EPSILON
+    );
+}
+
+#[test]
+fn file_upload_props_builder_sets_controlled_and_capture_fields() {
+    let files = vec![item("file-1", "a.png", Status::Pending)];
+
+    let controlled = Props::new().id("upload").files(files.clone());
+
+    assert_eq!(controlled.files, Some(files.clone()));
+
+    let captured = Props::new().capture("user");
+
+    assert_eq!(captured.capture.as_deref(), Some("user"));
+
+    let uncontrolled = Props::new()
+        .id("upload")
+        .files(files.clone())
+        .uncontrolled();
+
+    assert_eq!(uncontrolled.files, None);
+}
+
+#[test]
+fn file_upload_api_accessors_reflect_context_and_state() {
+    let mut service = Service::<Machine>::new(
+        Props::new()
+            .id("upload")
+            .max_files(1)
+            .default_files(vec![item("file-1", "a.png", Status::Pending)]),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    let api = service.connect(&|_| {});
+
+    assert!(!api.is_uploading());
+    assert_eq!(api.files().len(), 1);
+    assert!(api.is_max_files_reached());
+    assert!(api.rejected_files().is_empty());
+
+    drop(service.send(Event::FilesSelected(vec![raw_file(
+        "b.png",
+        10,
+        "image/png",
+    )])));
+
+    let api = service.connect(&|_| {});
+
+    assert_eq!(api.rejected_files().len(), 1);
+}
+
+#[test]
+fn file_upload_api_is_uploading_true_in_uploading_state() {
+    let service = uploading_service("file-1");
+
+    assert!(service.connect(&|_| {}).is_uploading());
+}
+
+#[test]
+fn file_upload_focus_sets_focused_part() {
+    let mut service = Service::<Machine>::new(test_props(), &Env::default(), &Messages::default());
+
+    drop(service.send(Event::Focus { part: "dropzone" }));
+
+    assert_eq!(service.context().focused_part, Some("dropzone"));
+}
+
+#[test]
+fn file_upload_blur_clears_focused_part() {
+    let mut service = Service::<Machine>::new(test_props(), &Env::default(), &Messages::default());
+
+    drop(service.send(Event::Focus { part: "dropzone" }));
+    drop(service.send(Event::Blur { part: "dropzone" }));
+
+    assert_eq!(service.context().focused_part, None);
+}
+
+#[test]
+fn file_upload_disabled_blur_clears_focused_part() {
+    let mut service = Service::<Machine>::new(
+        Props::new().id("upload").disabled(true),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    drop(service.send(Event::Focus { part: "dropzone" }));
+    drop(service.send(Event::Blur { part: "dropzone" }));
+
+    assert_eq!(service.context().focused_part, None);
+}
+
+#[test]
+fn file_upload_props_default_matches_spec() {
+    let props = Props::default();
+
+    assert!(!props.disabled);
+    assert!(!props.readonly);
+    assert!(!props.auto_upload);
+    assert!(props.files.is_none());
+    assert!(props.default_files.is_empty());
+}
+
+#[test]
+fn file_upload_idle_to_drag_over_on_drag_enter() {
+    let mut service = Service::<Machine>::new(test_props(), &Env::default(), &Messages::default());
+
+    let result = service.send(Event::DragEnter);
+
+    assert!(result.state_changed);
+    assert_eq!(service.state(), &State::DragOver);
+    assert!(service.context().dragging);
+    assert_eq!(service.context().drag_counter, 1);
+    assert_eq!(
+        result.pending_effects[0].name,
+        Effect::AnnounceDropzoneActive
+    );
+}
+
+#[test]
+fn file_upload_nested_drag_enter_increments_counter() {
+    let mut service = Service::<Machine>::new(test_props(), &Env::default(), &Messages::default());
+
+    drop(service.send(Event::DragEnter));
+    drop(service.send(Event::DragEnter));
+
+    assert_eq!(service.state(), &State::DragOver);
+    assert_eq!(service.context().drag_counter, 2);
+}
+
+#[test]
+fn file_upload_drag_leave_at_zero_returns_idle() {
+    let mut service = Service::<Machine>::new(test_props(), &Env::default(), &Messages::default());
+
+    drop(service.send(Event::DragEnter));
+
+    let result = service.send(Event::DragLeave);
+
+    assert!(result.state_changed);
+    assert_eq!(service.state(), &State::Idle);
+    assert!(!service.context().dragging);
+    assert_eq!(service.context().drag_counter, 0);
+}
+
+#[test]
+fn file_upload_nested_drag_leave_stays_drag_over_until_counter_zero() {
+    let mut service = Service::<Machine>::new(test_props(), &Env::default(), &Messages::default());
+
+    drop(service.send(Event::DragEnter));
+    drop(service.send(Event::DragEnter));
+    drop(service.send(Event::DragLeave));
+
+    assert_eq!(service.state(), &State::DragOver);
+    assert_eq!(service.context().drag_counter, 1);
+
+    drop(service.send(Event::DragLeave));
+
+    assert_eq!(service.state(), &State::Idle);
+}
+
+#[test]
+fn file_upload_drop_from_drag_over_adds_files_and_returns_idle() {
+    let mut service = Service::<Machine>::new(test_props(), &Env::default(), &Messages::default());
+
+    drop(service.send(Event::DragEnter));
+
+    let result = service.send(Event::Drop(vec![raw_file("a.png", 100, "image/png")]));
+
+    assert!(result.state_changed);
+    assert_eq!(service.state(), &State::Idle);
+    assert_eq!(service.context().files.get().len(), 1);
+    assert_eq!(service.context().files.get()[0].name, "a.png");
+}
+
+#[test]
+fn file_upload_files_selected_appends_validated_files() {
+    let mut service = Service::<Machine>::new(test_props(), &Env::default(), &Messages::default());
+
+    let result = service.send(Event::FilesSelected(vec![raw_file(
+        "b.pdf",
+        200,
+        "application/pdf",
+    )]));
+
+    assert!(!result.state_changed);
+    assert_eq!(service.context().files.get().len(), 1);
+}
+
+#[test]
+fn file_upload_auto_upload_chains_start_upload() {
+    let mut service = Service::<Machine>::new(
+        Props::new().id("upload").auto_upload(true),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    drop(service.send(Event::FilesSelected(vec![raw_file(
+        "c.png",
+        50,
+        "image/png",
+    )])));
+
+    assert_eq!(service.state(), &State::Uploading);
+    assert_eq!(service.context().files.get()[0].status, Status::Uploading);
+}
+
+#[test]
+fn file_upload_start_upload_moves_pending_to_uploading() {
+    let mut service = Service::<Machine>::new(
+        Props::new()
+            .id("upload")
+            .default_files(vec![item("file-1", "doc.txt", Status::Pending)]),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    let result = service.send(Event::StartUpload);
+
+    assert!(result.state_changed);
+    assert_eq!(service.state(), &State::Uploading);
+    assert_eq!(service.context().files.get()[0].status, Status::Uploading);
+}
+
+#[test]
+fn file_upload_upload_progress_updates_fraction() {
+    let mut service = uploading_service("file-1");
+
+    drop(service.send(Event::UploadProgress {
+        file_id: "file-1".into(),
+        progress: 0.5,
+    }));
+
+    assert!((service.context().files.get()[0].progress - 0.5).abs() < f64::EPSILON);
+}
+
+#[test]
+fn file_upload_upload_complete_returns_idle_when_done() {
+    let mut service = uploading_service("file-1");
+
+    let result = service.send(Event::UploadComplete {
+        file_id: "file-1".into(),
+    });
+
+    assert!(result.state_changed);
+    assert_eq!(service.state(), &State::Idle);
+    assert_eq!(service.context().files.get()[0].status, Status::Complete);
+}
+
+#[test]
+fn file_upload_upload_error_marks_failed() {
+    let mut service = uploading_service("file-1");
+
+    drop(service.send(Event::UploadError {
+        file_id: "file-1".into(),
+        error: "network".into(),
+    }));
+
+    assert_eq!(
+        service.context().files.get()[0].status,
+        Status::Failed("network".into())
+    );
+}
+
+#[test]
+fn file_upload_accept_extension_pattern_matches_by_filename() {
+    let mut service = Service::<Machine>::new(
+        Props::new().id("upload").accept(vec![".png".into()]),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    drop(service.send(Event::FilesSelected(vec![raw_file(
+        "photo.png",
+        100,
+        "application/octet-stream",
+    )])));
+
+    assert_eq!(service.context().files.get().len(), 1);
+}
+
+#[test]
+fn file_upload_cancel_file_marks_cancelled_and_returns_idle() {
+    let mut service = uploading_service("file-1");
+
+    let result = service.send(Event::CancelFile {
+        file_id: "file-1".into(),
+    });
+
+    assert!(result.state_changed);
+    assert_eq!(service.state(), &State::Idle);
+    assert_eq!(service.context().files.get()[0].status, Status::Cancelled);
+}
+
+#[test]
+fn file_upload_api_cancel_file_dispatches_event() {
+    let events = Arc::new(Mutex::new(Vec::<Event>::new()));
+    let events_capture = Arc::clone(&events);
+    let send = move |event: Event| {
+        events_capture.lock().unwrap().push(event);
+    };
+
+    let service = uploading_service("file-1");
+
+    service.connect(&send).cancel_file("file-1");
+
+    let recorded = events.lock().unwrap();
+
+    assert_eq!(
+        recorded.as_slice(),
+        &[Event::CancelFile {
+            file_id: "file-1".into(),
+        }]
+    );
+}
+
+#[test]
+fn file_upload_on_props_changed_syncs_controlled_files_and_context_props() {
+    let base = test_props();
+
+    assert!(Machine::on_props_changed(&base, &base).is_empty());
+
+    assert_eq!(
+        Machine::on_props_changed(
+            &base,
+            &Props {
+                files: Some(vec![item("ext-1", "external.png", Status::Pending)]),
+                ..base.clone()
+            },
+        ),
+        vec![Event::SetFiles(Some(vec![item(
+            "ext-1",
+            "external.png",
+            Status::Pending
+        )]))]
+    );
+
+    assert_eq!(
+        Machine::on_props_changed(
+            &base,
+            &Props {
+                required: true,
+                ..base.clone()
+            },
+        ),
+        vec![Event::SetProps]
+    );
+
+    let mut service = Service::<Machine>::new(
+        Props::new()
+            .id("upload")
+            .files(vec![item("file-1", "a.png", Status::Pending)]),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    let result = service.set_props(Props {
+        files: Some(vec![item("file-2", "b.png", Status::Complete)]),
+        required: true,
+        ..service.props().clone()
+    });
+
+    assert!(result.context_changed);
+    assert_eq!(service.context().files.get().len(), 1);
+    assert_eq!(service.context().files.get()[0].id, "file-2");
+    assert!(service.context().required);
+}
+
+#[test]
+fn file_upload_accept_exact_mime_pattern_matches() {
+    let mut service = Service::<Machine>::new(
+        Props::new()
+            .id("upload")
+            .accept(vec!["application/pdf".into()]),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    drop(service.send(Event::FilesSelected(vec![raw_file(
+        "doc.pdf",
+        100,
+        "application/pdf",
+    )])));
+
+    assert_eq!(service.context().files.get().len(), 1);
+}
+
+#[test]
+fn file_upload_set_files_event_replaces_controlled_queue() {
+    let mut service = Service::<Machine>::new(
+        Props::new()
+            .id("upload")
+            .files(vec![item("file-1", "a.png", Status::Pending)]),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    drop(service.send(Event::SetFiles(Some(vec![item(
+        "file-2",
+        "b.png",
+        Status::Complete,
+    )]))));
+
+    assert_eq!(service.context().files.get()[0].id, "file-2");
+}
+
+#[test]
+fn file_upload_accept_rejects_invalid_mime() {
+    let mut service = Service::<Machine>::new(
+        Props::new().id("upload").accept(vec!["image/*".into()]),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    drop(service.send(Event::FilesSelected(vec![raw_file(
+        "doc.pdf",
+        100,
+        "application/pdf",
+    )])));
+
+    assert!(service.context().files.get().is_empty());
+    assert_eq!(
+        service.context().rejected_files[0].reason,
+        RejectionReason::InvalidType
+    );
+}
+
+#[test]
+fn file_upload_max_file_size_rejects_large_files() {
+    let mut service = Service::<Machine>::new(
+        Props::new().id("upload").max_file_size(50),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    drop(service.send(Event::FilesSelected(vec![raw_file(
+        "big.png",
+        100,
+        "image/png",
+    )])));
+
+    assert!(service.context().files.get().is_empty());
+    assert_eq!(
+        service.context().rejected_files[0].reason,
+        RejectionReason::TooLarge
+    );
+}
+
+#[test]
+fn file_upload_min_file_size_rejects_small_files() {
+    let mut service = Service::<Machine>::new(
+        Props::new().id("upload").min_file_size(100),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    drop(service.send(Event::FilesSelected(vec![raw_file(
+        "tiny.png",
+        10,
+        "image/png",
+    )])));
+
+    assert_eq!(
+        service.context().rejected_files[0].reason,
+        RejectionReason::TooSmall
+    );
+}
+
+#[test]
+fn file_upload_max_files_rejects_excess() {
+    let mut service = Service::<Machine>::new(
+        Props::new()
+            .id("upload")
+            .max_files(1)
+            .default_files(vec![item("file-1", "existing.png", Status::Pending)]),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    drop(service.send(Event::FilesSelected(vec![raw_file(
+        "new.png",
+        100,
+        "image/png",
+    )])));
+
+    assert_eq!(service.context().files.get().len(), 1);
+    assert_eq!(
+        service.context().rejected_files[0].reason,
+        RejectionReason::TooMany
+    );
+}
+
+#[test]
+fn file_upload_remove_file_filters_queue() {
+    let mut service = Service::<Machine>::new(
+        Props::new().id("upload").default_files(vec![
+            item("file-1", "a.png", Status::Pending),
+            item("file-2", "b.png", Status::Pending),
+        ]),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    drop(service.send(Event::RemoveFile {
+        file_id: "file-1".into(),
+    }));
+
+    assert_eq!(service.context().files.get().len(), 1);
+    assert_eq!(service.context().files.get()[0].id, "file-2");
+}
+
+#[test]
+fn file_upload_clear_files_resets_queue() {
+    let mut service = Service::<Machine>::new(
+        Props::new()
+            .id("upload")
+            .default_files(vec![item("file-1", "a.png", Status::Pending)]),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    drop(service.send(Event::ClearFiles));
+
+    assert_eq!(service.state(), &State::Idle);
+    assert!(service.context().files.get().is_empty());
+}
+
+#[test]
+fn file_upload_retry_failed_resets_to_pending() {
+    let mut service = Service::<Machine>::new(
+        Props::new().id("upload").default_files(vec![Item {
+            status: Status::Failed("err".into()),
+            error: Some("err".into()),
+            ..item("file-1", "a.png", Status::Failed("err".into()))
+        }]),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    drop(service.send(Event::RetryFile {
+        file_id: "file-1".into(),
+    }));
+
+    assert_eq!(service.context().files.get()[0].status, Status::Pending);
+    assert_eq!(service.context().files.get()[0].error, None);
+}
+
+#[test]
+fn file_upload_disabled_blocks_file_selection() {
+    let mut service = Service::<Machine>::new(
+        Props::new().id("upload").disabled(true),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    let result = service.send(Event::FilesSelected(vec![raw_file(
+        "a.png",
+        100,
+        "image/png",
+    )]));
+
+    assert!(!result.state_changed);
+    assert!(service.context().files.get().is_empty());
+}
+
+#[test]
+fn file_upload_readonly_allows_focus_only() {
+    let mut service = Service::<Machine>::new(
+        Props::new().id("upload").readonly(true),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    assert!(
+        service
+            .send(Event::Focus { part: "dropzone" })
+            .context_changed
+    );
+
+    let remove = service.send(Event::RemoveFile {
+        file_id: "file-1".into(),
+    });
+
+    assert!(!remove.state_changed);
+    assert!(!remove.context_changed);
+}
+
+#[test]
+fn file_upload_open_file_picker_emits_effect() {
+    let mut service = Service::<Machine>::new(test_props(), &Env::default(), &Messages::default());
+
+    let result = service.send(Event::OpenFilePicker);
+
+    assert_eq!(result.pending_effects[0].name, Effect::OpenFilePicker);
+}
+
+#[test]
+fn file_upload_api_open_file_picker_sends_event() {
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let captured = Arc::clone(&events);
+    let send_event = move |event| captured.lock().unwrap().push(event);
+
+    let service = Service::<Machine>::new(test_props(), &Env::default(), &Messages::default());
+
+    service.connect(&send_event).open_file_picker();
+
+    assert_eq!(*events.lock().unwrap(), vec![Event::OpenFilePicker]);
+}
+
+#[test]
+fn file_upload_dropzone_click_opens_picker() {
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let captured = Arc::clone(&events);
+    let send_event = move |event| captured.lock().unwrap().push(event);
+
+    let service = Service::<Machine>::new(test_props(), &Env::default(), &Messages::default());
+
+    service.connect(&send_event).on_dropzone_click();
+
+    assert_eq!(*events.lock().unwrap(), vec![Event::OpenFilePicker]);
+}
+
+#[test]
+fn file_upload_dropzone_keydown_enter_opens_picker() {
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let captured = Arc::clone(&events);
+    let send_event = move |event| captured.lock().unwrap().push(event);
+
+    let service = Service::<Machine>::new(test_props(), &Env::default(), &Messages::default());
+
+    service
+        .connect(&send_event)
+        .on_dropzone_keydown(&KeyboardEventData {
+            key: KeyboardKey::Enter,
+            character: None,
+            code: String::new(),
+            repeat: false,
+            shift_key: false,
+            ctrl_key: false,
+            alt_key: false,
+            meta_key: false,
+            is_composing: false,
+        });
+
+    assert_eq!(*events.lock().unwrap(), vec![Event::OpenFilePicker]);
+}
+
+#[test]
+fn file_upload_hidden_input_change_selects_files() {
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let captured = Arc::clone(&events);
+    let send_event = move |event| captured.lock().unwrap().push(event);
+
+    let service = Service::<Machine>::new(test_props(), &Env::default(), &Messages::default());
+
+    service
+        .connect(&send_event)
+        .on_hidden_input_change(vec![raw_file("x.png", 1, "image/png")]);
+
+    assert_eq!(
+        *events.lock().unwrap(),
+        vec![Event::FilesSelected(vec![raw_file(
+            "x.png",
+            1,
+            "image/png"
+        )])]
+    );
+}
+
+#[test]
+fn file_upload_item_delete_trigger_removes_by_index() {
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let captured = Arc::clone(&events);
+    let send_event = move |event| captured.lock().unwrap().push(event);
+
+    let service = Service::<Machine>::new(
+        Props::new()
+            .id("upload")
+            .default_files(vec![item("file-9", "nine.png", Status::Pending)]),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    service.connect(&send_event).on_item_delete_trigger_click(0);
+
+    assert_eq!(
+        *events.lock().unwrap(),
+        vec![Event::RemoveFile {
+            file_id: "file-9".into()
+        }]
+    );
+}
+
+#[test]
+fn file_upload_dropzone_attrs_include_button_role_and_state() {
+    let attrs = api_for_state(State::DragOver).dropzone_attrs();
+
+    assert_eq!(attrs.get(&HtmlAttr::Role), Some("button"));
+    assert_eq!(attrs.get(&HtmlAttr::TabIndex), Some("0"));
+    assert_eq!(attrs.get(&HtmlAttr::Data("ars-state")), Some("drag-over"));
+    assert_eq!(
+        attrs.get(&HtmlAttr::Aria(AriaAttr::LabelledBy)),
+        Some("upload-label")
+    );
+}
+
+#[test]
+fn file_upload_dropzone_disabled_sets_aria_disabled() {
+    let mut ctx = Machine::init(&test_props(), &Env::default(), &Messages::default()).1;
+
+    ctx.disabled = true;
+
+    let attrs = api_with_context(ctx, State::Idle).dropzone_attrs();
+
+    assert_eq!(attrs.get(&HtmlAttr::Aria(AriaAttr::Disabled)), Some("true"));
+}
+
+#[test]
+fn file_upload_messages_include_drag_and_drop_announcement_defaults() {
+    let messages = Messages::default();
+
+    let locale = ars_core::Locale::parse("en-US").expect("locale");
+
+    assert_eq!(
+        (messages.drop_zone_left)(&locale),
+        "Drop zone is no longer active"
+    );
+    assert_eq!((messages.files_added)(2, &locale), "2 files added");
+    assert_eq!((messages.trigger_label)(&locale), "Choose files to upload");
+}
+
+#[test]
+fn file_upload_root_dragging_sets_data_flag() {
+    let mut ctx = Machine::init(&test_props(), &Env::default(), &Messages::default()).1;
+
+    ctx.dragging = true;
+
+    let attrs = api_with_context(ctx, State::DragOver).root_attrs();
+
+    assert!(attrs.contains(&HtmlAttr::Data("ars-dragging")));
+}
+
+#[test]
+fn file_upload_state_display_matches_data_state_tokens() {
+    assert_eq!(State::Idle.to_string(), "idle");
+    assert_eq!(State::DragOver.to_string(), "drag-over");
+    assert_eq!(State::Uploading.to_string(), "uploading");
+}
+
+#[test]
+fn file_upload_root_idle_snapshot() {
+    assert_snapshot!(snapshot_attrs(&api_for_state(State::Idle).root_attrs()));
+}
+
+#[test]
+fn file_upload_root_dragging_snapshot() {
+    let mut ctx = Machine::init(&test_props(), &Env::default(), &Messages::default()).1;
+
+    ctx.dragging = true;
+
+    assert_snapshot!(snapshot_attrs(
+        &api_with_context(ctx, State::DragOver).root_attrs()
+    ));
+}
+
+#[test]
+fn file_upload_root_disabled_snapshot() {
+    let mut ctx = Machine::init(&test_props(), &Env::default(), &Messages::default()).1;
+
+    ctx.disabled = true;
+
+    assert_snapshot!(snapshot_attrs(
+        &api_with_context(ctx, State::Idle).root_attrs()
+    ));
+}
+
+#[test]
+fn file_upload_root_readonly_snapshot() {
+    let mut ctx = Machine::init(&test_props(), &Env::default(), &Messages::default()).1;
+
+    ctx.readonly = true;
+
+    assert_snapshot!(snapshot_attrs(
+        &api_with_context(ctx, State::Idle).root_attrs()
+    ));
+}
+
+#[test]
+fn file_upload_label_snapshot() {
+    assert_snapshot!(snapshot_attrs(&api_for_state(State::Idle).label_attrs()));
+}
+
+#[test]
+fn file_upload_dropzone_idle_snapshot() {
+    assert_snapshot!(snapshot_attrs(&api_for_state(State::Idle).dropzone_attrs()));
+}
+
+#[test]
+fn file_upload_dropzone_drag_over_snapshot() {
+    assert_snapshot!(snapshot_attrs(
+        &api_for_state(State::DragOver).dropzone_attrs()
+    ));
+}
+
+#[test]
+fn file_upload_dropzone_uploading_snapshot() {
+    assert_snapshot!(snapshot_attrs(
+        &api_for_state(State::Uploading).dropzone_attrs()
+    ));
+}
+
+#[test]
+fn file_upload_dropzone_disabled_snapshot() {
+    let mut ctx = Machine::init(&test_props(), &Env::default(), &Messages::default()).1;
+
+    ctx.disabled = true;
+
+    assert_snapshot!(snapshot_attrs(
+        &api_with_context(ctx, State::Idle).dropzone_attrs()
+    ));
+}
+
+#[test]
+fn file_upload_trigger_enabled_snapshot() {
+    assert_snapshot!(snapshot_attrs(&api_for_state(State::Idle).trigger_attrs()));
+}
+
+#[test]
+fn file_upload_trigger_disabled_snapshot() {
+    let mut ctx = Machine::init(&test_props(), &Env::default(), &Messages::default()).1;
+
+    ctx.disabled = true;
+
+    assert_snapshot!(snapshot_attrs(
+        &api_with_context(ctx, State::Idle).trigger_attrs()
+    ));
+}
+
+#[test]
+fn file_upload_hidden_input_default_snapshot() {
+    assert_snapshot!(snapshot_attrs(
+        &api_for_state(State::Idle).hidden_input_attrs()
+    ));
+}
+
+#[test]
+fn file_upload_hidden_input_multiple_snapshot() {
+    let mut ctx = Machine::init(&test_props(), &Env::default(), &Messages::default()).1;
+
+    ctx.multiple = true;
+
+    assert_snapshot!(snapshot_attrs(
+        &api_with_context(ctx, State::Idle).hidden_input_attrs()
+    ));
+}
+
+#[test]
+fn file_upload_hidden_input_accept_snapshot() {
+    let mut ctx = Machine::init(&test_props(), &Env::default(), &Messages::default()).1;
+
+    ctx.accept = vec!["image/*".into()];
+
+    assert_snapshot!(snapshot_attrs(
+        &api_with_context(ctx, State::Idle).hidden_input_attrs()
+    ));
+}
+
+#[test]
+fn file_upload_hidden_input_directory_snapshot() {
+    let mut ctx = Machine::init(&test_props(), &Env::default(), &Messages::default()).1;
+
+    ctx.directory = true;
+
+    assert_snapshot!(snapshot_attrs(
+        &api_with_context(ctx, State::Idle).hidden_input_attrs()
+    ));
+}
+
+#[test]
+fn file_upload_hidden_input_name_snapshot() {
+    let props = Props::new().id("upload").name("attachments");
+
+    let (_, ctx) = Machine::init(&props, &Env::default(), &Messages::default());
+
+    assert_snapshot!(snapshot_attrs(
+        &api_with_props(props, ctx, State::Idle).hidden_input_attrs()
+    ));
+}
+
+#[test]
+fn file_upload_hidden_input_capture_snapshot() {
+    let props = Props::new().id("upload").capture("user");
+
+    let (_, ctx) = Machine::init(&props, &Env::default(), &Messages::default());
+
+    assert_snapshot!(snapshot_attrs(
+        &api_with_props(props, ctx, State::Idle).hidden_input_attrs()
+    ));
+}
+
+#[test]
+fn file_upload_hidden_input_required_snapshot() {
+    let props = Props::new().id("upload").required(true);
+
+    let (_, ctx) = Machine::init(&props, &Env::default(), &Messages::default());
+
+    assert_snapshot!(snapshot_attrs(
+        &api_with_props(props, ctx, State::Idle).hidden_input_attrs()
+    ));
+}
+
+#[test]
+fn file_upload_hidden_input_disabled_snapshot() {
+    let mut ctx = Machine::init(&test_props(), &Env::default(), &Messages::default()).1;
+
+    ctx.disabled = true;
+
+    assert_snapshot!(snapshot_attrs(
+        &api_with_context(ctx, State::Idle).hidden_input_attrs()
+    ));
+}
+
+#[test]
+fn file_upload_item_group_with_files_snapshot() {
+    assert_snapshot!(snapshot_attrs(
+        &api_with_files(vec![item("file-1", "photo.png", Status::Pending)]).item_group_attrs()
+    ));
+}
+
+#[test]
+fn file_upload_item_pending_snapshot() {
+    assert_snapshot!(snapshot_attrs(
+        &api_with_files(vec![item("file-1", "photo.png", Status::Pending)]).item_attrs(0)
+    ));
+}
+
+#[test]
+fn file_upload_item_uploading_snapshot() {
+    assert_snapshot!(snapshot_attrs(
+        &api_with_files(vec![item("file-1", "photo.png", Status::Uploading)]).item_attrs(0)
+    ));
+}
+
+#[test]
+fn file_upload_item_complete_snapshot() {
+    assert_snapshot!(snapshot_attrs(
+        &api_with_files(vec![item("file-1", "photo.png", Status::Complete)]).item_attrs(0)
+    ));
+}
+
+#[test]
+fn file_upload_item_error_snapshot() {
+    assert_snapshot!(snapshot_attrs(
+        &api_with_files(vec![item(
+            "file-1",
+            "photo.png",
+            Status::Failed("network".into())
+        )])
+        .item_attrs(0)
+    ));
+}
+
+#[test]
+fn file_upload_item_cancelled_snapshot() {
+    assert_snapshot!(snapshot_attrs(
+        &api_with_files(vec![item("file-1", "photo.png", Status::Cancelled)]).item_attrs(0)
+    ));
+}
+
+#[test]
+fn file_upload_item_delete_trigger_snapshot() {
+    assert_snapshot!(snapshot_attrs(
+        &api_with_files(vec![item("file-1", "photo.png", Status::Pending)])
+            .item_delete_trigger_attrs(0)
+    ));
+}

--- a/crates/ars-components/src/specialized/file_upload/tests.rs
+++ b/crates/ars-components/src/specialized/file_upload/tests.rs
@@ -601,7 +601,7 @@ fn file_upload_max_file_size_rejects_large_files() {
     assert!(service.context().files.get().is_empty());
     assert_eq!(
         service.context().rejected_files[0].reason,
-        RejectionReason::TooLarge
+        RejectionReason::TooLarge { max: 50 }
     );
 }
 
@@ -621,7 +621,7 @@ fn file_upload_min_file_size_rejects_small_files() {
 
     assert_eq!(
         service.context().rejected_files[0].reason,
-        RejectionReason::TooSmall
+        RejectionReason::TooSmall { min: 100 }
     );
 }
 
@@ -2329,6 +2329,80 @@ fn file_upload_retry_non_failed_file_does_not_auto_start() {
 
     assert_eq!(service.state(), &State::Idle);
     assert_eq!(service.context().files.get()[0].status, Status::Pending);
+}
+
+#[test]
+fn file_upload_clear_while_dragging_returns_to_drag_over() {
+    let mut service = uploading_service("file-1");
+
+    drop(service.send(Event::DragEnter));
+    assert!(service.context().dragging);
+
+    let result = service.send(Event::ClearFiles);
+    assert!(result.state_changed);
+    assert_eq!(service.state(), &State::DragOver);
+    assert!(service.context().dragging);
+    assert!(service.context().files.get().is_empty());
+
+    drop(service.send(Event::DragLeave));
+    assert_eq!(service.state(), &State::Idle);
+    assert!(!service.context().dragging);
+}
+
+#[test]
+fn file_upload_auto_upload_not_triggered_by_all_rejected_selection() {
+    let mut service = Service::<Machine>::new(
+        Props::new()
+            .id("upload")
+            .multiple(true)
+            .auto_upload(true)
+            .max_file_size(50)
+            .default_files(vec![item("file-1", "a.png", Status::Pending)]),
+        &Env::default(),
+        &Messages::default(),
+    );
+    assert_eq!(service.state(), &State::Idle);
+
+    // The selection is entirely rejected (too large), so auto-upload must not
+    // start the pre-existing pending file.
+    drop(service.send(Event::FilesSelected(vec![raw_file(
+        "big.png",
+        100,
+        "image/png",
+    )])));
+
+    assert_eq!(service.state(), &State::Idle);
+    assert_eq!(service.context().files.get()[0].status, Status::Pending);
+}
+
+#[test]
+fn file_upload_validation_error_text_uses_rejection_time_limit() {
+    let mut service = Service::<Machine>::new(
+        Props::new().id("upload").max_file_size(50),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    drop(service.send(Event::FilesSelected(vec![raw_file(
+        "big.png",
+        100,
+        "image/png",
+    )])));
+    let rejection = service.context().rejected_files[0].clone();
+
+    // The parent clears the size limit after the rejection.
+    drop(service.set_props(Props {
+        max_file_size: None,
+        ..service.props().clone()
+    }));
+
+    // The error text must reflect the limit at rejection time (50), not the now-
+    // cleared prop (which would render "0 bytes").
+    let text = service.connect(&|_| {}).validation_error_text(&rejection);
+    assert!(
+        text.contains("50"),
+        "expected the rejection-time limit, got: {text}"
+    );
 }
 
 #[test]

--- a/crates/ars-components/src/specialized/mod.rs
+++ b/crates/ars-components/src/specialized/mod.rs
@@ -5,3 +5,6 @@ pub mod clipboard;
 
 /// Contextual help composition API over [`crate::overlay::popover`].
 pub mod contextual_help;
+
+/// File upload component machine.
+pub mod file_upload;

--- a/crates/ars-components/tests/spec_conformance/specialized.rs
+++ b/crates/ars-components/tests/spec_conformance/specialized.rs
@@ -23,6 +23,44 @@ fn clipboard_anatomy_matches_spec() {
 }
 
 #[test]
+fn file_upload_anatomy_matches_spec() {
+    assert_anatomy(
+        "file-upload",
+        &[
+            (specialized_core::file_upload::Part::Root, "root"),
+            (specialized_core::file_upload::Part::Label, "label"),
+            (specialized_core::file_upload::Part::Dropzone, "dropzone"),
+            (specialized_core::file_upload::Part::Trigger, "trigger"),
+            (specialized_core::file_upload::Part::ItemGroup, "item-group"),
+            (
+                specialized_core::file_upload::Part::Item { index: 0 },
+                "item",
+            ),
+            (
+                specialized_core::file_upload::Part::ItemName { index: 0 },
+                "item-name",
+            ),
+            (
+                specialized_core::file_upload::Part::ItemSizeText { index: 0 },
+                "item-size-text",
+            ),
+            (
+                specialized_core::file_upload::Part::ItemDeleteTrigger { index: 0 },
+                "item-delete-trigger",
+            ),
+            (
+                specialized_core::file_upload::Part::ItemProgress { index: 0 },
+                "item-progress",
+            ),
+            (
+                specialized_core::file_upload::Part::HiddenInput,
+                "hidden-input",
+            ),
+        ],
+    );
+}
+
+#[test]
 fn contextual_help_anatomy_matches_spec() {
     assert_anatomy(
         "contextual-help",

--- a/spec/components/specialized/file-upload.md
+++ b/spec/components/specialized/file-upload.md
@@ -495,7 +495,10 @@ fn reconciled_state(current: State, files: &[Item]) -> Option<State> {
     let any_uploading = files.iter().any(|f| f.status == Status::Uploading);
     match (current, any_uploading) {
         (State::Uploading, false) => Some(State::Idle),
-        (State::Idle, true) => Some(State::Uploading),
+        // Enter Uploading even from DragOver (keeping the drag flags) when a
+        // controlled queue begins an upload mid-drag, so upload events are
+        // processed and the Uploading drag-leave path can clear the flags.
+        (State::Idle | State::DragOver, true) => Some(State::Uploading),
         _ => None,
     }
 }
@@ -888,10 +891,14 @@ impl ars_core::Machine for Machine {
             (_, Event::SetProps) => {
                 // Becoming disabled/read-only while dragging would trap the machine:
                 // the disabled guard swallows the DragLeave/Drop that clears
-                // `dragging`, so reset to Idle and clear the drag flags as part of
-                // the sync.
-                let reset_drag = (props.disabled || props.readonly)
-                    && matches!(state, State::DragOver);
+                // `dragging`. Clear the drag flags as part of the sync — from
+                // DragOver that returns to Idle; while Uploading (a drag started
+                // via the uploading drag-enter path) only the flags are cleared so
+                // the upload continues.
+                let becoming_inert = props.disabled || props.readonly;
+                let reset_to_idle = becoming_inert && matches!(state, State::DragOver);
+                let clear_drag = reset_to_idle
+                    || (becoming_inert && matches!(state, State::Uploading) && ctx.dragging);
                 let apply = {
                     let disabled = props.disabled;
                     let readonly = props.readonly;
@@ -919,13 +926,13 @@ impl ars_core::Machine for Machine {
                         ctx.directory = directory;
                         ctx.capture = capture;
                         ctx.name = name;
-                        if reset_drag {
+                        if clear_drag {
                             ctx.dragging = false;
                             ctx.drag_counter = 0;
                         }
                     }
                 };
-                Some(if reset_drag {
+                Some(if reset_to_idle {
                     TransitionPlan::to(State::Idle).apply(apply)
                 } else {
                     TransitionPlan::context_only(apply)
@@ -1130,6 +1137,10 @@ impl<'a> Api<'a> {
         let files = self.ctx.files.get();
         if let Some(file) = files.get(index) {
             attrs.set(HtmlAttr::Role, "listitem");
+            // Keyboard-focusable so Tab reaches items and `on_item_keydown`
+            // (Delete/Backspace removal) is usable — a plain listitem is skipped
+            // by sequential focus.
+            attrs.set(HtmlAttr::TabIndex, "0");
             attrs.set(HtmlAttr::Data("ars-state"), match file.status {
                 Status::Pending => "pending",
                 Status::Uploading => "uploading",
@@ -1339,7 +1350,7 @@ FileUpload
 | Dropzone          | `<div>`               | `role="button"`, `tabindex="0"`, `aria-labelledby`      |
 | Trigger           | `<button>`            | `aria-label`                                            |
 | ItemGroup         | `<ul>`                | `role="list"`, `aria-label`                             |
-| Item              | `<li>`                | `role="listitem"`, `data-ars-state`, `data-ars-file-id` |
+| Item              | `<li>`                | `role="listitem"`, `tabindex="0"`, `data-ars-state`, `data-ars-file-id` |
 | ItemName          | `<span>`              | file name text                                          |
 | ItemSizeText      | `<span>`              | formatted file size                                     |
 | ItemDeleteTrigger | `<button>`            | `aria-label="Remove {filename}"`                        |
@@ -1358,6 +1369,7 @@ FileUpload
 | `aria-disabled="true"` | Dropzone, Trigger, ItemDeleteTrigger | When disabled or read-only |
 | `role="list"`          | ItemGroup                            | Semantic list              |
 | `role="listitem"`      | Item                                 | Semantic list item         |
+| `tabindex="0"`         | Item                                 | Keyboard focusable         |
 | `aria-label`           | Trigger                              | `"Choose files to upload"` |
 | `aria-label`           | ItemDeleteTrigger                    | `"Remove {filename}"`      |
 | `aria-label`           | ItemGroup                            | `"Uploaded files"`         |

--- a/spec/components/specialized/file-upload.md
+++ b/spec/components/specialized/file-upload.md
@@ -309,6 +309,10 @@ pub struct Props {
     pub directory: bool,
     /// Name for form submission.
     pub name: Option<String>,
+    /// Invoked with the updated queue when the file set changes (selection,
+    /// drop, removal, clear). Required for controlled mode so the parent can sync
+    /// its `files` prop; fired via the `FilesChanged` effect.
+    pub on_files_change: Option<Callback<dyn Fn(Vec<Item>) + Send + Sync>>,
     /// Component instance ID.
     pub id: String,
 }
@@ -330,6 +334,7 @@ impl Default for Props {
             auto_upload: false,
             directory: false,
             name: None,
+            on_files_change: None,
             id: String::new(),
         }
     }
@@ -380,7 +385,22 @@ fn validate_files(
     let mut rejected = Vec::new();
     let current_count = ctx.files.get().len();
 
+    // A directory upload imports a folder's contents, so it accepts many files
+    // regardless of `multiple`; only `max_files` constrains it.
+    let single_file = !ctx.multiple && !ctx.directory;
+
     for (i, file) in raw.iter().enumerate() {
+        // Enforce single-file mode unless `multiple`/`directory` allow more.
+        if single_file && (current_count >= 1 || !accepted.is_empty()) {
+            rejected.push(Rejection {
+                name: file.name.clone(),
+                size: file.size,
+                mime_type: file.mime_type.clone(),
+                reason: RejectionReason::TooMany,
+            });
+            continue;
+        }
+
         // Check max files
         if let Some(max) = ctx.max_files {
             if current_count + accepted.len() >= max {
@@ -480,6 +500,18 @@ fn reconciled_state(current: State, files: &[Item]) -> Option<State> {
     }
 }
 
+/// Writes the queue, mirroring it into the controlled value when controlled.
+/// In controlled mode `Bindable::get` returns the parent's value, so a bare
+/// `set` would leave `api.files()` stale; this optimistically syncs the
+/// controlled value so the queue is visible immediately, while the parent
+/// confirms it via `SetFiles` (driven by the `FilesChanged` callback).
+fn commit_files(ctx: &mut Context, files: Vec<Item>) {
+    if ctx.files.is_controlled() {
+        ctx.files.sync_controlled(Some(files.clone()));
+    }
+    ctx.files.set(files);
+}
+
 fn mime_matches(mime: &str, name: &str, patterns: &[String]) -> bool {
     patterns.iter().any(|pattern| {
         if pattern.ends_with("/*") {
@@ -520,8 +552,11 @@ impl ars_core::Machine for Machine {
         let locale = env.locale.clone();
         let messages = messages.clone();
         let next_file_id = next_id_after(files.get());
+        // Honor the `State::Uploading` invariant from the start: a seeded queue
+        // with an uploading item boots in `Uploading`, not `Idle`.
+        let initial_state = reconciled_state(State::Idle, files.get()).unwrap_or(State::Idle);
 
-        (State::Idle, Context {
+        (initial_state, Context {
             files,
             rejected_files: Vec::new(),
             dragging: false,
@@ -623,8 +658,9 @@ impl ars_core::Machine for Machine {
 
             (State::DragOver, Event::Drop(raw_files)) => {
                 // Validate up front so the accepted/rejected counts can drive the
-                // `announce-files-added` / `announce-files-rejected` effects
-                // (polite; `messages.files_added` / `messages.rejection_message`).
+                // `announce-files-added` / `announce-files-rejected` effects, and
+                // the accepted set drives `files-changed`. `commit_files` syncs the
+                // controlled value so `api.files()` reflects the drop.
                 let raw = raw_files.clone();
                 Some(TransitionPlan::to(State::Idle).apply(move |ctx| {
                     ctx.dragging = false;
@@ -635,8 +671,43 @@ impl ars_core::Machine for Machine {
                     ctx.rejected_files = rejected;
                     let mut current = ctx.files.get().clone();
                     current.extend(accepted);
-                    ctx.files.set(current);
-                })) // + announce-files-added{count} / announce-files-rejected{count}
+                    commit_files(ctx, current);
+                })) // + announce-files-added/rejected{count} + files-changed{queue}
+            }
+
+            // Drag-and-drop stays available during an active upload, mirroring
+            // `FilesSelected`. Drag is tracked via `dragging`/`drag_counter` without
+            // leaving `Uploading`; the first `DragEnter` announces dropzone-active,
+            // and `DragLeave` to 0 announces dropzone-left.
+            (State::Uploading, Event::DragEnter) => {
+                let first = ctx.drag_counter == 0;
+                let plan = TransitionPlan::context_only(|ctx| {
+                    ctx.drag_counter = ctx.drag_counter.saturating_add(1);
+                    ctx.dragging = true;
+                });
+                Some(if first { plan /* + announce-dropzone-active */ } else { plan })
+            }
+            (State::Uploading, Event::DragLeave) => {
+                let new_counter = ctx.drag_counter.saturating_sub(1);
+                Some(TransitionPlan::context_only(move |ctx| {
+                    ctx.drag_counter = new_counter;
+                    if new_counter == 0 { ctx.dragging = false; }
+                })) // + announce-dropzone-left when new_counter == 0
+            }
+            (State::Uploading, Event::Drop(raw_files)) => {
+                // Same as the DragOver drop, but stays in `Uploading`.
+                let raw = raw_files.clone();
+                Some(TransitionPlan::context_only(move |ctx| {
+                    ctx.dragging = false;
+                    ctx.drag_counter = 0;
+                    let mut next_file_id = ctx.next_file_id;
+                    let (accepted, rejected) = validate_files(&raw, ctx, &mut next_file_id);
+                    ctx.next_file_id = next_file_id;
+                    ctx.rejected_files = rejected;
+                    let mut current = ctx.files.get().clone();
+                    current.extend(accepted);
+                    commit_files(ctx, current);
+                })) // + announce-files-added/rejected{count} + files-changed{queue}
             }
 
             // --- File selection via input ---
@@ -650,9 +721,9 @@ impl ars_core::Machine for Machine {
                     ctx.rejected_files = rejected;
                     let mut current = ctx.files.get().clone();
                     current.extend(accepted);
-                    ctx.files.set(current);
+                    commit_files(ctx, current);
                     // If auto_upload, chain a StartUpload event.
-                })) // + announce-files-added{count} / announce-files-rejected{count}
+                })) // + announce-files-added/rejected{count} + files-changed{queue}
             }
 
             // --- Upload lifecycle ---
@@ -725,26 +796,33 @@ impl ars_core::Machine for Machine {
 
             // --- File management ---
             (_, Event::RemoveFile { file_id }) => {
+                // `commit_files` writes the queue and, when controlled, mirrors it
+                // into the controlled value so `api.files()` reflects the change.
+                // Removing a file changes the set, so emit `FilesChanged` so a
+                // controlled parent can sync its `files` prop.
                 let fid = file_id.clone();
                 Some(TransitionPlan::context_only(move |ctx| {
                     let files = ctx.files.get().clone();
                     let updated: Vec<Item> = files.into_iter()
                         .filter(|f| f.id != fid)
                         .collect();
-                    ctx.files.set(updated);
-                }))
+                    commit_files(ctx, updated);
+                })) // + files-changed{queue}
             }
 
             (_, Event::ClearFiles) => {
                 Some(TransitionPlan::to(State::Idle).apply(|ctx| {
-                    ctx.files.set(Vec::new());
+                    commit_files(ctx, Vec::new());
                     ctx.rejected_files.clear();
-                }))
+                })) // + files-changed{[]}
             }
 
             (_, Event::RetryFile { file_id }) => {
+                // Reset the failed file to Pending. Mirror `FilesSelected`: when
+                // `auto_upload` is set, immediately resume uploading so the retry
+                // control is not a silent no-op.
                 let fid = file_id.clone();
-                Some(TransitionPlan::context_only(move |ctx| {
+                let plan = TransitionPlan::context_only(move |ctx| {
                     let files = ctx.files.get().clone();
                     let updated: Vec<Item> = files.into_iter().map(|mut f| {
                         if f.id == fid && matches!(f.status, Status::Failed(_)) {
@@ -754,8 +832,9 @@ impl ars_core::Machine for Machine {
                         }
                         f
                     }).collect();
-                    ctx.files.set(updated);
-                }))
+                    commit_files(ctx, updated);
+                });
+                Some(if props.auto_upload { plan.then(Event::StartUpload) } else { plan })
             }
 
             (_, Event::OpenFilePicker) => {
@@ -1127,7 +1206,8 @@ impl<'a> Api<'a> {
         attrs.set(HtmlAttr::Type, "file");
         attrs.set(HtmlAttr::TabIndex, "-1");
         attrs.set(HtmlAttr::Class, "ars-sr-input");
-        if self.ctx.multiple {
+        // Directory uploads inherently select multiple files.
+        if self.ctx.multiple || self.ctx.directory {
             attrs.set_bool(HtmlAttr::Multiple, true);
         }
         if !self.ctx.accept.is_empty() {
@@ -1439,8 +1519,8 @@ drop zone activity. The adapter populates the live region text from
 
 | Callback      | ars-ui                    | Ark UI         | Notes                               |
 | ------------- | ------------------------- | -------------- | ----------------------------------- |
-| File accepted | `Bindable` reactivity     | `onFileAccept` | Equivalent via binding              |
-| File changed  | `Bindable` reactivity     | `onFileChange` | Equivalent via binding              |
+| File accepted | `on_files_change`         | `onFileAccept` | Fired with the updated queue        |
+| File changed  | `on_files_change`         | `onFileChange` | Fired on add/drop/remove/clear      |
 | File rejected | rejection list on context | `onFileReject` | ars-ui stores rejections in context |
 
 **Gaps:** None.

--- a/spec/components/specialized/file-upload.md
+++ b/spec/components/specialized/file-upload.md
@@ -18,11 +18,11 @@ dropzone area, a file list, and integrates with the native `<input type="file">`
 ```rust
 // crates/ars-core/src/components/file_upload.rs
 
-use crate::{Bindable, ComponentId};
+use crate::Bindable;
 use crate::machine::{Machine, TransitionPlan, ComponentIds, AttrMap};
 
 /// Represents a single file in the upload queue.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Item {
     /// Unique identifier for this file item.
     pub id: String,
@@ -189,6 +189,10 @@ pub enum Event {
         /// The part that was blurred.
         part: &'static str,
     },
+    /// Synchronize the externally controlled file list prop.
+    SetFiles(Option<Vec<Item>>),
+    /// Synchronize output-affecting props stored in context.
+    SetProps,
 }
 
 /// Raw file data from the browser File API, prior to validation.
@@ -243,8 +247,8 @@ pub struct Context {
     pub locale: Locale,
     /// Resolved translatable messages.
     pub messages: Messages,
-    /// Component instance IDs.
-    pub id: ComponentId,
+    /// Component instance base id.
+    pub id: String,
     /// The id of the dropzone.
     pub dropzone_id: String,
     /// The id of the input.
@@ -372,7 +376,9 @@ fn validate_files(
         }
 
         // Check MIME type
-        if !ctx.accept.is_empty() && !mime_matches(&file.mime_type, &ctx.accept) {
+        if !ctx.accept.is_empty()
+            && !mime_matches(&file.mime_type, &file.name, &ctx.accept)
+        {
             rejected.push(Rejection {
                 name: file.name.clone(),
                 size: file.size,
@@ -421,14 +427,13 @@ fn validate_files(
     (accepted, rejected)
 }
 
-fn mime_matches(mime: &str, patterns: &[String]) -> bool {
+fn mime_matches(mime: &str, name: &str, patterns: &[String]) -> bool {
     patterns.iter().any(|pattern| {
         if pattern.ends_with("/*") {
             let prefix = &pattern[..pattern.len() - 1];
             mime.starts_with(prefix)
         } else if pattern.starts_with('.') {
-            // Extension-based: ".pdf", ".png"
-            mime.ends_with(pattern) || mime_from_extension(pattern).map_or(false, |m| m == mime)
+            name.ends_with(pattern)
         } else {
             mime == pattern
         }
@@ -693,8 +698,75 @@ impl ars_core::Machine for Machine {
                 }))
             }
 
+            (_, Event::SetFiles(files)) => {
+                let files = files.clone();
+                Some(TransitionPlan::context_only(move |ctx| {
+                    if let Some(files) = files {
+                        ctx.files.set(files.clone());
+                        ctx.files.sync_controlled(Some(files));
+                    } else {
+                        ctx.files.sync_controlled(None);
+                    }
+                }))
+            }
+
+            (_, Event::SetProps) => Some(TransitionPlan::context_only({
+                let disabled = props.disabled;
+                let readonly = props.readonly;
+                let required = props.required;
+                let multiple = props.multiple;
+                let accept = props.accept.clone();
+                let max_file_size = props.max_file_size;
+                let min_file_size = props.min_file_size;
+                let max_files = props.max_files;
+                let auto_upload = props.auto_upload;
+                let directory = props.directory;
+
+                move |ctx| {
+                    ctx.disabled = disabled;
+                    ctx.readonly = readonly;
+                    ctx.required = required;
+                    ctx.multiple = multiple;
+                    ctx.accept = accept;
+                    ctx.max_file_size = max_file_size;
+                    ctx.min_file_size = min_file_size;
+                    ctx.max_files = max_files;
+                    ctx.auto_upload = auto_upload;
+                    ctx.directory = directory;
+                }
+            })),
+
             _ => None,
         }
+    }
+
+    fn on_props_changed(old: &Self::Props, new: &Self::Props) -> Vec<Self::Event> {
+        assert_eq!(
+            old.id, new.id,
+            "file_upload::Props.id must remain stable after init"
+        );
+
+        let mut events = Vec::new();
+
+        if old.files != new.files {
+            events.push(Event::SetFiles(new.files.clone()));
+        }
+
+        if old.disabled != new.disabled
+            || old.readonly != new.readonly
+            || old.required != new.required
+            || old.multiple != new.multiple
+            || old.accept != new.accept
+            || old.max_file_size != new.max_file_size
+            || old.min_file_size != new.min_file_size
+            || old.max_files != new.max_files
+            || old.auto_upload != new.auto_upload
+            || old.directory != new.directory
+        {
+            events.push(Event::SetProps);
+        }
+
+        events
     }
 
     fn connect<'a>(
@@ -865,6 +937,7 @@ impl<'a> Api<'a> {
                 Status::Uploading => "uploading",
                 Status::Complete => "complete",
                 Status::Failed(_) => "error",
+                Status::Cancelled => "cancelled",
             });
             attrs.set(HtmlAttr::Data("ars-file-id"), &file.id);
             attrs.set(HtmlAttr::Aria(AriaAttr::Description),
@@ -937,8 +1010,14 @@ impl<'a> Api<'a> {
         if self.ctx.directory {
             attrs.set(HtmlAttr::WebkitDirectory, "");
         }
+        if let Some(ref capture) = self.props.capture {
+            attrs.set(HtmlAttr::Capture, capture);
+        }
         if let Some(ref name) = self.props.name {
             attrs.set(HtmlAttr::Name, name);
+        }
+        if self.ctx.required {
+            attrs.set_bool(HtmlAttr::Required, true);
         }
         if self.ctx.disabled {
             attrs.set_bool(HtmlAttr::Disabled, true);
@@ -992,6 +1071,11 @@ impl<'a> Api<'a> {
     /// Retry a failed upload.
     pub fn retry_file(&self, file_id: &str) {
         (self.send)(Event::RetryFile { file_id: file_id.to_string() });
+    }
+
+    /// Cancel an in-progress upload.
+    pub fn cancel_file(&self, file_id: &str) {
+        (self.send)(Event::CancelFile { file_id: file_id.to_string() });
     }
 }
 
@@ -1081,7 +1165,7 @@ The adapter MUST:
 
 1. Insert a visually-hidden `<div aria-live="assertive" aria-atomic="true">` as
    a sibling of the dropzone.
-2. On `DragEnter` transition, set its text content to `messages.drop_zone_active`.
+2. On `DragEnter` transition, set its text content to `messages.dropzone_active`.
 3. On `DragLeave` (when `drag_counter` reaches 0), set text to `messages.drop_zone_left`.
 4. On `Drop` transition, set text to `(messages.files_added)(accepted_count)`.
 5. Clear the live region text after a 3-second timeout to avoid stale announcements.
@@ -1095,6 +1179,8 @@ The adapter MUST:
 pub struct Messages {
     pub dropzone_label: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
     pub dropzone_active: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
+    pub drop_zone_left: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
+    pub files_added: MessageFn<dyn Fn(usize, &Locale) -> String + Send + Sync>,
     pub trigger_label: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
     pub file_list_label: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
     pub remove_label: MessageFn<dyn Fn(&str, &Locale) -> String + Send + Sync>,
@@ -1110,7 +1196,9 @@ impl Default for Messages {
         Self {
             dropzone_label: MessageFn::static_str("Drag and drop files here, or click to browse"),
             dropzone_active: MessageFn::static_str("Drop files to upload"),
-            trigger_label: MessageFn::static_str("Browse files"),
+            drop_zone_left: MessageFn::static_str("Drop zone is no longer active"),
+            files_added: MessageFn::new(|count, _locale| format!("{} files added", count)),
+            trigger_label: MessageFn::static_str("Choose files to upload"),
             file_list_label: MessageFn::static_str("Uploaded files"),
             remove_label: MessageFn::new(|name, _locale| format!("Remove {}", name)),
             rejection_message: MessageFn::new(|count, _locale| format!("{} files rejected", count)),
@@ -1159,7 +1247,7 @@ drop zone activity. The adapter populates the live region text from
 
 | DnD Event   | Live Region Text Source         | Default (en-US)                   |
 | ----------- | ------------------------------- | --------------------------------- |
-| `dragenter` | `messages.drop_zone_active`     | `"Drop zone is active"`           |
+| `dragenter` | `messages.dropzone_active`      | `"Drop files to upload"`          |
 | `dragleave` | `messages.drop_zone_left`       | `"Drop zone is no longer active"` |
 | `drop`      | `(messages.files_added)(count)` | `"{N} files added"`               |
 

--- a/spec/components/specialized/file-upload.md
+++ b/spec/components/specialized/file-upload.md
@@ -239,8 +239,18 @@ pub struct Context {
     pub auto_upload: bool,
     /// Whether the dropzone is a directory upload.
     pub directory: bool,
+    /// Camera selection for mobile capture (`"user"` front, `"environment"` rear).
+    pub capture: Option<String>,
+    /// Name for form submission.
+    pub name: Option<String>,
     /// Drag-over nesting counter (for nested elements).
     pub drag_counter: u32,
+    /// Monotonic counter for the next generated file id.
+    ///
+    /// Only ever increases, so ids are never reused after files are removed —
+    /// preventing late async upload events from being applied to a different
+    /// file that happened to reuse an earlier id.
+    pub next_file_id: u64,
     /// Focused part.
     pub focused_part: Option<&'static str>,
     /// Locale for internationalized messages.
@@ -353,9 +363,13 @@ fn has_uploading_files(ctx: &Context, _props: &Props) -> bool {
 
 ```rust
 /// Validate a set of raw files against the constraints, returning accepted and rejected.
+///
+/// `next_file_id` is the machine's monotonic id counter; each accepted file
+/// consumes the next value and advances it so ids are never reused.
 fn validate_files(
     raw: &[RawFile],
     ctx: &Context,
+    next_file_id: &mut u64,
 ) -> (Vec<Item>, Vec<Rejection>) {
     let mut accepted = Vec::new();
     let mut rejected = Vec::new();
@@ -414,7 +428,7 @@ fn validate_files(
         }
 
         accepted.push(Item {
-            id: generate_file_id(),
+            id: generate_file_id(next_file_id),
             name: file.name.clone(),
             size: file.size,
             mime_type: file.mime_type.clone(),
@@ -425,6 +439,40 @@ fn validate_files(
     }
 
     (accepted, rejected)
+}
+
+/// Consumes the next monotonic file id and advances the counter, so ids are
+/// never reused after files are removed.
+fn generate_file_id(next_file_id: &mut u64) -> String {
+    let id = *next_file_id;
+    *next_file_id = next_file_id.saturating_add(1);
+    format!("file-{id}")
+}
+
+/// The next monotonic id that sits strictly above every `file-N` id in `files`.
+/// Seeds `Context::next_file_id` at init and advances it past externally
+/// supplied ids on `Event::SetFiles`.
+fn next_id_after(files: &[Item]) -> u64 {
+    files
+        .iter()
+        .filter_map(|file| file.id.strip_prefix("file-")?.parse::<u64>().ok())
+        .max()
+        .unwrap_or(0)
+        .saturating_add(1)
+}
+
+/// Reconciles the machine state with an externally replaced file set.
+/// `State::Uploading` must hold exactly when at least one file is uploading, so
+/// a controlled queue replacement drives the resting state between Idle and
+/// Uploading. Returns `None` when no change is required (including in DragOver,
+/// whose transient drag lifecycle is left untouched).
+fn reconciled_state(current: State, files: &[Item]) -> Option<State> {
+    let any_uploading = files.iter().any(|f| f.status == Status::Uploading);
+    match (current, any_uploading) {
+        (State::Uploading, false) => Some(State::Idle),
+        (State::Idle, true) => Some(State::Uploading),
+        _ => None,
+    }
 }
 
 fn mime_matches(mime: &str, name: &str, patterns: &[String]) -> bool {
@@ -464,6 +512,7 @@ impl ars_core::Machine for Machine {
         let ids = ComponentIds::from_id(&props.id);
         let locale = env.locale.clone();
         let messages = messages.clone();
+        let next_file_id = next_id_after(files.get());
 
         (State::Idle, Context {
             files,
@@ -479,7 +528,10 @@ impl ars_core::Machine for Machine {
             max_files: props.max_files,
             auto_upload: props.auto_upload,
             directory: props.directory,
+            capture: props.capture.clone(),
+            name: props.name.clone(),
             drag_counter: 0,
+            next_file_id,
             focused_part: None,
             locale,
             messages,
@@ -556,7 +608,9 @@ impl ars_core::Machine for Machine {
                 Some(TransitionPlan::to(State::Idle).apply(move |ctx| {
                     ctx.dragging = false;
                     ctx.drag_counter = 0;
-                    let (accepted, rejected) = validate_files(&raw, ctx);
+                    let mut next_file_id = ctx.next_file_id;
+                    let (accepted, rejected) = validate_files(&raw, ctx, &mut next_file_id);
+                    ctx.next_file_id = next_file_id;
                     ctx.rejected_files = rejected;
                     let mut current = ctx.files.get().clone();
                     current.extend(accepted);
@@ -569,7 +623,9 @@ impl ars_core::Machine for Machine {
             | (State::Uploading, Event::FilesSelected(raw_files)) => {
                 let raw = raw_files.clone();
                 Some(TransitionPlan::context_only(move |ctx| {
-                    let (accepted, rejected) = validate_files(&raw, ctx);
+                    let mut next_file_id = ctx.next_file_id;
+                    let (accepted, rejected) = validate_files(&raw, ctx, &mut next_file_id);
+                    ctx.next_file_id = next_file_id;
                     ctx.rejected_files = rejected;
                     let mut current = ctx.files.get().clone();
                     current.extend(accepted);
@@ -599,7 +655,10 @@ impl ars_core::Machine for Machine {
                 Some(TransitionPlan::context_only(move |ctx| {
                     let files = ctx.files.get().clone();
                     let updated: Vec<Item> = files.into_iter().map(|mut f| {
-                        if f.id == fid {
+                        // Only the actively uploading file accepts progress: a late
+                        // callback for a file already cancelled/failed/completed must
+                        // not mutate its terminal progress.
+                        if f.id == fid && f.status == Status::Uploading {
                             f.progress = prog;
                         }
                         f
@@ -700,41 +759,76 @@ impl ars_core::Machine for Machine {
 
             (_, Event::SetFiles(files)) => {
                 let files = files.clone();
-                Some(TransitionPlan::context_only(move |ctx| {
+                // A controlled queue replacement must reconcile the machine state:
+                // `State::Uploading` holds exactly when at least one file is
+                // uploading, so dropping (or adding) the last uploading file drives
+                // the resting state between Idle and Uploading. `DragOver` is left
+                // untouched. The monotonic id counter is advanced past any supplied
+                // ids so later generated ids cannot collide with them.
+                let target = files
+                    .as_deref()
+                    .and_then(|files| reconciled_state(*state, files));
+                let apply = move |ctx: &mut Context| {
                     if let Some(files) = files {
+                        ctx.next_file_id = ctx.next_file_id.max(next_id_after(&files));
                         ctx.files.set(files.clone());
                         ctx.files.sync_controlled(Some(files));
                     } else {
                         ctx.files.sync_controlled(None);
                     }
-                }))
+                };
+                Some(match target {
+                    Some(state) => TransitionPlan::to(state).apply(apply),
+                    None => TransitionPlan::context_only(apply),
+                })
             }
 
-            (_, Event::SetProps) => Some(TransitionPlan::context_only({
-                let disabled = props.disabled;
-                let readonly = props.readonly;
-                let required = props.required;
-                let multiple = props.multiple;
-                let accept = props.accept.clone();
-                let max_file_size = props.max_file_size;
-                let min_file_size = props.min_file_size;
-                let max_files = props.max_files;
-                let auto_upload = props.auto_upload;
-                let directory = props.directory;
+            (_, Event::SetProps) => {
+                // Becoming disabled/read-only while dragging would trap the machine:
+                // the disabled guard swallows the DragLeave/Drop that clears
+                // `dragging`, so reset to Idle and clear the drag flags as part of
+                // the sync.
+                let reset_drag = (props.disabled || props.readonly)
+                    && matches!(state, State::DragOver);
+                let apply = {
+                    let disabled = props.disabled;
+                    let readonly = props.readonly;
+                    let required = props.required;
+                    let multiple = props.multiple;
+                    let accept = props.accept.clone();
+                    let max_file_size = props.max_file_size;
+                    let min_file_size = props.min_file_size;
+                    let max_files = props.max_files;
+                    let auto_upload = props.auto_upload;
+                    let directory = props.directory;
+                    let capture = props.capture.clone();
+                    let name = props.name.clone();
 
-                move |ctx| {
-                    ctx.disabled = disabled;
-                    ctx.readonly = readonly;
-                    ctx.required = required;
-                    ctx.multiple = multiple;
-                    ctx.accept = accept;
-                    ctx.max_file_size = max_file_size;
-                    ctx.min_file_size = min_file_size;
-                    ctx.max_files = max_files;
-                    ctx.auto_upload = auto_upload;
-                    ctx.directory = directory;
-                }
-            })),
+                    move |ctx: &mut Context| {
+                        ctx.disabled = disabled;
+                        ctx.readonly = readonly;
+                        ctx.required = required;
+                        ctx.multiple = multiple;
+                        ctx.accept = accept;
+                        ctx.max_file_size = max_file_size;
+                        ctx.min_file_size = min_file_size;
+                        ctx.max_files = max_files;
+                        ctx.auto_upload = auto_upload;
+                        ctx.directory = directory;
+                        ctx.capture = capture;
+                        ctx.name = name;
+                        if reset_drag {
+                            ctx.dragging = false;
+                            ctx.drag_counter = 0;
+                        }
+                    }
+                };
+                Some(if reset_drag {
+                    TransitionPlan::to(State::Idle).apply(apply)
+                } else {
+                    TransitionPlan::context_only(apply)
+                })
+            }
 
             _ => None,
         }
@@ -760,6 +854,8 @@ impl ars_core::Machine for Machine {
             || old.max_file_size != new.max_file_size
             || old.min_file_size != new.min_file_size
             || old.max_files != new.max_files
+            || old.capture != new.capture
+            || old.name != new.name
             || old.auto_upload != new.auto_upload
             || old.directory != new.directory
         {
@@ -1010,10 +1106,10 @@ impl<'a> Api<'a> {
         if self.ctx.directory {
             attrs.set(HtmlAttr::WebkitDirectory, "");
         }
-        if let Some(ref capture) = self.props.capture {
+        if let Some(ref capture) = self.ctx.capture {
             attrs.set(HtmlAttr::Capture, capture);
         }
-        if let Some(ref name) = self.props.name {
+        if let Some(ref name) = self.ctx.name {
             attrs.set(HtmlAttr::Name, name);
         }
         if self.ctx.required {

--- a/spec/components/specialized/file-upload.md
+++ b/spec/components/specialized/file-upload.md
@@ -491,10 +491,13 @@ fn next_id_after(files: &[Item]) -> u64 {
 /// a controlled queue replacement drives the resting state between Idle and
 /// Uploading. Returns `None` when no change is required (including in DragOver,
 /// whose transient drag lifecycle is left untouched).
-fn reconciled_state(current: State, files: &[Item]) -> Option<State> {
+fn reconciled_state(current: State, files: &[Item], dragging: bool) -> Option<State> {
     let any_uploading = files.iter().any(|f| f.status == Status::Uploading);
     match (current, any_uploading) {
-        (State::Uploading, false) => Some(State::Idle),
+        // Leaving Uploading is drag-aware (like `upload_finish_plan`): settle in
+        // DragOver if a drag is still active so the drag-leave path clears the
+        // flags, otherwise Idle.
+        (State::Uploading, false) => Some(finished_uploading_state(dragging)),
         // Enter Uploading even from DragOver (keeping the drag flags) when a
         // controlled queue begins an upload mid-drag, so upload events are
         // processed and the Uploading drag-leave path can clear the flags.
@@ -560,7 +563,8 @@ impl ars_core::Machine for Machine {
         let next_file_id = next_id_after(files.get());
         // Honor the `State::Uploading` invariant from the start: a seeded queue
         // with an uploading item boots in `Uploading`, not `Idle`.
-        let initial_state = reconciled_state(State::Idle, files.get()).unwrap_or(State::Idle);
+        let initial_state =
+            reconciled_state(State::Idle, files.get(), false).unwrap_or(State::Idle);
 
         (initial_state, Context {
             files,
@@ -830,7 +834,11 @@ impl ars_core::Machine for Machine {
             (_, Event::RetryFile { file_id }) => {
                 // Reset the failed file to Pending. Mirror `FilesSelected`: when
                 // `auto_upload` is set, immediately resume uploading so the retry
-                // control is not a silent no-op.
+                // control is not a silent no-op — but only when this id actually
+                // identifies a failed file, so a stale/duplicate retry does not
+                // start unrelated pending files.
+                let will_retry = ctx.files.get().iter()
+                    .any(|f| &f.id == file_id && matches!(f.status, Status::Failed(_)));
                 let fid = file_id.clone();
                 let plan = TransitionPlan::context_only(move |ctx| {
                     let files = ctx.files.get().clone();
@@ -844,7 +852,7 @@ impl ars_core::Machine for Machine {
                     }).collect();
                     commit_files(ctx, updated);
                 });
-                Some(if props.auto_upload { plan.then(Event::StartUpload) } else { plan })
+                Some(if props.auto_upload && will_retry { plan.then(Event::StartUpload) } else { plan })
             }
 
             (_, Event::OpenFilePicker) => {
@@ -890,9 +898,10 @@ impl ars_core::Machine for Machine {
 
             (_, Event::ReconcileState) => {
                 // `State::Uploading` holds exactly when at least one file is
-                // uploading. Drive the resting state between Idle and Uploading to
-                // match the currently visible queue; `DragOver` is left untouched.
-                reconciled_state(*state, ctx.files.get()).map(TransitionPlan::to)
+                // uploading. Drive the resting state to match the currently visible
+                // queue; passing `ctx.dragging` keeps a finishing-mid-drag upload
+                // in DragOver rather than Idle.
+                reconciled_state(*state, ctx.files.get(), ctx.dragging).map(TransitionPlan::to)
             }
 
             (_, Event::SetProps) => {

--- a/spec/components/specialized/file-upload.md
+++ b/spec/components/specialized/file-upload.md
@@ -309,9 +309,10 @@ pub struct Props {
     pub directory: bool,
     /// Name for form submission.
     pub name: Option<String>,
-    /// Invoked with the updated queue when the file set changes (selection,
-    /// drop, removal, clear). Required for controlled mode so the parent can sync
-    /// its `files` prop; fired via the `FilesChanged` effect.
+    /// Invoked with the updated working queue when the file set changes
+    /// (selection, drop, removal, clear). An observation hook: the component owns
+    /// its working queue and this lets the parent mirror it (e.g. to persist or
+    /// to seed the controlled `files` prop). Fired via the `FilesChanged` effect.
     pub on_files_change: Option<Callback<dyn Fn(Vec<Item>) + Send + Sync>>,
     /// Component instance ID.
     pub id: String,
@@ -506,14 +507,14 @@ fn reconciled_state(current: State, files: &[Item], dragging: bool) -> Option<St
     }
 }
 
-/// Writes the queue, mirroring it into the controlled value when controlled.
-/// In controlled mode `Bindable::get` returns the parent's value, so a bare
-/// `set` would leave `api.files()` stale; this optimistically syncs the
-/// controlled value so the queue is visible immediately, while the parent
-/// confirms it via `SetFiles` (driven by the `FilesChanged` callback). The
-/// `FilesChanged` effect reads the queue from the run-time context snapshot
-/// (taken after the event queue drains), so an `auto_upload` selection reports
-/// the post-`StartUpload` queue (Uploading), not the intermediate Pending one.
+/// Writes the working upload queue. FileUpload owns its working queue —
+/// `api.files()` and the lifecycle read it in both modes (like react-dropzone);
+/// the controlled `files` prop is a seed/sync source (init + `SetFiles`) and
+/// `on_files_change` is an observation hook (no mid-flight veto). To keep
+/// `Bindable::get` returning the working queue in controlled mode, mirror the
+/// queue into the controlled slot too. The `FilesChanged` effect reads the queue
+/// from the run-time context snapshot (after the queue drains), so an
+/// `auto_upload` selection reports the post-`StartUpload` queue.
 fn commit_files(ctx: &mut Context, files: Vec<Item>) {
     if ctx.files.is_controlled() {
         ctx.files.sync_controlled(Some(files.clone()));
@@ -1547,8 +1548,8 @@ drop zone activity. The adapter populates the live region text from
 
 | Callback      | ars-ui                    | Ark UI         | Notes                               |
 | ------------- | ------------------------- | -------------- | ----------------------------------- |
-| File accepted | `on_files_change`         | `onFileAccept` | Fired with the updated queue        |
-| File changed  | `on_files_change`         | `onFileChange` | Fired on add/drop/remove/clear      |
+| File accepted | `on_files_change`         | `onFileAccept` | Observe the updated working queue   |
+| File changed  | `on_files_change`         | `onFileChange` | Observe add/drop/remove/clear       |
 | File rejected | rejection list on context | `onFileReject` | ars-ui stores rejections in context |
 
 **Gaps:** None.

--- a/spec/components/specialized/file-upload.md
+++ b/spec/components/specialized/file-upload.md
@@ -81,12 +81,13 @@ impl Progress {
 pub enum RejectionReason {
     /// File type not in the accepted list.
     InvalidType,
-    /// File exceeds the maximum size.
-    TooLarge,
+    /// File exceeds the maximum size; carries the limit in effect at rejection
+    /// time so the message stays accurate if the prop later changes.
+    TooLarge { max: u64 },
     /// Adding this file would exceed the maximum count.
     TooMany,
-    /// File is smaller than the minimum size.
-    TooSmall,
+    /// File is smaller than the minimum size; carries the limit at rejection time.
+    TooSmall { min: u64 },
     /// Custom validation failed.
     CustomValidation(String),
 }
@@ -435,7 +436,7 @@ fn validate_files(
                     name: file.name.clone(),
                     size: file.size,
                     mime_type: file.mime_type.clone(),
-                    reason: RejectionReason::TooLarge,
+                    reason: RejectionReason::TooLarge { max: max_size },
                 });
                 continue;
             }
@@ -447,7 +448,7 @@ fn validate_files(
                     name: file.name.clone(),
                     size: file.size,
                     mime_type: file.mime_type.clone(),
-                    reason: RejectionReason::TooSmall,
+                    reason: RejectionReason::TooSmall { min: min_size },
                 });
                 continue;
             }
@@ -735,7 +736,9 @@ impl ars_core::Machine for Machine {
                     let mut current = ctx.files.get().clone();
                     current.extend(accepted);
                     commit_files(ctx, current);
-                    // If auto_upload, chain a StartUpload event.
+                    // If auto_upload AND accepted_count > 0, chain a StartUpload
+                    // event — an all-rejected selection must not start existing
+                    // pending files.
                 })) // + announce-files-added/rejected{count} + files-changed{queue}
             }
 
@@ -826,7 +829,9 @@ impl ars_core::Machine for Machine {
             }
 
             (_, Event::ClearFiles) => {
-                Some(TransitionPlan::to(State::Idle).apply(|ctx| {
+                // Drag-aware (like the upload-finish paths): clearing mid-drag
+                // settles in DragOver so the drag-leave path clears the flags.
+                Some(TransitionPlan::to(finished_uploading_state(ctx.dragging)).apply(|ctx| {
                     commit_files(ctx, Vec::new());
                     ctx.rejected_files.clear();
                 })) // + files-changed{[]}
@@ -1264,11 +1269,9 @@ impl<'a> Api<'a> {
     /// Adapters can use this to display per-file error messages in the file list.
     pub fn validation_error_text(&self, rejection: &Rejection) -> String {
         match &rejection.reason {
-            RejectionReason::TooLarge => {
-                (self.ctx.messages.too_large)(
-                    self.ctx.max_file_size.unwrap_or(0),
-                    &self.ctx.locale,
-                )
+            // Use the limit captured at rejection time, not the current prop.
+            RejectionReason::TooLarge { max } => {
+                (self.ctx.messages.too_large)(*max, &self.ctx.locale)
             }
             RejectionReason::InvalidType => {
                 (self.ctx.messages.wrong_type)(&self.ctx.locale)
@@ -1276,11 +1279,8 @@ impl<'a> Api<'a> {
             RejectionReason::TooMany => {
                 (self.ctx.messages.too_many_files)(&self.ctx.locale)
             }
-            RejectionReason::TooSmall => {
-                (self.ctx.messages.too_small)(
-                    self.ctx.min_file_size.unwrap_or(0),
-                    &self.ctx.locale,
-                )
+            RejectionReason::TooSmall { min } => {
+                (self.ctx.messages.too_small)(*min, &self.ctx.locale)
             }
             RejectionReason::CustomValidation(msg) => msg.clone(),
         }

--- a/spec/components/specialized/file-upload.md
+++ b/spec/components/specialized/file-upload.md
@@ -507,7 +507,10 @@ fn reconciled_state(current: State, files: &[Item]) -> Option<State> {
 /// In controlled mode `Bindable::get` returns the parent's value, so a bare
 /// `set` would leave `api.files()` stale; this optimistically syncs the
 /// controlled value so the queue is visible immediately, while the parent
-/// confirms it via `SetFiles` (driven by the `FilesChanged` callback).
+/// confirms it via `SetFiles` (driven by the `FilesChanged` callback). The
+/// `FilesChanged` effect reads the queue from the run-time context snapshot
+/// (taken after the event queue drains), so an `auto_upload` selection reports
+/// the post-`StartUpload` queue (Uploading), not the intermediate Pending one.
 fn commit_files(ctx: &mut Context, files: Vec<Item>) {
     if ctx.files.is_controlled() {
         ctx.files.sync_controlled(Some(files.clone()));
@@ -663,7 +666,9 @@ impl ars_core::Machine for Machine {
                 // Validate up front so the accepted/rejected counts can drive the
                 // `announce-files-added` / `announce-files-rejected` effects, and
                 // the accepted set drives `files-changed`. `commit_files` syncs the
-                // controlled value so `api.files()` reflects the drop.
+                // controlled value so `api.files()` reflects the drop. A drop tags
+                // `announce-files-added` as `from_drop` (assertive live region per
+                // §4.2); a picker selection leaves it polite (§3.3).
                 let raw = raw_files.clone();
                 Some(TransitionPlan::to(State::Idle).apply(move |ctx| {
                     ctx.dragging = false;
@@ -776,8 +781,10 @@ impl ars_core::Machine for Machine {
                     ctx.files.set(updated);
                 }))
                 // The Service should check after this action whether any files
-                // are still Uploading. If none, transition to Idle. When a file
-                // that was still uploading actually completes, also emit the
+                // are still Uploading. If none, transition out of Uploading: to
+                // `DragOver` if a drag is still in progress (`ctx.dragging`) so the
+                // drag-leave path can clear the flags, otherwise to `Idle`. When a
+                // file that was still uploading actually completes, also emit the
                 // `announce-upload-complete` effect (polite).
             }
 
@@ -1343,19 +1350,19 @@ FileUpload
 └── HiddenInput        (native <input type="file">)
 ```
 
-| Part              | Element               | Key Attributes                                          |
-| ----------------- | --------------------- | ------------------------------------------------------- |
-| Root              | `<div>`               | `data-ars-scope`, `data-ars-part`, `aria-label`         |
-| Label             | `<label>`             | `id`, `for`                                             |
-| Dropzone          | `<div>`               | `role="button"`, `tabindex="0"`, `aria-labelledby`      |
-| Trigger           | `<button>`            | `aria-label`                                            |
-| ItemGroup         | `<ul>`                | `role="list"`, `aria-label`                             |
-| Item              | `<li>`                | `role="listitem"`, `tabindex="0"`, `data-ars-state`, `data-ars-file-id` |
-| ItemName          | `<span>`              | file name text                                          |
-| ItemSizeText      | `<span>`              | formatted file size                                     |
-| ItemDeleteTrigger | `<button>`            | `aria-label="Remove {filename}"`                        |
-| ItemProgress      | `<div>`               | upload progress indicator                               |
-| HiddenInput       | `<input type="file">` | `tabindex="-1"`, `multiple`, `accept`                   |
+| Part              | Element               | Key Attributes                                     |
+| ----------------- | --------------------- | -------------------------------------------------- |
+| Root              | `<div>`               | `data-ars-scope`, `data-ars-part`, `aria-label`    |
+| Label             | `<label>`             | `id`, `for`                                        |
+| Dropzone          | `<div>`               | `role="button"`, `tabindex="0"`, `aria-labelledby` |
+| Trigger           | `<button>`            | `aria-label`                                       |
+| ItemGroup         | `<ul>`                | `role="list"`, `aria-label`                        |
+| Item              | `<li>`                | `role="listitem"`, `tabindex="0"`, `data-ars-*`    |
+| ItemName          | `<span>`              | file name text                                     |
+| ItemSizeText      | `<span>`              | formatted file size                                |
+| ItemDeleteTrigger | `<button>`            | `aria-label="Remove {filename}"`                   |
+| ItemProgress      | `<div>`               | upload progress indicator                          |
+| HiddenInput       | `<input type="file">` | `tabindex="-1"`, `multiple`, `accept`              |
 
 ## 3. Accessibility
 

--- a/spec/components/specialized/file-upload.md
+++ b/spec/components/specialized/file-upload.md
@@ -193,6 +193,11 @@ pub enum Event {
     SetFiles(Option<Vec<Item>>),
     /// Synchronize output-affecting props stored in context.
     SetProps,
+    /// Reconcile the machine state with the currently visible file queue.
+    /// Chained after `SetFiles` so the resting state tracks the queue revealed by
+    /// the sync (a freshly controlled value, or the internal value exposed when
+    /// control is released).
+    ReconcileState,
 }
 
 /// Raw file data from the browser File API, prior to validation.
@@ -481,7 +486,9 @@ fn mime_matches(mime: &str, name: &str, patterns: &[String]) -> bool {
             let prefix = &pattern[..pattern.len() - 1];
             mime.starts_with(prefix)
         } else if pattern.starts_with('.') {
-            name.ends_with(pattern)
+            // Match the full dotted suffix, case-insensitively, so compound
+            // extensions like `.tar.gz` match `archive.tar.gz`.
+            name.to_ascii_lowercase().ends_with(&pattern.to_ascii_lowercase())
         } else {
             mime == pattern
         }
@@ -592,18 +599,32 @@ impl ars_core::Machine for Machine {
             }
 
             (State::DragOver, Event::DragLeave) => {
-                // Decrement counter; only leave DragOver when counter hits 0
-                Some(TransitionPlan::context_only(|ctx| {
-                    ctx.drag_counter = ctx.drag_counter.saturating_sub(1);
-                    if ctx.drag_counter == 0 {
-                        ctx.dragging = false;
-                    }
-                }))
-                // Note: actual state change to Idle happens in a follow-up check.
-                // For simplicity, we handle this in the transition:
+                // Decrement the nesting counter; only leave DragOver at 0. On the
+                // transition to Idle, announce that the dropzone is no longer
+                // active (assertive) via the `announce-dropzone-left` effect
+                // (`messages.drop_zone_left`).
+                let new_counter = ctx.drag_counter.saturating_sub(1);
+                if new_counter == 0 {
+                    Some(TransitionPlan::to(State::Idle)
+                        .apply(|ctx| {
+                            ctx.drag_counter = 0;
+                            ctx.dragging = false;
+                        })
+                        .with_named_effect("announce-dropzone-left", |ctx, _props, _send| {
+                            use_platform_effects().announce(&(ctx.messages.drop_zone_left)(&ctx.locale));
+                            no_cleanup()
+                        }))
+                } else {
+                    Some(TransitionPlan::context_only(move |ctx| {
+                        ctx.drag_counter = new_counter;
+                    }))
+                }
             }
 
             (State::DragOver, Event::Drop(raw_files)) => {
+                // Validate up front so the accepted/rejected counts can drive the
+                // `announce-files-added` / `announce-files-rejected` effects
+                // (polite; `messages.files_added` / `messages.rejection_message`).
                 let raw = raw_files.clone();
                 Some(TransitionPlan::to(State::Idle).apply(move |ctx| {
                     ctx.dragging = false;
@@ -615,7 +636,7 @@ impl ars_core::Machine for Machine {
                     let mut current = ctx.files.get().clone();
                     current.extend(accepted);
                     ctx.files.set(current);
-                }))
+                })) // + announce-files-added{count} / announce-files-rejected{count}
             }
 
             // --- File selection via input ---
@@ -630,8 +651,8 @@ impl ars_core::Machine for Machine {
                     let mut current = ctx.files.get().clone();
                     current.extend(accepted);
                     ctx.files.set(current);
-                    // If auto_upload, chain a StartUpload event
-                }))
+                    // If auto_upload, chain a StartUpload event.
+                })) // + announce-files-added{count} / announce-files-rejected{count}
             }
 
             // --- Upload lifecycle ---
@@ -681,7 +702,9 @@ impl ars_core::Machine for Machine {
                     ctx.files.set(updated);
                 }))
                 // The Service should check after this action whether any files
-                // are still Uploading. If none, transition to Idle.
+                // are still Uploading. If none, transition to Idle. When a file
+                // that was still uploading actually completes, also emit the
+                // `announce-upload-complete` effect (polite).
             }
 
             (State::Uploading, Event::UploadError { file_id, error }) => {
@@ -759,15 +782,11 @@ impl ars_core::Machine for Machine {
 
             (_, Event::SetFiles(files)) => {
                 let files = files.clone();
-                // A controlled queue replacement must reconcile the machine state:
-                // `State::Uploading` holds exactly when at least one file is
-                // uploading, so dropping (or adding) the last uploading file drives
-                // the resting state between Idle and Uploading. `DragOver` is left
-                // untouched. The monotonic id counter is advanced past any supplied
-                // ids so later generated ids cannot collide with them.
-                let target = files
-                    .as_deref()
-                    .and_then(|files| reconciled_state(*state, files));
+                // Advance the monotonic id counter past any supplied ids so later
+                // generated ids cannot collide with them, then reconcile the state
+                // via a chained `ReconcileState` once the sync has landed (so it
+                // sees the controlled value, or the internal value revealed by
+                // `sync_controlled(None)`).
                 let apply = move |ctx: &mut Context| {
                     if let Some(files) = files {
                         ctx.next_file_id = ctx.next_file_id.max(next_id_after(&files));
@@ -777,10 +796,14 @@ impl ars_core::Machine for Machine {
                         ctx.files.sync_controlled(None);
                     }
                 };
-                Some(match target {
-                    Some(state) => TransitionPlan::to(state).apply(apply),
-                    None => TransitionPlan::context_only(apply),
-                })
+                Some(TransitionPlan::context_only(apply).then(Event::ReconcileState))
+            }
+
+            (_, Event::ReconcileState) => {
+                // `State::Uploading` holds exactly when at least one file is
+                // uploading. Drive the resting state between Idle and Uploading to
+                // match the currently visible queue; `DragOver` is left untouched.
+                reconciled_state(*state, ctx.files.get()).map(TransitionPlan::to)
             }
 
             (_, Event::SetProps) => {
@@ -1073,7 +1096,14 @@ impl<'a> Api<'a> {
         if let Some(file) = files.get(index) {
             attrs.set(HtmlAttr::Aria(AriaAttr::Label), (self.ctx.messages.remove_label)(&file.name, &self.ctx.locale));
         }
-        // Event handlers (click to remove file) are typed methods on the Api struct.
+        // The transition guard ignores `RemoveFile` while disabled/read-only, so
+        // mark the control inert to match the trigger and hidden input.
+        if self.ctx.disabled || self.ctx.readonly {
+            attrs.set_bool(HtmlAttr::Disabled, true);
+            attrs.set(HtmlAttr::Aria(AriaAttr::Disabled), "true");
+        }
+        // Event handlers (click to remove, Delete/Backspace keydown) are typed
+        // methods on the Api struct.
         attrs
     }
 
@@ -1173,6 +1203,15 @@ impl<'a> Api<'a> {
     pub fn cancel_file(&self, file_id: &str) {
         (self.send)(Event::CancelFile { file_id: file_id.to_string() });
     }
+
+    /// Keyboard intent on the file item at `index`: Delete/Backspace removes it.
+    /// The adapter passes the item index so the core resolves the file id
+    /// without tracking per-item focus.
+    pub fn on_item_keydown(&self, index: usize, data: &KeyboardEventData) {
+        if matches!(data.key, KeyboardKey::Delete | KeyboardKey::Backspace) {
+            self.on_item_delete_trigger_click(index);
+        }
+    }
 }
 
 impl ConnectApi for Api<'_> {
@@ -1231,17 +1270,17 @@ FileUpload
 
 ### 3.1 ARIA Roles, States, and Properties
 
-| Attribute / Behaviour  | Element           | Value                      |
-| ---------------------- | ----------------- | -------------------------- |
-| `role="button"`        | Dropzone          | Clickable drop area        |
-| `tabindex="0"`         | Dropzone          | Keyboard focusable         |
-| `aria-labelledby`      | Dropzone          | Label ID                   |
-| `aria-disabled="true"` | Dropzone, Trigger | When disabled              |
-| `role="list"`          | ItemGroup         | Semantic list              |
-| `role="listitem"`      | Item              | Semantic list item         |
-| `aria-label`           | Trigger           | `"Choose files to upload"` |
-| `aria-label`           | ItemDeleteTrigger | `"Remove {filename}"`      |
-| `aria-label`           | ItemGroup         | `"Uploaded files"`         |
+| Attribute / Behaviour  | Element                              | Value                      |
+| ---------------------- | ------------------------------------ | -------------------------- |
+| `role="button"`        | Dropzone                             | Clickable drop area        |
+| `tabindex="0"`         | Dropzone                             | Keyboard focusable         |
+| `aria-labelledby`      | Dropzone                             | Label ID                   |
+| `aria-disabled="true"` | Dropzone, Trigger, ItemDeleteTrigger | When disabled or read-only |
+| `role="list"`          | ItemGroup                            | Semantic list              |
+| `role="listitem"`      | Item                                 | Semantic list item         |
+| `aria-label`           | Trigger                              | `"Choose files to upload"` |
+| `aria-label`           | ItemDeleteTrigger                    | `"Remove {filename}"`      |
+| `aria-label`           | ItemGroup                            | `"Uploaded files"`         |
 
 ### 3.2 Keyboard Interaction
 

--- a/spec/dioxus-components/specialized/file-upload.md
+++ b/spec/dioxus-components/specialized/file-upload.md
@@ -69,7 +69,7 @@ Dropzone button semantics, item-list semantics, item removal labels, and native 
 
 ## 7. Prop Sync and Event Mapping
 
-Controlled file-list sync flows through the writable signal and `Service::set_props`, which dispatches core `SetFiles` / `SetProps` via `Machine::on_props_changed`. `Dropzone` drag events dispatch enter/leave/over/drop machine events. `Trigger` and `Dropzone` keyboard activation forward to the hidden input. Native input change events normalize `FileList` data into core `RawFile` values before validation.
+Controlled file-list sync flows through the writable signal and `Service::set_props`, which dispatches core `SetFiles` / `SetProps` via `Machine::on_props_changed`. The reverse direction — selections, drops, removals, and clears — surfaces through the core `FilesChanged` effect, which invokes `Props::on_files_change` with the updated queue so the controlled parent can write it back. `Dropzone` drag events dispatch enter/leave/over/drop machine events (drag-and-drop stays active during uploads). `Trigger` and `Dropzone` keyboard activation forward to the hidden input, and item-level Delete/Backspace forwards to `Api::on_item_keydown`. Native input change events normalize `FileList` data into core `RawFile` values before validation.
 
 ## 8. Registration and Cleanup Contract
 

--- a/spec/dioxus-components/specialized/file-upload.md
+++ b/spec/dioxus-components/specialized/file-upload.md
@@ -69,7 +69,7 @@ Dropzone button semantics, item-list semantics, item removal labels, and native 
 
 ## 7. Prop Sync and Event Mapping
 
-Controlled file-list sync flows through the writable signal. `Dropzone` drag events dispatch enter/leave/over/drop machine events. `Trigger` and `Dropzone` keyboard activation forward to the hidden input. Native input change events normalize `FileList` data into core `RawFile` values before validation.
+Controlled file-list sync flows through the writable signal and `Service::set_props`, which dispatches core `SetFiles` / `SetProps` via `Machine::on_props_changed`. `Dropzone` drag events dispatch enter/leave/over/drop machine events. `Trigger` and `Dropzone` keyboard activation forward to the hidden input. Native input change events normalize `FileList` data into core `RawFile` values before validation.
 
 ## 8. Registration and Cleanup Contract
 

--- a/spec/leptos-components/specialized/file-upload.md
+++ b/spec/leptos-components/specialized/file-upload.md
@@ -54,7 +54,7 @@ Dropzone button semantics, item-list semantics, item removal labels, and native 
 
 ## 7. Prop Sync and Event Mapping
 
-Controlled file-list sync flows through the writable signal. `Dropzone` drag events dispatch enter/leave/over/drop machine events. `Trigger` and `Dropzone` keyboard activation forward to the hidden input. Native input change events normalize `FileList` data into core `RawFile` values before validation.
+Controlled file-list sync flows through the writable signal and `Service::set_props`, which dispatches core `SetFiles` / `SetProps` via `Machine::on_props_changed`. `Dropzone` drag events dispatch enter/leave/over/drop machine events. `Trigger` and `Dropzone` keyboard activation forward to the hidden input. Native input change events normalize `FileList` data into core `RawFile` values before validation.
 
 ## 8. Registration and Cleanup Contract
 

--- a/spec/leptos-components/specialized/file-upload.md
+++ b/spec/leptos-components/specialized/file-upload.md
@@ -54,7 +54,7 @@ Dropzone button semantics, item-list semantics, item removal labels, and native 
 
 ## 7. Prop Sync and Event Mapping
 
-Controlled file-list sync flows through the writable signal and `Service::set_props`, which dispatches core `SetFiles` / `SetProps` via `Machine::on_props_changed`. `Dropzone` drag events dispatch enter/leave/over/drop machine events. `Trigger` and `Dropzone` keyboard activation forward to the hidden input. Native input change events normalize `FileList` data into core `RawFile` values before validation.
+Controlled file-list sync flows through the writable signal and `Service::set_props`, which dispatches core `SetFiles` / `SetProps` via `Machine::on_props_changed`. The reverse direction — selections, drops, removals, and clears — surfaces through the core `FilesChanged` effect, which invokes `Props::on_files_change` with the updated queue so the controlled parent can write it back. `Dropzone` drag events dispatch enter/leave/over/drop machine events (drag-and-drop stays active during uploads). `Trigger` and `Dropzone` keyboard activation forward to the hidden input, and item-level Delete/Backspace forwards to `Api::on_item_keydown`. Native input change events normalize `FileList` data into core `RawFile` values before validation.
 
 ## 8. Registration and Cleanup Contract
 


### PR DESCRIPTION
## Summary

- Add framework-agnostic `FileUpload` in `ars-components` with Idle / DragOver / Uploading states, file validation, upload lifecycle, and `ConnectApi` typed handlers.
- Include 71 unit tests, 26 insta snapshots, and `file_upload_anatomy_matches_spec` conformance coverage.
- Sync core and adapter specs after post-implementation audit (controlled `SetFiles`/`SetProps`, hidden-input `capture`/`required`, DnD announcement messages).

Closes #301

## Test plan

- [x] `cargo test -p ars-components --lib file_upload` (71 passed)
- [x] `cargo test -p ars-components --test spec_conformance file_upload_anatomy_matches_spec`
- [x] `cargo xci-fast`
- [x] `cargo xtask spec validate`
- [ ] `cargo xmutants -p ars-components -f crates/ars-components/src/specialized/file_upload/mod.rs` (run when `mutants.out` lock is free; triage any missed mutations before merge)


Made with [Cursor](https://cursor.com)