### PR TITLE
Implement RangeCalendar agnostic core

### DIFF
--- a/crates/ars-components/src/date_time/calendar/grid.rs
+++ b/crates/ars-components/src/date_time/calendar/grid.rs
@@ -19,7 +19,7 @@ use ars_i18n::{CalendarDate, Weekday};
 /// helper isolates that conversion so every grid call site uses the same
 /// convention.
 #[must_use]
-pub(super) const fn weekday_sunday_zero(weekday: Weekday) -> u8 {
+pub(crate) const fn weekday_sunday_zero(weekday: Weekday) -> u8 {
     match weekday {
         Weekday::Sunday => 0,
         Weekday::Monday => 1,
@@ -35,7 +35,7 @@ pub(super) const fn weekday_sunday_zero(weekday: Weekday) -> u8 {
 /// month, normalising the result to the 1..=12 month range with a year
 /// adjustment.
 #[must_use]
-pub(super) const fn month_year_at_offset(
+pub(crate) const fn month_year_at_offset(
     visible_month: u8,
     visible_year: i32,
     offset: usize,
@@ -51,7 +51,7 @@ pub(super) const fn month_year_at_offset(
 /// Advances `(month, year)` by `n` months (signed), normalising the month
 /// back into the 1..=12 range.
 #[must_use]
-pub(super) const fn advance_month(visible_month: u8, visible_year: i32, n: i32) -> (u8, i32) {
+pub(crate) const fn advance_month(visible_month: u8, visible_year: i32, n: i32) -> (u8, i32) {
     let raw_index = visible_month as i64 - 1 + n as i64;
 
     let normalised_month = raw_index.rem_euclid(12) as u8 + 1;
@@ -72,7 +72,7 @@ pub(super) const fn advance_month(visible_month: u8, visible_year: i32, n: i32) 
 /// empty in that case, signalling that the adapter should render an empty
 /// grid for the boundary month rather than panic.
 #[must_use]
-pub(super) fn weeks_for(
+pub(crate) fn weeks_for(
     visible_month: u8,
     visible_year: i32,
     first_day_of_week: Weekday,
@@ -135,7 +135,7 @@ fn build_week(start: &CalendarDate) -> Option<[CalendarDate; 7]> {
 /// Whether `date` belongs to a different `(month, year)` than the month at
 /// the given visible-month offset.
 #[must_use]
-pub(super) const fn is_outside_month_at_offset(
+pub(crate) const fn is_outside_month_at_offset(
     date: &CalendarDate,
     visible_month: u8,
     visible_year: i32,
@@ -149,7 +149,7 @@ pub(super) const fn is_outside_month_at_offset(
 /// Whether `date` falls within any of the `visible_months` months starting
 /// at `(visible_month, visible_year)`.
 #[must_use]
-pub(super) fn is_in_visible_range(
+pub(crate) fn is_in_visible_range(
     date: &CalendarDate,
     visible_month: u8,
     visible_year: i32,
@@ -166,7 +166,7 @@ pub(super) fn is_in_visible_range(
 /// `(weekday, sunday_zero_index)` pairs so callers can fetch labels from the
 /// `IntlBackend` without re-deriving the index.
 #[must_use]
-pub(super) fn ordered_weekdays(first_day_of_week: Weekday) -> [Weekday; 7] {
+pub(crate) fn ordered_weekdays(first_day_of_week: Weekday) -> [Weekday; 7] {
     let start = weekday_sunday_zero(first_day_of_week);
 
     let mut out = [Weekday::Sunday; 7];

--- a/crates/ars-components/src/date_time/mod.rs
+++ b/crates/ars-components/src/date_time/mod.rs
@@ -9,5 +9,8 @@ pub mod date_field;
 /// DatePicker machine.
 pub mod date_picker;
 
+/// RangeCalendar machine.
+pub mod range_calendar;
+
 /// TimeField machine.
 pub mod time_field;

--- a/crates/ars-components/src/date_time/range_calendar/mod.rs
+++ b/crates/ars-components/src/date_time/range_calendar/mod.rs
@@ -167,7 +167,7 @@ pub struct Props {
     /// Right-to-left layout direction.
     pub is_rtl: bool,
 
-    /// Number of months displayed side-by-side. Clamped to at least 1.
+    /// Number of months displayed side-by-side. Zero falls back to the default.
     pub visible_months: usize,
 
     /// Controls navigation step size.
@@ -613,28 +613,21 @@ impl Context {
     /// Whether a confirmed range includes `date`.
     #[must_use]
     pub fn is_in_range(&self, date: &CalendarDate) -> bool {
-        self.value
-            .get()
-            .as_ref()
+        self.visible_range()
             .is_some_and(|range| range.contains(date))
     }
 
     /// Whether `date` is the confirmed range start.
     #[must_use]
     pub fn is_range_start(&self, date: &CalendarDate) -> bool {
-        self.value
-            .get()
-            .as_ref()
+        self.visible_range()
             .is_some_and(|range| range.start == *date)
     }
 
     /// Whether `date` is the confirmed range end.
     #[must_use]
     pub fn is_range_end(&self, date: &CalendarDate) -> bool {
-        self.value
-            .get()
-            .as_ref()
-            .is_some_and(|range| range.end == *date)
+        self.visible_range().is_some_and(|range| range.end == *date)
     }
 
     /// Whether `date` falls in the pending hover preview range.
@@ -686,6 +679,14 @@ impl Context {
         }
 
         true
+    }
+
+    fn visible_range(&self) -> Option<&DateRange> {
+        if self.anchor_date.is_some() {
+            self.value.pending().as_ref()
+        } else {
+            self.value.get().as_ref()
+        }
     }
 
     /// Scrolls the visible window to include the focused date.
@@ -764,6 +765,115 @@ fn inclusive_range_days(range: &DateRange) -> Option<u32> {
     let days = range.start.days_until(&range.end).ok()?;
 
     u32::try_from(days).ok()?.checked_add(1)
+}
+
+fn visible_months_or_default(visible_months: usize) -> usize {
+    if visible_months == 0 {
+        Props::default().visible_months
+    } else {
+        visible_months
+    }
+}
+
+fn sanitize_external_range(props: &Props, range: Option<DateRange>) -> Option<DateRange> {
+    range.filter(|range| external_range_is_selectable(props, range))
+}
+
+fn external_range_is_selectable(props: &Props, range: &DateRange) -> bool {
+    if !range_satisfies_span_constraints(
+        range,
+        props.allow_single_date_range,
+        props.min_range_days,
+        props.max_range_days,
+    ) {
+        return false;
+    }
+
+    if date_outside_bounds(&range.start, props.min.as_ref(), props.max.as_ref())
+        || date_outside_bounds(&range.end, props.min.as_ref(), props.max.as_ref())
+    {
+        return false;
+    }
+
+    let Some(predicate) = &props.is_date_unavailable else {
+        return true;
+    };
+
+    range_dates_all_for_range(range, |date| !predicate(date))
+}
+
+fn range_satisfies_span_constraints(
+    range: &DateRange,
+    allow_single_date_range: bool,
+    min_range_days: Option<u32>,
+    max_range_days: Option<u32>,
+) -> bool {
+    if !allow_single_date_range && range.start == range.end {
+        return false;
+    }
+
+    let Some(length) = inclusive_range_days(range) else {
+        return false;
+    };
+
+    if let Some(min) = min_range_days
+        && length < min
+    {
+        return false;
+    }
+
+    if let Some(max) = max_range_days
+        && length > max
+    {
+        return false;
+    }
+
+    true
+}
+
+fn date_outside_bounds(
+    date: &CalendarDate,
+    min: Option<&CalendarDate>,
+    max: Option<&CalendarDate>,
+) -> bool {
+    if let Some(min) = min
+        && date.compare(min) == Ordering::Less
+    {
+        return true;
+    }
+
+    if let Some(max) = max
+        && date.compare(max) == Ordering::Greater
+    {
+        return true;
+    }
+
+    false
+}
+
+fn range_dates_all_for_range(
+    range: &DateRange,
+    mut predicate: impl FnMut(&CalendarDate) -> bool,
+) -> bool {
+    let Some(days) = inclusive_range_days(range) else {
+        return false;
+    };
+
+    for offset in 0..days {
+        let Ok(offset) = i32::try_from(offset) else {
+            return false;
+        };
+
+        let Ok(date) = range.start.add_days(offset) else {
+            return false;
+        };
+
+        if !predicate(&date) {
+            return false;
+        }
+    }
+
+    true
 }
 
 // ────────────────────────────────────────────────────────────────────
@@ -855,9 +965,9 @@ impl ars_core::Machine for Machine {
         messages: &Self::Messages,
     ) -> (Self::State, Self::Context) {
         let value = if let Some(controlled) = &props.value {
-            Bindable::controlled(controlled.clone())
+            Bindable::controlled(sanitize_external_range(props, controlled.clone()))
         } else {
-            Bindable::uncontrolled(props.default_value.clone())
+            Bindable::uncontrolled(sanitize_external_range(props, props.default_value.clone()))
         };
 
         let mut initial_date = value
@@ -882,7 +992,7 @@ impl ars_core::Machine for Machine {
             .first_day_of_week
             .unwrap_or_else(|| locale.first_day_of_week(&*env.intl_backend));
 
-        let visible_months = props.visible_months.max(1);
+        let visible_months = visible_months_or_default(props.visible_months);
 
         let focused_date = initial_date;
 
@@ -1065,7 +1175,12 @@ impl ars_core::Machine for Machine {
 }
 
 fn sync_props_into_ctx(ctx: &mut Context, props: &Props) {
-    ctx.value.sync_controlled(props.value.clone());
+    ctx.value.sync_controlled(
+        props
+            .value
+            .clone()
+            .map(|range| sanitize_external_range(props, range)),
+    );
     ctx.min = props.min.clone();
     ctx.max = props.max.clone();
     ctx.disabled = props.disabled;
@@ -1073,7 +1188,7 @@ fn sync_props_into_ctx(ctx: &mut Context, props: &Props) {
     ctx.is_date_unavailable_fn = props.is_date_unavailable.clone();
     ctx.show_week_numbers = props.show_week_numbers;
     ctx.is_rtl = props.is_rtl;
-    ctx.visible_months = props.visible_months.max(1);
+    ctx.visible_months = visible_months_or_default(props.visible_months);
     ctx.page_behavior = props.page_behavior;
     ctx.today = props.today.clone();
     ctx.allow_single_date_range = props.allow_single_date_range;
@@ -1084,9 +1199,26 @@ fn sync_props_into_ctx(ctx: &mut Context, props: &Props) {
         .unwrap_or_else(|| ctx.locale.first_day_of_week(&*ctx.intl_backend));
 
     ctx.focused_date = ctx.clamp_date(ctx.focused_date.clone());
+    revalidate_current_value(ctx);
 
     revalidate_pending_selection(ctx);
     ctx.sync_visible_to_focused();
+}
+
+fn revalidate_current_value(ctx: &mut Context) {
+    let value_still_selectable = ctx
+        .value
+        .get()
+        .as_ref()
+        .is_none_or(|range| range_is_selectable(ctx, range));
+
+    if !value_still_selectable {
+        ctx.value.set(None);
+
+        if ctx.value.is_controlled() {
+            ctx.value.sync_controlled(Some(None));
+        }
+    }
 }
 
 fn revalidate_pending_selection(ctx: &mut Context) {
@@ -1161,7 +1293,9 @@ fn range_is_selectable(ctx: &Context, range: &DateRange) -> bool {
         return false;
     }
 
-    if ctx.is_date_disabled(&range.start) || ctx.is_date_disabled(&range.end) {
+    if date_outside_bounds(&range.start, ctx.min.as_ref(), ctx.max.as_ref())
+        || date_outside_bounds(&range.end, ctx.min.as_ref(), ctx.max.as_ref())
+    {
         return false;
     }
 
@@ -1169,33 +1303,7 @@ fn range_is_selectable(ctx: &Context, range: &DateRange) -> bool {
         return true;
     }
 
-    range_dates_all(ctx, range, |ctx, date| !ctx.is_date_unavailable(date))
-}
-
-fn range_dates_all(
-    ctx: &Context,
-    range: &DateRange,
-    mut predicate: impl FnMut(&Context, &CalendarDate) -> bool,
-) -> bool {
-    let Some(days) = inclusive_range_days(range) else {
-        return false;
-    };
-
-    for offset in 0..days {
-        let Ok(offset) = i32::try_from(offset) else {
-            return false;
-        };
-
-        let Ok(date) = range.start.add_days(offset) else {
-            return false;
-        };
-
-        if !predicate(ctx, &date) {
-            return false;
-        }
-    }
-
-    true
+    range_dates_all_for_range(range, |date| !ctx.is_date_unavailable(date))
 }
 
 fn step_for_page_behavior(ctx: &Context) -> i32 {

--- a/crates/ars-components/src/date_time/range_calendar/mod.rs
+++ b/crates/ars-components/src/date_time/range_calendar/mod.rs
@@ -1165,7 +1165,7 @@ fn range_is_selectable(ctx: &Context, range: &DateRange) -> bool {
         return false;
     }
 
-    if ctx.is_date_unavailable_fn.is_none() {
+    if ctx.unavailable_dates.is_empty() && ctx.is_date_unavailable_fn.is_none() {
         return true;
     }
 

--- a/crates/ars-components/src/date_time/range_calendar/mod.rs
+++ b/crates/ars-components/src/date_time/range_calendar/mod.rs
@@ -202,8 +202,8 @@ impl Default for Props {
             is_rtl: false,
             visible_months: 2,
             page_behavior: PageBehavior::Visible,
-            today: CalendarDate::new_gregorian(2025, 1, 1)
-                .expect("2025-01-01 is a valid Gregorian date"),
+            today: CalendarDate::new_gregorian(2024, 1, 1)
+                .expect("2024-01-01 is a valid Gregorian date"),
             allow_single_date_range: true,
             min_range_days: None,
             max_range_days: None,
@@ -1629,6 +1629,12 @@ impl<'a> Api<'a> {
         self.cell_attrs_inner(date, Some(offset))
     }
 
+    /// Whether `date` is outside the month at `offset`.
+    #[must_use]
+    pub const fn is_outside_month_for(&self, date: &CalendarDate, offset: usize) -> bool {
+        self.ctx.is_outside_month_at_offset(date, offset)
+    }
+
     fn cell_attrs_inner(&self, date: &CalendarDate, offset: Option<usize>) -> AttrMap {
         let mut attrs = AttrMap::new();
         let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Cell {
@@ -1758,16 +1764,24 @@ impl<'a> Api<'a> {
             let suffix = (self.ctx.messages.disabled_suffix)(&self.ctx.locale);
 
             format!("{base} {suffix}")
-        } else if self.is_range_start(date) {
-            let suffix = (self.ctx.messages.range_start_suffix)(&self.ctx.locale);
-
-            format!("{base} {suffix}")
-        } else if self.is_range_end(date) {
-            let suffix = (self.ctx.messages.range_end_suffix)(&self.ctx.locale);
-
-            format!("{base} {suffix}")
         } else {
-            base
+            let mut label = base;
+
+            if self.is_range_start(date) {
+                let suffix = (self.ctx.messages.range_start_suffix)(&self.ctx.locale);
+
+                label.push(' ');
+                label.push_str(&suffix);
+            }
+
+            if self.is_range_end(date) {
+                let suffix = (self.ctx.messages.range_end_suffix)(&self.ctx.locale);
+
+                label.push(' ');
+                label.push_str(&suffix);
+            }
+
+            label
         }
     }
 

--- a/crates/ars-components/src/date_time/range_calendar/mod.rs
+++ b/crates/ars-components/src/date_time/range_calendar/mod.rs
@@ -1,0 +1,1965 @@
+//! `RangeCalendar` component state machine and connect API.
+//!
+//! Framework-agnostic implementation of the grid-based date range picker
+//! defined in `spec/components/date-time/range-calendar.md`. The machine
+//! owns visible month/year state, focused-date roving tab state, two-step
+//! range selection, hover preview, min/max constraints, range length
+//! constraints, and the connect API attribute contract.
+
+#[cfg(test)]
+mod tests;
+
+use alloc::{
+    boxed::Box,
+    format,
+    string::{String, ToString as _},
+    sync::Arc,
+    vec,
+    vec::Vec,
+};
+use core::{
+    cmp::Ordering,
+    fmt::{self, Debug},
+};
+
+use ars_core::{
+    AriaAttr, AttrMap, Bindable, Callback, ComponentIds, ComponentMessages, ComponentPart,
+    ConnectApi, Env, HtmlAttr, IntlBackend, KeyboardKey, Locale, MessageFn, TransitionPlan,
+};
+use ars_i18n::{CalendarDate, DateRange, Weekday};
+
+use super::calendar::{PageBehavior, grid};
+
+// ────────────────────────────────────────────────────────────────────
+// State / Event / Effect
+// ────────────────────────────────────────────────────────────────────
+
+/// States for the `RangeCalendar` component.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum State {
+    /// Calendar rendered but no cell has keyboard focus.
+    Idle,
+
+    /// A specific date cell holds keyboard focus within the grid.
+    Focused,
+}
+
+/// Events for the `RangeCalendar` component.
+#[derive(Clone, Debug, PartialEq)]
+pub enum Event {
+    /// Move keyboard focus to a specific date.
+    FocusDate {
+        /// The date to focus.
+        date: CalendarDate,
+    },
+
+    /// User selected a date via click or `Enter`/`Space`.
+    SelectDate {
+        /// The date that was selected.
+        date: CalendarDate,
+    },
+
+    /// Pointer is hovering over a date cell for pending range preview.
+    HoverDate {
+        /// The date currently being hovered.
+        date: CalendarDate,
+    },
+
+    /// Pointer left the grid; clear hover preview.
+    HoverEnd,
+
+    /// Navigate to the next month or visible page.
+    NextMonth,
+
+    /// Navigate to the previous month or visible page.
+    PrevMonth,
+
+    /// Navigate forward by one year.
+    NextYear,
+
+    /// Navigate backward by one year.
+    PrevYear,
+
+    /// Jump to a specific month.
+    SetMonth {
+        /// The 1-based month to display.
+        month: u8,
+    },
+
+    /// Jump to a specific year.
+    SetYear {
+        /// The year to display.
+        year: i32,
+    },
+
+    /// Grid received focus.
+    FocusIn,
+
+    /// Focus left the grid entirely.
+    FocusOut,
+
+    /// Keyboard event on the grid.
+    KeyDown {
+        /// The key that was pressed.
+        key: KeyboardKey,
+
+        /// Whether the shift modifier was held.
+        shift: bool,
+    },
+
+    /// Synchronize context from a new props snapshot.
+    SyncProps(Box<Props>),
+}
+
+/// Typed identifier for every named effect intent emitted by `RangeCalendar`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Effect {
+    /// Announce the newly visible month or month range.
+    AnnounceMonth,
+
+    /// Announce that the first range endpoint was selected.
+    AnnounceRangeStart,
+
+    /// Announce that the range was completed.
+    AnnounceRangeComplete,
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Props / Messages
+// ────────────────────────────────────────────────────────────────────
+
+/// Predicate type for marking dates unavailable.
+pub type IsDateUnavailableFn = Callback<dyn for<'a> Fn(&'a CalendarDate) -> bool + Send + Sync>;
+
+/// Props for the `RangeCalendar` component.
+#[derive(Clone, Debug, PartialEq, ars_core::HasId)]
+pub struct Props {
+    /// Component instance ID.
+    pub id: String,
+
+    /// Controlled range value. `None` means uncontrolled.
+    pub value: Option<Option<DateRange>>,
+
+    /// Default range value for uncontrolled mode.
+    pub default_value: Option<DateRange>,
+
+    /// Minimum selectable date.
+    pub min: Option<CalendarDate>,
+
+    /// Maximum selectable date.
+    pub max: Option<CalendarDate>,
+
+    /// Whether the entire calendar is non-interactive.
+    pub disabled: bool,
+
+    /// Whether navigation and focus are allowed but selection is blocked.
+    pub readonly: bool,
+
+    /// Predicate returning `true` for dates that are unavailable.
+    pub is_date_unavailable: Option<IsDateUnavailableFn>,
+
+    /// Explicit override of the locale default first day of week.
+    pub first_day_of_week: Option<Weekday>,
+
+    /// Whether the head row exposes ISO week numbers.
+    pub show_week_numbers: bool,
+
+    /// Right-to-left layout direction.
+    pub is_rtl: bool,
+
+    /// Number of months displayed side-by-side. Clamped to at least 1.
+    pub visible_months: usize,
+
+    /// Controls navigation step size.
+    pub page_behavior: PageBehavior,
+
+    /// The "today" date supplied by the adapter for determinism.
+    pub today: CalendarDate,
+
+    /// Whether a range with identical start and end dates is valid.
+    pub allow_single_date_range: bool,
+
+    /// Minimum inclusive range length in calendar days.
+    pub min_range_days: Option<u32>,
+
+    /// Maximum inclusive range length in calendar days.
+    pub max_range_days: Option<u32>,
+}
+
+impl Default for Props {
+    fn default() -> Self {
+        Self {
+            id: String::new(),
+            value: None,
+            default_value: None,
+            min: None,
+            max: None,
+            disabled: false,
+            readonly: false,
+            is_date_unavailable: None,
+            first_day_of_week: None,
+            show_week_numbers: false,
+            is_rtl: false,
+            visible_months: 2,
+            page_behavior: PageBehavior::Visible,
+            today: CalendarDate::new_gregorian(2025, 1, 1)
+                .expect("2025-01-01 is a valid Gregorian date"),
+            allow_single_date_range: true,
+            min_range_days: None,
+            max_range_days: None,
+        }
+    }
+}
+
+impl Props {
+    /// Creates default props.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets [`Props::id`].
+    #[must_use]
+    pub fn id(mut self, id: impl Into<String>) -> Self {
+        self.id = id.into();
+        self
+    }
+
+    /// Sets [`Props::value`].
+    #[must_use]
+    pub fn value(mut self, value: Option<DateRange>) -> Self {
+        self.value = Some(value);
+        self
+    }
+
+    /// Sets [`Props::default_value`].
+    #[must_use]
+    pub fn default_value(mut self, value: Option<DateRange>) -> Self {
+        self.default_value = value;
+        self
+    }
+
+    /// Sets [`Props::min`].
+    #[must_use]
+    pub fn min(mut self, value: Option<CalendarDate>) -> Self {
+        self.min = value;
+        self
+    }
+
+    /// Sets [`Props::max`].
+    #[must_use]
+    pub fn max(mut self, value: Option<CalendarDate>) -> Self {
+        self.max = value;
+        self
+    }
+
+    /// Sets [`Props::disabled`].
+    #[must_use]
+    pub const fn disabled(mut self, value: bool) -> Self {
+        self.disabled = value;
+        self
+    }
+
+    /// Sets [`Props::readonly`].
+    #[must_use]
+    pub const fn readonly(mut self, value: bool) -> Self {
+        self.readonly = value;
+        self
+    }
+
+    /// Sets [`Props::is_date_unavailable`].
+    #[must_use]
+    pub fn is_date_unavailable(mut self, value: Option<IsDateUnavailableFn>) -> Self {
+        self.is_date_unavailable = value;
+        self
+    }
+
+    /// Sets [`Props::first_day_of_week`].
+    #[must_use]
+    pub const fn first_day_of_week(mut self, value: Option<Weekday>) -> Self {
+        self.first_day_of_week = value;
+        self
+    }
+
+    /// Sets [`Props::show_week_numbers`].
+    #[must_use]
+    pub const fn show_week_numbers(mut self, value: bool) -> Self {
+        self.show_week_numbers = value;
+        self
+    }
+
+    /// Sets [`Props::is_rtl`].
+    #[must_use]
+    pub const fn is_rtl(mut self, value: bool) -> Self {
+        self.is_rtl = value;
+        self
+    }
+
+    /// Sets [`Props::visible_months`].
+    #[must_use]
+    pub const fn visible_months(mut self, value: usize) -> Self {
+        self.visible_months = value;
+        self
+    }
+
+    /// Sets [`Props::page_behavior`].
+    #[must_use]
+    pub const fn page_behavior(mut self, value: PageBehavior) -> Self {
+        self.page_behavior = value;
+        self
+    }
+
+    /// Sets [`Props::today`].
+    #[must_use]
+    pub fn today(mut self, value: CalendarDate) -> Self {
+        self.today = value;
+        self
+    }
+
+    /// Sets [`Props::allow_single_date_range`].
+    #[must_use]
+    pub const fn allow_single_date_range(mut self, value: bool) -> Self {
+        self.allow_single_date_range = value;
+        self
+    }
+
+    /// Sets [`Props::min_range_days`].
+    #[must_use]
+    pub const fn min_range_days(mut self, value: Option<u32>) -> Self {
+        self.min_range_days = value;
+        self
+    }
+
+    /// Sets [`Props::max_range_days`].
+    #[must_use]
+    pub const fn max_range_days(mut self, value: Option<u32>) -> Self {
+        self.max_range_days = value;
+        self
+    }
+}
+
+/// `MessageFn` carrying a locale-only label closure.
+pub type LocaleLabelFn = dyn Fn(&Locale) -> String + Send + Sync;
+
+/// `MessageFn` carrying a page step label closure.
+pub type PageLabelFn = dyn Fn(usize, &Locale) -> String + Send + Sync;
+
+/// `MessageFn` carrying a date label announcement closure.
+pub type RangeStartLabelFn = dyn Fn(&str, &Locale) -> String + Send + Sync;
+
+/// `MessageFn` carrying a completed range announcement closure.
+pub type RangeCompleteLabelFn = dyn Fn(&str, &str, &Locale) -> String + Send + Sync;
+
+/// Locale-specific labels for the `RangeCalendar` component.
+#[derive(Clone)]
+pub struct Messages {
+    /// Accessible label for the previous-month button.
+    pub prev_month_label: MessageFn<LocaleLabelFn>,
+
+    /// Accessible label for the next-month button.
+    pub next_month_label: MessageFn<LocaleLabelFn>,
+
+    /// Accessible label for previous-page navigation.
+    pub prev_page_label: MessageFn<PageLabelFn>,
+
+    /// Accessible label for next-page navigation.
+    pub next_page_label: MessageFn<PageLabelFn>,
+
+    /// Separator inserted between month names in a multi-month heading.
+    pub month_range_separator: MessageFn<LocaleLabelFn>,
+
+    /// Suffix appended to unavailable cell labels.
+    pub unavailable_suffix: MessageFn<LocaleLabelFn>,
+
+    /// Suffix appended to disabled cell labels.
+    pub disabled_suffix: MessageFn<LocaleLabelFn>,
+
+    /// Suffix appended to range-start cell labels.
+    pub range_start_suffix: MessageFn<LocaleLabelFn>,
+
+    /// Suffix appended to range-end cell labels.
+    pub range_end_suffix: MessageFn<LocaleLabelFn>,
+
+    /// Announcement after selecting the first range endpoint.
+    pub range_start_label: MessageFn<RangeStartLabelFn>,
+
+    /// Announcement after completing a range.
+    pub range_complete_label: MessageFn<RangeCompleteLabelFn>,
+}
+
+impl Default for Messages {
+    fn default() -> Self {
+        Self {
+            prev_month_label: MessageFn::static_str("Previous month"),
+            next_month_label: MessageFn::static_str("Next month"),
+            prev_page_label: MessageFn::new(|count: usize, _locale: &Locale| {
+                format!("Previous {count} months")
+            }),
+            next_page_label: MessageFn::new(|count: usize, _locale: &Locale| {
+                format!("Next {count} months")
+            }),
+            month_range_separator: MessageFn::static_str(" \u{2013} "),
+            unavailable_suffix: MessageFn::static_str("(unavailable)"),
+            disabled_suffix: MessageFn::static_str("(disabled)"),
+            range_start_suffix: MessageFn::static_str("(range start)"),
+            range_end_suffix: MessageFn::static_str("(range end)"),
+            range_start_label: MessageFn::new(|start: &str, _locale: &Locale| {
+                format!("Selected {start} as range start. Select an end date.")
+            }),
+            range_complete_label: MessageFn::new(|start: &str, end: &str, _locale: &Locale| {
+                format!("Selected {start} to {end}")
+            }),
+        }
+    }
+}
+
+impl Debug for Messages {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Messages").finish_non_exhaustive()
+    }
+}
+
+impl PartialEq for Messages {
+    fn eq(&self, other: &Self) -> bool {
+        self.prev_month_label == other.prev_month_label
+            && self.next_month_label == other.next_month_label
+            && self.prev_page_label == other.prev_page_label
+            && self.next_page_label == other.next_page_label
+            && self.month_range_separator == other.month_range_separator
+            && self.unavailable_suffix == other.unavailable_suffix
+            && self.disabled_suffix == other.disabled_suffix
+            && self.range_start_suffix == other.range_start_suffix
+            && self.range_end_suffix == other.range_end_suffix
+            && self.range_start_label == other.range_start_label
+            && self.range_complete_label == other.range_complete_label
+    }
+}
+
+impl ComponentMessages for Messages {}
+
+// ────────────────────────────────────────────────────────────────────
+// Context
+// ────────────────────────────────────────────────────────────────────
+
+/// Context for the `RangeCalendar` component.
+#[derive(Clone)]
+pub struct Context {
+    /// Selected date range.
+    pub value: Bindable<Option<DateRange>>,
+
+    /// First selected date while a range is pending.
+    pub anchor_date: Option<CalendarDate>,
+
+    /// Hovered date while a range is pending.
+    pub hovering_date: Option<CalendarDate>,
+
+    /// The date that currently holds keyboard focus.
+    pub focused_date: CalendarDate,
+
+    /// The first visible month.
+    pub visible_month: u8,
+
+    /// The year of the first visible month.
+    pub visible_year: i32,
+
+    /// Number of months displayed side-by-side.
+    pub visible_months: usize,
+
+    /// Navigation step size for prev/next.
+    pub page_behavior: PageBehavior,
+
+    /// Minimum selectable date.
+    pub min: Option<CalendarDate>,
+
+    /// Maximum selectable date.
+    pub max: Option<CalendarDate>,
+
+    /// Resolved first day of week.
+    pub first_day_of_week: Weekday,
+
+    /// Whether the calendar is rendered right-to-left.
+    pub is_rtl: bool,
+
+    /// Whether the calendar is globally disabled.
+    pub disabled: bool,
+
+    /// Whether the calendar is read-only.
+    pub readonly: bool,
+
+    /// Whether week numbers should be rendered.
+    pub show_week_numbers: bool,
+
+    /// Date marked as today.
+    pub today: CalendarDate,
+
+    /// Predicate marking dates unavailable.
+    pub is_date_unavailable_fn: Option<IsDateUnavailableFn>,
+
+    /// Whether same-day ranges are valid.
+    pub allow_single_date_range: bool,
+
+    /// Minimum inclusive range length.
+    pub min_range_days: Option<u32>,
+
+    /// Maximum inclusive range length.
+    pub max_range_days: Option<u32>,
+
+    /// Resolved locale.
+    pub locale: Locale,
+
+    /// Resolved translatable messages.
+    pub messages: Messages,
+
+    /// Backend used for locale-dependent labels.
+    pub intl_backend: Arc<dyn IntlBackend>,
+
+    /// Component part IDs.
+    pub ids: ComponentIds,
+}
+
+impl Debug for Context {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Context")
+            .field("value", &self.value)
+            .field("anchor_date", &self.anchor_date)
+            .field("hovering_date", &self.hovering_date)
+            .field("focused_date", &self.focused_date)
+            .field("visible_month", &self.visible_month)
+            .field("visible_year", &self.visible_year)
+            .field("visible_months", &self.visible_months)
+            .field("page_behavior", &self.page_behavior)
+            .field("min", &self.min)
+            .field("max", &self.max)
+            .field("first_day_of_week", &self.first_day_of_week)
+            .field("is_rtl", &self.is_rtl)
+            .field("disabled", &self.disabled)
+            .field("readonly", &self.readonly)
+            .field("show_week_numbers", &self.show_week_numbers)
+            .field("today", &self.today)
+            .field(
+                "is_date_unavailable_fn",
+                &self.is_date_unavailable_fn.as_ref().map(|_| "<callback>"),
+            )
+            .field("allow_single_date_range", &self.allow_single_date_range)
+            .field("min_range_days", &self.min_range_days)
+            .field("max_range_days", &self.max_range_days)
+            .field("locale", &self.locale)
+            .field("messages", &self.messages)
+            .field("intl_backend", &"<dyn IntlBackend>")
+            .field("ids", &self.ids)
+            .finish()
+    }
+}
+
+impl Context {
+    /// Whether `date` is disabled.
+    #[must_use]
+    pub fn is_date_disabled(&self, date: &CalendarDate) -> bool {
+        if self.disabled {
+            return true;
+        }
+
+        if let Some(min) = &self.min
+            && date.compare(min) == Ordering::Less
+        {
+            return true;
+        }
+
+        if let Some(max) = &self.max
+            && date.compare(max) == Ordering::Greater
+        {
+            return true;
+        }
+
+        false
+    }
+
+    /// Whether `date` is marked unavailable.
+    #[must_use]
+    pub fn is_date_unavailable(&self, date: &CalendarDate) -> bool {
+        self.is_date_unavailable_fn
+            .as_ref()
+            .is_some_and(|predicate| predicate(date))
+    }
+
+    /// Clamps `date` into the configured selectable bounds.
+    #[must_use]
+    pub fn clamp_date(&self, date: CalendarDate) -> CalendarDate {
+        let mut clamped = date;
+
+        if let Some(min) = &self.min
+            && clamped.compare(min) == Ordering::Less
+        {
+            clamped = min.clone();
+        }
+
+        if let Some(max) = &self.max
+            && clamped.compare(max) == Ordering::Greater
+        {
+            clamped = max.clone();
+        }
+
+        clamped
+    }
+
+    /// Whether a confirmed range includes `date`.
+    #[must_use]
+    pub fn is_in_range(&self, date: &CalendarDate) -> bool {
+        self.value
+            .get()
+            .as_ref()
+            .is_some_and(|range| range.contains(date))
+    }
+
+    /// Whether `date` is the confirmed range start.
+    #[must_use]
+    pub fn is_range_start(&self, date: &CalendarDate) -> bool {
+        self.value
+            .get()
+            .as_ref()
+            .is_some_and(|range| range.start == *date)
+    }
+
+    /// Whether `date` is the confirmed range end.
+    #[must_use]
+    pub fn is_range_end(&self, date: &CalendarDate) -> bool {
+        self.value
+            .get()
+            .as_ref()
+            .is_some_and(|range| range.end == *date)
+    }
+
+    /// Whether `date` falls in the pending hover preview range.
+    #[must_use]
+    pub fn is_in_hover_range(&self, date: &CalendarDate) -> bool {
+        match (&self.anchor_date, &self.hovering_date) {
+            (Some(anchor), Some(hovering)) => {
+                DateRange::normalized(anchor.clone(), hovering.clone())
+                    .is_some_and(|range| range.contains(date))
+            }
+
+            _ => false,
+        }
+    }
+
+    /// Whether `date` is the pending range anchor.
+    #[must_use]
+    pub fn is_anchor(&self, date: &CalendarDate) -> bool {
+        self.anchor_date.as_ref() == Some(date)
+    }
+
+    /// Whether a range selection is pending.
+    #[must_use]
+    pub const fn is_range_pending(&self) -> bool {
+        self.anchor_date.is_some()
+    }
+
+    /// Whether `range` satisfies same-day and length constraints.
+    #[must_use]
+    pub fn range_is_allowed(&self, range: &DateRange) -> bool {
+        if !self.allow_single_date_range && range.start == range.end {
+            return false;
+        }
+
+        let Some(length) = inclusive_range_days(range) else {
+            return false;
+        };
+
+        if let Some(min) = self.min_range_days
+            && length < min
+        {
+            return false;
+        }
+
+        if let Some(max) = self.max_range_days
+            && length > max
+        {
+            return false;
+        }
+
+        true
+    }
+
+    /// Scrolls the visible window to include the focused date.
+    pub fn sync_visible_to_focused(&mut self) {
+        if !grid::is_in_visible_range(
+            &self.focused_date,
+            self.visible_month,
+            self.visible_year,
+            self.visible_months,
+        ) {
+            self.visible_month = self.focused_date.month();
+            self.visible_year = self.focused_date.year();
+        }
+    }
+
+    /// Returns `(month, year)` for the visible month at `offset`.
+    #[must_use]
+    pub const fn month_year_at_offset(&self, offset: usize) -> (u8, i32) {
+        grid::month_year_at_offset(self.visible_month, self.visible_year, offset)
+    }
+
+    /// Whether `date` belongs outside the month at `offset`.
+    #[must_use]
+    pub const fn is_outside_month_at_offset(&self, date: &CalendarDate, offset: usize) -> bool {
+        grid::is_outside_month_at_offset(date, self.visible_month, self.visible_year, offset)
+    }
+
+    /// Whether `date` belongs outside the first visible month.
+    #[must_use]
+    pub const fn is_outside_visible_month(&self, date: &CalendarDate) -> bool {
+        date.month() != self.visible_month || date.year() != self.visible_year
+    }
+
+    /// Builds the 6-week grid for the first visible month.
+    #[must_use]
+    pub fn weeks(&self) -> Vec<[CalendarDate; 7]> {
+        self.weeks_for(0)
+    }
+
+    /// Builds the 6-week grid for the month at `offset`.
+    #[must_use]
+    pub fn weeks_for(&self, offset: usize) -> Vec<[CalendarDate; 7]> {
+        grid::weeks_for(
+            self.visible_month,
+            self.visible_year,
+            self.first_day_of_week,
+            offset,
+        )
+    }
+
+    /// Returns the ordered weekday list.
+    #[must_use]
+    pub fn ordered_weekdays(&self) -> [Weekday; 7] {
+        grid::ordered_weekdays(self.first_day_of_week)
+    }
+
+    /// Ordered `(weekday, short-label)` pairs for the head row.
+    #[must_use]
+    pub fn week_day_labels(&self) -> Vec<(Weekday, String)> {
+        self.ordered_weekdays()
+            .into_iter()
+            .map(|wd| (wd, self.intl_backend.weekday_short_label(wd, &self.locale)))
+            .collect()
+    }
+
+    /// Advances visible month/year by `n` whole months.
+    pub const fn advance_month(&mut self, n: i32) {
+        let (month, year) = grid::advance_month(self.visible_month, self.visible_year, n);
+
+        self.visible_month = month;
+        self.visible_year = year;
+    }
+}
+
+fn inclusive_range_days(range: &DateRange) -> Option<u32> {
+    let days = range.start.days_until(&range.end).ok()?;
+
+    u32::try_from(days).ok()?.checked_add(1)
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Part / Machine
+// ────────────────────────────────────────────────────────────────────
+
+/// Parts of the `RangeCalendar` anatomy.
+#[derive(ars_core::ComponentPart)]
+#[scope = "range-calendar"]
+pub enum Part {
+    /// The outer component root.
+    Root,
+
+    /// Header container for navigation and heading.
+    Header,
+
+    /// The previous-month or previous-page button.
+    PrevTrigger,
+
+    /// The next-month or next-page button.
+    NextTrigger,
+
+    /// The textual month/year heading.
+    Heading,
+
+    /// The grid wrapper for a visible month.
+    Grid,
+
+    /// Wrapper grouping multiple visible month grids.
+    GridGroup,
+
+    /// The header row of weekday labels.
+    HeadRow,
+
+    /// Individual weekday header cell.
+    HeadCell {
+        /// The weekday this cell describes.
+        #[part(default = Weekday::Monday)]
+        day: Weekday,
+    },
+
+    /// A row of day cells.
+    Row {
+        /// Zero-based week index.
+        week_index: usize,
+    },
+
+    /// A grid cell wrapping a date trigger.
+    Cell {
+        /// The date represented by this cell.
+        #[part(default = default_calendar_date())]
+        date: CalendarDate,
+
+        /// Zero-based visible month offset.
+        offset: usize,
+    },
+
+    /// Interactive trigger inside a date cell.
+    CellTrigger {
+        /// The date represented by this trigger.
+        #[part(default = default_calendar_date())]
+        date: CalendarDate,
+
+        /// Zero-based visible month offset.
+        offset: usize,
+    },
+}
+
+fn default_calendar_date() -> CalendarDate {
+    CalendarDate::new_gregorian(1, 1, 1).expect("1-01-01 is a valid Gregorian date")
+}
+
+/// Machine for the `RangeCalendar` component.
+#[derive(Debug)]
+pub struct Machine;
+
+impl ars_core::Machine for Machine {
+    type State = State;
+    type Event = Event;
+    type Context = Context;
+    type Props = Props;
+    type Messages = Messages;
+    type Effect = Effect;
+    type Api<'a> = Api<'a>;
+
+    fn init(
+        props: &Self::Props,
+        env: &Env,
+        messages: &Self::Messages,
+    ) -> (Self::State, Self::Context) {
+        let value = if let Some(controlled) = &props.value {
+            Bindable::controlled(controlled.clone())
+        } else {
+            Bindable::uncontrolled(props.default_value.clone())
+        };
+
+        let mut initial_date = value
+            .get()
+            .as_ref()
+            .map_or_else(|| props.today.clone(), |range| range.start.clone());
+
+        if let Some(min) = &props.min
+            && initial_date.compare(min) == Ordering::Less
+        {
+            initial_date = min.clone();
+        }
+        if let Some(max) = &props.max
+            && initial_date.compare(max) == Ordering::Greater
+        {
+            initial_date = max.clone();
+        }
+
+        let locale = env.locale.clone();
+
+        let first_day_of_week = props
+            .first_day_of_week
+            .unwrap_or_else(|| locale.first_day_of_week(&*env.intl_backend));
+
+        let visible_months = props.visible_months.max(1);
+
+        let focused_date = initial_date;
+
+        let visible_month = focused_date.month();
+        let visible_year = focused_date.year();
+
+        let ctx = Context {
+            value,
+            anchor_date: None,
+            hovering_date: None,
+            focused_date,
+            visible_month,
+            visible_year,
+            visible_months,
+            page_behavior: props.page_behavior,
+            min: props.min.clone(),
+            max: props.max.clone(),
+            first_day_of_week,
+            is_rtl: props.is_rtl,
+            disabled: props.disabled,
+            readonly: props.readonly,
+            show_week_numbers: props.show_week_numbers,
+            today: props.today.clone(),
+            is_date_unavailable_fn: props.is_date_unavailable.clone(),
+            allow_single_date_range: props.allow_single_date_range,
+            min_range_days: props.min_range_days,
+            max_range_days: props.max_range_days,
+            locale,
+            messages: messages.clone(),
+            intl_backend: Arc::clone(&env.intl_backend),
+            ids: ComponentIds::from_id(&props.id),
+        };
+
+        (State::Idle, ctx)
+    }
+
+    fn on_props_changed(old: &Self::Props, new: &Self::Props) -> Vec<Self::Event> {
+        debug_assert_eq!(
+            old.id, new.id,
+            "range_calendar::Props.id must remain stable after init",
+        );
+
+        if old == new {
+            Vec::new()
+        } else {
+            vec![Event::SyncProps(Box::new(new.clone()))]
+        }
+    }
+
+    fn transition(
+        _state: &Self::State,
+        event: &Self::Event,
+        ctx: &Self::Context,
+        _props: &Self::Props,
+    ) -> Option<TransitionPlan<Self>> {
+        if matches!(event, Event::FocusOut) {
+            return Some(TransitionPlan::to(State::Idle));
+        }
+
+        if let Event::SyncProps(props) = event {
+            let props = props.as_ref().clone();
+
+            return Some(TransitionPlan::context_only(move |ctx: &mut Context| {
+                sync_props_into_ctx(ctx, &props);
+            }));
+        }
+
+        if ctx.disabled {
+            return None;
+        }
+
+        match event {
+            Event::FocusIn => Some(TransitionPlan::to(State::Focused)),
+
+            Event::FocusOut | Event::SyncProps(_) => None,
+
+            Event::FocusDate { date } => {
+                let clamped = ctx.clamp_date(date.clone());
+                Some(
+                    TransitionPlan::to(State::Focused).apply(move |ctx: &mut Context| {
+                        ctx.focused_date = clamped;
+                        ctx.sync_visible_to_focused();
+                    }),
+                )
+            }
+
+            Event::SelectDate { date } => apply_select_date(ctx, date.clone()),
+
+            Event::HoverDate { date } => {
+                if ctx.readonly || ctx.anchor_date.is_none() {
+                    return None;
+                }
+
+                let date = date.clone();
+                Some(TransitionPlan::context_only(move |ctx: &mut Context| {
+                    ctx.hovering_date = Some(date);
+                }))
+            }
+
+            Event::HoverEnd => {
+                ctx.hovering_date.as_ref()?;
+
+                Some(TransitionPlan::context_only(|ctx: &mut Context| {
+                    ctx.hovering_date = None;
+                }))
+            }
+
+            Event::NextMonth => month_step_plan(ctx, step_for_page_behavior(ctx)),
+
+            Event::PrevMonth => month_step_plan(ctx, -step_for_page_behavior(ctx)),
+
+            Event::NextYear => month_step_plan(ctx, 12),
+
+            Event::PrevYear => month_step_plan(ctx, -12),
+
+            Event::SetMonth { month } => {
+                let month = *month;
+
+                if !(1..=12).contains(&month) {
+                    return None;
+                }
+
+                let delta = i32::from(month) - i32::from(ctx.visible_month);
+
+                let shifted = ctx
+                    .focused_date
+                    .add(ars_i18n::DateDuration {
+                        months: delta,
+                        ..ars_i18n::DateDuration::default()
+                    })
+                    .ok()?;
+
+                Some(
+                    TransitionPlan::context_only(move |ctx: &mut Context| {
+                        ctx.visible_month = month;
+                        ctx.focused_date = ctx.clamp_date(shifted);
+
+                        ctx.sync_visible_to_focused();
+                    })
+                    .with_effect(announce_month_effect()),
+                )
+            }
+
+            Event::SetYear { year } => {
+                let year = *year;
+                let delta_years = year.checked_sub(ctx.visible_year)?;
+
+                let shifted = ctx
+                    .focused_date
+                    .add(ars_i18n::DateDuration {
+                        years: delta_years,
+                        ..ars_i18n::DateDuration::default()
+                    })
+                    .ok()?;
+
+                Some(
+                    TransitionPlan::context_only(move |ctx: &mut Context| {
+                        ctx.visible_year = year;
+                        ctx.focused_date = ctx.clamp_date(shifted);
+
+                        ctx.sync_visible_to_focused();
+                    })
+                    .with_effect(announce_month_effect()),
+                )
+            }
+
+            Event::KeyDown { key, shift } => handle_keydown(*key, *shift, ctx),
+        }
+    }
+
+    fn connect<'a>(
+        state: &'a Self::State,
+        context: &'a Self::Context,
+        props: &'a Self::Props,
+        send: &'a dyn Fn(Self::Event),
+    ) -> Self::Api<'a> {
+        Api::new(state, context, props, send)
+    }
+}
+
+fn sync_props_into_ctx(ctx: &mut Context, props: &Props) {
+    ctx.value.sync_controlled(props.value.clone());
+    ctx.min = props.min.clone();
+    ctx.max = props.max.clone();
+    ctx.disabled = props.disabled;
+    ctx.readonly = props.readonly;
+    ctx.is_date_unavailable_fn = props.is_date_unavailable.clone();
+    ctx.show_week_numbers = props.show_week_numbers;
+    ctx.is_rtl = props.is_rtl;
+    ctx.visible_months = props.visible_months.max(1);
+    ctx.page_behavior = props.page_behavior;
+    ctx.today = props.today.clone();
+    ctx.allow_single_date_range = props.allow_single_date_range;
+    ctx.min_range_days = props.min_range_days;
+    ctx.max_range_days = props.max_range_days;
+    ctx.first_day_of_week = props
+        .first_day_of_week
+        .unwrap_or_else(|| ctx.locale.first_day_of_week(&*ctx.intl_backend));
+
+    ctx.focused_date = ctx.clamp_date(ctx.focused_date.clone());
+
+    ctx.sync_visible_to_focused();
+}
+
+fn apply_select_date(ctx: &Context, date: CalendarDate) -> Option<TransitionPlan<Machine>> {
+    if ctx.readonly || ctx.is_date_disabled(&date) || ctx.is_date_unavailable(&date) {
+        return None;
+    }
+
+    if let Some(anchor) = &ctx.anchor_date {
+        let range = DateRange::normalized(anchor.clone(), date.clone())?;
+        if !ctx.range_is_allowed(&range) {
+            let focused = date;
+
+            return Some(
+                TransitionPlan::to(State::Focused).apply(move |ctx: &mut Context| {
+                    ctx.focused_date = focused;
+                    ctx.sync_visible_to_focused();
+                }),
+            );
+        }
+
+        Some(
+            TransitionPlan::to(State::Focused)
+                .apply(move |ctx: &mut Context| {
+                    ctx.value.set(Some(range));
+                    ctx.anchor_date = None;
+                    ctx.hovering_date = None;
+                    ctx.focused_date = date;
+                    ctx.sync_visible_to_focused();
+                })
+                .with_effect(ars_core::PendingEffect::named(
+                    Effect::AnnounceRangeComplete,
+                )),
+        )
+    } else {
+        Some(
+            TransitionPlan::to(State::Focused)
+                .apply(move |ctx: &mut Context| {
+                    ctx.anchor_date = Some(date.clone());
+                    ctx.hovering_date = None;
+                    ctx.focused_date = date;
+                    ctx.value.set(None);
+                })
+                .with_effect(ars_core::PendingEffect::named(Effect::AnnounceRangeStart)),
+        )
+    }
+}
+
+fn step_for_page_behavior(ctx: &Context) -> i32 {
+    match ctx.page_behavior {
+        PageBehavior::Visible => i32::try_from(ctx.visible_months).unwrap_or(1).max(1),
+        PageBehavior::Single => 1,
+    }
+}
+
+fn month_step_plan(ctx: &Context, step: i32) -> Option<TransitionPlan<Machine>> {
+    let shifted = ctx
+        .focused_date
+        .add(ars_i18n::DateDuration {
+            months: step,
+            ..ars_i18n::DateDuration::default()
+        })
+        .ok()?;
+
+    Some(
+        TransitionPlan::context_only(move |ctx: &mut Context| {
+            ctx.advance_month(step);
+            ctx.focused_date = ctx.clamp_date(shifted);
+
+            ctx.sync_visible_to_focused();
+        })
+        .with_effect(announce_month_effect()),
+    )
+}
+
+fn announce_month_effect() -> ars_core::PendingEffect<Machine> {
+    ars_core::PendingEffect::named(Effect::AnnounceMonth)
+}
+
+fn handle_keydown(key: KeyboardKey, shift: bool, ctx: &Context) -> Option<TransitionPlan<Machine>> {
+    if shift {
+        match key {
+            KeyboardKey::PageUp => return month_step_plan(ctx, -12),
+            KeyboardKey::PageDown => return month_step_plan(ctx, 12),
+            _ => {}
+        }
+    }
+
+    let focused = ctx.focused_date.clone();
+
+    let (prev_day_key, next_day_key) = if ctx.is_rtl {
+        (KeyboardKey::ArrowRight, KeyboardKey::ArrowLeft)
+    } else {
+        (KeyboardKey::ArrowLeft, KeyboardKey::ArrowRight)
+    };
+
+    let new_focus = if key == prev_day_key {
+        focused.add_days(-1).ok()
+    } else if key == next_day_key {
+        focused.add_days(1).ok()
+    } else {
+        match key {
+            KeyboardKey::ArrowUp => focused.add_days(-7).ok(),
+
+            KeyboardKey::ArrowDown => focused.add_days(7).ok(),
+
+            KeyboardKey::Home => {
+                let wd = grid::weekday_sunday_zero(focused.weekday());
+                let start = grid::weekday_sunday_zero(ctx.first_day_of_week);
+                let offset = i32::from((wd + 7 - start) % 7);
+
+                focused.add_days(-offset).ok()
+            }
+
+            KeyboardKey::End => {
+                let wd = grid::weekday_sunday_zero(focused.weekday());
+                let start = grid::weekday_sunday_zero(ctx.first_day_of_week);
+                let offset = i32::from((wd + 7 - start) % 7);
+
+                focused.add_days(6 - offset).ok()
+            }
+
+            KeyboardKey::PageUp => focused
+                .add(ars_i18n::DateDuration {
+                    months: -1,
+                    ..ars_i18n::DateDuration::default()
+                })
+                .ok(),
+
+            KeyboardKey::PageDown => focused
+                .add(ars_i18n::DateDuration {
+                    months: 1,
+                    ..ars_i18n::DateDuration::default()
+                })
+                .ok(),
+
+            _ => None,
+        }
+    };
+
+    if let Some(date) = new_focus {
+        let clamped = ctx.clamp_date(date);
+
+        return Some(
+            TransitionPlan::to(State::Focused).apply(move |ctx: &mut Context| {
+                ctx.focused_date = clamped;
+                ctx.sync_visible_to_focused();
+            }),
+        );
+    }
+
+    match key {
+        KeyboardKey::Enter | KeyboardKey::Space => {
+            let date = focused;
+            Some(
+                TransitionPlan::context_only(|_ctx: &mut Context| {})
+                    .then(Event::SelectDate { date }),
+            )
+        }
+
+        _ => None,
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Api
+// ────────────────────────────────────────────────────────────────────
+
+/// API for the `RangeCalendar` component.
+pub struct Api<'a> {
+    state: &'a State,
+    ctx: &'a Context,
+    props: &'a Props,
+    send: &'a dyn Fn(Event),
+}
+
+impl Debug for Api<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Api")
+            .field("state", self.state)
+            .field("ctx", self.ctx)
+            .field("props", self.props)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<'a> Api<'a> {
+    /// Creates a new `RangeCalendar` connect API.
+    #[must_use]
+    pub const fn new(
+        state: &'a State,
+        ctx: &'a Context,
+        props: &'a Props,
+        send: &'a dyn Fn(Event),
+    ) -> Self {
+        Self {
+            state,
+            ctx,
+            props,
+            send,
+        }
+    }
+
+    /// Returns attributes for the outer root element.
+    #[must_use]
+    pub fn root_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Root.data_attrs();
+
+        attrs
+            .set(HtmlAttr::Id, self.ctx.ids.id())
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Data("ars-state"), self.state_name());
+
+        if self.ctx.disabled {
+            attrs.set_bool(HtmlAttr::Data("ars-disabled"), true);
+        }
+
+        if self.ctx.readonly {
+            attrs.set_bool(HtmlAttr::Data("ars-readonly"), true);
+        }
+
+        if self.ctx.is_rtl {
+            attrs.set(HtmlAttr::Dir, "rtl");
+        }
+
+        if self.ctx.is_range_pending() {
+            attrs.set_bool(HtmlAttr::Data("ars-range-pending"), true);
+        }
+
+        attrs
+    }
+
+    /// Returns attributes for the header container.
+    #[must_use]
+    pub fn header_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Header.data_attrs();
+
+        attrs
+            .set(HtmlAttr::Id, self.ctx.ids.part("header"))
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val);
+
+        attrs
+    }
+
+    /// Returns attributes for the previous button.
+    #[must_use]
+    pub fn prev_trigger_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::PrevTrigger.data_attrs();
+
+        let step = self.nav_step_size();
+
+        let label = if step > 1 {
+            (self.ctx.messages.prev_page_label)(step, &self.ctx.locale)
+        } else {
+            (self.ctx.messages.prev_month_label)(&self.ctx.locale)
+        };
+
+        attrs
+            .set(HtmlAttr::Id, self.ctx.ids.part("prev-trigger"))
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Type, "button")
+            .set(HtmlAttr::Aria(AriaAttr::Label), label)
+            .set(HtmlAttr::TabIndex, "-1");
+
+        if self.is_prev_disabled() {
+            attrs
+                .set_bool(HtmlAttr::Disabled, true)
+                .set(HtmlAttr::Aria(AriaAttr::Disabled), "true");
+        }
+
+        attrs
+    }
+
+    /// Returns attributes for the next button.
+    #[must_use]
+    pub fn next_trigger_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::NextTrigger.data_attrs();
+
+        let step = self.nav_step_size();
+
+        let label = if step > 1 {
+            (self.ctx.messages.next_page_label)(step, &self.ctx.locale)
+        } else {
+            (self.ctx.messages.next_month_label)(&self.ctx.locale)
+        };
+
+        attrs
+            .set(HtmlAttr::Id, self.ctx.ids.part("next-trigger"))
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Type, "button")
+            .set(HtmlAttr::Aria(AriaAttr::Label), label)
+            .set(HtmlAttr::TabIndex, "-1");
+
+        if self.is_next_disabled() {
+            attrs
+                .set_bool(HtmlAttr::Disabled, true)
+                .set(HtmlAttr::Aria(AriaAttr::Disabled), "true");
+        }
+
+        attrs
+    }
+
+    /// Returns attributes for the main heading.
+    #[must_use]
+    pub fn heading_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Heading.data_attrs();
+
+        attrs
+            .set(HtmlAttr::Id, self.ctx.ids.part("heading"))
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Aria(AriaAttr::Live), "polite")
+            .set(HtmlAttr::Aria(AriaAttr::Atomic), "true");
+
+        attrs
+    }
+
+    /// Heading text for the first visible month.
+    #[must_use]
+    pub fn heading_text(&self) -> String {
+        self.heading_text_for(0)
+    }
+
+    /// Attributes for the first visible grid.
+    #[must_use]
+    pub fn grid_attrs(&self) -> AttrMap {
+        self.grid_attrs_with_ids(self.ctx.ids.part("grid"), self.ctx.ids.part("heading"))
+    }
+
+    /// Attributes for the grid at `offset`.
+    #[must_use]
+    pub fn grid_attrs_for(&self, offset: usize) -> AttrMap {
+        self.grid_attrs_with_ids(
+            self.ctx.ids.item("grid", &offset),
+            self.ctx.ids.item("heading", &offset),
+        )
+    }
+
+    fn grid_attrs_with_ids(&self, grid_id: String, heading_id: String) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Grid.data_attrs();
+
+        attrs
+            .set(HtmlAttr::Id, grid_id)
+            .set(HtmlAttr::Role, "grid")
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Aria(AriaAttr::LabelledBy), heading_id)
+            .set(HtmlAttr::Aria(AriaAttr::MultiSelectable), "true");
+
+        if self.ctx.readonly {
+            attrs.set(HtmlAttr::Aria(AriaAttr::ReadOnly), "true");
+        }
+
+        if self.ctx.disabled {
+            attrs.set(HtmlAttr::Aria(AriaAttr::Disabled), "true");
+        }
+
+        attrs
+    }
+
+    /// Returns attributes for the multi-grid wrapper.
+    #[must_use]
+    pub fn grid_group_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::GridGroup.data_attrs();
+
+        attrs
+            .set(HtmlAttr::Id, format!("{}-grid-group", self.ctx.ids.id()))
+            .set(HtmlAttr::Role, "group")
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Aria(AriaAttr::Label), self.range_heading_text());
+
+        attrs
+    }
+
+    /// Heading attributes for a per-grid hidden heading.
+    #[must_use]
+    pub fn heading_attrs_for(&self, offset: usize) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Heading.data_attrs();
+
+        attrs
+            .set(HtmlAttr::Id, self.ctx.ids.item("heading", &offset))
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val);
+
+        attrs
+    }
+
+    /// Heading text for the month at `offset`.
+    #[must_use]
+    pub fn heading_text_for(&self, offset: usize) -> String {
+        let (month, year) = self.ctx.month_year_at_offset(offset);
+
+        format!(
+            "{} {}",
+            self.ctx
+                .intl_backend
+                .month_long_name(month, &self.ctx.locale),
+            year,
+        )
+    }
+
+    /// Heading text spanning all visible months.
+    #[must_use]
+    pub fn range_heading_text(&self) -> String {
+        if self.ctx.visible_months <= 1 {
+            return self.heading_text();
+        }
+
+        let first = self.heading_text_for(0);
+        let last = self.heading_text_for(self.ctx.visible_months - 1);
+
+        let sep = (self.ctx.messages.month_range_separator)(&self.ctx.locale);
+
+        format!("{first}{sep}{last}")
+    }
+
+    /// Returns attributes for the weekday header row.
+    #[must_use]
+    pub fn head_row_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::HeadRow.data_attrs();
+
+        attrs.set(scope_attr, scope_val).set(part_attr, part_val);
+
+        attrs
+    }
+
+    /// Returns attributes for one weekday header cell.
+    #[must_use]
+    pub fn head_cell_attrs(&self, weekday: Weekday) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] =
+            Part::HeadCell { day: weekday }.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Scope, "col")
+            .set(
+                HtmlAttr::Abbr,
+                self.ctx
+                    .intl_backend
+                    .weekday_long_label(weekday, &self.ctx.locale),
+            );
+
+        attrs
+    }
+
+    /// Returns attributes for a week row.
+    #[must_use]
+    pub fn row_attrs(&self, week_index: usize) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] =
+            Part::Row { week_index }.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Data("ars-week-index"), week_index.to_string());
+
+        attrs
+    }
+
+    /// Returns attributes for a date cell.
+    #[must_use]
+    pub fn cell_attrs(&self, date: &CalendarDate) -> AttrMap {
+        self.cell_attrs_inner(date, None)
+    }
+
+    /// Returns attributes for a date cell in a specific month offset.
+    #[must_use]
+    pub fn cell_attrs_for(&self, date: &CalendarDate, offset: usize) -> AttrMap {
+        self.cell_attrs_inner(date, Some(offset))
+    }
+
+    fn cell_attrs_inner(&self, date: &CalendarDate, offset: Option<usize>) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Cell {
+            date: date.clone(),
+            offset: offset.unwrap_or(0),
+        }
+        .data_attrs();
+
+        attrs
+            .set(HtmlAttr::Role, "gridcell")
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val);
+
+        if self.is_in_range(date) {
+            attrs.set(HtmlAttr::Aria(AriaAttr::Selected), "true");
+        }
+
+        let outside = if let Some(offset) = offset {
+            self.ctx.is_outside_month_at_offset(date, offset)
+        } else {
+            self.ctx.is_outside_visible_month(date)
+        };
+
+        if outside {
+            attrs.set_bool(HtmlAttr::Data("ars-outside-month"), true);
+        }
+
+        if self.is_disabled(date) {
+            attrs.set(HtmlAttr::Aria(AriaAttr::Disabled), "true");
+        }
+
+        attrs
+    }
+
+    /// Returns attributes for a date cell trigger.
+    #[must_use]
+    pub fn cell_trigger_attrs(&self, date: &CalendarDate) -> AttrMap {
+        self.cell_trigger_attrs_inner(date, None)
+    }
+
+    /// Returns attributes for a date cell trigger in a specific month offset.
+    #[must_use]
+    pub fn cell_trigger_attrs_for(&self, date: &CalendarDate, offset: usize) -> AttrMap {
+        self.cell_trigger_attrs_inner(date, Some(offset))
+    }
+
+    fn cell_trigger_attrs_inner(&self, date: &CalendarDate, offset: Option<usize>) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::CellTrigger {
+            date: date.clone(),
+            offset: offset.unwrap_or(0),
+        }
+        .data_attrs();
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Type, "button");
+
+        let disabled = self.is_disabled(date);
+        let unavailable = self.is_unavailable(date);
+        let focused = &self.ctx.focused_date == date;
+
+        attrs.set(HtmlAttr::TabIndex, if focused { "0" } else { "-1" });
+
+        if disabled || unavailable {
+            attrs.set(HtmlAttr::Aria(AriaAttr::Disabled), "true");
+        }
+
+        if disabled {
+            attrs.set_bool(HtmlAttr::Disabled, true);
+        }
+
+        if self.is_in_range(date) {
+            attrs
+                .set(HtmlAttr::Aria(AriaAttr::Selected), "true")
+                .set_bool(HtmlAttr::Data("ars-in-range"), true);
+        }
+
+        if self.is_today(date) {
+            attrs.set_bool(HtmlAttr::Data("ars-today"), true);
+        }
+
+        let outside = if let Some(offset) = offset {
+            self.ctx.is_outside_month_at_offset(date, offset)
+        } else {
+            self.ctx.is_outside_visible_month(date)
+        };
+
+        if outside {
+            attrs.set_bool(HtmlAttr::Data("ars-outside-month"), true);
+        }
+
+        if unavailable {
+            attrs.set_bool(HtmlAttr::Data("ars-unavailable"), true);
+        }
+
+        if self.is_range_start(date) {
+            attrs.set_bool(HtmlAttr::Data("ars-range-start"), true);
+        }
+
+        if self.is_range_end(date) {
+            attrs.set_bool(HtmlAttr::Data("ars-range-end"), true);
+        }
+
+        if self.is_in_hover_range(date) {
+            attrs.set_bool(HtmlAttr::Data("ars-in-hover-range"), true);
+        }
+
+        if self.is_anchor(date) {
+            attrs.set_bool(HtmlAttr::Data("ars-anchor"), true);
+        }
+
+        attrs.set(HtmlAttr::Aria(AriaAttr::Label), self.cell_label(date));
+
+        attrs
+    }
+
+    fn cell_label(&self, date: &CalendarDate) -> String {
+        let base = format_date_label(date, &*self.ctx.intl_backend, &self.ctx.locale);
+
+        if self.is_unavailable(date) {
+            let suffix = (self.ctx.messages.unavailable_suffix)(&self.ctx.locale);
+
+            format!("{base} {suffix}")
+        } else if self.is_disabled(date) {
+            let suffix = (self.ctx.messages.disabled_suffix)(&self.ctx.locale);
+
+            format!("{base} {suffix}")
+        } else if self.is_range_start(date) {
+            let suffix = (self.ctx.messages.range_start_suffix)(&self.ctx.locale);
+
+            format!("{base} {suffix}")
+        } else if self.is_range_end(date) {
+            let suffix = (self.ctx.messages.range_end_suffix)(&self.ctx.locale);
+
+            format!("{base} {suffix}")
+        } else {
+            base
+        }
+    }
+
+    /// Whether `date` falls inside the confirmed range.
+    #[must_use]
+    pub fn is_in_range(&self, date: &CalendarDate) -> bool {
+        self.ctx.is_in_range(date)
+    }
+
+    /// Whether `date` is the confirmed range start.
+    #[must_use]
+    pub fn is_range_start(&self, date: &CalendarDate) -> bool {
+        self.ctx.is_range_start(date)
+    }
+
+    /// Whether `date` is the confirmed range end.
+    #[must_use]
+    pub fn is_range_end(&self, date: &CalendarDate) -> bool {
+        self.ctx.is_range_end(date)
+    }
+
+    /// Whether `date` falls in the pending hover range.
+    #[must_use]
+    pub fn is_in_hover_range(&self, date: &CalendarDate) -> bool {
+        self.ctx.is_in_hover_range(date)
+    }
+
+    /// Whether `date` is the pending anchor.
+    #[must_use]
+    pub fn is_anchor(&self, date: &CalendarDate) -> bool {
+        self.ctx.is_anchor(date)
+    }
+
+    /// Whether `date` equals the configured today.
+    #[must_use]
+    pub fn is_today(&self, date: &CalendarDate) -> bool {
+        date == &self.ctx.today
+    }
+
+    /// Whether `date` is disabled.
+    #[must_use]
+    pub fn is_disabled(&self, date: &CalendarDate) -> bool {
+        self.ctx.is_date_disabled(date)
+    }
+
+    /// Whether `date` is unavailable.
+    #[must_use]
+    pub fn is_unavailable(&self, date: &CalendarDate) -> bool {
+        self.ctx.is_date_unavailable(date)
+    }
+
+    /// Returns the configured today date.
+    #[must_use]
+    pub const fn today(&self) -> &CalendarDate {
+        &self.ctx.today
+    }
+
+    /// Returns the focused date.
+    #[must_use]
+    pub const fn focused_date(&self) -> &CalendarDate {
+        &self.ctx.focused_date
+    }
+
+    /// Whether the grid has focus.
+    #[must_use]
+    pub const fn is_focused(&self) -> bool {
+        matches!(self.state, State::Focused)
+    }
+
+    /// Number of visible months.
+    #[must_use]
+    pub const fn visible_month_count(&self) -> usize {
+        self.ctx.visible_months
+    }
+
+    /// Iterator over visible month offsets.
+    #[must_use]
+    pub const fn month_offsets(&self) -> core::ops::Range<usize> {
+        0..self.ctx.visible_months
+    }
+
+    /// Whether week numbers should be rendered.
+    #[must_use]
+    pub const fn show_week_numbers(&self) -> bool {
+        self.ctx.show_week_numbers
+    }
+
+    /// Grid weeks for the first visible month.
+    #[must_use]
+    pub fn weeks(&self) -> Vec<[CalendarDate; 7]> {
+        self.ctx.weeks()
+    }
+
+    /// Grid weeks for a month offset.
+    #[must_use]
+    pub fn weeks_for(&self, offset: usize) -> Vec<[CalendarDate; 7]> {
+        self.ctx.weeks_for(offset)
+    }
+
+    /// Ordered weekday labels.
+    #[must_use]
+    pub fn week_day_labels(&self) -> Vec<(Weekday, String)> {
+        self.ctx.week_day_labels()
+    }
+
+    /// Whether the previous trigger should be disabled.
+    #[must_use]
+    pub fn is_prev_disabled(&self) -> bool {
+        if self.ctx.disabled {
+            return true;
+        }
+
+        let step = self.nav_step_size();
+
+        let (new_first_month, new_first_year) = grid::advance_month(
+            self.ctx.visible_month,
+            self.ctx.visible_year,
+            -i32::try_from(step).unwrap_or(1),
+        );
+
+        let last_offset = self.ctx.visible_months.saturating_sub(1);
+
+        let (new_last_month, new_last_year) =
+            grid::month_year_at_offset(new_first_month, new_first_year, last_offset);
+
+        let Ok(first_of_new_last) = CalendarDate::new_gregorian(new_last_year, new_last_month, 1)
+        else {
+            return true;
+        };
+
+        let Ok(last_of_new_last) = CalendarDate::new_gregorian(
+            new_last_year,
+            new_last_month,
+            first_of_new_last.days_in_month(),
+        ) else {
+            return true;
+        };
+
+        let Some(min) = &self.ctx.min else {
+            return false;
+        };
+
+        matches!(last_of_new_last.compare(min), Ordering::Less)
+    }
+
+    /// Whether the next trigger should be disabled.
+    #[must_use]
+    pub fn is_next_disabled(&self) -> bool {
+        if self.ctx.disabled {
+            return true;
+        }
+
+        let step = self.nav_step_size();
+
+        let (new_first_month, new_first_year) = grid::advance_month(
+            self.ctx.visible_month,
+            self.ctx.visible_year,
+            i32::try_from(step).unwrap_or(1),
+        );
+
+        let Ok(first_of_new_first) =
+            CalendarDate::new_gregorian(new_first_year, new_first_month, 1)
+        else {
+            return true;
+        };
+
+        let Some(max) = &self.ctx.max else {
+            return false;
+        };
+
+        matches!(first_of_new_first.compare(max), Ordering::Greater)
+    }
+
+    /// Handle click on a day cell.
+    pub fn on_cell_click(&self, date: CalendarDate) {
+        (self.send)(Event::SelectDate { date });
+    }
+
+    /// Handle hover over a day cell.
+    pub fn on_cell_hover(&self, date: CalendarDate) {
+        (self.send)(Event::HoverDate { date });
+    }
+
+    /// Handle pointer leaving the grid.
+    pub fn on_grid_mouseleave(&self) {
+        (self.send)(Event::HoverEnd);
+    }
+
+    /// Handle focus entering the grid.
+    pub fn on_grid_focusin(&self) {
+        (self.send)(Event::FocusIn);
+    }
+
+    /// Handle focus leaving the grid.
+    pub fn on_grid_focusout(&self, focus_leaving_grid: bool) {
+        if focus_leaving_grid {
+            (self.send)(Event::FocusOut);
+        }
+    }
+
+    /// Handle keydown on the grid.
+    pub fn on_grid_keydown(&self, key: KeyboardKey, shift: bool) {
+        (self.send)(Event::KeyDown { key, shift });
+    }
+
+    /// Handle previous button click.
+    pub fn on_prev_click(&self) {
+        (self.send)(Event::PrevMonth);
+    }
+
+    /// Handle next button click.
+    pub fn on_next_click(&self) {
+        (self.send)(Event::NextMonth);
+    }
+
+    const fn nav_step_size(&self) -> usize {
+        match self.ctx.page_behavior {
+            PageBehavior::Visible => self.ctx.visible_months,
+            PageBehavior::Single => 1,
+        }
+    }
+
+    const fn state_name(&self) -> &'static str {
+        match self.state {
+            State::Idle => "idle",
+            State::Focused => "focused",
+        }
+    }
+}
+
+fn format_date_label(date: &CalendarDate, backend: &dyn IntlBackend, locale: &Locale) -> String {
+    format!(
+        "{} {}, {}, {}",
+        backend.month_long_name(date.month(), locale),
+        date.day(),
+        date.year(),
+        backend.weekday_long_label(date.weekday(), locale),
+    )
+}
+
+impl ConnectApi for Api<'_> {
+    type Part = Part;
+
+    fn part_attrs(&self, part: Part) -> AttrMap {
+        match part {
+            Part::Root => self.root_attrs(),
+            Part::Header => self.header_attrs(),
+            Part::PrevTrigger => self.prev_trigger_attrs(),
+            Part::NextTrigger => self.next_trigger_attrs(),
+            Part::Heading => self.heading_attrs(),
+            Part::Grid => self.grid_attrs(),
+            Part::GridGroup => self.grid_group_attrs(),
+            Part::HeadRow => self.head_row_attrs(),
+            Part::HeadCell { day } => self.head_cell_attrs(day),
+            Part::Row { week_index } => self.row_attrs(week_index),
+            Part::Cell { date, offset } => self.cell_attrs_for(&date, offset),
+            Part::CellTrigger { date, offset } => self.cell_trigger_attrs_for(&date, offset),
+        }
+    }
+}

