### PR TITLE
Implement Toolbar agnostic core

### DIFF
--- a/crates/ars-components/src/layout/mod.rs
+++ b/crates/ars-components/src/layout/mod.rs
@@ -26,3 +26,6 @@ pub mod splitter;
 
 /// Stack component connect API.
 pub mod stack;
+
+/// Toolbar component machine.
+pub mod toolbar;

--- a/crates/ars-components/src/layout/toolbar/mod.rs
+++ b/crates/ars-components/src/layout/toolbar/mod.rs
@@ -1,0 +1,1069 @@
+//! Toolbar layout component machine.
+//!
+//! `Toolbar` owns DOM-free item registration, disabled item skipping,
+//! orientation-aware keyboard navigation, and roving tabindex attributes.
+//! Framework adapters resolve the focused item index to a live element handle.
+
+use alloc::{string::String, vec::Vec};
+use core::fmt::{self, Debug};
+
+use ars_core::{
+    AriaAttr, AttrMap, ComponentIds, ComponentMessages, ComponentPart, ConnectApi, Direction, Env,
+    HtmlAttr, KeyboardKey, NoEffect, Orientation, TransitionPlan,
+};
+use ars_interactions::KeyboardEventData;
+
+/// Toolbar is always idle; focus tracking is kept in [`Context`].
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum State {
+    /// The idle state.
+    #[default]
+    Idle,
+}
+
+/// Events accepted by the `Toolbar` machine.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Event {
+    /// Focus a specific item by zero-based rendered index.
+    FocusItem(usize),
+
+    /// Move focus to the next enabled item, wrapping at the end.
+    FocusNext,
+
+    /// Move focus to the previous enabled item, wrapping at the start.
+    FocusPrev,
+
+    /// Move focus to the first enabled item.
+    FocusFirst,
+
+    /// Move focus to the last enabled item.
+    FocusLast,
+
+    /// Focus entered the toolbar.
+    Focus {
+        /// Whether focus entry was caused by keyboard interaction.
+        is_keyboard: bool,
+    },
+
+    /// Focus left the toolbar.
+    Blur,
+
+    /// Replace the rendered item registry.
+    SetItems {
+        /// Number of rendered toolbar items.
+        count: usize,
+
+        /// Disabled item indices in the current rendered order.
+        disabled_items: Vec<usize>,
+    },
+
+    /// Synchronize output-affecting props stored in context.
+    SetProps {
+        /// Latest props snapshot.
+        props: Props,
+    },
+}
+
+/// Runtime context for the `Toolbar` state machine.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Context {
+    /// Index of the currently focused item, which receives `tabindex="0"`.
+    pub focused_index: Option<usize>,
+
+    /// Toolbar orientation for ARIA and arrow-key handling.
+    pub orientation: Orientation,
+
+    /// Text direction for RTL-aware horizontal navigation.
+    pub dir: Direction,
+
+    /// Whether the entire toolbar is disabled.
+    pub disabled: bool,
+
+    /// Number of rendered toolbar items.
+    pub item_count: usize,
+
+    /// Disabled item indices in rendered order.
+    pub disabled_items: Vec<usize>,
+
+    /// Component identifiers for derived part IDs.
+    pub ids: ComponentIds,
+}
+
+/// Props for the `Toolbar` component.
+#[derive(Clone, Debug, PartialEq, Eq, ars_core::HasId)]
+pub struct Props {
+    /// The id of the toolbar.
+    pub id: String,
+
+    /// Toolbar orientation.
+    pub orientation: Orientation,
+
+    /// Text direction for RTL support.
+    pub dir: Direction,
+
+    /// Accessible label for the toolbar.
+    pub aria_label: Option<String>,
+
+    /// Whether the toolbar and all child items are disabled.
+    pub disabled: bool,
+}
+
+impl Default for Props {
+    fn default() -> Self {
+        Self {
+            id: String::new(),
+            orientation: Orientation::Horizontal,
+            dir: Direction::Ltr,
+            aria_label: None,
+            disabled: false,
+        }
+    }
+}
+
+impl Props {
+    /// Returns fresh toolbar props with documented defaults.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ars_components::layout::toolbar::{Machine, Messages, Props};
+    /// use ars_core::{Env, HtmlAttr, Service};
+    ///
+    /// let service = Service::<Machine>::new(
+    ///     Props::new().id("formatting").aria_label("Formatting tools"),
+    ///     &Env::default(),
+    ///     &Messages::default(),
+    /// );
+    /// let attrs = service.connect(&|_| {}).root_attrs();
+    ///
+    /// assert_eq!(attrs.get(&HtmlAttr::Role), Some("toolbar"));
+    /// ```
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets [`id`](Self::id).
+    #[must_use]
+    pub fn id(mut self, id: impl Into<String>) -> Self {
+        self.id = id.into();
+        self
+    }
+
+    /// Sets [`orientation`](Self::orientation).
+    #[must_use]
+    pub const fn orientation(mut self, orientation: Orientation) -> Self {
+        self.orientation = orientation;
+        self
+    }
+
+    /// Sets [`dir`](Self::dir).
+    #[must_use]
+    pub const fn dir(mut self, dir: Direction) -> Self {
+        self.dir = dir;
+        self
+    }
+
+    /// Sets [`aria_label`](Self::aria_label).
+    #[must_use]
+    pub fn aria_label(mut self, aria_label: impl Into<String>) -> Self {
+        self.aria_label = Some(aria_label.into());
+        self
+    }
+
+    /// Sets [`disabled`](Self::disabled).
+    #[must_use]
+    pub const fn disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
+    }
+}
+
+/// This component has no translatable strings.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Messages;
+
+impl ComponentMessages for Messages {}
+
+/// Machine for the `Toolbar` component.
+#[derive(Debug)]
+pub struct Machine;
+
+impl ars_core::Machine for Machine {
+    type State = State;
+    type Event = Event;
+    type Context = Context;
+    type Props = Props;
+    type Messages = Messages;
+    type Effect = NoEffect;
+    type Api<'a> = Api<'a>;
+
+    fn init(
+        props: &Self::Props,
+        _env: &Env,
+        _messages: &Self::Messages,
+    ) -> (Self::State, Self::Context) {
+        (
+            State::Idle,
+            Context {
+                focused_index: None,
+                orientation: props.orientation,
+                dir: props.dir,
+                disabled: props.disabled,
+                item_count: 0,
+                disabled_items: Vec::new(),
+                ids: ComponentIds::from_id(&props.id),
+            },
+        )
+    }
+
+    fn transition(
+        _state: &Self::State,
+        event: &Self::Event,
+        ctx: &Self::Context,
+        _props: &Self::Props,
+    ) -> Option<TransitionPlan<Self>> {
+        match event {
+            Event::SetItems {
+                count,
+                disabled_items,
+            } => set_items_plan(ctx, *count, disabled_items),
+
+            Event::SetProps { props } => {
+                let props = props.clone();
+
+                if ctx.orientation == props.orientation
+                    && ctx.dir == props.dir
+                    && ctx.disabled == props.disabled
+                {
+                    return None;
+                }
+
+                Some(TransitionPlan::context_only(move |ctx: &mut Context| {
+                    ctx.orientation = props.orientation;
+                    ctx.dir = props.dir;
+                    ctx.disabled = props.disabled;
+
+                    if ctx.disabled {
+                        ctx.focused_index = None;
+                    }
+                }))
+            }
+
+            _ if ctx.disabled => None,
+
+            Event::FocusItem(index) => {
+                let index = *index;
+
+                if !can_focus_index(ctx.item_count, &ctx.disabled_items, index)
+                    || ctx.focused_index == Some(index)
+                {
+                    return None;
+                }
+
+                Some(focus_plan(Some(index)))
+            }
+
+            Event::FocusNext => {
+                let target = next_enabled_index(
+                    ctx.focused_index.unwrap_or(0),
+                    ctx.item_count,
+                    &ctx.disabled_items,
+                    true,
+                );
+
+                focus_if_changed(ctx, target)
+            }
+
+            Event::FocusPrev => {
+                let target = next_enabled_index(
+                    ctx.focused_index.unwrap_or(0),
+                    ctx.item_count,
+                    &ctx.disabled_items,
+                    false,
+                );
+
+                focus_if_changed(ctx, target)
+            }
+
+            Event::FocusFirst => focus_if_changed(
+                ctx,
+                first_enabled_index(ctx.item_count, &ctx.disabled_items),
+            ),
+
+            Event::FocusLast => {
+                focus_if_changed(ctx, last_enabled_index(ctx.item_count, &ctx.disabled_items))
+            }
+
+            Event::Focus { is_keyboard: _ } => {
+                if ctx.focused_index.is_some() {
+                    return None;
+                }
+
+                focus_if_changed(
+                    ctx,
+                    first_enabled_index(ctx.item_count, &ctx.disabled_items),
+                )
+            }
+
+            Event::Blur => None,
+        }
+    }
+
+    fn connect<'a>(
+        state: &'a Self::State,
+        ctx: &'a Self::Context,
+        props: &'a Self::Props,
+        send: &'a dyn Fn(Self::Event),
+    ) -> Self::Api<'a> {
+        Api {
+            state,
+            ctx,
+            props,
+            send,
+        }
+    }
+
+    fn on_props_changed(old: &Self::Props, new: &Self::Props) -> Vec<Self::Event> {
+        if old.orientation == new.orientation && old.dir == new.dir && old.disabled == new.disabled
+        {
+            Vec::new()
+        } else {
+            alloc::vec![Event::SetProps { props: new.clone() }]
+        }
+    }
+}
+
+fn set_items_plan(
+    ctx: &Context,
+    count: usize,
+    disabled_items: &[usize],
+) -> Option<TransitionPlan<Machine>> {
+    let disabled_items = normalized_disabled_items(count, disabled_items);
+
+    let focused_index = ctx
+        .focused_index
+        .filter(|index| can_focus_index(count, &disabled_items, *index));
+
+    if ctx.item_count == count
+        && ctx.disabled_items == disabled_items
+        && ctx.focused_index == focused_index
+    {
+        return None;
+    }
+
+    Some(TransitionPlan::context_only(move |ctx: &mut Context| {
+        ctx.item_count = count;
+        ctx.disabled_items = disabled_items;
+        ctx.focused_index = focused_index;
+    }))
+}
+
+fn normalized_disabled_items(count: usize, disabled_items: &[usize]) -> Vec<usize> {
+    let mut normalized = disabled_items
+        .iter()
+        .copied()
+        .filter(|index| *index < count)
+        .collect::<Vec<_>>();
+
+    normalized.sort_unstable();
+    normalized.dedup();
+
+    normalized
+}
+
+fn can_focus_index(count: usize, disabled: &[usize], index: usize) -> bool {
+    index < count && !disabled.contains(&index)
+}
+
+fn focus_if_changed(ctx: &Context, target: Option<usize>) -> Option<TransitionPlan<Machine>> {
+    (ctx.focused_index != target).then(|| focus_plan(target))
+}
+
+fn focus_plan(target: Option<usize>) -> TransitionPlan<Machine> {
+    TransitionPlan::context_only(move |ctx: &mut Context| {
+        ctx.focused_index = target;
+    })
+}
+
+fn next_enabled_index(
+    current: usize,
+    count: usize,
+    disabled: &[usize],
+    forward: bool,
+) -> Option<usize> {
+    if count == 0 {
+        return None;
+    }
+
+    for step in 1..=count {
+        let index = if forward {
+            (current + step) % count
+        } else {
+            (current + count - (step % count)) % count
+        };
+
+        if !disabled.contains(&index) {
+            return Some(index);
+        }
+    }
+
+    None
+}
+
+fn first_enabled_index(count: usize, disabled: &[usize]) -> Option<usize> {
+    (0..count).find(|index| !disabled.contains(index))
+}
+
+fn last_enabled_index(count: usize, disabled: &[usize]) -> Option<usize> {
+    (0..count).rev().find(|index| !disabled.contains(index))
+}
+
+/// Structural parts exposed by the `Toolbar` connect API.
+#[derive(ComponentPart)]
+#[scope = "toolbar"]
+pub enum Part {
+    /// The root toolbar container.
+    Root,
+
+    /// A toolbar item by rendered index.
+    Item {
+        /// Zero-based rendered item index.
+        index: usize,
+    },
+
+    /// A visual and semantic separator between toolbar groups.
+    Separator,
+}
+
+/// API for producing `Toolbar` attributes and dispatching typed events.
+#[derive(Clone)]
+pub struct Api<'a> {
+    state: &'a State,
+    ctx: &'a Context,
+    props: &'a Props,
+    send: &'a dyn Fn(Event),
+}
+
+impl Debug for Api<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Api")
+            .field("state", self.state)
+            .field("ctx", self.ctx)
+            .field("props", self.props)
+            .finish_non_exhaustive()
+    }
+}
+
+impl PartialEq for Api<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.state == other.state && self.ctx == other.ctx && self.props == other.props
+    }
+}
+
+impl Eq for Api<'_> {}
+
+impl Api<'_> {
+    /// Returns root toolbar attributes.
+    #[must_use]
+    pub fn root_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Root.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Role, "toolbar")
+            .set(
+                HtmlAttr::Aria(AriaAttr::Orientation),
+                orientation_attr(self.ctx.orientation),
+            );
+
+        if let Some(label) = &self.props.aria_label {
+            attrs.set(HtmlAttr::Aria(AriaAttr::Label), label.as_str());
+        }
+
+        if self.ctx.disabled {
+            attrs.set(HtmlAttr::Aria(AriaAttr::Disabled), "true");
+        }
+
+        attrs.set(HtmlAttr::Dir, self.ctx.dir.as_html_attr());
+
+        attrs
+    }
+
+    /// Returns attributes for the toolbar item at `index`.
+    #[must_use]
+    pub fn item_attrs(&self, index: usize) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Item { index: 0 }.data_attrs();
+
+        let disabled = self.ctx.disabled || self.ctx.disabled_items.contains(&index);
+        let focused = self.ctx.focused_index == Some(index);
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::TabIndex, if focused { "0" } else { "-1" });
+
+        if disabled {
+            attrs
+                .set(HtmlAttr::Aria(AriaAttr::Disabled), "true")
+                .set_bool(HtmlAttr::Data("ars-disabled"), true);
+        }
+
+        if focused {
+            attrs.set_bool(HtmlAttr::Data("ars-focused"), true);
+        }
+
+        attrs
+    }
+
+    /// Returns separator attributes.
+    #[must_use]
+    pub fn separator_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Separator.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Role, "separator")
+            .set(
+                HtmlAttr::Aria(AriaAttr::Orientation),
+                match self.ctx.orientation {
+                    Orientation::Horizontal => "vertical",
+                    Orientation::Vertical => "horizontal",
+                },
+            );
+
+        attrs
+    }
+
+    /// Dispatches roving-focus navigation for a root keydown event.
+    pub fn on_root_keydown(&self, data: &KeyboardEventData) {
+        let horizontal = self.ctx.orientation == Orientation::Horizontal;
+        let rtl = self.ctx.dir == Direction::Rtl;
+
+        match data.key {
+            KeyboardKey::ArrowRight if horizontal && rtl => (self.send)(Event::FocusPrev),
+            KeyboardKey::ArrowRight if horizontal => (self.send)(Event::FocusNext),
+            KeyboardKey::ArrowLeft if horizontal && rtl => (self.send)(Event::FocusNext),
+            KeyboardKey::ArrowLeft if horizontal => (self.send)(Event::FocusPrev),
+            KeyboardKey::ArrowDown if !horizontal => (self.send)(Event::FocusNext),
+            KeyboardKey::ArrowUp if !horizontal => (self.send)(Event::FocusPrev),
+            KeyboardKey::Home => (self.send)(Event::FocusFirst),
+            KeyboardKey::End => (self.send)(Event::FocusLast),
+            _ => {}
+        }
+    }
+
+    /// Dispatches focus for a rendered toolbar item.
+    pub fn on_item_focus(&self, index: usize, _is_keyboard: bool) {
+        (self.send)(Event::FocusItem(index));
+    }
+
+    /// Dispatches toolbar root blur.
+    pub fn on_root_blur(&self) {
+        (self.send)(Event::Blur);
+    }
+}
+
+impl ConnectApi for Api<'_> {
+    type Part = Part;
+
+    fn part_attrs(&self, part: Part) -> AttrMap {
+        match part {
+            Part::Root => self.root_attrs(),
+            Part::Item { index } => self.item_attrs(index),
+            Part::Separator => self.separator_attrs(),
+        }
+    }
+}
+
+const fn orientation_attr(orientation: Orientation) -> &'static str {
+    match orientation {
+        Orientation::Horizontal => "horizontal",
+        Orientation::Vertical => "vertical",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::{string::String, vec};
+
+    use ars_core::{
+        AriaAttr, AttrMap, ConnectApi, Direction, Env, HtmlAttr, KeyboardKey, Orientation, Service,
+    };
+    use ars_interactions::KeyboardEventData;
+    use insta::assert_snapshot;
+
+    use super::{Event, Machine, Messages, Part, Props};
+
+    fn service(props: Props) -> Service<Machine> {
+        let props = if props.id.is_empty() {
+            props.id("toolbar")
+        } else {
+            props
+        };
+
+        let mut service = Service::<Machine>::new(props, &Env::default(), &Messages);
+
+        drop(service.send(Event::SetItems {
+            count: 4,
+            disabled_items: vec![2],
+        }));
+
+        service
+    }
+
+    fn keyboard(key: KeyboardKey) -> KeyboardEventData {
+        KeyboardEventData {
+            key,
+            character: None,
+            code: String::new(),
+            ctrl_key: false,
+            shift_key: false,
+            alt_key: false,
+            meta_key: false,
+            repeat: false,
+            is_composing: false,
+        }
+    }
+
+    fn snapshot_attrs(attrs: &AttrMap) -> String {
+        format!("{attrs:#?}")
+    }
+
+    #[test]
+    fn root_attrs_emit_toolbar_role_orientation_label_disabled_and_dir() {
+        let service = service(
+            Props::new()
+                .id("tools")
+                .aria_label("Formatting tools")
+                .orientation(Orientation::Vertical)
+                .dir(Direction::Rtl)
+                .disabled(true),
+        );
+
+        let attrs = service.connect(&|_| {}).root_attrs();
+
+        assert_eq!(attrs.get(&HtmlAttr::Role), Some("toolbar"));
+        assert_eq!(
+            attrs.get(&HtmlAttr::Aria(AriaAttr::Orientation)),
+            Some("vertical")
+        );
+        assert_eq!(
+            attrs.get(&HtmlAttr::Aria(AriaAttr::Label)),
+            Some("Formatting tools")
+        );
+        assert_eq!(attrs.get(&HtmlAttr::Aria(AriaAttr::Disabled)), Some("true"));
+        assert_eq!(attrs.get(&HtmlAttr::Dir), Some("rtl"));
+    }
+
+    #[test]
+    fn roving_tabindex_tracks_focused_item_and_skips_disabled_items() {
+        let mut service = service(Props::new().id("tools"));
+
+        drop(service.send(Event::FocusFirst));
+
+        assert_eq!(
+            service
+                .connect(&|_| {})
+                .item_attrs(0)
+                .get(&HtmlAttr::TabIndex),
+            Some("0")
+        );
+
+        drop(service.send(Event::FocusNext));
+
+        assert_eq!(service.context().focused_index, Some(1));
+
+        drop(service.send(Event::FocusNext));
+
+        assert_eq!(service.context().focused_index, Some(3));
+
+        let api = service.connect(&|_| {});
+
+        assert_eq!(api.item_attrs(1).get(&HtmlAttr::TabIndex), Some("-1"));
+        assert_eq!(api.item_attrs(2).get(&HtmlAttr::TabIndex), Some("-1"));
+        assert_eq!(
+            api.item_attrs(2).get(&HtmlAttr::Aria(AriaAttr::Disabled)),
+            Some("true")
+        );
+        assert_eq!(api.item_attrs(3).get(&HtmlAttr::TabIndex), Some("0"));
+    }
+
+    #[test]
+    fn keyboard_navigation_respects_orientation_and_rtl() {
+        let captured = alloc::rc::Rc::new(core::cell::RefCell::new(Vec::new()));
+
+        let toolbar = service(Props::new().dir(Direction::Rtl));
+
+        let send = {
+            let captured = alloc::rc::Rc::clone(&captured);
+            move |event| captured.borrow_mut().push(event)
+        };
+
+        toolbar
+            .connect(&send)
+            .on_root_keydown(&keyboard(KeyboardKey::ArrowRight));
+        toolbar
+            .connect(&send)
+            .on_root_keydown(&keyboard(KeyboardKey::ArrowLeft));
+
+        assert_eq!(
+            captured.borrow().as_slice(),
+            &[Event::FocusPrev, Event::FocusNext]
+        );
+
+        captured.borrow_mut().clear();
+
+        service(Props::new().orientation(Orientation::Vertical))
+            .connect(&send)
+            .on_root_keydown(&keyboard(KeyboardKey::ArrowDown));
+
+        service(Props::new().orientation(Orientation::Vertical))
+            .connect(&send)
+            .on_root_keydown(&keyboard(KeyboardKey::ArrowUp));
+
+        assert_eq!(
+            captured.borrow().as_slice(),
+            &[Event::FocusNext, Event::FocusPrev]
+        );
+    }
+
+    #[test]
+    fn home_end_focus_first_and_last_enabled_items() {
+        let mut service = service(Props::new());
+
+        drop(service.send(Event::FocusLast));
+
+        assert_eq!(service.context().focused_index, Some(3));
+
+        drop(service.send(Event::FocusFirst));
+
+        assert_eq!(service.context().focused_index, Some(0));
+    }
+
+    #[test]
+    fn previous_focus_wraps_and_skips_disabled_items() {
+        let mut service = service(Props::new());
+
+        drop(service.send(Event::FocusFirst));
+        drop(service.send(Event::FocusPrev));
+
+        assert_eq!(service.context().focused_index, Some(3));
+
+        drop(service.send(Event::FocusPrev));
+
+        assert_eq!(service.context().focused_index, Some(1));
+    }
+
+    #[test]
+    fn focus_entry_targets_first_enabled_item_and_blur_preserves_focus() {
+        let mut service = service(Props::new());
+
+        drop(service.send(Event::Focus { is_keyboard: true }));
+
+        assert_eq!(service.context().focused_index, Some(0));
+
+        drop(service.send(Event::Focus { is_keyboard: false }));
+
+        assert_eq!(service.context().focused_index, Some(0));
+
+        drop(service.send(Event::Blur));
+
+        assert_eq!(service.context().focused_index, Some(0));
+    }
+
+    #[test]
+    fn zero_all_disabled_and_out_of_range_focus_requests_are_ignored() {
+        let mut service =
+            Service::<Machine>::new(Props::new().id("toolbar"), &Env::default(), &Messages);
+
+        drop(service.send(Event::FocusNext));
+
+        assert_eq!(service.context().focused_index, None);
+
+        drop(service.send(Event::SetItems {
+            count: 2,
+            disabled_items: vec![0, 1],
+        }));
+        drop(service.send(Event::FocusFirst));
+
+        assert_eq!(service.context().focused_index, None);
+
+        drop(service.send(Event::FocusItem(4)));
+
+        assert_eq!(service.context().focused_index, None);
+    }
+
+    #[test]
+    fn set_items_normalizes_disabled_items_and_prunes_invalid_focus() {
+        let mut service = service(Props::new());
+
+        drop(service.send(Event::FocusLast));
+
+        assert_eq!(service.context().focused_index, Some(3));
+
+        drop(service.send(Event::SetItems {
+            count: 3,
+            disabled_items: vec![1, 1, 9],
+        }));
+
+        assert_eq!(service.context().item_count, 3);
+        assert_eq!(service.context().disabled_items, vec![1]);
+        assert_eq!(service.context().focused_index, None);
+
+        let before = service.context().clone();
+
+        drop(service.send(Event::SetItems {
+            count: 3,
+            disabled_items: vec![1],
+        }));
+
+        assert_eq!(*service.context(), before);
+    }
+
+    #[test]
+    fn disabled_toolbar_suppresses_navigation() {
+        let mut service = service(Props::new().disabled(true));
+
+        drop(service.send(Event::FocusFirst));
+
+        assert_eq!(service.context().focused_index, None);
+    }
+
+    #[test]
+    fn set_props_syncs_output_affecting_context() {
+        let mut service = service(Props::new().id("toolbar"));
+
+        drop(service.send(Event::FocusFirst));
+        drop(
+            service.set_props(
+                Props::new()
+                    .id("toolbar")
+                    .orientation(Orientation::Vertical)
+                    .dir(Direction::Rtl)
+                    .disabled(true),
+            ),
+        );
+
+        let attrs = service.connect(&|_| {}).root_attrs();
+
+        assert_eq!(service.context().orientation, Orientation::Vertical);
+        assert_eq!(service.context().dir, Direction::Rtl);
+        assert!(service.context().disabled);
+        assert_eq!(service.context().focused_index, None);
+        assert_eq!(
+            attrs.get(&HtmlAttr::Aria(AriaAttr::Orientation)),
+            Some("vertical")
+        );
+        assert_eq!(attrs.get(&HtmlAttr::Dir), Some("rtl"));
+        assert_eq!(attrs.get(&HtmlAttr::Aria(AriaAttr::Disabled)), Some("true"));
+    }
+
+    #[test]
+    fn unchanged_output_props_do_not_emit_sync_events() {
+        let mut service = service(Props::new().id("toolbar"));
+
+        let before = service.context().clone();
+
+        drop(service.set_props(Props::new().id("toolbar")));
+
+        assert_eq!(*service.context(), before);
+
+        drop(
+            service.set_props(
+                Props::new()
+                    .id("toolbar")
+                    .orientation(Orientation::Vertical)
+                    .dir(Direction::Rtl),
+            ),
+        );
+
+        assert_eq!(service.context().orientation, Orientation::Vertical);
+        assert_eq!(service.context().dir, Direction::Rtl);
+        assert!(!service.context().disabled);
+    }
+
+    #[test]
+    fn separator_attrs_use_perpendicular_orientation() {
+        let service = service(Props::new().orientation(Orientation::Horizontal));
+
+        let attrs = service.connect(&|_| {}).separator_attrs();
+
+        assert_eq!(attrs.get(&HtmlAttr::Role), Some("separator"));
+        assert_eq!(
+            attrs.get(&HtmlAttr::Aria(AriaAttr::Orientation)),
+            Some("vertical")
+        );
+    }
+
+    #[test]
+    fn vertical_separator_attrs_use_horizontal_orientation() {
+        let service = service(Props::new().orientation(Orientation::Vertical));
+
+        let attrs = service.connect(&|_| {}).separator_attrs();
+
+        assert_eq!(
+            attrs.get(&HtmlAttr::Aria(AriaAttr::Orientation)),
+            Some("horizontal")
+        );
+    }
+
+    #[test]
+    fn typed_handlers_dispatch_focus_and_blur_events() {
+        let captured = alloc::rc::Rc::new(core::cell::RefCell::new(Vec::new()));
+        let send = {
+            let captured = alloc::rc::Rc::clone(&captured);
+            move |event| captured.borrow_mut().push(event)
+        };
+
+        let service = service(Props::new());
+
+        let api = service.connect(&send);
+
+        api.on_item_focus(1, true);
+        api.on_root_blur();
+
+        assert_eq!(
+            captured.borrow().as_slice(),
+            &[Event::FocusItem(1), Event::Blur]
+        );
+    }
+
+    #[test]
+    fn keydown_handler_dispatches_ltr_home_end_and_ignores_unhandled_keys() {
+        let captured = alloc::rc::Rc::new(core::cell::RefCell::new(Vec::new()));
+        let send = {
+            let captured = alloc::rc::Rc::clone(&captured);
+            move |event| captured.borrow_mut().push(event)
+        };
+
+        let service = service(Props::new());
+
+        let api = service.connect(&send);
+
+        api.on_root_keydown(&keyboard(KeyboardKey::ArrowRight));
+        api.on_root_keydown(&keyboard(KeyboardKey::ArrowLeft));
+        api.on_root_keydown(&keyboard(KeyboardKey::Home));
+        api.on_root_keydown(&keyboard(KeyboardKey::End));
+        api.on_root_keydown(&keyboard(KeyboardKey::Tab));
+
+        assert_eq!(
+            captured.borrow().as_slice(),
+            &[
+                Event::FocusNext,
+                Event::FocusPrev,
+                Event::FocusFirst,
+                Event::FocusLast,
+            ]
+        );
+    }
+
+    #[test]
+    fn part_attrs_delegate_to_specific_attr_methods() {
+        let service = service(Props::new());
+
+        let api = service.connect(&|_| {});
+
+        assert_eq!(api.part_attrs(Part::Root), api.root_attrs());
+        assert_eq!(api.part_attrs(Part::Item { index: 1 }), api.item_attrs(1));
+        assert_eq!(api.part_attrs(Part::Separator), api.separator_attrs());
+    }
+
+    #[test]
+    fn api_debug_and_equality_reflect_state_context_and_props() {
+        let toolbar = service(Props::new().aria_label("Tools"));
+
+        let api = toolbar.connect(&|_| {});
+
+        let same = toolbar.connect(&|_| {});
+
+        let other_service = service(Props::new().orientation(Orientation::Vertical));
+
+        let other = other_service.connect(&|_| {});
+
+        assert_eq!(api, same);
+        assert_ne!(api, other);
+        assert!(format!("{api:?}").contains("Api"));
+    }
+
+    #[test]
+    fn toolbar_root_snapshot() {
+        assert_snapshot!(
+            "toolbar_root",
+            snapshot_attrs(
+                &service(Props::new().id("toolbar").aria_label("Formatting tools"))
+                    .connect(&|_| {})
+                    .root_attrs()
+            )
+        );
+    }
+
+    #[test]
+    fn toolbar_item_focused_snapshot() {
+        let mut service = service(Props::new());
+
+        drop(service.send(Event::FocusFirst));
+
+        assert_snapshot!(
+            "toolbar_item_focused",
+            snapshot_attrs(&service.connect(&|_| {}).item_attrs(0))
+        );
+    }
+
+    #[test]
+    fn toolbar_item_disabled_snapshot() {
+        assert_snapshot!(
+            "toolbar_item_disabled",
+            snapshot_attrs(&service(Props::new()).connect(&|_| {}).item_attrs(2))
+        );
+    }
+
+    #[test]
+    fn toolbar_root_disabled_snapshot() {
+        assert_snapshot!(
+            "toolbar_root_disabled",
+            snapshot_attrs(
+                &service(Props::new().disabled(true))
+                    .connect(&|_| {})
+                    .root_attrs()
+            )
+        );
+    }
+
+    #[test]
+    fn toolbar_separator_snapshot() {
+        assert_snapshot!(
+            "toolbar_separator",
+            snapshot_attrs(&service(Props::new()).connect(&|_| {}).separator_attrs())
+        );
+    }
+
+    #[test]
+    fn toolbar_vertical_root_snapshot() {
+        assert_snapshot!(
+            "toolbar_vertical_root",
+            snapshot_attrs(
+                &service(Props::new().orientation(Orientation::Vertical))
+                    .connect(&|_| {})
+                    .root_attrs()
+            )
+        );
+    }
+
+    #[test]
+    fn toolbar_rtl_root_snapshot() {
+        assert_snapshot!(
+            "toolbar_rtl_root",
+            snapshot_attrs(
+                &service(Props::new().dir(Direction::Rtl))
+                    .connect(&|_| {})
+                    .root_attrs()
+            )
+        );
+    }
+}

