### PR TITLE
Add adapter component dependency tooling

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -27,7 +27,7 @@ body:
     id: depends_on
     attributes:
       label: Depends on
-      description: Reference prerequisite issues, or say none. Native GitHub issue dependencies should be added after creation.
+      description: Reference prerequisite issues, or say none. For adapter tasks, derive this from `cargo xtask spec issue-deps --adapter <leptos|dioxus> --component <component> --dry-run`. Native GitHub issue dependencies should be added after creation for every hard blocker.
     validations:
       required: true
   - type: dropdown
@@ -109,6 +109,14 @@ body:
       placeholder: If blocked, keep Status in Todo and name the dependency or spec ambiguity.
     validations:
       required: true
+  - type: textarea
+    id: component_dependency_notes
+    attributes:
+      label: Component dependency notes
+      description: For adapter tasks, copy non-blocking `boundary` or `related` notes from `cargo xtask spec component-deps <component> --adapter <framework>`. Say none when there are no component dependency notes.
+      placeholder: "Not a blocker: this interaction belongs to a separate component."
+    validations:
+      required: false
   - type: textarea
     id: eight_point_rationale
     attributes:

--- a/spec/manifest.toml
+++ b/spec/manifest.toml
@@ -66,6 +66,7 @@ category        = "input"
 foundation_deps = ["architecture", "accessibility", "interactions", "forms"]
 shared_deps     = []
 related         = ["checkbox-group"]
+component_deps  = []
 
 [components.checkbox-group]
 path            = "components/input/checkbox-group.md"
@@ -73,6 +74,7 @@ category        = "input"
 foundation_deps = ["architecture", "accessibility", "interactions", "forms"]
 shared_deps     = []
 related         = ["checkbox"]
+component_deps  = []
 
 [components.editable]
 path            = "components/input/editable.md"
@@ -80,6 +82,7 @@ category        = "input"
 foundation_deps = ["architecture", "accessibility", "interactions", "forms"]
 shared_deps     = []
 related         = []
+component_deps  = []
 
 [components.file-trigger]
 path            = "components/input/file-trigger.md"
@@ -87,6 +90,7 @@ category        = "input"
 foundation_deps = ["architecture", "accessibility", "interactions", "forms"]
 shared_deps     = []
 related         = ["file-upload"]
+component_deps  = []
 
 [components.number-input]
 path            = "components/input/number-input.md"
@@ -94,6 +98,7 @@ category        = "input"
 foundation_deps = ["architecture", "accessibility", "interactions", "forms"]
 shared_deps     = []
 related         = []
+component_deps  = []
 
 [components.password-input]
 path            = "components/input/password-input.md"
@@ -101,6 +106,7 @@ category        = "input"
 foundation_deps = ["architecture", "accessibility", "interactions", "forms"]
 shared_deps     = []
 related         = ["text-field"]
+component_deps  = []
 
 [components.pin-input]
 path            = "components/input/pin-input.md"
@@ -108,6 +114,7 @@ category        = "input"
 foundation_deps = ["architecture", "accessibility", "interactions", "forms"]
 shared_deps     = []
 related         = []
+component_deps  = []
 
 [components.radio-group]
 path            = "components/input/radio-group.md"
@@ -115,6 +122,7 @@ category        = "input"
 foundation_deps = ["architecture", "accessibility", "interactions", "forms"]
 shared_deps     = []
 related         = []
+component_deps  = []
 
 [components.range-slider]
 path            = "components/input/range-slider.md"
@@ -122,6 +130,7 @@ category        = "input"
 foundation_deps = ["architecture", "accessibility", "interactions", "forms"]
 shared_deps     = []
 related         = ["slider"]
+component_deps  = []
 
 [components.search-input]
 path            = "components/input/search-input.md"
@@ -129,6 +138,7 @@ category        = "input"
 foundation_deps = ["architecture", "accessibility", "interactions", "forms"]
 shared_deps     = []
 related         = ["text-field"]
+component_deps  = []
 
 [components.slider]
 path            = "components/input/slider.md"
@@ -136,6 +146,7 @@ category        = "input"
 foundation_deps = ["architecture", "accessibility", "interactions", "forms"]
 shared_deps     = []
 related         = ["range-slider"]
+component_deps  = []
 
 [components.switch]
 path            = "components/input/switch.md"
@@ -143,6 +154,7 @@ category        = "input"
 foundation_deps = ["architecture", "accessibility", "interactions", "forms"]
 shared_deps     = []
 related         = []
+component_deps  = []
 
 [components.text-field]
 path            = "components/input/text-field.md"
@@ -150,6 +162,7 @@ category        = "input"
 foundation_deps = ["architecture", "accessibility", "interactions", "forms"]
 shared_deps     = []
 related         = ["textarea", "password-input", "search-input"]
+component_deps  = []
 
 [components.textarea]
 path            = "components/input/textarea.md"
@@ -157,6 +170,7 @@ category        = "input"
 foundation_deps = ["architecture", "accessibility", "interactions", "forms"]
 shared_deps     = []
 related         = ["text-field"]
+component_deps  = []
 
 # ══════════════════════════════════════════════
 # Components — selection
@@ -168,6 +182,7 @@ category        = "selection"
 foundation_deps = ["architecture", "accessibility", "interactions", "collections"]
 shared_deps     = ["selection-patterns"]
 related         = []
+component_deps  = []
 
 [components.combobox]
 path            = "components/selection/combobox.md"
@@ -175,6 +190,7 @@ category        = "selection"
 foundation_deps = ["architecture", "accessibility", "interactions", "collections"]
 shared_deps     = ["selection-patterns"]
 related         = []
+component_deps  = []
 
 [components.context-menu]
 path            = "components/selection/context-menu.md"
@@ -182,6 +198,7 @@ category        = "selection"
 foundation_deps = ["architecture", "accessibility", "interactions", "collections"]
 shared_deps     = ["selection-patterns"]
 related         = []
+component_deps  = []
 
 [components.listbox]
 path            = "components/selection/listbox.md"
@@ -196,6 +213,7 @@ category        = "selection"
 foundation_deps = ["architecture", "accessibility", "interactions", "collections"]
 shared_deps     = ["selection-patterns"]
 related         = []
+component_deps  = []
 
 [components.menu-bar]
 path            = "components/selection/menu-bar.md"
@@ -203,6 +221,7 @@ category        = "selection"
 foundation_deps = ["architecture", "accessibility", "interactions", "collections"]
 shared_deps     = ["selection-patterns"]
 related         = []
+component_deps  = []
 
 [components.select]
 path            = "components/selection/select.md"
@@ -217,6 +236,7 @@ category        = "selection"
 foundation_deps = ["architecture", "accessibility", "interactions", "collections"]
 shared_deps     = ["selection-patterns"]
 related         = []
+component_deps  = []
 
 [components.segment-group]
 path            = "components/selection/segment-group.md"
@@ -224,6 +244,7 @@ category        = "selection"
 foundation_deps = ["architecture", "accessibility", "interactions"]
 shared_deps     = []
 related         = ["radio-group", "toggle-group"]
+component_deps  = []
 
 # ══════════════════════════════════════════════
 # Components — overlay
@@ -235,6 +256,10 @@ category        = "overlay"
 foundation_deps = ["architecture", "accessibility", "interactions"]
 shared_deps     = ["z-index-stacking"]
 related         = ["dialog"]
+component_deps  = [
+    { component = "dialog", kind = "requires", frameworks = ["leptos", "dioxus"], reason = "AlertDialog reuses the modal dialog interaction and semantics contract." },
+    { component = "focus-scope", kind = "requires", frameworks = ["leptos", "dioxus"], reason = "AlertDialog focus trapping depends on FocusScope." },
+]
 
 [components.dialog]
 path            = "components/overlay/dialog.md"
@@ -242,6 +267,9 @@ category        = "overlay"
 foundation_deps = ["architecture", "accessibility", "interactions"]
 shared_deps     = ["z-index-stacking"]
 related         = []
+component_deps  = [
+    { component = "focus-scope", kind = "requires", frameworks = ["leptos", "dioxus"], reason = "Dialog focus trapping depends on FocusScope." },
+]
 
 [components.drawer]
 path            = "components/overlay/drawer.md"
@@ -249,6 +277,9 @@ category        = "overlay"
 foundation_deps = ["architecture", "accessibility", "interactions"]
 shared_deps     = ["z-index-stacking"]
 related         = ["dialog"]
+component_deps  = [
+    { component = "dialog", kind = "composes", frameworks = ["leptos", "dioxus"], blocking = true, reason = "Drawer is a dialog-like overlay surface and should reuse dialog focus and dismissal semantics." },
+]
 
 [components.floating-panel]
 path            = "components/overlay/floating-panel.md"
@@ -256,6 +287,7 @@ category        = "overlay"
 foundation_deps = ["architecture", "accessibility", "interactions"]
 shared_deps     = ["z-index-stacking"]
 related         = []
+component_deps  = []
 
 [components.hover-card]
 path            = "components/overlay/hover-card.md"
@@ -263,6 +295,7 @@ category        = "overlay"
 foundation_deps = ["architecture", "accessibility", "interactions"]
 shared_deps     = ["z-index-stacking"]
 related         = ["popover", "tooltip"]
+component_deps  = []
 
 [components.popover]
 path            = "components/overlay/popover.md"
@@ -270,6 +303,7 @@ category        = "overlay"
 foundation_deps = ["architecture", "accessibility", "interactions"]
 shared_deps     = ["z-index-stacking"]
 related         = ["dialog"]
+component_deps  = []
 
 [components.presence]
 path            = "components/overlay/presence.md"
@@ -277,6 +311,7 @@ category        = "overlay"
 foundation_deps = ["architecture", "accessibility", "interactions"]
 shared_deps     = []
 related         = []
+component_deps  = []
 
 [components.toast]
 path            = "components/overlay/toast.md"
@@ -284,6 +319,7 @@ category        = "overlay"
 foundation_deps = ["architecture", "accessibility", "interactions"]
 shared_deps     = ["z-index-stacking"]
 related         = []
+component_deps  = []
 
 [components.tooltip]
 path            = "components/overlay/tooltip.md"
@@ -291,6 +327,7 @@ category        = "overlay"
 foundation_deps = ["architecture", "accessibility", "interactions"]
 shared_deps     = ["z-index-stacking"]
 related         = ["hover-card"]