--- a/crates/ars-components/src/date_time/range_calendar/mod.rs
+++ b/crates/ars-components/src/date_time/range_calendar/mod.rs
@@ -1076,7 +1076,30 @@ fn sync_props_into_ctx(ctx: &mut Context, props: &Props) {
 
     ctx.focused_date = ctx.clamp_date(ctx.focused_date.clone());
 
+    revalidate_pending_selection(ctx);
     ctx.sync_visible_to_focused();
+}
+
+fn revalidate_pending_selection(ctx: &mut Context) {
+    let anchor_still_selectable = ctx
+        .anchor_date
+        .as_ref()
+        .is_some_and(|date| !ctx.is_date_disabled(date) && !ctx.is_date_unavailable(date));
+
+    if !anchor_still_selectable {
+        ctx.anchor_date = None;
+        ctx.hovering_date = None;
+
+        return;
+    }
+
+    if ctx
+        .hovering_date
+        .as_ref()
+        .is_some_and(|date| ctx.is_date_disabled(date) || ctx.is_date_unavailable(date))
+    {
+        ctx.hovering_date = None;
+    }
 }
 
 fn apply_select_date(ctx: &Context, date: CalendarDate) -> Option<TransitionPlan<Machine>> {
@@ -1086,7 +1109,7 @@ fn apply_select_date(ctx: &Context, date: CalendarDate) -> Option<TransitionPlan
 
     if let Some(anchor) = &ctx.anchor_date {
         let range = DateRange::normalized(anchor.clone(), date.clone())?;
-        if !ctx.range_is_allowed(&range) {
+        if !range_is_selectable(ctx, &range) {
             let focused = date;
 
             return Some(
@@ -1122,6 +1145,48 @@ fn apply_select_date(ctx: &Context, date: CalendarDate) -> Option<TransitionPlan
                 .with_effect(ars_core::PendingEffect::named(Effect::AnnounceRangeStart)),
         )
     }
+}
+
+fn range_is_selectable(ctx: &Context, range: &DateRange) -> bool {
+    if !ctx.range_is_allowed(range) {
+        return false;
+    }
+
+    if ctx.is_date_disabled(&range.start) || ctx.is_date_disabled(&range.end) {
+        return false;
+    }
+
+    if ctx.is_date_unavailable_fn.is_none() {
+        return true;
+    }
+
+    range_dates_all(ctx, range, |ctx, date| !ctx.is_date_unavailable(date))
+}
+
+fn range_dates_all(
+    ctx: &Context,
+    range: &DateRange,
+    mut predicate: impl FnMut(&Context, &CalendarDate) -> bool,
+) -> bool {
+    let Some(days) = inclusive_range_days(range) else {
+        return false;
+    };
+
+    for offset in 0..days {
+        let Ok(offset) = i32::try_from(offset) else {
+            return false;
+        };
+
+        let Ok(date) = range.start.add_days(offset) else {
+            return false;
+        };
+
+        if !predicate(ctx, &date) {
+            return false;
+        }
+    }
+
+    true
 }
 
 fn step_for_page_behavior(ctx: &Context) -> i32 {

--- a/crates/ars-components/src/date_time/range_calendar/mod.rs
+++ b/crates/ars-components/src/date_time/range_calendar/mod.rs
@@ -492,6 +492,9 @@ pub struct Context {
     /// Date marked as today.
     pub today: CalendarDate,
 
+    /// Static dates marked unavailable for the visible range.
+    pub unavailable_dates: Vec<CalendarDate>,
+
     /// Predicate marking dates unavailable.
     pub is_date_unavailable_fn: Option<IsDateUnavailableFn>,
 
@@ -536,6 +539,7 @@ impl Debug for Context {
             .field("readonly", &self.readonly)
             .field("show_week_numbers", &self.show_week_numbers)
             .field("today", &self.today)
+            .field("unavailable_dates", &self.unavailable_dates)
             .field(
                 "is_date_unavailable_fn",
                 &self.is_date_unavailable_fn.as_ref().map(|_| "<callback>"),
@@ -577,6 +581,10 @@ impl Context {
     /// Whether `date` is marked unavailable.
     #[must_use]
     pub fn is_date_unavailable(&self, date: &CalendarDate) -> bool {
+        if self.unavailable_dates.contains(date) {
+            return true;
+        }
+
         self.is_date_unavailable_fn
             .as_ref()
             .is_some_and(|predicate| predicate(date))
@@ -898,6 +906,7 @@ impl ars_core::Machine for Machine {
             readonly: props.readonly,
             show_week_numbers: props.show_week_numbers,
             today: props.today.clone(),
+            unavailable_dates: Vec::new(),
             is_date_unavailable_fn: props.is_date_unavailable.clone(),
             allow_single_date_range: props.allow_single_date_range,
             min_range_days: props.min_range_days,
@@ -1696,7 +1705,8 @@ impl<'a> Api<'a> {
 
         let disabled = self.is_disabled(date);
         let unavailable = self.is_unavailable(date);
-        let focused = &self.ctx.focused_date == date;
+        let focused = &self.ctx.focused_date == date
+            && !offset.is_some_and(|offset| self.ctx.is_outside_month_at_offset(date, offset));
 
         attrs.set(HtmlAttr::TabIndex, if focused { "0" } else { "-1" });
 

--- a/crates/ars-components/src/date_time/range_calendar/snapshots/ars_components__date_time__range_calendar__tests__cell_anchor.snap
+++ b/crates/ars-components/src/date_time/range_calendar/snapshots/ars_components__date_time__range_calendar__tests__cell_anchor.snap
@@ -1,0 +1,31 @@
+---
+source: crates/ars-components/src/date_time/range_calendar/tests.rs
+expression: "snapshot_attrs(&api.cell_attrs(&date(2024, 1, 10)))"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "cell",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "range-calendar",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "gridcell",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/range_calendar/snapshots/ars_components__date_time__range_calendar__tests__cell_trigger_anchor.snap
+++ b/crates/ars-components/src/date_time/range_calendar/snapshots/ars_components__date_time__range_calendar__tests__cell_trigger_anchor.snap
@@ -1,0 +1,61 @@
+---
+source: crates/ars-components/src/date_time/range_calendar/tests.rs
+expression: "snapshot_attrs(&api.cell_trigger_attrs(&date(2024, 1, 10)))"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-anchor",
+            ),
+            Bool(
+                true,
+            ),
+        ),
+        (
+            Data(
+                "ars-in-hover-range",
+            ),
+            Bool(
+                true,
+            ),
+        ),
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "cell-trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "range-calendar",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "January 10, 2024, Wednesday",
+            ),
+        ),
+        (
+            TabIndex,
+            String(
+                "0",
+            ),
+        ),
+        (
+            Type,
+            String(
+                "button",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/range_calendar/snapshots/ars_components__date_time__range_calendar__tests__cell_trigger_disabled.snap
+++ b/crates/ars-components/src/date_time/range_calendar/snapshots/ars_components__date_time__range_calendar__tests__cell_trigger_disabled.snap
@@ -1,0 +1,59 @@
+---
+source: crates/ars-components/src/date_time/range_calendar/tests.rs
+expression: "snapshot_attrs(&api.cell_trigger_attrs(&date(2024, 1, 1)))"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "cell-trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "range-calendar",
+            ),
+        ),
+        (
+            Aria(
+                Disabled,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "January 1, 2024, Monday (disabled)",
+            ),
+        ),
+        (
+            TabIndex,
+            String(
+                "-1",
+            ),
+        ),
+        (
+            Disabled,
+            Bool(
+                true,
+            ),
+        ),
+        (
+            Type,
+            String(
+                "button",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/range_calendar/snapshots/ars_components__date_time__range_calendar__tests__cell_trigger_hover_range.snap
+++ b/crates/ars-components/src/date_time/range_calendar/snapshots/ars_components__date_time__range_calendar__tests__cell_trigger_hover_range.snap
@@ -1,0 +1,53 @@
+---
+source: crates/ars-components/src/date_time/range_calendar/tests.rs
+expression: "snapshot_attrs(&api.cell_trigger_attrs(&date(2024, 1, 11)))"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-in-hover-range",
+            ),
+            Bool(
+                true,
+            ),
+        ),
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "cell-trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "range-calendar",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "January 11, 2024, Thursday",
+            ),
+        ),
+        (
+            TabIndex,
+            String(
+                "-1",
+            ),
+        ),
+        (
+            Type,
+            String(
+                "button",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/range_calendar/snapshots/ars_components__date_time__range_calendar__tests__cell_trigger_in_range.snap
+++ b/crates/ars-components/src/date_time/range_calendar/snapshots/ars_components__date_time__range_calendar__tests__cell_trigger_in_range.snap
@@ -1,0 +1,61 @@
+---
+source: crates/ars-components/src/date_time/range_calendar/tests.rs
+expression: "snapshot_attrs(&api.cell_trigger_attrs(&date(2024, 1, 11)))"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-in-range",
+            ),
+            Bool(
+                true,
+            ),
+        ),
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "cell-trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "range-calendar",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "January 11, 2024, Thursday",
+            ),
+        ),
+        (
+            Aria(
+                Selected,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            TabIndex,
+            String(
+                "-1",
+            ),
+        ),
+        (
+            Type,
+            String(
+                "button",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/range_calendar/snapshots/ars_components__date_time__range_calendar__tests__cell_trigger_range_end.snap
+++ b/crates/ars-components/src/date_time/range_calendar/snapshots/ars_components__date_time__range_calendar__tests__cell_trigger_range_end.snap
@@ -1,0 +1,69 @@
+---
+source: crates/ars-components/src/date_time/range_calendar/tests.rs
+expression: "snapshot_attrs(&api.cell_trigger_attrs(&date(2024, 1, 12)))"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-in-range",
+            ),
+            Bool(
+                true,
+            ),
+        ),
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "cell-trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-range-end",
+            ),
+            Bool(
+                true,
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "range-calendar",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "January 12, 2024, Friday (range end)",
+            ),
+        ),
+        (
+            Aria(
+                Selected,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            TabIndex,
+            String(
+                "-1",
+            ),
+        ),
+        (
+            Type,
+            String(
+                "button",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/range_calendar/snapshots/ars_components__date_time__range_calendar__tests__cell_trigger_range_start.snap
+++ b/crates/ars-components/src/date_time/range_calendar/snapshots/ars_components__date_time__range_calendar__tests__cell_trigger_range_start.snap
@@ -1,0 +1,69 @@
+---
+source: crates/ars-components/src/date_time/range_calendar/tests.rs
+expression: "snapshot_attrs(&api.cell_trigger_attrs(&date(2024, 1, 10)))"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-in-range",
+            ),
+            Bool(
+                true,
+            ),
+        ),
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "cell-trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-range-start",
+            ),
+            Bool(
+                true,
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "range-calendar",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "January 10, 2024, Wednesday (range start)",
+            ),
+        ),
+        (
+            Aria(
+                Selected,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            TabIndex,
+            String(
+                "0",
+            ),
+        ),
+        (
+            Type,
+            String(
+                "button",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/range_calendar/snapshots/ars_components__date_time__range_calendar__tests__cell_trigger_today.snap
+++ b/crates/ars-components/src/date_time/range_calendar/snapshots/ars_components__date_time__range_calendar__tests__cell_trigger_today.snap
@@ -1,0 +1,53 @@
+---
+source: crates/ars-components/src/date_time/range_calendar/tests.rs
+expression: "snapshot_attrs(&api.cell_trigger_attrs(&date(2024, 1, 15)))"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "cell-trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "range-calendar",
+            ),
+        ),
+        (
+            Data(
+                "ars-today",
+            ),
+            Bool(
+                true,
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "January 15, 2024, Monday",
+            ),
+        ),
+        (
+            TabIndex,
+            String(
+                "-1",
+            ),
+        ),
+        (
+            Type,
+            String(
+                "button",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/range_calendar/snapshots/ars_components__date_time__range_calendar__tests__cell_trigger_unavailable.snap
+++ b/crates/ars-components/src/date_time/range_calendar/snapshots/ars_components__date_time__range_calendar__tests__cell_trigger_unavailable.snap
@@ -1,0 +1,61 @@
+---
+source: crates/ars-components/src/date_time/range_calendar/tests.rs
+expression: "snapshot_attrs(&api.cell_trigger_attrs(&date(2024, 1, 5)))"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "cell-trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "range-calendar",
+            ),
+        ),
+        (
+            Data(
+                "ars-unavailable",
+            ),
+            Bool(
+                true,
+            ),
+        ),
+        (
+            Aria(
+                Disabled,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "January 5, 2024, Friday (unavailable)",
+            ),
+        ),
+        (
+            TabIndex,
+            String(
+                "-1",
+            ),
+        ),
+        (
+            Type,
+            String(
+                "button",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/range_calendar/snapshots/ars_components__date_time__range_calendar__tests__grid.snap
+++ b/crates/ars-components/src/date_time/range_calendar/snapshots/ars_components__date_time__range_calendar__tests__grid.snap
@@ -1,0 +1,53 @@
+---
+source: crates/ars-components/src/date_time/range_calendar/tests.rs
+expression: snapshot_attrs(&api.grid_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "grid",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "range-calendar",
+            ),
+        ),
+        (
+            Aria(
+                LabelledBy,
+            ),
+            String(
+                "range-cal-heading",
+            ),
+        ),
+        (
+            Aria(
+                MultiSelectable,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "range-cal-grid",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "grid",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/range_calendar/snapshots/ars_components__date_time__range_calendar__tests__grid_group.snap
+++ b/crates/ars-components/src/date_time/range_calendar/snapshots/ars_components__date_time__range_calendar__tests__grid_group.snap
@@ -1,0 +1,45 @@
+---
+source: crates/ars-components/src/date_time/range_calendar/tests.rs
+expression: snapshot_attrs(&api.grid_group_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "grid-group",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "range-calendar",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "January 2024 – February 2024",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "range-cal-grid-group",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "group",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/range_calendar/snapshots/ars_components__date_time__range_calendar__tests__head_cell.snap
+++ b/crates/ars-components/src/date_time/range_calendar/snapshots/ars_components__date_time__range_calendar__tests__head_cell.snap
@@ -1,0 +1,37 @@
+---
+source: crates/ars-components/src/date_time/range_calendar/tests.rs
+expression: "snapshot_attrs(&api.head_cell_attrs(Weekday::Sunday))"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "head-cell",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "range-calendar",
+            ),
+        ),
+        (
+            Abbr,
+            String(
+                "Sunday",
+            ),
+        ),
+        (
+            Scope,
+            String(
+                "col",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/range_calendar/snapshots/ars_components__date_time__range_calendar__tests__head_row.snap
+++ b/crates/ars-components/src/date_time/range_calendar/snapshots/ars_components__date_time__range_calendar__tests__head_row.snap
@@ -1,0 +1,25 @@
+---
+source: crates/ars-components/src/date_time/range_calendar/tests.rs
+expression: snapshot_attrs(&api.head_row_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "head-row",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "range-calendar",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/range_calendar/snapshots/ars_components__date_time__range_calendar__tests__header.snap
+++ b/crates/ars-components/src/date_time/range_calendar/snapshots/ars_components__date_time__range_calendar__tests__header.snap
@@ -1,0 +1,31 @@
+---
+source: crates/ars-components/src/date_time/range_calendar/tests.rs
+expression: snapshot_attrs(&api.header_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "header",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "range-calendar",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "range-cal-header",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/range_calendar/snapshots/ars_components__date_time__range_calendar__tests__heading.snap
+++ b/crates/ars-components/src/date_time/range_calendar/snapshots/ars_components__date_time__range_calendar__tests__heading.snap
@@ -1,0 +1,47 @@
+---
+source: crates/ars-components/src/date_time/range_calendar/tests.rs
+expression: snapshot_attrs(&api.heading_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "heading",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "range-calendar",
+            ),
+        ),
+        (
+            Aria(
+                Atomic,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Aria(
+                Live,
+            ),
+            String(
+                "polite",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "range-cal-heading",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/range_calendar/snapshots/ars_components__date_time__range_calendar__tests__next_trigger.snap
+++ b/crates/ars-components/src/date_time/range_calendar/snapshots/ars_components__date_time__range_calendar__tests__next_trigger.snap
@@ -1,0 +1,51 @@
+---
+source: crates/ars-components/src/date_time/range_calendar/tests.rs
+expression: snapshot_attrs(&api.next_trigger_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "next-trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "range-calendar",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Next 2 months",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "range-cal-next-trigger",
+            ),
+        ),
+        (
+            TabIndex,
+            String(
+                "-1",
+            ),
+        ),
+        (
+            Type,
+            String(
+                "button",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/range_calendar/snapshots/ars_components__date_time__range_calendar__tests__prev_trigger.snap
+++ b/crates/ars-components/src/date_time/range_calendar/snapshots/ars_components__date_time__range_calendar__tests__prev_trigger.snap
@@ -1,0 +1,51 @@
+---
+source: crates/ars-components/src/date_time/range_calendar/tests.rs
+expression: snapshot_attrs(&api.prev_trigger_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "prev-trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "range-calendar",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Previous 2 months",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "range-cal-prev-trigger",
+            ),
+        ),
+        (
+            TabIndex,
+            String(
+                "-1",
+            ),
+        ),
+        (
+            Type,
+            String(
+                "button",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/range_calendar/snapshots/ars_components__date_time__range_calendar__tests__root_disabled_readonly_rtl.snap
+++ b/crates/ars-components/src/date_time/range_calendar/snapshots/ars_components__date_time__range_calendar__tests__root_disabled_readonly_rtl.snap
@@ -1,0 +1,61 @@
+---
+source: crates/ars-components/src/date_time/range_calendar/tests.rs
+expression: snapshot_attrs(&api.root_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-disabled",
+            ),
+            Bool(
+                true,
+            ),
+        ),
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-readonly",
+            ),
+            Bool(
+                true,
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "range-calendar",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "idle",
+            ),
+        ),
+        (
+            Dir,
+            String(
+                "rtl",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "range-cal",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/range_calendar/snapshots/ars_components__date_time__range_calendar__tests__root_idle.snap
+++ b/crates/ars-components/src/date_time/range_calendar/snapshots/ars_components__date_time__range_calendar__tests__root_idle.snap
@@ -1,0 +1,39 @@
+---
+source: crates/ars-components/src/date_time/range_calendar/tests.rs
+expression: snapshot_attrs(&api.root_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "range-calendar",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "idle",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "range-cal",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/range_calendar/snapshots/ars_components__date_time__range_calendar__tests__root_pending.snap
+++ b/crates/ars-components/src/date_time/range_calendar/snapshots/ars_components__date_time__range_calendar__tests__root_pending.snap
@@ -1,0 +1,47 @@
+---
+source: crates/ars-components/src/date_time/range_calendar/tests.rs
+expression: snapshot_attrs(&api.root_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-range-pending",
+            ),
+            Bool(
+                true,
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "range-calendar",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "focused",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "range-cal",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/range_calendar/snapshots/ars_components__date_time__range_calendar__tests__row.snap
+++ b/crates/ars-components/src/date_time/range_calendar/snapshots/ars_components__date_time__range_calendar__tests__row.snap
@@ -1,0 +1,33 @@
+---
+source: crates/ars-components/src/date_time/range_calendar/tests.rs
+expression: snapshot_attrs(&api.row_attrs(0))
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "row",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "range-calendar",
+            ),
+        ),
+        (
+            Data(
+                "ars-week-index",
+            ),
+            String(
+                "0",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/range_calendar/tests.rs
+++ b/crates/ars-components/src/date_time/range_calendar/tests.rs
@@ -183,6 +183,30 @@ fn same_day_range_label_preserves_start_and_end_suffixes() {
 }
 
 #[test]
+fn duplicate_outside_month_cell_does_not_share_roving_tab_stop() {
+    let svc = service_with(props().today(date(2024, 1, 31)).visible_months(2), en_us());
+
+    let api = svc.connect(&|_| {});
+
+    assert_eq!(
+        attr(
+            &api.cell_trigger_attrs_for(&date(2024, 1, 31), 0),
+            HtmlAttr::TabIndex,
+        )
+        .as_deref(),
+        Some("0"),
+    );
+    assert_eq!(
+        attr(
+            &api.cell_trigger_attrs_for(&date(2024, 1, 31), 1),
+            HtmlAttr::TabIndex,
+        )
+        .as_deref(),
+        Some("-1"),
+    );
+}
+
+#[test]
 fn keyboard_enter_and_space_follow_two_step_range_selection() {
     let mut svc = service();
 
@@ -249,6 +273,30 @@ fn min_max_and_unavailable_dates_block_selection() {
     }));
 
     assert_eq!(svc.context().anchor_date, None);
+}
+
+#[test]
+fn static_unavailable_dates_drive_context_and_trigger_attrs() {
+    let svc = service();
+    let mut ctx = svc.context().clone();
+
+    ctx.unavailable_dates = vec![date(2024, 1, 12)];
+
+    assert!(ctx.is_date_unavailable(&date(2024, 1, 12)));
+
+    let state = State::Idle;
+    let props = props();
+    let api = Api::new(&state, &ctx, &props, &|_| {});
+    let attrs = api.cell_trigger_attrs(&date(2024, 1, 12));
+
+    assert_eq!(
+        attr(&attrs, HtmlAttr::Aria(AriaAttr::Disabled)).as_deref(),
+        Some("true"),
+    );
+    assert_eq!(
+        attr(&attrs, HtmlAttr::Data("ars-unavailable")).as_deref(),
+        Some("true"),
+    );
 }
 
 #[test]

--- a/crates/ars-components/src/date_time/range_calendar/tests.rs
+++ b/crates/ars-components/src/date_time/range_calendar/tests.rs
@@ -477,6 +477,111 @@ fn invalid_external_ranges_are_ignored_on_init_and_sync() {
 }
 
 #[test]
+fn external_range_validation_covers_span_bounds_and_unavailable_branches() {
+    let unavailable = Callback::new_ref(|date: &CalendarDate| date.day() == 12);
+
+    let svc = service_with(
+        props()
+            .allow_single_date_range(false)
+            .value(Some(range(date(2024, 1, 10), date(2024, 1, 10)))),
+        en_us(),
+    );
+
+    assert_eq!(*svc.context().value.get(), None);
+
+    let svc = service_with(
+        props()
+            .min_range_days(Some(5))
+            .value(Some(range(date(2024, 1, 10), date(2024, 1, 11)))),
+        en_us(),
+    );
+
+    assert_eq!(*svc.context().value.get(), None);
+
+    let svc = service_with(
+        props()
+            .max(Some(date(2024, 1, 10)))
+            .value(Some(range(date(2024, 1, 11), date(2024, 1, 12)))),
+        en_us(),
+    );
+
+    assert_eq!(*svc.context().value.get(), None);
+
+    let svc = service_with(
+        props()
+            .is_date_unavailable(Some(unavailable.clone()))
+            .value(Some(range(date(2024, 1, 10), date(2024, 1, 13)))),
+        en_us(),
+    );
+
+    assert_eq!(*svc.context().value.get(), None);
+
+    let svc = service_with(
+        props()
+            .is_date_unavailable(Some(unavailable))
+            .value(Some(range(date(2024, 1, 10), date(2024, 1, 11)))),
+        en_us(),
+    );
+
+    assert_eq!(
+        *svc.context().value.get(),
+        Some(range(date(2024, 1, 10), date(2024, 1, 11))),
+    );
+}
+
+#[test]
+fn prop_sync_revalidates_uncontrolled_value_and_pending_hover() {
+    let mut svc = service_with(
+        props().default_value(Some(range(date(2024, 1, 10), date(2024, 1, 15)))),
+        en_us(),
+    );
+
+    drop(svc.set_props(props().max(Some(date(2024, 1, 12)))));
+
+    assert_eq!(*svc.context().value.get(), None);
+
+    let mut svc = service();
+
+    drop(svc.send(Event::SelectDate {
+        date: date(2024, 1, 10),
+    }));
+    drop(svc.send(Event::HoverDate {
+        date: date(2024, 1, 20),
+    }));
+    drop(svc.set_props(props().max(Some(date(2024, 1, 15)))));
+
+    assert_eq!(svc.context().anchor_date, Some(date(2024, 1, 10)));
+    assert_eq!(svc.context().hovering_date, None);
+}
+
+#[test]
+fn current_value_revalidation_can_clear_controlled_static_unavailable_range() {
+    let mut ctx = service_with(
+        props().value(Some(range(date(2024, 1, 10), date(2024, 1, 12)))),
+        en_us(),
+    )
+    .context()
+    .clone();
+
+    ctx.unavailable_dates = vec![date(2024, 1, 11)];
+
+    revalidate_current_value(&mut ctx);
+
+    assert_eq!(*ctx.value.get(), None);
+}
+
+#[test]
+fn context_range_validation_rejects_bound_violating_endpoints() {
+    let svc = service_with(props().min(Some(date(2024, 1, 10))), en_us());
+    let ctx = svc.context();
+
+    assert!(!range_is_selectable(
+        ctx,
+        &range(date(2024, 1, 5), date(2024, 1, 12)),
+    ));
+}
+
+#[test]
 fn constraint_sync_clears_pending_anchor_and_hover_when_anchor_becomes_invalid() {
     let mut svc = service();
 

--- a/crates/ars-components/src/date_time/range_calendar/tests.rs
+++ b/crates/ars-components/src/date_time/range_calendar/tests.rs
@@ -221,6 +221,31 @@ fn min_max_and_unavailable_dates_block_selection() {
 }
 
 #[test]
+fn unavailable_dates_inside_pending_range_block_completion() {
+    let unavailable = Callback::new_ref(|date: &CalendarDate| date.day() == 12);
+    let mut svc = service_with(props().is_date_unavailable(Some(unavailable)), en_us());
+
+    drop(svc.send(Event::SelectDate {
+        date: date(2024, 1, 10),
+    }));
+    drop(svc.send(Event::SelectDate {
+        date: date(2024, 1, 15),
+    }));
+
+    assert_eq!(*svc.context().value.get(), None);
+    assert_eq!(svc.context().anchor_date, Some(date(2024, 1, 10)));
+
+    drop(svc.send(Event::SelectDate {
+        date: date(2024, 1, 11),
+    }));
+
+    assert_eq!(
+        *svc.context().value.get(),
+        Some(range(date(2024, 1, 10), date(2024, 1, 11))),
+    );
+}
+
+#[test]
 fn range_span_constraints_keep_anchor_pending_when_invalid() {
     let mut svc = service_with(props().max_range_days(Some(3)), en_us());
 
@@ -290,6 +315,44 @@ fn controlled_value_sync_preserves_pending_anchor() {
         *svc.context().value.get(),
         Some(range(date(2024, 1, 3), date(2024, 1, 4))),
     );
+}
+
+#[test]
+fn constraint_sync_clears_pending_anchor_and_hover_when_anchor_becomes_invalid() {
+    let mut svc = service();
+
+    drop(svc.send(Event::SelectDate {
+        date: date(2024, 1, 10),
+    }));
+    drop(svc.send(Event::HoverDate {
+        date: date(2024, 1, 12),
+    }));
+    drop(svc.set_props(props().min(Some(date(2024, 1, 15)))));
+
+    assert_eq!(svc.context().anchor_date, None);
+    assert_eq!(svc.context().hovering_date, None);
+
+    drop(svc.send(Event::SelectDate {
+        date: date(2024, 1, 16),
+    }));
+
+    assert_eq!(*svc.context().value.get(), None);
+    assert_eq!(svc.context().anchor_date, Some(date(2024, 1, 16)));
+}
+
+#[test]
+fn unavailable_sync_clears_pending_anchor_when_predicate_rejects_it() {
+    let mut svc = service();
+
+    drop(svc.send(Event::SelectDate {
+        date: date(2024, 1, 10),
+    }));
+
+    let unavailable = Callback::new_ref(|date: &CalendarDate| date.day() == 10);
+    drop(svc.set_props(props().is_date_unavailable(Some(unavailable))));
+
+    assert_eq!(svc.context().anchor_date, None);
+    assert_eq!(svc.context().hovering_date, None);
 }
 
 #[test]

--- a/crates/ars-components/src/date_time/range_calendar/tests.rs
+++ b/crates/ars-components/src/date_time/range_calendar/tests.rs
@@ -300,6 +300,17 @@ fn static_unavailable_dates_drive_context_and_trigger_attrs() {
 }
 
 #[test]
+fn static_unavailable_dates_inside_range_block_validation() {
+    let svc = service();
+    let mut ctx = svc.context().clone();
+    let blocked = range(date(2024, 1, 10), date(2024, 1, 15));
+
+    ctx.unavailable_dates = vec![date(2024, 1, 12)];
+
+    assert!(!range_is_selectable(&ctx, &blocked));
+}
+
+#[test]
 fn unavailable_dates_inside_pending_range_block_completion() {
     let unavailable = Callback::new_ref(|date: &CalendarDate| date.day() == 12);
     let mut svc = service_with(props().is_date_unavailable(Some(unavailable)), en_us());

--- a/crates/ars-components/src/date_time/range_calendar/tests.rs
+++ b/crates/ars-components/src/date_time/range_calendar/tests.rs
@@ -2,7 +2,12 @@
 
 use alloc::{format, string::String, sync::Arc};
 
-use ars_core::{AriaAttr, AttrMap, Callback, ComponentPart, Env, HtmlAttr, KeyboardKey, Service};
+use std::sync::Mutex;
+
+use ars_core::{
+    AriaAttr, AttrMap, Callback, ComponentPart, ConnectApi, Env, HtmlAttr, KeyboardKey, MessageFn,
+    Service,
+};
 use ars_i18n::{
     CalendarDate, DateRange, Locale, StubIntlBackend, Weekday,
     locales::{en_gb, en_us, fa},
@@ -168,6 +173,75 @@ fn grid_attrs_mark_range_selection_as_multiselectable() {
 }
 
 #[test]
+fn range_messages_debug_and_announcement_labels_are_exercised() {
+    let messages = Messages::default();
+
+    assert_eq!(
+        (messages.range_start_label)("January 10, 2024", &en_us()),
+        "Selected January 10, 2024 as range start. Select an end date.",
+    );
+    assert_eq!(
+        (messages.range_complete_label)("January 10, 2024", "January 12, 2024", &en_us()),
+        "Selected January 10, 2024 to January 12, 2024",
+    );
+    assert!(format!("{messages:?}").contains("Messages"));
+    assert_eq!(messages, messages.clone());
+}
+
+#[test]
+fn range_messages_partial_eq_covers_mismatched_fields() {
+    let messages = Messages::default();
+
+    let mut other = messages.clone();
+    other.prev_month_label = MessageFn::static_str("Prev");
+    assert_ne!(messages, other);
+
+    let mut other = messages.clone();
+    other.next_month_label = MessageFn::static_str("Next");
+    assert_ne!(messages, other);
+
+    let mut other = messages.clone();
+    other.prev_page_label =
+        MessageFn::new(|count: usize, _locale: &Locale| format!("Back {count}"));
+    assert_ne!(messages, other);
+
+    let mut other = messages.clone();
+    other.next_page_label =
+        MessageFn::new(|count: usize, _locale: &Locale| format!("Forward {count}"));
+    assert_ne!(messages, other);
+
+    let mut other = messages.clone();
+    other.month_range_separator = MessageFn::static_str(" to ");
+    assert_ne!(messages, other);
+
+    let mut other = messages.clone();
+    other.unavailable_suffix = MessageFn::static_str("not available");
+    assert_ne!(messages, other);
+
+    let mut other = messages.clone();
+    other.disabled_suffix = MessageFn::static_str("not allowed");
+    assert_ne!(messages, other);
+
+    let mut other = messages.clone();
+    other.range_start_suffix = MessageFn::static_str("start");
+    assert_ne!(messages, other);
+
+    let mut other = messages.clone();
+    other.range_end_suffix = MessageFn::static_str("end");
+    assert_ne!(messages, other);
+
+    let mut other = messages.clone();
+    other.range_start_label =
+        MessageFn::new(|start: &str, _locale: &Locale| format!("Start {start}"));
+    assert_ne!(messages, other);
+
+    let mut other = messages.clone();
+    other.range_complete_label =
+        MessageFn::new(|start: &str, end: &str, _locale: &Locale| format!("{start} through {end}"));
+    assert_ne!(messages, other);
+}
+
+#[test]
 fn api_exposes_offset_specific_outside_month_helper() {
     let svc = service_with(props().visible_months(2), en_us());
 
@@ -176,6 +250,101 @@ fn api_exposes_offset_specific_outside_month_helper() {
     assert!(!api.is_outside_month_for(&date(2024, 1, 15), 0));
     assert!(api.is_outside_month_for(&date(2024, 1, 15), 1));
     assert!(!api.is_outside_month_for(&date(2024, 2, 15), 1));
+}
+
+#[test]
+fn offset_cell_attrs_and_nav_disabled_branches_are_covered() {
+    let svc = service();
+    let api = svc.connect(&|_| {});
+
+    let outside = api.cell_attrs_for(&date(2023, 12, 31), 0);
+    assert_eq!(
+        attr(&outside, HtmlAttr::Data("ars-outside-month")).as_deref(),
+        Some("true"),
+    );
+
+    let inside = api.cell_attrs_for(&date(2024, 1, 15), 0);
+    assert!(inside.get(&HtmlAttr::Data("ars-outside-month")).is_none());
+
+    let disabled = service_with(props().disabled(true), en_us());
+    let api = disabled.connect(&|_| {});
+    assert!(api.is_prev_disabled());
+    assert!(api.is_next_disabled());
+
+    let min_limited = service_with(props().min(Some(date(2024, 2, 1))), en_us());
+    let api = min_limited.connect(&|_| {});
+    assert!(api.is_prev_disabled());
+
+    let min_allowed = service_with(props().min(Some(date(2023, 1, 1))), en_us());
+    let api = min_allowed.connect(&|_| {});
+    assert!(!api.is_prev_disabled());
+
+    let max_limited = service_with(props().max(Some(date(2024, 1, 31))), en_us());
+    let api = max_limited.connect(&|_| {});
+    assert!(api.is_next_disabled());
+
+    let max_allowed = service_with(props().max(Some(date(2025, 12, 31))), en_us());
+    let api = max_allowed.connect(&|_| {});
+    assert!(!api.is_next_disabled());
+
+    let single_step = service_with(props().page_behavior(PageBehavior::Single), en_us());
+    let api = single_step.connect(&|_| {});
+    assert_eq!(
+        attr(&api.prev_trigger_attrs(), HtmlAttr::Aria(AriaAttr::Label)).as_deref(),
+        Some("Previous month"),
+    );
+}
+
+#[test]
+fn disabled_readonly_and_single_month_attrs_cover_remaining_branches() {
+    let svc = service_with(
+        props()
+            .disabled(true)
+            .readonly(true)
+            .visible_months(1)
+            .page_behavior(PageBehavior::Single),
+        en_us(),
+    );
+    let api = svc.connect(&|_| {});
+
+    assert_eq!(api.range_heading_text(), api.heading_text());
+
+    let grid = api.grid_attrs_for(0);
+    assert_eq!(
+        attr(&grid, HtmlAttr::Aria(AriaAttr::ReadOnly)).as_deref(),
+        Some("true"),
+    );
+    assert_eq!(
+        attr(&grid, HtmlAttr::Aria(AriaAttr::Disabled)).as_deref(),
+        Some("true"),
+    );
+
+    let prev = api.prev_trigger_attrs();
+    assert_eq!(attr(&prev, HtmlAttr::Disabled).as_deref(), Some("true"));
+    assert_eq!(
+        attr(&prev, HtmlAttr::Aria(AriaAttr::Disabled)).as_deref(),
+        Some("true"),
+    );
+
+    let next = api.next_trigger_attrs();
+    assert_eq!(
+        attr(&next, HtmlAttr::Aria(AriaAttr::Label)).as_deref(),
+        Some("Next month"),
+    );
+    assert_eq!(attr(&next, HtmlAttr::Disabled).as_deref(), Some("true"));
+
+    let cell = api.cell_attrs(&date(2024, 1, 15));
+    assert_eq!(
+        attr(&cell, HtmlAttr::Aria(AriaAttr::Disabled)).as_deref(),
+        Some("true"),
+    );
+
+    let outside = api.cell_attrs(&date(2023, 12, 31));
+    assert_eq!(
+        attr(&outside, HtmlAttr::Data("ars-outside-month")).as_deref(),
+        Some("true"),
+    );
+    assert!(api.is_disabled(&date(2024, 1, 15)));
 }
 
 #[test]
@@ -239,6 +408,239 @@ fn keyboard_enter_and_space_follow_two_step_range_selection() {
         *svc.context().value.get(),
         Some(range(date(2024, 1, 15), date(2024, 1, 16))),
     );
+}
+
+#[test]
+fn hover_events_are_noops_when_readonly_without_anchor_or_without_hover() {
+    let mut svc = service_with(props().readonly(true), en_us());
+
+    drop(svc.send(Event::HoverDate {
+        date: date(2024, 1, 12),
+    }));
+
+    assert_eq!(svc.context().hovering_date, None);
+
+    let mut svc = service();
+
+    drop(svc.send(Event::HoverDate {
+        date: date(2024, 1, 12),
+    }));
+    drop(svc.send(Event::HoverEnd));
+
+    assert_eq!(svc.context().hovering_date, None);
+}
+
+#[test]
+fn readonly_selection_and_unavailable_hover_sync_branches_are_covered() {
+    let mut svc = service_with(props().readonly(true), en_us());
+
+    drop(svc.send(Event::SelectDate {
+        date: date(2024, 1, 12),
+    }));
+
+    assert_eq!(svc.context().anchor_date, None);
+
+    let unavailable = Callback::new_ref(|date: &CalendarDate| date.day() == 12);
+    let mut svc = service();
+
+    drop(svc.send(Event::SelectDate {
+        date: date(2024, 1, 10),
+    }));
+    drop(svc.send(Event::HoverDate {
+        date: date(2024, 1, 12),
+    }));
+    drop(svc.set_props(props().is_date_unavailable(Some(unavailable))));
+
+    assert_eq!(svc.context().anchor_date, Some(date(2024, 1, 10)));
+    assert_eq!(svc.context().hovering_date, None);
+}
+
+#[test]
+fn direct_navigation_events_and_set_month_year_update_focus() {
+    let mut svc = service();
+
+    drop(svc.send(Event::NextMonth));
+    assert_eq!(svc.context().visible_month, 3);
+
+    drop(svc.send(Event::PrevMonth));
+    assert_eq!(svc.context().visible_month, 1);
+
+    drop(svc.send(Event::NextYear));
+    assert_eq!(svc.context().visible_year, 2025);
+
+    drop(svc.send(Event::PrevYear));
+    assert_eq!(svc.context().visible_year, 2024);
+
+    drop(svc.send(Event::SetMonth { month: 2 }));
+    assert_eq!(svc.context().visible_month, 2);
+
+    drop(svc.send(Event::SetMonth { month: 13 }));
+    assert_eq!(svc.context().visible_month, 2);
+
+    drop(svc.send(Event::SetYear { year: 2026 }));
+    assert_eq!(svc.context().visible_year, 2026);
+}
+
+#[test]
+fn focus_events_and_single_page_navigation_branches_are_covered() {
+    let mut svc = service_with(props().page_behavior(PageBehavior::Single), en_us());
+
+    drop(svc.send(Event::FocusIn));
+    assert_eq!(*svc.state(), State::Focused);
+
+    drop(svc.send(Event::FocusDate {
+        date: date(2024, 1, 20),
+    }));
+    assert_eq!(svc.context().focused_date, date(2024, 1, 20));
+
+    drop(svc.send(Event::NextMonth));
+    assert_eq!(svc.context().visible_month, 2);
+
+    drop(svc.send(Event::PrevMonth));
+    assert_eq!(svc.context().visible_month, 1);
+
+    drop(svc.send(Event::FocusOut));
+    assert_eq!(*svc.state(), State::Idle);
+
+    let mut disabled = service_with(props().disabled(true), en_us());
+    drop(disabled.send(Event::FocusIn));
+    assert_eq!(*disabled.state(), State::Idle);
+}
+
+#[test]
+fn keyboard_navigation_covers_calendar_movement_branches() {
+    let mut svc = service();
+
+    drop(svc.send(Event::KeyDown {
+        key: KeyboardKey::ArrowLeft,
+        shift: false,
+    }));
+    assert_eq!(svc.context().focused_date, date(2024, 1, 14));
+
+    drop(svc.send(Event::KeyDown {
+        key: KeyboardKey::ArrowUp,
+        shift: false,
+    }));
+    assert_eq!(svc.context().focused_date, date(2024, 1, 7));
+
+    drop(svc.send(Event::KeyDown {
+        key: KeyboardKey::ArrowDown,
+        shift: false,
+    }));
+    assert_eq!(svc.context().focused_date, date(2024, 1, 14));
+
+    drop(svc.send(Event::KeyDown {
+        key: KeyboardKey::Home,
+        shift: false,
+    }));
+    assert_eq!(svc.context().focused_date, date(2024, 1, 14));
+
+    drop(svc.send(Event::KeyDown {
+        key: KeyboardKey::End,
+        shift: false,
+    }));
+    assert_eq!(svc.context().focused_date, date(2024, 1, 20));
+
+    drop(svc.send(Event::KeyDown {
+        key: KeyboardKey::PageUp,
+        shift: false,
+    }));
+    assert_eq!(svc.context().focused_date, date(2023, 12, 20));
+
+    drop(svc.send(Event::KeyDown {
+        key: KeyboardKey::PageDown,
+        shift: false,
+    }));
+    assert_eq!(svc.context().focused_date, date(2024, 1, 20));
+
+    drop(svc.send(Event::KeyDown {
+        key: KeyboardKey::ArrowRight,
+        shift: false,
+    }));
+    assert_eq!(svc.context().focused_date, date(2024, 1, 21));
+
+    drop(svc.send(Event::KeyDown {
+        key: KeyboardKey::Escape,
+        shift: true,
+    }));
+    assert_eq!(svc.context().focused_date, date(2024, 1, 21));
+}
+
+#[test]
+fn api_accessors_part_dispatch_and_event_helpers_are_covered() {
+    let mut svc = service_with(props().show_week_numbers(true), en_us());
+    drop(svc.send(Event::FocusIn));
+    drop(svc.send(Event::SelectDate {
+        date: date(2024, 1, 10),
+    }));
+    drop(svc.send(Event::HoverDate {
+        date: date(2024, 1, 12),
+    }));
+
+    let sent = Arc::new(Mutex::new(Vec::new()));
+    let captured = Arc::clone(&sent);
+    let send = move |event| captured.lock().expect("events lock").push(event);
+    let api = svc.connect(&send);
+
+    assert!(format!("{api:?}").contains("Api"));
+    assert_eq!(api.today(), &date(2024, 1, 15));
+    assert_eq!(api.focused_date(), &date(2024, 1, 10));
+    assert!(api.is_focused());
+    assert_eq!(api.visible_month_count(), 2);
+    assert_eq!(api.month_offsets().collect::<Vec<_>>(), vec![0, 1]);
+    assert!(api.show_week_numbers());
+    assert_eq!(api.weeks().len(), 6);
+    assert_eq!(api.weeks_for(1).len(), 6);
+    assert_eq!(api.week_day_labels().len(), 7);
+    assert!(format!("{:?}", svc.context()).contains("Context"));
+
+    let parts = [
+        Part::Root,
+        Part::Header,
+        Part::PrevTrigger,
+        Part::NextTrigger,
+        Part::Heading,
+        Part::Grid,
+        Part::GridGroup,
+        Part::HeadRow,
+        Part::HeadCell {
+            day: Weekday::Monday,
+        },
+        Part::Row { week_index: 0 },
+        Part::Cell {
+            date: date(2024, 1, 10),
+            offset: 0,
+        },
+        Part::CellTrigger {
+            date: date(2024, 1, 10),
+            offset: 0,
+        },
+    ];
+
+    for part in parts {
+        assert!(!ConnectApi::part_attrs(&api, part).attrs().is_empty());
+    }
+
+    api.on_cell_click(date(2024, 1, 11));
+    api.on_cell_hover(date(2024, 1, 12));
+    api.on_grid_mouseleave();
+    api.on_grid_focusin();
+    api.on_grid_focusout(false);
+    api.on_grid_focusout(true);
+    api.on_grid_keydown(KeyboardKey::Enter, false);
+    api.on_prev_click();
+    api.on_next_click();
+
+    let sent = sent.lock().expect("events lock");
+    assert_eq!(sent.len(), 8);
+    assert!(matches!(sent[0], Event::SelectDate { .. }));
+    assert!(matches!(sent[1], Event::HoverDate { .. }));
+    assert_eq!(sent[2], Event::HoverEnd);
+    assert_eq!(sent[3], Event::FocusIn);
+    assert_eq!(sent[4], Event::FocusOut);
+    assert!(matches!(sent[5], Event::KeyDown { .. }));
+    assert_eq!(sent[6], Event::PrevMonth);
+    assert_eq!(sent[7], Event::NextMonth);
 }
 
 #[test]

--- a/crates/ars-components/src/date_time/range_calendar/tests.rs
+++ b/crates/ars-components/src/date_time/range_calendar/tests.rs
@@ -44,6 +44,11 @@ fn attr(attrs: &AttrMap, key: HtmlAttr) -> Option<String> {
 }
 
 #[test]
+fn default_today_matches_spec_contract() {
+    assert_eq!(Props::default().today, date(2024, 1, 1));
+}
+
+#[test]
 fn first_click_sets_anchor_and_second_click_completes_range() {
     let mut svc = service();
 
@@ -149,6 +154,32 @@ fn grid_attrs_mark_range_selection_as_multiselectable() {
         attr(&api.grid_group_attrs(), HtmlAttr::Role).as_deref(),
         Some("group"),
     );
+}
+
+#[test]
+fn api_exposes_offset_specific_outside_month_helper() {
+    let svc = service_with(props().visible_months(2), en_us());
+
+    let api = svc.connect(&|_| {});
+
+    assert!(!api.is_outside_month_for(&date(2024, 1, 15), 0));
+    assert!(api.is_outside_month_for(&date(2024, 1, 15), 1));
+    assert!(!api.is_outside_month_for(&date(2024, 2, 15), 1));
+}
+
+#[test]
+fn same_day_range_label_preserves_start_and_end_suffixes() {
+    let svc = service_with(
+        props().value(Some(range(date(2024, 1, 10), date(2024, 1, 10)))),
+        en_us(),
+    );
+
+    let api = svc.connect(&|_| {});
+    let attrs = api.cell_trigger_attrs(&date(2024, 1, 10));
+    let label = attr(&attrs, HtmlAttr::Aria(AriaAttr::Label)).expect("cell label");
+
+    assert!(label.contains("(range start)"), "{label}");
+    assert!(label.contains("(range end)"), "{label}");
 }
 
 #[test]

--- a/crates/ars-components/src/date_time/range_calendar/tests.rs
+++ b/crates/ars-components/src/date_time/range_calendar/tests.rs
@@ -49,6 +49,17 @@ fn default_today_matches_spec_contract() {
 }
 
 #[test]
+fn zero_visible_months_falls_back_to_two_month_default() {
+    let mut svc = service_with(props().visible_months(0), en_us());
+
+    assert_eq!(svc.context().visible_months, 2);
+
+    drop(svc.set_props(props().visible_months(0)));
+
+    assert_eq!(svc.context().visible_months, 2);
+}
+
+#[test]
 fn first_click_sets_anchor_and_second_click_completes_range() {
     let mut svc = service();
 
@@ -405,6 +416,64 @@ fn controlled_value_sync_preserves_pending_anchor() {
         *svc.context().value.get(),
         Some(range(date(2024, 1, 3), date(2024, 1, 4))),
     );
+}
+
+#[test]
+fn controlled_first_click_hides_stale_confirmed_range_attrs() {
+    let mut svc = service_with(
+        props().value(Some(range(date(2024, 1, 1), date(2024, 1, 3)))),
+        en_us(),
+    );
+
+    drop(svc.send(Event::SelectDate {
+        date: date(2024, 1, 10),
+    }));
+
+    let api = svc.connect(&|_| {});
+    let stale_attrs = api.cell_attrs(&date(2024, 1, 2));
+
+    assert!(
+        stale_attrs
+            .get(&HtmlAttr::Aria(AriaAttr::Selected))
+            .is_none()
+    );
+    assert!(!svc.context().is_in_range(&date(2024, 1, 2)));
+}
+
+#[test]
+fn invalid_external_ranges_are_ignored_on_init_and_sync() {
+    let invalid = range(date(2024, 1, 1), date(2024, 1, 3));
+    let valid = range(date(2024, 1, 10), date(2024, 1, 11));
+
+    let svc = service_with(
+        props()
+            .min(Some(date(2024, 1, 10)))
+            .value(Some(invalid.clone())),
+        en_us(),
+    );
+
+    assert_eq!(*svc.context().value.get(), None);
+
+    let svc = service_with(
+        props().max_range_days(Some(2)).default_value(Some(invalid)),
+        en_us(),
+    );
+
+    assert_eq!(*svc.context().value.get(), None);
+
+    let mut svc = service_with(props().value(Some(valid.clone())), en_us());
+
+    assert_eq!(*svc.context().value.get(), Some(valid));
+
+    drop(
+        svc.set_props(
+            props()
+                .max_range_days(Some(2))
+                .value(Some(range(date(2024, 1, 10), date(2024, 1, 15)))),
+        ),
+    );
+
+    assert_eq!(*svc.context().value.get(), None);
 }
 
 #[test]

--- a/crates/ars-components/src/date_time/range_calendar/tests.rs
+++ b/crates/ars-components/src/date_time/range_calendar/tests.rs
@@ -1,7 +1,6 @@
 //! Unit and snapshot tests for the `RangeCalendar` component.
 
 use alloc::{format, string::String, sync::Arc};
-
 use std::sync::Mutex;
 
 use ars_core::{

--- a/crates/ars-components/src/date_time/range_calendar/tests.rs
+++ b/crates/ars-components/src/date_time/range_calendar/tests.rs
@@ -1,0 +1,470 @@
+//! Unit and snapshot tests for the `RangeCalendar` component.
+
+use alloc::{format, string::String, sync::Arc};
+
+use ars_core::{AriaAttr, AttrMap, Callback, ComponentPart, Env, HtmlAttr, KeyboardKey, Service};
+use ars_i18n::{
+    CalendarDate, DateRange, Locale, StubIntlBackend, Weekday,
+    locales::{en_gb, en_us, fa},
+};
+use insta::assert_snapshot;
+
+use super::*;
+
+fn date(year: i32, month: u8, day: u8) -> CalendarDate {
+    CalendarDate::new_gregorian(year, month, day).expect("valid test date")
+}
+
+fn range(start: CalendarDate, end: CalendarDate) -> DateRange {
+    DateRange::new(start, end).expect("valid test range")
+}
+
+fn props() -> Props {
+    Props::new().id("range-cal").today(date(2024, 1, 15))
+}
+
+fn env(locale: Locale) -> Env {
+    Env::new(locale, Arc::new(StubIntlBackend))
+}
+
+fn service() -> Service<Machine> {
+    Service::<Machine>::new(props(), &env(en_us()), &Messages::default())
+}
+
+fn service_with(props: Props, locale: Locale) -> Service<Machine> {
+    Service::<Machine>::new(props, &env(locale), &Messages::default())
+}
+
+fn snapshot_attrs(attrs: &AttrMap) -> String {
+    format!("{attrs:#?}")
+}
+
+fn attr(attrs: &AttrMap, key: HtmlAttr) -> Option<String> {
+    attrs.get(&key).map(ToString::to_string)
+}
+
+#[test]
+fn first_click_sets_anchor_and_second_click_completes_range() {
+    let mut svc = service();
+
+    drop(svc.send(Event::SelectDate {
+        date: date(2024, 1, 10),
+    }));
+
+    assert_eq!(svc.context().anchor_date, Some(date(2024, 1, 10)));
+    assert_eq!(*svc.context().value.get(), None);
+
+    drop(svc.send(Event::SelectDate {
+        date: date(2024, 1, 15),
+    }));
+
+    assert_eq!(
+        *svc.context().value.get(),
+        Some(range(date(2024, 1, 10), date(2024, 1, 15))),
+    );
+    assert_eq!(svc.context().anchor_date, None);
+    assert_eq!(svc.context().hovering_date, None);
+}
+
+#[test]
+fn second_click_normalizes_reverse_order_range() {
+    let mut svc = service();
+
+    drop(svc.send(Event::SelectDate {
+        date: date(2024, 1, 20),
+    }));
+    drop(svc.send(Event::SelectDate {
+        date: date(2024, 1, 12),
+    }));
+
+    assert_eq!(
+        *svc.context().value.get(),
+        Some(range(date(2024, 1, 12), date(2024, 1, 20))),
+    );
+}
+
+#[test]
+fn hover_preview_sets_and_clears_hover_range_attributes() {
+    let mut svc = service();
+
+    drop(svc.send(Event::SelectDate {
+        date: date(2024, 1, 10),
+    }));
+    drop(svc.send(Event::HoverDate {
+        date: date(2024, 1, 13),
+    }));
+
+    let api = svc.connect(&|_| {});
+
+    let trigger = api.cell_trigger_attrs(&date(2024, 1, 12));
+
+    assert_eq!(
+        attr(&trigger, HtmlAttr::Data("ars-in-hover-range")).as_deref(),
+        Some("true"),
+    );
+
+    drop(svc.send(Event::HoverEnd));
+
+    let api = svc.connect(&|_| {});
+
+    let trigger = api.cell_trigger_attrs(&date(2024, 1, 12));
+
+    assert!(trigger.get(&HtmlAttr::Data("ars-in-hover-range")).is_none());
+}
+
+#[test]
+fn cells_in_confirmed_range_have_aria_selected() {
+    let svc = service_with(
+        props().value(Some(range(date(2024, 1, 10), date(2024, 1, 12)))),
+        en_us(),
+    );
+
+    let api = svc.connect(&|_| {});
+
+    for day in 10..=12 {
+        let attrs = api.cell_attrs(&date(2024, 1, day));
+
+        assert_eq!(
+            attr(&attrs, HtmlAttr::Aria(AriaAttr::Selected)).as_deref(),
+            Some("true"),
+        );
+    }
+}
+
+#[test]
+fn grid_attrs_mark_range_selection_as_multiselectable() {
+    let svc = service_with(props().visible_months(2), en_us());
+
+    let api = svc.connect(&|_| {});
+
+    assert_eq!(
+        attr(&api.grid_attrs(), HtmlAttr::Role).as_deref(),
+        Some("grid")
+    );
+    assert_eq!(
+        attr(&api.grid_attrs(), HtmlAttr::Aria(AriaAttr::MultiSelectable),).as_deref(),
+        Some("true"),
+    );
+    assert_eq!(
+        attr(&api.grid_group_attrs(), HtmlAttr::Role).as_deref(),
+        Some("group"),
+    );
+}
+
+#[test]
+fn keyboard_enter_and_space_follow_two_step_range_selection() {
+    let mut svc = service();
+
+    drop(svc.send(Event::FocusIn));
+    drop(svc.send(Event::KeyDown {
+        key: KeyboardKey::Enter,
+        shift: false,
+    }));
+    drop(svc.send(Event::KeyDown {
+        key: KeyboardKey::ArrowRight,
+        shift: false,
+    }));
+    drop(svc.send(Event::KeyDown {
+        key: KeyboardKey::Space,
+        shift: false,
+    }));
+
+    assert_eq!(
+        *svc.context().value.get(),
+        Some(range(date(2024, 1, 15), date(2024, 1, 16))),
+    );
+}
+
+#[test]
+fn shift_page_keys_navigate_years() {
+    let mut svc = service();
+
+    drop(svc.send(Event::FocusIn));
+    drop(svc.send(Event::KeyDown {
+        key: KeyboardKey::PageDown,
+        shift: true,
+    }));
+
+    assert_eq!(svc.context().visible_year, 2025);
+
+    drop(svc.send(Event::KeyDown {
+        key: KeyboardKey::PageUp,
+        shift: true,
+    }));
+
+    assert_eq!(svc.context().visible_year, 2024);
+}
+
+#[test]
+fn min_max_and_unavailable_dates_block_selection() {
+    let unavailable = Callback::new_ref(|date: &CalendarDate| date.day() == 12);
+
+    let mut svc = service_with(
+        props()
+            .min(Some(date(2024, 1, 10)))
+            .max(Some(date(2024, 1, 20)))
+            .is_date_unavailable(Some(unavailable)),
+        en_us(),
+    );
+
+    drop(svc.send(Event::SelectDate {
+        date: date(2024, 1, 5),
+    }));
+
+    assert_eq!(svc.context().anchor_date, None);
+
+    drop(svc.send(Event::SelectDate {
+        date: date(2024, 1, 12),
+    }));
+
+    assert_eq!(svc.context().anchor_date, None);
+}
+
+#[test]
+fn range_span_constraints_keep_anchor_pending_when_invalid() {
+    let mut svc = service_with(props().max_range_days(Some(3)), en_us());
+
+    drop(svc.send(Event::SelectDate {
+        date: date(2024, 1, 10),
+    }));
+    drop(svc.send(Event::SelectDate {
+        date: date(2024, 1, 15),
+    }));
+
+    assert_eq!(*svc.context().value.get(), None);
+    assert_eq!(svc.context().anchor_date, Some(date(2024, 1, 10)));
+
+    drop(svc.send(Event::SelectDate {
+        date: date(2024, 1, 12),
+    }));
+
+    assert_eq!(
+        *svc.context().value.get(),
+        Some(range(date(2024, 1, 10), date(2024, 1, 12))),
+    );
+}
+
+#[test]
+fn min_range_days_and_single_date_option_are_enforced() {
+    let mut svc = service_with(
+        props()
+            .allow_single_date_range(false)
+            .min_range_days(Some(2)),
+        en_us(),
+    );
+
+    drop(svc.send(Event::SelectDate {
+        date: date(2024, 1, 10),
+    }));
+    drop(svc.send(Event::SelectDate {
+        date: date(2024, 1, 10),
+    }));
+
+    assert_eq!(*svc.context().value.get(), None);
+    assert_eq!(svc.context().anchor_date, Some(date(2024, 1, 10)));
+
+    drop(svc.send(Event::SelectDate {
+        date: date(2024, 1, 11),
+    }));
+
+    assert_eq!(
+        *svc.context().value.get(),
+        Some(range(date(2024, 1, 10), date(2024, 1, 11))),
+    );
+}
+
+#[test]
+fn controlled_value_sync_preserves_pending_anchor() {
+    let mut svc = service_with(
+        props().value(Some(range(date(2024, 1, 1), date(2024, 1, 2)))),
+        en_us(),
+    );
+
+    drop(svc.send(Event::SelectDate {
+        date: date(2024, 1, 10),
+    }));
+    drop(svc.set_props(props().value(Some(range(date(2024, 1, 3), date(2024, 1, 4))))));
+
+    assert_eq!(svc.context().anchor_date, Some(date(2024, 1, 10)));
+    assert_eq!(
+        *svc.context().value.get(),
+        Some(range(date(2024, 1, 3), date(2024, 1, 4))),
+    );
+}
+
+#[test]
+fn rtl_arrow_keys_swap_horizontal_direction() {
+    let mut svc = service_with(props().is_rtl(true), fa());
+
+    drop(svc.send(Event::FocusIn));
+
+    let before = svc.context().focused_date.clone();
+
+    drop(svc.send(Event::KeyDown {
+        key: KeyboardKey::ArrowLeft,
+        shift: false,
+    }));
+
+    assert_eq!(svc.context().focused_date, before.add_days(1).unwrap());
+}
+
+#[test]
+fn week_day_labels_follow_locale() {
+    let svc = service_with(props(), en_gb());
+
+    assert_eq!(
+        svc.context()
+            .week_day_labels()
+            .first()
+            .map(|(weekday, _)| *weekday),
+        Some(Weekday::Monday),
+    );
+}
+
+#[test]
+fn part_anatomy_matches_spec() {
+    assert_eq!(Part::scope(), "range-calendar");
+
+    let names: Vec<&'static str> = Part::all().iter().map(ComponentPart::name).collect();
+
+    let expected: &[&'static str] = &[
+        "root",
+        "header",
+        "prev-trigger",
+        "next-trigger",
+        "heading",
+        "grid",
+        "grid-group",
+        "head-row",
+        "head-cell",
+        "row",
+        "cell",
+        "cell-trigger",
+    ];
+
+    assert_eq!(names.as_slice(), expected);
+}
+
+#[test]
+fn snapshot_root_idle() {
+    let svc = service();
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!("root_idle", snapshot_attrs(&api.root_attrs()));
+}
+
+#[test]
+fn snapshot_root_pending() {
+    let mut svc = service();
+
+    drop(svc.send(Event::SelectDate {
+        date: date(2024, 1, 10),
+    }));
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!("root_pending", snapshot_attrs(&api.root_attrs()));
+}
+
+#[test]
+fn snapshot_root_disabled_readonly_rtl() {
+    let svc = service_with(props().disabled(true).readonly(true).is_rtl(true), en_us());
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!(
+        "root_disabled_readonly_rtl",
+        snapshot_attrs(&api.root_attrs()),
+    );
+}
+
+#[test]
+fn snapshot_structural_parts() {
+    let svc = service_with(props().visible_months(2), en_us());
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!("header", snapshot_attrs(&api.header_attrs()));
+    assert_snapshot!("prev_trigger", snapshot_attrs(&api.prev_trigger_attrs()));
+    assert_snapshot!("next_trigger", snapshot_attrs(&api.next_trigger_attrs()));
+    assert_snapshot!("heading", snapshot_attrs(&api.heading_attrs()));
+    assert_snapshot!("grid", snapshot_attrs(&api.grid_attrs()));
+    assert_snapshot!("grid_group", snapshot_attrs(&api.grid_group_attrs()));
+    assert_snapshot!("head_row", snapshot_attrs(&api.head_row_attrs()));
+    assert_snapshot!(
+        "head_cell",
+        snapshot_attrs(&api.head_cell_attrs(Weekday::Sunday)),
+    );
+    assert_snapshot!("row", snapshot_attrs(&api.row_attrs(0)));
+}
+
+#[test]
+fn snapshot_cell_branches() {
+    let unavailable = Callback::new_ref(|date: &CalendarDate| date.day() == 5);
+
+    let mut svc = service_with(
+        props()
+            .today(date(2024, 1, 15))
+            .min(Some(date(2024, 1, 3)))
+            .is_date_unavailable(Some(unavailable)),
+        en_us(),
+    );
+
+    drop(svc.send(Event::SelectDate {
+        date: date(2024, 1, 10),
+    }));
+    drop(svc.send(Event::HoverDate {
+        date: date(2024, 1, 12),
+    }));
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!(
+        "cell_anchor",
+        snapshot_attrs(&api.cell_attrs(&date(2024, 1, 10)))
+    );
+    assert_snapshot!(
+        "cell_trigger_anchor",
+        snapshot_attrs(&api.cell_trigger_attrs(&date(2024, 1, 10))),
+    );
+    assert_snapshot!(
+        "cell_trigger_hover_range",
+        snapshot_attrs(&api.cell_trigger_attrs(&date(2024, 1, 11))),
+    );
+    assert_snapshot!(
+        "cell_trigger_disabled",
+        snapshot_attrs(&api.cell_trigger_attrs(&date(2024, 1, 1))),
+    );
+    assert_snapshot!(
+        "cell_trigger_unavailable",
+        snapshot_attrs(&api.cell_trigger_attrs(&date(2024, 1, 5))),
+    );
+    assert_snapshot!(
+        "cell_trigger_today",
+        snapshot_attrs(&api.cell_trigger_attrs(&date(2024, 1, 15))),
+    );
+}
+
+#[test]
+fn snapshot_confirmed_range_branches() {
+    let svc = service_with(
+        props().value(Some(range(date(2024, 1, 10), date(2024, 1, 12)))),
+        en_us(),
+    );
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!(
+        "cell_trigger_range_start",
+        snapshot_attrs(&api.cell_trigger_attrs(&date(2024, 1, 10))),
+    );
+    assert_snapshot!(
+        "cell_trigger_in_range",
+        snapshot_attrs(&api.cell_trigger_attrs(&date(2024, 1, 11))),
+    );
+    assert_snapshot!(
+        "cell_trigger_range_end",
+        snapshot_attrs(&api.cell_trigger_attrs(&date(2024, 1, 12))),
+    );
+}

--- a/crates/ars-components/tests/proptest_state_machines/date_time.rs
+++ b/crates/ars-components/tests/proptest_state_machines/date_time.rs
@@ -1,10 +1,10 @@
 use ars_components::date_time::{
     calendar::{self, PageBehavior, SelectionMode},
     date_field::{self, DateSegmentKind},
-    date_picker, time_field,
+    date_picker, range_calendar, time_field,
 };
 use ars_core::{ComponentPart, ConnectApi, Env, KeyboardKey, Service};
-use ars_i18n::{CalendarDate, HourCycle, Time, Weekday};
+use ars_i18n::{CalendarDate, DateRange, HourCycle, Time, Weekday};
 use proptest::prelude::*;
 
 #[derive(Clone, Debug)]
@@ -535,6 +535,219 @@ proptest! {
 
         prop_assert_eq!(service.context().visible_month, expected_month as u8);
         prop_assert_eq!(service.context().visible_year, expected_year);
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────
+// RangeCalendar
+// ────────────────────────────────────────────────────────────────────
+
+#[derive(Clone, Debug)]
+enum RangeCalendarAction {
+    Send(range_calendar::Event),
+    SetDisabled(bool),
+    SetReadonly(bool),
+    SetMin(Option<CalendarDate>),
+    SetMax(Option<CalendarDate>),
+}
+
+fn range_calendar_props() -> range_calendar::Props {
+    range_calendar::Props::new()
+        .id("range-calendar")
+        .today(date(2024, 1, 15))
+        .max_range_days(Some(14))
+}
+
+fn arb_range_calendar_key() -> impl Strategy<Value = KeyboardKey> {
+    prop_oneof![
+        Just(KeyboardKey::ArrowLeft),
+        Just(KeyboardKey::ArrowRight),
+        Just(KeyboardKey::ArrowUp),
+        Just(KeyboardKey::ArrowDown),
+        Just(KeyboardKey::Home),
+        Just(KeyboardKey::End),
+        Just(KeyboardKey::PageUp),
+        Just(KeyboardKey::PageDown),
+        Just(KeyboardKey::Enter),
+        Just(KeyboardKey::Space),
+    ]
+}
+
+fn arb_range_calendar_event() -> impl Strategy<Value = range_calendar::Event> {
+    prop_oneof![
+        arb_calendar_date().prop_map(|date| range_calendar::Event::FocusDate { date }),
+        arb_calendar_date().prop_map(|date| range_calendar::Event::SelectDate { date }),
+        arb_calendar_date().prop_map(|date| range_calendar::Event::HoverDate { date }),
+        Just(range_calendar::Event::HoverEnd),
+        Just(range_calendar::Event::NextMonth),
+        Just(range_calendar::Event::PrevMonth),
+        Just(range_calendar::Event::NextYear),
+        Just(range_calendar::Event::PrevYear),
+        (1u8..=12).prop_map(|month| range_calendar::Event::SetMonth { month }),
+        (1900i32..=2100).prop_map(|year| range_calendar::Event::SetYear { year }),
+        Just(range_calendar::Event::FocusIn),
+        Just(range_calendar::Event::FocusOut),
+        (arb_range_calendar_key(), any::<bool>())
+            .prop_map(|(key, shift)| range_calendar::Event::KeyDown { key, shift }),
+    ]
+}
+
+fn arb_range_calendar_action() -> impl Strategy<Value = RangeCalendarAction> {
+    prop_oneof![
+        arb_range_calendar_event().prop_map(RangeCalendarAction::Send),
+        any::<bool>().prop_map(RangeCalendarAction::SetDisabled),
+        any::<bool>().prop_map(RangeCalendarAction::SetReadonly),
+        prop::option::of(arb_calendar_date()).prop_map(RangeCalendarAction::SetMin),
+        prop::option::of(arb_calendar_date()).prop_map(RangeCalendarAction::SetMax),
+    ]
+}
+
+fn apply_range_calendar_action(
+    service: &mut Service<range_calendar::Machine>,
+    action: RangeCalendarAction,
+    base_props: &range_calendar::Props,
+) {
+    match action {
+        RangeCalendarAction::Send(event) => {
+            drop(service.send(event));
+        }
+
+        RangeCalendarAction::SetDisabled(value) => {
+            drop(service.set_props(base_props.clone().disabled(value)));
+        }
+
+        RangeCalendarAction::SetReadonly(value) => {
+            drop(service.set_props(base_props.clone().readonly(value)));
+        }
+
+        RangeCalendarAction::SetMin(value) => {
+            drop(service.set_props(base_props.clone().min(value)));
+        }
+
+        RangeCalendarAction::SetMax(value) => {
+            drop(service.set_props(base_props.clone().max(value)));
+        }
+    }
+}
+
+fn assert_range_calendar_invariants(service: &Service<range_calendar::Machine>) {
+    let ctx = service.context();
+
+    assert!(ctx.visible_month >= 1, "visible_month must be 1-based");
+    assert!(ctx.visible_month <= 12, "visible_month must be 1..=12");
+    assert!(ctx.visible_months >= 1, "visible_months must be >= 1");
+
+    if let Some(min) = &ctx.min {
+        assert!(
+            !matches!(ctx.focused_date.compare(min), core::cmp::Ordering::Less),
+            "focused_date must be >= min",
+        );
+    }
+
+    if let Some(max) = &ctx.max {
+        assert!(
+            !matches!(ctx.focused_date.compare(max), core::cmp::Ordering::Greater),
+            "focused_date must be <= max",
+        );
+    }
+
+    if let Some(range) = ctx.value.get() {
+        assert!(
+            !matches!(
+                range.start.compare(&range.end),
+                core::cmp::Ordering::Greater,
+            ),
+            "range must be normalized",
+        );
+        assert!(
+            ctx.range_is_allowed(range),
+            "completed range must satisfy span constraints",
+        );
+    }
+
+    if ctx.anchor_date.is_none() {
+        assert!(
+            ctx.hovering_date.is_none(),
+            "hovering_date must not outlive a pending anchor",
+        );
+    }
+
+    let weeks = ctx.weeks();
+
+    if !weeks.is_empty() {
+        assert_eq!(weeks.len(), 6, "grid must always render 6 weeks");
+
+        for row in &weeks {
+            assert_eq!(row.len(), 7, "every row must contain 7 days");
+        }
+    }
+
+    assert!(matches!(
+        service.state(),
+        range_calendar::State::Idle | range_calendar::State::Focused,
+    ));
+}
+
+proptest! {
+    #![proptest_config(super::common::proptest_config())]
+
+    #[test]
+    #[ignore = "proptest — nightly extended-proptest job"]
+    fn proptest_range_calendar_sequences_preserve_invariants(
+        actions in prop::collection::vec(arb_range_calendar_action(), 0..64),
+        allow_single in any::<bool>(),
+        min_range_days in prop::option::of(1u32..=5),
+        max_range_days in prop::option::of(6u32..=21),
+    ) {
+        let base = range_calendar_props()
+            .allow_single_date_range(allow_single)
+            .min_range_days(min_range_days)
+            .max_range_days(max_range_days);
+
+        let mut service = Service::<range_calendar::Machine>::new(
+            base.clone(),
+            &Env::default(),
+            &range_calendar::Messages::default(),
+        );
+
+        for action in actions {
+            apply_range_calendar_action(&mut service, action, &base);
+
+            assert_range_calendar_invariants(&service);
+        }
+    }
+
+    #[test]
+    #[ignore = "proptest — nightly extended-proptest job"]
+    fn proptest_range_calendar_accepts_only_allowed_completed_ranges(
+        first in arb_calendar_date(),
+        second in arb_calendar_date(),
+        max_days in 1u32..=20,
+    ) {
+        let base = range_calendar_props().max_range_days(Some(max_days));
+        let mut service = Service::<range_calendar::Machine>::new(
+            base,
+            &Env::default(),
+            &range_calendar::Messages::default(),
+        );
+
+        drop(service.send(range_calendar::Event::SelectDate { date: first.clone() }));
+        drop(service.send(range_calendar::Event::SelectDate { date: second.clone() }));
+
+        if let Some(expected) = DateRange::normalized(first, second)
+            && expected
+                .start
+                .days_until(&expected.end)
+                .ok()
+                .and_then(|days| u32::try_from(days).ok())
+                .and_then(|days| days.checked_add(1))
+                .is_some_and(|days| days <= max_days)
+        {
+            prop_assert_eq!(service.context().value.get(), &Some(expected));
+        } else {
+            prop_assert!(service.context().value.get().is_none());
+            prop_assert!(service.context().anchor_date.is_some());
+        }
     }
 }
 

--- a/crates/ars-components/tests/spec_conformance/date_time.rs
+++ b/crates/ars-components/tests/spec_conformance/date_time.rs
@@ -2,7 +2,9 @@
 //!
 //! Asserts each date-time component's `Part` enum matches the spec anatomy.
 
-use ars_components::date_time::{calendar, date_field::DateSegmentKind, date_picker, time_field};
+use ars_components::date_time::{
+    calendar, date_field::DateSegmentKind, date_picker, range_calendar, time_field,
+};
 use ars_i18n::{CalendarDate, Weekday};
 
 use super::helper::assert_anatomy;
@@ -47,6 +49,45 @@ fn calendar_anatomy_matches_spec() {
             (
                 calendar::Part::CellTrigger {
                     date: example.clone(),
+                    offset: 0,
+                },
+                "cell-trigger",
+            ),
+        ],
+    );
+}
+
+#[test]
+fn range_calendar_anatomy_matches_spec() {
+    let example = calendar_date_default_for_part_all();
+    assert_anatomy(
+        "range-calendar",
+        &[
+            (range_calendar::Part::Root, "root"),
+            (range_calendar::Part::Header, "header"),
+            (range_calendar::Part::PrevTrigger, "prev-trigger"),
+            (range_calendar::Part::NextTrigger, "next-trigger"),
+            (range_calendar::Part::Heading, "heading"),
+            (range_calendar::Part::Grid, "grid"),
+            (range_calendar::Part::GridGroup, "grid-group"),
+            (range_calendar::Part::HeadRow, "head-row"),
+            (
+                range_calendar::Part::HeadCell {
+                    day: Weekday::Monday,
+                },
+                "head-cell",
+            ),
+            (range_calendar::Part::Row { week_index: 0 }, "row"),
+            (
+                range_calendar::Part::Cell {
+                    date: example.clone(),
+                    offset: 0,
+                },
+                "cell",
+            ),
+            (
+                range_calendar::Part::CellTrigger {
+                    date: example,
                     offset: 0,
                 },
                 "cell-trigger",

--- a/spec/components/date-time/range-calendar.md
+++ b/spec/components/date-time/range-calendar.md
@@ -115,6 +115,12 @@ pub struct Context {
     pub unavailable_dates: Vec<CalendarDate>,
     /// User-provided predicate for dynamic unavailability checks.
     pub is_date_unavailable_fn: Option<IsDateUnavailableFn>,
+    /// Whether same-day ranges are valid.
+    pub allow_single_date_range: bool,
+    /// Minimum inclusive range length in calendar days.
+    pub min_range_days: Option<u32>,
+    /// Maximum inclusive range length in calendar days.
+    pub max_range_days: Option<u32>,
     /// Component IDs.
     pub ids: ComponentIds,
     /// Number of months displayed side-by-side. Default: 2 (common for range pickers).
@@ -128,7 +134,7 @@ pub struct Context {
 
 Context shares the same navigation fields as Calendar (`focused_date`, `visible_month`, `visible_year`, `page_behavior`, etc.) and the same grid computation methods -- see Calendar `calendar.md` section 1.6 for `weeks()`, `weeks_for()`, `month_year_at_offset()`, `advance_month()`, `sync_visible_to_focused()`, `clamp_date()`, and related helpers. These methods are identical and should be extracted into a shared module by implementors.
 
-The range-specific fields are `anchor_date`, `hovering_date`, and the `Bindable<Option<DateRange>>` value type.
+The range-specific fields are `anchor_date`, `hovering_date`, `allow_single_date_range`, `min_range_days`, `max_range_days`, and the `Bindable<Option<DateRange>>` value type.
 
 **Date constraint methods** (identical to Calendar):
 
@@ -167,6 +173,31 @@ impl Context {
             Some(max) if date > *max => max.clone(),
             _ => date,
         }
+    }
+
+    /// Whether a completed range satisfies same-day and span constraints.
+    pub fn range_is_allowed(&self, range: &DateRange) -> bool {
+        if !self.allow_single_date_range && range.start == range.end {
+            return false;
+        }
+
+        let Some(length) = inclusive_range_days(range) else {
+            return false;
+        };
+
+        if let Some(min) = self.min_range_days {
+            if length < min {
+                return false;
+            }
+        }
+
+        if let Some(max) = self.max_range_days {
+            if length > max {
+                return false;
+            }
+        }
+
+        true
     }
 }
 ```
@@ -378,6 +409,9 @@ impl ars_core::Machine for Machine {
             readonly: props.readonly,
             unavailable_dates: Vec::new(),
             is_date_unavailable_fn: props.is_date_unavailable,
+            allow_single_date_range: props.allow_single_date_range,
+            min_range_days: props.min_range_days,
+            max_range_days: props.max_range_days,
             ids: ComponentIds::from_id(&props.id),
             visible_months: props.visible_months.max(1),
             page_behavior: props.page_behavior.clone(),
@@ -449,12 +483,19 @@ impl ars_core::Machine for Machine {
                     Some(ref anchor) => {
                         // Second click: complete the range.
                         let anchor = anchor.clone();
+                        let Some(range) = DateRange::normalized(anchor.clone(), date.clone()) else {
+                            return None;
+                        };
+                        if !range_is_selectable(ctx, &range) {
+                            return Some(TransitionPlan::to(State::Focused)
+                                .apply(move |ctx| {
+                                    ctx.focused_date = date;
+                                    ctx.sync_visible_to_focused();
+                                }));
+                        }
+
                         Some(TransitionPlan::to(State::Focused)
                             .apply(move |ctx| {
-                                let range = DateRange::normalized(
-                                    anchor,
-                                    date.clone(),
-                                );
                                 ctx.value.set(Some(range));
                                 ctx.anchor_date = None;
                                 ctx.hovering_date = None;
@@ -481,6 +522,7 @@ impl ars_core::Machine for Machine {
 
             // ── Hover preview ────────────────────────────────────────────
             Event::HoverDate { date } => {
+                if ctx.readonly { return None; }
                 if ctx.anchor_date.is_none() { return None; }
                 let date = date.clone();
                 Some(TransitionPlan::context_only(move |ctx| {
@@ -583,6 +625,48 @@ impl ars_core::Machine for Machine {
     ) -> Self::Api<'a> {
         Api { state, ctx, props, send }
     }
+}
+
+fn range_is_selectable(ctx: &Context, range: &DateRange) -> bool {
+    if !ctx.range_is_allowed(range) {
+        return false;
+    }
+
+    if ctx.is_date_disabled(&range.start) || ctx.is_date_disabled(&range.end) {
+        return false;
+    }
+
+    if ctx.unavailable_dates.is_empty() && ctx.is_date_unavailable_fn.is_none() {
+        return true;
+    }
+
+    range_dates_all(ctx, range, |ctx, date| !ctx.is_date_unavailable(date))
+}
+
+fn range_dates_all(
+    ctx: &Context,
+    range: &DateRange,
+    mut predicate: impl FnMut(&Context, &CalendarDate) -> bool,
+) -> bool {
+    let Some(days) = inclusive_range_days(range) else {
+        return false;
+    };
+
+    for offset in 0..days {
+        let Ok(offset) = i32::try_from(offset) else {
+            return false;
+        };
+
+        let Ok(date) = range.start.add_days(offset) else {
+            return false;
+        };
+
+        if !predicate(ctx, &date) {
+            return false;
+        }
+    }
+
+    true
 }
 
 impl Machine {

--- a/spec/components/date-time/range-calendar.md
+++ b/spec/components/date-time/range-calendar.md
@@ -114,7 +114,7 @@ pub struct Context {
     /// Static list of unavailable dates (pre-computed for the visible month range).
     pub unavailable_dates: Vec<CalendarDate>,
     /// User-provided predicate for dynamic unavailability checks.
-    pub is_date_unavailable_fn: Option<fn(&CalendarDate) -> bool>,
+    pub is_date_unavailable_fn: Option<IsDateUnavailableFn>,
     /// Component IDs.
     pub ids: ComponentIds,
     /// Number of months displayed side-by-side. Default: 2 (common for range pickers).
@@ -174,6 +174,9 @@ impl Context {
 ### 1.4 Props
 
 ```rust
+/// Predicate type for marking dates unavailable.
+pub type IsDateUnavailableFn = Callback<dyn for<'a> Fn(&'a CalendarDate) -> bool + Send + Sync>;
+
 /// Props for the RangeCalendar component.
 #[derive(Clone, Debug, PartialEq, HasId)]
 pub struct Props {
@@ -194,7 +197,7 @@ pub struct Props {
     pub readonly: bool,
     /// Predicate returning true for dates that should be marked unavailable.
     /// Unavailable dates are focusable but not selectable.
-    pub is_date_unavailable: Option<fn(&CalendarDate) -> bool>,
+    pub is_date_unavailable: Option<IsDateUnavailableFn>,
     /// Explicit override of the locale's default first day of week.
     pub first_day_of_week: Option<Weekday>,
     /// Whether to display ISO week numbers.
@@ -207,6 +210,13 @@ pub struct Props {
     pub page_behavior: PageBehavior,
     /// The "today" date, injected by the adapter for testability.
     pub today: CalendarDate,
+    /// Whether a range whose start and end are the same date is valid.
+    /// Default: true.
+    pub allow_single_date_range: bool,
+    /// Minimum inclusive range length in calendar days. `None` means no minimum.
+    pub min_range_days: Option<u32>,
+    /// Maximum inclusive range length in calendar days. `None` means no maximum.
+    pub max_range_days: Option<u32>,
 }
 
 impl Default for Props {
@@ -226,6 +236,9 @@ impl Default for Props {
             visible_months: 2,
             page_behavior: PageBehavior::Visible,
             today: CalendarDate::new_gregorian(2024, nzu8(1), nzu8(1)),
+            allow_single_date_range: true,
+            min_range_days: None,
+            max_range_days: None,
         }
     }
 }
@@ -252,6 +265,14 @@ Range selection follows a two-click workflow:
 4. **Subsequent click**: Starts a new range -- sets a new `anchor_date`, clears the previous range value, and repeats from step 1.
 
 **Keyboard selection** follows the same two-click model: pressing Enter or Space on a focused date triggers `SelectDate`, functioning identically to a pointer click.
+
+**Range length constraints** are checked only when the second click would
+complete a range. The inclusive range length is `start.days_until(end) + 1`,
+so a same-day range has length 1. When `allow_single_date_range` is `false`,
+same-day completion is rejected. When `min_range_days` or `max_range_days` is
+set, the completed range must fall within those inclusive bounds. Rejected
+second clicks leave `anchor_date` intact and do not write `ctx.value`, allowing
+the user to choose another end date without restarting the range.
 
 ### 1.7 Range Context Helpers
 
@@ -643,8 +664,8 @@ pub enum Part {
     HeadRow,
     HeadCell { day: Weekday },
     Row { week_index: usize },
-    Cell { date: CalendarDate },
-    CellTrigger { date: CalendarDate },
+    Cell { date: CalendarDate, offset: usize },
+    CellTrigger { date: CalendarDate, offset: usize },
 }
 
 /// API for the RangeCalendar component.
@@ -836,12 +857,12 @@ impl<'a> Api<'a> {
     pub fn cell_attrs(&self, date: &CalendarDate) -> AttrMap {
         let mut attrs = AttrMap::new();
         let [(scope_attr, scope_val), (part_attr, part_val)] =
-            Part::Cell { date: date.clone() }.data_attrs();
+            Part::Cell { date: date.clone(), offset: 0 }.data_attrs();
         attrs.set(scope_attr, scope_val);
         attrs.set(part_attr, part_val);
         attrs.set(HtmlAttr::Role, "gridcell");
 
-        if self.ctx.is_range_start(date) || self.ctx.is_range_end(date) {
+        if self.ctx.is_in_range(date) {
             attrs.set(HtmlAttr::Aria(AriaAttr::Selected), "true");
         }
         if self.ctx.is_outside_visible_month(date) {
@@ -859,7 +880,7 @@ impl<'a> Api<'a> {
     pub fn cell_trigger_attrs(&self, date: &CalendarDate) -> AttrMap {
         let mut attrs = AttrMap::new();
         let [(scope_attr, scope_val), (part_attr, part_val)] =
-            Part::CellTrigger { date: date.clone() }.data_attrs();
+            Part::CellTrigger { date: date.clone(), offset: 0 }.data_attrs();
         attrs.set(scope_attr, scope_val);
         attrs.set(part_attr, part_val);
 
@@ -872,10 +893,12 @@ impl<'a> Api<'a> {
         attrs.set(HtmlAttr::TabIndex, if is_focused { "0" } else { "-1" });
 
         if disabled || unavailable {
-            attrs.set_bool(HtmlAttr::Disabled, true);
             attrs.set(HtmlAttr::Aria(AriaAttr::Disabled), "true");
         }
-        if self.ctx.is_range_start(date) || self.ctx.is_range_end(date) {
+        if disabled {
+            attrs.set_bool(HtmlAttr::Disabled, true);
+        }
+        if self.ctx.is_in_range(date) {
             attrs.set(HtmlAttr::Aria(AriaAttr::Selected), "true");
         }
         if is_today {
@@ -1199,7 +1222,7 @@ These attributes enable CSS styling for range backgrounds, rounded endpoints, an
 | -------------------- | ----------------------- | ------------------------------------------------------------------------------------------- |
 | `Grid`               | `role="grid"`           | `aria-labelledby` points to `Heading`; `aria-multiselectable="true"` always set             |
 | `HeadCell`           | `<th scope="col">`      | `abbr` attribute holds full weekday name                                                    |
-| `Cell`               | `role="gridcell"`       | `aria-selected` on range start/end dates                                                    |
+| `Cell`               | `role="gridcell"`       | `aria-selected` on every date inside the confirmed range                                    |
 | `CellTrigger`        | `<button>`              | `aria-label` = full date string with range position suffix; `aria-disabled` when restricted |
 | `Heading`            | --                      | `aria-live="polite"` + `aria-atomic="true"` for month changes                               |
 | `PrevTrigger`        | `<button>`              | `aria-label="Previous month"` (or `"Previous N months"` for multi-step)                     |

--- a/spec/dioxus-components/date-time/range-calendar.md
+++ b/spec/dioxus-components/date-time/range-calendar.md
@@ -36,6 +36,12 @@ pub struct RangeCalendarProps {
     pub page_behavior: calendar::PageBehavior,
     #[props(default = false)]
     pub show_week_numbers: bool,
+    #[props(default = true)]
+    pub allow_single_date_range: bool,
+    #[props(optional)]
+    pub min_range_days: Option<u32>,
+    #[props(optional)]
+    pub max_range_days: Option<u32>,
     #[props(optional)]
     pub on_value_change: Option<EventHandler<Option<DateRange>>>,
 }
@@ -48,7 +54,7 @@ Plain props remain preferred; the controlled range uses `Signal` only when post-
 
 ## 3. Mapping to Core Component Contract
 
-- Props parity: full parity with the core range calendar contract.
+- Props parity: full parity with the core range calendar contract, including `allow_single_date_range`, `min_range_days`, and `max_range_days`.
 - Part parity: full parity with the same part set as `Calendar`, plus range-specific data attrs and preview semantics on cell triggers.
 - Known adapter deviations: desktop/mobile hosts may expose logical equivalents for DOM-specific attrs and announcements.
 

--- a/spec/dioxus-components/date-time/range-calendar.md
+++ b/spec/dioxus-components/date-time/range-calendar.md
@@ -165,12 +165,13 @@ Plain props remain preferred; the controlled range uses `Signal` only when post-
 
 - Do not compute in-range and hover-range styling outside the machine snapshot.
 - Do not keep stale hover preview after selection completion.
-- Do not treat every in-range cell as an endpoint for accessibility.
+- Do not derive selection styling locally; every confirmed in-range cell receives machine-owned `aria-selected` while endpoint shape comes from `data-ars-range-start` / `data-ars-range-end`.
 
 ## 19. Consumer Expectations and Guarantees
 
 - Consumers may assume endpoint, in-range, and preview state stay coherent.
 - Consumers may assume first click sets an anchor without completing the range.
+- Consumers may assume `allow_single_date_range`, `min_range_days`, and `max_range_days` are enforced by the core machine before a pending range is committed.
 - Consumers must not assume every host exposes browser-native hover semantics.
 
 ## 20. Platform Support Matrix

--- a/spec/foundation/02-component-catalog.md
+++ b/spec/foundation/02-component-catalog.md
@@ -84,7 +84,7 @@ ars-ui targets **112 components (including 1 internal utility: Dismissable) and 
 | **TimeField**       |   —    |     Y      |    P2    | Segmented time input (hour/minute/period)    |
 | **DateRangePicker** |   —    |     Y      |    P2    | Two date fields + range calendar             |
 | **DateRangeField**  |   —    |     Y      |    P2    | Inline two-field range input without popover |
-| **RangeCalendar**   |   —    |     Y      |    P2    | See Calendar with `is_range: true` prop      |
+| **RangeCalendar**   |   —    |     Y      |    P2    | Two-click date range grid with hover preview |
 | **DateTimePicker**  |   Y    |     —      |    P2    | Combined date and time picker                |
 
 ## 7. Data Display Components

--- a/spec/leptos-components/date-time/range-calendar.md
+++ b/spec/leptos-components/date-time/range-calendar.md
@@ -27,6 +27,9 @@ pub fn RangeCalendar(
     #[prop(optional)] visible_months: usize,
     #[prop(optional)] page_behavior: calendar::PageBehavior,
     #[prop(optional)] show_week_numbers: bool,
+    #[prop(default = true)] allow_single_date_range: bool,
+    #[prop(optional)] min_range_days: Option<u32>,
+    #[prop(optional)] max_range_days: Option<u32>,
     #[prop(optional)] on_value_change: Option<Callback<Option<DateRange>>>,
 ) -> impl IntoView
 ```
@@ -36,6 +39,7 @@ The adapter keeps the full range-selection machine and surfaces only machine-com
 ## 3. Mapping to Core Component Contract
 
 - Props parity: full parity with the core range calendar contract, including anchor, preview, and normalized range semantics.
+- Range constraint props map directly to the core `allow_single_date_range`, `min_range_days`, and `max_range_days` fields.
 - Part parity: full parity with the same part set as `Calendar`, plus range-specific data attrs on cell triggers.
 - Known adapter deviations: none beyond Leptos event and ref mechanics.
 

--- a/spec/leptos-components/date-time/range-calendar.md
+++ b/spec/leptos-components/date-time/range-calendar.md
@@ -152,12 +152,13 @@ The adapter keeps the full range-selection machine and surfaces only machine-com
 
 - Do not compute in-range and hover-range styling outside the machine-derived snapshot.
 - Do not keep stale hover preview after selection completion.
-- Do not treat every selected cell as `aria-selected`; only range endpoints expose selection semantics.
+- Do not derive selection styling locally; every confirmed in-range cell receives machine-owned `aria-selected` while endpoint shape comes from `data-ars-range-start` / `data-ars-range-end`.
 
 ## 19. Consumer Expectations and Guarantees
 
 - Consumers may assume range start, range end, in-range, and hover-range attrs are mutually coherent.
 - Consumers may assume the first click sets an anchor without immediately completing the range.
+- Consumers may assume `allow_single_date_range`, `min_range_days`, and `max_range_days` are enforced by the core machine before a pending range is committed.
 - Consumers must not assume hover preview is available during SSR.
 
 ## 20. Platform Support Matrix


### PR DESCRIPTION
Closes #287

## Summary
- add the framework-agnostic RangeCalendar core in ars-components with two-click range selection, hover preview, keyboard navigation, range ARIA/data attributes, and span validation
- reuse the existing Calendar grid machinery and export the new date_time::range_calendar module
- update RangeCalendar specs and add unit, snapshot, spec-conformance, and proptest coverage

## Verification
- cargo test -p ars-components --lib -- date_time::range_calendar
- cargo test -p ars-components --test spec_conformance -- date_time
- cargo insta test -p ars-components --lib -- range_calendar
- cargo test -p ars-components --tests -- proptest_range_calendar
- cargo clippy -p ars-components --all-targets --all-features -- -D warnings
- cargo xtask spec validate
- cargo llvm-cov test -p ars-components --lib --text -- range_calendar
- cargo xci --profile fast