--- a/crates/ars-components/src/layout/toolbar/mod.rs
+++ b/crates/ars-components/src/layout/toolbar/mod.rs
@@ -67,7 +67,7 @@ pub enum Event {
 /// Runtime context for the `Toolbar` state machine.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Context {
-    /// Index of the currently focused item, which receives `tabindex="0"`.
+    /// Index of the roving focus target, which receives `tabindex="0"`.
     pub focused_index: Option<usize>,
 
     /// Toolbar orientation for ARIA and arrow-key handling.
@@ -246,6 +246,13 @@ impl ars_core::Machine for Machine {
 
                     if ctx.disabled {
                         ctx.focused_index = None;
+                    } else {
+                        ctx.focused_index = roving_target(
+                            ctx.focused_index,
+                            ctx.item_count,
+                            &ctx.disabled_items,
+                            false,
+                        );
                     }
                 }))
             }
@@ -341,13 +348,7 @@ fn set_items_plan(
 ) -> Option<TransitionPlan<Machine>> {
     let disabled_items = normalized_disabled_items(count, disabled_items);
 
-    let focused_index = if ctx.disabled {
-        None
-    } else {
-        ctx.focused_index
-            .filter(|index| can_focus_index(count, &disabled_items, *index))
-            .or_else(|| first_enabled_index(count, &disabled_items))
-    };
+    let focused_index = roving_target(ctx.focused_index, count, &disabled_items, ctx.disabled);
 
     if ctx.item_count == count
         && ctx.disabled_items == disabled_items
@@ -378,6 +379,21 @@ fn normalized_disabled_items(count: usize, disabled_items: &[usize]) -> Vec<usiz
 
 fn can_focus_index(count: usize, disabled: &[usize], index: usize) -> bool {
     index < count && !disabled.contains(&index)
+}
+
+fn roving_target(
+    current: Option<usize>,
+    count: usize,
+    disabled: &[usize],
+    toolbar_disabled: bool,
+) -> Option<usize> {
+    if toolbar_disabled {
+        None
+    } else {
+        current
+            .filter(|index| can_focus_index(count, disabled, *index))
+            .or_else(|| first_enabled_index(count, disabled))
+    }
 }
 
 fn focus_if_changed(ctx: &Context, target: Option<usize>) -> Option<TransitionPlan<Machine>> {
@@ -882,6 +898,31 @@ mod tests {
         );
         assert_eq!(attrs.get(&HtmlAttr::Dir), Some("rtl"));
         assert_eq!(attrs.get(&HtmlAttr::Aria(AriaAttr::Disabled)), Some("true"));
+    }
+
+    #[test]
+    fn re_enabling_toolbar_restores_roving_target() {
+        let mut service = service(Props::new().id("toolbar").disabled(true));
+
+        assert_eq!(service.context().focused_index, None);
+        assert_eq!(
+            service
+                .connect(&|_| {})
+                .item_attrs(0)
+                .get(&HtmlAttr::TabIndex),
+            Some("-1")
+        );
+
+        drop(service.set_props(Props::new().id("toolbar")));
+
+        assert_eq!(service.context().focused_index, Some(0));
+        assert_eq!(
+            service
+                .connect(&|_| {})
+                .item_attrs(0)
+                .get(&HtmlAttr::TabIndex),
+            Some("0")
+        );
     }
 
     #[test]

--- a/crates/ars-components/src/layout/toolbar/mod.rs
+++ b/crates/ars-components/src/layout/toolbar/mod.rs
@@ -341,9 +341,13 @@ fn set_items_plan(
 ) -> Option<TransitionPlan<Machine>> {
     let disabled_items = normalized_disabled_items(count, disabled_items);
 
-    let focused_index = ctx
-        .focused_index
-        .filter(|index| can_focus_index(count, &disabled_items, *index));
+    let focused_index = if ctx.disabled {
+        None
+    } else {
+        ctx.focused_index
+            .filter(|index| can_focus_index(count, &disabled_items, *index))
+            .or_else(|| first_enabled_index(count, &disabled_items))
+    };
 
     if ctx.item_count == count
         && ctx.disabled_items == disabled_items
@@ -665,8 +669,6 @@ mod tests {
     fn roving_tabindex_tracks_focused_item_and_skips_disabled_items() {
         let mut service = service(Props::new().id("tools"));
 
-        drop(service.send(Event::FocusFirst));
-
         assert_eq!(
             service
                 .connect(&|_| {})
@@ -692,6 +694,24 @@ mod tests {
             Some("true")
         );
         assert_eq!(api.item_attrs(3).get(&HtmlAttr::TabIndex), Some("0"));
+    }
+
+    #[test]
+    fn set_items_seeds_first_enabled_roving_target() {
+        let mut service =
+            Service::<Machine>::new(Props::new().id("toolbar"), &Env::default(), &Messages);
+
+        drop(service.send(Event::SetItems {
+            count: 4,
+            disabled_items: vec![0, 2],
+        }));
+
+        assert_eq!(service.context().focused_index, Some(1));
+
+        let api = service.connect(&|_| {});
+
+        assert_eq!(api.item_attrs(0).get(&HtmlAttr::TabIndex), Some("-1"));
+        assert_eq!(api.item_attrs(1).get(&HtmlAttr::TabIndex), Some("0"));
     }
 
     #[test]
@@ -814,7 +834,7 @@ mod tests {
 
         assert_eq!(service.context().item_count, 3);
         assert_eq!(service.context().disabled_items, vec![1]);
-        assert_eq!(service.context().focused_index, None);
+        assert_eq!(service.context().focused_index, Some(0));
 
         let before = service.context().clone();
 

--- a/crates/ars-components/src/layout/toolbar/snapshots/ars_components__layout__toolbar__tests__toolbar_item_disabled.snap
+++ b/crates/ars-components/src/layout/toolbar/snapshots/ars_components__layout__toolbar__tests__toolbar_item_disabled.snap
@@ -1,0 +1,47 @@
+---
+source: crates/ars-components/src/layout/toolbar/mod.rs
+expression: "snapshot_attrs(&service(Props::new()).connect(&|_| {}).item_attrs(2))"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-disabled",
+            ),
+            Bool(
+                true,
+            ),
+        ),
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "item",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "toolbar",
+            ),
+        ),
+        (
+            Aria(
+                Disabled,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            TabIndex,
+            String(
+                "-1",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/layout/toolbar/snapshots/ars_components__layout__toolbar__tests__toolbar_item_focused.snap
+++ b/crates/ars-components/src/layout/toolbar/snapshots/ars_components__layout__toolbar__tests__toolbar_item_focused.snap
@@ -1,0 +1,39 @@
+---
+source: crates/ars-components/src/layout/toolbar/mod.rs
+expression: "snapshot_attrs(&service.connect(&|_| {}).item_attrs(0))"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-focused",
+            ),
+            Bool(
+                true,
+            ),
+        ),
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "item",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "toolbar",
+            ),
+        ),
+        (
+            TabIndex,
+            String(
+                "0",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/layout/toolbar/snapshots/ars_components__layout__toolbar__tests__toolbar_root.snap
+++ b/crates/ars-components/src/layout/toolbar/snapshots/ars_components__layout__toolbar__tests__toolbar_root.snap
@@ -1,0 +1,53 @@
+---
+source: crates/ars-components/src/layout/toolbar/mod.rs
+expression: "snapshot_attrs(&service(Props::new().id(\"toolbar\").aria_label(\"Formatting tools\")).connect(&|_|\n{}).root_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "toolbar",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Formatting tools",
+            ),
+        ),
+        (
+            Aria(
+                Orientation,
+            ),
+            String(
+                "horizontal",
+            ),
+        ),
+        (
+            Dir,
+            String(
+                "ltr",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "toolbar",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/layout/toolbar/snapshots/ars_components__layout__toolbar__tests__toolbar_root_disabled.snap
+++ b/crates/ars-components/src/layout/toolbar/snapshots/ars_components__layout__toolbar__tests__toolbar_root_disabled.snap
@@ -1,0 +1,53 @@
+---
+source: crates/ars-components/src/layout/toolbar/mod.rs
+expression: "snapshot_attrs(&service(Props::new().disabled(true)).connect(&|_|\n{}).root_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "toolbar",
+            ),
+        ),
+        (
+            Aria(
+                Disabled,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Aria(
+                Orientation,
+            ),
+            String(
+                "horizontal",
+            ),
+        ),
+        (
+            Dir,
+            String(
+                "ltr",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "toolbar",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/layout/toolbar/snapshots/ars_components__layout__toolbar__tests__toolbar_rtl_root.snap
+++ b/crates/ars-components/src/layout/toolbar/snapshots/ars_components__layout__toolbar__tests__toolbar_rtl_root.snap
@@ -1,0 +1,45 @@
+---
+source: crates/ars-components/src/layout/toolbar/mod.rs
+expression: "snapshot_attrs(&service(Props::new().dir(Direction::Rtl)).connect(&|_|\n{}).root_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "toolbar",
+            ),
+        ),
+        (
+            Aria(
+                Orientation,
+            ),
+            String(
+                "horizontal",
+            ),
+        ),
+        (
+            Dir,
+            String(
+                "rtl",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "toolbar",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/layout/toolbar/snapshots/ars_components__layout__toolbar__tests__toolbar_separator.snap
+++ b/crates/ars-components/src/layout/toolbar/snapshots/ars_components__layout__toolbar__tests__toolbar_separator.snap
@@ -1,0 +1,39 @@
+---
+source: crates/ars-components/src/layout/toolbar/mod.rs
+expression: "snapshot_attrs(&service(Props::new()).connect(&|_| {}).separator_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "separator",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "toolbar",
+            ),
+        ),
+        (
+            Aria(
+                Orientation,
+            ),
+            String(
+                "vertical",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "separator",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/layout/toolbar/snapshots/ars_components__layout__toolbar__tests__toolbar_vertical_root.snap
+++ b/crates/ars-components/src/layout/toolbar/snapshots/ars_components__layout__toolbar__tests__toolbar_vertical_root.snap
@@ -1,0 +1,45 @@
+---
+source: crates/ars-components/src/layout/toolbar/mod.rs
+expression: "snapshot_attrs(&service(Props::new().orientation(Orientation::Vertical)).connect(&|_|\n{}).root_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "toolbar",
+            ),
+        ),
+        (
+            Aria(
+                Orientation,
+            ),
+            String(
+                "vertical",
+            ),
+        ),
+        (
+            Dir,
+            String(
+                "ltr",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "toolbar",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/tests/proptest_state_machines/layout.rs
+++ b/crates/ars-components/tests/proptest_state_machines/layout.rs
@@ -189,6 +189,14 @@ fn assert_toolbar_invariants(service: &Service<toolbar::Machine>) -> TestCaseRes
         prop_assert!(!ctx.disabled_items.contains(&index));
     }
 
+    if !ctx.disabled {
+        let first_enabled = (0..ctx.item_count).find(|index| !ctx.disabled_items.contains(index));
+
+        if first_enabled.is_some() {
+            prop_assert!(ctx.focused_index.is_some());
+        }
+    }
+
     let api = service.connect(&|_| {});
 
     let root = api.root_attrs();

--- a/crates/ars-components/tests/proptest_state_machines/layout.rs
+++ b/crates/ars-components/tests/proptest_state_machines/layout.rs
@@ -1,4 +1,4 @@
-use ars_components::layout::{collapsible, portal, scroll_area, splitter};
+use ars_components::layout::{collapsible, portal, scroll_area, splitter, toolbar};
 use ars_core::{
     AriaAttr, Direction, Env, HtmlAttr, KeyboardKey, Orientation, RenderMode, SendResult, Service,
 };
@@ -131,6 +131,122 @@ proptest! {
             }
 
             assert_collapsible_invariants(&service)?;
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+enum ToolbarStep {
+    Send(toolbar::Event),
+    SetProps(toolbar::Props),
+}
+
+fn arb_toolbar_props() -> impl Strategy<Value = toolbar::Props> {
+    (
+        prop_oneof![Just(Orientation::Horizontal), Just(Orientation::Vertical),],
+        prop_oneof![Just(Direction::Ltr), Just(Direction::Rtl)],
+        any::<bool>(),
+    )
+        .prop_map(|(orientation, dir, disabled)| {
+            toolbar::Props::new()
+                .id("toolbar")
+                .orientation(orientation)
+                .dir(dir)
+                .disabled(disabled)
+        })
+}
+
+fn arb_toolbar_event() -> impl Strategy<Value = toolbar::Event> {
+    prop_oneof![
+        (0usize..8).prop_map(toolbar::Event::FocusItem),
+        Just(toolbar::Event::FocusNext),
+        Just(toolbar::Event::FocusPrev),
+        Just(toolbar::Event::FocusFirst),
+        Just(toolbar::Event::FocusLast),
+        any::<bool>().prop_map(|is_keyboard| toolbar::Event::Focus { is_keyboard }),
+        Just(toolbar::Event::Blur),
+        (0usize..8, prop::collection::vec(0usize..8, 0..8)).prop_map(|(count, disabled_items)| {
+            toolbar::Event::SetItems {
+                count,
+                disabled_items,
+            }
+        },),
+    ]
+}
+
+fn arb_toolbar_step() -> impl Strategy<Value = ToolbarStep> {
+    prop_oneof![
+        arb_toolbar_event().prop_map(ToolbarStep::Send),
+        arb_toolbar_props().prop_map(ToolbarStep::SetProps),
+    ]
+}
+
+fn assert_toolbar_invariants(service: &Service<toolbar::Machine>) -> TestCaseResult {
+    let ctx = service.context();
+
+    if let Some(index) = ctx.focused_index {
+        prop_assert!(index < ctx.item_count);
+        prop_assert!(!ctx.disabled_items.contains(&index));
+    }
+
+    let api = service.connect(&|_| {});
+
+    let root = api.root_attrs();
+
+    prop_assert_eq!(root.get(&HtmlAttr::Role), Some("toolbar"));
+    prop_assert_eq!(
+        root.get(&HtmlAttr::Aria(AriaAttr::Orientation)),
+        Some(match ctx.orientation {
+            Orientation::Horizontal => "horizontal",
+            Orientation::Vertical => "vertical",
+        })
+    );
+
+    for index in 0..ctx.item_count {
+        let attrs = api.item_attrs(index);
+
+        let expected_tabindex = if ctx.focused_index == Some(index) {
+            "0"
+        } else {
+            "-1"
+        };
+
+        prop_assert_eq!(attrs.get(&HtmlAttr::TabIndex), Some(expected_tabindex));
+
+        if ctx.disabled || ctx.disabled_items.contains(&index) {
+            prop_assert_eq!(attrs.get(&HtmlAttr::Aria(AriaAttr::Disabled)), Some("true"));
+        }
+    }
+
+    Ok(())
+}
+
+proptest! {
+    #![proptest_config(super::common::proptest_config())]
+
+    #[test]
+    #[ignore = "proptest — nightly extended-proptest job"]
+    fn proptest_toolbar_event_sequences_preserve_invariants(
+        props in arb_toolbar_props(),
+        steps in prop::collection::vec(arb_toolbar_step(), 0..128),
+    ) {
+        let mut service = Service::<toolbar::Machine>::new(
+            props,
+            &Env::default(),
+            &toolbar::Messages,
+        );
+
+        assert_toolbar_invariants(&service)?;
+
+        for step in steps {
+            let result = match step {
+                ToolbarStep::Send(event) => service.send(event),
+                ToolbarStep::SetProps(props) => service.set_props(props),
+            };
+
+            prop_assert!(result.pending_effects.is_empty());
+            prop_assert!(result.cancel_effects.is_empty());
+            assert_toolbar_invariants(&service)?;
         }
     }
 }

--- a/crates/ars-components/tests/spec_conformance/layout.rs
+++ b/crates/ars-components/tests/spec_conformance/layout.rs
@@ -4,7 +4,7 @@
 //! spec's §2 anatomy table and asserts the impl's `Part` enum matches.
 
 use ars_components::layout::{
-    aspect_ratio, center, collapsible, frame, grid, scroll_area, splitter, stack,
+    aspect_ratio, center, collapsible, frame, grid, scroll_area, splitter, stack, toolbar,
 };
 
 use super::helper::assert_anatomy;
@@ -75,6 +75,18 @@ fn splitter_anatomy_matches_spec() {
             (splitter::Part::Root, "root"),
             (splitter::Part::Panel { index: 0 }, "panel"),
             (splitter::Part::Handle { index: 0 }, "handle"),
+        ],
+    );
+}
+
+#[test]
+fn toolbar_anatomy_matches_spec() {
+    assert_anatomy(
+        "toolbar",
+        &[
+            (toolbar::Part::Root, "root"),
+            (toolbar::Part::Item { index: 0 }, "item"),
+            (toolbar::Part::Separator, "separator"),
         ],
     );
 }