+component_deps  = []
 
 [components.tour]
 path            = "components/overlay/tour.md"
@@ -298,6 +335,7 @@ category        = "overlay"
 foundation_deps = ["architecture", "accessibility", "interactions"]
 shared_deps     = ["z-index-stacking"]
 related         = []
+component_deps  = []
 
 # ══════════════════════════════════════════════
 # Components — navigation
@@ -309,6 +347,7 @@ category        = "navigation"
 foundation_deps = ["architecture", "accessibility", "interactions"]
 shared_deps     = []
 related         = []
+component_deps  = []
 
 [components.breadcrumbs]
 path            = "components/navigation/breadcrumbs.md"
@@ -316,6 +355,7 @@ category        = "navigation"
 foundation_deps = ["architecture", "accessibility", "interactions"]
 shared_deps     = []
 related         = []
+component_deps  = []
 
 [components.link]
 path            = "components/navigation/link.md"
@@ -323,6 +363,7 @@ category        = "navigation"
 foundation_deps = ["architecture", "accessibility", "interactions"]
 shared_deps     = []
 related         = []
+component_deps  = []
 
 [components.navigation-menu]
 path            = "components/navigation/navigation-menu.md"
@@ -330,6 +371,7 @@ category        = "navigation"
 foundation_deps = ["architecture", "accessibility", "interactions"]
 shared_deps     = ["z-index-stacking"]
 related         = ["menu", "menu-bar", "tabs"]
+component_deps  = []
 
 [components.pagination]
 path            = "components/navigation/pagination.md"
@@ -337,6 +379,7 @@ category        = "navigation"
 foundation_deps = ["architecture", "accessibility", "interactions"]
 shared_deps     = []
 related         = []
+component_deps  = []
 
 [components.steps]
 path            = "components/navigation/steps.md"
@@ -344,6 +387,7 @@ category        = "navigation"
 foundation_deps = ["architecture", "accessibility", "interactions"]
 shared_deps     = []
 related         = []
+component_deps  = []
 
 [components.tabs]
 path            = "components/navigation/tabs.md"
@@ -351,6 +395,7 @@ category        = "navigation"
 foundation_deps = ["architecture", "accessibility", "interactions"]
 shared_deps     = []
 related         = []
+component_deps  = []
 
 [components.tree-view]
 path            = "components/navigation/tree-view.md"
@@ -358,6 +403,7 @@ category        = "navigation"
 foundation_deps = ["architecture", "accessibility", "interactions", "collections"]
 shared_deps     = []
 related         = []
+component_deps  = []
 
 # ══════════════════════════════════════════════
 # Components — date-time
@@ -369,6 +415,7 @@ category        = "date-time"
 foundation_deps = ["architecture", "accessibility", "i18n", "interactions"]
 shared_deps     = ["date-time-types"]
 related         = ["range-calendar", "date-picker", "date-range-picker"]
+component_deps  = []
 
 [components.date-field]
 path            = "components/date-time/date-field.md"
@@ -376,6 +423,7 @@ category        = "date-time"
 foundation_deps = ["architecture", "accessibility", "i18n", "interactions", "forms"]
 shared_deps     = ["date-time-types"]
 related         = ["date-picker", "date-range-field", "time-field"]
+component_deps  = []
 
 [components.date-picker]
 path            = "components/date-time/date-picker.md"
@@ -383,6 +431,13 @@ category        = "date-time"
 foundation_deps = ["architecture", "accessibility", "i18n", "interactions", "forms"]
 shared_deps     = ["date-time-types"]
 related         = ["calendar", "date-field", "date-range-picker"]
+component_deps  = [
+    { component = "calendar", kind = "composes", frameworks = ["leptos", "dioxus"], blocking = true, reason = "DatePicker popup selection composes a Calendar adapter." },
+    { component = "date-field", kind = "composes", frameworks = ["leptos", "dioxus"], blocking = true, reason = "DatePicker control composes date-field input semantics." },
+    { component = "button", kind = "composes", frameworks = ["leptos", "dioxus"], blocking = true, reason = "DatePicker trigger and clear controls should reuse Button semantics." },
+    { component = "field", kind = "composes", frameworks = ["leptos", "dioxus"], blocking = true, reason = "DatePicker label, invalid, and description wiring should reuse Field semantics." },
+    { component = "form", kind = "composes", frameworks = ["leptos", "dioxus"], blocking = true, reason = "DatePicker native form participation should align with Form integration." },
+]
 
 [components.date-range-field]
 path            = "components/date-time/date-range-field.md"
@@ -390,6 +445,11 @@ category        = "date-time"
 foundation_deps = ["architecture", "accessibility", "i18n", "interactions", "forms"]
 shared_deps     = ["date-time-types"]
 related         = ["date-field", "date-range-picker"]
+component_deps  = [
+    { component = "date-field", kind = "composes", frameworks = ["leptos", "dioxus"], blocking = true, reason = "DateRangeField composes two DateField-style segmented inputs." },
+    { component = "field", kind = "composes", frameworks = ["leptos", "dioxus"], blocking = true, reason = "DateRangeField label, invalid, and description wiring should reuse Field semantics." },
+    { component = "form", kind = "composes", frameworks = ["leptos", "dioxus"], blocking = true, reason = "DateRangeField native form participation should align with Form integration." },
+]
 
 [components.date-range-picker]
 path            = "components/date-time/date-range-picker.md"
@@ -397,6 +457,13 @@ category        = "date-time"
 foundation_deps = ["architecture", "accessibility", "i18n", "interactions", "forms"]
 shared_deps     = ["date-time-types"]
 related         = ["calendar", "range-calendar", "date-field", "date-range-field"]
+component_deps  = [
+    { component = "date-field", kind = "composes", frameworks = ["leptos", "dioxus"], blocking = true, reason = "DateRangePicker composes start and end DateField adapters." },
+    { component = "range-calendar", kind = "composes", frameworks = ["leptos", "dioxus"], blocking = true, reason = "DateRangePicker popup range selection composes RangeCalendar." },
+    { component = "button", kind = "composes", frameworks = ["leptos", "dioxus"], blocking = true, reason = "DateRangePicker trigger and clear controls should reuse Button semantics." },
+    { component = "field", kind = "composes", frameworks = ["leptos", "dioxus"], blocking = true, reason = "DateRangePicker label, invalid, and description wiring should reuse Field semantics." },
+    { component = "form", kind = "composes", frameworks = ["leptos", "dioxus"], blocking = true, reason = "DateRangePicker native form participation should align with Form integration." },
+]
 
 [components.date-time-picker]
 path            = "components/date-time/date-time-picker.md"
@@ -404,6 +471,14 @@ category        = "date-time"
 foundation_deps = ["architecture", "accessibility", "i18n", "interactions", "forms"]
 shared_deps     = ["date-time-types"]
 related         = ["date-picker", "time-field", "calendar"]
+component_deps  = [
+    { component = "date-field", kind = "composes", frameworks = ["leptos", "dioxus"], blocking = true, reason = "DateTimePicker date segments reuse DateField adapter behavior." },
+    { component = "time-field", kind = "composes", frameworks = ["leptos", "dioxus"], blocking = true, reason = "DateTimePicker time segments reuse TimeField adapter behavior." },
+    { component = "calendar", kind = "composes", frameworks = ["leptos", "dioxus"], blocking = true, reason = "DateTimePicker popup date selection composes Calendar." },
+    { component = "button", kind = "composes", frameworks = ["leptos", "dioxus"], blocking = true, reason = "DateTimePicker trigger and clear controls should reuse Button semantics." },
+    { component = "field", kind = "composes", frameworks = ["leptos", "dioxus"], blocking = true, reason = "DateTimePicker label, invalid, and description wiring should reuse Field semantics." },
+    { component = "form", kind = "composes", frameworks = ["leptos", "dioxus"], blocking = true, reason = "DateTimePicker native form participation should align with Form integration." },
+]
 
 [components.time-field]
 path            = "components/date-time/time-field.md"
@@ -411,6 +486,7 @@ category        = "date-time"
 foundation_deps = ["architecture", "accessibility", "i18n", "interactions", "forms"]
 shared_deps     = ["date-time-types"]
 related         = ["date-field", "date-time-picker"]
+component_deps  = []
 
 [components.range-calendar]
 path            = "components/date-time/range-calendar.md"
@@ -418,6 +494,7 @@ category        = "date-time"
 foundation_deps = ["architecture", "accessibility", "i18n", "interactions"]
 shared_deps     = ["date-time-types"]
 related         = ["calendar", "date-range-picker"]
+component_deps  = []
 
 # ══════════════════════════════════════════════
 # Components — data-display
@@ -429,6 +506,7 @@ category        = "data-display"
 foundation_deps = ["architecture", "accessibility"]
 shared_deps     = []
 related         = []
+component_deps  = []
 
 [components.badge]
 path            = "components/data-display/badge.md"
@@ -436,6 +514,7 @@ category        = "data-display"
 foundation_deps = ["architecture", "accessibility"]
 shared_deps     = []
 related         = []
+component_deps  = []
 
 [components.grid-list]
 path            = "components/data-display/grid-list.md"
@@ -443,6 +522,7 @@ category        = "data-display"
 foundation_deps = ["architecture", "accessibility", "collections", "interactions"]
 shared_deps     = []
 related         = []
+component_deps  = []
 
 [components.marquee]
 path            = "components/data-display/marquee.md"
@@ -450,6 +530,7 @@ category        = "data-display"
 foundation_deps = ["architecture", "accessibility"]
 shared_deps     = []
 related         = []
+component_deps  = []
 
 [components.meter]
 path            = "components/data-display/meter.md"
@@ -457,6 +538,7 @@ category        = "data-display"
 foundation_deps = ["architecture", "accessibility"]
 shared_deps     = []
 related         = []
+component_deps  = []
 
 [components.progress]
 path            = "components/data-display/progress.md"
@@ -464,6 +546,7 @@ category        = "data-display"
 foundation_deps = ["architecture", "accessibility"]
 shared_deps     = []
 related         = []
+component_deps  = []
 
 [components.rating-group]
 path            = "components/data-display/rating-group.md"
@@ -471,6 +554,7 @@ category        = "data-display"
 foundation_deps = ["architecture", "accessibility"]
 shared_deps     = []
 related         = []
+component_deps  = []
 
 [components.skeleton]
 path            = "components/data-display/skeleton.md"
