### PR TITLE
Implement Timer agnostic core (#294)

### DIFF
--- a/crates/ars-components/src/specialized/mod.rs
+++ b/crates/ars-components/src/specialized/mod.rs
@@ -35,3 +35,6 @@ pub mod file_upload;
 
 /// `QrCode` stateless QR-matrix rendering connect API.
 pub mod qr_code;
+
+/// `Timer` countdown/stopwatch machine and connect API.
+pub mod timer;

--- a/crates/ars-components/src/specialized/timer/mod.rs
+++ b/crates/ars-components/src/specialized/timer/mod.rs
@@ -428,8 +428,15 @@ impl ars_core::Machine for Machine {
 
             (_, Event::Reset) => {
                 let initial = initial_duration(ctx.mode, ctx.target);
+                // A zero-duration countdown resets back to `Completed`, not
+                // `Idle`, so it can never be (re)started into a running `00:00`.
+                let target_state = if is_instantly_complete(ctx.mode, ctx.target) {
+                    State::Completed
+                } else {
+                    State::Idle
+                };
                 Some(
-                    TransitionPlan::to(State::Idle)
+                    TransitionPlan::to(target_state)
                         .apply(move |ctx: &mut Context| {
                             ctx.current = initial;
                         })
@@ -473,17 +480,47 @@ impl ars_core::Machine for Machine {
                 let target = props.target;
                 let interval = effective_interval(props.interval);
                 let mode = props.mode;
-                // While idle the displayed value mirrors the (new) initial; once
-                // running/paused/completed the in-progress `current` is kept.
-                let reset_current = matches!(state, State::Idle);
-                Some(TransitionPlan::context_only(move |ctx: &mut Context| {
-                    ctx.target = target;
-                    ctx.interval = interval;
-                    ctx.mode = mode;
-                    if reset_current {
-                        ctx.current = initial_duration(mode, target);
+
+                // Syncing into a zero-duration countdown completes on arrival,
+                // matching init/reset/restart, so it is never left idle and
+                // startable into a running `00:00`.
+                if is_instantly_complete(mode, target) {
+                    Some(
+                        TransitionPlan::to(State::Completed)
+                            .apply(move |ctx: &mut Context| {
+                                ctx.target = target;
+                                ctx.interval = interval;
+                                ctx.mode = mode;
+                                ctx.current = Duration::ZERO;
+                            })
+                            .cancel_effect(Effect::TimerInterval),
+                    )
+                } else {
+                    // While idle the displayed value mirrors the (new) initial;
+                    // once running/paused the in-progress `current` is kept.
+                    let reset_current = matches!(state, State::Idle);
+                    // A live cadence change must re-arm the adapter interval,
+                    // otherwise it keeps firing at the old rate while ticks use
+                    // the new interval.
+                    let rearm = matches!(state, State::Running) && interval != ctx.interval;
+
+                    let mut plan = TransitionPlan::context_only(move |ctx: &mut Context| {
+                        ctx.target = target;
+                        ctx.interval = interval;
+                        ctx.mode = mode;
+                        if reset_current {
+                            ctx.current = initial_duration(mode, target);
+                        }
+                    });
+
+                    if rearm {
+                        plan = plan
+                            .cancel_effect(Effect::TimerInterval)
+                            .with_effect(interval_effect());
                     }
-                }))
+
+                    Some(plan)
+                }
             }
 
             _ => None,
@@ -1277,6 +1314,61 @@ mod tests {
         assert_eq!(service.context().interval, Duration::from_secs(2));
         // Mid-run elapsed value is preserved (not reset to the target).
         assert_eq!(service.context().current, Duration::from_secs(59));
+    }
+
+    #[test]
+    fn timer_set_props_interval_change_while_running_rearms_interval() {
+        let mut service = fresh_service(
+            test_props()
+                .target(Duration::from_secs(60))
+                .interval(Duration::from_secs(1)),
+        );
+        drop(service.send(Event::Start));
+
+        // Changing the cadence mid-run cancels and re-emits the adapter
+        // interval so it restarts at the new rate.
+        let changed = service.set_props(
+            test_props()
+                .target(Duration::from_secs(60))
+                .interval(Duration::from_secs(2)),
+        );
+        assert_eq!(changed.cancel_effects, vec![Effect::TimerInterval]);
+        assert_eq!(effect_names(&changed), vec![Effect::TimerInterval]);
+
+        // A sync that does not change the cadence does not churn the interval.
+        let unchanged = service.set_props(
+            test_props()
+                .target(Duration::from_secs(30))
+                .interval(Duration::from_secs(2)),
+        );
+        assert!(unchanged.cancel_effects.is_empty());
+        assert!(unchanged.pending_effects.is_empty());
+    }
+
+    #[test]
+    fn timer_zero_target_reset_stays_completed() {
+        let mut service = fresh_service(test_props().target(Duration::ZERO));
+        assert_eq!(service.state(), &State::Completed);
+
+        // Reset must not drop a zero-duration countdown back to a startable Idle.
+        drop(service.send(Event::Reset));
+        assert_eq!(service.state(), &State::Completed);
+        assert_eq!(service.context().current, Duration::ZERO);
+    }
+
+    #[test]
+    fn timer_sync_into_zero_target_countdown_completes() {
+        let mut service = fresh_service(test_props().target(Duration::from_secs(60)));
+        assert_eq!(service.state(), &State::Idle);
+
+        // Updating props to a zero-duration countdown completes on sync rather
+        // than leaving an idle, startable zero timer.
+        let result = service.set_props(test_props().mode(Mode::Countdown).target(Duration::ZERO));
+
+        assert_eq!(service.state(), &State::Completed);
+        assert_eq!(service.context().current, Duration::ZERO);
+        assert_eq!(result.cancel_effects, vec![Effect::TimerInterval]);
+        assert!(result.pending_effects.is_empty());
     }
 
     // ───────────────────── transitions ─────────────────────

--- a/crates/ars-components/src/specialized/timer/mod.rs
+++ b/crates/ars-components/src/specialized/timer/mod.rs
@@ -496,22 +496,35 @@ impl ars_core::Machine for Machine {
                             .cancel_effect(Effect::TimerInterval),
                     )
                 } else {
-                    // While idle the displayed value mirrors the (new) initial;
-                    // once running/paused the in-progress `current` is kept.
-                    let reset_current = matches!(state, State::Idle);
+                    // Reconfiguring a completed timer to a now-runnable config
+                    // must leave `Completed`, otherwise the timer renders
+                    // `data-ars-state="completed"` with a disabled start trigger
+                    // (or strands a stopwatch in `Completed`) until manual reset.
+                    let was_completed = matches!(state, State::Completed);
+                    // Idle and (newly-runnable) Completed both mirror the new
+                    // initial; running/paused keep the in-progress `current`.
+                    let reset_current = matches!(state, State::Idle | State::Completed);
                     // A live cadence change must re-arm the adapter interval,
                     // otherwise it keeps firing at the old rate while ticks use
                     // the new interval.
                     let rearm = matches!(state, State::Running) && interval != ctx.interval;
 
-                    let mut plan = TransitionPlan::context_only(move |ctx: &mut Context| {
+                    let apply = move |ctx: &mut Context| {
                         ctx.target = target;
                         ctx.interval = interval;
                         ctx.mode = mode;
                         if reset_current {
                             ctx.current = initial_duration(mode, target);
                         }
-                    });
+                    };
+
+                    let mut plan = if was_completed {
+                        TransitionPlan::to(State::Idle)
+                            .apply(apply)
+                            .cancel_effect(Effect::TimerInterval)
+                    } else {
+                        TransitionPlan::context_only(apply)
+                    };
 
                     if rearm {
                         plan = plan
@@ -644,7 +657,10 @@ impl Api<'_> {
     #[must_use]
     pub fn progress(&self) -> f64 {
         if self.ctx.target.is_zero() {
-            return 0.0;
+            // A zero-duration countdown is complete on arrival, so it reports
+            // full progress; a zero-target stopwatch has no meaningful target
+            // and is reported as indeterminate (0.0).
+            return if self.is_completed() { 1.0 } else { 0.0 };
         }
 
         let fraction = self.ctx.current.as_secs_f64() / self.ctx.target.as_secs_f64();
@@ -701,6 +717,13 @@ impl Api<'_> {
     }
 
     /// Root element attributes.
+    ///
+    /// The Root is the polite, atomic `aria-live` region. It deliberately does
+    /// **not** carry the formatted time as an `aria-label`: live regions
+    /// announce changes to their *content* (the [`Display`](Part::Display) text),
+    /// not to `aria-label`, so labelling the region with the live value would
+    /// not be announced and would shadow the visible text. Associate an
+    /// accessible name via the optional [`Label`](Part::Label) part.
     #[must_use]
     pub fn root_attrs(&self) -> AttrMap {
         let mut attrs = AttrMap::new();
@@ -712,8 +735,7 @@ impl Api<'_> {
             .set(HtmlAttr::Role, "timer")
             .set(HtmlAttr::Data("ars-state"), self.state_str())
             .set(HtmlAttr::Aria(AriaAttr::Live), "polite")
-            .set(HtmlAttr::Aria(AriaAttr::Atomic), "true")
-            .set(HtmlAttr::Aria(AriaAttr::Label), self.formatted_time());
+            .set(HtmlAttr::Aria(AriaAttr::Atomic), "true");
 
         attrs
     }
@@ -733,6 +755,10 @@ impl Api<'_> {
     }
 
     /// Display element attributes.
+    ///
+    /// The Display holds the visible formatted time and is intentionally **not**
+    /// `aria-hidden`: as the changing content of the Root `aria-live` region it
+    /// is what assistive technology announces on each tick (spec §3.3).
     #[must_use]
     pub fn display_attrs(&self) -> AttrMap {
         let mut attrs = AttrMap::new();
@@ -741,8 +767,7 @@ impl Api<'_> {
         attrs
             .set(scope_attr, scope_val)
             .set(part_attr, part_val)
-            .set(HtmlAttr::Id, self.ctx.ids.part("display"))
-            .set(HtmlAttr::Aria(AriaAttr::Hidden), "true");
+            .set(HtmlAttr::Id, self.ctx.ids.part("display"));
 
         attrs
     }
@@ -1371,6 +1396,53 @@ mod tests {
         assert!(result.pending_effects.is_empty());
     }
 
+    #[test]
+    fn timer_sync_from_completed_to_live_target_returns_to_idle() {
+        // A finished zero-duration countdown reconfigured to a runnable target
+        // must leave Completed so it is startable again (not stranded).
+        let mut service = fresh_service(test_props().target(Duration::ZERO));
+        assert_eq!(service.state(), &State::Completed);
+
+        let result = service.set_props(test_props().target(Duration::from_secs(30)));
+
+        assert_eq!(service.state(), &State::Idle);
+        assert_eq!(service.context().current, Duration::from_secs(30));
+        assert_eq!(result.cancel_effects, vec![Effect::TimerInterval]);
+
+        // Switching a completed timer to stopwatch likewise frees it from Completed.
+        let mut sw = fresh_service(test_props().target(Duration::ZERO));
+        drop(
+            sw.set_props(
+                test_props()
+                    .mode(Mode::Stopwatch)
+                    .target(Duration::from_secs(30)),
+            ),
+        );
+        assert_eq!(sw.state(), &State::Idle);
+        assert_eq!(sw.context().current, Duration::ZERO);
+    }
+
+    #[test]
+    fn timer_completed_zero_target_reports_full_progress() {
+        // A zero-duration countdown sits in Completed; its progress must read as
+        // 100% (not 0%) so the progressbar reflects completion.
+        let service = fresh_service(test_props().target(Duration::ZERO));
+        assert_eq!(service.state(), &State::Completed);
+
+        let api = service.connect(&|_| {});
+        assert!((api.progress() - 1.0).abs() < 1e-9);
+        assert_eq!(
+            api.progress_attrs()
+                .get(&HtmlAttr::Aria(AriaAttr::ValueNow)),
+            Some("100")
+        );
+
+        // A zero-target stopwatch has no meaningful target and stays indeterminate.
+        let stopwatch = fresh_service(test_props().mode(Mode::Stopwatch).target(Duration::ZERO));
+        let sw_api = stopwatch.connect(&|_| {});
+        assert!((sw_api.progress() - 0.0).abs() < 1e-9);
+    }
+
     // ───────────────────── transitions ─────────────────────
 
     #[test]
@@ -1675,7 +1747,7 @@ mod tests {
     }
 
     #[test]
-    fn timer_root_attrs_carry_timer_role_live_region_and_label() {
+    fn timer_root_attrs_carry_timer_role_and_live_region() {
         let api = api_for(
             State::Running,
             Duration::from_secs(30),
@@ -1688,8 +1760,23 @@ mod tests {
         assert_eq!(attrs.get(&HtmlAttr::Role), Some("timer"));
         assert_eq!(attrs.get(&HtmlAttr::Aria(AriaAttr::Live)), Some("polite"));
         assert_eq!(attrs.get(&HtmlAttr::Aria(AriaAttr::Atomic)), Some("true"));
-        assert_eq!(attrs.get(&HtmlAttr::Aria(AriaAttr::Label)), Some("00:30"));
         assert_eq!(attrs.get(&HtmlAttr::Data("ars-state")), Some("running"));
+        // The live value lives in the Display content, not on the Root label.
+        assert!(!attrs.contains(&HtmlAttr::Aria(AriaAttr::Label)));
+    }
+
+    #[test]
+    fn timer_display_is_not_aria_hidden() {
+        // The Display is the announced content of the Root live region, so it
+        // must remain in the accessibility tree.
+        let attrs = api_for(
+            State::Running,
+            Duration::from_secs(30),
+            Mode::Countdown,
+            Duration::from_secs(60),
+        )
+        .display_attrs();
+        assert!(!attrs.contains(&HtmlAttr::Aria(AriaAttr::Hidden)));
     }
 
     #[test]
@@ -1941,16 +2028,11 @@ mod tests {
     #[test]
     fn timer_formatted_time_routes_digits_through_intl_backend() {
         // 90s -> 01:30; the localizing backend prefixes each segment with `loc-`.
+        // `formatted_time` is the string adapters render into the Display, which
+        // is the announced live-region content.
         let api = api_with_localized_backend(Duration::from_secs(90));
 
         assert_eq!(api.formatted_time(), "loc-01:loc-30");
-
-        // The root `aria-label` is sourced from `formatted_time`, so it inherits
-        // the localized digits too.
-        assert_eq!(
-            api.root_attrs().get(&HtmlAttr::Aria(AriaAttr::Label)),
-            Some("loc-01:loc-30")
-        );
     }
 
     // ─────────────────────── snapshots ───────────────────────

--- a/crates/ars-components/src/specialized/timer/mod.rs
+++ b/crates/ars-components/src/specialized/timer/mod.rs
@@ -1,0 +1,1533 @@
+//! Timer component state machine and connect API.
+//!
+//! The `Timer` implements countdown or stopwatch functionality with start,
+//! pause, resume, reset, and restart controls. It ticks at a configurable
+//! interval and transitions to a [`State::Completed`] state when a countdown
+//! reaches zero.
+//!
+//! The agnostic core only emits typed `Effect` intents and exposes the `Api`
+//! connect surface; framework adapters translate
+//! `Effect::TimerInterval` into a real recurring interval (e.g. `setInterval`)
+//! that dispatches `Event::Tick`, and translate `Effect::AnnounceCompleted`
+//! into a live-region announcement.
+
+use alloc::{format, string::String, vec::Vec};
+use core::{
+    fmt::{self, Debug},
+    time::Duration,
+};
+
+use ars_core::{
+    AriaAttr, AttrMap, ComponentIds, ComponentMessages, ComponentPart, ConnectApi, CssProperty,
+    Env, HasId, HtmlAttr, Locale, MessageFn, PendingEffect, TransitionPlan,
+};
+
+/// Timer mode.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum Mode {
+    /// Counts down from a target duration to zero.
+    #[default]
+    Countdown,
+
+    /// Counts up from zero indefinitely.
+    Stopwatch,
+}
+
+/// The state of the `Timer` component.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum State {
+    /// Timer is not running, at its initial value.
+    Idle,
+
+    /// Timer is actively ticking.
+    Running,
+
+    /// Timer is paused, preserving its current value.
+    Paused,
+
+    /// Countdown reached zero (only for [`Mode::Countdown`]).
+    Completed,
+}
+
+/// Events for the `Timer` component.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Event {
+    /// Start or resume the timer.
+    Start,
+
+    /// Pause the timer.
+    Pause,
+
+    /// Resume from the paused state.
+    Resume,
+
+    /// Reset to the initial value.
+    Reset,
+
+    /// Reset to the initial value and immediately start.
+    Restart,
+
+    /// A single tick interval elapsed (dispatched by the adapter's interval).
+    Tick,
+
+    /// Set the remaining/elapsed time directly.
+    SetTime(Duration),
+}
+
+/// Context for the `Timer` component.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Context {
+    /// Current time value. For countdown this is the remaining time; for
+    /// stopwatch this is the elapsed time.
+    pub current: Duration,
+
+    /// The target duration (for countdown).
+    pub target: Duration,
+
+    /// Tick interval.
+    pub interval: Duration,
+
+    /// Timer mode.
+    pub mode: Mode,
+
+    /// Whether auto-start is enabled.
+    pub auto_start: bool,
+
+    /// Active locale inherited from provider context.
+    pub locale: Locale,
+
+    /// Resolved translatable messages.
+    pub messages: Messages,
+
+    /// Component instance IDs.
+    pub ids: ComponentIds,
+}
+
+/// Props for the `Timer` component.
+#[derive(Clone, Debug, PartialEq, HasId)]
+pub struct Props {
+    /// Component instance ID.
+    pub id: String,
+
+    /// Target duration (for countdown mode).
+    pub target: Duration,
+
+    /// Tick interval.
+    pub interval: Duration,
+
+    /// Timer mode (countdown or stopwatch).
+    pub mode: Mode,
+
+    /// Auto-start when mounted.
+    pub auto_start: bool,
+}
+
+impl Default for Props {
+    fn default() -> Self {
+        Self {
+            id: String::new(),
+            target: Duration::from_secs(60),
+            interval: Duration::from_secs(1),
+            mode: Mode::Countdown,
+            auto_start: false,
+        }
+    }
+}
+
+impl Props {
+    /// Returns a fresh [`Props`] with every field at its [`Default`] value.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets [`id`](Self::id).
+    #[must_use]
+    pub fn id(mut self, id: impl Into<String>) -> Self {
+        self.id = id.into();
+        self
+    }
+
+    /// Sets [`target`](Self::target).
+    #[must_use]
+    pub const fn target(mut self, target: Duration) -> Self {
+        self.target = target;
+        self
+    }
+
+    /// Sets [`interval`](Self::interval).
+    #[must_use]
+    pub const fn interval(mut self, interval: Duration) -> Self {
+        self.interval = interval;
+        self
+    }
+
+    /// Sets [`mode`](Self::mode).
+    #[must_use]
+    pub const fn mode(mut self, mode: Mode) -> Self {
+        self.mode = mode;
+        self
+    }
+
+    /// Sets [`auto_start`](Self::auto_start).
+    #[must_use]
+    pub const fn auto_start(mut self, auto_start: bool) -> Self {
+        self.auto_start = auto_start;
+        self
+    }
+}
+
+/// Messages for the `Timer` component.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Messages {
+    /// Start button label. Default: `"Start timer"`.
+    pub start_label: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
+
+    /// Pause button label. Default: `"Pause timer"`.
+    pub pause_label: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
+
+    /// Reset button label. Default: `"Reset timer"`.
+    pub reset_label: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
+
+    /// Resume button label. Default: `"Resume timer"`.
+    pub resume_label: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
+
+    /// Progress bar label. Default: `"Timer progress"`.
+    pub progress_label: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
+
+    /// Completion announcement. Default: `"Timer completed"`.
+    pub completed_announcement: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
+}
+
+impl Default for Messages {
+    fn default() -> Self {
+        Self {
+            start_label: MessageFn::static_str("Start timer"),
+            pause_label: MessageFn::static_str("Pause timer"),
+            reset_label: MessageFn::static_str("Reset timer"),
+            resume_label: MessageFn::static_str("Resume timer"),
+            progress_label: MessageFn::static_str("Timer progress"),
+            completed_announcement: MessageFn::static_str("Timer completed"),
+        }
+    }
+}
+
+impl ComponentMessages for Messages {}
+
+/// Typed effect intents emitted by the timer machine.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Effect {
+    /// Adapter starts a recurring interval of [`Context::interval`] that
+    /// dispatches [`Event::Tick`] on each elapse. Emitted on initial mount when
+    /// the timer auto-starts (via
+    /// [`Machine::initial_effects`](ars_core::Machine::initial_effects)) and on
+    /// every transition into [`State::Running`]. Cancelled whenever the timer
+    /// leaves [`State::Running`] (pause, completion, reset, or restart); the
+    /// adapter no-ops the cancellation when no interval is active.
+    TimerInterval,
+
+    /// Adapter announces the [`Messages::completed_announcement`] message into a
+    /// polite `aria-live` region. Emitted on the countdown transition into
+    /// [`State::Completed`].
+    AnnounceCompleted,
+}
+
+/// The machine for the `Timer` component.
+///
+/// # Examples
+///
+/// Drive a two-second countdown to completion. Each [`Event::Tick`] is
+/// dispatched by the adapter-owned interval started by
+/// [`Effect::TimerInterval`]; here we send them directly:
+///
+/// ```
+/// use core::time::Duration;
+///
+/// use ars_components::specialized::timer::{Event, Machine, Messages, Props, State};
+/// use ars_core::{Env, Service};
+///
+/// let mut timer = Service::<Machine>::new(
+///     Props::new()
+///         .id("egg")
+///         .target(Duration::from_secs(2))
+///         .interval(Duration::from_secs(1)),
+///     &Env::default(),
+///     &Messages::default(),
+/// );
+///
+/// drop(timer.send(Event::Start));
+/// assert_eq!(timer.state(), &State::Running);
+///
+/// drop(timer.send(Event::Tick)); // 2s -> 1s remaining
+/// assert_eq!(timer.context().current, Duration::from_secs(1));
+///
+/// drop(timer.send(Event::Tick)); // 1s -> 0s: the countdown completes
+/// assert_eq!(timer.state(), &State::Completed);
+/// assert_eq!(timer.connect(&|_| {}).formatted_time(), "00:00");
+/// ```
+#[derive(Debug)]
+pub struct Machine;
+
+impl ars_core::Machine for Machine {
+    type State = State;
+    type Event = Event;
+    type Context = Context;
+    type Props = Props;
+    type Messages = Messages;
+    type Effect = Effect;
+    type Api<'a> = Api<'a>;
+
+    fn init(props: &Self::Props, env: &Env, messages: &Self::Messages) -> (State, Context) {
+        let current = initial_duration(props.mode, props.target);
+
+        let state = if props.auto_start {
+            State::Running
+        } else {
+            State::Idle
+        };
+
+        (
+            state,
+            Context {
+                current,
+                target: props.target,
+                interval: props.interval,
+                mode: props.mode,
+                auto_start: props.auto_start,
+                locale: env.locale.clone(),
+                messages: messages.clone(),
+                ids: ComponentIds::from_id(&props.id),
+            },
+        )
+    }
+
+    fn initial_effects(
+        state: &Self::State,
+        _ctx: &Self::Context,
+        _props: &Self::Props,
+    ) -> Vec<PendingEffect<Self>> {
+        let mut effects = Vec::new();
+
+        // Auto-started timers boot directly into `Running` without a
+        // transition, so the interval intent is emitted here on first mount.
+        if matches!(state, State::Running) {
+            effects.push(PendingEffect::named(Effect::TimerInterval));
+        }
+
+        effects
+    }
+
+    fn transition(
+        state: &Self::State,
+        event: &Self::Event,
+        ctx: &Self::Context,
+        _props: &Self::Props,
+    ) -> Option<TransitionPlan<Self>> {
+        match (state, event) {
+            // Idle start, paused resume, and paused start all enter `Running`
+            // and (re)emit the interval intent.
+            (State::Idle, Event::Start) | (State::Paused, Event::Resume | Event::Start) => {
+                Some(TransitionPlan::to(State::Running).with_effect(interval_effect()))
+            }
+
+            (State::Running, Event::Tick) => match ctx.mode {
+                Mode::Countdown => {
+                    let new = ctx.current.saturating_sub(ctx.interval);
+
+                    if new.is_zero() {
+                        Some(
+                            TransitionPlan::to(State::Completed)
+                                .apply(|ctx: &mut Context| {
+                                    ctx.current = Duration::ZERO;
+                                })
+                                .cancel_effect(Effect::TimerInterval)
+                                .with_effect(PendingEffect::named(Effect::AnnounceCompleted)),
+                        )
+                    } else {
+                        Some(TransitionPlan::context_only(move |ctx: &mut Context| {
+                            ctx.current = new;
+                        }))
+                    }
+                }
+                Mode::Stopwatch => {
+                    let interval = ctx.interval;
+                    Some(TransitionPlan::context_only(move |ctx: &mut Context| {
+                        ctx.current = ctx.current.saturating_add(interval);
+                    }))
+                }
+            },
+
+            (State::Running, Event::Pause) => {
+                Some(TransitionPlan::to(State::Paused).cancel_effect(Effect::TimerInterval))
+            }
+
+            (_, Event::Reset) => {
+                let initial = initial_duration(ctx.mode, ctx.target);
+                Some(
+                    TransitionPlan::to(State::Idle)
+                        .apply(move |ctx: &mut Context| {
+                            ctx.current = initial;
+                        })
+                        .cancel_effect(Effect::TimerInterval),
+                )
+            }
+
+            (_, Event::Restart) => {
+                let initial = initial_duration(ctx.mode, ctx.target);
+                Some(
+                    TransitionPlan::to(State::Running)
+                        .apply(move |ctx: &mut Context| {
+                            ctx.current = initial;
+                        })
+                        .cancel_effect(Effect::TimerInterval)
+                        .with_effect(PendingEffect::named(Effect::TimerInterval)),
+                )
+            }
+
+            (_, Event::SetTime(duration)) => {
+                let duration = *duration;
+                Some(TransitionPlan::context_only(move |ctx: &mut Context| {
+                    ctx.current = duration;
+                }))
+            }
+
+            _ => None,
+        }
+    }
+
+    fn connect<'a>(
+        state: &'a Self::State,
+        ctx: &'a Self::Context,
+        props: &'a Self::Props,
+        send: &'a dyn Fn(Self::Event),
+    ) -> Self::Api<'a> {
+        Api {
+            state,
+            ctx,
+            props,
+            send,
+        }
+    }
+}
+
+/// DOM parts of the `Timer` component.
+#[derive(ComponentPart)]
+#[scope = "timer"]
+pub enum Part {
+    /// Root wrapper element (`role="timer"`, `aria-live` region).
+    Root,
+
+    /// Label describing the timer.
+    Label,
+
+    /// Formatted time-string display.
+    Display,
+
+    /// Progress indicator (`role="progressbar"`).
+    Progress,
+
+    /// Start/resume button.
+    StartTrigger,
+
+    /// Pause button.
+    PauseTrigger,
+
+    /// Reset button.
+    ResetTrigger,
+
+    /// Decorative colon between time segments.
+    Separator,
+}
+
+/// API for the `Timer` component.
+pub struct Api<'a> {
+    state: &'a State,
+    ctx: &'a Context,
+    props: &'a Props,
+    send: &'a dyn Fn(Event),
+}
+
+impl Debug for Api<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("timer::Api")
+            .field("state", self.state)
+            .field("ctx", self.ctx)
+            .field("props", self.props)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Api<'_> {
+    /// Whether the timer is actively ticking.
+    #[must_use]
+    pub const fn is_running(&self) -> bool {
+        matches!(self.state, State::Running)
+    }
+
+    /// Whether the timer is paused.
+    #[must_use]
+    pub const fn is_paused(&self) -> bool {
+        matches!(self.state, State::Paused)
+    }
+
+    /// Whether the countdown has completed.
+    #[must_use]
+    pub const fn is_completed(&self) -> bool {
+        matches!(self.state, State::Completed)
+    }
+
+    /// Whether the timer is idle at its initial value.
+    #[must_use]
+    pub const fn is_idle(&self) -> bool {
+        matches!(self.state, State::Idle)
+    }
+
+    /// The current time value.
+    #[must_use]
+    pub const fn current(&self) -> Duration {
+        self.ctx.current
+    }
+
+    /// Current time broken into hours, minutes, seconds, and milliseconds.
+    #[must_use]
+    pub const fn display_time(&self) -> (u64, u64, u64, u64) {
+        let total_ms = self.ctx.current.as_millis() as u64;
+
+        let hours = total_ms / 3_600_000;
+        let minutes = (total_ms % 3_600_000) / 60_000;
+        let seconds = (total_ms % 60_000) / 1_000;
+        let millis = total_ms % 1_000;
+
+        (hours, minutes, seconds, millis)
+    }
+
+    /// Progress as a fraction in `[0.0, 1.0]`.
+    ///
+    /// For countdown this is the fraction of [`Context::target`] already
+    /// elapsed; for stopwatch this is the elapsed time as a fraction of
+    /// [`Context::target`].
+    #[must_use]
+    pub fn progress(&self) -> f64 {
+        if self.ctx.target.is_zero() {
+            return 0.0;
+        }
+
+        let fraction = self.ctx.current.as_secs_f64() / self.ctx.target.as_secs_f64();
+
+        match self.ctx.mode {
+            Mode::Countdown => 1.0 - fraction,
+            Mode::Stopwatch => fraction,
+        }
+    }
+
+    /// Formatted time string (`HH:MM:SS` when hours are present, else `MM:SS`).
+    #[must_use]
+    pub fn formatted_time(&self) -> String {
+        let (hours, minutes, seconds, _millis) = self.display_time();
+
+        if hours > 0 {
+            format!("{hours:02}:{minutes:02}:{seconds:02}")
+        } else {
+            format!("{minutes:02}:{seconds:02}")
+        }
+    }
+
+    const fn state_str(&self) -> &'static str {
+        match self.state {
+            State::Idle => "idle",
+            State::Running => "running",
+            State::Paused => "paused",
+            State::Completed => "completed",
+        }
+    }
+
+    /// Root element attributes.
+    #[must_use]
+    pub fn root_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Root.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Role, "timer")
+            .set(HtmlAttr::Data("ars-state"), self.state_str())
+            .set(HtmlAttr::Aria(AriaAttr::Live), "polite")
+            .set(HtmlAttr::Aria(AriaAttr::Atomic), "true")
+            .set(HtmlAttr::Aria(AriaAttr::Label), self.formatted_time());
+
+        attrs
+    }
+
+    /// Label element attributes.
+    #[must_use]
+    pub fn label_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Label.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Id, self.ctx.ids.part("label"));
+
+        attrs
+    }
+
+    /// Display element attributes.
+    #[must_use]
+    pub fn display_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Display.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Id, self.ctx.ids.part("display"))
+            .set(HtmlAttr::Aria(AriaAttr::Hidden), "true");
+
+        attrs
+    }
+
+    /// Progress indicator attributes.
+    #[must_use]
+    pub fn progress_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Progress.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Role, "progressbar")
+            .set(
+                HtmlAttr::Aria(AriaAttr::ValueNow),
+                format!("{:.0}", self.progress() * 100.0),
+            )
+            .set(HtmlAttr::Aria(AriaAttr::ValueMin), "0")
+            .set(HtmlAttr::Aria(AriaAttr::ValueMax), "100")
+            .set(
+                HtmlAttr::Aria(AriaAttr::Label),
+                (self.ctx.messages.progress_label)(&self.ctx.locale),
+            )
+            .set_style(
+                CssProperty::Custom("ars-timer-progress"),
+                format!("{:.2}", self.progress()),
+            );
+
+        attrs
+    }
+
+    /// Start/resume trigger attributes.
+    #[must_use]
+    pub fn start_trigger_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::StartTrigger.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(
+                HtmlAttr::Aria(AriaAttr::Label),
+                if self.is_paused() {
+                    (self.ctx.messages.resume_label)(&self.ctx.locale)
+                } else {
+                    (self.ctx.messages.start_label)(&self.ctx.locale)
+                },
+            );
+
+        if self.is_running() || self.is_completed() {
+            attrs.set_bool(HtmlAttr::Disabled, true);
+        }
+
+        attrs
+    }
+
+    /// Pause trigger attributes.
+    #[must_use]
+    pub fn pause_trigger_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::PauseTrigger.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(
+                HtmlAttr::Aria(AriaAttr::Label),
+                (self.ctx.messages.pause_label)(&self.ctx.locale),
+            );
+
+        if !self.is_running() {
+            attrs.set_bool(HtmlAttr::Disabled, true);
+        }
+
+        attrs
+    }
+
+    /// Reset trigger attributes.
+    #[must_use]
+    pub fn reset_trigger_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::ResetTrigger.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(
+                HtmlAttr::Aria(AriaAttr::Label),
+                (self.ctx.messages.reset_label)(&self.ctx.locale),
+            );
+
+        if self.is_idle() {
+            attrs.set_bool(HtmlAttr::Disabled, true);
+        }
+
+        attrs
+    }
+
+    /// Separator element attributes.
+    #[must_use]
+    pub fn separator_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Separator.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Aria(AriaAttr::Hidden), "true");
+
+        attrs
+    }
+
+    /// Dispatches start/resume intent from the start trigger.
+    pub fn on_start_trigger_click(&self) {
+        if self.is_paused() {
+            (self.send)(Event::Resume);
+        } else {
+            (self.send)(Event::Start);
+        }
+    }
+
+    /// Dispatches pause intent from the pause trigger.
+    pub fn on_pause_trigger_click(&self) {
+        (self.send)(Event::Pause);
+    }
+
+    /// Dispatches reset intent from the reset trigger.
+    pub fn on_reset_trigger_click(&self) {
+        (self.send)(Event::Reset);
+    }
+
+    /// Dispatches restart intent (reset and immediately start).
+    pub fn on_restart(&self) {
+        (self.send)(Event::Restart);
+    }
+}
+
+impl ConnectApi for Api<'_> {
+    type Part = Part;
+
+    fn part_attrs(&self, part: Part) -> AttrMap {
+        match part {
+            Part::Root => self.root_attrs(),
+            Part::Label => self.label_attrs(),
+            Part::Display => self.display_attrs(),
+            Part::Progress => self.progress_attrs(),
+            Part::StartTrigger => self.start_trigger_attrs(),
+            Part::PauseTrigger => self.pause_trigger_attrs(),
+            Part::ResetTrigger => self.reset_trigger_attrs(),
+            Part::Separator => self.separator_attrs(),
+        }
+    }
+}
+
+/// The initial `current` value for a given mode and target.
+const fn initial_duration(mode: Mode, target: Duration) -> Duration {
+    match mode {
+        Mode::Countdown => target,
+        Mode::Stopwatch => Duration::ZERO,
+    }
+}
+
+/// Builds the marker effect that starts the adapter-owned tick interval.
+fn interval_effect() -> PendingEffect<Machine> {
+    PendingEffect::named(Effect::TimerInterval)
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::{boxed::Box, sync::Arc, vec, vec::Vec};
+    use std::sync::Mutex;
+
+    use ars_core::{Machine as _, Service};
+    use insta::assert_snapshot;
+
+    use super::*;
+
+    fn test_props() -> Props {
+        Props::new().id("timer")
+    }
+
+    fn fresh_service(props: Props) -> Service<Machine> {
+        Service::<Machine>::new(props, &Env::default(), &Messages::default())
+    }
+
+    fn snapshot_attrs(attrs: &AttrMap) -> String {
+        format!("{attrs:#?}")
+    }
+
+    fn effect_names(result: &ars_core::SendResult<Machine>) -> Vec<Effect> {
+        result
+            .pending_effects
+            .iter()
+            .map(|effect| effect.name)
+            .collect()
+    }
+
+    /// Leaks a fully-formed [`Api`] in an arbitrary state for attribute and
+    /// accessor assertions, mirroring the clipboard test helper.
+    fn api_for(state: State, current: Duration, mode: Mode, target: Duration) -> Api<'static> {
+        let props = Box::leak(Box::new(Props::new().id("timer").mode(mode).target(target)));
+
+        let messages = Messages::default();
+
+        let (_, mut ctx) = Machine::init(props, &Env::default(), &messages);
+
+        ctx.current = current;
+
+        let ctx = Box::leak(Box::new(ctx));
+        let state = Box::leak(Box::new(state));
+        let send = Box::leak(Box::new(|_: Event| {}));
+
+        Api {
+            state,
+            ctx,
+            props,
+            send,
+        }
+    }
+
+    // ───────────────────────── Props ─────────────────────────
+
+    #[test]
+    fn timer_props_default_matches_spec() {
+        let props = Props::default();
+
+        assert_eq!(props.id, "");
+        assert_eq!(props.target, Duration::from_secs(60));
+        assert_eq!(props.interval, Duration::from_secs(1));
+        assert_eq!(props.mode, Mode::Countdown);
+        assert!(!props.auto_start);
+    }
+
+    #[test]
+    fn timer_props_builder_sets_expected_fields() {
+        let props = Props::new()
+            .id("timer")
+            .target(Duration::from_secs(5))
+            .interval(Duration::from_millis(250))
+            .mode(Mode::Stopwatch)
+            .auto_start(true);
+
+        assert_eq!(props.id, "timer");
+        assert_eq!(props.target, Duration::from_secs(5));
+        assert_eq!(props.interval, Duration::from_millis(250));
+        assert_eq!(props.mode, Mode::Stopwatch);
+        assert!(props.auto_start);
+    }
+
+    #[test]
+    fn timer_mode_default_is_countdown() {
+        assert_eq!(Mode::default(), Mode::Countdown);
+    }
+
+    // ───────────────────────── init ─────────────────────────
+
+    #[test]
+    fn timer_countdown_init_starts_idle_at_target() {
+        let service = fresh_service(test_props().target(Duration::from_secs(30)));
+
+        assert_eq!(service.state(), &State::Idle);
+        assert_eq!(service.context().current, Duration::from_secs(30));
+        assert_eq!(service.context().target, Duration::from_secs(30));
+        assert_eq!(service.context().mode, Mode::Countdown);
+        assert_eq!(service.context().ids.id(), "timer");
+    }
+
+    #[test]
+    fn timer_stopwatch_init_starts_idle_at_zero() {
+        let service = fresh_service(
+            test_props()
+                .mode(Mode::Stopwatch)
+                .target(Duration::from_secs(30)),
+        );
+
+        assert_eq!(service.state(), &State::Idle);
+        assert_eq!(service.context().current, Duration::ZERO);
+    }
+
+    #[test]
+    fn timer_auto_start_boots_running_and_emits_interval_effect() {
+        let mut service = fresh_service(test_props().auto_start(true));
+
+        assert_eq!(service.state(), &State::Running);
+        assert_eq!(
+            service
+                .take_initial_effects()
+                .iter()
+                .map(|effect| effect.name)
+                .collect::<Vec<_>>(),
+            vec![Effect::TimerInterval]
+        );
+    }
+
+    #[test]
+    fn timer_without_auto_start_emits_no_initial_effects() {
+        let mut service = fresh_service(test_props());
+
+        assert_eq!(service.state(), &State::Idle);
+        assert!(service.take_initial_effects().is_empty());
+    }
+
+    // ───────────────────── transitions ─────────────────────
+
+    #[test]
+    fn timer_full_lifecycle_idle_running_paused_running_completed() {
+        let mut service = fresh_service(
+            test_props()
+                .target(Duration::from_secs(2))
+                .interval(Duration::from_secs(1)),
+        );
+
+        let started = service.send(Event::Start);
+
+        assert!(started.state_changed);
+        assert_eq!(service.state(), &State::Running);
+        assert_eq!(effect_names(&started), vec![Effect::TimerInterval]);
+
+        let tick = service.send(Event::Tick);
+
+        assert_eq!(service.state(), &State::Running);
+        assert_eq!(service.context().current, Duration::from_secs(1));
+        assert!(tick.pending_effects.is_empty());
+
+        let paused = service.send(Event::Pause);
+
+        assert_eq!(service.state(), &State::Paused);
+        assert_eq!(paused.cancel_effects, vec![Effect::TimerInterval]);
+
+        let resumed = service.send(Event::Resume);
+
+        assert_eq!(service.state(), &State::Running);
+        assert_eq!(effect_names(&resumed), vec![Effect::TimerInterval]);
+
+        let completed = service.send(Event::Tick);
+
+        assert_eq!(service.state(), &State::Completed);
+        assert_eq!(service.context().current, Duration::ZERO);
+        assert_eq!(completed.cancel_effects, vec![Effect::TimerInterval]);
+        assert_eq!(effect_names(&completed), vec![Effect::AnnounceCompleted]);
+    }
+
+    #[test]
+    fn timer_countdown_tick_decrements_by_interval() {
+        let mut service = fresh_service(
+            test_props()
+                .target(Duration::from_secs(10))
+                .interval(Duration::from_millis(2_500)),
+        );
+
+        drop(service.send(Event::Start));
+
+        drop(service.send(Event::Tick));
+
+        assert_eq!(service.context().current, Duration::from_millis(7_500));
+
+        drop(service.send(Event::Tick));
+
+        assert_eq!(service.context().current, Duration::from_secs(5));
+    }
+
+    #[test]
+    fn timer_countdown_tick_at_or_below_interval_completes() {
+        // current (500ms) < interval (1s) saturates to zero and completes.
+        let mut service = fresh_service(
+            test_props()
+                .target(Duration::from_millis(500))
+                .interval(Duration::from_secs(1)),
+        );
+
+        drop(service.send(Event::Start));
+
+        let result = service.send(Event::Tick);
+
+        assert_eq!(service.state(), &State::Completed);
+        assert_eq!(service.context().current, Duration::ZERO);
+        assert_eq!(effect_names(&result), vec![Effect::AnnounceCompleted]);
+    }
+
+    #[test]
+    fn timer_stopwatch_tick_increments_from_zero() {
+        let mut service = fresh_service(
+            test_props()
+                .mode(Mode::Stopwatch)
+                .interval(Duration::from_secs(1)),
+        );
+
+        drop(service.send(Event::Start));
+
+        drop(service.send(Event::Tick));
+
+        assert_eq!(service.state(), &State::Running);
+        assert_eq!(service.context().current, Duration::from_secs(1));
+
+        drop(service.send(Event::Tick));
+
+        assert_eq!(service.context().current, Duration::from_secs(2));
+    }
+
+    #[test]
+    fn timer_stopwatch_never_completes() {
+        let mut service = fresh_service(
+            test_props()
+                .mode(Mode::Stopwatch)
+                .target(Duration::from_secs(1)),
+        );
+
+        drop(service.send(Event::Start));
+
+        for _ in 0..5 {
+            drop(service.send(Event::Tick));
+        }
+
+        assert_eq!(service.state(), &State::Running);
+        assert_eq!(service.context().current, Duration::from_secs(5));
+    }
+
+    #[test]
+    fn timer_reset_returns_to_idle_and_cancels_interval() {
+        let mut service = fresh_service(test_props().target(Duration::from_secs(10)));
+
+        drop(service.send(Event::Start));
+        drop(service.send(Event::Tick));
+
+        let result = service.send(Event::Reset);
+
+        assert_eq!(service.state(), &State::Idle);
+        assert_eq!(service.context().current, Duration::from_secs(10));
+        assert_eq!(result.cancel_effects, vec![Effect::TimerInterval]);
+        assert!(result.pending_effects.is_empty());
+    }
+
+    #[test]
+    fn timer_reset_stopwatch_returns_to_zero() {
+        let mut service = fresh_service(test_props().mode(Mode::Stopwatch));
+
+        drop(service.send(Event::Start));
+        drop(service.send(Event::Tick));
+
+        drop(service.send(Event::Reset));
+
+        assert_eq!(service.state(), &State::Idle);
+        assert_eq!(service.context().current, Duration::ZERO);
+    }
+
+    #[test]
+    fn timer_restart_resets_value_and_restarts_interval() {
+        let mut service = fresh_service(test_props().target(Duration::from_secs(10)));
+
+        drop(service.send(Event::Start));
+        drop(service.send(Event::Tick));
+        drop(service.send(Event::Pause));
+
+        let result = service.send(Event::Restart);
+
+        assert_eq!(service.state(), &State::Running);
+        assert_eq!(service.context().current, Duration::from_secs(10));
+        assert_eq!(result.cancel_effects, vec![Effect::TimerInterval]);
+        assert_eq!(effect_names(&result), vec![Effect::TimerInterval]);
+    }
+
+    #[test]
+    fn timer_set_time_updates_current_without_changing_state() {
+        let mut service = fresh_service(test_props().target(Duration::from_secs(10)));
+
+        drop(service.send(Event::Start));
+
+        let result = service.send(Event::SetTime(Duration::from_millis(3_333)));
+
+        assert_eq!(service.state(), &State::Running);
+        assert_eq!(service.context().current, Duration::from_millis(3_333));
+        assert!(result.context_changed);
+    }
+
+    #[test]
+    fn timer_ignores_unhandled_events() {
+        let mut service = fresh_service(test_props());
+
+        // Tick while idle is a no-op.
+        let result = service.send(Event::Tick);
+
+        assert!(!result.state_changed);
+        assert_eq!(service.state(), &State::Idle);
+
+        // Pause while idle is a no-op.
+        let result = service.send(Event::Pause);
+
+        assert!(!result.state_changed);
+
+        // Start from completed is rejected.
+        let mut service = fresh_service(
+            test_props()
+                .target(Duration::from_secs(1))
+                .interval(Duration::from_secs(1)),
+        );
+
+        drop(service.send(Event::Start));
+        drop(service.send(Event::Tick));
+
+        assert_eq!(service.state(), &State::Completed);
+
+        let result = service.send(Event::Start);
+
+        assert!(!result.state_changed);
+        assert_eq!(service.state(), &State::Completed);
+    }
+
+    // ───────────────────────── Api ─────────────────────────
+
+    #[test]
+    fn timer_api_state_predicates_match_state() {
+        let one_sec = Duration::from_secs(1);
+
+        assert!(api_for(State::Idle, Duration::ZERO, Mode::Countdown, one_sec).is_idle());
+        assert!(api_for(State::Running, Duration::ZERO, Mode::Countdown, one_sec).is_running());
+        assert!(api_for(State::Paused, Duration::ZERO, Mode::Countdown, one_sec).is_paused());
+        assert!(api_for(State::Completed, Duration::ZERO, Mode::Countdown, one_sec).is_completed());
+    }
+
+    #[test]
+    fn timer_api_current_reports_context() {
+        assert_eq!(
+            api_for(
+                State::Running,
+                Duration::from_millis(4_200),
+                Mode::Countdown,
+                Duration::from_secs(10),
+            )
+            .current(),
+            Duration::from_millis(4_200)
+        );
+    }
+
+    #[test]
+    fn timer_api_display_time_splits_segments() {
+        let value = Duration::from_millis(3_661_000);
+
+        let api = api_for(State::Running, value, Mode::Countdown, value);
+
+        assert_eq!(api.display_time(), (1, 1, 1, 0));
+
+        let value = Duration::from_millis(90_500);
+
+        let api = api_for(State::Running, value, Mode::Countdown, value);
+
+        assert_eq!(api.display_time(), (0, 1, 30, 500));
+    }
+
+    #[test]
+    fn timer_api_formatted_time_uses_hours_only_when_present() {
+        let with_hours = Duration::from_millis(3_661_000);
+
+        assert_eq!(
+            api_for(State::Running, with_hours, Mode::Countdown, with_hours).formatted_time(),
+            "01:01:01"
+        );
+
+        let without_hours = Duration::from_secs(90);
+
+        assert_eq!(
+            api_for(
+                State::Running,
+                without_hours,
+                Mode::Countdown,
+                without_hours
+            )
+            .formatted_time(),
+            "01:30"
+        );
+    }
+
+    #[test]
+    fn timer_api_progress_countdown_and_stopwatch() {
+        let one_sec = Duration::from_secs(1);
+        let half_sec = Duration::from_millis(500);
+
+        // Countdown: progress is the elapsed fraction.
+        assert!(
+            (api_for(State::Idle, one_sec, Mode::Countdown, one_sec).progress() - 0.0).abs() < 1e-9
+        );
+        assert!(
+            (api_for(State::Running, half_sec, Mode::Countdown, one_sec).progress() - 0.5).abs()
+                < 1e-9
+        );
+        assert!(
+            (api_for(State::Completed, Duration::ZERO, Mode::Countdown, one_sec).progress() - 1.0)
+                .abs()
+                < 1e-9
+        );
+
+        // Stopwatch: progress is the elapsed fraction of target.
+        assert!(
+            (api_for(State::Running, half_sec, Mode::Stopwatch, one_sec).progress() - 0.5).abs()
+                < 1e-9
+        );
+
+        // Zero target guards against division by zero.
+        assert!(
+            (api_for(State::Idle, Duration::ZERO, Mode::Countdown, Duration::ZERO).progress()
+                - 0.0)
+                .abs()
+                < 1e-9
+        );
+    }
+
+    #[test]
+    fn timer_root_attrs_carry_timer_role_live_region_and_label() {
+        let api = api_for(
+            State::Running,
+            Duration::from_secs(30),
+            Mode::Countdown,
+            Duration::from_secs(60),
+        );
+
+        let attrs = api.root_attrs();
+
+        assert_eq!(attrs.get(&HtmlAttr::Role), Some("timer"));
+        assert_eq!(attrs.get(&HtmlAttr::Aria(AriaAttr::Live)), Some("polite"));
+        assert_eq!(attrs.get(&HtmlAttr::Aria(AriaAttr::Atomic)), Some("true"));
+        assert_eq!(attrs.get(&HtmlAttr::Aria(AriaAttr::Label)), Some("00:30"));
+        assert_eq!(attrs.get(&HtmlAttr::Data("ars-state")), Some("running"));
+    }
+
+    #[test]
+    fn timer_root_data_state_tracks_each_state() {
+        let one_sec = Duration::from_secs(1);
+
+        assert_eq!(
+            api_for(State::Idle, Duration::ZERO, Mode::Countdown, one_sec)
+                .root_attrs()
+                .get(&HtmlAttr::Data("ars-state")),
+            Some("idle")
+        );
+        assert_eq!(
+            api_for(State::Paused, Duration::ZERO, Mode::Countdown, one_sec)
+                .root_attrs()
+                .get(&HtmlAttr::Data("ars-state")),
+            Some("paused")
+        );
+        assert_eq!(
+            api_for(State::Completed, Duration::ZERO, Mode::Countdown, one_sec)
+                .root_attrs()
+                .get(&HtmlAttr::Data("ars-state")),
+            Some("completed")
+        );
+    }
+
+    #[test]
+    fn timer_progress_attrs_expose_progressbar_role_and_values() {
+        let attrs = api_for(
+            State::Completed,
+            Duration::ZERO,
+            Mode::Countdown,
+            Duration::from_secs(1),
+        )
+        .progress_attrs();
+
+        assert_eq!(attrs.get(&HtmlAttr::Role), Some("progressbar"));
+        assert_eq!(attrs.get(&HtmlAttr::Aria(AriaAttr::ValueNow)), Some("100"));
+        assert_eq!(attrs.get(&HtmlAttr::Aria(AriaAttr::ValueMin)), Some("0"));
+        assert_eq!(attrs.get(&HtmlAttr::Aria(AriaAttr::ValueMax)), Some("100"));
+        assert_eq!(
+            attrs.get(&HtmlAttr::Aria(AriaAttr::Label)),
+            Some("Timer progress")
+        );
+    }
+
+    #[test]
+    fn timer_trigger_disabled_states_match_spec() {
+        let one_sec = Duration::from_secs(1);
+
+        // StartTrigger disabled while running or completed.
+        assert!(
+            api_for(State::Running, Duration::ZERO, Mode::Countdown, one_sec)
+                .start_trigger_attrs()
+                .contains(&HtmlAttr::Disabled)
+        );
+        assert!(
+            api_for(State::Completed, Duration::ZERO, Mode::Countdown, one_sec)
+                .start_trigger_attrs()
+                .contains(&HtmlAttr::Disabled)
+        );
+        assert!(
+            !api_for(State::Idle, Duration::ZERO, Mode::Countdown, one_sec)
+                .start_trigger_attrs()
+                .contains(&HtmlAttr::Disabled)
+        );
+
+        // PauseTrigger disabled unless running.
+        assert!(
+            !api_for(State::Running, Duration::ZERO, Mode::Countdown, one_sec)
+                .pause_trigger_attrs()
+                .contains(&HtmlAttr::Disabled)
+        );
+        assert!(
+            api_for(State::Idle, Duration::ZERO, Mode::Countdown, one_sec)
+                .pause_trigger_attrs()
+                .contains(&HtmlAttr::Disabled)
+        );
+
+        // ResetTrigger disabled while idle.
+        assert!(
+            api_for(State::Idle, Duration::ZERO, Mode::Countdown, one_sec)
+                .reset_trigger_attrs()
+                .contains(&HtmlAttr::Disabled)
+        );
+        assert!(
+            !api_for(State::Running, Duration::ZERO, Mode::Countdown, one_sec)
+                .reset_trigger_attrs()
+                .contains(&HtmlAttr::Disabled)
+        );
+    }
+
+    #[test]
+    fn timer_start_trigger_label_switches_to_resume_when_paused() {
+        let one_sec = Duration::from_secs(1);
+
+        assert_eq!(
+            api_for(State::Idle, Duration::ZERO, Mode::Countdown, one_sec)
+                .start_trigger_attrs()
+                .get(&HtmlAttr::Aria(AriaAttr::Label)),
+            Some("Start timer")
+        );
+        assert_eq!(
+            api_for(State::Paused, Duration::ZERO, Mode::Countdown, one_sec)
+                .start_trigger_attrs()
+                .get(&HtmlAttr::Aria(AriaAttr::Label)),
+            Some("Resume timer")
+        );
+    }
+
+    #[test]
+    fn timer_click_handlers_dispatch_expected_events() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+
+        let start_from_idle = {
+            let captured = Arc::clone(&events);
+            move |event| captured.lock().unwrap().push(event)
+        };
+
+        fresh_service(test_props())
+            .connect(&start_from_idle)
+            .on_start_trigger_click();
+
+        // Resume path from paused.
+        let mut paused = fresh_service(test_props());
+
+        drop(paused.send(Event::Start));
+        drop(paused.send(Event::Pause));
+
+        {
+            let captured = Arc::clone(&events);
+
+            let sink = move |event| captured.lock().unwrap().push(event);
+
+            paused.connect(&sink).on_start_trigger_click();
+        }
+
+        let service = fresh_service(test_props());
+
+        {
+            let captured = Arc::clone(&events);
+
+            let sink = move |event| captured.lock().unwrap().push(event);
+
+            let api = service.connect(&sink);
+
+            api.on_pause_trigger_click();
+            api.on_reset_trigger_click();
+            api.on_restart();
+        }
+
+        assert_eq!(
+            *events.lock().unwrap(),
+            vec![
+                Event::Start,
+                Event::Resume,
+                Event::Pause,
+                Event::Reset,
+                Event::Restart,
+            ]
+        );
+    }
+
+    #[test]
+    fn timer_connect_api_dispatch_matches_inherent_attrs() {
+        let api = api_for(
+            State::Running,
+            Duration::from_secs(30),
+            Mode::Countdown,
+            Duration::from_secs(60),
+        );
+
+        assert_eq!(api.part_attrs(Part::Root), api.root_attrs());
+        assert_eq!(api.part_attrs(Part::Label), api.label_attrs());
+        assert_eq!(api.part_attrs(Part::Display), api.display_attrs());
+        assert_eq!(api.part_attrs(Part::Progress), api.progress_attrs());
+        assert_eq!(
+            api.part_attrs(Part::StartTrigger),
+            api.start_trigger_attrs()
+        );
+        assert_eq!(
+            api.part_attrs(Part::PauseTrigger),
+            api.pause_trigger_attrs()
+        );
+        assert_eq!(
+            api.part_attrs(Part::ResetTrigger),
+            api.reset_trigger_attrs()
+        );
+        assert_eq!(api.part_attrs(Part::Separator), api.separator_attrs());
+    }
+
+    // ─────────────────────── snapshots ───────────────────────
+
+    fn countdown_api(state: State, current_secs: u64) -> Api<'static> {
+        api_for(
+            state,
+            Duration::from_secs(current_secs),
+            Mode::Countdown,
+            Duration::from_secs(60),
+        )
+    }
+
+    #[test]
+    fn timer_root_idle_snapshot() {
+        assert_snapshot!(snapshot_attrs(&countdown_api(State::Idle, 60).root_attrs()));
+    }
+
+    #[test]
+    fn timer_root_running_snapshot() {
+        assert_snapshot!(snapshot_attrs(
+            &countdown_api(State::Running, 30).root_attrs()
+        ));
+    }
+
+    #[test]
+    fn timer_root_paused_snapshot() {
+        assert_snapshot!(snapshot_attrs(
+            &countdown_api(State::Paused, 30).root_attrs()
+        ));
+    }
+
+    #[test]
+    fn timer_root_completed_snapshot() {
+        assert_snapshot!(snapshot_attrs(
+            &countdown_api(State::Completed, 0).root_attrs()
+        ));
+    }
+
+    #[test]
+    fn timer_root_with_hours_snapshot() {
+        assert_snapshot!(snapshot_attrs(
+            &api_for(
+                State::Running,
+                Duration::from_secs(3_600),
+                Mode::Countdown,
+                Duration::from_secs(3_600),
+            )
+            .root_attrs()
+        ));
+    }
+
+    #[test]
+    fn timer_label_snapshot() {
+        assert_snapshot!(snapshot_attrs(
+            &countdown_api(State::Idle, 60).label_attrs()
+        ));
+    }
+
+    #[test]
+    fn timer_display_snapshot() {
+        assert_snapshot!(snapshot_attrs(
+            &countdown_api(State::Idle, 60).display_attrs()
+        ));
+    }
+
+    #[test]
+    fn timer_progress_idle_snapshot() {
+        assert_snapshot!(snapshot_attrs(
+            &countdown_api(State::Idle, 60).progress_attrs()
+        ));
+    }
+
+    #[test]
+    fn timer_progress_completed_snapshot() {
+        assert_snapshot!(snapshot_attrs(
+            &countdown_api(State::Completed, 0).progress_attrs()
+        ));
+    }
+
+    #[test]
+    fn timer_start_trigger_idle_snapshot() {
+        assert_snapshot!(snapshot_attrs(
+            &countdown_api(State::Idle, 60).start_trigger_attrs()
+        ));
+    }
+
+    #[test]
+    fn timer_start_trigger_paused_snapshot() {
+        assert_snapshot!(snapshot_attrs(
+            &countdown_api(State::Paused, 30).start_trigger_attrs()
+        ));
+    }
+
+    #[test]
+    fn timer_start_trigger_running_snapshot() {
+        assert_snapshot!(snapshot_attrs(
+            &countdown_api(State::Running, 30).start_trigger_attrs()
+        ));
+    }
+
+    #[test]
+    fn timer_pause_trigger_running_snapshot() {
+        assert_snapshot!(snapshot_attrs(
+            &countdown_api(State::Running, 30).pause_trigger_attrs()
+        ));
+    }
+
+    #[test]
+    fn timer_pause_trigger_idle_snapshot() {
+        assert_snapshot!(snapshot_attrs(
+            &countdown_api(State::Idle, 60).pause_trigger_attrs()
+        ));
+    }
+
+    #[test]
+    fn timer_reset_trigger_idle_snapshot() {
+        assert_snapshot!(snapshot_attrs(
+            &countdown_api(State::Idle, 60).reset_trigger_attrs()
+        ));
+    }
+
+    #[test]
+    fn timer_reset_trigger_running_snapshot() {
+        assert_snapshot!(snapshot_attrs(
+            &countdown_api(State::Running, 30).reset_trigger_attrs()
+        ));
+    }
+
+    #[test]
+    fn timer_separator_snapshot() {
+        assert_snapshot!(snapshot_attrs(
+            &countdown_api(State::Idle, 60).separator_attrs()
+        ));
+    }
+}