--- a/spec/components/layout/toolbar.md
+++ b/spec/components/layout/toolbar.md
@@ -72,8 +72,7 @@ pub enum Event {
 #[derive(Clone, Debug, PartialEq)]
 pub struct Context {
     /// Index of the currently focused item (roving tabindex target).
-    /// `None` when no item has been focused yet (first Tab into toolbar
-    /// focuses the first enabled item).
+    /// `None` when the toolbar is disabled or has no enabled items.
     pub focused_index: Option<usize>,
     /// Toolbar orientation.
     pub orientation: Orientation,
@@ -167,13 +166,8 @@ impl ars_core::Machine for Machine {
             Event::SetItems { count, disabled_items } => {
                 let count = *count;
                 let disabled_items = normalize_disabled_items(count, disabled_items);
-                let focused_index = if ctx.disabled {
-                    None
-                } else {
-                    ctx.focused_index
-                        .filter(|index| index < count && !disabled_items.contains(index))
-                        .or_else(|| first_enabled_index(count, &disabled_items))
-                };
+                let focused_index =
+                    roving_target(ctx.focused_index, count, &disabled_items, ctx.disabled);
                 Some(TransitionPlan::context_only(move |ctx| {
                     ctx.item_count = count;
                     ctx.disabled_items = disabled_items;
@@ -188,6 +182,13 @@ impl ars_core::Machine for Machine {
                     ctx.disabled = props.disabled;
                     if ctx.disabled {
                         ctx.focused_index = None;
+                    } else {
+                        ctx.focused_index = roving_target(
+                            ctx.focused_index,
+                            ctx.item_count,
+                            &ctx.disabled_items,
+                            false,
+                        );
                     }
                 }))
             }
@@ -272,6 +273,21 @@ fn normalize_disabled_items(count: usize, disabled: &[usize]) -> Vec<usize> {
     disabled.sort_unstable();
     disabled.dedup();
     disabled
+}
+
+fn roving_target(
+    current: Option<usize>,
+    count: usize,
+    disabled: &[usize],
+    toolbar_disabled: bool,
+) -> Option<usize> {
+    if toolbar_disabled {
+        None
+    } else {
+        current
+            .filter(|index| index < count && !disabled.contains(index))
+            .or_else(|| first_enabled_index(count, disabled))
+    }
 }
 
 /// Find the next enabled index, wrapping around.

--- a/spec/components/layout/toolbar.md
+++ b/spec/components/layout/toolbar.md
@@ -6,8 +6,8 @@ foundation_deps: [architecture, accessibility, interactions]
 shared_deps: [layout-shared-types]
 related: []
 references:
-  radix-ui: Toolbar
-  react-aria: Toolbar
+    radix-ui: Toolbar
+    react-aria: Toolbar
 ---
 
 # Toolbar
@@ -50,6 +50,18 @@ pub enum Event {
     },
     /// Focus left the toolbar.
     Blur,
+    /// Replace the rendered item registry.
+    SetItems {
+        /// Number of rendered toolbar items.
+        count: usize,
+        /// Disabled item indices in the current rendered order.
+        disabled_items: Vec<usize>,
+    },
+    /// Synchronize output-affecting props stored in context.
+    SetProps {
+        /// Latest props snapshot.
+        props: Props,
+    },
 }
 ```
 
@@ -129,6 +141,7 @@ impl ars_core::Machine for Machine {
     type Context = Context;
     type Props = Props;
     type Messages = Messages;
+    type Effect = NoEffect;
     type Api<'a> = Api<'a>;
 
     fn init(props: &Self::Props, _env: &Env, _messages: &Self::Messages) -> (Self::State, Self::Context) {
@@ -150,10 +163,31 @@ impl ars_core::Machine for Machine {
         ctx: &Self::Context,
         _props: &Self::Props,
     ) -> Option<TransitionPlan<Self>> {
-        if ctx.disabled { return None; }
-
         match event {
+            Event::SetItems { count, disabled_items } => {
+                let count = *count;
+                let disabled_items = normalize_disabled_items(count, disabled_items);
+                let focused_index = ctx.focused_index
+                    .filter(|index| index < count && !disabled_items.contains(index));
+                Some(TransitionPlan::context_only(move |ctx| {
+                    ctx.item_count = count;
+                    ctx.disabled_items = disabled_items;
+                    ctx.focused_index = focused_index;
+                }))
+            }
+            Event::SetProps { props } => {
+                let props = props.clone();
+                Some(TransitionPlan::context_only(move |ctx| {
+                    ctx.orientation = props.orientation;
+                    ctx.dir = props.dir;
+                    ctx.disabled = props.disabled;
+                    if ctx.disabled {
+                        ctx.focused_index = None;
+                    }
+                }))
+            }
             Event::FocusItem(index) => {
+                if ctx.disabled { return None; }
                 let idx = *index;
                 if idx >= ctx.item_count || ctx.disabled_items.contains(&idx) {
                     return None;
@@ -163,6 +197,7 @@ impl ars_core::Machine for Machine {
                 }))
             }
             Event::FocusNext => {
+                if ctx.disabled { return None; }
                 let next = next_enabled_index(
                     ctx.focused_index.unwrap_or(0),
                     ctx.item_count,
@@ -174,6 +209,7 @@ impl ars_core::Machine for Machine {
                 }))
             }
             Event::FocusPrev => {
+                if ctx.disabled { return None; }
                 let prev = next_enabled_index(
                     ctx.focused_index.unwrap_or(0),
                     ctx.item_count,
@@ -185,18 +221,21 @@ impl ars_core::Machine for Machine {
                 }))
             }
             Event::FocusFirst => {
+                if ctx.disabled { return None; }
                 let first = first_enabled_index(ctx.item_count, &ctx.disabled_items);
                 Some(TransitionPlan::context_only(move |ctx| {
                     ctx.focused_index = first;
                 }))
             }
             Event::FocusLast => {
+                if ctx.disabled { return None; }
                 let last = last_enabled_index(ctx.item_count, &ctx.disabled_items);
                 Some(TransitionPlan::context_only(move |ctx| {
                     ctx.focused_index = last;
                 }))
             }
             Event::Focus { .. } => {
+                if ctx.disabled { return None; }
                 if ctx.focused_index.is_some() { return None; }
                 let first = first_enabled_index(ctx.item_count, &ctx.disabled_items);
                 Some(TransitionPlan::context_only(move |ctx| {
@@ -220,16 +259,26 @@ impl ars_core::Machine for Machine {
     }
 }
 
+fn normalize_disabled_items(count: usize, disabled: &[usize]) -> Vec<usize> {
+    let mut disabled = disabled.iter()
+        .copied()
+        .filter(|index| *index < count)
+        .collect::<Vec<_>>();
+    disabled.sort_unstable();
+    disabled.dedup();
+    disabled
+}
+
 /// Find the next enabled index, wrapping around.
 fn next_enabled_index(
     current: usize, count: usize, disabled: &[usize], forward: bool,
 ) -> Option<usize> {
     if count == 0 { return None; }
-    for i in 1..count {
+    for i in 1..=count {
         let idx = if forward {
             (current + i) % count
         } else {
-            (current + count - i) % count
+            (current + count - (i % count)) % count
         };
         if !disabled.contains(&idx) { return Some(idx); }
     }

--- a/spec/components/layout/toolbar.md
+++ b/spec/components/layout/toolbar.md
@@ -167,8 +167,13 @@ impl ars_core::Machine for Machine {
             Event::SetItems { count, disabled_items } => {
                 let count = *count;
                 let disabled_items = normalize_disabled_items(count, disabled_items);
-                let focused_index = ctx.focused_index
-                    .filter(|index| index < count && !disabled_items.contains(index));
+                let focused_index = if ctx.disabled {
+                    None
+                } else {
+                    ctx.focused_index
+                        .filter(|index| index < count && !disabled_items.contains(index))
+                        .or_else(|| first_enabled_index(count, &disabled_items))
+                };
                 Some(TransitionPlan::context_only(move |ctx| {
                     ctx.item_count = count;
                     ctx.disabled_items = disabled_items;

--- a/spec/dioxus-components/layout/toolbar.md
+++ b/spec/dioxus-components/layout/toolbar.md
@@ -80,9 +80,9 @@ pub mod toolbar {
 
 | Adapter prop  | Mode       | Sync trigger            | Machine event / update path | Visible effect                                      | Notes                                      |
 | ------------- | ---------- | ----------------------- | --------------------------- | --------------------------------------------------- | ------------------------------------------ |
-| `orientation` | controlled | rerender with new props | core prop update            | changes arrow-key mapping and separator orientation | must remain stable with rendered structure |
-| `dir`         | controlled | rerender with new props | core prop update            | reverses horizontal navigation in RTL               | applies only to horizontal toolbars        |
-| `disabled`    | controlled | prop change after mount | core prop update            | disables navigation and marks items disabled        | roving focus is frozen while disabled      |
+| `orientation` | controlled | rerender with new props | `SetProps { props }`        | changes arrow-key mapping and separator orientation | must remain stable with rendered structure |
+| `dir`         | controlled | rerender with new props | `SetProps { props }`        | reverses horizontal navigation in RTL               | applies only to horizontal toolbars        |
+| `disabled`    | controlled | prop change after mount | `SetProps { props }`        | disables navigation and marks items disabled        | clears roving focus while disabled         |
 
 | UI event             | Preconditions                     | Machine event / callback path                          | Ordering notes                                                                          | Notes                                    |
 | -------------------- | --------------------------------- | ------------------------------------------------------ | --------------------------------------------------------------------------------------- | ---------------------------------------- |
@@ -92,10 +92,10 @@ pub mod toolbar {
 
 ## 8. Registration and Cleanup Contract
 
-| Registered entity | Registration trigger | Identity key     | Cleanup trigger | Cleanup action                                               | Notes                                    |
-| ----------------- | -------------------- | ---------------- | --------------- | ------------------------------------------------------------ | ---------------------------------------- |
-| item registration | `Item` mount         | composite        | `Item` cleanup  | remove the item from the root registry and recompute indices | registration order must follow DOM order |
-| root context      | `Root` mount         | instance-derived | `Root` cleanup  | drop toolbar context and registry                            | one registry per toolbar                 |
+| Registered entity | Registration trigger | Identity key     | Cleanup trigger | Cleanup action                                                                                               | Notes                                    |
+| ----------------- | -------------------- | ---------------- | --------------- | ------------------------------------------------------------------------------------------------------------ | ---------------------------------------- |
+| item registration | `Item` mount         | composite        | `Item` cleanup  | remove the item from the root registry and send `SetItems { count, disabled_items }` with recomputed indices | registration order must follow DOM order |
+| root context      | `Root` mount         | instance-derived | `Root` cleanup  | drop toolbar context and registry                                                                            | one registry per toolbar                 |
 
 ## 9. Ref and Node Contract
 

--- a/spec/leptos-components/layout/toolbar.md
+++ b/spec/leptos-components/layout/toolbar.md
@@ -71,9 +71,9 @@ pub mod toolbar {
 
 | Adapter prop  | Mode       | Sync trigger              | Machine event / update path | Visible effect                                      | Notes                                      |
 | ------------- | ---------- | ------------------------- | --------------------------- | --------------------------------------------------- | ------------------------------------------ |
-| `orientation` | controlled | rerender with new props   | core prop update            | changes arrow-key mapping and separator orientation | must remain stable with rendered structure |
-| `dir`         | controlled | rerender with new props   | core prop update            | reverses horizontal navigation in RTL               | applies only to horizontal toolbars        |
-| `disabled`    | controlled | signal change after mount | core prop update            | disables navigation and marks items disabled        | roving focus is frozen while disabled      |
+| `orientation` | controlled | rerender with new props   | `SetProps { props }`        | changes arrow-key mapping and separator orientation | must remain stable with rendered structure |
+| `dir`         | controlled | rerender with new props   | `SetProps { props }`        | reverses horizontal navigation in RTL               | applies only to horizontal toolbars        |
+| `disabled`    | controlled | signal change after mount | `SetProps { props }`        | disables navigation and marks items disabled        | clears roving focus while disabled         |
 
 | UI event             | Preconditions                     | Machine event / callback path                          | Ordering notes                                                                          | Notes                                    |
 | -------------------- | --------------------------------- | ------------------------------------------------------ | --------------------------------------------------------------------------------------- | ---------------------------------------- |
@@ -83,10 +83,10 @@ pub mod toolbar {
 
 ## 8. Registration and Cleanup Contract
 
-| Registered entity | Registration trigger | Identity key     | Cleanup trigger | Cleanup action                                               | Notes                                    |
-| ----------------- | -------------------- | ---------------- | --------------- | ------------------------------------------------------------ | ---------------------------------------- |
-| item registration | `Item` mount         | composite        | `Item` cleanup  | remove the item from the root registry and recompute indices | registration order must follow DOM order |
-| root context      | `Root` mount         | instance-derived | `Root` cleanup  | drop toolbar context and registry                            | one registry per toolbar                 |
+| Registered entity | Registration trigger | Identity key     | Cleanup trigger | Cleanup action                                                                                               | Notes                                    |
+| ----------------- | -------------------- | ---------------- | --------------- | ------------------------------------------------------------------------------------------------------------ | ---------------------------------------- |
+| item registration | `Item` mount         | composite        | `Item` cleanup  | remove the item from the root registry and send `SetItems { count, disabled_items }` with recomputed indices | registration order must follow DOM order |
+| root context      | `Root` mount         | instance-derived | `Root` cleanup  | drop toolbar context and registry                                                                            | one registry per toolbar                 |
 
 ## 9. Ref and Node Contract
 


### PR DESCRIPTION
Closes #276

## Summary
- add the framework-agnostic Toolbar state machine, connect API, item registration sync, roving tabindex attrs, disabled item skipping, RTL/vertical keyboard routing, and separator attrs in `ars-components`
- add Toolbar unit tests, snapshots, spec-conformance anatomy coverage, and a state-machine proptest invariant
- synchronize the core and adapter specs around `SetItems` and `SetProps`

## Verification
- cargo xci --profile fast
- cargo test -p ars-components --lib -- layout::toolbar
- cargo test -p ars-components --test spec_conformance -- layout::toolbar
- cargo test -p ars-components --test proptest_state_machines -- layout::proptest_toolbar
- cargo insta test -p ars-components --lib -- layout::toolbar
- cargo insta test -p ars-components --features i18n --lib --unreferenced=reject
- cargo clippy -p ars-components --all-targets --all-features -- -D warnings
- cargo xtask spec validate
- cargo llvm-cov test -p ars-components --lib --summary-only --json --output-path /tmp/toolbar-coverage-summary-2.json -- layout::toolbar