@@ -478,6 +562,7 @@ category        = "data-display"
 foundation_deps = ["architecture", "accessibility"]
 shared_deps     = []
 related         = []
+component_deps  = []
 
 [components.stat]
 path            = "components/data-display/stat.md"
@@ -485,6 +570,7 @@ category        = "data-display"
 foundation_deps = ["architecture", "accessibility"]
 shared_deps     = []
 related         = []
+component_deps  = []
 
 [components.table]
 path            = "components/data-display/table.md"
@@ -492,6 +578,7 @@ category        = "data-display"
 foundation_deps = ["architecture", "accessibility", "collections", "interactions"]
 shared_deps     = []
 related         = []
+component_deps  = []
 
 [components.tag-group]
 path            = "components/data-display/tag-group.md"
@@ -499,6 +586,7 @@ category        = "data-display"
 foundation_deps = ["architecture", "accessibility", "collections", "interactions"]
 shared_deps     = []
 related         = []
+component_deps  = []
 
 # ══════════════════════════════════════════════
 # Components — layout
@@ -510,6 +598,7 @@ category        = "layout"
 foundation_deps = ["architecture", "accessibility"]
 shared_deps     = []
 related         = []
+component_deps  = []
 
 [components.carousel]
 path            = "components/layout/carousel.md"
@@ -517,6 +606,7 @@ category        = "layout"
 foundation_deps = ["architecture", "accessibility", "interactions"]
 shared_deps     = ["layout-shared-types"]
 related         = []
+component_deps  = []
 
 [components.collapsible]
 path            = "components/layout/collapsible.md"
@@ -524,6 +614,7 @@ category        = "layout"
 foundation_deps = ["architecture", "accessibility", "interactions"]
 shared_deps     = ["layout-shared-types"]
 related         = []
+component_deps  = []
 
 [components.portal]
 path            = "components/layout/portal.md"
@@ -531,6 +622,7 @@ category        = "layout"
 foundation_deps = ["architecture", "accessibility", "interactions"]
 shared_deps     = ["layout-shared-types"]
 related         = []
+component_deps  = []
 
 [components.scroll-area]
 path            = "components/layout/scroll-area.md"
@@ -538,6 +630,7 @@ category        = "layout"
 foundation_deps = ["architecture", "accessibility", "interactions"]
 shared_deps     = ["layout-shared-types"]
 related         = []
+component_deps  = []
 
 [components.splitter]
 path            = "components/layout/splitter.md"
@@ -545,6 +638,7 @@ category        = "layout"
 foundation_deps = ["architecture", "accessibility", "interactions"]
 shared_deps     = ["layout-shared-types"]
 related         = []
+component_deps  = []
 
 [components.stack]
 path            = "components/layout/stack.md"
@@ -552,6 +646,7 @@ category        = "layout"
 foundation_deps = ["architecture", "accessibility"]
 shared_deps     = ["layout-shared-types"]
 related         = ["center", "grid"]
+component_deps  = []
 
 [components.center]
 path            = "components/layout/center.md"
@@ -559,6 +654,7 @@ category        = "layout"
 foundation_deps = ["architecture", "accessibility"]
 shared_deps     = ["layout-shared-types"]
 related         = ["stack", "grid"]
+component_deps  = []
 
 [components.grid]
 path            = "components/layout/grid.md"
@@ -566,6 +662,7 @@ category        = "layout"
 foundation_deps = ["architecture", "accessibility"]
 shared_deps     = ["layout-shared-types"]
 related         = ["stack", "center"]
+component_deps  = []
 
 [components.toolbar]
 path            = "components/layout/toolbar.md"
@@ -573,6 +670,7 @@ category        = "layout"
 foundation_deps = ["architecture", "accessibility", "interactions"]
 shared_deps     = ["layout-shared-types"]
 related         = []
+component_deps  = []
 
 [components.frame]
 path            = "components/layout/frame.md"
@@ -580,6 +678,7 @@ category        = "layout"
 foundation_deps = ["architecture", "accessibility"]
 shared_deps     = []
 related         = ["aspect-ratio"]
+component_deps  = []
 
 # ══════════════════════════════════════════════
 # Components — specialized
@@ -591,6 +690,7 @@ category        = "specialized"
 foundation_deps = ["architecture", "accessibility", "interactions"]
 shared_deps     = []
 related         = ["color-picker"]
+component_deps  = []
 
 [components.clipboard]
 path            = "components/specialized/clipboard.md"
@@ -598,6 +698,7 @@ category        = "specialized"
 foundation_deps = ["architecture", "accessibility", "interactions"]
 shared_deps     = []
 related         = []
+component_deps  = []
 
 [components.color-area]
 path            = "components/specialized/color-area.md"
@@ -605,6 +706,7 @@ category        = "specialized"
 foundation_deps = ["architecture", "accessibility", "interactions"]
 shared_deps     = []
 related         = ["color-picker", "color-slider"]
+component_deps  = []
 
 [components.color-field]
 path            = "components/specialized/color-field.md"
@@ -612,14 +714,15 @@ category        = "specialized"
 foundation_deps = ["architecture", "accessibility", "interactions"]
 shared_deps     = []
 related         = ["color-picker"]
+component_deps  = []
 
 [components.color-picker]
-path = "components/specialized/color-picker.md"
-category = "specialized"
-tier = "complex"
+path            = "components/specialized/color-picker.md"
+category        = "specialized"
+tier            = "complex"
 foundation_deps = ["architecture", "accessibility", "interactions"]