--- a/crates/ars-components/src/specialized/timer/mod.rs
+++ b/crates/ars-components/src/specialized/timer/mod.rs
@@ -73,6 +73,11 @@ pub enum Event {
 
     /// Set the remaining/elapsed time directly.
     SetTime(Duration),
+
+    /// Synchronize the context-backed props (`target`, `interval`, `mode`)
+    /// after a controlled prop update. Emitted by
+    /// [`Machine::on_props_changed`](ars_core::Machine::on_props_changed).
+    SyncProps,
 }
 
 /// Context for the `Timer` component.
@@ -318,7 +323,12 @@ impl ars_core::Machine for Machine {
     fn init(props: &Self::Props, env: &Env, messages: &Self::Messages) -> (State, Context) {
         let current = initial_duration(props.mode, props.target);
 
-        let state = if props.auto_start {
+        // A zero-duration countdown is already complete; it must not enter
+        // `Running` (which would show `00:00` ticking and defer the
+        // announcement). `auto_start` is ignored in that degenerate case.
+        let state = if is_instantly_complete(props.mode, props.target) {
+            State::Completed
+        } else if props.auto_start {
             State::Running
         } else {
             State::Idle
@@ -329,7 +339,10 @@ impl ars_core::Machine for Machine {
             Context {
                 current,
                 target: props.target,
-                interval: props.interval,
+                // Guarantee forward progress: a zero interval would make every
+                // tick a no-op (countdown never reaches zero, stopwatch never
+                // advances) and keep the adapter interval alive forever.
+                interval: effective_interval(props.interval),
                 mode: props.mode,
                 auto_start: props.auto_start,
                 locale: env.locale.clone(),
@@ -338,6 +351,19 @@ impl ars_core::Machine for Machine {
                 intl_backend: Arc::clone(&env.intl_backend),
             },
         )
+    }
+
+    fn on_props_changed(old: &Props, new: &Props) -> Vec<Event> {
+        assert_eq!(
+            old.id, new.id,
+            "timer::Props.id must remain stable after init"
+        );
+
+        if old.target != new.target || old.interval != new.interval || old.mode != new.mode {
+            alloc::vec![Event::SyncProps]
+        } else {
+            Vec::new()
+        }
     }
 
     fn initial_effects(
@@ -360,7 +386,7 @@ impl ars_core::Machine for Machine {
         state: &Self::State,
         event: &Self::Event,
         ctx: &Self::Context,
-        _props: &Self::Props,
+        props: &Self::Props,
     ) -> Option<TransitionPlan<Self>> {
         match (state, event) {
             // Idle start, paused resume, and paused start all enter `Running`
@@ -413,20 +439,50 @@ impl ars_core::Machine for Machine {
 
             (_, Event::Restart) => {
                 let initial = initial_duration(ctx.mode, ctx.target);
-                Some(
-                    TransitionPlan::to(State::Running)
-                        .apply(move |ctx: &mut Context| {
-                            ctx.current = initial;
-                        })
-                        .cancel_effect(Effect::TimerInterval)
-                        .with_effect(PendingEffect::named(Effect::TimerInterval)),
-                )
+
+                // Restarting a zero-duration countdown completes immediately
+                // rather than entering `Running`; otherwise reset and run.
+                if is_instantly_complete(ctx.mode, ctx.target) {
+                    Some(
+                        TransitionPlan::to(State::Completed)
+                            .apply(move |ctx: &mut Context| {
+                                ctx.current = initial;
+                            })
+                            .cancel_effect(Effect::TimerInterval),
+                    )
+                } else {
+                    Some(
+                        TransitionPlan::to(State::Running)
+                            .apply(move |ctx: &mut Context| {
+                                ctx.current = initial;
+                            })
+                            .cancel_effect(Effect::TimerInterval)
+                            .with_effect(PendingEffect::named(Effect::TimerInterval)),
+                    )
+                }
             }
 
             (_, Event::SetTime(duration)) => {
                 let duration = *duration;
                 Some(TransitionPlan::context_only(move |ctx: &mut Context| {
                     ctx.current = duration;
+                }))
+            }
+
+            (_, Event::SyncProps) => {
+                let target = props.target;
+                let interval = effective_interval(props.interval);
+                let mode = props.mode;
+                // While idle the displayed value mirrors the (new) initial; once
+                // running/paused/completed the in-progress `current` is kept.
+                let reset_current = matches!(state, State::Idle);
+                Some(TransitionPlan::context_only(move |ctx: &mut Context| {
+                    ctx.target = target;
+                    ctx.interval = interval;
+                    ctx.mode = mode;
+                    if reset_current {
+                        ctx.current = initial_duration(mode, target);
+                    }
                 }))
             }
 
@@ -816,6 +872,29 @@ const fn initial_duration(mode: Mode, target: Duration) -> Duration {
     }
 }
 
+/// The fallback tick interval substituted for a zero interval.
+///
+/// A zero interval makes every tick a no-op (a countdown never reaches zero and
+/// a stopwatch never advances), so it is replaced with 1ms to guarantee the
+/// timer always makes forward progress.
+const MIN_INTERVAL: Duration = Duration::from_millis(1);
+
+/// Replaces a zero interval with [`MIN_INTERVAL`]; any non-zero interval (even
+/// sub-millisecond) already makes progress and is left untouched.
+const fn effective_interval(interval: Duration) -> Duration {
+    if interval.is_zero() {
+        MIN_INTERVAL
+    } else {
+        interval
+    }
+}
+
+/// Whether a `(mode, target)` pair describes a countdown that is already at
+/// zero and therefore complete on arrival.
+const fn is_instantly_complete(mode: Mode, target: Duration) -> bool {
+    matches!(mode, Mode::Countdown) && target.is_zero()
+}
+
 /// Builds the marker effect that starts the adapter-owned tick interval.
 fn interval_effect() -> PendingEffect<Machine> {
     PendingEffect::named(Effect::TimerInterval)
@@ -1054,6 +1133,150 @@ mod tests {
 
         assert!(debug.contains("timer::Context"));
         assert!(debug.contains("<dyn IntlBackend>"));
+    }
+
+    #[test]
+    fn timer_zero_interval_is_clamped_to_guarantee_progress() {
+        let mut service = fresh_service(
+            test_props()
+                .target(Duration::from_secs(1))
+                .interval(Duration::ZERO),
+        );
+
+        // The zero interval is replaced with the 1ms floor.
+        assert_eq!(service.context().interval, Duration::from_millis(1));
+
+        // And a countdown therefore still makes progress instead of stalling.
+        drop(service.send(Event::Start));
+        drop(service.send(Event::Tick));
+        assert_eq!(service.context().current, Duration::from_millis(999));
+    }
+
+    #[test]
+    fn timer_zero_target_countdown_initializes_completed() {
+        let mut service = fresh_service(test_props().target(Duration::ZERO));
+
+        assert_eq!(service.state(), &State::Completed);
+        assert_eq!(service.context().current, Duration::ZERO);
+        // No interval is armed for an already-complete timer, even with auto-start.
+        assert!(service.take_initial_effects().is_empty());
+
+        let mut auto = fresh_service(test_props().target(Duration::ZERO).auto_start(true));
+        assert_eq!(auto.state(), &State::Completed);
+        assert!(auto.take_initial_effects().is_empty());
+
+        // A zero-target stopwatch is not "complete" — it counts up from zero.
+        let stopwatch = fresh_service(test_props().mode(Mode::Stopwatch).target(Duration::ZERO));
+        assert_eq!(stopwatch.state(), &State::Idle);
+    }
+
+    #[test]
+    fn timer_zero_target_restart_completes_immediately() {
+        let mut service = fresh_service(test_props().target(Duration::ZERO));
+
+        let result = service.send(Event::Restart);
+
+        assert_eq!(service.state(), &State::Completed);
+        assert_eq!(service.context().current, Duration::ZERO);
+        // No interval armed; it completed on arrival.
+        assert!(result.pending_effects.is_empty());
+        assert_eq!(result.cancel_effects, vec![Effect::TimerInterval]);
+    }
+
+    #[test]
+    fn timer_on_props_changed_emits_sync_only_for_context_backed_props() {
+        let base = test_props();
+
+        // No change -> no event.
+        assert!(<Machine as ars_core::Machine>::on_props_changed(&base, &base).is_empty());
+
+        // auto_start is consumed only at init, so it is not synced.
+        assert!(
+            <Machine as ars_core::Machine>::on_props_changed(
+                &base,
+                &Props {
+                    auto_start: true,
+                    ..base.clone()
+                },
+            )
+            .is_empty()
+        );
+
+        // target / interval / mode each trigger a sync.
+        for changed in [
+            Props {
+                target: Duration::from_secs(5),
+                ..base.clone()
+            },
+            Props {
+                interval: Duration::from_millis(250),
+                ..base.clone()
+            },
+            Props {
+                mode: Mode::Stopwatch,
+                ..base.clone()
+            },
+        ] {
+            assert_eq!(
+                <Machine as ars_core::Machine>::on_props_changed(&base, &changed),
+                vec![Event::SyncProps]
+            );
+        }
+    }
+
+    #[test]
+    fn timer_set_props_syncs_context_backed_props() {
+        let mut service = fresh_service(
+            test_props()
+                .target(Duration::from_secs(60))
+                .interval(Duration::from_secs(1)),
+        );
+        assert_eq!(service.context().current, Duration::from_secs(60));
+
+        // Idle: synced fields land in context and `current` re-mirrors the target.
+        let result = service.set_props(
+            test_props()
+                .target(Duration::from_secs(30))
+                .interval(Duration::from_millis(500)),
+        );
+        assert!(result.context_changed);
+        assert_eq!(service.context().target, Duration::from_secs(30));
+        assert_eq!(service.context().interval, Duration::from_millis(500));
+        assert_eq!(service.context().current, Duration::from_secs(30));
+
+        // A zero interval pushed via props is clamped on sync, too.
+        drop(
+            service.set_props(
+                test_props()
+                    .target(Duration::from_secs(30))
+                    .interval(Duration::ZERO),
+            ),
+        );
+        assert_eq!(service.context().interval, Duration::from_millis(1));
+    }
+
+    #[test]
+    fn timer_set_props_while_running_keeps_current_but_updates_interval() {
+        let mut service = fresh_service(
+            test_props()
+                .target(Duration::from_secs(60))
+                .interval(Duration::from_secs(1)),
+        );
+        drop(service.send(Event::Start));
+        drop(service.send(Event::Tick)); // current -> 59s
+
+        drop(
+            service.set_props(
+                test_props()
+                    .target(Duration::from_secs(60))
+                    .interval(Duration::from_secs(2)),
+            ),
+        );
+
+        assert_eq!(service.state(), &State::Running);
+        assert_eq!(service.context().interval, Duration::from_secs(2));
+        // Mid-run elapsed value is preserved (not reset to the target).
+        assert_eq!(service.context().current, Duration::from_secs(59));
     }
 
     // ───────────────────── transitions ─────────────────────

--- a/crates/ars-components/src/specialized/timer/mod.rs
+++ b/crates/ars-components/src/specialized/timer/mod.rs
@@ -11,15 +11,16 @@
 //! that dispatches `Event::Tick`, and translate `Effect::AnnounceCompleted`
 //! into a live-region announcement.
 
-use alloc::{format, string::String, vec::Vec};
+use alloc::{format, string::String, sync::Arc, vec::Vec};
 use core::{
     fmt::{self, Debug},
+    num::NonZeroU8,
     time::Duration,
 };
 
 use ars_core::{
     AriaAttr, AttrMap, ComponentIds, ComponentMessages, ComponentPart, ConnectApi, CssProperty,
-    Env, HasId, HtmlAttr, Locale, MessageFn, PendingEffect, TransitionPlan,
+    Env, HasId, HtmlAttr, IntlBackend, Locale, MessageFn, PendingEffect, TransitionPlan,
 };
 
 /// Timer mode.
@@ -75,7 +76,12 @@ pub enum Event {
 }
 
 /// Context for the `Timer` component.
-#[derive(Clone, Debug, PartialEq)]
+///
+/// Cloneable but not `Debug`/`PartialEq`-derivable because [`Context::intl_backend`]
+/// is a trait object; both impls are provided manually and exclude the backend
+/// (it is an injected service, not observable state), mirroring
+/// [`time_field`](crate::date_time::time_field).
+#[derive(Clone)]
 pub struct Context {
     /// Current time value. For countdown this is the remaining time; for
     /// stopwatch this is the elapsed time.
@@ -101,6 +107,38 @@ pub struct Context {
 
     /// Component instance IDs.
     pub ids: ComponentIds,
+
+    /// Backend used for locale-aware digit formatting of the displayed time.
+    pub intl_backend: Arc<dyn IntlBackend>,
+}
+
+impl Debug for Context {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("timer::Context")
+            .field("current", &self.current)
+            .field("target", &self.target)
+            .field("interval", &self.interval)
+            .field("mode", &self.mode)
+            .field("auto_start", &self.auto_start)
+            .field("locale", &self.locale)
+            .field("messages", &self.messages)
+            .field("ids", &self.ids)
+            .field("intl_backend", &"<dyn IntlBackend>")
+            .finish()
+    }
+}
+
+impl PartialEq for Context {
+    fn eq(&self, other: &Self) -> bool {
+        self.current == other.current
+            && self.target == other.target
+            && self.interval == other.interval
+            && self.mode == other.mode
+            && self.auto_start == other.auto_start
+            && self.locale == other.locale
+            && self.messages == other.messages
+            && self.ids == other.ids
+    }
 }
 
 /// Props for the `Timer` component.
@@ -297,6 +335,7 @@ impl ars_core::Machine for Machine {
                 locale: env.locale.clone(),
                 messages: messages.clone(),
                 ids: ComponentIds::from_id(&props.id),
+                intl_backend: Arc::clone(&env.intl_backend),
             },
         )
     }
@@ -505,7 +544,10 @@ impl Api<'_> {
     ///
     /// For countdown this is the fraction of [`Context::target`] already
     /// elapsed; for stopwatch this is the elapsed time as a fraction of
-    /// [`Context::target`].
+    /// [`Context::target`]. The result is clamped to `[0.0, 1.0]` so an
+    /// over-target stopwatch or an out-of-range [`Event::SetTime`] never yields
+    /// a value outside the documented range (which would otherwise break the
+    /// `progressbar` `aria-valuenow`/`valuemin`/`valuemax` semantics).
     #[must_use]
     pub fn progress(&self) -> f64 {
         if self.ctx.target.is_zero() {
@@ -514,21 +556,45 @@ impl Api<'_> {
 
         let fraction = self.ctx.current.as_secs_f64() / self.ctx.target.as_secs_f64();
 
-        match self.ctx.mode {
+        let progress = match self.ctx.mode {
             Mode::Countdown => 1.0 - fraction,
             Mode::Stopwatch => fraction,
-        }
+        };
+
+        progress.clamp(0.0, 1.0)
     }
 
     /// Formatted time string (`HH:MM:SS` when hours are present, else `MM:SS`).
+    ///
+    /// Digits are rendered through [`Context::intl_backend`] so non-ASCII
+    /// numbering systems (e.g. Arabic-Indic) are honored when a localizing
+    /// backend is provided; the default
+    /// [`StubIntlBackend`](ars_core::StubIntlBackend) yields ASCII digits.
     #[must_use]
     pub fn formatted_time(&self) -> String {
         let (hours, minutes, seconds, _millis) = self.display_time();
 
+        let format_segment = |value: u64| {
+            let width = NonZeroU8::new(2).expect("segment width is non-zero");
+            u32::try_from(value).map_or_else(
+                |_| value.to_string(),
+                |value| {
+                    self.ctx
+                        .intl_backend
+                        .format_segment_digits(value, width, &self.ctx.locale)
+                },
+            )
+        };
+
         if hours > 0 {
-            format!("{hours:02}:{minutes:02}:{seconds:02}")
+            format!(
+                "{}:{}:{}",
+                format_segment(hours),
+                format_segment(minutes),
+                format_segment(seconds)
+            )
         } else {
-            format!("{minutes:02}:{seconds:02}")
+            format!("{}:{}", format_segment(minutes), format_segment(seconds))
         }
     }
 
@@ -625,6 +691,7 @@ impl Api<'_> {
         attrs
             .set(scope_attr, scope_val)
             .set(part_attr, part_val)
+            .set(HtmlAttr::Type, "button")
             .set(
                 HtmlAttr::Aria(AriaAttr::Label),
                 if self.is_paused() {
@@ -650,6 +717,7 @@ impl Api<'_> {
         attrs
             .set(scope_attr, scope_val)
             .set(part_attr, part_val)
+            .set(HtmlAttr::Type, "button")
             .set(
                 HtmlAttr::Aria(AriaAttr::Label),
                 (self.ctx.messages.pause_label)(&self.ctx.locale),
@@ -671,6 +739,7 @@ impl Api<'_> {
         attrs
             .set(scope_attr, scope_val)
             .set(part_attr, part_val)
+            .set(HtmlAttr::Type, "button")
             .set(
                 HtmlAttr::Aria(AriaAttr::Label),
                 (self.ctx.messages.reset_label)(&self.ctx.locale),
@@ -757,10 +826,82 @@ mod tests {
     use alloc::{boxed::Box, sync::Arc, vec, vec::Vec};
     use std::sync::Mutex;
 
-    use ars_core::{Machine as _, Service};
+    use ars_core::{Machine as _, Service, StubIntlBackend};
+    use ars_i18n::{HourCycle, WeekInfo, Weekday};
     use insta::assert_snapshot;
 
     use super::*;
+
+    /// Test backend that prefixes segment digits with `loc-` so we can assert
+    /// `formatted_time`/`aria-label` actually route through the locale backend
+    /// rather than hard-coding ASCII. Mirrors `time_field`'s test double.
+    struct LocalizedDigitsBackend;
+
+    impl IntlBackend for LocalizedDigitsBackend {
+        fn weekday_short_label(&self, weekday: Weekday, locale: &Locale) -> String {
+            StubIntlBackend.weekday_short_label(weekday, locale)
+        }
+
+        fn weekday_long_label(&self, weekday: Weekday, locale: &Locale) -> String {
+            StubIntlBackend.weekday_long_label(weekday, locale)
+        }
+
+        fn month_long_name(&self, month: u8, locale: &Locale) -> String {
+            StubIntlBackend.month_long_name(month, locale)
+        }
+
+        fn day_period_label(&self, is_pm: bool, locale: &Locale) -> String {
+            StubIntlBackend.day_period_label(is_pm, locale)
+        }
+
+        fn day_period_from_char(&self, ch: char, locale: &Locale) -> Option<bool> {
+            StubIntlBackend.day_period_from_char(ch, locale)
+        }
+
+        fn format_segment_digits(
+            &self,
+            value: u32,
+            min_digits: NonZeroU8,
+            _locale: &Locale,
+        ) -> String {
+            let width = usize::from(min_digits.get());
+            format!("loc-{value:0>width$}")
+        }
+
+        fn hour_cycle(&self, locale: &Locale) -> HourCycle {
+            StubIntlBackend.hour_cycle(locale)
+        }
+
+        fn week_info(&self, locale: &Locale) -> WeekInfo {
+            StubIntlBackend.week_info(locale)
+        }
+    }
+
+    /// Leaks an [`Api`] whose context carries a localizing backend, for digit
+    /// routing assertions.
+    fn api_with_localized_backend(current: Duration) -> Api<'static> {
+        let env = Env::new(
+            Locale::parse("ar").expect("`ar` is a valid BCP-47 tag"),
+            Arc::new(LocalizedDigitsBackend),
+        );
+        let props = Box::leak(Box::new(
+            Props::new().id("timer").target(Duration::from_secs(60)),
+        ));
+        let messages = Messages::default();
+        let (_, mut ctx) = Machine::init(props, &env, &messages);
+        ctx.current = current;
+
+        let ctx = Box::leak(Box::new(ctx));
+        let state = Box::leak(Box::new(State::Running));
+        let send = Box::leak(Box::new(|_: Event| {}));
+
+        Api {
+            state,
+            ctx,
+            props,
+            send,
+        }
+    }
 
     fn test_props() -> Props {
         Props::new().id("timer")
@@ -1395,6 +1536,78 @@ mod tests {
             api.reset_trigger_attrs()
         );
         assert_eq!(api.part_attrs(Part::Separator), api.separator_attrs());
+    }
+
+    #[test]
+    fn timer_progress_clamped_to_unit_range() {
+        // Stopwatch past its target: raw fraction 2.0 clamps to 1.0.
+        let stopwatch = api_for(
+            State::Running,
+            Duration::from_secs(2),
+            Mode::Stopwatch,
+            Duration::from_secs(1),
+        );
+        assert!((stopwatch.progress() - 1.0).abs() < 1e-9);
+        assert_eq!(
+            stopwatch
+                .progress_attrs()
+                .get(&HtmlAttr::Aria(AriaAttr::ValueNow)),
+            Some("100")
+        );
+
+        // Countdown whose current exceeds target (e.g. via an out-of-range
+        // SetTime): raw -1.0 clamps to 0.0 instead of rendering "-100".
+        let countdown = api_for(
+            State::Running,
+            Duration::from_secs(2),
+            Mode::Countdown,
+            Duration::from_secs(1),
+        );
+        assert!((countdown.progress() - 0.0).abs() < 1e-9);
+        assert_eq!(
+            countdown
+                .progress_attrs()
+                .get(&HtmlAttr::Aria(AriaAttr::ValueNow)),
+            Some("0")
+        );
+    }
+
+    #[test]
+    fn timer_triggers_are_type_button() {
+        let api = api_for(
+            State::Running,
+            Duration::from_secs(30),
+            Mode::Countdown,
+            Duration::from_secs(60),
+        );
+
+        assert_eq!(
+            api.start_trigger_attrs().get(&HtmlAttr::Type),
+            Some("button")
+        );
+        assert_eq!(
+            api.pause_trigger_attrs().get(&HtmlAttr::Type),
+            Some("button")
+        );
+        assert_eq!(
+            api.reset_trigger_attrs().get(&HtmlAttr::Type),
+            Some("button")
+        );
+    }
+
+    #[test]
+    fn timer_formatted_time_routes_digits_through_intl_backend() {
+        // 90s -> 01:30; the localizing backend prefixes each segment with `loc-`.
+        let api = api_with_localized_backend(Duration::from_secs(90));
+
+        assert_eq!(api.formatted_time(), "loc-01:loc-30");
+
+        // The root `aria-label` is sourced from `formatted_time`, so it inherits
+        // the localized digits too.
+        assert_eq!(
+            api.root_attrs().get(&HtmlAttr::Aria(AriaAttr::Label)),
+            Some("loc-01:loc-30")
+        );
     }
 
     // ─────────────────────── snapshots ───────────────────────

--- a/crates/ars-components/src/specialized/timer/mod.rs
+++ b/crates/ars-components/src/specialized/timer/mod.rs
@@ -1028,6 +1028,34 @@ mod tests {
         assert!(service.take_initial_effects().is_empty());
     }
 
+    #[test]
+    fn timer_context_eq_excludes_backend_and_debug_redacts_it() {
+        let props = test_props();
+
+        let (_, ctx) = Machine::init(&props, &Env::default(), &Messages::default());
+
+        // Equality ignores the injected backend (it is a service, not state):
+        // swapping the backend instance leaves the contexts equal.
+        let mut other_backend = ctx.clone();
+
+        other_backend.intl_backend = Arc::new(LocalizedDigitsBackend);
+
+        assert_eq!(ctx, other_backend);
+
+        // ...but a difference in observable state is detected.
+        let mut shifted = ctx.clone();
+
+        shifted.current = Duration::from_secs(5);
+
+        assert_ne!(ctx, shifted);
+
+        // Debug redacts the trait object rather than attempting to print it.
+        let debug = format!("{ctx:?}");
+
+        assert!(debug.contains("timer::Context"));
+        assert!(debug.contains("<dyn IntlBackend>"));
+    }
+
     // ───────────────────── transitions ─────────────────────
 
     #[test]

--- a/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_display_snapshot.snap
+++ b/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_display_snapshot.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ars-components/src/specialized/timer/mod.rs
-expression: "snapshot_attrs(&api_for(State::Idle, 60_000, Mode::Countdown,\n60_000).display_attrs())"
+expression: "snapshot_attrs(&countdown_api(State::Idle, 60).display_attrs())"
 ---
 AttrMap {
     attrs: [
@@ -18,14 +18,6 @@ AttrMap {
             ),
             String(
                 "timer",
-            ),
-        ),
-        (
-            Aria(
-                Hidden,
-            ),
-            String(
-                "true",
             ),
         ),
         (

--- a/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_display_snapshot.snap
+++ b/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_display_snapshot.snap
@@ -1,0 +1,39 @@
+---
+source: crates/ars-components/src/specialized/timer/mod.rs
+expression: "snapshot_attrs(&api_for(State::Idle, 60_000, Mode::Countdown,\n60_000).display_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "display",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "timer",
+            ),
+        ),
+        (
+            Aria(
+                Hidden,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "timer-display",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_label_snapshot.snap
+++ b/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_label_snapshot.snap
@@ -1,0 +1,31 @@
+---
+source: crates/ars-components/src/specialized/timer/mod.rs
+expression: "snapshot_attrs(&api_for(State::Idle, 60_000, Mode::Countdown,\n60_000).label_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "label",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "timer",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "timer-label",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_pause_trigger_idle_snapshot.snap
+++ b/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_pause_trigger_idle_snapshot.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ars-components/src/specialized/timer/mod.rs
-expression: "snapshot_attrs(&api_for(State::Idle, 60_000, Mode::Countdown,\n60_000).pause_trigger_attrs())"
+expression: "snapshot_attrs(&countdown_api(State::Idle, 60).pause_trigger_attrs())"
 ---
 AttrMap {
     attrs: [
@@ -32,6 +32,12 @@ AttrMap {
             Disabled,
             Bool(
                 true,
+            ),
+        ),
+        (
+            Type,
+            String(
+                "button",
             ),
         ),
     ],

--- a/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_pause_trigger_idle_snapshot.snap
+++ b/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_pause_trigger_idle_snapshot.snap
@@ -1,0 +1,39 @@
+---
+source: crates/ars-components/src/specialized/timer/mod.rs
+expression: "snapshot_attrs(&api_for(State::Idle, 60_000, Mode::Countdown,\n60_000).pause_trigger_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "pause-trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "timer",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Pause timer",
+            ),
+        ),
+        (
+            Disabled,
+            Bool(
+                true,
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_pause_trigger_running_snapshot.snap
+++ b/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_pause_trigger_running_snapshot.snap
@@ -1,0 +1,33 @@
+---
+source: crates/ars-components/src/specialized/timer/mod.rs
+expression: "snapshot_attrs(&api_for(State::Running, 30_000, Mode::Countdown,\n60_000).pause_trigger_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "pause-trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "timer",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Pause timer",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_pause_trigger_running_snapshot.snap
+++ b/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_pause_trigger_running_snapshot.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ars-components/src/specialized/timer/mod.rs
-expression: "snapshot_attrs(&api_for(State::Running, 30_000, Mode::Countdown,\n60_000).pause_trigger_attrs())"
+expression: "snapshot_attrs(&countdown_api(State::Running, 30).pause_trigger_attrs())"
 ---
 AttrMap {
     attrs: [
@@ -26,6 +26,12 @@ AttrMap {
             ),
             String(
                 "Pause timer",
+            ),
+        ),
+        (
+            Type,
+            String(
+                "button",
             ),
         ),
     ],

--- a/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_progress_completed_snapshot.snap
+++ b/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_progress_completed_snapshot.snap
@@ -1,0 +1,70 @@
+---
+source: crates/ars-components/src/specialized/timer/mod.rs
+expression: "snapshot_attrs(&api_for(State::Completed, 0, Mode::Countdown,\n60_000).progress_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "progress",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "timer",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Timer progress",
+            ),
+        ),
+        (
+            Aria(
+                ValueMax,
+            ),
+            String(
+                "100",
+            ),
+        ),
+        (
+            Aria(
+                ValueMin,
+            ),
+            String(
+                "0",
+            ),
+        ),
+        (
+            Aria(
+                ValueNow,
+            ),
+            String(
+                "100",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "progressbar",
+            ),
+        ),
+    ],
+    styles: [
+        (
+            Custom(
+                "ars-timer-progress",
+            ),
+            "1.00",
+        ),
+    ],
+}

--- a/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_progress_idle_snapshot.snap
+++ b/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_progress_idle_snapshot.snap
@@ -1,0 +1,70 @@
+---
+source: crates/ars-components/src/specialized/timer/mod.rs
+expression: "snapshot_attrs(&api_for(State::Idle, 60_000, Mode::Countdown,\n60_000).progress_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "progress",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "timer",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Timer progress",
+            ),
+        ),
+        (
+            Aria(
+                ValueMax,
+            ),
+            String(
+                "100",
+            ),
+        ),
+        (
+            Aria(
+                ValueMin,
+            ),
+            String(
+                "0",
+            ),
+        ),
+        (
+            Aria(
+                ValueNow,
+            ),
+            String(
+                "0",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "progressbar",
+            ),
+        ),
+    ],
+    styles: [
+        (
+            Custom(
+                "ars-timer-progress",
+            ),
+            "0.00",
+        ),
+    ],
+}

--- a/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_reset_trigger_idle_snapshot.snap
+++ b/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_reset_trigger_idle_snapshot.snap
@@ -1,0 +1,39 @@
+---
+source: crates/ars-components/src/specialized/timer/mod.rs
+expression: "snapshot_attrs(&api_for(State::Idle, 60_000, Mode::Countdown,\n60_000).reset_trigger_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "reset-trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "timer",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Reset timer",
+            ),
+        ),
+        (
+            Disabled,
+            Bool(
+                true,
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_reset_trigger_idle_snapshot.snap
+++ b/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_reset_trigger_idle_snapshot.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ars-components/src/specialized/timer/mod.rs
-expression: "snapshot_attrs(&api_for(State::Idle, 60_000, Mode::Countdown,\n60_000).reset_trigger_attrs())"
+expression: "snapshot_attrs(&countdown_api(State::Idle, 60).reset_trigger_attrs())"
 ---
 AttrMap {
     attrs: [
@@ -32,6 +32,12 @@ AttrMap {
             Disabled,
             Bool(
                 true,
+            ),
+        ),
+        (
+            Type,
+            String(
+                "button",
             ),
         ),
     ],

--- a/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_reset_trigger_running_snapshot.snap
+++ b/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_reset_trigger_running_snapshot.snap
@@ -1,0 +1,33 @@
+---
+source: crates/ars-components/src/specialized/timer/mod.rs
+expression: "snapshot_attrs(&api_for(State::Running, 30_000, Mode::Countdown,\n60_000).reset_trigger_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "reset-trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "timer",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Reset timer",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_reset_trigger_running_snapshot.snap
+++ b/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_reset_trigger_running_snapshot.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ars-components/src/specialized/timer/mod.rs
-expression: "snapshot_attrs(&api_for(State::Running, 30_000, Mode::Countdown,\n60_000).reset_trigger_attrs())"
+expression: "snapshot_attrs(&countdown_api(State::Running, 30).reset_trigger_attrs())"
 ---
 AttrMap {
     attrs: [
@@ -26,6 +26,12 @@ AttrMap {
             ),
             String(
                 "Reset timer",
+            ),
+        ),
+        (
+            Type,
+            String(
+                "button",
             ),
         ),
     ],

--- a/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_root_completed_snapshot.snap
+++ b/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_root_completed_snapshot.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ars-components/src/specialized/timer/mod.rs
-expression: "snapshot_attrs(&api_for(State::Completed, 0, Mode::Countdown,\n60_000).root_attrs())"
+expression: "snapshot_attrs(&countdown_api(State::Completed, 0).root_attrs())"
 ---
 AttrMap {
     attrs: [
@@ -26,14 +26,6 @@ AttrMap {
             ),
             String(
                 "completed",
-            ),
-        ),
-        (
-            Aria(
-                Label,
-            ),
-            String(
-                "00:00",
             ),
         ),
         (

--- a/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_root_completed_snapshot.snap
+++ b/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_root_completed_snapshot.snap
@@ -1,0 +1,63 @@
+---
+source: crates/ars-components/src/specialized/timer/mod.rs
+expression: "snapshot_attrs(&api_for(State::Completed, 0, Mode::Countdown,\n60_000).root_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "timer",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "completed",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "00:00",
+            ),
+        ),
+        (
+            Aria(
+                Atomic,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Aria(
+                Live,
+            ),
+            String(
+                "polite",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "timer",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_root_idle_snapshot.snap
+++ b/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_root_idle_snapshot.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ars-components/src/specialized/timer/mod.rs
-expression: "snapshot_attrs(&api_for(State::Idle, 60_000, Mode::Countdown,\n60_000).root_attrs())"
+expression: "snapshot_attrs(&countdown_api(State::Idle, 60).root_attrs())"
 ---
 AttrMap {
     attrs: [
@@ -26,14 +26,6 @@ AttrMap {
             ),
             String(
                 "idle",
-            ),
-        ),
-        (
-            Aria(
-                Label,
-            ),
-            String(
-                "01:00",
             ),
         ),
         (

--- a/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_root_idle_snapshot.snap
+++ b/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_root_idle_snapshot.snap
@@ -1,0 +1,63 @@
+---
+source: crates/ars-components/src/specialized/timer/mod.rs
+expression: "snapshot_attrs(&api_for(State::Idle, 60_000, Mode::Countdown,\n60_000).root_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "timer",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "idle",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "01:00",
+            ),
+        ),
+        (
+            Aria(
+                Atomic,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Aria(
+                Live,
+            ),
+            String(
+                "polite",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "timer",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_root_paused_snapshot.snap
+++ b/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_root_paused_snapshot.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ars-components/src/specialized/timer/mod.rs
-expression: "snapshot_attrs(&api_for(State::Paused, 30_000, Mode::Countdown,\n60_000).root_attrs())"
+expression: "snapshot_attrs(&countdown_api(State::Paused, 30).root_attrs())"
 ---
 AttrMap {
     attrs: [
@@ -26,14 +26,6 @@ AttrMap {
             ),
             String(
                 "paused",
-            ),
-        ),
-        (
-            Aria(
-                Label,
-            ),
-            String(
-                "00:30",
             ),
         ),
         (

--- a/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_root_paused_snapshot.snap
+++ b/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_root_paused_snapshot.snap
@@ -1,0 +1,63 @@
+---
+source: crates/ars-components/src/specialized/timer/mod.rs
+expression: "snapshot_attrs(&api_for(State::Paused, 30_000, Mode::Countdown,\n60_000).root_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "timer",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "paused",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "00:30",
+            ),
+        ),
+        (
+            Aria(
+                Atomic,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Aria(
+                Live,
+            ),
+            String(
+                "polite",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "timer",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_root_running_snapshot.snap
+++ b/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_root_running_snapshot.snap
@@ -1,0 +1,63 @@
+---
+source: crates/ars-components/src/specialized/timer/mod.rs
+expression: "snapshot_attrs(&api_for(State::Running, 30_000, Mode::Countdown,\n60_000).root_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "timer",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "running",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "00:30",
+            ),
+        ),
+        (
+            Aria(
+                Atomic,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Aria(
+                Live,
+            ),
+            String(
+                "polite",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "timer",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_root_running_snapshot.snap
+++ b/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_root_running_snapshot.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ars-components/src/specialized/timer/mod.rs
-expression: "snapshot_attrs(&api_for(State::Running, 30_000, Mode::Countdown,\n60_000).root_attrs())"
+expression: "snapshot_attrs(&countdown_api(State::Running, 30).root_attrs())"
 ---
 AttrMap {
     attrs: [
@@ -26,14 +26,6 @@ AttrMap {
             ),
             String(
                 "running",
-            ),
-        ),
-        (
-            Aria(
-                Label,
-            ),
-            String(
-                "00:30",
             ),
         ),
         (

--- a/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_root_with_hours_snapshot.snap
+++ b/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_root_with_hours_snapshot.snap
@@ -1,0 +1,63 @@
+---
+source: crates/ars-components/src/specialized/timer/mod.rs
+expression: "snapshot_attrs(&api_for(State::Running, 3_600_000, Mode::Countdown,\n3_600_000).root_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "timer",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "running",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "01:00:00",
+            ),
+        ),
+        (
+            Aria(
+                Atomic,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Aria(
+                Live,
+            ),
+            String(
+                "polite",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "timer",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_root_with_hours_snapshot.snap
+++ b/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_root_with_hours_snapshot.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ars-components/src/specialized/timer/mod.rs
-expression: "snapshot_attrs(&api_for(State::Running, 3_600_000, Mode::Countdown,\n3_600_000).root_attrs())"
+expression: "snapshot_attrs(&api_for(State::Running, Duration::from_secs(3_600),\nMode::Countdown, Duration::from_secs(3_600),).root_attrs())"
 ---
 AttrMap {
     attrs: [
@@ -26,14 +26,6 @@ AttrMap {
             ),
             String(
                 "running",
-            ),
-        ),
-        (
-            Aria(
-                Label,
-            ),
-            String(
-                "01:00:00",
             ),
         ),
         (

--- a/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_separator_snapshot.snap
+++ b/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_separator_snapshot.snap
@@ -1,0 +1,33 @@
+---
+source: crates/ars-components/src/specialized/timer/mod.rs
+expression: "snapshot_attrs(&api_for(State::Idle, 60_000, Mode::Countdown,\n60_000).separator_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "separator",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "timer",
+            ),
+        ),
+        (
+            Aria(
+                Hidden,
+            ),
+            String(
+                "true",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_start_trigger_idle_snapshot.snap
+++ b/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_start_trigger_idle_snapshot.snap
@@ -1,0 +1,33 @@
+---
+source: crates/ars-components/src/specialized/timer/mod.rs
+expression: "snapshot_attrs(&api_for(State::Idle, 60_000, Mode::Countdown,\n60_000).start_trigger_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "start-trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "timer",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Start timer",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_start_trigger_idle_snapshot.snap
+++ b/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_start_trigger_idle_snapshot.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ars-components/src/specialized/timer/mod.rs
-expression: "snapshot_attrs(&api_for(State::Idle, 60_000, Mode::Countdown,\n60_000).start_trigger_attrs())"
+expression: "snapshot_attrs(&countdown_api(State::Idle, 60).start_trigger_attrs())"
 ---
 AttrMap {
     attrs: [
@@ -26,6 +26,12 @@ AttrMap {
             ),
             String(
                 "Start timer",
+            ),
+        ),
+        (
+            Type,
+            String(
+                "button",
             ),
         ),
     ],

--- a/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_start_trigger_paused_snapshot.snap
+++ b/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_start_trigger_paused_snapshot.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ars-components/src/specialized/timer/mod.rs
-expression: "snapshot_attrs(&api_for(State::Paused, 30_000, Mode::Countdown,\n60_000).start_trigger_attrs())"
+expression: "snapshot_attrs(&countdown_api(State::Paused, 30).start_trigger_attrs())"
 ---
 AttrMap {
     attrs: [
@@ -26,6 +26,12 @@ AttrMap {
             ),
             String(
                 "Resume timer",
+            ),
+        ),
+        (
+            Type,
+            String(
+                "button",
             ),
         ),
     ],

--- a/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_start_trigger_paused_snapshot.snap
+++ b/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_start_trigger_paused_snapshot.snap
@@ -1,0 +1,33 @@
+---
+source: crates/ars-components/src/specialized/timer/mod.rs
+expression: "snapshot_attrs(&api_for(State::Paused, 30_000, Mode::Countdown,\n60_000).start_trigger_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "start-trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "timer",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Resume timer",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_start_trigger_running_snapshot.snap
+++ b/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_start_trigger_running_snapshot.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ars-components/src/specialized/timer/mod.rs
-expression: "snapshot_attrs(&api_for(State::Running, 30_000, Mode::Countdown,\n60_000).start_trigger_attrs())"
+expression: "snapshot_attrs(&countdown_api(State::Running, 30).start_trigger_attrs())"
 ---
 AttrMap {
     attrs: [
@@ -32,6 +32,12 @@ AttrMap {
             Disabled,
             Bool(
                 true,
+            ),
+        ),
+        (
+            Type,
+            String(
+                "button",
             ),
         ),
     ],

--- a/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_start_trigger_running_snapshot.snap
+++ b/crates/ars-components/src/specialized/timer/snapshots/ars_components__specialized__timer__tests__timer_start_trigger_running_snapshot.snap
@@ -1,0 +1,39 @@
+---
+source: crates/ars-components/src/specialized/timer/mod.rs
+expression: "snapshot_attrs(&api_for(State::Running, 30_000, Mode::Countdown,\n60_000).start_trigger_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "start-trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "timer",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Start timer",
+            ),
+        ),
+        (
+            Disabled,
+            Bool(
+                true,
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/tests/proptest_state_machines/specialized.rs
+++ b/crates/ars-components/tests/proptest_state_machines/specialized.rs
@@ -725,3 +725,107 @@ mod qr_code_proptests {
         }
     }
 }
+
+// ────────────────────────────────────────────────────────────────────
+// Timer
+// ────────────────────────────────────────────────────────────────────
+
+mod timer_proptests {
+    use core::time::Duration;
+
+    use ars_components::specialized::timer::{Event, Machine, Mode, Props, State};
+    use ars_core::{Env, Service};
+    use proptest::prelude::*;
+
+    fn arb_mode() -> impl Strategy<Value = Mode> {
+        prop_oneof![Just(Mode::Countdown), Just(Mode::Stopwatch)]
+    }
+
+    prop_compose! {
+        fn arb_props()(
+            mode in arb_mode(),
+            target_ms in 1_000u64..=600_000,
+            interval_ms in 1u64..=60_000,
+            auto_start in any::<bool>(),
+        ) -> Props {
+            Props::new()
+                .id("timer")
+                .mode(mode)
+                .target(Duration::from_millis(target_ms))
+                .interval(Duration::from_millis(interval_ms))
+                .auto_start(auto_start)
+        }
+    }
+
+    /// Events parameterised by `target` so `SetTime` stays within the target
+    /// range; this keeps the "countdown never exceeds target" invariant true
+    /// while still exercising the `SetTime` branch.
+    fn arb_event(target: Duration) -> impl Strategy<Value = Event> {
+        let target_ms = u64::try_from(target.as_millis()).unwrap_or(u64::MAX);
+        prop_oneof![
+            Just(Event::Start),
+            Just(Event::Pause),
+            Just(Event::Resume),
+            Just(Event::Reset),
+            Just(Event::Restart),
+            Just(Event::Tick),
+            (0u64..=target_ms).prop_map(|ms| Event::SetTime(Duration::from_millis(ms))),
+        ]
+    }
+
+    fn arb_scenario() -> impl Strategy<Value = (Props, Vec<Event>)> {
+        arb_props().prop_flat_map(|props| {
+            let events = prop::collection::vec(arb_event(props.target), 0..128);
+
+            (Just(props), events)
+        })
+    }
+
+    proptest! {
+        #![proptest_config(super::super::common::proptest_config())]
+
+        #[test]
+        #[ignore = "proptest — nightly extended-proptest job"]
+        fn timer_event_sequences_preserve_invariants((props, events) in arb_scenario()) {
+            let mode = props.mode;
+            let target = props.target;
+
+            let mut svc = Service::<Machine>::new(props, &Env::default(), &Default::default());
+
+            drop(svc.take_initial_effects());
+
+            for ev in events {
+                drop(svc.send(ev));
+
+                let state = *svc.state();
+                let current = svc.context().current;
+
+                // Stopwatch mode can never reach the completed state; only a
+                // countdown Tick reaching zero produces `Completed`. (`SetTime`
+                // is unconditional and may set a non-zero value while completed,
+                // so completion-at-zero is asserted in the unit lifecycle test.)
+                if mode == Mode::Stopwatch {
+                    prop_assert_ne!(state, State::Completed);
+                }
+
+                // Countdown never exceeds its target (SetTime is bounded to it).
+                if mode == Mode::Countdown {
+                    prop_assert!(current <= target);
+                }
+
+                // `connect()` and its output methods never panic and always
+                // produce finite progress and a non-empty formatted time.
+                let api = svc.connect(&|_| {});
+
+                prop_assert!(api.progress().is_finite());
+                prop_assert!(!api.formatted_time().is_empty());
+
+                drop(api.root_attrs());
+                drop(api.progress_attrs());
+                drop(api.start_trigger_attrs());
+                drop(api.pause_trigger_attrs());
+                drop(api.reset_trigger_attrs());
+            }
+        }
+    }
+}

--- a/crates/ars-components/tests/spec_conformance/specialized.rs
+++ b/crates/ars-components/tests/spec_conformance/specialized.rs
@@ -273,3 +273,20 @@ fn qr_code_anatomy_matches_spec() {
         ],
     );
 }
+
+#[test]
+fn timer_anatomy_matches_spec() {
+    assert_anatomy(
+        "timer",
+        &[
+            (specialized_core::timer::Part::Root, "root"),
+            (specialized_core::timer::Part::Label, "label"),
+            (specialized_core::timer::Part::Display, "display"),
+            (specialized_core::timer::Part::Progress, "progress"),
+            (specialized_core::timer::Part::StartTrigger, "start-trigger"),
+            (specialized_core::timer::Part::PauseTrigger, "pause-trigger"),
+            (specialized_core::timer::Part::ResetTrigger, "reset-trigger"),
+            (specialized_core::timer::Part::Separator, "separator"),
+        ],
+    );
+}

--- a/spec/components/specialized/timer.md
+++ b/spec/components/specialized/timer.md
@@ -89,8 +89,14 @@ pub struct Context {
     pub messages: Messages,
     /// Component instance IDs.
     pub ids: ComponentIds,
+    /// Backend used for locale-aware digit formatting of the displayed time.
+    pub intl_backend: Arc<dyn IntlBackend>,
 }
 ```
+
+`Context` therefore implements `Clone` only via derive; `Debug` and `PartialEq`
+are provided manually and exclude `intl_backend` (an injected service, not
+observable state), mirroring `TimeField`.
 
 ### 1.4 Props
 
@@ -184,6 +190,7 @@ impl ars_core::Machine for Machine {
             locale: env.locale.clone(),
             messages: messages.clone(),
             ids: ComponentIds::from_id(&props.id),
+            intl_backend: Arc::clone(&env.intl_backend),
         })
     }
 
@@ -325,23 +332,38 @@ impl<'a> Api<'a> {
         (hours, minutes, seconds, millis)
     }
 
-    /// Progress as a fraction [0.0, 1.0] (countdown only).
+    /// Progress as a fraction [0.0, 1.0].
+    ///
+    /// Clamped so an over-target stopwatch or out-of-range `SetTime` never
+    /// produces a value outside [0.0, 1.0] (which would break the progressbar
+    /// `aria-valuenow`/`valuemin`/`valuemax` semantics).
     pub fn progress(&self) -> f64 {
         if self.ctx.target.is_zero() { return 0.0; }
         let fraction = self.ctx.current.as_secs_f64() / self.ctx.target.as_secs_f64();
-        match self.ctx.mode {
+        let progress = match self.ctx.mode {
             Mode::Countdown => 1.0 - fraction,
             Mode::Stopwatch => fraction,
-        }
+        };
+        progress.clamp(0.0, 1.0)
     }
 
     /// Formatted time string (HH:MM:SS or MM:SS).
+    ///
+    /// Digits are rendered through `intl_backend.format_segment_digits` so
+    /// non-ASCII numbering systems are honored; the colon separator is fixed.
     pub fn formatted_time(&self) -> String {
-        let (h, m, s, _) = self.display_time();
-        if h > 0 {
-            format!("{:02}:{:02}:{:02}", h, m, s)
+        let (hours, minutes, seconds, _) = self.display_time();
+        let width = NonZeroU8::new(2).expect("segment width is non-zero");
+        let segment = |value: u64| {
+            u32::try_from(value).map_or_else(
+                |_| value.to_string(),
+                |value| self.ctx.intl_backend.format_segment_digits(value, width, &self.ctx.locale),
+            )
+        };
+        if hours > 0 {
+            format!("{}:{}:{}", segment(hours), segment(minutes), segment(seconds))
         } else {
-            format!("{:02}:{:02}", m, s)
+            format!("{}:{}", segment(minutes), segment(seconds))
         }
     }
 
@@ -405,6 +427,7 @@ impl<'a> Api<'a> {
         let [(scope_attr, scope_val), (part_attr, part_val)] = Part::StartTrigger.data_attrs();
         attrs.set(scope_attr, scope_val);
         attrs.set(part_attr, part_val);
+        attrs.set(HtmlAttr::Type, "button");
         attrs.set(HtmlAttr::Aria(AriaAttr::Label), if self.is_paused() {
             (self.ctx.messages.resume_label)(&self.ctx.locale)
         } else {
@@ -421,6 +444,7 @@ impl<'a> Api<'a> {
         let [(scope_attr, scope_val), (part_attr, part_val)] = Part::PauseTrigger.data_attrs();
         attrs.set(scope_attr, scope_val);
         attrs.set(part_attr, part_val);
+        attrs.set(HtmlAttr::Type, "button");
         attrs.set(HtmlAttr::Aria(AriaAttr::Label), (self.ctx.messages.pause_label)(&self.ctx.locale));
         if !self.is_running() {
             attrs.set_bool(HtmlAttr::Disabled, true);
@@ -433,6 +457,7 @@ impl<'a> Api<'a> {
         let [(scope_attr, scope_val), (part_attr, part_val)] = Part::ResetTrigger.data_attrs();
         attrs.set(scope_attr, scope_val);
         attrs.set(part_attr, part_val);
+        attrs.set(HtmlAttr::Type, "button");
         attrs.set(HtmlAttr::Aria(AriaAttr::Label), (self.ctx.messages.reset_label)(&self.ctx.locale));
         if self.is_idle() {
             attrs.set_bool(HtmlAttr::Disabled, true);
@@ -493,16 +518,16 @@ Timer
 └── Separator        (optional — decorative colon between time segments)
 ```
 
-| Part         | Element    | Key Attributes                                       |
-| ------------ | ---------- | ---------------------------------------------------- |
-| Root         | `<div>`    | `role="timer"`, `aria-live="polite"`, `aria-atomic`  |
-| Label        | `<label>`  | `id` for association                                 |
-| Display      | `<span>`   | `aria-hidden="true"` (Root handles live region)      |
-| Progress     | `<div>`    | `role="progressbar"`, `aria-valuenow/min/max`        |
-| StartTrigger | `<button>` | `aria-label` (Start/Resume), `disabled` when running |
-| PauseTrigger | `<button>` | `aria-label` (Pause), `disabled` when not running    |
-| ResetTrigger | `<button>` | `aria-label` (Reset), `disabled` when idle           |
-| Separator    | `<span>`   | `aria-hidden="true"` (decorative)                    |
+| Part         | Element    | Key Attributes                                                        |
+| ------------ | ---------- | --------------------------------------------------------------------- |
+| Root         | `<div>`    | `role="timer"`, `aria-live="polite"`, `aria-atomic`                   |
+| Label        | `<label>`  | `id` for association                                                  |
+| Display      | `<span>`   | `aria-hidden="true"` (Root handles live region)                       |
+| Progress     | `<div>`    | `role="progressbar"`, `aria-valuenow/min/max`                         |
+| StartTrigger | `<button>` | `type="button"`, `aria-label` (Start/Resume), `disabled` when running |
+| PauseTrigger | `<button>` | `type="button"`, `aria-label` (Pause), `disabled` when not running    |
+| ResetTrigger | `<button>` | `type="button"`, `aria-label` (Reset), `disabled` when idle           |
+| Separator    | `<span>`   | `aria-hidden="true"` (decorative)                                     |
 
 ## 3. Accessibility
 

--- a/spec/components/specialized/timer.md
+++ b/spec/components/specialized/timer.md
@@ -64,6 +64,9 @@ pub enum Event {
     Tick,
     /// Set the remaining/elapsed time directly.
     SetTime(Duration),
+    /// Synchronize the context-backed props (`target`, `interval`, `mode`)
+    /// after a controlled prop update. Emitted by `Machine::on_props_changed`.
+    SyncProps,
 }
 ```
 
@@ -175,7 +178,11 @@ impl ars_core::Machine for Machine {
             Mode::Stopwatch => Duration::ZERO,
         };
 
-        let state = if props.auto_start {
+        // A zero-duration countdown is already complete; it must not enter
+        // `Running` (auto_start is ignored in that degenerate case).
+        let state = if is_instantly_complete(props.mode, props.target) {
+            State::Completed
+        } else if props.auto_start {
             State::Running
         } else {
             State::Idle
@@ -184,7 +191,8 @@ impl ars_core::Machine for Machine {
         (state, Context {
             current,
             target: props.target,
-            interval: props.interval,
+            // A zero interval would make every tick a no-op, so clamp to 1ms.
+            interval: effective_interval(props.interval),
             mode: props.mode,
             auto_start: props.auto_start,
             locale: env.locale.clone(),
@@ -192,6 +200,17 @@ impl ars_core::Machine for Machine {
             ids: ComponentIds::from_id(&props.id),
             intl_backend: Arc::clone(&env.intl_backend),
         })
+    }
+
+    // Sync the context-backed props after a controlled update so transitions
+    // (Tick/Reset/Restart/SyncProps) read the latest target/interval/mode.
+    fn on_props_changed(old: &Props, new: &Props) -> Vec<Event> {
+        assert_eq!(old.id, new.id, "timer::Props.id must remain stable after init");
+        if old.target != new.target || old.interval != new.interval || old.mode != new.mode {
+            vec![Event::SyncProps]
+        } else {
+            Vec::new()
+        }
     }
 
     // Auto-started timers boot directly into `Running` without a transition,
@@ -212,7 +231,7 @@ impl ars_core::Machine for Machine {
         state: &Self::State,
         event: &Self::Event,
         ctx: &Self::Context,
-        _props: &Self::Props,
+        props: &Self::Props,
     ) -> Option<TransitionPlan<Self>> {
         match (state, event) {
             // Idle start, paused resume, and paused start all enter `Running`
@@ -260,20 +279,40 @@ impl ars_core::Machine for Machine {
             }
 
             (_, Event::Restart) => {
-                let initial = match ctx.mode {
-                    Mode::Countdown => ctx.target,
-                    Mode::Stopwatch => Duration::ZERO,
-                };
-                Some(TransitionPlan::to(State::Running)
-                    .apply(move |ctx| { ctx.current = initial; })
-                    .cancel_effect(Effect::TimerInterval)
-                    .with_effect(PendingEffect::named(Effect::TimerInterval)))
+                let initial = initial_duration(ctx.mode, ctx.target);
+                // Restarting a zero-duration countdown completes immediately.
+                if is_instantly_complete(ctx.mode, ctx.target) {
+                    Some(TransitionPlan::to(State::Completed)
+                        .apply(move |ctx| { ctx.current = initial; })
+                        .cancel_effect(Effect::TimerInterval))
+                } else {
+                    Some(TransitionPlan::to(State::Running)
+                        .apply(move |ctx| { ctx.current = initial; })
+                        .cancel_effect(Effect::TimerInterval)
+                        .with_effect(PendingEffect::named(Effect::TimerInterval)))
+                }
             }
 
             (_, Event::SetTime(duration)) => {
                 let duration = *duration;
                 Some(TransitionPlan::context_only(move |ctx| {
                     ctx.current = duration;
+                }))
+            }
+
+            (_, Event::SyncProps) => {
+                let target = props.target;
+                let interval = effective_interval(props.interval);
+                let mode = props.mode;
+                // Idle mirrors the new initial; running/paused keep `current`.
+                let reset_current = matches!(state, State::Idle);
+                Some(TransitionPlan::context_only(move |ctx| {
+                    ctx.target = target;
+                    ctx.interval = interval;
+                    ctx.mode = mode;
+                    if reset_current {
+                        ctx.current = initial_duration(mode, target);
+                    }
                 }))
             }
 
@@ -289,6 +328,24 @@ impl ars_core::Machine for Machine {
     ) -> Self::Api<'a> {
         Api { state, ctx, props, send }
     }
+}
+
+/// The initial `current` value for a given mode and target.
+const fn initial_duration(mode: Mode, target: Duration) -> Duration {
+    match mode {
+        Mode::Countdown => target,
+        Mode::Stopwatch => Duration::ZERO,
+    }
+}
+
+/// Replaces a zero interval with a 1ms floor so ticks always make progress.
+const fn effective_interval(interval: Duration) -> Duration {
+    if interval.is_zero() { Duration::from_millis(1) } else { interval }
+}
+
+/// Whether a `(mode, target)` describes a countdown that is already complete.
+const fn is_instantly_complete(mode: Mode, target: Duration) -> bool {
+    matches!(mode, Mode::Countdown) && target.is_zero()
 }
 ```
 

--- a/spec/components/specialized/timer.md
+++ b/spec/components/specialized/timer.md
@@ -269,11 +269,15 @@ impl ars_core::Machine for Machine {
             }
 
             (_, Event::Reset) => {
-                let initial = match ctx.mode {
-                    Mode::Countdown => ctx.target,
-                    Mode::Stopwatch => Duration::ZERO,
+                let initial = initial_duration(ctx.mode, ctx.target);
+                // A zero-duration countdown resets to Completed, not Idle, so it
+                // cannot be (re)started into a running 00:00.
+                let target_state = if is_instantly_complete(ctx.mode, ctx.target) {
+                    State::Completed
+                } else {
+                    State::Idle
                 };
-                Some(TransitionPlan::to(State::Idle)
+                Some(TransitionPlan::to(target_state)
                     .apply(move |ctx| { ctx.current = initial; })
                     .cancel_effect(Effect::TimerInterval))
             }
@@ -304,16 +308,36 @@ impl ars_core::Machine for Machine {
                 let target = props.target;
                 let interval = effective_interval(props.interval);
                 let mode = props.mode;
-                // Idle mirrors the new initial; running/paused keep `current`.
-                let reset_current = matches!(state, State::Idle);
-                Some(TransitionPlan::context_only(move |ctx| {
-                    ctx.target = target;
-                    ctx.interval = interval;
-                    ctx.mode = mode;
-                    if reset_current {
-                        ctx.current = initial_duration(mode, target);
+                // Syncing into a zero-duration countdown completes on arrival.
+                if is_instantly_complete(mode, target) {
+                    Some(TransitionPlan::to(State::Completed)
+                        .apply(move |ctx| {
+                            ctx.target = target;
+                            ctx.interval = interval;
+                            ctx.mode = mode;
+                            ctx.current = Duration::ZERO;
+                        })
+                        .cancel_effect(Effect::TimerInterval))
+                } else {
+                    // Idle mirrors the new initial; running/paused keep `current`.
+                    let reset_current = matches!(state, State::Idle);
+                    // A live cadence change re-arms the adapter interval.
+                    let rearm = matches!(state, State::Running) && interval != ctx.interval;
+                    let mut plan = TransitionPlan::context_only(move |ctx| {
+                        ctx.target = target;
+                        ctx.interval = interval;
+                        ctx.mode = mode;
+                        if reset_current {
+                            ctx.current = initial_duration(mode, target);
+                        }
+                    });
+                    if rearm {
+                        plan = plan
+                            .cancel_effect(Effect::TimerInterval)
+                            .with_effect(PendingEffect::named(Effect::TimerInterval));
                     }
-                }))
+                    Some(plan)
+                }
             }
 
             _ => None,

--- a/spec/components/specialized/timer.md
+++ b/spec/components/specialized/timer.md
@@ -319,18 +319,28 @@ impl ars_core::Machine for Machine {
                         })
                         .cancel_effect(Effect::TimerInterval))
                 } else {
-                    // Idle mirrors the new initial; running/paused keep `current`.
-                    let reset_current = matches!(state, State::Idle);
+                    // Reconfiguring a completed timer to a runnable config must
+                    // leave Completed, else it stays completed/disabled (or a
+                    // stopwatch stuck in Completed) until manual reset.
+                    let was_completed = matches!(state, State::Completed);
+                    // Idle and (newly-runnable) Completed mirror the new initial;
+                    // running/paused keep the in-progress `current`.
+                    let reset_current = matches!(state, State::Idle | State::Completed);
                     // A live cadence change re-arms the adapter interval.
                     let rearm = matches!(state, State::Running) && interval != ctx.interval;
-                    let mut plan = TransitionPlan::context_only(move |ctx| {
+                    let apply = move |ctx: &mut Context| {
                         ctx.target = target;
                         ctx.interval = interval;
                         ctx.mode = mode;
                         if reset_current {
                             ctx.current = initial_duration(mode, target);
                         }
-                    });
+                    };
+                    let mut plan = if was_completed {
+                        TransitionPlan::to(State::Idle).apply(apply).cancel_effect(Effect::TimerInterval)
+                    } else {
+                        TransitionPlan::context_only(apply)
+                    };
                     if rearm {
                         plan = plan
                             .cancel_effect(Effect::TimerInterval)
@@ -419,7 +429,11 @@ impl<'a> Api<'a> {
     /// produces a value outside [0.0, 1.0] (which would break the progressbar
     /// `aria-valuenow`/`valuemin`/`valuemax` semantics).
     pub fn progress(&self) -> f64 {
-        if self.ctx.target.is_zero() { return 0.0; }
+        if self.ctx.target.is_zero() {
+            // A completed zero-duration countdown is fully elapsed (100%); a
+            // zero-target stopwatch is indeterminate (0%).
+            return if self.is_completed() { 1.0 } else { 0.0 };
+        }
         let fraction = self.ctx.current.as_secs_f64() / self.ctx.target.as_secs_f64();
         let progress = match self.ctx.mode {
             Mode::Countdown => 1.0 - fraction,
@@ -457,6 +471,10 @@ impl<'a> Api<'a> {
         }
     }
 
+    // The Root is the polite, atomic aria-live region. It does NOT carry the
+    // formatted time as aria-label: live regions announce changes to their
+    // content (the Display text), not to aria-label. Associate a name via the
+    // optional Label part.
     pub fn root_attrs(&self) -> AttrMap {
         let mut attrs = AttrMap::new();
         let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Root.data_attrs();
@@ -466,7 +484,6 @@ impl<'a> Api<'a> {
         attrs.set(HtmlAttr::Data("ars-state"), self.state_str());
         attrs.set(HtmlAttr::Aria(AriaAttr::Live), "polite");
         attrs.set(HtmlAttr::Aria(AriaAttr::Atomic), "true");
-        attrs.set(HtmlAttr::Aria(AriaAttr::Label), self.formatted_time());
         attrs
     }
 
@@ -479,13 +496,15 @@ impl<'a> Api<'a> {
         attrs
     }
 
+    // The Display holds the visible formatted time and is NOT aria-hidden: as
+    // the changing content of the Root live region it is what assistive tech
+    // announces on each tick (§3.3).
     pub fn display_attrs(&self) -> AttrMap {
         let mut attrs = AttrMap::new();
         let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Display.data_attrs();
         attrs.set(scope_attr, scope_val);
         attrs.set(part_attr, part_val);
         attrs.set(HtmlAttr::Id, self.ctx.ids.part("display"));
-        attrs.set(HtmlAttr::Aria(AriaAttr::Hidden), "true");
         attrs
     }
 
@@ -603,7 +622,7 @@ Timer
 | ------------ | ---------- | --------------------------------------------------------------------- |
 | Root         | `<div>`    | `role="timer"`, `aria-live="polite"`, `aria-atomic`                   |
 | Label        | `<label>`  | `id` for association                                                  |
-| Display      | `<span>`   | `aria-hidden="true"` (Root handles live region)                       |
+| Display      | `<span>`   | visible time; announced as the Root live region's content             |
 | Progress     | `<div>`    | `role="progressbar"`, `aria-valuenow/min/max`                         |
 | StartTrigger | `<button>` | `type="button"`, `aria-label` (Start/Resume), `disabled` when running |
 | PauseTrigger | `<button>` | `type="button"`, `aria-label` (Pause), `disabled` when not running    |
@@ -616,7 +635,7 @@ Timer
 
 | Part         | Role          | Properties                                               |
 | ------------ | ------------- | -------------------------------------------------------- |
-| Root         | `timer`       | `aria-live="polite"`, `aria-atomic="true"`, `aria-label` |
+| Root         | `timer`       | `aria-live="polite"`, `aria-atomic="true"`               |
 | Progress     | `progressbar` | `aria-valuenow`, `aria-valuemin`, `aria-valuemax`        |
 | StartTrigger | `button`      | `aria-label`, `disabled`                                 |
 | PauseTrigger | `button`      | `aria-label`, `disabled`                                 |
@@ -631,7 +650,7 @@ Timer
 
 ### 3.3 Screen Reader Announcements
 
-The Root element has `role="timer"` with `aria-live="polite"` and `aria-atomic="true"`. Time changes are announced periodically. When countdown completes, the `completed_announcement` message is announced.
+The Root element has `role="timer"` with `aria-live="polite"` and `aria-atomic="true"`. The changing time text lives in the `Display` child (which is **not** `aria-hidden`), so it is the live region's content and is announced as it changes — the Root does **not** carry the time as an `aria-label`, because live regions announce content mutations, not `aria-label` changes. Associate an accessible name through the optional `Label` part. When a countdown completes, the `completed_announcement` message is announced.
 
 ## 4. Internationalization
 

--- a/spec/components/specialized/timer.md
+++ b/spec/components/specialized/timer.md
@@ -63,7 +63,7 @@ pub enum Event {
     /// A single tick interval elapsed.
     Tick,
     /// Set the remaining/elapsed time directly.
-    SetTime(u64),
+    SetTime(Duration),
 }
 ```
 
@@ -72,13 +72,13 @@ pub enum Event {
 ```rust
 #[derive(Clone, Debug, PartialEq)]
 pub struct Context {
-    /// Current time value in milliseconds.
+    /// Current time value.
     /// For countdown: remaining time. For stopwatch: elapsed time.
-    pub current_ms: u64,
-    /// The target duration in milliseconds (for countdown).
-    pub target_ms: u64,
-    /// Tick interval in milliseconds.
-    pub interval_ms: u32,
+    pub current: Duration,
+    /// The target duration (for countdown).
+    pub target: Duration,
+    /// Tick interval.
+    pub interval: Duration,
     /// Timer mode.
     pub mode: Mode,
     /// Whether auto-start is enabled.
@@ -99,10 +99,10 @@ pub struct Context {
 pub struct Props {
     /// Component instance ID.
     pub id: String,
-    /// Target duration in milliseconds (for countdown mode).
-    pub target_ms: u64,
-    /// Tick interval in milliseconds.
-    pub interval_ms: u32,
+    /// Target duration (for countdown mode).
+    pub target: Duration,
+    /// Tick interval.
+    pub interval: Duration,
     /// Timer mode (countdown or stopwatch).
     pub mode: Mode,
     /// Auto-start when mounted.
@@ -113,8 +113,8 @@ impl Default for Props {
     fn default() -> Self {
         Self {
             id: String::new(),
-            target_ms: 60_000,
-            interval_ms: 1000,
+            target: Duration::from_secs(60),
+            interval: Duration::from_secs(1),
             mode: Mode::Countdown,
             auto_start: false,
         }
@@ -122,7 +122,34 @@ impl Default for Props {
 }
 ```
 
-### 1.5 Full Machine Implementation
+### 1.5 Effects
+
+The recurring tick and the completion announcement are side effects the agnostic core cannot
+perform itself (it has no DOM and no recurring-interval primitive — `PlatformEffects` exposes only
+`set_timeout`). They are therefore emitted as typed **marker effects** that framework adapters
+translate into real platform calls, exactly like `clipboard::Effect::FeedbackTimer` and
+`toast::single::Effect::DurationTimer`.
+
+```rust
+/// Typed effect intents emitted by the timer machine.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Effect {
+    /// Adapter starts a recurring interval of `Context::interval`
+    /// milliseconds that dispatches `Event::Tick` on each elapse. Emitted on
+    /// initial mount when the timer auto-starts (via `Machine::initial_effects`)
+    /// and on every transition into `State::Running`. Cancelled whenever the
+    /// timer leaves `State::Running` (pause, completion, reset, or restart);
+    /// the adapter no-ops the cancellation when no interval is active.
+    TimerInterval,
+
+    /// Adapter announces the `Messages::completed_announcement` message into a
+    /// polite `aria-live` region. Emitted on the countdown transition into
+    /// `State::Completed`.
+    AnnounceCompleted,
+}
+```
+
+### 1.6 Full Machine Implementation
 
 ```rust
 pub struct Machine;
@@ -133,17 +160,14 @@ impl ars_core::Machine for Machine {
     type Context = Context;
     type Props = Props;
     type Messages = Messages;
+    type Effect = Effect;
     type Api<'a> = Api<'a>;
 
     fn init(props: &Self::Props, env: &Env, messages: &Self::Messages) -> (Self::State, Self::Context) {
-        let current_ms = match props.mode {
-            Mode::Countdown => props.target_ms,
-            Mode::Stopwatch => 0,
+        let current = match props.mode {
+            Mode::Countdown => props.target,
+            Mode::Stopwatch => Duration::ZERO,
         };
-
-        let ids = ComponentIds::from_id(&props.id);
-        let locale = env.locale.clone();
-        let messages = messages.clone();
 
         let state = if props.auto_start {
             State::Running
@@ -152,15 +176,29 @@ impl ars_core::Machine for Machine {
         };
 
         (state, Context {
-            current_ms,
-            target_ms: props.target_ms,
-            interval_ms: props.interval_ms,
+            current,
+            target: props.target,
+            interval: props.interval,
             mode: props.mode,
             auto_start: props.auto_start,
-            locale,
-            messages,
-            ids,
+            locale: env.locale.clone(),
+            messages: messages.clone(),
+            ids: ComponentIds::from_id(&props.id),
         })
+    }
+
+    // Auto-started timers boot directly into `Running` without a transition,
+    // so the interval intent is emitted here on first mount.
+    fn initial_effects(
+        state: &Self::State,
+        _ctx: &Self::Context,
+        _props: &Self::Props,
+    ) -> Vec<PendingEffect<Self>> {
+        let mut effects = Vec::new();
+        if matches!(state, State::Running) {
+            effects.push(PendingEffect::named(Effect::TimerInterval));
+        }
+        effects
     }
 
     fn transition(
@@ -170,88 +208,65 @@ impl ars_core::Machine for Machine {
         _props: &Self::Props,
     ) -> Option<TransitionPlan<Self>> {
         match (state, event) {
-            (State::Idle, Event::Start) => {
-                Some(TransitionPlan::to(State::Running).with_named_effect("timer-interval", |ctx, _props, send| {
-                    let interval = ctx.interval_ms;
-                    let timer = set_interval(interval, move || {
-                        send(Event::Tick);
-                    });
-                    Box::new(move || cancel_interval(timer))
-                }))
+            // Idle start, paused resume, and paused start all enter `Running`
+            // and (re)emit the interval intent.
+            (State::Idle, Event::Start)
+            | (State::Paused, Event::Resume | Event::Start) => {
+                Some(TransitionPlan::to(State::Running)
+                    .with_effect(PendingEffect::named(Effect::TimerInterval)))
             }
 
-            (State::Running, Event::Tick) => {
-                match ctx.mode {
-                    Mode::Countdown => {
-                        let new_ms = ctx.current_ms.saturating_sub(ctx.interval_ms as u64);
-                        if new_ms == 0 {
-                            Some(TransitionPlan::to(State::Completed).apply(|ctx| {
-                                ctx.current_ms = 0;
-                            }).with_named_effect("announce", |ctx, _props, _send| {
-                                let platform = use_platform_effects();
-                                platform.announce(&(ctx.messages.completed_announcement)(&ctx.locale));
-                                no_cleanup()
-                            }))
-                        } else {
-                            Some(TransitionPlan::context_only(move |ctx| {
-                                ctx.current_ms = new_ms;
-                            }))
-                        }
-                    }
-                    Mode::Stopwatch => {
-                        let interval = ctx.interval_ms as u64;
+            (State::Running, Event::Tick) => match ctx.mode {
+                Mode::Countdown => {
+                    let new = ctx.current.saturating_sub(ctx.interval);
+                    if new.is_zero() {
+                        Some(TransitionPlan::to(State::Completed)
+                            .apply(|ctx| { ctx.current = Duration::ZERO; })
+                            .cancel_effect(Effect::TimerInterval)
+                            .with_effect(PendingEffect::named(Effect::AnnounceCompleted)))
+                    } else {
                         Some(TransitionPlan::context_only(move |ctx| {
-                            ctx.current_ms += interval;
+                            ctx.current = new;
                         }))
                     }
                 }
-            }
+                Mode::Stopwatch => {
+                    let interval = ctx.interval;
+                    Some(TransitionPlan::context_only(move |ctx| {
+                        ctx.current = ctx.current.saturating_add(interval);
+                    }))
+                }
+            },
 
             (State::Running, Event::Pause) => {
-                Some(TransitionPlan::to(State::Paused))
-            }
-
-            (State::Paused, Event::Resume)
-            | (State::Paused, Event::Start) => {
-                Some(TransitionPlan::to(State::Running).with_named_effect("timer-interval", |ctx, _props, send| {
-                    let interval = ctx.interval_ms;
-                    let timer = set_interval(interval, move || {
-                        send(Event::Tick);
-                    });
-                    Box::new(move || cancel_interval(timer))
-                }))
+                Some(TransitionPlan::to(State::Paused).cancel_effect(Effect::TimerInterval))
             }
 
             (_, Event::Reset) => {
-                let initial_ms = match ctx.mode {
-                    Mode::Countdown => ctx.target_ms,
-                    Mode::Stopwatch => 0,
+                let initial = match ctx.mode {
+                    Mode::Countdown => ctx.target,
+                    Mode::Stopwatch => Duration::ZERO,
                 };
-                Some(TransitionPlan::to(State::Idle).apply(move |ctx| {
-                    ctx.current_ms = initial_ms;
-                }))
+                Some(TransitionPlan::to(State::Idle)
+                    .apply(move |ctx| { ctx.current = initial; })
+                    .cancel_effect(Effect::TimerInterval))
             }
 
             (_, Event::Restart) => {
-                let initial_ms = match ctx.mode {
-                    Mode::Countdown => ctx.target_ms,
-                    Mode::Stopwatch => 0,
+                let initial = match ctx.mode {
+                    Mode::Countdown => ctx.target,
+                    Mode::Stopwatch => Duration::ZERO,
                 };
-                Some(TransitionPlan::to(State::Running).apply(move |ctx| {
-                    ctx.current_ms = initial_ms;
-                }).with_named_effect("timer-interval", |ctx, _props, send| {
-                    let interval = ctx.interval_ms;
-                    let timer = set_interval(interval, move || {
-                        send(Event::Tick);
-                    });
-                    Box::new(move || cancel_interval(timer))
-                }))
+                Some(TransitionPlan::to(State::Running)
+                    .apply(move |ctx| { ctx.current = initial; })
+                    .cancel_effect(Effect::TimerInterval)
+                    .with_effect(PendingEffect::named(Effect::TimerInterval)))
             }
 
-            (_, Event::SetTime(ms)) => {
-                let ms = *ms;
+            (_, Event::SetTime(duration)) => {
+                let duration = *duration;
                 Some(TransitionPlan::context_only(move |ctx| {
-                    ctx.current_ms = ms;
+                    ctx.current = duration;
                 }))
             }
 
@@ -270,7 +285,7 @@ impl ars_core::Machine for Machine {
 }
 ```
 
-### 1.6 Connect / API
+### 1.7 Connect / API
 
 ```rust
 #[derive(ComponentPart)]
@@ -298,11 +313,11 @@ impl<'a> Api<'a> {
     pub fn is_paused(&self) -> bool { *self.state == State::Paused }
     pub fn is_completed(&self) -> bool { *self.state == State::Completed }
     pub fn is_idle(&self) -> bool { *self.state == State::Idle }
-    pub fn current_ms(&self) -> u64 { self.ctx.current_ms }
+    pub fn current(&self) -> Duration { self.ctx.current }
 
     /// Current time broken into hours, minutes, seconds, milliseconds.
     pub fn display_time(&self) -> (u64, u64, u64, u64) {
-        let ms = self.ctx.current_ms;
+        let ms = self.ctx.current.as_millis() as u64;
         let hours = ms / 3_600_000;
         let minutes = (ms % 3_600_000) / 60_000;
         let seconds = (ms % 60_000) / 1_000;
@@ -312,10 +327,11 @@ impl<'a> Api<'a> {
 
     /// Progress as a fraction [0.0, 1.0] (countdown only).
     pub fn progress(&self) -> f64 {
-        if self.ctx.target_ms == 0 { return 0.0; }
+        if self.ctx.target.is_zero() { return 0.0; }
+        let fraction = self.ctx.current.as_secs_f64() / self.ctx.target.as_secs_f64();
         match self.ctx.mode {
-            Mode::Countdown => 1.0 - (self.ctx.current_ms as f64 / self.ctx.target_ms as f64),
-            Mode::Stopwatch => self.ctx.current_ms as f64 / self.ctx.target_ms as f64,
+            Mode::Countdown => 1.0 - fraction,
+            Mode::Stopwatch => fraction,
         }
     }
 
@@ -570,9 +586,9 @@ impl ComponentMessages for Messages {}
 | ------------------ | ---------------------------- | --------------------- | ----------------------------------- |
 | `autoStart`        | `auto_start`                 | `autoStart`           | Equivalent                          |
 | `countdown` / mode | `mode` (Countdown/Stopwatch) | `countdown` (boolean) | Equivalent (ars-ui uses enum)       |
-| `interval`         | `interval_ms`                | `interval`            | Equivalent                          |
+| `interval`         | `interval` (`Duration`)      | `interval`            | Equivalent (ars-ui uses `Duration`) |
 | `startMs`          | --                           | `startMs`             | Ark can start from arbitrary offset |
-| `targetMs`         | `target_ms`                  | `targetMs`            | Equivalent                          |
+| `targetMs`         | `target` (`Duration`)        | `targetMs`            | Equivalent (ars-ui uses `Duration`) |
 
 **Gaps:** None. `startMs` is niche; ars-ui can achieve via `Event::SetTime`.
 


### PR DESCRIPTION
## Summary

Implements the framework-agnostic **Timer** component (`ars-components`), per issue #294 (Epic #227).

- Stateful machine: `Idle → Running → Paused → Running → Completed`, countdown + stopwatch modes, configurable tick interval, auto-start.
- `ConnectApi` with 8 parts: `Root` (`role="timer"`, `aria-live="polite"`, `aria-atomic`, `aria-label`), `Label`, `Display`, `Progress` (`role="progressbar"`), `StartTrigger`/`PauseTrigger`/`ResetTrigger` (state-dependent labels + `disabled`), `Separator`. Plus `display_time`, `formatted_time`, `progress`.

## Design notes (spec drift resolved in-PR)

The spec's original §1.5 machine impl would not compile against current conventions. Resolved per CLAUDE.md (spec/code mismatch in the same PR):

- Recurring tick + completion announcement modelled as typed **marker effects** (`Effect::TimerInterval`, `Effect::AnnounceCompleted`) owned by adapters — matching the `clipboard`/`toast` precedent (no nonexistent `set_interval`, no inline `use_platform_effects`). Auto-start emits the interval via `initial_effects`; the interval is cancelled whenever the timer leaves `Running`.
- All time-related fields use **`core::time::Duration`** (no raw `u32`/`u64` milliseconds), matching the `search_input`/`scroll_area` convention.

Spec §1.2/1.3/1.4/1.6/1.7 + §5.1 synced to the Effect-enum + `Duration` model.

## Tests

- 33 unit + 17 snapshot (committed `.snap`, inspected) covering every part across idle/running/paused/completed/hours branches
- 1 spec-conformance anatomy test, 1 proptest invariant block, 1 doctest
- `post-implementation-audit` run (spec-drift, 2× "anything missing", coverage); doctest added, intra-doc links fixed

## Verification

`cargo xci-fast`: all 10 gates pass (fmt, clippy, unit, integration, adapter, spec-compile-snippets, error-variant-coverage, mutual-exclusion, snapshot-count, coverage-native). `ars-components` coverage 98.4% line / 90.2% branch.

Closes #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)