-shared_deps = []
-related = [
+shared_deps     = []
+related         = [
     "color-area",
     "color-slider",
     "color-field",
@@ -628,6 +731,13 @@ related = [
     "color-wheel",
     "angle-slider"
 ]
+component_deps  = [
+    { component = "color-area", kind = "composes", frameworks = ["leptos", "dioxus"], blocking = true, reason = "ColorPicker composes the standalone ColorArea adapter." },
+    { component = "color-slider", kind = "composes", frameworks = ["leptos", "dioxus"], blocking = true, reason = "ColorPicker composes color channel sliders." },
+    { component = "color-wheel", kind = "composes", frameworks = ["leptos", "dioxus"], blocking = true, reason = "ColorPicker may compose hue wheel behavior." },
+    { component = "color-field", kind = "composes", frameworks = ["leptos", "dioxus"], blocking = true, reason = "ColorPicker format and numeric entry should reuse ColorField semantics." },
+    { component = "color-swatch-picker", kind = "composes", frameworks = ["leptos", "dioxus"], blocking = true, reason = "ColorPicker preset swatches should reuse ColorSwatchPicker semantics." },
+]
 
 [components.color-slider]
 path            = "components/specialized/color-slider.md"
@@ -635,6 +745,7 @@ category        = "specialized"
 foundation_deps = ["architecture", "accessibility", "interactions"]
 shared_deps     = []
 related         = ["color-picker", "color-area"]
+component_deps  = []
 
 [components.color-swatch]
 path            = "components/specialized/color-swatch.md"
@@ -642,6 +753,7 @@ category        = "specialized"
 foundation_deps = ["architecture", "accessibility", "interactions"]
 shared_deps     = []
 related         = ["color-swatch-picker", "color-picker"]
+component_deps  = []
 
 [components.color-swatch-picker]
 path            = "components/specialized/color-swatch-picker.md"
@@ -649,6 +761,7 @@ category        = "specialized"
 foundation_deps = ["architecture", "accessibility", "interactions"]
 shared_deps     = []
 related         = ["color-swatch", "color-picker"]
+component_deps  = []
 
 [components.color-wheel]
 path            = "components/specialized/color-wheel.md"
@@ -656,6 +769,7 @@ category        = "specialized"
 foundation_deps = ["architecture", "accessibility", "interactions"]
 shared_deps     = []
 related         = ["color-picker"]
+component_deps  = []
 
 [components.contextual-help]
 path            = "components/specialized/contextual-help.md"
@@ -663,6 +777,9 @@ category        = "specialized"
 foundation_deps = ["architecture", "accessibility", "interactions"]
 shared_deps     = []
 related         = ["popover"]
+component_deps  = [
+    { component = "popover", kind = "composes", frameworks = ["leptos", "dioxus"], blocking = true, reason = "ContextualHelp displays explanatory content through a popover-style overlay." },
+]
 
 [components.file-upload]
 path            = "components/specialized/file-upload.md"
@@ -670,6 +787,10 @@ category        = "specialized"
 foundation_deps = ["architecture", "accessibility", "interactions"]
 shared_deps     = []
 related         = []
+component_deps  = [
+    { component = "drop-zone", kind = "composes", frameworks = ["leptos", "dioxus"], blocking = true, reason = "FileUpload drag-and-drop surface should reuse DropZone behavior." },
+    { component = "file-trigger", kind = "composes", frameworks = ["leptos", "dioxus"], blocking = true, reason = "FileUpload native picker path should reuse FileTrigger behavior." },
+]
 
 [components.image-cropper]
 path            = "components/specialized/image-cropper.md"
@@ -677,6 +798,7 @@ category        = "specialized"
 foundation_deps = ["architecture", "accessibility", "interactions"]
 shared_deps     = []
 related         = []
+component_deps  = []
 
 [components.qr-code]
 path            = "components/specialized/qr-code.md"
@@ -684,6 +806,7 @@ category        = "specialized"
 foundation_deps = ["architecture", "accessibility", "interactions"]
 shared_deps     = []
 related         = []
+component_deps  = []
 
 [components.signature-pad]
 path            = "components/specialized/signature-pad.md"
@@ -691,6 +814,7 @@ category        = "specialized"
 foundation_deps = ["architecture", "accessibility", "interactions"]
 shared_deps     = []
 related         = []
+component_deps  = []
 
 [components.timer]
 path            = "components/specialized/timer.md"
@@ -698,6 +822,7 @@ category        = "specialized"
 foundation_deps = ["architecture", "accessibility", "interactions"]
 shared_deps     = []
 related         = []
+component_deps  = []
 
 # ══════════════════════════════════════════════
 # Components — utility
@@ -709,6 +834,7 @@ category        = "utility"
 foundation_deps = ["architecture", "accessibility", "interactions", "i18n"]
 shared_deps     = []
 related         = ["toggle-group"]
+component_deps  = []
 
 [components.as-child]
 path            = "components/utility/as-child.md"
@@ -716,6 +842,7 @@ category        = "utility"
 foundation_deps = ["architecture", "accessibility"]
 shared_deps     = []
 related         = []
+component_deps  = []
 
 [components.button]
 path            = "components/utility/button.md"
@@ -723,6 +850,7 @@ category        = "utility"
 foundation_deps = ["architecture", "accessibility", "interactions"]
 shared_deps     = []
 related         = ["toggle-button"]
+component_deps  = []
 
 [components.client-only]
 path            = "components/utility/client-only.md"
@@ -730,6 +858,7 @@ category        = "utility"
 foundation_deps = ["architecture", "accessibility"]
 shared_deps     = []
 related         = []
+component_deps  = []
 
 [components.dismissable]
 path            = "components/utility/dismissable.md"
@@ -738,6 +867,7 @@ internal        = true
 foundation_deps = ["architecture", "accessibility"]
 shared_deps     = []
 related         = []
+component_deps  = []
 
 [components.error-boundary]
 path            = "components/utility/error-boundary.md"
@@ -745,6 +875,7 @@ category        = "utility"
 foundation_deps = ["architecture", "accessibility"]
 shared_deps     = []
 related         = ["ars-provider"]
+component_deps  = []
 
 [components.download-trigger]
 path            = "components/utility/download-trigger.md"
@@ -752,6 +883,7 @@ category        = "utility"
 foundation_deps = ["architecture", "accessibility"]
 shared_deps     = []
 related         = []
+component_deps  = []
 
 [components.drop-zone]
 path            = "components/utility/drop-zone.md"
@@ -759,6 +891,7 @@ category        = "utility"
 foundation_deps = ["architecture", "accessibility", "interactions", "forms"]
 shared_deps     = []
 related         = []
+component_deps  = []
 
 [components.ars-provider]
 path            = "components/utility/ars-provider.md"
@@ -766,6 +899,7 @@ category        = "utility"
 foundation_deps = ["architecture", "accessibility"]
 shared_deps     = []
 related         = []
+component_deps  = []
 
 [components.focus-ring]
 path            = "components/utility/focus-ring.md"
@@ -773,6 +907,7 @@ category        = "utility"
 foundation_deps = ["architecture", "accessibility"]
 shared_deps     = []
 related         = []
+component_deps  = []
 
 [components.focus-scope]
 path            = "components/utility/focus-scope.md"
@@ -780,6 +915,7 @@ category        = "utility"
 foundation_deps = ["architecture", "accessibility"]
 shared_deps     = []
 related         = []
+component_deps  = []
 
 [components.group]
 path            = "components/utility/group.md"
@@ -787,6 +923,7 @@ category        = "utility"
 foundation_deps = ["architecture", "accessibility"]
 shared_deps     = []
 related         = ["fieldset", "action-group"]
+component_deps  = []
 
 [components.heading]
 path            = "components/utility/heading.md"
@@ -794,6 +931,7 @@ category        = "utility"
 foundation_deps = ["architecture", "accessibility"]
 shared_deps     = []
 related         = []
+component_deps  = []
 
 [components.highlight]
 path            = "components/utility/highlight.md"
@@ -801,6 +939,7 @@ category        = "utility"
 foundation_deps = ["architecture", "accessibility"]
 shared_deps     = []
 related         = []
+component_deps  = []
 
 [components.keyboard]
 path            = "components/utility/keyboard.md"
@@ -808,6 +947,7 @@ category        = "utility"
 foundation_deps = ["architecture", "accessibility"]
 shared_deps     = []
 related         = []
+component_deps  = []
 
 [components.landmark]
 path            = "components/utility/landmark.md"
@@ -815,6 +955,7 @@ category        = "utility"
 foundation_deps = ["architecture", "accessibility"]
 shared_deps     = []
 related         = []
+component_deps  = []
 
 [components.live-region]
 path            = "components/utility/live-region.md"
@@ -822,6 +963,7 @@ category        = "utility"
 foundation_deps = ["architecture", "accessibility"]
 shared_deps     = []
 related         = []
+component_deps  = []
 
 [components.separator]
 path            = "components/utility/separator.md"
@@ -829,6 +971,7 @@ category        = "utility"
 foundation_deps = ["architecture", "accessibility"]
 shared_deps     = []
 related         = []
+component_deps  = []
 
 [components.swap]
 path            = "components/utility/swap.md"
@@ -836,6 +979,7 @@ category        = "utility"
 foundation_deps = ["architecture", "accessibility", "interactions"]
 shared_deps     = []
 related         = []
+component_deps  = []
 
 [components.toggle]
 path            = "components/utility/toggle.md"
@@ -843,6 +987,7 @@ category        = "utility"
 foundation_deps = ["architecture", "accessibility"]
 shared_deps     = []
 related         = ["toggle-group", "toggle-button"]
+component_deps  = []
 
 [components.visually-hidden]
 path            = "components/utility/visually-hidden.md"
@@ -850,6 +995,7 @@ category        = "utility"
 foundation_deps = ["architecture", "accessibility"]
 shared_deps     = []
 related         = []
+component_deps  = []
 
 [components.z-index-allocator]
 path            = "components/utility/z-index-allocator.md"
@@ -857,6 +1003,7 @@ category        = "utility"
 foundation_deps = ["architecture", "accessibility"]
 shared_deps     = ["z-index-stacking"]
 related         = []
+component_deps  = []
 
 [components.field]
 path            = "components/utility/field.md"
@@ -864,6 +1011,7 @@ category        = "utility"
 foundation_deps = ["architecture", "accessibility", "forms"]
 shared_deps     = []
 related         = ["fieldset", "form"]
+component_deps  = []
 
 [components.fieldset]
 path            = "components/utility/fieldset.md"
@@ -871,6 +1019,7 @@ category        = "utility"
 foundation_deps = ["architecture", "accessibility", "forms"]
 shared_deps     = []
 related         = ["field", "form"]
+component_deps  = []
 
 [components.toggle-button]
 path            = "components/utility/toggle-button.md"
@@ -878,6 +1027,7 @@ category        = "utility"
 foundation_deps = ["architecture", "accessibility", "interactions", "forms"]
 shared_deps     = []
 related         = ["button", "toggle-group", "toggle"]
+component_deps  = []
 
 [components.toggle-group]
 path            = "components/utility/toggle-group.md"
@@ -885,6 +1035,7 @@ category        = "utility"
 foundation_deps = ["architecture", "accessibility", "interactions", "forms", "collections"]
 shared_deps     = []
 related         = ["toggle-button", "toggle"]
+component_deps  = []
 
 [components.form]
 path            = "components/utility/form.md"
@@ -892,6 +1043,7 @@ category        = "utility"
 foundation_deps = ["architecture", "accessibility", "forms"]
 shared_deps     = []
 related         = ["field", "fieldset", "form-submit"]
+component_deps  = []
 
 [components.form-submit]
 path            = "components/utility/form-submit.md"
@@ -899,6 +1051,7 @@ category        = "utility"
 foundation_deps = ["architecture", "accessibility", "forms"]
 shared_deps     = []
 related         = ["form", "field", "fieldset"]
+component_deps  = []
 
 # ══════════════════════════════════════════════
 # Leptos adapter — per-component files

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -453,6 +453,43 @@ enum SpecCommand {
         component: String,
     },
 
+    /// Report component dependency metadata.
+    ComponentDeps {
+        /// Optional positional component name. Use "all" for every component.
+        name: Option<String>,
+
+        /// Component name, or "all".
+        #[arg(long)]
+        component: Option<String>,
+
+        /// Report every component.
+        #[arg(long)]
+        all: bool,
+
+        /// Adapter filter: "leptos" or "dioxus".
+        #[arg(long)]
+        adapter: Option<String>,
+    },
+
+    /// Report or synchronize adapter issue dependency metadata.
+    IssueDeps {
+        /// Adapter filter: "leptos" or "dioxus".
+        #[arg(long)]
+        adapter: String,
+
+        /// Component name, or "all".
+        #[arg(long, default_value = "all")]
+        component: String,
+
+        /// Print the expected issue dependency changes without mutating GitHub.
+        #[arg(long)]
+        dry_run: bool,
+
+        /// Apply missing native GitHub dependencies.
+        #[arg(long)]
+        apply: bool,
+    },
+
     /// List files for a review profile.
     Profile {
         /// Profile name (e.g., "accessibility").
@@ -854,6 +891,28 @@ fn main() {
                 SpecCommand::Reverse { shared_type } => spec::reverse::execute(&root, &shared_type),
 
                 SpecCommand::Related { component } => spec::related::execute(&root, &component),
+
+                SpecCommand::ComponentDeps {
+                    name,
+                    component,
+                    all,
+                    adapter,
+                } => {
+                    let component = if all {
+                        Some("all")
+                    } else {
+                        component.as_deref().or(name.as_deref())
+                    };
+
+                    spec::component_deps::execute(&root, component, adapter.as_deref())
+                }
+
+                SpecCommand::IssueDeps {
+                    adapter,
+                    component,
+                    dry_run: _,
+                    apply,
+                } => spec::issue_deps::execute(&root, &adapter, Some(&component), !apply),
 
                 SpecCommand::Profile { name } => spec::profile::execute(&root, &name),
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -13,6 +13,28 @@ struct Cli {
     command: Command,
 }
 
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::Cli;
+
+    #[test]
+    fn issue_deps_rejects_dry_run_with_apply() {
+        let result = Cli::try_parse_from([
+            "xtask",
+            "spec",
+            "issue-deps",
+            "--adapter",
+            "leptos",
+            "--dry-run",
+            "--apply",
+        ]);
+
+        assert!(result.is_err());
+    }
+}
+
 #[derive(Subcommand)]
 enum Command {
     /// Run CI pipeline steps locally (alias: `cargo xci`).
@@ -482,7 +504,7 @@ enum SpecCommand {
         component: String,
 
         /// Print the expected issue dependency changes without mutating GitHub.
-        #[arg(long)]
+        #[arg(long, conflicts_with = "apply")]
         dry_run: bool,
 
         /// Apply missing native GitHub dependencies.

--- a/xtask/src/manifest.rs
+++ b/xtask/src/manifest.rs
@@ -53,9 +53,75 @@ pub struct Component {
     #[serde(default)]
     pub related: Vec<String>,
 
+    /// Explicit component dependency metadata used for adapter issue blockers.
+    #[serde(default)]
+    pub component_deps: Vec<ComponentDependency>,
+
     /// Whether this component is internal/unstable.
     #[serde(default)]
     pub internal: bool,
+}
+
+/// A component dependency or documented non-dependency boundary.
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct ComponentDependency {
+    /// Component slug from `spec/manifest.toml`.
+    pub component: String,
+
+    /// Dependency relationship kind.
+    pub kind: ComponentDependencyKind,
+
+    /// Framework adapter scope for this dependency.
+    pub frameworks: Vec<String>,
+
+    /// Whether this dependency blocks adapter issue pickup.
+    #[serde(default)]
+    pub blocking: bool,
+
+    /// Human-readable reason for the relationship.
+    pub reason: String,
+}
+
+/// Supported component dependency relationship kinds.
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum ComponentDependencyKind {
+    /// Hard blocker: the dependency must be completed first.
+    Requires,
+
+    /// Composition relationship. Blocks only when `blocking = true`.
+    Composes,
+
+    /// Explicit non-dependency: the referenced feature belongs elsewhere.
+    Boundary,
+
+    /// Non-blocking conceptual relationship.
+    Related,
+}
+
+impl ComponentDependencyKind {
+    /// Return the manifest spelling for this dependency kind.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Requires => "requires",
+            Self::Composes => "composes",
+            Self::Boundary => "boundary",
+            Self::Related => "related",
+        }
+    }
+
+    /// Return whether this kind can create a native GitHub blocker.
+    #[must_use]
+    pub const fn can_block(self) -> bool {
+        matches!(self, Self::Requires | Self::Composes)
+    }
+}
+
+impl Display for ComponentDependencyKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
 }
 
 /// A named review profile.

--- a/xtask/src/spec/component_deps.rs
+++ b/xtask/src/spec/component_deps.rs
@@ -1,0 +1,162 @@
+//! `spec component-deps` — report component dependency metadata.
+
+use std::fmt::Write;
+
+use crate::manifest::{self, ComponentDependencyKind, Error, SpecRoot};
+
+/// Framework adapter filter for component dependency reports.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AdapterFilter {
+    /// No framework filter.
+    Any,
+
+    /// Leptos adapter dependencies.
+    Leptos,
+
+    /// Dioxus adapter dependencies.
+    Dioxus,
+}
+
+impl AdapterFilter {
+    /// Parse an optional adapter string.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::UnknownFramework`] when the filter is not recognized.
+    pub fn parse(value: Option<&str>) -> Result<Self, Error> {
+        match value {
+            None => Ok(Self::Any),
+            Some("leptos") => Ok(Self::Leptos),
+            Some("dioxus") => Ok(Self::Dioxus),
+            Some(other) => Err(Error::UnknownFramework(other.to_owned())),
+        }
+    }
+
+    /// Return the framework manifest spelling.
+    #[must_use]
+    pub const fn as_str(self) -> Option<&'static str> {
+        match self {
+            Self::Any => None,
+            Self::Leptos => Some("leptos"),
+            Self::Dioxus => Some("dioxus"),
+        }
+    }
+}
+
+/// Return dependency metadata for one component or all components.
+///
+/// # Errors
+///
+/// Returns [`Error::ComponentNotFound`] when `component` is neither `all` nor
+/// a manifest component.
+pub fn execute(
+    root: &SpecRoot,
+    component: Option<&str>,
+    adapter: Option<&str>,
+) -> Result<String, Error> {
+    let adapter = AdapterFilter::parse(adapter)?;
+    let component = component.unwrap_or("all");
+    let mut out = String::new();
+
+    if component == "all" {
+        writeln!(
+            out,
+            "Component | Adapter | Dependency | Kind | Blocking | Reason"
+        )
+        .expect("write to String");
+
+        for (name, comp) in &root.manifest.components {
+            write_component_rows(&mut out, name, comp, adapter);
+        }
+    } else {
+        let (name, comp) = manifest::find_component(&root.manifest, component)?;
+
+        writeln!(out, "component: {name}").expect("write to String");
+        if let Some(adapter) = adapter.as_str() {
+            writeln!(out, "adapter: {adapter}").expect("write to String");
+        }
+
+        if comp.component_deps.is_empty() {
+            writeln!(out, "component_deps: []").expect("write to String");
+        } else {
+            writeln!(out, "component_deps:").expect("write to String");
+            for dep in &comp.component_deps {
+                if !framework_matches(&dep.frameworks, adapter) {
+                    continue;
+                }
+
+                writeln!(
+                    out,
+                    "- component: {}\n  kind: {}\n  frameworks: [{}]\n  blocking: {}\n  reason: {}",
+                    dep.component,
+                    dep.kind,
+                    dep.frameworks.join(", "),
+                    is_blocking(dep.kind, dep.blocking),
+                    dep.reason
+                )
+                .expect("write to String");
+            }
+        }
+    }
+
+    Ok(out)
+}
+
+fn write_component_rows(
+    out: &mut String,
+    name: &str,
+    comp: &manifest::Component,
+    adapter: AdapterFilter,
+) {
+    if comp.component_deps.is_empty() {
+        writeln!(
+            out,
+            "{name} | {} | - | - | false | -",
+            adapter_label(adapter)
+        )
+        .expect("write to String");
+        return;
+    }
+
+    for dep in &comp.component_deps {
+        if !framework_matches(&dep.frameworks, adapter) {
+            continue;
+        }
+
+        let adapters = match adapter.as_str() {
+            Some(value) => value.to_owned(),
+            None => dep.frameworks.join(","),
+        };
+
+        writeln!(
+            out,
+            "{name} | {adapters} | {} | {} | {} | {}",
+            dep.component,
+            dep.kind,
+            is_blocking(dep.kind, dep.blocking),
+            dep.reason
+        )
+        .expect("write to String");
+    }
+}
+
+fn adapter_label(adapter: AdapterFilter) -> &'static str {
+    adapter.as_str().unwrap_or("all")
+}
+
+fn framework_matches(frameworks: &[String], adapter: AdapterFilter) -> bool {
+    match adapter.as_str() {
+        None => true,
+        Some(adapter) => frameworks.iter().any(|framework| framework == adapter),
+    }
+}
+
+/// Return whether a dependency should block issue pickup.
+#[must_use]
+pub const fn is_blocking(kind: ComponentDependencyKind, blocking: bool) -> bool {
+    match kind {
+        ComponentDependencyKind::Requires => true,
+        ComponentDependencyKind::Composes => blocking,
+        ComponentDependencyKind::Boundary | ComponentDependencyKind::Related => false,
+    }
+}

--- a/xtask/src/spec/deps.rs
+++ b/xtask/src/spec/deps.rs
@@ -86,5 +86,33 @@ pub fn execute(root: &SpecRoot, component: &str) -> Result<String, Error> {
         writeln!(out).expect("write to String");
     }
 
+    if !comp.component_deps.is_empty() {
+        writeln!(out, "## Component deps").expect("write to String");
+
+        for dep in &comp.component_deps {
+            if let Some(dep_comp) = m.components.get(&dep.component) {
+                writeln!(
+                    out,
+                    "{}  ({}; frameworks: {}; blocking: {}; reason: {})",
+                    dep_comp.path,
+                    dep.kind,
+                    dep.frameworks.join(","),
+                    crate::spec::component_deps::is_blocking(dep.kind, dep.blocking),
+                    dep.reason
+                )
+                .expect("write to String");
+            } else {
+                writeln!(
+                    out,
+                    "# WARNING: unknown component dep '{}' ({})",
+                    dep.component, dep.kind
+                )
+                .expect("write to String");
+            }
+        }
+
+        writeln!(out).expect("write to String");
+    }
+
     Ok(out)
 }

--- a/xtask/src/spec/info.rs
+++ b/xtask/src/spec/info.rs
@@ -27,6 +27,23 @@ pub fn execute(root: &SpecRoot, component: &str) -> Result<String, Error> {
 
     writeln!(out, "shared_deps: [{}]", comp.shared_deps.join(", ")).expect("write to String");
     writeln!(out, "related: [{}]", comp.related.join(", ")).expect("write to String");
+    if comp.component_deps.is_empty() {
+        writeln!(out, "component_deps: []").expect("write to String");
+    } else {
+        writeln!(out, "component_deps:").expect("write to String");
+        for dep in &comp.component_deps {
+            writeln!(
+                out,
+                "- component: {}; kind: {}; frameworks: [{}]; blocking: {}; reason: {}",
+                dep.component,
+                dep.kind,
+                dep.frameworks.join(", "),
+                crate::spec::component_deps::is_blocking(dep.kind, dep.blocking),
+                dep.reason
+            )
+            .expect("write to String");
+        }
+    }
 
     if comp.internal {
         writeln!(out, "internal: true").expect("write to String");

--- a/xtask/src/spec/issue_deps.rs
+++ b/xtask/src/spec/issue_deps.rs
@@ -156,7 +156,7 @@ impl IssueIndex {
     fn load_core() -> Result<Self, Error> {
         Self::load_from_search(
             "repo:fogodev/ars-ui is:issue in:title agnostic core",
-            |title| component_from_core_title(title),
+            component_from_core_title,
         )
     }
 

--- a/xtask/src/spec/issue_deps.rs
+++ b/xtask/src/spec/issue_deps.rs
@@ -29,7 +29,8 @@ pub fn execute(
     let core_issue_index = IssueIndex::load_core()?;
     let mut out = String::new();
 
-    let components = if component == "all" {
+    let all_components = component == "all";
+    let components = if all_components {
         root.manifest.components.keys().cloned().collect::<Vec<_>>()
     } else {
         vec![manifest::find_component_key(&root.manifest, component)?]
@@ -43,9 +44,10 @@ pub fn execute(
     .expect("write to String");
 
     for name in components {
-        let Some(issue) = issue_index.by_component.get(&name) else {
+        let issue = issue_index.by_component.get(&name);
+        if issue.is_none() && all_components {
             continue;
-        };
+        }
 
         let comp = &root.manifest.components[&name];
         let expected = expected_blockers(
@@ -55,7 +57,11 @@ pub fn execute(
             &issue_index,
             &core_issue_index,
         )?;
-        let current = issue_blocked_by(issue.number)?;
+        let current = if let Some(issue) = issue {
+            issue_blocked_by(issue.number)?
+        } else {
+            Vec::new()
+        };
         let expected_numbers = expected
             .iter()
             .map(|blocker| blocker.number)
@@ -71,7 +77,16 @@ pub fn execute(
             .collect::<Vec<_>>();
 
         writeln!(out).expect("write to String");
-        writeln!(out, "## #{} {}", issue.number, issue.title).expect("write to String");
+        if let Some(issue) = issue {
+            writeln!(out, "## #{} {}", issue.number, issue.title).expect("write to String");
+        } else {
+            writeln!(out, "## (adapter issue not found)").expect("write to String");
+            writeln!(
+                out,
+                "adapter_issue_status: missing from GitHub search; report is draft-only"
+            )
+            .expect("write to String");
+        }
         writeln!(out, "component: {name}").expect("write to String");
         writeln!(
             out,
@@ -118,6 +133,12 @@ pub fn execute(
         write_boundary_notes(&mut out, comp, adapter_filter);
 
         if !dry_run {
+            let Some(issue) = issue else {
+                return Err(Error::FrontmatterError(format!(
+                    "cannot apply issue dependencies for '{name}' because no {adapter} adapter issue was found"
+                )));
+            };
+
             for blocker in expected {
                 if missing.contains(&blocker.number) {
                     add_blocked_by(issue.number, blocker.id)?;

--- a/xtask/src/spec/issue_deps.rs
+++ b/xtask/src/spec/issue_deps.rs
@@ -1,0 +1,447 @@
+//! `spec issue-deps` — report or synchronize adapter issue dependencies.
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt::Write,
+    process::Command,
+};
+
+use crate::{
+    manifest::{self, ComponentDependencyKind, Error, SpecRoot},
+    spec::component_deps::{self, AdapterFilter},
+};
+
+/// Execute the adapter issue dependency report.
+///
+/// # Errors
+///
+/// Returns an error when the adapter filter is invalid or GitHub issue data
+/// cannot be queried.
+pub fn execute(
+    root: &SpecRoot,
+    adapter: &str,
+    component: Option<&str>,
+    dry_run: bool,
+) -> Result<String, Error> {
+    let adapter_filter = AdapterFilter::parse(Some(adapter))?;
+    let component = component.unwrap_or("all");
+    let issue_index = IssueIndex::load(adapter)?;
+    let core_issue_index = IssueIndex::load_core()?;
+    let mut out = String::new();
+
+    let components = if component == "all" {
+        root.manifest.components.keys().cloned().collect::<Vec<_>>()
+    } else {
+        vec![manifest::find_component_key(&root.manifest, component)?]
+    };
+
+    writeln!(
+        out,
+        "Adapter issue dependency report: adapter={adapter} mode={}",
+        if dry_run { "dry-run" } else { "apply" }
+    )
+    .expect("write to String");
+
+    for name in components {
+        let Some(issue) = issue_index.by_component.get(&name) else {
+            continue;
+        };
+
+        let comp = &root.manifest.components[&name];
+        let expected = expected_blockers(
+            comp,
+            adapter,
+            adapter_filter,
+            &issue_index,
+            &core_issue_index,
+        )?;
+        let current = issue_blocked_by(issue.number)?;
+        let expected_numbers = expected
+            .iter()
+            .map(|blocker| blocker.number)
+            .collect::<BTreeSet<_>>();
+        let current_numbers = current.iter().copied().collect::<BTreeSet<_>>();
+        let missing = expected_numbers
+            .difference(&current_numbers)
+            .copied()
+            .collect::<Vec<_>>();
+        let extra = current_numbers
+            .difference(&expected_numbers)
+            .copied()
+            .collect::<Vec<_>>();
+
+        writeln!(out).expect("write to String");
+        writeln!(out, "## #{} {}", issue.number, issue.title).expect("write to String");
+        writeln!(out, "component: {name}").expect("write to String");
+        writeln!(
+            out,
+            "expected_blocked_by: [{}]",
+            expected_numbers
+                .iter()
+                .map(u64::to_string)
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+        .expect("write to String");
+        writeln!(
+            out,
+            "current_blocked_by: [{}]",
+            current_numbers
+                .iter()
+                .map(u64::to_string)
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+        .expect("write to String");
+        writeln!(
+            out,
+            "missing_native_dependencies: [{}]",
+            missing
+                .iter()
+                .map(u64::to_string)
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+        .expect("write to String");
+        writeln!(
+            out,
+            "extra_native_dependencies: [{}]",
+            extra
+                .iter()
+                .map(u64::to_string)
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+        .expect("write to String");
+
+        write_expected_dep_section(&mut out, &expected);
+        write_boundary_notes(&mut out, comp, adapter_filter);
+
+        if !dry_run {
+            for blocker in expected {
+                if missing.contains(&blocker.number) {
+                    add_blocked_by(issue.number, blocker.id)?;
+                    writeln!(
+                        out,
+                        "added_native_dependency: #{} blocked by #{}",
+                        issue.number, blocker.number
+                    )
+                    .expect("write to String");
+                }
+            }
+        }
+    }
+
+    Ok(out)
+}
+
+#[derive(Debug, Clone)]
+struct IssueSummary {
+    number: u64,
+    id: u64,
+    title: String,
+}
+
+#[derive(Debug)]
+struct IssueIndex {
+    by_component: BTreeMap<String, IssueSummary>,
+}
+
+impl IssueIndex {
+    fn load(adapter: &str) -> Result<Self, Error> {
+        let query = format!("repo:fogodev/ars-ui is:issue in:title adapter {adapter}");
+        Self::load_from_search(&query, |title| component_from_adapter_title(title, adapter))
+    }
+
+    fn load_core() -> Result<Self, Error> {
+        Self::load_from_search(
+            "repo:fogodev/ars-ui is:issue in:title agnostic core",
+            |title| component_from_core_title(title),
+        )
+    }
+
+    fn load_from_search<F>(query: &str, mut keys_for_title: F) -> Result<Self, Error>
+    where
+        F: FnMut(&str) -> Vec<String>,
+    {
+        let output = gh_output([
+            "api",
+            "-X",
+            "GET",
+            "search/issues",
+            "--paginate",
+            "-f",
+            &format!("q={query}"),
+            "--jq",
+            ".items[] | [.number, .id, .title] | @tsv",
+        ])?;
+
+        let mut by_component = BTreeMap::new();
+        for line in output.lines() {
+            let mut parts = line.splitn(3, '\t');
+            let Some(number) = parts.next().and_then(|value| value.parse::<u64>().ok()) else {
+                continue;
+            };
+            let Some(id) = parts.next().and_then(|value| value.parse::<u64>().ok()) else {
+                continue;
+            };
+            let Some(title) = parts.next() else {
+                continue;
+            };
+            for component in keys_for_title(title) {
+                by_component.insert(
+                    component,
+                    IssueSummary {
+                        number,
+                        id,
+                        title: title.to_owned(),
+                    },
+                );
+            }
+        }
+
+        Ok(Self { by_component })
+    }
+}
+
+fn expected_blockers(
+    comp: &manifest::Component,
+    adapter_name: &str,
+    adapter: AdapterFilter,
+    adapter_issues: &IssueIndex,
+    core_issues: &IssueIndex,
+) -> Result<Vec<IssueSummary>, Error> {
+    let mut blockers = Vec::new();
+    for issue in baseline_adapter_dependencies(adapter_name)? {
+        blockers.push(issue);
+    }
+
+    if let Some(core_issue) = core_issues
+        .by_component
+        .get(&component_key_from_path(&comp.path))
+    {
+        blockers.push(core_issue.clone());
+    }
+
+    for dep in &comp.component_deps {
+        if !dep.frameworks.iter().any(|framework| {
+            adapter
+                .as_str()
+                .is_none_or(|adapter| framework.as_str() == adapter)
+        }) {
+            continue;
+        }
+
+        if !component_deps::is_blocking(dep.kind, dep.blocking) {
+            continue;
+        }
+
+        if let Some(issue) = adapter_issues.by_component.get(&dep.component) {
+            blockers.push(issue.clone());
+        }
+    }
+
+    blockers.sort_by_key(|issue| issue.number);
+    blockers.dedup_by_key(|issue| issue.number);
+    Ok(blockers)
+}
+
+fn baseline_adapter_dependencies(adapter: &str) -> Result<Vec<IssueSummary>, Error> {
+    let numbers = match adapter {
+        "leptos" => [190, 191].as_slice(),
+        "dioxus" => [193, 194].as_slice(),
+        _ => &[],
+    };
+
+    let mut issues = Vec::new();
+    for number in numbers {
+        issues.push(issue_summary(*number)?);
+    }
+    Ok(issues)
+}
+
+fn issue_summary(number: u64) -> Result<IssueSummary, Error> {
+    let path = format!("repos/fogodev/ars-ui/issues/{number}");
+    let output = gh_output([
+        "api",
+        "-H",
+        "Accept: application/vnd.github+json",
+        "-H",
+        "X-GitHub-Api-Version: 2026-03-10",
+        &path,
+        "--jq",
+        "[.number, .id, .title] | @tsv",
+    ])?;
+
+    let mut parts = output.trim().splitn(3, '\t');
+    let Some(number) = parts.next().and_then(|value| value.parse::<u64>().ok()) else {
+        return Err(Error::FrontmatterError(format!(
+            "could not parse issue summary for #{number}"
+        )));
+    };
+    let Some(id) = parts.next().and_then(|value| value.parse::<u64>().ok()) else {
+        return Err(Error::FrontmatterError(format!(
+            "could not parse issue id for #{number}"
+        )));
+    };
+    let title = parts.next().unwrap_or_default().to_owned();
+
+    Ok(IssueSummary { number, id, title })
+}
+
+fn write_expected_dep_section(out: &mut String, blockers: &[IssueSummary]) {
+    writeln!(out, "expected_depends_on_section:").expect("write to String");
+    if blockers.is_empty() {
+        writeln!(out, "- none").expect("write to String");
+    } else {
+        for blocker in blockers {
+            writeln!(out, "- #{} ({})", blocker.number, blocker.title).expect("write to String");
+        }
+    }
+}
+
+fn write_boundary_notes(out: &mut String, comp: &manifest::Component, adapter: AdapterFilter) {
+    let notes = comp
+        .component_deps
+        .iter()
+        .filter(|dep| dep.kind == ComponentDependencyKind::Boundary)
+        .filter(|dep| {
+            adapter
+                .as_str()
+                .is_none_or(|adapter| dep.frameworks.iter().any(|f| f == adapter))
+        })
+        .collect::<Vec<_>>();
+
+    if notes.is_empty() {
+        return;
+    }
+
+    writeln!(out, "component_dependency_notes:").expect("write to String");
+    for note in notes {
+        writeln!(out, "- not a blocker: {} — {}", note.component, note.reason)
+            .expect("write to String");
+    }
+}
+
+fn issue_blocked_by(issue: u64) -> Result<Vec<u64>, Error> {
+    let path = format!("repos/fogodev/ars-ui/issues/{issue}/dependencies/blocked_by");
+    let output = gh_output([
+        "api",
+        "-H",
+        "Accept: application/vnd.github+json",
+        "-H",
+        "X-GitHub-Api-Version: 2026-03-10",
+        &path,
+        "--jq",
+        ".[].number",
+    ])?;
+
+    Ok(output
+        .lines()
+        .filter_map(|line| line.trim().parse::<u64>().ok())
+        .collect())
+}
+
+fn add_blocked_by(issue: u64, blocker_id: u64) -> Result<(), Error> {
+    let path = format!("repos/fogodev/ars-ui/issues/{issue}/dependencies/blocked_by");
+    let issue_id = format!("issue_id={blocker_id}");
+    gh_output([
+        "api",
+        "-X",
+        "POST",
+        "-H",
+        "Accept: application/vnd.github+json",
+        "-H",
+        "X-GitHub-Api-Version: 2026-03-10",
+        &path,
+        "-F",
+        &issue_id,
+    ])?;
+    Ok(())
+}
+
+fn gh_output<const N: usize>(args: [&str; N]) -> Result<String, Error> {
+    let output = Command::new("gh").args(args).output().map_err(Error::Io)?;
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).to_string())
+    } else {
+        Err(Error::FrontmatterError(format!(
+            "gh command failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )))
+    }
+}
+
+fn component_from_adapter_title(title: &str, adapter: &str) -> Vec<String> {
+    let prefix = "task: Implement ";
+    let Some(title) = title.strip_prefix(prefix) else {
+        return Vec::new();
+    };
+    let lower = title.to_lowercase();
+    let suffix = format!(" {adapter} adapter");
+    if !lower.ends_with(&suffix) {
+        return Vec::new();
+    }
+
+    let component_len = title.len().saturating_sub(suffix.len());
+    let component = &title[..component_len];
+    split_components(component)
+}
+
+fn component_from_core_title(title: &str) -> Vec<String> {
+    let prefix = "task: Implement ";
+    let suffix = " agnostic core";
+    let Some(title) = title.strip_prefix(prefix) else {
+        return Vec::new();
+    };
+    let Some(component) = title.strip_suffix(suffix) else {
+        return Vec::new();
+    };
+    split_components(component)
+}
+
+fn component_key_from_path(path: &str) -> String {
+    path.rsplit_once('/')
+        .map_or(path, |(_, file)| file)
+        .trim_end_matches(".md")
+        .to_owned()
+}
+
+fn slug(value: &str) -> String {
+    let mut out = String::new();
+    let mut previous_was_lower_or_digit = false;
+
+    for ch in value.trim().chars() {
+        if ch.is_whitespace() || ch == '_' || ch == '-' {
+            if !out.ends_with('-') && !out.is_empty() {
+                out.push('-');
+            }
+            previous_was_lower_or_digit = false;
+            continue;
+        }
+
+        if ch.is_ascii_uppercase() {
+            if previous_was_lower_or_digit && !out.ends_with('-') && !out.is_empty() {
+                out.push('-');
+            }
+            out.push(ch.to_ascii_lowercase());
+            previous_was_lower_or_digit = false;
+        } else {
+            out.push(ch.to_ascii_lowercase());
+            previous_was_lower_or_digit = ch.is_ascii_lowercase() || ch.is_ascii_digit();
+        }
+    }
+
+    out.trim_matches('-').to_owned()
+}
+
+fn split_components(value: &str) -> Vec<String> {
+    value
+        .replace(", and ", ", ")
+        .replace(" and ", ", ")
+        .split(',')
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+        .map(slug)
+        .collect()
+}

--- a/xtask/src/spec/mod.rs
+++ b/xtask/src/spec/mod.rs
@@ -3,10 +3,12 @@
 pub mod adapters;
 pub mod category;
 pub mod compile_snippets;
+pub mod component_deps;
 pub mod context;
 pub mod deps;
 pub mod digest;
 pub mod info;
+pub mod issue_deps;
 pub mod lint_code;
 pub mod profile;
 pub mod related;

--- a/xtask/src/spec/validate.rs
+++ b/xtask/src/spec/validate.rs
@@ -172,7 +172,7 @@ pub fn execute(root: &SpecRoot) -> Result<String, Error> {
 fn validate_component_dependencies(root: &SpecRoot, errors: &mut Vec<String>) {
     let components = &root.manifest.components;
     let valid_frameworks = BTreeSet::from(["leptos", "dioxus"]);
-    let mut blocking_edges = BTreeMap::<String, Vec<String>>::new();
+    let mut blocking_edges_by_framework = BTreeMap::<String, BTreeMap<String, Vec<String>>>::new();
 
     for (name, comp) in components {
         for dep in &comp.component_deps {
@@ -225,36 +225,48 @@ fn validate_component_dependencies(root: &SpecRoot, errors: &mut Vec<String>) {
             }
 
             if component_deps::is_blocking(dep.kind, dep.blocking) {
-                if dep.component == *name {
-                    errors.push(format!(
-                        "[{name}] {} component_dep cannot point to itself",
-                        dep.kind
-                    ));
-                }
+                for framework in &dep.frameworks {
+                    if !valid_frameworks.contains(framework.as_str()) {
+                        continue;
+                    }
 
-                blocking_edges
-                    .entry(name.clone())
-                    .or_default()
-                    .push(dep.component.clone());
+                    if dep.component == *name {
+                        errors.push(format!(
+                            "[{name}] {} component_dep cannot point to itself for {framework}",
+                            dep.kind
+                        ));
+                    }
+
+                    blocking_edges_by_framework
+                        .entry(framework.clone())
+                        .or_default()
+                        .entry(name.clone())
+                        .or_default()
+                        .push(dep.component.clone());
+                }
             }
         }
     }
 
-    for start in components.keys() {
-        let mut visiting = BTreeSet::new();
-        let mut visited = BTreeSet::new();
-        detect_blocking_cycle(
-            start,
-            start,
-            &blocking_edges,
-            &mut visiting,
-            &mut visited,
-            errors,
-        );
+    for (framework, blocking_edges) in &blocking_edges_by_framework {
+        for start in components.keys() {
+            let mut visiting = BTreeSet::new();
+            let mut visited = BTreeSet::new();
+            detect_blocking_cycle(
+                framework,
+                start,
+                start,
+                blocking_edges,
+                &mut visiting,
+                &mut visited,
+                errors,
+            );
+        }
     }
 }
 
 fn detect_blocking_cycle(
+    framework: &str,
     start: &str,
     current: &str,
     edges: &BTreeMap<String, Vec<String>>,
@@ -270,13 +282,13 @@ fn detect_blocking_cycle(
         for next in nexts {
             if next == start {
                 errors.push(format!(
-                    "[{start}] blocking component_deps contain a cycle through '{current}'"
+                    "[{start}] {framework} blocking component_deps contain a cycle through '{current}'"
                 ));
                 continue;
             }
 
             if !visited.contains(next) {
-                detect_blocking_cycle(start, next, edges, visiting, visited, errors);
+                detect_blocking_cycle(framework, start, next, edges, visiting, visited, errors);
             }
         }
     }
@@ -306,18 +318,27 @@ mod tests {
         }
     }
 
+    fn dependency_with_frameworks(
+        component: &str,
+        kind: ComponentDependencyKind,
+        blocking: bool,
+        frameworks: Vec<&str>,
+    ) -> ComponentDependency {
+        ComponentDependency {
+            component: component.to_owned(),
+            kind,
+            frameworks: frameworks.into_iter().map(ToString::to_string).collect(),
+            blocking,
+            reason: "test dependency".to_owned(),
+        }
+    }
+
     fn dependency(
         component: &str,
         kind: ComponentDependencyKind,
         blocking: bool,
     ) -> ComponentDependency {
-        ComponentDependency {
-            component: component.to_owned(),
-            kind,
-            frameworks: vec!["leptos".to_owned()],
-            blocking,
-            reason: "test dependency".to_owned(),
-        }
+        dependency_with_frameworks(component, kind, blocking, vec!["leptos"])
     }
 
     fn root_with(components: BTreeMap<String, Component>) -> SpecRoot {
@@ -385,6 +406,38 @@ mod tests {
         assert!(
             errors.iter().any(|error| error.contains("contain a cycle")),
             "expected blocking cycle error, got {errors:?}"
+        );
+    }
+
+    #[test]
+    fn blocking_cycles_are_scoped_per_adapter() {
+        let mut components = BTreeMap::new();
+        components.insert(
+            "dialog".to_owned(),
+            component(vec![dependency_with_frameworks(
+                "drawer",
+                ComponentDependencyKind::Composes,
+                true,
+                vec!["leptos"],
+            )]),
+        );
+        components.insert(
+            "drawer".to_owned(),
+            component(vec![dependency_with_frameworks(
+                "dialog",
+                ComponentDependencyKind::Composes,
+                true,
+                vec!["dioxus"],
+            )]),
+        );
+        let root = root_with(components);
+        let mut errors = Vec::new();
+
+        validate_component_dependencies(&root, &mut errors);
+
+        assert!(
+            !errors.iter().any(|error| error.contains("contain a cycle")),
+            "opposite framework-specific edges are not one adapter cycle: {errors:?}"
         );
     }
 }

--- a/xtask/src/spec/validate.rs
+++ b/xtask/src/spec/validate.rs
@@ -172,7 +172,7 @@ pub fn execute(root: &SpecRoot) -> Result<String, Error> {
 fn validate_component_dependencies(root: &SpecRoot, errors: &mut Vec<String>) {
     let components = &root.manifest.components;
     let valid_frameworks = BTreeSet::from(["leptos", "dioxus"]);
-    let mut requires_edges = BTreeMap::<String, Vec<String>>::new();
+    let mut blocking_edges = BTreeMap::<String, Vec<String>>::new();
 
     for (name, comp) in components {
         for dep in &comp.component_deps {
@@ -217,24 +217,25 @@ fn validate_component_dependencies(root: &SpecRoot, errors: &mut Vec<String>) {
                 ));
             }
 
-            if dep.kind == ComponentDependencyKind::Requires {
-                if dep.component == *name {
-                    errors.push(format!(
-                        "[{name}] requires component_dep cannot point to itself"
-                    ));
-                }
-
-                requires_edges
-                    .entry(name.clone())
-                    .or_default()
-                    .push(dep.component.clone());
-            }
-
             if !dep.kind.can_block() && component_deps::is_blocking(dep.kind, dep.blocking) {
                 errors.push(format!(
                     "[{name}] {} component_dep '{}' unexpectedly blocks",
                     dep.kind, dep.component
                 ));
+            }
+
+            if component_deps::is_blocking(dep.kind, dep.blocking) {
+                if dep.component == *name {
+                    errors.push(format!(
+                        "[{name}] {} component_dep cannot point to itself",
+                        dep.kind
+                    ));
+                }
+
+                blocking_edges
+                    .entry(name.clone())
+                    .or_default()
+                    .push(dep.component.clone());
             }
         }
     }
@@ -242,10 +243,10 @@ fn validate_component_dependencies(root: &SpecRoot, errors: &mut Vec<String>) {
     for start in components.keys() {
         let mut visiting = BTreeSet::new();
         let mut visited = BTreeSet::new();
-        detect_requires_cycle(
+        detect_blocking_cycle(
             start,
             start,
-            &requires_edges,
+            &blocking_edges,
             &mut visiting,
             &mut visited,
             errors,
@@ -253,7 +254,7 @@ fn validate_component_dependencies(root: &SpecRoot, errors: &mut Vec<String>) {
     }
 }
 
-fn detect_requires_cycle(
+fn detect_blocking_cycle(
     start: &str,
     current: &str,
     edges: &BTreeMap<String, Vec<String>>,
@@ -269,17 +270,121 @@ fn detect_requires_cycle(
         for next in nexts {
             if next == start {
                 errors.push(format!(
-                    "[{start}] requires component_deps contain a cycle through '{current}'"
+                    "[{start}] blocking component_deps contain a cycle through '{current}'"
                 ));
                 continue;
             }
 
             if !visited.contains(next) {
-                detect_requires_cycle(start, next, edges, visiting, visited, errors);
+                detect_blocking_cycle(start, next, edges, visiting, visited, errors);
             }
         }
     }
 
     visiting.remove(current);
     visited.insert(current.to_owned());
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::BTreeMap, path::PathBuf};
+
+    use super::validate_component_dependencies;
+    use crate::manifest::{
+        Component, ComponentDependency, ComponentDependencyKind, Manifest, SpecRoot,
+    };
+
+    fn component(component_deps: Vec<ComponentDependency>) -> Component {
+        Component {
+            path: "components/test.md".to_owned(),
+            category: "test".to_owned(),
+            foundation_deps: Vec::new(),
+            shared_deps: Vec::new(),
+            related: Vec::new(),
+            component_deps,
+            internal: false,
+        }
+    }
+
+    fn dependency(
+        component: &str,
+        kind: ComponentDependencyKind,
+        blocking: bool,
+    ) -> ComponentDependency {
+        ComponentDependency {
+            component: component.to_owned(),
+            kind,
+            frameworks: vec!["leptos".to_owned()],
+            blocking,
+            reason: "test dependency".to_owned(),
+        }
+    }
+
+    fn root_with(components: BTreeMap<String, Component>) -> SpecRoot {
+        SpecRoot {
+            path: PathBuf::new(),
+            manifest: Manifest {
+                foundation: BTreeMap::new(),
+                shared: BTreeMap::new(),
+                components,
+                review_profiles: None,
+                leptos_adapters: BTreeMap::new(),
+                dioxus_adapters: BTreeMap::new(),
+            },
+        }
+    }
+
+    #[test]
+    fn blocking_composes_self_dependency_is_rejected() {
+        let mut components = BTreeMap::new();
+        components.insert(
+            "dialog".to_owned(),
+            component(vec![dependency(
+                "dialog",
+                ComponentDependencyKind::Composes,
+                true,
+            )]),
+        );
+        let root = root_with(components);
+        let mut errors = Vec::new();
+
+        validate_component_dependencies(&root, &mut errors);
+
+        assert!(
+            errors
+                .iter()
+                .any(|error| error.contains("cannot point to itself")),
+            "expected blocking self dependency error, got {errors:?}"
+        );
+    }
+
+    #[test]
+    fn blocking_composes_cycle_is_rejected() {
+        let mut components = BTreeMap::new();
+        components.insert(
+            "dialog".to_owned(),
+            component(vec![dependency(
+                "drawer",
+                ComponentDependencyKind::Composes,
+                true,
+            )]),
+        );
+        components.insert(
+            "drawer".to_owned(),
+            component(vec![dependency(
+                "dialog",
+                ComponentDependencyKind::Composes,
+                true,
+            )]),
+        );
+        let root = root_with(components);
+        let mut errors = Vec::new();
+
+        validate_component_dependencies(&root, &mut errors);
+
+        assert!(
+            errors.iter().any(|error| error.contains("contain a cycle")),
+            "expected blocking cycle error, got {errors:?}"
+        );
+    }
 }

--- a/xtask/src/spec/validate.rs
+++ b/xtask/src/spec/validate.rs
@@ -1,8 +1,15 @@
 //! `spec validate` — validate frontmatter against manifest.
 
-use std::{fmt::Write, fs};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt::Write,
+    fs,
+};
 
-use crate::manifest::{self, Error, SpecRoot};
+use crate::{
+    manifest::{self, ComponentDependencyKind, Error, SpecRoot},
+    spec::component_deps,
+};
 
 /// Validate all spec file frontmatter against manifest entries.
 ///
@@ -13,6 +20,7 @@ pub fn execute(root: &SpecRoot) -> Result<String, Error> {
     let m = &root.manifest;
 
     let mut errors = Vec::new();
+    validate_component_dependencies(root, &mut errors);
 
     let mut checked = 0u32;
 
@@ -159,4 +167,119 @@ pub fn execute(root: &SpecRoot) -> Result<String, Error> {
     }
 
     Ok(out)
+}
+
+fn validate_component_dependencies(root: &SpecRoot, errors: &mut Vec<String>) {
+    let components = &root.manifest.components;
+    let valid_frameworks = BTreeSet::from(["leptos", "dioxus"]);
+    let mut requires_edges = BTreeMap::<String, Vec<String>>::new();
+
+    for (name, comp) in components {
+        for dep in &comp.component_deps {
+            if !components.contains_key(&dep.component) {
+                errors.push(format!(
+                    "[{name}] unknown component_dep component '{}'",
+                    dep.component
+                ));
+            }
+
+            if dep.reason.trim().is_empty() {
+                errors.push(format!(
+                    "[{name}] component_dep '{}' has an empty reason",
+                    dep.component
+                ));
+            }
+
+            if dep.frameworks.is_empty() {
+                errors.push(format!(
+                    "[{name}] component_dep '{}' must list leptos and/or dioxus",
+                    dep.component
+                ));
+            }
+
+            for framework in &dep.frameworks {
+                if !valid_frameworks.contains(framework.as_str()) {
+                    errors.push(format!(
+                        "[{name}] component_dep '{}' has invalid framework '{framework}'",
+                        dep.component
+                    ));
+                }
+            }
+
+            if matches!(
+                dep.kind,
+                ComponentDependencyKind::Boundary | ComponentDependencyKind::Related
+            ) && dep.blocking
+            {
+                errors.push(format!(
+                    "[{name}] {} component_dep '{}' cannot be blocking",
+                    dep.kind, dep.component
+                ));
+            }
+
+            if dep.kind == ComponentDependencyKind::Requires {
+                if dep.component == *name {
+                    errors.push(format!(
+                        "[{name}] requires component_dep cannot point to itself"
+                    ));
+                }
+
+                requires_edges
+                    .entry(name.clone())
+                    .or_default()
+                    .push(dep.component.clone());
+            }
+
+            if !dep.kind.can_block() && component_deps::is_blocking(dep.kind, dep.blocking) {
+                errors.push(format!(
+                    "[{name}] {} component_dep '{}' unexpectedly blocks",
+                    dep.kind, dep.component
+                ));
+            }
+        }
+    }
+
+    for start in components.keys() {
+        let mut visiting = BTreeSet::new();
+        let mut visited = BTreeSet::new();
+        detect_requires_cycle(
+            start,
+            start,
+            &requires_edges,
+            &mut visiting,
+            &mut visited,
+            errors,
+        );
+    }
+}
+
+fn detect_requires_cycle(
+    start: &str,
+    current: &str,
+    edges: &BTreeMap<String, Vec<String>>,
+    visiting: &mut BTreeSet<String>,
+    visited: &mut BTreeSet<String>,
+    errors: &mut Vec<String>,
+) {
+    if !visiting.insert(current.to_owned()) {
+        return;
+    }
+
+    if let Some(nexts) = edges.get(current) {
+        for next in nexts {
+            if next == start {
+                errors.push(format!(
+                    "[{start}] requires component_deps contain a cycle through '{current}'"
+                ));
+                continue;
+            }
+
+            if !visited.contains(next) {
+                detect_requires_cycle(start, next, edges, visiting, visited, errors);
+            }
+        }
+    }
+
+    visiting.remove(current);
+    visited.insert(current.to_owned());
 }


### PR DESCRIPTION
## Summary

- adds manifest-backed component dependency metadata for adapter task planning
- adds `cargo xtask spec component-deps` and `cargo xtask spec issue-deps` reporting/sync commands
- validates dependency kinds, framework scopes, blocking semantics, unknown components, self-dependencies, and `requires` cycles
- updates the task issue template to point adapter tasks at the dependency tooling

This PR intentionally does not include ListBox/Select component work or ListBox/Select-specific dependency metadata.

## Validation

- `cargo +nightly fmt --all --check`
- `cargo test -p xtask manifest`
- `cargo test -p xtask spec`
- `cargo xtask spec validate`
- `cargo xtask spec component-deps --all`
- `cargo xtask spec issue-deps --adapter leptos --component all --dry-run`
- `cargo xtask spec issue-deps --adapter dioxus --component all --dry-run`
- `git diff --check --cached`
