### PR TITLE
Implement DateRangePicker agnostic core (#290)

### DIFF
--- a/crates/ars-components/src/date_time/date_range_field/mod.rs
+++ b/crates/ars-components/src/date_time/date_range_field/mod.rs
@@ -195,7 +195,10 @@ impl Context {
 
 /// Returns `true` when `date` is present and falls outside the inclusive
 /// `[min, max]` bounds (either bound absent means unbounded on that side).
-fn date_out_of_bounds(
+///
+/// Exposed to sibling `date_time` components (e.g. `date_range_picker`) that
+/// share the same range-bounds invalidity rule, so the check is defined once.
+pub(crate) fn date_out_of_bounds(
     date: Option<&CalendarDate>,
     min: Option<&CalendarDate>,
     max: Option<&CalendarDate>,
@@ -1105,7 +1108,16 @@ impl ConnectApi for Api<'_> {
 
 /// Formats a single date as a human-readable label for screen-reader range
 /// descriptions (e.g. "March 1, 2025").
-fn format_date_label(date: &CalendarDate, backend: &dyn IntlBackend, locale: &Locale) -> String {
+///
+/// Exposed to sibling `date_time` components (e.g. `date_range_picker`) so the
+/// month/day/year range-label form is produced identically across them. (The
+/// `range_calendar` variant intentionally appends the weekday and keeps its own
+/// copy.)
+pub(crate) fn format_date_label(
+    date: &CalendarDate,
+    backend: &dyn IntlBackend,
+    locale: &Locale,
+) -> String {
     format!(
         "{} {}, {}",
         backend.month_long_name(date.month(), locale),

--- a/crates/ars-components/src/date_time/date_range_picker/mod.rs
+++ b/crates/ars-components/src/date_time/date_range_picker/mod.rs
@@ -666,6 +666,19 @@ impl ars_core::Machine for Machine {
         match (state, event) {
             (_, Event::SyncProps(next)) => {
                 let next = next.as_ref().clone();
+
+                // Disabling an open picker must dismiss it: while disabled the
+                // guard above blocks Close/Escape/FocusOut, so a popover left
+                // open here could never be closed again.
+                if next.disabled && *state == State::Open {
+                    return Some(TransitionPlan::to(State::Closed).apply(
+                        move |ctx: &mut Context| {
+                            sync_props(ctx, &next);
+                            ctx.open.set(false);
+                        },
+                    ));
+                }
+
                 Some(TransitionPlan::context_only(move |ctx: &mut Context| {
                     sync_props(ctx, &next);
                 }))
@@ -683,19 +696,23 @@ impl ars_core::Machine for Machine {
                 }),
             ),
 
-            (State::Open, Event::SelectRangeComplete { range }) => {
+            (_, Event::SelectRangeComplete { range }) => {
                 if ctx.readonly {
                     return None;
                 }
 
+                // Accept the completed range regardless of open state: a browser
+                // can fire `FocusOut` (closing the popover) before the calendar
+                // reports the cell click, and the selection must not be dropped.
+                // The close side-effect only applies when the picker was open.
                 let range = range.clone();
 
-                let should_close = props.close_on_select;
+                let should_close = props.close_on_select && *state == State::Open;
 
                 let next_state = if should_close {
                     State::Closed
                 } else {
-                    State::Open
+                    state.clone()
                 };
 
                 Some(
@@ -1196,8 +1213,9 @@ impl<'a> Api<'a> {
 
     /// Returns attributes for the clear trigger element.
     ///
-    /// The button is disabled when the component is disabled or no range is
-    /// selected.
+    /// The button is disabled when the component is disabled or read-only, or
+    /// when no range is selected — matching the machine, which rejects
+    /// [`Event::Clear`] in those states.
     #[must_use]
     pub fn clear_trigger_attrs(&self) -> AttrMap {
         let mut attrs = AttrMap::new();
@@ -1212,7 +1230,7 @@ impl<'a> Api<'a> {
                 (self.ctx.messages.clear_label)(&self.ctx.locale),
             );
 
-        if self.ctx.disabled || self.ctx.value.get().is_none() {
+        if self.ctx.disabled || self.ctx.readonly || self.ctx.value.get().is_none() {
             attrs.set_bool(HtmlAttr::Disabled, true);
         }
 
@@ -1221,8 +1239,9 @@ impl<'a> Api<'a> {
 
     /// Returns attributes for the preset trigger at `index`.
     ///
-    /// The trigger is disabled when the component is disabled or the index is out
-    /// of range.
+    /// The trigger is disabled when the component is disabled or read-only, or
+    /// when the index is out of range — matching the machine, which rejects
+    /// [`Event::SelectPreset`] in those states.
     #[must_use]
     pub fn preset_trigger_attrs(&self, index: usize) -> AttrMap {
         let mut attrs = AttrMap::new();
@@ -1235,7 +1254,7 @@ impl<'a> Api<'a> {
             .set(HtmlAttr::Type, "button")
             .set(HtmlAttr::Data("ars-index"), index.to_string());
 
-        if self.ctx.disabled || index >= self.ctx.presets.len() {
+        if self.ctx.disabled || self.ctx.readonly || index >= self.ctx.presets.len() {
             attrs.set_bool(HtmlAttr::Disabled, true);
         }
 

--- a/crates/ars-components/src/date_time/date_range_picker/mod.rs
+++ b/crates/ars-components/src/date_time/date_range_picker/mod.rs
@@ -1,0 +1,1568 @@
+//! `DateRangePicker` component state machine and connect API.
+//!
+//! Framework-agnostic implementation of the composite date range picker defined
+//! in `spec/components/date-time/date-range-picker.md`. The machine pairs two
+//! [`DateField`](super::date_field) inputs (start and end) with an embedded
+//! [`RangeCalendar`](super::range_calendar) shown in a popover, and owns the
+//! popover open/close lifecycle, the canonical selected range, per-field value
+//! coordination, preset ranges, form integration, and the ARIA/`data-ars-*`
+//! attribute surface.
+//!
+//! ## Spec-vs-implementation reconciliation
+//!
+//! The spec's §1 code examples predate the finalized sibling components. This
+//! implementation keeps the spec's semantics while using the real APIs:
+//!
+//! - **Value-based fields, not text parsing.** A [`DateField`](super::date_field)
+//!   is a *segmented* input that emits an [`Option<CalendarDate>`], not a raw
+//!   string, and has no `format` string. The spec's `StartInputChange { value:
+//!   String }` / `format: DateFormat` / in-core `parse_date` are replaced by
+//!   [`Event::StartValueChange`]/[`Event::EndValueChange`] carrying
+//!   `Option<CalendarDate>` and per-field `start_date`/`end_date`, mirroring the
+//!   proven [`date_range_field`](super::date_range_field).
+//! - **Dedicated [`RangeCalendar`](super::range_calendar).** Range selection
+//!   lives in its own component; [`calendar`](super::calendar) has no `is_range`
+//!   mode. [`Api::range_calendar_props`] builds [`range_calendar::Props`], and
+//!   the adapter bridges its completed-range change back as
+//!   [`Event::SelectRangeComplete`].
+//! - **Real ISO helpers.** Form values use [`DateRange::to_iso8601`] (the
+//!   `"start/end"` interval) and [`CalendarDate::to_iso8601`]; there is no
+//!   `to_iso_string`.
+//! - **`NoEffect`, adapter-owned focus.** Live focus, popover positioning, and
+//!   return-focus are driven by the adapter from element handles per the issue's
+//!   element/ref note; the agnostic core emits no effects and exposes state via
+//!   the connect API (mirrors [`date_range_field`](super::date_range_field)).
+//! - **Controlled-prop sync.** A [`Event::SyncProps`] event plus
+//!   [`Machine::on_props_changed`](ars_core::Machine::on_props_changed) keep a
+//!   controlled `value` and the cached `min`/`max`/`today`/`presets`/flags live.
+//! - **Presets.** [`Preset`] adds named, pre-localized ranges (selected via
+//!   [`Event::SelectPreset`] / the [`Part::PresetTrigger`] anatomy part) so a
+//!   consumer can offer "Last 7 days"-style shortcuts. The consumer supplies a
+//!   concrete [`DateRange`] computed relative to the same injected `today`,
+//!   keeping the core deterministic.
+
+#[cfg(test)]
+mod tests;
+
+use alloc::{
+    boxed::Box,
+    string::{String, ToString as _},
+    sync::Arc,
+    vec,
+    vec::Vec,
+};
+use core::fmt::{self, Debug};
+
+use ars_core::{
+    AriaAttr, AttrMap, Bindable, ComponentIds, ComponentMessages, ComponentPart, ConnectApi, Env,
+    HtmlAttr, IntlBackend, Locale, MessageFn, NoEffect, TransitionPlan,
+};
+use ars_i18n::{CalendarDate, DateRange};
+use ars_interactions::KeyboardKey;
+
+// `ActiveField` is owned by `date_range_field` as the first range component to
+// need it; per its own documentation, later range components reuse the enum
+// rather than redefining it.
+pub use super::date_range_field::ActiveField;
+use super::{
+    date_field,
+    date_range_field::{date_out_of_bounds, format_date_label},
+    range_calendar,
+};
+
+// ────────────────────────────────────────────────────────────────────
+// State / Event
+// ────────────────────────────────────────────────────────────────────
+
+/// States for the `DateRangePicker` component.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum State {
+    /// The calendar popover is closed.
+    Closed,
+
+    /// The calendar popover is open.
+    Open,
+}
+
+/// Events for the `DateRangePicker` component.
+#[derive(Clone, Debug, PartialEq)]
+pub enum Event {
+    /// Open the calendar popover.
+    Open,
+
+    /// Close the calendar popover.
+    Close,
+
+    /// Toggle the popover open/closed.
+    Toggle,
+
+    /// The embedded calendar completed a range selection.
+    SelectRangeComplete {
+        /// The selected range.
+        range: DateRange,
+    },
+
+    /// The start field's value changed (segmented `DateField` emits a date, not
+    /// raw text).
+    StartValueChange(Option<CalendarDate>),
+
+    /// The end field's value changed.
+    EndValueChange(Option<CalendarDate>),
+
+    /// A preset range was chosen by its index into [`Props::presets`].
+    SelectPreset {
+        /// Zero-based index into the configured presets.
+        index: usize,
+    },
+
+    /// Clear the selected range (the clear trigger).
+    Clear,
+
+    /// Focus entered the component.
+    FocusIn,
+
+    /// Focus left the component entirely.
+    FocusOut,
+
+    /// A key was pressed on the trigger or within the popover.
+    KeyDown {
+        /// The key that was pressed.
+        key: KeyboardKey,
+    },
+
+    /// Re-apply context-backed prop fields after a props change.
+    ///
+    /// Emitted by [`Machine::on_props_changed`](ars_core::Machine::on_props_changed)
+    /// so a controlled `value` and the cached `min`/`max`/`today`/`presets`/
+    /// flags follow parent-driven prop updates.
+    SyncProps(Box<Props>),
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Preset
+// ────────────────────────────────────────────────────────────────────
+
+/// A named preset range offered as a one-click shortcut (e.g. "Last 7 days").
+///
+/// The consumer supplies an already-localized [`label`](Self::label) and a
+/// concrete [`range`](Self::range). Relative presets (such as "Last 7 days")
+/// are computed by the consumer against the same `today` injected into
+/// [`Props::today`], which keeps the agnostic core deterministic and free of
+/// closures.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Preset {
+    /// The pre-localized label shown on the preset trigger.
+    pub label: String,
+
+    /// The concrete range applied when this preset is selected.
+    pub range: DateRange,
+}
+
+impl Preset {
+    /// Creates a preset from a label and a concrete range.
+    #[must_use]
+    pub fn new(label: impl Into<String>, range: DateRange) -> Self {
+        Self {
+            label: label.into(),
+            range,
+        }
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Props
+// ────────────────────────────────────────────────────────────────────
+
+/// Props for the `DateRangePicker` component.
+#[derive(Clone, Debug, PartialEq, ars_core::HasId)]
+pub struct Props {
+    /// The stable DOM id for the component. [`ComponentIds`] derives part ids
+    /// from it.
+    pub id: String,
+
+    /// Controlled range value. `None` = uncontrolled, `Some(None)` =
+    /// controlled-and-empty, `Some(Some(range))` = controlled with a range.
+    pub value: Option<Option<DateRange>>,
+
+    /// The initial range used when the component is uncontrolled.
+    pub default_value: Option<DateRange>,
+
+    /// The minimum selectable date (forwarded to both fields and the calendar).
+    pub min: Option<CalendarDate>,
+
+    /// The maximum selectable date (forwarded to both fields and the calendar).
+    pub max: Option<CalendarDate>,
+
+    /// The "today" date, injected by the adapter for testability and SSR
+    /// determinism. Forwarded to the embedded [`RangeCalendar`](super::range_calendar)
+    /// so an empty picker opens on the current month. Defaults to a fixed date;
+    /// adapters inject the real today.
+    pub today: CalendarDate,
+
+    /// Named preset ranges offered as one-click shortcuts (rendered as
+    /// [`Part::PresetTrigger`] items inside the popover).
+    pub presets: Vec<Preset>,
+
+    /// Number of months displayed side-by-side in the calendar popover.
+    /// Default: `2`. Forwarded to the embedded calendar's `visible_months`.
+    pub visible_months: usize,
+
+    /// Right-to-left layout direction (forwarded to the embedded calendar).
+    pub is_rtl: bool,
+
+    /// Whether the component is disabled.
+    pub disabled: bool,
+
+    /// Whether the component is read-only (viewing allowed, editing blocked).
+    pub readonly: bool,
+
+    /// Whether the component is required for form submission.
+    pub required: bool,
+
+    /// When `true`, numeric segments in both child fields display with leading
+    /// zeros. Defaults to `false`, which uses locale-aware formatting.
+    pub force_leading_zeros: bool,
+
+    /// Whether a `Description` element is rendered. When `true`, the control's
+    /// `aria-describedby` references the description part id.
+    pub has_description: bool,
+
+    /// Whether an `ErrorMessage` element is rendered. When `true`, the control's
+    /// `aria-describedby` references the error-message part id.
+    pub has_error_message: bool,
+
+    /// Form field name for a single hidden input carrying the range value as the
+    /// ISO 8601 interval `YYYY-MM-DD/YYYY-MM-DD`.
+    pub name: Option<String>,
+
+    /// Form field name for a separate hidden input carrying the start date
+    /// (alternative to [`name`](Self::name)).
+    pub start_name: Option<String>,
+
+    /// Form field name for a separate hidden input carrying the end date.
+    pub end_name: Option<String>,
+
+    /// Whether to close the popover after a range is completed. Default: `true`.
+    pub close_on_select: bool,
+}
+
+impl Default for Props {
+    fn default() -> Self {
+        Self {
+            id: String::new(),
+            value: None,
+            default_value: None,
+            min: None,
+            max: None,
+            today: CalendarDate::new_gregorian(2025, 1, 1)
+                .expect("2025-01-01 is a valid Gregorian date"),
+            presets: Vec::new(),
+            visible_months: 2,
+            is_rtl: false,
+            disabled: false,
+            readonly: false,
+            required: false,
+            force_leading_zeros: false,
+            has_description: false,
+            has_error_message: false,
+            name: None,
+            start_name: None,
+            end_name: None,
+            close_on_select: true,
+        }
+    }
+}
+
+impl Props {
+    /// Returns a fresh [`Props`] value with the `DateRangePicker` defaults.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets [`id`](Self::id), the stable DOM id for the component.
+    #[must_use]
+    pub fn id(mut self, id: impl Into<String>) -> Self {
+        self.id = id.into();
+        self
+    }
+
+    /// Sets [`value`](Self::value), the externally controlled range value.
+    #[must_use]
+    pub fn value(mut self, value: Option<DateRange>) -> Self {
+        self.value = Some(value);
+        self
+    }
+
+    /// Sets [`default_value`](Self::default_value), the uncontrolled initial range.
+    #[must_use]
+    pub fn default_value(mut self, value: Option<DateRange>) -> Self {
+        self.default_value = value;
+        self
+    }
+
+    /// Sets [`min`](Self::min), the minimum selectable date.
+    #[must_use]
+    pub fn min(mut self, value: Option<CalendarDate>) -> Self {
+        self.min = value;
+        self
+    }
+
+    /// Sets [`max`](Self::max), the maximum selectable date.
+    #[must_use]
+    pub fn max(mut self, value: Option<CalendarDate>) -> Self {
+        self.max = value;
+        self
+    }
+
+    /// Sets [`today`](Self::today), the adapter-injected current date.
+    #[must_use]
+    pub fn today(mut self, today: CalendarDate) -> Self {
+        self.today = today;
+        self
+    }
+
+    /// Sets [`presets`](Self::presets), the named preset ranges.
+    #[must_use]
+    pub fn presets(mut self, presets: Vec<Preset>) -> Self {
+        self.presets = presets;
+        self
+    }
+
+    /// Sets [`visible_months`](Self::visible_months), the side-by-side month count.
+    #[must_use]
+    pub const fn visible_months(mut self, visible_months: usize) -> Self {
+        self.visible_months = visible_months;
+        self
+    }
+
+    /// Sets [`is_rtl`](Self::is_rtl), the layout direction.
+    #[must_use]
+    pub const fn is_rtl(mut self, is_rtl: bool) -> Self {
+        self.is_rtl = is_rtl;
+        self
+    }
+
+    /// Sets [`disabled`](Self::disabled), whether the component is disabled.
+    #[must_use]
+    pub const fn disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
+    }
+
+    /// Sets [`readonly`](Self::readonly), whether the component is read-only.
+    #[must_use]
+    pub const fn readonly(mut self, readonly: bool) -> Self {
+        self.readonly = readonly;
+        self
+    }
+
+    /// Sets [`required`](Self::required), whether the component is required.
+    #[must_use]
+    pub const fn required(mut self, required: bool) -> Self {
+        self.required = required;
+        self
+    }
+
+    /// Sets [`force_leading_zeros`](Self::force_leading_zeros).
+    #[must_use]
+    pub const fn force_leading_zeros(mut self, force: bool) -> Self {
+        self.force_leading_zeros = force;
+        self
+    }
+
+    /// Sets [`has_description`](Self::has_description).
+    #[must_use]
+    pub const fn has_description(mut self, has_description: bool) -> Self {
+        self.has_description = has_description;
+        self
+    }
+
+    /// Sets [`has_error_message`](Self::has_error_message).
+    #[must_use]
+    pub const fn has_error_message(mut self, has_error_message: bool) -> Self {
+        self.has_error_message = has_error_message;
+        self
+    }
+
+    /// Sets [`name`](Self::name), the combined hidden input form name.
+    #[must_use]
+    pub fn name(mut self, name: Option<String>) -> Self {
+        self.name = name;
+        self
+    }
+
+    /// Sets [`start_name`](Self::start_name), the separate start-date form name.
+    #[must_use]
+    pub fn start_name(mut self, name: Option<String>) -> Self {
+        self.start_name = name;
+        self
+    }
+
+    /// Sets [`end_name`](Self::end_name), the separate end-date form name.
+    #[must_use]
+    pub fn end_name(mut self, name: Option<String>) -> Self {
+        self.end_name = name;
+        self
+    }
+
+    /// Sets [`close_on_select`](Self::close_on_select).
+    #[must_use]
+    pub const fn close_on_select(mut self, close_on_select: bool) -> Self {
+        self.close_on_select = close_on_select;
+        self
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Context
+// ────────────────────────────────────────────────────────────────────
+
+/// Context for the `DateRangePicker` component.
+#[derive(Clone)]
+pub struct Context {
+    /// The canonical selected range.
+    ///
+    /// `Some` only when both [`start_date`](Self::start_date) and
+    /// [`end_date`](Self::end_date) are set; always normalized so `start <= end`.
+    pub value: Bindable<Option<DateRange>>,
+
+    /// Whether the popover is open (always uncontrolled).
+    pub open: Bindable<bool>,
+
+    /// The start field's current value, tracked independently so a range can be
+    /// assembled incrementally as each field changes.
+    pub start_date: Option<CalendarDate>,
+
+    /// The end field's current value, tracked independently.
+    pub end_date: Option<CalendarDate>,
+
+    /// Which field most recently received a value change.
+    pub active_field: ActiveField,
+
+    /// The minimum selectable date.
+    pub min: Option<CalendarDate>,
+
+    /// The maximum selectable date.
+    pub max: Option<CalendarDate>,
+
+    /// The adapter-injected "today" date, forwarded to the embedded calendar.
+    pub today: CalendarDate,
+
+    /// Named preset ranges offered as one-click shortcuts.
+    pub presets: Vec<Preset>,
+
+    /// Number of months displayed side-by-side, forwarded to the calendar.
+    pub visible_months: usize,
+
+    /// Right-to-left layout direction, forwarded to the calendar.
+    pub is_rtl: bool,
+
+    /// The resolved locale.
+    pub locale: Locale,
+
+    /// Backend used for locale-dependent labels in range descriptions.
+    pub intl_backend: Arc<dyn IntlBackend>,
+
+    /// Resolved translatable messages.
+    pub messages: Messages,
+
+    /// Whether the component is disabled.
+    pub disabled: bool,
+
+    /// Whether the component is read-only.
+    pub readonly: bool,
+
+    /// Whether the component is required for form submission.
+    pub required: bool,
+
+    /// When `true`, numeric segments in both child fields display with leading
+    /// zeros.
+    pub force_leading_zeros: bool,
+
+    /// Whether the `Description` part is rendered.
+    pub has_description: bool,
+
+    /// Whether the `ErrorMessage` part is rendered.
+    pub has_error_message: bool,
+
+    /// Form field name for a single hidden input carrying the range value.
+    pub name: Option<String>,
+
+    /// Form field name for a separate hidden input carrying the start date.
+    pub start_name: Option<String>,
+
+    /// Form field name for a separate hidden input carrying the end date.
+    pub end_name: Option<String>,
+
+    /// Derived component part ids.
+    pub ids: ComponentIds,
+}
+
+impl Debug for Context {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Context")
+            .field("value", &self.value)
+            .field("open", &self.open)
+            .field("start_date", &self.start_date)
+            .field("end_date", &self.end_date)
+            .field("active_field", &self.active_field)
+            .field("min", &self.min)
+            .field("max", &self.max)
+            .field("today", &self.today)
+            .field("presets", &self.presets)
+            .field("visible_months", &self.visible_months)
+            .field("is_rtl", &self.is_rtl)
+            .field("locale", &self.locale)
+            .field("intl_backend", &"<dyn IntlBackend>")
+            .field("messages", &self.messages)
+            .field("disabled", &self.disabled)
+            .field("readonly", &self.readonly)
+            .field("required", &self.required)
+            .field("force_leading_zeros", &self.force_leading_zeros)
+            .field("has_description", &self.has_description)
+            .field("has_error_message", &self.has_error_message)
+            .field("name", &self.name)
+            .field("start_name", &self.start_name)
+            .field("end_name", &self.end_name)
+            .field("ids", &self.ids)
+            .finish()
+    }
+}
+
+impl Context {
+    /// Returns `true` when the current range violates the configured min/max
+    /// bounds. A normalized range lies within `[min, max]` iff neither endpoint
+    /// is out of bounds.
+    #[must_use]
+    pub fn is_invalid(&self) -> bool {
+        let Some(range) = self.value.get() else {
+            return false;
+        };
+
+        date_out_of_bounds(Some(&range.start), self.min.as_ref(), self.max.as_ref())
+            || date_out_of_bounds(Some(&range.end), self.min.as_ref(), self.max.as_ref())
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Messages
+// ────────────────────────────────────────────────────────────────────
+
+/// Closure type for the range description message, given the formatted start
+/// and end date strings plus the active locale.
+type RangeDescriptionFn = dyn Fn(&str, &str, &Locale) -> String + Send + Sync;
+
+/// Translatable messages for the `DateRangePicker` component.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Messages {
+    /// Accessible label for the trigger button.
+    pub trigger_label: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
+
+    /// Accessible label for the start date field.
+    pub start_label: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
+
+    /// Accessible label for the end date field.
+    pub end_label: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
+
+    /// Screen-reader description of the full range, given formatted start and
+    /// end date strings.
+    pub range_description: MessageFn<RangeDescriptionFn>,
+
+    /// Accessible label for the clear trigger button.
+    pub clear_label: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
+}
+
+impl Default for Messages {
+    fn default() -> Self {
+        Self {
+            trigger_label: MessageFn::static_str("Open date range picker"),
+            start_label: MessageFn::static_str("Start date"),
+            end_label: MessageFn::static_str("End date"),
+            range_description: MessageFn::new(|start: &str, end: &str, _locale: &Locale| {
+                alloc::format!("{start} to {end}")
+            }),
+            clear_label: MessageFn::static_str("Clear date range"),
+        }
+    }
+}
+
+impl ComponentMessages for Messages {}
+
+// ────────────────────────────────────────────────────────────────────
+// Machine
+// ────────────────────────────────────────────────────────────────────
+
+/// State machine for the `DateRangePicker` component.
+#[derive(Debug)]
+pub struct Machine;
+
+impl ars_core::Machine for Machine {
+    type State = State;
+    type Event = Event;
+    type Context = Context;
+    type Props = Props;
+    type Messages = Messages;
+    type Effect = NoEffect;
+    type Api<'a> = Api<'a>;
+
+    fn init(
+        props: &Self::Props,
+        env: &Env,
+        messages: &Self::Messages,
+    ) -> (Self::State, Self::Context) {
+        let value = if let Some(value) = &props.value {
+            Bindable::controlled(value.clone())
+        } else {
+            Bindable::uncontrolled(props.default_value.clone())
+        };
+
+        let initial_range = value.get().clone();
+        let start_date = initial_range.as_ref().map(|range| range.start.clone());
+        let end_date = initial_range.as_ref().map(|range| range.end.clone());
+
+        let ctx = Context {
+            value,
+            open: Bindable::uncontrolled(false),
+            start_date,
+            end_date,
+            active_field: ActiveField::Start,
+            min: props.min.clone(),
+            max: props.max.clone(),
+            today: props.today.clone(),
+            presets: props.presets.clone(),
+            visible_months: props.visible_months,
+            is_rtl: props.is_rtl,
+            locale: env.locale.clone(),
+            intl_backend: Arc::clone(&env.intl_backend),
+            messages: messages.clone(),
+            disabled: props.disabled,
+            readonly: props.readonly,
+            required: props.required,
+            force_leading_zeros: props.force_leading_zeros,
+            has_description: props.has_description,
+            has_error_message: props.has_error_message,
+            name: props.name.clone(),
+            start_name: props.start_name.clone(),
+            end_name: props.end_name.clone(),
+            ids: ComponentIds::from_id(&props.id),
+        };
+
+        (State::Closed, ctx)
+    }
+
+    fn transition(
+        state: &Self::State,
+        event: &Self::Event,
+        ctx: &Self::Context,
+        props: &Self::Props,
+    ) -> Option<TransitionPlan<Self>> {
+        // `SyncProps` must process even when disabled so adapter-driven prop
+        // updates (including re-enabling) still reach the context.
+        if ctx.disabled && !matches!(event, Event::SyncProps(_)) {
+            return None;
+        }
+
+        match (state, event) {
+            (_, Event::SyncProps(next)) => {
+                let next = next.as_ref().clone();
+                Some(TransitionPlan::context_only(move |ctx: &mut Context| {
+                    sync_props(ctx, &next);
+                }))
+            }
+
+            (State::Closed, Event::Open | Event::Toggle) => {
+                Some(TransitionPlan::to(State::Open).apply(|ctx: &mut Context| {
+                    ctx.open.set(true);
+                }))
+            }
+
+            (State::Open, Event::Close | Event::Toggle) => Some(
+                TransitionPlan::to(State::Closed).apply(|ctx: &mut Context| {
+                    ctx.open.set(false);
+                }),
+            ),
+
+            (State::Open, Event::SelectRangeComplete { range }) => {
+                if ctx.readonly {
+                    return None;
+                }
+
+                let range = range.clone();
+
+                let should_close = props.close_on_select;
+
+                let next_state = if should_close {
+                    State::Closed
+                } else {
+                    State::Open
+                };
+
+                Some(
+                    TransitionPlan::to(next_state).apply(move |ctx: &mut Context| {
+                        apply_complete_range(ctx, range, should_close);
+                    }),
+                )
+            }
+
+            (_, Event::SelectPreset { index }) => {
+                if ctx.readonly {
+                    return None;
+                }
+
+                let range = ctx.presets.get(*index)?.range.clone();
+                // A preset always completes a full range; close iff configured
+                // and currently open (closing a closed popover is a no-op).
+                let should_close = props.close_on_select && *state == State::Open;
+
+                let next_state = if should_close {
+                    State::Closed
+                } else {
+                    state.clone()
+                };
+
+                Some(
+                    TransitionPlan::to(next_state).apply(move |ctx: &mut Context| {
+                        apply_complete_range(ctx, range, should_close);
+                    }),
+                )
+            }
+
+            (_, Event::StartValueChange(date)) => {
+                if ctx.readonly {
+                    return None;
+                }
+
+                let date = date.clone();
+                Some(TransitionPlan::context_only(move |ctx: &mut Context| {
+                    ctx.active_field = ActiveField::Start;
+                    ctx.start_date = date;
+                    recompute_range(ctx);
+                }))
+            }
+
+            (_, Event::EndValueChange(date)) => {
+                if ctx.readonly {
+                    return None;
+                }
+
+                let date = date.clone();
+                Some(TransitionPlan::context_only(move |ctx: &mut Context| {
+                    ctx.active_field = ActiveField::End;
+                    ctx.end_date = date;
+                    recompute_range(ctx);
+                }))
+            }
+
+            (_, Event::Clear) => {
+                if ctx.readonly {
+                    return None;
+                }
+
+                Some(TransitionPlan::context_only(|ctx: &mut Context| {
+                    ctx.start_date = None;
+                    ctx.end_date = None;
+                    ctx.value.set(None);
+                }))
+            }
+
+            (State::Open, Event::KeyDown { key }) if *key == KeyboardKey::Escape => {
+                Self::transition(state, &Event::Close, ctx, props)
+            }
+
+            (State::Closed, Event::KeyDown { key }) if *key == KeyboardKey::ArrowDown => {
+                Self::transition(state, &Event::Open, ctx, props)
+            }
+
+            (State::Open, Event::FocusOut) => Self::transition(state, &Event::Close, ctx, props),
+
+            _ => None,
+        }
+    }
+
+    fn on_props_changed(old: &Self::Props, new: &Self::Props) -> Vec<Self::Event> {
+        debug_assert_eq!(
+            old.id, new.id,
+            "date_range_picker::Props.id must remain stable after init"
+        );
+
+        if old == new {
+            Vec::new()
+        } else {
+            vec![Event::SyncProps(Box::new(new.clone()))]
+        }
+    }
+
+    fn connect<'a>(
+        state: &'a Self::State,
+        ctx: &'a Self::Context,
+        props: &'a Self::Props,
+        send: &'a dyn Fn(Self::Event),
+    ) -> Self::Api<'a> {
+        Api::new(state, ctx, props, send)
+    }
+}
+
+/// Re-derives mutable context fields from changed props.
+///
+/// `id` is fixed at construction (see [`Machine::on_props_changed`]). For a
+/// controlled component (`props.value` is `Some`) the controlled override and
+/// the per-field working values are reconciled to the new range; an uncontrolled
+/// component keeps its internal working state and merely drops any stale
+/// controlled override. `open` is always uncontrolled and is left untouched.
+fn sync_props(ctx: &mut Context, props: &Props) {
+    ctx.min = props.min.clone();
+    ctx.max = props.max.clone();
+    ctx.today = props.today.clone();
+    ctx.presets = props.presets.clone();
+    ctx.visible_months = props.visible_months;
+    ctx.is_rtl = props.is_rtl;
+    ctx.disabled = props.disabled;
+    ctx.readonly = props.readonly;
+    ctx.required = props.required;
+    ctx.force_leading_zeros = props.force_leading_zeros;
+    ctx.has_description = props.has_description;
+    ctx.has_error_message = props.has_error_message;
+    ctx.name = props.name.clone();
+    ctx.start_name = props.start_name.clone();
+    ctx.end_name = props.end_name.clone();
+
+    if let Some(controlled) = &props.value {
+        ctx.value.sync_controlled(Some(controlled.clone()));
+        // Keep the internal (pending) value in lockstep with the controlled
+        // override. `get()` returns the override while controlled, so this is
+        // invisible now; it matters if the component later returns to
+        // uncontrolled mode (`value` prop dropped to `None`), where the revealed
+        // internal value must stay consistent with the per-field values below
+        // rather than expose a stale earlier value.
+        ctx.value.set(controlled.clone());
+        ctx.start_date = controlled.as_ref().map(|range| range.start.clone());
+        ctx.end_date = controlled.as_ref().map(|range| range.end.clone());
+    } else {
+        // Genuinely uncontrolled: drop any stale override but keep the internal
+        // working state and per-field values so in-progress edits survive an
+        // unrelated prop update (mirrors `date_range_field`).
+        ctx.value.sync_controlled(None);
+    }
+}
+
+/// Applies a completed range to the context: the per-field values, the canonical
+/// value, and (when `close`) the open state.
+fn apply_complete_range(ctx: &mut Context, range: DateRange, close: bool) {
+    ctx.start_date = Some(range.start.clone());
+    ctx.end_date = Some(range.end.clone());
+    ctx.value.set(Some(range));
+
+    if close {
+        ctx.open.set(false);
+    }
+}
+
+/// Recomputes the canonical range from the two field values.
+///
+/// When both fields hold a value the range is normalized (swapping if needed so
+/// `start <= end`) and the normalized order is reflected back into the field
+/// values. When either field is empty, or the two dates are not comparable, the
+/// range is cleared.
+fn recompute_range(ctx: &mut Context) {
+    match (ctx.start_date.clone(), ctx.end_date.clone()) {
+        (Some(start), Some(end)) => {
+            if let Some(range) = DateRange::normalized(start, end) {
+                ctx.start_date = Some(range.start.clone());
+                ctx.end_date = Some(range.end.clone());
+                ctx.value.set(Some(range));
+            } else {
+                ctx.value.set(None);
+            }
+        }
+        _ => ctx.value.set(None),
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Anatomy
+// ────────────────────────────────────────────────────────────────────
+
+/// Structural parts exposed by the `DateRangePicker` connect API.
+#[derive(ars_core::ComponentPart)]
+#[scope = "date-range-picker"]
+pub enum Part {
+    /// The outermost container.
+    Root,
+
+    /// The label pointing at the start input.
+    Label,
+
+    /// The group wrapping the two inputs and triggers.
+    Control,
+
+    /// The start date input (a `DateField`).
+    StartInput,
+
+    /// The visual separator between the two inputs.
+    Separator,
+
+    /// The end date input (a `DateField`).
+    EndInput,
+
+    /// The button that toggles the calendar popover.
+    Trigger,
+
+    /// The button that clears the selected range.
+    ClearTrigger,
+
+    /// A preset shortcut button. The index selects into [`Props::presets`].
+    PresetTrigger {
+        /// Zero-based index into the configured presets.
+        index: usize,
+    },
+
+    /// The floating positioner for the popover content.
+    Positioner,
+
+    /// The popover content (`role="dialog"`) containing the calendar.
+    Content,
+
+    /// The optional description element.
+    Description,
+
+    /// The optional error message element.
+    ErrorMessage,
+
+    /// The hidden form input carrying the ISO 8601 range value.
+    HiddenInput,
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Connect API
+// ────────────────────────────────────────────────────────────────────
+
+/// API for the `DateRangePicker` component.
+pub struct Api<'a> {
+    /// The state of the component.
+    state: &'a State,
+
+    /// The context of the component.
+    ctx: &'a Context,
+
+    /// The props of the component.
+    props: &'a Props,
+
+    /// The send function.
+    send: &'a dyn Fn(Event),
+}
+
+impl Debug for Api<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Api")
+            .field("state", self.state)
+            .field("ctx", self.ctx)
+            .field("props", self.props)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<'a> Api<'a> {
+    /// Creates a `DateRangePicker` connect API from machine state.
+    #[must_use]
+    pub const fn new(
+        state: &'a State,
+        ctx: &'a Context,
+        props: &'a Props,
+        send: &'a dyn Fn(Event),
+    ) -> Self {
+        Self {
+            state,
+            ctx,
+            props,
+            send,
+        }
+    }
+
+    // ── AttrMap getters ──────────────────────────────────────────────────
+
+    /// Returns attributes for the root element.
+    #[must_use]
+    pub fn root_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Root.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Id, self.ctx.ids.id())
+            .set(HtmlAttr::Data("ars-state"), self.state_name());
+
+        if self.ctx.disabled {
+            attrs.set_bool(HtmlAttr::Data("ars-disabled"), true);
+        }
+
+        if self.ctx.readonly {
+            attrs.set_bool(HtmlAttr::Data("ars-readonly"), true);
+        }
+
+        if self.ctx.required {
+            attrs.set_bool(HtmlAttr::Data("ars-required"), true);
+        }
+
+        if self.ctx.is_invalid() {
+            attrs.set_bool(HtmlAttr::Data("ars-invalid"), true);
+        }
+
+        attrs
+    }
+
+    /// Returns attributes for the label element.
+    #[must_use]
+    pub fn label_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Label.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Id, self.ctx.ids.part("label"))
+            .set(HtmlAttr::For, self.ctx.ids.part("start-input"));
+
+        attrs
+    }
+
+    /// Returns attributes for the control element (the group wrapping the two
+    /// inputs and triggers).
+    #[must_use]
+    pub fn control_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Control.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Role, "group")
+            .set(
+                HtmlAttr::Aria(AriaAttr::LabelledBy),
+                self.ctx.ids.part("label"),
+            );
+
+        let mut described_by = Vec::new();
+
+        if self.ctx.has_description {
+            described_by.push(self.ctx.ids.part("description"));
+        }
+
+        if self.ctx.has_error_message {
+            described_by.push(self.ctx.ids.part("error-message"));
+        }
+
+        if !described_by.is_empty() {
+            attrs.set(
+                HtmlAttr::Aria(AriaAttr::DescribedBy),
+                described_by.join(" "),
+            );
+        }
+
+        attrs
+    }
+
+    /// Returns marker attributes for the start-input wrapper.
+    ///
+    /// The wrapper carries only the scope/part data hooks; the embedded child
+    /// `DateField` is configured through [`Api::start_field_props`].
+    #[must_use]
+    pub fn start_input_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::StartInput.data_attrs();
+
+        attrs.set(scope_attr, scope_val).set(part_attr, part_val);
+
+        attrs
+    }
+
+    /// Returns marker attributes for the end-input wrapper.
+    ///
+    /// The wrapper carries only the scope/part data hooks; the embedded child
+    /// `DateField` is configured through [`Api::end_field_props`].
+    #[must_use]
+    pub fn end_input_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::EndInput.data_attrs();
+
+        attrs.set(scope_attr, scope_val).set(part_attr, part_val);
+
+        attrs
+    }
+
+    /// Returns attributes for the separator element.
+    #[must_use]
+    pub fn separator_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Separator.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Aria(AriaAttr::Hidden), "true");
+
+        attrs
+    }
+
+    /// Builds the child [`date_field::Props`] for the start date input.
+    ///
+    /// Both child fields are bounded only by the global `min`/`max`, never by
+    /// the opposite endpoint: a child `DateField` clamps completed dates to its
+    /// own bounds, so binding the start field to the current end date would clamp
+    /// away an out-of-order edit before the parent can perform the normalizing
+    /// swap. Cross-field ordering is enforced by the parent's range
+    /// recomputation when the changed value reaches it. `invalid` reflects
+    /// whether this field's
+    /// own value lies outside the global bounds.
+    #[must_use]
+    pub fn start_field_props(&self) -> date_field::Props {
+        date_field::Props {
+            id: self.ctx.ids.part("start-input"),
+            value: Some(self.ctx.start_date.clone()),
+            min_value: self.ctx.min.clone(),
+            max_value: self.ctx.max.clone(),
+            disabled: self.ctx.disabled,
+            readonly: self.ctx.readonly,
+            required: self.ctx.required,
+            invalid: date_out_of_bounds(
+                self.ctx.start_date.as_ref(),
+                self.ctx.min.as_ref(),
+                self.ctx.max.as_ref(),
+            ),
+            aria_label: Some((self.ctx.messages.start_label)(&self.ctx.locale)),
+            force_leading_zeros: self.ctx.force_leading_zeros,
+            ..date_field::Props::default()
+        }
+    }
+
+    /// Builds the child [`date_field::Props`] for the end date input.
+    ///
+    /// Bounded only by the global `min`/`max` for the same reason as
+    /// [`Api::start_field_props`]; `invalid` reflects whether the end field's own
+    /// value lies outside the global bounds.
+    #[must_use]
+    pub fn end_field_props(&self) -> date_field::Props {
+        date_field::Props {
+            id: self.ctx.ids.part("end-input"),
+            value: Some(self.ctx.end_date.clone()),
+            min_value: self.ctx.min.clone(),
+            max_value: self.ctx.max.clone(),
+            disabled: self.ctx.disabled,
+            readonly: self.ctx.readonly,
+            required: self.ctx.required,
+            invalid: date_out_of_bounds(
+                self.ctx.end_date.as_ref(),
+                self.ctx.min.as_ref(),
+                self.ctx.max.as_ref(),
+            ),
+            aria_label: Some((self.ctx.messages.end_label)(&self.ctx.locale)),
+            force_leading_zeros: self.ctx.force_leading_zeros,
+            ..date_field::Props::default()
+        }
+    }
+
+    /// Returns attributes for the trigger element.
+    #[must_use]
+    pub fn trigger_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Trigger.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Id, self.ctx.ids.part("trigger"))
+            .set(HtmlAttr::Type, "button")
+            .set(
+                HtmlAttr::Aria(AriaAttr::Label),
+                (self.ctx.messages.trigger_label)(&self.ctx.locale),
+            )
+            .set(HtmlAttr::Aria(AriaAttr::HasPopup), "dialog")
+            .set(
+                HtmlAttr::Aria(AriaAttr::Expanded),
+                if self.is_open() { "true" } else { "false" },
+            )
+            .set(
+                HtmlAttr::Aria(AriaAttr::Controls),
+                self.ctx.ids.part("content"),
+            );
+
+        if self.ctx.disabled {
+            attrs.set_bool(HtmlAttr::Disabled, true);
+        }
+
+        attrs
+    }
+
+    /// Returns attributes for the clear trigger element.
+    ///
+    /// The button is disabled when the component is disabled or no range is
+    /// selected.
+    #[must_use]
+    pub fn clear_trigger_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::ClearTrigger.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Type, "button")
+            .set(
+                HtmlAttr::Aria(AriaAttr::Label),
+                (self.ctx.messages.clear_label)(&self.ctx.locale),
+            );
+
+        if self.ctx.disabled || self.ctx.value.get().is_none() {
+            attrs.set_bool(HtmlAttr::Disabled, true);
+        }
+
+        attrs
+    }
+
+    /// Returns attributes for the preset trigger at `index`.
+    ///
+    /// The trigger is disabled when the component is disabled or the index is out
+    /// of range.
+    #[must_use]
+    pub fn preset_trigger_attrs(&self, index: usize) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] =
+            Part::PresetTrigger { index }.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Type, "button")
+            .set(HtmlAttr::Data("ars-index"), index.to_string());
+
+        if self.ctx.disabled || index >= self.ctx.presets.len() {
+            attrs.set_bool(HtmlAttr::Disabled, true);
+        }
+
+        attrs
+    }
+
+    /// Returns attributes for the positioner element.
+    #[must_use]
+    pub fn positioner_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Positioner.data_attrs();
+
+        attrs.set(scope_attr, scope_val).set(part_attr, part_val);
+
+        attrs
+    }
+
+    /// Returns attributes for the content element.
+    #[must_use]
+    pub fn content_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Content.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Id, self.ctx.ids.part("content"))
+            .set(HtmlAttr::Role, "dialog")
+            .set(HtmlAttr::Aria(AriaAttr::Modal), "false")
+            .set(
+                HtmlAttr::Aria(AriaAttr::LabelledBy),
+                self.ctx.ids.part("label"),
+            );
+
+        attrs
+    }
+
+    /// Returns attributes for the description element.
+    #[must_use]
+    pub fn description_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Description.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Id, self.ctx.ids.part("description"));
+
+        attrs
+    }
+
+    /// Returns attributes for the error message element.
+    #[must_use]
+    pub fn error_message_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::ErrorMessage.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Id, self.ctx.ids.part("error-message"))
+            .set(HtmlAttr::Role, "alert");
+
+        attrs
+    }
+
+    /// Returns attributes for the combined hidden input element.
+    ///
+    /// The value is the ISO 8601 interval `YYYY-MM-DD/YYYY-MM-DD`, or empty when
+    /// no range is selected.
+    #[must_use]
+    pub fn hidden_input_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::HiddenInput.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Type, "hidden");
+
+        if let Some(name) = &self.ctx.name {
+            attrs.set(HtmlAttr::Name, name);
+        }
+
+        // A disabled control is excluded from form submission; mark it disabled
+        // rather than submit a stale value (mirrors `date_range_field`).
+        if self.ctx.disabled {
+            attrs.set_bool(HtmlAttr::Disabled, true);
+        }
+
+        let value = if let Some(range) = self.ctx.value.get() {
+            range.to_iso8601()
+        } else {
+            String::new()
+        };
+
+        attrs.set(HtmlAttr::Value, value);
+
+        attrs
+    }
+
+    /// Returns attributes for the separate hidden input carrying the start date.
+    ///
+    /// Only meaningful when `start_name` is set on `Props`. The value is the
+    /// start field's own date, so a partially-entered range still submits the
+    /// start date.
+    #[must_use]
+    pub fn start_hidden_input_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        attrs.set(HtmlAttr::Type, "hidden");
+
+        if let Some(name) = &self.ctx.start_name {
+            attrs.set(HtmlAttr::Name, name);
+        }
+
+        if self.ctx.disabled {
+            attrs.set_bool(HtmlAttr::Disabled, true);
+        }
+
+        let value = if let Some(start) = &self.ctx.start_date {
+            start.to_iso8601()
+        } else {
+            String::new()
+        };
+
+        attrs.set(HtmlAttr::Value, value);
+
+        attrs
+    }
+
+    /// Returns attributes for the separate hidden input carrying the end date.
+    ///
+    /// Only meaningful when `end_name` is set on `Props`. The value is the end
+    /// field's own date.
+    #[must_use]
+    pub fn end_hidden_input_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        attrs.set(HtmlAttr::Type, "hidden");
+
+        if let Some(name) = &self.ctx.end_name {
+            attrs.set(HtmlAttr::Name, name);
+        }
+
+        if self.ctx.disabled {
+            attrs.set_bool(HtmlAttr::Disabled, true);
+        }
+
+        let value = if let Some(end) = &self.ctx.end_date {
+            end.to_iso8601()
+        } else {
+            String::new()
+        };
+
+        attrs.set(HtmlAttr::Value, value);
+
+        attrs
+    }
+
+    /// Builds the child [`range_calendar::Props`] for the embedded calendar.
+    ///
+    /// The calendar reflects the picker's canonical range as a controlled value,
+    /// and inherits the picker's bounds, today, visible-month count, and layout
+    /// direction. Defaults supply `page_behavior` and the remaining fields.
+    #[must_use]
+    pub fn range_calendar_props(&self) -> range_calendar::Props {
+        range_calendar::Props {
+            id: self.ctx.ids.part("calendar"),
+            value: Some(self.ctx.value.get().clone()),
+            min: self.ctx.min.clone(),
+            max: self.ctx.max.clone(),
+            today: self.ctx.today.clone(),
+            visible_months: self.ctx.visible_months,
+            is_rtl: self.ctx.is_rtl,
+            disabled: self.ctx.disabled,
+            readonly: self.ctx.readonly,
+            ..range_calendar::Props::default()
+        }
+    }
+
+    /// Returns a screen-reader description of the full range (e.g. "March 1, 2025
+    /// to March 15, 2025"), or `None` if no complete range is selected.
+    #[must_use]
+    pub fn range_description(&self) -> Option<String> {
+        let range = self.ctx.value.get().as_ref()?;
+
+        let start = format_date_label(
+            &range.start,
+            self.ctx.intl_backend.as_ref(),
+            &self.ctx.locale,
+        );
+
+        let end = format_date_label(&range.end, self.ctx.intl_backend.as_ref(), &self.ctx.locale);
+
+        Some((self.ctx.messages.range_description)(
+            &start,
+            &end,
+            &self.ctx.locale,
+        ))
+    }
+
+    // ── Event dispatch (called by adapters) ──────────────────────────────
+
+    /// Opens the popover.
+    pub fn open(&self) {
+        (self.send)(Event::Open);
+    }
+
+    /// Closes the popover.
+    pub fn close(&self) {
+        (self.send)(Event::Close);
+    }
+
+    /// Toggles the popover.
+    pub fn toggle(&self) {
+        (self.send)(Event::Toggle);
+    }
+
+    /// Clears the selected range.
+    pub fn clear(&self) {
+        (self.send)(Event::Clear);
+    }
+
+    /// Reports a completed range selection from the embedded calendar.
+    pub fn select_range(&self, range: DateRange) {
+        (self.send)(Event::SelectRangeComplete { range });
+    }
+
+    /// Selects the preset at `index`.
+    pub fn select_preset(&self, index: usize) {
+        (self.send)(Event::SelectPreset { index });
+    }
+
+    /// Reports a start-date change from the start field.
+    pub fn set_start_value(&self, date: Option<CalendarDate>) {
+        (self.send)(Event::StartValueChange(date));
+    }
+
+    /// Reports an end-date change from the end field.
+    pub fn set_end_value(&self, date: Option<CalendarDate>) {
+        (self.send)(Event::EndValueChange(date));
+    }
+
+    /// Notifies the machine that focus entered the component.
+    pub fn focus_in(&self) {
+        (self.send)(Event::FocusIn);
+    }
+
+    /// Notifies the machine that focus left the component entirely.
+    pub fn focus_out(&self) {
+        (self.send)(Event::FocusOut);
+    }
+
+    /// Dispatches a keyboard event from the trigger or popover.
+    pub fn on_key_down(&self, key: KeyboardKey) {
+        (self.send)(Event::KeyDown { key });
+    }
+
+    // ── Convenience getters ──────────────────────────────────────────────
+
+    /// Returns `true` when the popover is open.
+    #[must_use]
+    pub const fn is_open(&self) -> bool {
+        matches!(self.state, State::Open)
+    }
+
+    /// Returns the currently selected range, if any.
+    #[must_use]
+    pub fn selected_range(&self) -> Option<&DateRange> {
+        self.ctx.value.get().as_ref()
+    }
+
+    /// Returns the field that most recently received a value change.
+    #[must_use]
+    pub const fn active_field(&self) -> ActiveField {
+        self.ctx.active_field
+    }
+
+    /// Returns the configured preset ranges.
+    #[must_use]
+    pub fn presets(&self) -> &[Preset] {
+        &self.ctx.presets
+    }
+
+    /// Returns the label of the preset at `index`, if it exists.
+    #[must_use]
+    pub fn preset_label(&self, index: usize) -> Option<&str> {
+        self.ctx
+            .presets
+            .get(index)
+            .map(|preset| preset.label.as_str())
+    }
+
+    /// Returns `true` when the current range violates the min/max bounds.
+    #[must_use]
+    pub fn is_invalid(&self) -> bool {
+        self.ctx.is_invalid()
+    }
+
+    /// Returns the stable state token used for `data-ars-state`.
+    #[must_use]
+    pub const fn state_name(&self) -> &'static str {
+        match self.state {
+            State::Closed => "closed",
+            State::Open => "open",
+        }
+    }
+}
+
+impl ConnectApi for Api<'_> {
+    type Part = Part;
+
+    fn part_attrs(&self, part: Part) -> AttrMap {
+        match part {
+            Part::Root => self.root_attrs(),
+            Part::Label => self.label_attrs(),
+            Part::Control => self.control_attrs(),
+            Part::StartInput => self.start_input_attrs(),
+            Part::Separator => self.separator_attrs(),
+            Part::EndInput => self.end_input_attrs(),
+            Part::Trigger => self.trigger_attrs(),
+            Part::ClearTrigger => self.clear_trigger_attrs(),
+            Part::PresetTrigger { index } => self.preset_trigger_attrs(index),
+            Part::Positioner => self.positioner_attrs(),
+            Part::Content => self.content_attrs(),
+            Part::Description => self.description_attrs(),
+            Part::ErrorMessage => self.error_message_attrs(),
+            Part::HiddenInput => self.hidden_input_attrs(),
+        }
+    }
+}

--- a/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_clear_trigger_empty.snap
+++ b/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_clear_trigger_empty.snap
@@ -1,0 +1,45 @@
+---
+source: crates/ars-components/src/date_time/date_range_picker/tests.rs
+expression: snapshot_attrs(&api.clear_trigger_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "clear-trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "date-range-picker",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Clear date range",
+            ),
+        ),
+        (
+            Disabled,
+            Bool(
+                true,
+            ),
+        ),
+        (
+            Type,
+            String(
+                "button",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_clear_trigger_with_value.snap
+++ b/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_clear_trigger_with_value.snap
@@ -1,0 +1,39 @@
+---
+source: crates/ars-components/src/date_time/date_range_picker/tests.rs
+expression: snapshot_attrs(&api.clear_trigger_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "clear-trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "date-range-picker",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Clear date range",
+            ),
+        ),
+        (
+            Type,
+            String(
+                "button",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_content.snap
+++ b/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_content.snap
@@ -1,0 +1,53 @@
+---
+source: crates/ars-components/src/date_time/date_range_picker/tests.rs
+expression: snapshot_attrs(&api.content_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "content",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "date-range-picker",
+            ),
+        ),
+        (
+            Aria(
+                LabelledBy,
+            ),
+            String(
+                "trip-label",
+            ),
+        ),
+        (
+            Aria(
+                Modal,
+            ),
+            String(
+                "false",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "trip-content",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "dialog",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_control.snap
+++ b/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_control.snap
@@ -1,0 +1,39 @@
+---
+source: crates/ars-components/src/date_time/date_range_picker/tests.rs
+expression: snapshot_attrs(&api.control_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "control",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "date-range-picker",
+            ),
+        ),
+        (
+            Aria(
+                LabelledBy,
+            ),
+            String(
+                "trip-label",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "group",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_control_with_description_and_error.snap
+++ b/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_control_with_description_and_error.snap
@@ -1,0 +1,47 @@
+---
+source: crates/ars-components/src/date_time/date_range_picker/tests.rs
+expression: snapshot_attrs(&api.control_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "control",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "date-range-picker",
+            ),
+        ),
+        (
+            Aria(
+                LabelledBy,
+            ),
+            String(
+                "trip-label",
+            ),
+        ),
+        (
+            Aria(
+                DescribedBy,
+            ),
+            String(
+                "trip-description trip-error-message",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "group",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_description.snap
+++ b/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_description.snap
@@ -1,0 +1,31 @@
+---
+source: crates/ars-components/src/date_time/date_range_picker/tests.rs
+expression: snapshot_attrs(&api.description_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "description",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "date-range-picker",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "trip-description",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_end_field_props.snap
+++ b/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_end_field_props.snap
@@ -1,0 +1,45 @@
+---
+source: crates/ars-components/src/date_time/date_range_picker/tests.rs
+expression: snapshot_attrs(&child)
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "field-group",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "date-field",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "End date",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "trip-end-input-field-group",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "group",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_end_hidden_input.snap
+++ b/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_end_hidden_input.snap
@@ -1,0 +1,27 @@
+---
+source: crates/ars-components/src/date_time/date_range_picker/tests.rs
+expression: snapshot_attrs(&api.end_hidden_input_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Name,
+            String(
+                "to",
+            ),
+        ),
+        (
+            Type,
+            String(
+                "hidden",
+            ),
+        ),
+        (
+            Value,
+            String(
+                "2024-01-20",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_end_input_marker.snap
+++ b/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_end_input_marker.snap
@@ -1,0 +1,25 @@
+---
+source: crates/ars-components/src/date_time/date_range_picker/tests.rs
+expression: snapshot_attrs(&api.end_input_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "end-input",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "date-range-picker",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_error_message.snap
+++ b/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_error_message.snap
@@ -1,0 +1,37 @@
+---
+source: crates/ars-components/src/date_time/date_range_picker/tests.rs
+expression: snapshot_attrs(&api.error_message_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "error-message",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "date-range-picker",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "trip-error-message",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "alert",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_hidden_input_empty.snap
+++ b/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_hidden_input_empty.snap
@@ -1,0 +1,43 @@
+---
+source: crates/ars-components/src/date_time/date_range_picker/tests.rs
+expression: snapshot_attrs(&api.hidden_input_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "hidden-input",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "date-range-picker",
+            ),
+        ),
+        (
+            Name,
+            String(
+                "range",
+            ),
+        ),
+        (
+            Type,
+            String(
+                "hidden",
+            ),
+        ),
+        (
+            Value,
+            String(
+                "",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_hidden_input_with_range.snap
+++ b/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_hidden_input_with_range.snap
@@ -1,0 +1,43 @@
+---
+source: crates/ars-components/src/date_time/date_range_picker/tests.rs
+expression: snapshot_attrs(&api.hidden_input_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "hidden-input",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "date-range-picker",
+            ),
+        ),
+        (
+            Name,
+            String(
+                "range",
+            ),
+        ),
+        (
+            Type,
+            String(
+                "hidden",
+            ),
+        ),
+        (
+            Value,
+            String(
+                "2024-01-10/2024-01-20",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_label.snap
+++ b/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_label.snap
@@ -1,0 +1,37 @@
+---
+source: crates/ars-components/src/date_time/date_range_picker/tests.rs
+expression: snapshot_attrs(&api.label_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "label",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "date-range-picker",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "trip-label",
+            ),
+        ),
+        (
+            For,
+            String(
+                "trip-start-input",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_positioner.snap
+++ b/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_positioner.snap
@@ -1,0 +1,25 @@
+---
+source: crates/ars-components/src/date_time/date_range_picker/tests.rs
+expression: snapshot_attrs(&api.positioner_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "positioner",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "date-range-picker",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_preset_trigger.snap
+++ b/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_preset_trigger.snap
@@ -1,0 +1,39 @@
+---
+source: crates/ars-components/src/date_time/date_range_picker/tests.rs
+expression: snapshot_attrs(&api.preset_trigger_attrs(1))
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-index",
+            ),
+            String(
+                "1",
+            ),
+        ),
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "preset-trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "date-range-picker",
+            ),
+        ),
+        (
+            Type,
+            String(
+                "button",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_root_closed.snap
+++ b/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_root_closed.snap
@@ -1,0 +1,39 @@
+---
+source: crates/ars-components/src/date_time/date_range_picker/tests.rs
+expression: snapshot_attrs(&api.root_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "date-range-picker",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "closed",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "trip",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_root_disabled.snap
+++ b/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_root_disabled.snap
@@ -1,0 +1,47 @@
+---
+source: crates/ars-components/src/date_time/date_range_picker/tests.rs
+expression: snapshot_attrs(&api.root_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-disabled",
+            ),
+            Bool(
+                true,
+            ),
+        ),
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "date-range-picker",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "closed",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "trip",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_root_invalid.snap
+++ b/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_root_invalid.snap
@@ -1,0 +1,47 @@
+---
+source: crates/ars-components/src/date_time/date_range_picker/tests.rs
+expression: snapshot_attrs(&api.root_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-invalid",
+            ),
+            Bool(
+                true,
+            ),
+        ),
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "date-range-picker",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "closed",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "trip",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_root_open.snap
+++ b/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_root_open.snap
@@ -1,0 +1,39 @@
+---
+source: crates/ars-components/src/date_time/date_range_picker/tests.rs
+expression: snapshot_attrs(&api.root_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "date-range-picker",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "open",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "trip",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_root_readonly.snap
+++ b/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_root_readonly.snap
@@ -1,0 +1,47 @@
+---
+source: crates/ars-components/src/date_time/date_range_picker/tests.rs
+expression: snapshot_attrs(&api.root_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-readonly",
+            ),
+            Bool(
+                true,
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "date-range-picker",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "closed",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "trip",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_root_required.snap
+++ b/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_root_required.snap
@@ -1,0 +1,47 @@
+---
+source: crates/ars-components/src/date_time/date_range_picker/tests.rs
+expression: snapshot_attrs(&api.root_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-required",
+            ),
+            Bool(
+                true,
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "date-range-picker",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "closed",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "trip",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_separator.snap
+++ b/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_separator.snap
@@ -1,0 +1,33 @@
+---
+source: crates/ars-components/src/date_time/date_range_picker/tests.rs
+expression: snapshot_attrs(&api.separator_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "separator",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "date-range-picker",
+            ),
+        ),
+        (
+            Aria(
+                Hidden,
+            ),
+            String(
+                "true",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_start_field_props.snap
+++ b/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_start_field_props.snap
@@ -1,0 +1,45 @@
+---
+source: crates/ars-components/src/date_time/date_range_picker/tests.rs
+expression: snapshot_attrs(&child)
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "field-group",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "date-field",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Start date",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "trip-start-input-field-group",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "group",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_start_hidden_input.snap
+++ b/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_start_hidden_input.snap
@@ -1,0 +1,27 @@
+---
+source: crates/ars-components/src/date_time/date_range_picker/tests.rs
+expression: snapshot_attrs(&api.start_hidden_input_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Name,
+            String(
+                "from",
+            ),
+        ),
+        (
+            Type,
+            String(
+                "hidden",
+            ),
+        ),
+        (
+            Value,
+            String(
+                "2024-01-10",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_start_input_marker.snap
+++ b/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_start_input_marker.snap
@@ -1,0 +1,25 @@
+---
+source: crates/ars-components/src/date_time/date_range_picker/tests.rs
+expression: snapshot_attrs(&api.start_input_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "start-input",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "date-range-picker",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_trigger_closed.snap
+++ b/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_trigger_closed.snap
@@ -1,0 +1,69 @@
+---
+source: crates/ars-components/src/date_time/date_range_picker/tests.rs
+expression: snapshot_attrs(&api.trigger_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "date-range-picker",
+            ),
+        ),
+        (
+            Aria(
+                Expanded,
+            ),
+            String(
+                "false",
+            ),
+        ),
+        (
+            Aria(
+                HasPopup,
+            ),
+            String(
+                "dialog",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Open date range picker",
+            ),
+        ),
+        (
+            Aria(
+                Controls,
+            ),
+            String(
+                "trip-content",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "trip-trigger",
+            ),
+        ),
+        (
+            Type,
+            String(
+                "button",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_trigger_disabled.snap
+++ b/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_trigger_disabled.snap
@@ -1,0 +1,75 @@
+---
+source: crates/ars-components/src/date_time/date_range_picker/tests.rs
+expression: snapshot_attrs(&api.trigger_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "date-range-picker",
+            ),
+        ),
+        (
+            Aria(
+                Expanded,
+            ),
+            String(
+                "false",
+            ),
+        ),
+        (
+            Aria(
+                HasPopup,
+            ),
+            String(
+                "dialog",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Open date range picker",
+            ),
+        ),
+        (
+            Aria(
+                Controls,
+            ),
+            String(
+                "trip-content",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "trip-trigger",
+            ),
+        ),
+        (
+            Disabled,
+            Bool(
+                true,
+            ),
+        ),
+        (
+            Type,
+            String(
+                "button",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_trigger_open.snap
+++ b/crates/ars-components/src/date_time/date_range_picker/snapshots/ars_components__date_time__date_range_picker__tests__snapshot_trigger_open.snap
@@ -1,0 +1,69 @@
+---
+source: crates/ars-components/src/date_time/date_range_picker/tests.rs
+expression: snapshot_attrs(&api.trigger_attrs())
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "date-range-picker",
+            ),
+        ),
+        (
+            Aria(
+                Expanded,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Aria(
+                HasPopup,
+            ),
+            String(
+                "dialog",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Open date range picker",
+            ),
+        ),
+        (
+            Aria(
+                Controls,
+            ),
+            String(
+                "trip-content",
+            ),
+        ),
+        (
+            Id,
+            String(
+                "trip-trigger",
+            ),
+        ),
+        (
+            Type,
+            String(
+                "button",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/date_time/date_range_picker/tests.rs
+++ b/crates/ars-components/src/date_time/date_range_picker/tests.rs
@@ -263,6 +263,27 @@ fn select_range_complete_blocked_when_readonly() {
     assert!(svc.context().value.get().is_none());
 }
 
+#[test]
+fn select_range_complete_commits_even_after_close() {
+    // Browser ordering: clicking a calendar cell can fire FocusOut (closing the
+    // popover) before the calendar reports the completed range. The selection
+    // must still commit; only the close side-effect is gated on being open.
+    let mut svc = service();
+    drop(svc.send(Event::Open));
+    drop(svc.send(Event::FocusOut));
+    assert_eq!(*svc.state(), State::Closed);
+
+    let selected = range(date(2025, 3, 1), date(2025, 3, 15));
+    drop(svc.send(Event::SelectRangeComplete {
+        range: selected.clone(),
+    }));
+
+    assert_eq!(*svc.state(), State::Closed);
+    assert_eq!(*svc.context().value.get(), Some(selected));
+    assert_eq!(svc.context().start_date, Some(date(2025, 3, 1)));
+    assert_eq!(svc.context().end_date, Some(date(2025, 3, 15)));
+}
+
 // ────────────────────────────────────────────────────────────────────
 // Field value coordination
 // ────────────────────────────────────────────────────────────────────
@@ -648,6 +669,23 @@ fn disabled_component_still_processes_sync_props() {
     assert_eq!(*svc.state(), State::Open);
 }
 
+#[test]
+fn disabling_via_props_while_open_closes_popover() {
+    // Disabling an open picker must dismiss it: otherwise the disabled guard
+    // blocks Escape/FocusOut/Close and the dialog is stuck open.
+    let mut svc = service();
+    drop(svc.send(Event::Open));
+    assert_eq!(*svc.state(), State::Open);
+
+    drop(svc.set_props(Props {
+        disabled: true,
+        ..props()
+    }));
+
+    assert_eq!(*svc.state(), State::Closed);
+    assert!(!*svc.context().open.get());
+}
+
 // ────────────────────────────────────────────────────────────────────
 // Connect API: ARIA / attributes
 // ────────────────────────────────────────────────────────────────────
@@ -756,6 +794,27 @@ fn clear_trigger_enabled_with_value() {
     let api = svc.connect(&|_| {});
 
     assert_eq!(attr(&api.clear_trigger_attrs(), HtmlAttr::Disabled), None);
+}
+
+#[test]
+fn clear_trigger_disabled_when_readonly() {
+    // `Event::Clear` is rejected when readonly, so the rendered control must be
+    // disabled rather than expose an actionable button that does nothing.
+    let svc = service_with(
+        Props {
+            default_value: Some(range(date(2025, 6, 1), date(2025, 6, 15))),
+            readonly: true,
+            ..props()
+        },
+        en_us(),
+    );
+
+    let api = svc.connect(&|_| {});
+
+    assert_eq!(
+        attr(&api.clear_trigger_attrs(), HtmlAttr::Disabled).as_deref(),
+        Some("true")
+    );
 }
 
 #[test]
@@ -1001,6 +1060,27 @@ fn preset_helpers_expose_labels_and_attrs() {
     // Out-of-range preset trigger is disabled.
     assert_eq!(
         attr(&api.preset_trigger_attrs(9), HtmlAttr::Disabled).as_deref(),
+        Some("true")
+    );
+}
+
+#[test]
+fn preset_trigger_disabled_when_readonly() {
+    // `Event::SelectPreset` is rejected when readonly, so a valid preset's
+    // button must render disabled rather than do nothing when clicked.
+    let svc = service_with(
+        Props {
+            presets: sample_presets(),
+            readonly: true,
+            ..props()
+        },
+        en_us(),
+    );
+
+    let api = svc.connect(&|_| {});
+
+    assert_eq!(
+        attr(&api.preset_trigger_attrs(0), HtmlAttr::Disabled).as_deref(),
         Some("true")
     );
 }

--- a/crates/ars-components/src/date_time/date_range_picker/tests.rs
+++ b/crates/ars-components/src/date_time/date_range_picker/tests.rs
@@ -1,0 +1,1499 @@
+//! Unit and snapshot tests for the `DateRangePicker` component.
+//!
+//! Test names that begin with `snapshot_` use `insta::assert_snapshot!` and
+//! commit golden output under `snapshots/`. Every other test is a pure
+//! state-machine or connect-API assertion that does not depend on `.snap` files.
+
+use alloc::{format, string::String, sync::Arc, vec, vec::Vec};
+
+use ars_core::{AriaAttr, AttrMap, Env, HtmlAttr, SendResult, Service};
+use ars_i18n::{CalendarDate, DateRange, Locale, StubIntlBackend, locales::en_us};
+use ars_interactions::KeyboardKey;
+use insta::assert_snapshot;
+
+use super::*;
+
+// ────────────────────────────────────────────────────────────────────
+// Helpers
+// ────────────────────────────────────────────────────────────────────
+
+fn date(year: i32, month: u8, day: u8) -> CalendarDate {
+    CalendarDate::new_gregorian(year, month, day).expect("valid test date")
+}
+
+fn range(start: CalendarDate, end: CalendarDate) -> DateRange {
+    DateRange::new(start, end).expect("ordered test range")
+}
+
+fn props() -> Props {
+    Props {
+        id: String::from("trip"),
+        ..Props::default()
+    }
+}
+
+fn env(locale: Locale) -> Env {
+    Env::new(locale, Arc::new(StubIntlBackend))
+}
+
+fn service() -> Service<Machine> {
+    Service::<Machine>::new(props(), &env(en_us()), &Messages::default())
+}
+
+fn service_with(props: Props, locale: Locale) -> Service<Machine> {
+    Service::<Machine>::new(props, &env(locale), &Messages::default())
+}
+
+fn sample_presets() -> Vec<Preset> {
+    vec![
+        Preset::new("Last 7 days", range(date(2025, 5, 26), date(2025, 6, 1))),
+        Preset::new("Last 30 days", range(date(2025, 5, 3), date(2025, 6, 1))),
+    ]
+}
+
+fn snapshot_attrs(attrs: &AttrMap) -> String {
+    format!("{attrs:#?}")
+}
+
+fn attr(attrs: &AttrMap, key: HtmlAttr) -> Option<String> {
+    attrs.get(&key).map(ToString::to_string)
+}
+
+/// Returns `true` when an event was a no-op: neither the state nor the context
+/// changed (the machine's `transition` returned `None`).
+fn unchanged(result: &SendResult<Machine>) -> bool {
+    !result.state_changed && !result.context_changed
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Initial state
+// ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn initial_state_is_closed() {
+    let svc = service();
+
+    assert_eq!(*svc.state(), State::Closed);
+    assert!(!*svc.context().open.get());
+    assert!(svc.context().value.get().is_none());
+    assert_eq!(svc.context().active_field, ActiveField::Start);
+}
+
+#[test]
+fn default_value_seeds_range_and_fields() {
+    let initial = range(date(2025, 6, 1), date(2025, 6, 15));
+
+    let svc = service_with(
+        Props {
+            default_value: Some(initial.clone()),
+            ..props()
+        },
+        en_us(),
+    );
+
+    assert_eq!(*svc.context().value.get(), Some(initial));
+    assert_eq!(svc.context().start_date, Some(date(2025, 6, 1)));
+    assert_eq!(svc.context().end_date, Some(date(2025, 6, 15)));
+}
+
+#[test]
+fn controlled_value_overrides_default() {
+    let controlled = range(date(2025, 1, 1), date(2025, 1, 31));
+
+    let svc = service_with(
+        Props {
+            value: Some(Some(controlled.clone())),
+            default_value: Some(range(date(2030, 1, 1), date(2030, 1, 2))),
+            ..props()
+        },
+        en_us(),
+    );
+
+    assert_eq!(*svc.context().value.get(), Some(controlled));
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Popover open / close
+// ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn open_and_close() {
+    let mut svc = service();
+
+    drop(svc.send(Event::Open));
+
+    assert_eq!(*svc.state(), State::Open);
+    assert!(*svc.context().open.get());
+
+    drop(svc.send(Event::Close));
+
+    assert_eq!(*svc.state(), State::Closed);
+    assert!(!*svc.context().open.get());
+}
+
+#[test]
+fn toggle_flips_open_state() {
+    let mut svc = service();
+
+    drop(svc.send(Event::Toggle));
+
+    assert_eq!(*svc.state(), State::Open);
+
+    drop(svc.send(Event::Toggle));
+
+    assert_eq!(*svc.state(), State::Closed);
+}
+
+#[test]
+fn arrow_down_opens_from_closed() {
+    let mut svc = service();
+
+    drop(svc.send(Event::KeyDown {
+        key: KeyboardKey::ArrowDown,
+    }));
+
+    assert_eq!(*svc.state(), State::Open);
+}
+
+#[test]
+fn escape_closes_when_open() {
+    let mut svc = service();
+
+    drop(svc.send(Event::Open));
+    drop(svc.send(Event::KeyDown {
+        key: KeyboardKey::Escape,
+    }));
+
+    assert_eq!(*svc.state(), State::Closed);
+}
+
+#[test]
+fn escape_is_ignored_when_closed() {
+    let mut svc = service();
+
+    let result = svc.send(Event::KeyDown {
+        key: KeyboardKey::Escape,
+    });
+
+    assert!(unchanged(&result));
+    assert_eq!(*svc.state(), State::Closed);
+}
+
+#[test]
+fn focusout_closes_when_open() {
+    let mut svc = service();
+
+    drop(svc.send(Event::Open));
+    drop(svc.send(Event::FocusOut));
+
+    assert_eq!(*svc.state(), State::Closed);
+}
+
+#[test]
+fn focusin_is_a_noop() {
+    let mut svc = service();
+
+    let result = svc.send(Event::FocusIn);
+
+    assert!(unchanged(&result));
+    assert_eq!(*svc.state(), State::Closed);
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Range selection from the calendar
+// ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn select_range_complete_sets_value_and_closes() {
+    let mut svc = service();
+
+    drop(svc.send(Event::Open));
+
+    let selected = range(date(2025, 3, 1), date(2025, 3, 15));
+
+    drop(svc.send(Event::SelectRangeComplete {
+        range: selected.clone(),
+    }));
+
+    assert_eq!(*svc.state(), State::Closed);
+    assert_eq!(*svc.context().value.get(), Some(selected));
+    assert_eq!(svc.context().start_date, Some(date(2025, 3, 1)));
+    assert_eq!(svc.context().end_date, Some(date(2025, 3, 15)));
+}
+
+#[test]
+fn select_range_complete_stays_open_when_not_close_on_select() {
+    let mut svc = service_with(
+        Props {
+            close_on_select: false,
+            ..props()
+        },
+        en_us(),
+    );
+
+    drop(svc.send(Event::Open));
+
+    let selected = range(date(2025, 3, 1), date(2025, 3, 15));
+
+    drop(svc.send(Event::SelectRangeComplete {
+        range: selected.clone(),
+    }));
+
+    assert_eq!(*svc.state(), State::Open);
+    assert_eq!(*svc.context().value.get(), Some(selected));
+}
+
+#[test]
+fn select_range_complete_blocked_when_readonly() {
+    let mut svc = service_with(
+        Props {
+            readonly: true,
+            ..props()
+        },
+        en_us(),
+    );
+
+    drop(svc.send(Event::Open));
+
+    let result = svc.send(Event::SelectRangeComplete {
+        range: range(date(2025, 3, 1), date(2025, 3, 15)),
+    });
+
+    assert!(unchanged(&result));
+    assert!(svc.context().value.get().is_none());
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Field value coordination
+// ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn start_value_change_tracks_field_and_active() {
+    let mut svc = service();
+
+    drop(svc.send(Event::StartValueChange(Some(date(2025, 6, 1)))));
+
+    assert_eq!(svc.context().start_date, Some(date(2025, 6, 1)));
+    assert_eq!(svc.context().active_field, ActiveField::Start);
+    // Range incomplete until both fields are set.
+    assert!(svc.context().value.get().is_none());
+}
+
+#[test]
+fn end_value_change_tracks_field_and_active() {
+    let mut svc = service();
+
+    drop(svc.send(Event::EndValueChange(Some(date(2025, 6, 15)))));
+
+    assert_eq!(svc.context().end_date, Some(date(2025, 6, 15)));
+    assert_eq!(svc.context().active_field, ActiveField::End);
+    assert!(svc.context().value.get().is_none());
+}
+
+#[test]
+fn field_edits_assemble_into_range() {
+    let mut svc = service();
+
+    drop(svc.send(Event::StartValueChange(Some(date(2025, 6, 1)))));
+    drop(svc.send(Event::EndValueChange(Some(date(2025, 6, 15)))));
+
+    assert_eq!(
+        *svc.context().value.get(),
+        Some(range(date(2025, 6, 1), date(2025, 6, 15)))
+    );
+}
+
+#[test]
+fn range_normalizes_when_start_after_end() {
+    let mut svc = service();
+
+    drop(svc.send(Event::StartValueChange(Some(date(2025, 6, 25)))));
+    drop(svc.send(Event::EndValueChange(Some(date(2025, 6, 1)))));
+
+    // The two field values are swapped so the canonical range stays ordered.
+    assert_eq!(
+        *svc.context().value.get(),
+        Some(range(date(2025, 6, 1), date(2025, 6, 25)))
+    );
+    assert_eq!(svc.context().start_date, Some(date(2025, 6, 1)));
+    assert_eq!(svc.context().end_date, Some(date(2025, 6, 25)));
+}
+
+#[test]
+fn clearing_a_field_clears_the_range() {
+    let mut svc = service_with(
+        Props {
+            default_value: Some(range(date(2025, 6, 1), date(2025, 6, 15))),
+            ..props()
+        },
+        en_us(),
+    );
+
+    drop(svc.send(Event::StartValueChange(None)));
+
+    assert!(svc.context().value.get().is_none());
+    assert!(svc.context().start_date.is_none());
+    assert_eq!(svc.context().end_date, Some(date(2025, 6, 15)));
+}
+
+#[test]
+fn field_value_change_blocked_when_readonly() {
+    let mut svc = service_with(
+        Props {
+            readonly: true,
+            ..props()
+        },
+        en_us(),
+    );
+
+    assert!(unchanged(
+        &svc.send(Event::StartValueChange(Some(date(2025, 6, 1))))
+    ));
+    assert!(unchanged(
+        &svc.send(Event::EndValueChange(Some(date(2025, 6, 15))))
+    ));
+    assert!(svc.context().start_date.is_none());
+    assert!(svc.context().end_date.is_none());
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Clear
+// ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn clear_resets_value_and_fields() {
+    let mut svc = service_with(
+        Props {
+            default_value: Some(range(date(2025, 6, 1), date(2025, 6, 15))),
+            ..props()
+        },
+        en_us(),
+    );
+
+    drop(svc.send(Event::Clear));
+
+    assert!(svc.context().value.get().is_none());
+    assert!(svc.context().start_date.is_none());
+    assert!(svc.context().end_date.is_none());
+}
+
+#[test]
+fn clear_blocked_when_readonly() {
+    let mut svc = service_with(
+        Props {
+            default_value: Some(range(date(2025, 6, 1), date(2025, 6, 15))),
+            readonly: true,
+            ..props()
+        },
+        en_us(),
+    );
+
+    let result = svc.send(Event::Clear);
+
+    assert!(unchanged(&result));
+    assert!(svc.context().value.get().is_some());
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Presets
+// ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn select_preset_applies_range_and_closes() {
+    let mut svc = service_with(
+        Props {
+            presets: sample_presets(),
+            ..props()
+        },
+        en_us(),
+    );
+
+    drop(svc.send(Event::Open));
+    drop(svc.send(Event::SelectPreset { index: 0 }));
+
+    assert_eq!(*svc.state(), State::Closed);
+    assert_eq!(
+        *svc.context().value.get(),
+        Some(range(date(2025, 5, 26), date(2025, 6, 1)))
+    );
+    assert_eq!(svc.context().start_date, Some(date(2025, 5, 26)));
+    assert_eq!(svc.context().end_date, Some(date(2025, 6, 1)));
+}
+
+#[test]
+fn select_preset_from_closed_stays_closed() {
+    let mut svc = service_with(
+        Props {
+            presets: sample_presets(),
+            ..props()
+        },
+        en_us(),
+    );
+
+    drop(svc.send(Event::SelectPreset { index: 1 }));
+
+    assert_eq!(*svc.state(), State::Closed);
+    assert_eq!(
+        *svc.context().value.get(),
+        Some(range(date(2025, 5, 3), date(2025, 6, 1)))
+    );
+}
+
+#[test]
+fn select_preset_out_of_range_is_ignored() {
+    let mut svc = service_with(
+        Props {
+            presets: sample_presets(),
+            ..props()
+        },
+        en_us(),
+    );
+
+    let result = svc.send(Event::SelectPreset { index: 9 });
+
+    assert!(unchanged(&result));
+    assert!(svc.context().value.get().is_none());
+}
+
+#[test]
+fn select_preset_blocked_when_readonly() {
+    let mut svc = service_with(
+        Props {
+            presets: sample_presets(),
+            readonly: true,
+            ..props()
+        },
+        en_us(),
+    );
+
+    let result = svc.send(Event::SelectPreset { index: 0 });
+
+    assert!(unchanged(&result));
+    assert!(svc.context().value.get().is_none());
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Disabled
+// ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn disabled_ignores_events() {
+    let mut svc = service_with(
+        Props {
+            disabled: true,
+            ..props()
+        },
+        en_us(),
+    );
+
+    assert!(unchanged(&svc.send(Event::Open)));
+    assert!(unchanged(&svc.send(Event::Toggle)));
+    assert!(unchanged(
+        &svc.send(Event::StartValueChange(Some(date(2025, 6, 1))))
+    ));
+    assert_eq!(*svc.state(), State::Closed);
+    assert!(svc.context().start_date.is_none());
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Controlled prop sync
+// ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn controlled_value_syncs_via_set_props() {
+    let mut svc = service_with(
+        Props {
+            value: Some(Some(range(date(2025, 6, 1), date(2025, 6, 15)))),
+            name: Some(String::from("trip-range")),
+            ..props()
+        },
+        en_us(),
+    );
+
+    drop(svc.set_props(Props {
+        value: Some(Some(range(date(2025, 9, 1), date(2025, 9, 30)))),
+        name: Some(String::from("trip-range")),
+        ..props()
+    }));
+
+    let ctx = svc.context();
+
+    assert_eq!(ctx.start_date, Some(date(2025, 9, 1)));
+    assert_eq!(ctx.end_date, Some(date(2025, 9, 30)));
+    assert_eq!(
+        *ctx.value.get(),
+        Some(range(date(2025, 9, 1), date(2025, 9, 30)))
+    );
+}
+
+#[test]
+fn controlled_to_uncontrolled_reveals_consistent_value() {
+    // A controlled instance whose parent later stops passing `value` (drops to
+    // uncontrolled) must reveal an internal value that matches the per-field
+    // values, not a stale earlier value.
+    let mut svc = service_with(
+        Props {
+            value: Some(Some(range(date(2025, 6, 1), date(2025, 6, 15)))),
+            ..props()
+        },
+        en_us(),
+    );
+
+    // The second update carries no `value` (uncontrolled), keeping the same id.
+    drop(svc.set_props(props()));
+
+    let ctx = svc.context();
+
+    assert!(!ctx.value.is_controlled());
+    assert_eq!(ctx.start_date, Some(date(2025, 6, 1)));
+    assert_eq!(ctx.end_date, Some(date(2025, 6, 15)));
+    assert_eq!(
+        *ctx.value.get(),
+        Some(range(date(2025, 6, 1), date(2025, 6, 15)))
+    );
+}
+
+#[test]
+fn identical_props_emit_no_sync() {
+    let mut svc = service();
+
+    // An unchanged props snapshot must not produce a SyncProps event.
+    let result = svc.set_props(props());
+
+    assert!(unchanged(&result));
+}
+
+#[test]
+fn hidden_inputs_when_disabled_and_empty() {
+    let svc = service_with(
+        Props {
+            disabled: true,
+            name: Some(String::from("range")),
+            start_name: Some(String::from("from")),
+            end_name: Some(String::from("to")),
+            ..props()
+        },
+        en_us(),
+    );
+
+    let api = svc.connect(&|_| {});
+
+    // Disabled controls are excluded from submission via `disabled`, and an
+    // empty range submits an empty value.
+    let combined = api.hidden_input_attrs();
+
+    assert_eq!(attr(&combined, HtmlAttr::Disabled).as_deref(), Some("true"));
+    assert_eq!(attr(&combined, HtmlAttr::Value).as_deref(), Some(""));
+
+    let start = api.start_hidden_input_attrs();
+
+    assert_eq!(attr(&start, HtmlAttr::Disabled).as_deref(), Some("true"));
+    assert_eq!(attr(&start, HtmlAttr::Value).as_deref(), Some(""));
+
+    let end = api.end_hidden_input_attrs();
+
+    assert_eq!(attr(&end, HtmlAttr::Disabled).as_deref(), Some("true"));
+    assert_eq!(attr(&end, HtmlAttr::Value).as_deref(), Some(""));
+}
+
+#[test]
+fn prop_updates_sync_bounds_today_and_presets() {
+    let mut svc = service();
+
+    drop(svc.set_props(Props {
+        min: Some(date(2025, 1, 1)),
+        max: Some(date(2025, 12, 31)),
+        today: date(2025, 7, 4),
+        presets: sample_presets(),
+        visible_months: 3,
+        is_rtl: true,
+        readonly: true,
+        required: true,
+        ..props()
+    }));
+
+    let ctx = svc.context();
+
+    assert_eq!(ctx.min, Some(date(2025, 1, 1)));
+    assert_eq!(ctx.max, Some(date(2025, 12, 31)));
+    assert_eq!(ctx.today, date(2025, 7, 4));
+    assert_eq!(ctx.presets.len(), 2);
+    assert_eq!(ctx.visible_months, 3);
+    assert!(ctx.is_rtl);
+    assert!(ctx.readonly);
+    assert!(ctx.required);
+}
+
+#[test]
+fn disabled_component_still_processes_sync_props() {
+    let mut svc = service_with(
+        Props {
+            disabled: true,
+            ..props()
+        },
+        en_us(),
+    );
+
+    // Re-enabling via props must reach the context even though the component is
+    // currently disabled.
+    drop(svc.set_props(Props {
+        disabled: false,
+        ..props()
+    }));
+
+    assert!(!svc.context().disabled);
+
+    drop(svc.send(Event::Open));
+
+    assert_eq!(*svc.state(), State::Open);
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Connect API: ARIA / attributes
+// ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn label_targets_start_input() {
+    let svc = service();
+
+    let api = svc.connect(&|_| {});
+
+    assert_eq!(
+        attr(&api.label_attrs(), HtmlAttr::For).as_deref(),
+        Some("trip-start-input")
+    );
+}
+
+#[test]
+fn control_is_a_labelled_group() {
+    let svc = service();
+
+    let api = svc.connect(&|_| {});
+
+    let attrs = api.control_attrs();
+
+    assert_eq!(attr(&attrs, HtmlAttr::Role).as_deref(), Some("group"));
+    assert_eq!(
+        attr(&attrs, HtmlAttr::Aria(AriaAttr::LabelledBy)).as_deref(),
+        Some("trip-label")
+    );
+}
+
+#[test]
+fn control_describedby_chains_description_and_error() {
+    let svc = service_with(
+        Props {
+            has_description: true,
+            has_error_message: true,
+            ..props()
+        },
+        en_us(),
+    );
+
+    let api = svc.connect(&|_| {});
+
+    assert_eq!(
+        attr(&api.control_attrs(), HtmlAttr::Aria(AriaAttr::DescribedBy)).as_deref(),
+        Some("trip-description trip-error-message")
+    );
+}
+
+#[test]
+fn trigger_exposes_popup_expanded_and_controls() {
+    let mut svc = service();
+
+    {
+        let api = svc.connect(&|_| {});
+
+        let attrs = api.trigger_attrs();
+
+        assert_eq!(
+            attr(&attrs, HtmlAttr::Aria(AriaAttr::HasPopup)).as_deref(),
+            Some("dialog")
+        );
+        assert_eq!(
+            attr(&attrs, HtmlAttr::Aria(AriaAttr::Expanded)).as_deref(),
+            Some("false")
+        );
+        assert_eq!(
+            attr(&attrs, HtmlAttr::Aria(AriaAttr::Controls)).as_deref(),
+            Some("trip-content")
+        );
+    }
+
+    drop(svc.send(Event::Open));
+
+    let api = svc.connect(&|_| {});
+
+    assert_eq!(
+        attr(&api.trigger_attrs(), HtmlAttr::Aria(AriaAttr::Expanded)).as_deref(),
+        Some("true")
+    );
+}
+
+#[test]
+fn clear_trigger_disabled_when_empty() {
+    let svc = service();
+
+    let api = svc.connect(&|_| {});
+
+    assert_eq!(
+        attr(&api.clear_trigger_attrs(), HtmlAttr::Disabled).as_deref(),
+        Some("true")
+    );
+}
+
+#[test]
+fn clear_trigger_enabled_with_value() {
+    let svc = service_with(
+        Props {
+            default_value: Some(range(date(2025, 6, 1), date(2025, 6, 15))),
+            ..props()
+        },
+        en_us(),
+    );
+
+    let api = svc.connect(&|_| {});
+
+    assert_eq!(attr(&api.clear_trigger_attrs(), HtmlAttr::Disabled), None);
+}
+
+#[test]
+fn content_is_a_non_modal_dialog() {
+    let svc = service();
+
+    let api = svc.connect(&|_| {});
+
+    let attrs = api.content_attrs();
+
+    assert_eq!(attr(&attrs, HtmlAttr::Role).as_deref(), Some("dialog"));
+    assert_eq!(
+        attr(&attrs, HtmlAttr::Aria(AriaAttr::Modal)).as_deref(),
+        Some("false")
+    );
+    assert_eq!(
+        attr(&attrs, HtmlAttr::Aria(AriaAttr::LabelledBy)).as_deref(),
+        Some("trip-label")
+    );
+    assert_eq!(attr(&attrs, HtmlAttr::Id).as_deref(), Some("trip-content"));
+}
+
+#[test]
+fn error_message_has_alert_role() {
+    let svc = service();
+
+    let api = svc.connect(&|_| {});
+
+    assert_eq!(
+        attr(&api.error_message_attrs(), HtmlAttr::Role).as_deref(),
+        Some("alert")
+    );
+}
+
+#[test]
+fn root_marks_invalid_when_out_of_bounds() {
+    let svc = service_with(
+        Props {
+            max: Some(date(2025, 6, 30)),
+            default_value: Some(range(date(2025, 6, 1), date(2025, 7, 15))),
+            ..props()
+        },
+        en_us(),
+    );
+
+    let api = svc.connect(&|_| {});
+
+    assert!(api.is_invalid());
+    assert_eq!(
+        attr(&api.root_attrs(), HtmlAttr::Data("ars-invalid")).as_deref(),
+        Some("true")
+    );
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Connect API: form integration
+// ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn hidden_input_carries_iso_interval() {
+    let svc = service_with(
+        Props {
+            default_value: Some(range(date(2024, 1, 10), date(2024, 1, 20))),
+            name: Some(String::from("range")),
+            ..props()
+        },
+        en_us(),
+    );
+
+    let api = svc.connect(&|_| {});
+
+    let attrs = api.hidden_input_attrs();
+
+    assert_eq!(attr(&attrs, HtmlAttr::Name).as_deref(), Some("range"));
+    assert_eq!(
+        attr(&attrs, HtmlAttr::Value).as_deref(),
+        Some("2024-01-10/2024-01-20")
+    );
+}
+
+#[test]
+fn hidden_input_empty_without_range() {
+    let svc = service_with(
+        Props {
+            name: Some(String::from("range")),
+            ..props()
+        },
+        en_us(),
+    );
+
+    let api = svc.connect(&|_| {});
+
+    assert_eq!(
+        attr(&api.hidden_input_attrs(), HtmlAttr::Value).as_deref(),
+        Some("")
+    );
+}
+
+#[test]
+fn split_hidden_inputs_carry_each_endpoint() {
+    let svc = service_with(
+        Props {
+            default_value: Some(range(date(2024, 1, 10), date(2024, 1, 20))),
+            start_name: Some(String::from("from")),
+            end_name: Some(String::from("to")),
+            ..props()
+        },
+        en_us(),
+    );
+
+    let api = svc.connect(&|_| {});
+
+    let start = api.start_hidden_input_attrs();
+
+    assert_eq!(attr(&start, HtmlAttr::Name).as_deref(), Some("from"));
+    assert_eq!(attr(&start, HtmlAttr::Value).as_deref(), Some("2024-01-10"));
+
+    let end = api.end_hidden_input_attrs();
+
+    assert_eq!(attr(&end, HtmlAttr::Name).as_deref(), Some("to"));
+    assert_eq!(attr(&end, HtmlAttr::Value).as_deref(), Some("2024-01-20"));
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Connect API: child props + descriptions
+// ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn start_field_props_carry_bounds_and_label() {
+    let svc = service_with(
+        Props {
+            default_value: Some(range(date(2025, 6, 1), date(2025, 6, 15))),
+            min: Some(date(2025, 1, 1)),
+            max: Some(date(2025, 12, 31)),
+            ..props()
+        },
+        en_us(),
+    );
+
+    let api = svc.connect(&|_| {});
+
+    let field = api.start_field_props();
+
+    assert_eq!(field.id, "trip-start-input");
+    assert_eq!(field.value, Some(Some(date(2025, 6, 1))));
+    assert_eq!(field.min_value, Some(date(2025, 1, 1)));
+    assert_eq!(field.max_value, Some(date(2025, 12, 31)));
+    assert_eq!(field.aria_label.as_deref(), Some("Start date"));
+}
+
+#[test]
+fn end_field_props_carry_bounds_and_label() {
+    let svc = service_with(
+        Props {
+            default_value: Some(range(date(2025, 6, 1), date(2025, 6, 15))),
+            ..props()
+        },
+        en_us(),
+    );
+
+    let api = svc.connect(&|_| {});
+
+    let field = api.end_field_props();
+
+    assert_eq!(field.id, "trip-end-input");
+    assert_eq!(field.value, Some(Some(date(2025, 6, 15))));
+    assert_eq!(field.aria_label.as_deref(), Some("End date"));
+}
+
+#[test]
+fn range_calendar_props_forward_today_and_visible_months() {
+    let svc = service_with(
+        Props {
+            default_value: Some(range(date(2025, 6, 1), date(2025, 6, 15))),
+            today: date(2025, 7, 4),
+            visible_months: 3,
+            is_rtl: true,
+            ..props()
+        },
+        en_us(),
+    );
+
+    let api = svc.connect(&|_| {});
+
+    let calendar = api.range_calendar_props();
+
+    assert_eq!(calendar.id, "trip-calendar");
+    assert_eq!(calendar.today, date(2025, 7, 4));
+    assert_eq!(calendar.visible_months, 3);
+    assert!(calendar.is_rtl);
+    assert_eq!(
+        calendar.value,
+        Some(Some(range(date(2025, 6, 1), date(2025, 6, 15))))
+    );
+}
+
+#[test]
+fn range_description_present_only_when_complete() {
+    let empty = service();
+
+    assert!(empty.connect(&|_| {}).range_description().is_none());
+
+    let svc = service_with(
+        Props {
+            default_value: Some(range(date(2025, 3, 1), date(2025, 3, 15))),
+            ..props()
+        },
+        en_us(),
+    );
+
+    let api = svc.connect(&|_| {});
+
+    assert_eq!(
+        api.range_description().as_deref(),
+        Some("March 1, 2025 to March 15, 2025")
+    );
+}
+
+#[test]
+fn preset_helpers_expose_labels_and_attrs() {
+    let svc = service_with(
+        Props {
+            presets: sample_presets(),
+            ..props()
+        },
+        en_us(),
+    );
+
+    let api = svc.connect(&|_| {});
+
+    assert_eq!(api.presets().len(), 2);
+    assert_eq!(api.preset_label(0), Some("Last 7 days"));
+    assert_eq!(api.preset_label(9), None);
+
+    let attrs = api.preset_trigger_attrs(0);
+
+    assert_eq!(
+        attr(&attrs, HtmlAttr::Data("ars-index")).as_deref(),
+        Some("0")
+    );
+    assert_eq!(attr(&attrs, HtmlAttr::Disabled), None);
+
+    // Out-of-range preset trigger is disabled.
+    assert_eq!(
+        attr(&api.preset_trigger_attrs(9), HtmlAttr::Disabled).as_deref(),
+        Some("true")
+    );
+}
+
+#[test]
+fn imperative_methods_dispatch_events() {
+    use core::cell::RefCell;
+
+    let events: RefCell<Vec<Event>> = RefCell::new(Vec::new());
+    let record = |event| events.borrow_mut().push(event);
+
+    let svc = service();
+
+    let api = svc.connect(&record);
+
+    api.open();
+    api.close();
+    api.toggle();
+    api.clear();
+    api.select_range(range(date(2025, 3, 1), date(2025, 3, 15)));
+    api.select_preset(0);
+    api.set_start_value(Some(date(2025, 3, 1)));
+    api.set_end_value(None);
+    api.focus_in();
+    api.focus_out();
+    api.on_key_down(KeyboardKey::ArrowDown);
+
+    let recorded = events.borrow();
+
+    assert_eq!(recorded.len(), 11);
+    assert_eq!(recorded[0], Event::Open);
+    assert_eq!(recorded[5], Event::SelectPreset { index: 0 });
+    assert_eq!(recorded[7], Event::EndValueChange(None));
+}
+
+#[test]
+fn connect_api_dispatches_every_part() {
+    use ars_core::{ComponentPart, ConnectApi};
+
+    let svc = service_with(
+        Props {
+            presets: sample_presets(),
+            ..props()
+        },
+        en_us(),
+    );
+
+    let api = svc.connect(&|_| {});
+
+    // Every anatomy part produces attributes without panicking, exercising the
+    // `ConnectApi::part_attrs` dispatch (including the data-carrying
+    // `PresetTrigger` arm).
+    for part in Part::all() {
+        drop(api.part_attrs(part));
+    }
+}
+
+#[test]
+fn convenience_getters_reflect_state() {
+    let svc = service_with(
+        Props {
+            default_value: Some(range(date(2025, 6, 1), date(2025, 6, 15))),
+            ..props()
+        },
+        en_us(),
+    );
+
+    let api = svc.connect(&|_| {});
+
+    assert_eq!(
+        api.selected_range(),
+        Some(&range(date(2025, 6, 1), date(2025, 6, 15)))
+    );
+    assert_eq!(api.active_field(), ActiveField::Start);
+    assert!(!api.is_open());
+}
+
+#[test]
+fn debug_impls_render() {
+    let svc = service();
+
+    let api = svc.connect(&|_| {});
+
+    assert!(format!("{:?}", svc.context()).contains("Context"));
+    assert!(format!("{api:?}").contains("Api"));
+}
+
+#[test]
+fn props_builders_match_struct_literal() {
+    let built = Props::new()
+        .id("trip")
+        .value(Some(range(date(2025, 1, 1), date(2025, 1, 2))))
+        .default_value(Some(range(date(2030, 1, 1), date(2030, 1, 2))))
+        .min(Some(date(2024, 1, 1)))
+        .max(Some(date(2026, 1, 1)))
+        .today(date(2025, 7, 4))
+        .presets(sample_presets())
+        .visible_months(3)
+        .is_rtl(true)
+        .disabled(true)
+        .readonly(true)
+        .required(true)
+        .force_leading_zeros(true)
+        .has_description(true)
+        .has_error_message(true)
+        .name(Some(String::from("range")))
+        .start_name(Some(String::from("from")))
+        .end_name(Some(String::from("to")))
+        .close_on_select(false);
+
+    let literal = Props {
+        id: String::from("trip"),
+        value: Some(Some(range(date(2025, 1, 1), date(2025, 1, 2)))),
+        default_value: Some(range(date(2030, 1, 1), date(2030, 1, 2))),
+        min: Some(date(2024, 1, 1)),
+        max: Some(date(2026, 1, 1)),
+        today: date(2025, 7, 4),
+        presets: sample_presets(),
+        visible_months: 3,
+        is_rtl: true,
+        disabled: true,
+        readonly: true,
+        required: true,
+        force_leading_zeros: true,
+        has_description: true,
+        has_error_message: true,
+        name: Some(String::from("range")),
+        start_name: Some(String::from("from")),
+        end_name: Some(String::from("to")),
+        close_on_select: false,
+    };
+
+    assert_eq!(built, literal);
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Snapshots
+// ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn snapshot_root_closed() {
+    let svc = service();
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!(snapshot_attrs(&api.root_attrs()));
+}
+
+#[test]
+fn snapshot_root_open() {
+    let mut svc = service();
+
+    drop(svc.send(Event::Open));
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!(snapshot_attrs(&api.root_attrs()));
+}
+
+#[test]
+fn snapshot_root_disabled() {
+    let svc = service_with(
+        Props {
+            disabled: true,
+            ..props()
+        },
+        en_us(),
+    );
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!(snapshot_attrs(&api.root_attrs()));
+}
+
+#[test]
+fn snapshot_root_readonly() {
+    let svc = service_with(
+        Props {
+            readonly: true,
+            ..props()
+        },
+        en_us(),
+    );
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!(snapshot_attrs(&api.root_attrs()));
+}
+
+#[test]
+fn snapshot_root_required() {
+    let svc = service_with(
+        Props {
+            required: true,
+            ..props()
+        },
+        en_us(),
+    );
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!(snapshot_attrs(&api.root_attrs()));
+}
+
+#[test]
+fn snapshot_root_invalid() {
+    let svc = service_with(
+        Props {
+            max: Some(date(2025, 6, 30)),
+            default_value: Some(range(date(2025, 6, 1), date(2025, 7, 15))),
+            ..props()
+        },
+        en_us(),
+    );
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!(snapshot_attrs(&api.root_attrs()));
+}
+
+#[test]
+fn snapshot_label() {
+    let svc = service();
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!(snapshot_attrs(&api.label_attrs()));
+}
+
+#[test]
+fn snapshot_control() {
+    let svc = service();
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!(snapshot_attrs(&api.control_attrs()));
+}
+
+#[test]
+fn snapshot_control_with_description_and_error() {
+    let svc = service_with(
+        Props {
+            has_description: true,
+            has_error_message: true,
+            ..props()
+        },
+        en_us(),
+    );
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!(snapshot_attrs(&api.control_attrs()));
+}
+
+#[test]
+fn snapshot_start_input_marker() {
+    let svc = service();
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!(snapshot_attrs(&api.start_input_attrs()));
+}
+
+#[test]
+fn snapshot_end_input_marker() {
+    let svc = service();
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!(snapshot_attrs(&api.end_input_attrs()));
+}
+
+#[test]
+fn snapshot_separator() {
+    let svc = service();
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!(snapshot_attrs(&api.separator_attrs()));
+}
+
+#[test]
+fn snapshot_trigger_closed() {
+    let svc = service();
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!(snapshot_attrs(&api.trigger_attrs()));
+}
+
+#[test]
+fn snapshot_trigger_open() {
+    let mut svc = service();
+
+    drop(svc.send(Event::Open));
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!(snapshot_attrs(&api.trigger_attrs()));
+}
+
+#[test]
+fn snapshot_trigger_disabled() {
+    let svc = service_with(
+        Props {
+            disabled: true,
+            ..props()
+        },
+        en_us(),
+    );
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!(snapshot_attrs(&api.trigger_attrs()));
+}
+
+#[test]
+fn snapshot_clear_trigger_empty() {
+    let svc = service();
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!(snapshot_attrs(&api.clear_trigger_attrs()));
+}
+
+#[test]
+fn snapshot_clear_trigger_with_value() {
+    let svc = service_with(
+        Props {
+            default_value: Some(range(date(2025, 6, 1), date(2025, 6, 15))),
+            ..props()
+        },
+        en_us(),
+    );
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!(snapshot_attrs(&api.clear_trigger_attrs()));
+}
+
+#[test]
+fn snapshot_preset_trigger() {
+    let svc = service_with(
+        Props {
+            presets: sample_presets(),
+            ..props()
+        },
+        en_us(),
+    );
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!(snapshot_attrs(&api.preset_trigger_attrs(1)));
+}
+
+#[test]
+fn snapshot_positioner() {
+    let svc = service();
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!(snapshot_attrs(&api.positioner_attrs()));
+}
+
+#[test]
+fn snapshot_content() {
+    let svc = service();
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!(snapshot_attrs(&api.content_attrs()));
+}
+
+#[test]
+fn snapshot_description() {
+    let svc = service();
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!(snapshot_attrs(&api.description_attrs()));
+}
+
+#[test]
+fn snapshot_error_message() {
+    let svc = service();
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!(snapshot_attrs(&api.error_message_attrs()));
+}
+
+#[test]
+fn snapshot_hidden_input_empty() {
+    let svc = service_with(
+        Props {
+            name: Some(String::from("range")),
+            ..props()
+        },
+        en_us(),
+    );
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!(snapshot_attrs(&api.hidden_input_attrs()));
+}
+
+#[test]
+fn snapshot_hidden_input_with_range() {
+    let svc = service_with(
+        Props {
+            default_value: Some(range(date(2024, 1, 10), date(2024, 1, 20))),
+            name: Some(String::from("range")),
+            ..props()
+        },
+        en_us(),
+    );
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!(snapshot_attrs(&api.hidden_input_attrs()));
+}
+
+#[test]
+fn snapshot_start_hidden_input() {
+    let svc = service_with(
+        Props {
+            default_value: Some(range(date(2024, 1, 10), date(2024, 1, 20))),
+            start_name: Some(String::from("from")),
+            ..props()
+        },
+        en_us(),
+    );
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!(snapshot_attrs(&api.start_hidden_input_attrs()));
+}
+
+#[test]
+fn snapshot_end_hidden_input() {
+    let svc = service_with(
+        Props {
+            default_value: Some(range(date(2024, 1, 10), date(2024, 1, 20))),
+            end_name: Some(String::from("to")),
+            ..props()
+        },
+        en_us(),
+    );
+
+    let api = svc.connect(&|_| {});
+
+    assert_snapshot!(snapshot_attrs(&api.end_hidden_input_attrs()));
+}
+
+#[test]
+fn snapshot_start_field_props() {
+    let svc = service_with(
+        Props {
+            default_value: Some(range(date(2025, 6, 1), date(2025, 6, 15))),
+            ..props()
+        },
+        en_us(),
+    );
+
+    let api = svc.connect(&|_| {});
+
+    let child = svc_child_field_group(api.start_field_props());
+
+    assert_snapshot!(snapshot_attrs(&child));
+}
+
+#[test]
+fn snapshot_end_field_props() {
+    let svc = service_with(
+        Props {
+            default_value: Some(range(date(2025, 6, 1), date(2025, 6, 15))),
+            ..props()
+        },
+        en_us(),
+    );
+
+    let api = svc.connect(&|_| {});
+
+    let child = svc_child_field_group(api.end_field_props());
+
+    assert_snapshot!(snapshot_attrs(&child));
+}
+
+/// Drives a child `DateField` from the given props and returns its field-group
+/// attributes, exercising the start/end child configuration end-to-end.
+fn svc_child_field_group(child: date_field::Props) -> AttrMap {
+    let service =
+        Service::<date_field::Machine>::new(child, &env(en_us()), &date_field::Messages::default());
+
+    service.connect(&|_| {}).field_group_attrs()
+}

--- a/crates/ars-components/src/date_time/mod.rs
+++ b/crates/ars-components/src/date_time/mod.rs
@@ -12,6 +12,9 @@ pub mod date_picker;
 /// DateRangeField machine.
 pub mod date_range_field;
 
+/// DateRangePicker machine.
+pub mod date_range_picker;
+
 /// DateTimePicker machine.
 pub mod date_time_picker;
 

--- a/crates/ars-components/tests/proptest_state_machines/date_time.rs
+++ b/crates/ars-components/tests/proptest_state_machines/date_time.rs
@@ -1,7 +1,7 @@
 use ars_components::date_time::{
     calendar::{self, PageBehavior, SelectionMode},
     date_field::{self, DateSegmentKind},
-    date_picker, date_range_field, date_time_picker, range_calendar, time_field,
+    date_picker, date_range_field, date_range_picker, date_time_picker, range_calendar, time_field,
 };
 use ars_core::{ComponentPart, ConnectApi, Env, KeyboardKey, Service};
 use ars_i18n::{CalendarDate, CalendarDateTime, DateRange, HourCycle, Time, Weekday};
@@ -1124,5 +1124,153 @@ proptest! {
 
         prop_assert_eq!(service.state(), &date_range_field::State::Idle);
         prop_assert_eq!(service.context().value.get().as_ref(), None);
+    }
+}
+
+// ── DateRangePicker ────────────────────────────────────────────────────────
+
+#[derive(Clone, Debug)]
+enum DateRangePickerAction {
+    Send(date_range_picker::Event),
+    SetControlledValue(Option<DateRange>),
+    SetDisabled(bool),
+}
+
+fn date_range_picker_presets() -> Vec<date_range_picker::Preset> {
+    vec![
+        date_range_picker::Preset::new(
+            "Last 7 days",
+            DateRange::new(date(2025, 5, 26), date(2025, 6, 1)).expect("ordered range"),
+        ),
+        date_range_picker::Preset::new(
+            "Last 30 days",
+            DateRange::new(date(2025, 5, 3), date(2025, 6, 1)).expect("ordered range"),
+        ),
+    ]
+}
+
+fn date_range_picker_props() -> date_range_picker::Props {
+    date_range_picker::Props {
+        id: "range-picker".to_string(),
+        presets: date_range_picker_presets(),
+        ..date_range_picker::Props::default()
+    }
+}
+
+fn arb_date_range_picker_event() -> impl Strategy<Value = date_range_picker::Event> {
+    prop_oneof![
+        Just(date_range_picker::Event::Open),
+        Just(date_range_picker::Event::Close),
+        Just(date_range_picker::Event::Toggle),
+        (arb_date(), arb_date())
+            .prop_map(|(first, second)| {
+                DateRange::normalized(first, second).expect("comparable generated dates")
+            })
+            .prop_map(|range| date_range_picker::Event::SelectRangeComplete { range }),
+        proptest::option::of(arb_date()).prop_map(date_range_picker::Event::StartValueChange),
+        proptest::option::of(arb_date()).prop_map(date_range_picker::Event::EndValueChange),
+        (0usize..=3).prop_map(|index| date_range_picker::Event::SelectPreset { index }),
+        Just(date_range_picker::Event::Clear),
+        Just(date_range_picker::Event::FocusIn),
+        Just(date_range_picker::Event::FocusOut),
+        Just(date_range_picker::Event::KeyDown {
+            key: KeyboardKey::Escape,
+        }),
+        Just(date_range_picker::Event::KeyDown {
+            key: KeyboardKey::ArrowDown,
+        }),
+    ]
+}
+
+fn arb_date_range_picker_action() -> impl Strategy<Value = DateRangePickerAction> {
+    prop_oneof![
+        arb_date_range_picker_event().prop_map(DateRangePickerAction::Send),
+        prop_oneof![
+            Just(None),
+            (arb_date(), arb_date())
+                .prop_map(|(first, second)| DateRange::normalized(first, second))
+        ]
+        .prop_map(DateRangePickerAction::SetControlledValue),
+        any::<bool>().prop_map(DateRangePickerAction::SetDisabled),
+    ]
+}
+
+proptest! {
+    #![proptest_config(super::common::proptest_config())]
+
+    /// Random event and controlled-prop sequences keep the picker's invariants:
+    /// the ID stays stable, the state is one of its two variants, the canonical
+    /// range stays normalized and consistent with the per-field values, and
+    /// connecting every anatomy part never panics.
+    #[test]
+    #[ignore = "proptest — nightly extended-proptest job"]
+    fn proptest_date_range_picker_sequences_preserve_invariants(
+        actions in prop::collection::vec(arb_date_range_picker_action(), 0..128),
+    ) {
+        let mut service = Service::<date_range_picker::Machine>::new(
+            date_range_picker_props(),
+            &Env::default(),
+            &date_range_picker::Messages::default(),
+        );
+
+        for action in actions {
+            match action {
+                DateRangePickerAction::Send(event) => {
+                    drop(service.send(event));
+                }
+
+                DateRangePickerAction::SetControlledValue(value) => {
+                    drop(service.set_props(date_range_picker::Props {
+                        value: Some(value),
+                        ..date_range_picker_props()
+                    }));
+                }
+
+                DateRangePickerAction::SetDisabled(disabled) => {
+                    drop(service.set_props(date_range_picker::Props {
+                        disabled,
+                        ..date_range_picker_props()
+                    }));
+                }
+            }
+
+            let ctx = service.context();
+
+            prop_assert_eq!(ctx.ids.id(), "range-picker");
+            prop_assert!(matches!(
+                service.state(),
+                date_range_picker::State::Open | date_range_picker::State::Closed,
+            ));
+
+            // A selected range is always normalized so `start <= end` (in both
+            // modes). In *uncontrolled* mode the canonical range additionally
+            // mirrors the per-field values — it is `Some` exactly when both
+            // fields are set. In controlled mode `get()` returns the parent's
+            // override, which is intentionally decoupled from local field edits
+            // (the parent reconciles via the next `SyncProps`), so the mirror
+            // check does not apply.
+            if let Some(range) = ctx.value.get() {
+                prop_assert!(matches!(
+                    range.start.compare_within_calendar(&range.end),
+                    Some(core::cmp::Ordering::Less | core::cmp::Ordering::Equal)
+                ));
+
+                if !ctx.value.is_controlled() {
+                    prop_assert!(ctx.start_date.is_some() && ctx.end_date.is_some());
+                    prop_assert_eq!(ctx.start_date.as_ref(), Some(&range.start));
+                    prop_assert_eq!(ctx.end_date.as_ref(), Some(&range.end));
+                }
+            } else if !ctx.value.is_controlled() {
+                prop_assert!(ctx.start_date.is_none() || ctx.end_date.is_none());
+            }
+
+            let send = |_event: date_range_picker::Event| {};
+
+            let api = service.connect(&send);
+
+            for part in date_range_picker::Part::all() {
+                drop(api.part_attrs(part));
+            }
+        }
     }
 }

--- a/crates/ars-components/tests/spec_conformance/date_time.rs
+++ b/crates/ars-components/tests/spec_conformance/date_time.rs
@@ -3,8 +3,8 @@
 //! Asserts each date-time component's `Part` enum matches the spec anatomy.
 
 use ars_components::date_time::{
-    calendar, date_field::DateSegmentKind, date_picker, date_range_field, date_time_picker,
-    range_calendar, time_field,
+    calendar, date_field::DateSegmentKind, date_picker, date_range_field, date_range_picker,
+    date_time_picker, range_calendar, time_field,
 };
 use ars_i18n::{CalendarDate, Weekday};
 
@@ -113,6 +113,32 @@ fn date_picker_anatomy_matches_spec() {
             (date_picker::Part::Description, "description"),
             (date_picker::Part::ErrorMessage, "error-message"),
             (date_picker::Part::HiddenInput, "hidden-input"),
+        ],
+    );
+}
+
+#[test]
+fn date_range_picker_anatomy_matches_spec() {
+    assert_anatomy(
+        "date-range-picker",
+        &[
+            (date_range_picker::Part::Root, "root"),
+            (date_range_picker::Part::Label, "label"),
+            (date_range_picker::Part::Control, "control"),
+            (date_range_picker::Part::StartInput, "start-input"),
+            (date_range_picker::Part::Separator, "separator"),
+            (date_range_picker::Part::EndInput, "end-input"),
+            (date_range_picker::Part::Trigger, "trigger"),
+            (date_range_picker::Part::ClearTrigger, "clear-trigger"),
+            (
+                date_range_picker::Part::PresetTrigger { index: 0 },
+                "preset-trigger",
+            ),
+            (date_range_picker::Part::Positioner, "positioner"),
+            (date_range_picker::Part::Content, "content"),
+            (date_range_picker::Part::Description, "description"),
+            (date_range_picker::Part::ErrorMessage, "error-message"),
+            (date_range_picker::Part::HiddenInput, "hidden-input"),
         ],
     );
 }

--- a/spec/components/date-time/date-range-picker.md
+++ b/spec/components/date-time/date-range-picker.md
@@ -378,6 +378,14 @@ impl ars_core::Machine for Machine {
         match (state, event) {
             (_, Event::SyncProps(next)) => {
                 let next = next.as_ref().clone();
+                // Disabling an open picker dismisses it: while disabled the guard
+                // above blocks Close/Escape/FocusOut, so it could never reopen.
+                if next.disabled && *state == State::Open {
+                    return Some(TransitionPlan::to(State::Closed).apply(move |ctx| {
+                        sync_props(ctx, &next);
+                        ctx.open.set(false);
+                    }));
+                }
                 Some(TransitionPlan::context_only(move |ctx| sync_props(ctx, &next)))
             }
 
@@ -389,11 +397,14 @@ impl ars_core::Machine for Machine {
                 Some(TransitionPlan::to(State::Closed).apply(|ctx| ctx.open.set(false)))
             }
 
-            (State::Open, Event::SelectRangeComplete { range }) => {
+            // Accept the completed range in any state: a browser may fire
+            // `FocusOut` (closing the popover) before the calendar reports the
+            // cell click. The close side-effect only applies when it was open.
+            (_, Event::SelectRangeComplete { range }) => {
                 if ctx.readonly { return None; }
                 let range = range.clone();
-                let should_close = props.close_on_select;
-                let next_state = if should_close { State::Closed } else { State::Open };
+                let should_close = props.close_on_select && *state == State::Open;
+                let next_state = if should_close { State::Closed } else { state.clone() };
                 Some(TransitionPlan::to(next_state)
                     .apply(move |ctx| apply_complete_range(ctx, range, should_close)))
             }
@@ -617,11 +628,13 @@ impl<'a> Api<'a> {
     pub fn trigger_attrs(&self) -> AttrMap { /* ... */ }
 
     /// Clear trigger: `aria-label` from `messages.clear_label`; `disabled` when
-    /// disabled or no range is selected.
+    /// the component is disabled or read-only, or no range is selected (matching
+    /// the machine, which rejects `Event::Clear` in those states).
     pub fn clear_trigger_attrs(&self) -> AttrMap { /* ... */ }
 
     /// Preset trigger at `index`: `data-ars-index={index}`, `type="button"`;
-    /// `disabled` when the component is disabled or the index is out of range.
+    /// `disabled` when the component is disabled or read-only, or the index is
+    /// out of range (matching the machine, which rejects `Event::SelectPreset`).
     pub fn preset_trigger_attrs(&self, index: usize) -> AttrMap { /* ... */ }
 
     /// Positioner: scope/part only (positioning is performed by the adapter).
@@ -746,8 +759,8 @@ DateRangePicker
 | `Separator`     | `<span>`              | `aria-hidden="true"`                                                                    |
 | `EndInput`      | `<div>` _(DateField)_ | End date field wrapper (child configured via `end_field_props`)                         |
 | `Trigger`       | `<button>`            | `aria-haspopup="dialog"`, `aria-expanded`, `aria-controls`                              |
-| `ClearTrigger`  | `<button>`            | `aria-label="Clear date range"`, disabled when empty                                    |
-| `PresetTrigger` | `<button>`            | `data-ars-index`, one per `Props::presets` entry; disabled when out of range            |
+| `ClearTrigger`  | `<button>`            | `aria-label="Clear date range"`, disabled when empty, disabled, or read-only            |
+| `PresetTrigger` | `<button>`            | `data-ars-index`, one per `Props::presets` entry; disabled when out of range/read-only  |
 | `Positioner`    | `<div>`               | Floating positioner (positioned by the adapter)                                         |
 | `Content`       | `<div>`               | `role="dialog"`, `aria-modal="false"`, `aria-labelledby`                                |
 | `Description`   | `<div>`               | Help text, wired via the control's `aria-describedby`                                   |

--- a/spec/components/date-time/date-range-picker.md
+++ b/spec/components/date-time/date-range-picker.md
@@ -6,13 +6,15 @@ foundation_deps: [architecture, accessibility, i18n, interactions, forms]
 shared_deps: [date-time-types]
 related: [calendar, range-calendar, date-field, date-range-field]
 references:
-  ark-ui: DatePicker
-  react-aria: DateRangePicker
+    ark-ui: DatePicker
+    react-aria: DateRangePicker
 ---
 
 # DateRangePicker
 
-Composes **two DateField instances** + **Calendar with `is_range: true`** in a popover. Follows DatePicker's composition pattern (event bridging via `calendar_props()`).
+Composes **two segmented DateField inputs** (start and end) + a **[RangeCalendar](range-calendar.md)** shown in a popover, with optional preset shortcuts. Follows DatePicker's composition pattern: the picker owns the canonical range and popover state and exposes child-props builders (`start_field_props()`, `end_field_props()`, `range_calendar_props()`) that the adapter feeds to the child machines, bridging their events back.
+
+> **Composition note.** A `DateField` is a _segmented_ input that emits an `Option<CalendarDate>` (it has no format string); range selection lives in the dedicated `RangeCalendar` component (`Calendar` has no range mode). The two-field value coordination mirrors [DateRangeField](date-range-field.md) (value-based events + `DateRange::normalized`), and the popover lifecycle mirrors [DatePicker](date-picker.md). Live focus, popover positioning, and return-focus are adapter concerns driven from element handles; the agnostic core emits no effects (`type Effect = NoEffect`).
 
 ## 1. State Machine
 
@@ -20,7 +22,7 @@ Composes **two DateField instances** + **Calendar with `is_range: true`** in a p
 
 ```rust
 /// States for the DateRangePicker component.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum State {
     /// The popover is closed.
     Closed,
@@ -35,36 +37,42 @@ pub enum State {
 /// Events for the DateRangePicker component.
 #[derive(Clone, Debug, PartialEq)]
 pub enum Event {
-    /// Open the popover.
+    /// Open the calendar popover.
     Open,
-    /// Close the popover.
+    /// Close the calendar popover.
     Close,
-    /// Toggle open/closed.
+    /// Toggle the popover open/closed.
     Toggle,
-    /// Calendar has completed range selection.
+    /// The embedded calendar completed a range selection.
     SelectRangeComplete {
         /// The selected range.
-        range: DateRange
+        range: DateRange,
     },
-    /// Start date field text changed.
-    StartInputChange {
-        /// The new value.
-        value: String
+    /// The start field's value changed. A segmented `DateField` emits an
+    /// `Option<CalendarDate>`, not raw text.
+    StartValueChange(Option<CalendarDate>),
+    /// The end field's value changed.
+    EndValueChange(Option<CalendarDate>),
+    /// A preset range was chosen by its index into `Props::presets`.
+    SelectPreset {
+        /// Zero-based index into the configured presets.
+        index: usize,
     },
-    /// End date field text changed.
-    EndInputChange {
-        /// The new value.
-        value: String
-    },
+    /// Clear the selected range (the clear trigger).
+    Clear,
     /// Focus entered the component.
     FocusIn,
     /// Focus left the component entirely.
     FocusOut,
-    /// Key pressed on trigger or within popover.
+    /// A key was pressed on the trigger or within the popover.
     KeyDown {
         /// The key that was pressed.
-        key: KeyboardKey
+        key: KeyboardKey,
     },
+    /// Re-apply context-backed prop fields after a props change. Emitted by
+    /// `Machine::on_props_changed` so a controlled `value` and the cached
+    /// `min`/`max`/`today`/`presets`/flags follow parent-driven prop updates.
+    SyncProps(Box<Props>),
 }
 ```
 
@@ -72,57 +80,66 @@ pub enum Event {
 
 ```rust
 /// Context for the DateRangePicker component.
-#[derive(Clone, Debug, PartialEq)]
+///
+/// `intl_backend` is not `PartialEq`/`Debug`-derivable, so `Context` provides a
+/// hand-written `Debug` and is not `PartialEq` (matching `DateRangeField`).
+#[derive(Clone)]
 pub struct Context {
-    /// The selected range.
+    /// The canonical selected range. `Some` only when both `start_date` and
+    /// `end_date` are set; always normalized so `start <= end`.
     pub value: Bindable<Option<DateRange>>,
-    /// Whether the popover is open.
+    /// Whether the popover is open (always uncontrolled).
     pub open: Bindable<bool>,
-    /// The text in the start input field.
-    pub start_input_text: String,
-    /// The text in the end input field.
-    pub end_input_text: String,
-    /// The parsed start date.
-    pub parsed_start: Option<CalendarDate>,
-    /// The parsed end date.
-    pub parsed_end: Option<CalendarDate>,
-    /// Which DateField is currently active.
+    /// The start field's current value, tracked independently so a range can be
+    /// assembled incrementally as each field changes.
+    pub start_date: Option<CalendarDate>,
+    /// The end field's current value, tracked independently.
+    pub end_date: Option<CalendarDate>,
+    /// Which field most recently received a value change.
     pub active_field: ActiveField,
-    /// The minimum date.
+    /// The minimum selectable date.
     pub min: Option<CalendarDate>,
-    /// The maximum date.
+    /// The maximum selectable date.
     pub max: Option<CalendarDate>,
-    /// The locale.
+    /// The adapter-injected "today" date, forwarded to the embedded calendar.
+    pub today: CalendarDate,
+    /// Named preset ranges offered as one-click shortcuts.
+    pub presets: Vec<Preset>,
+    /// Number of months displayed side-by-side, forwarded to the calendar.
+    pub visible_months: usize,
+    /// Right-to-left layout direction, forwarded to the calendar.
+    pub is_rtl: bool,
+    /// The resolved locale.
     pub locale: Locale,
+    /// Backend used for locale-dependent labels in range descriptions.
+    pub intl_backend: Arc<dyn IntlBackend>,
     /// Resolved translatable messages.
     pub messages: Messages,
-    /// The date format.
-    pub format: DateFormat,
     /// Whether the component is disabled.
     pub disabled: bool,
     /// Whether the component is readonly.
     pub readonly: bool,
     /// Whether the component is required.
     pub required: bool,
-    /// The name of the component.
+    /// When `true`, numeric segments in both child fields display with leading
+    /// zeros.
+    pub force_leading_zeros: bool,
+    /// Whether the `Description` part is rendered.
+    pub has_description: bool,
+    /// Whether the `ErrorMessage` part is rendered.
+    pub has_error_message: bool,
+    /// Form field name for a single hidden input carrying the range value.
     pub name: Option<String>,
-    /// Separate form name for start date.
+    /// Separate form name for the start date.
     pub start_name: Option<String>,
-    /// Separate form name for end date.
+    /// Separate form name for the end date.
     pub end_name: Option<String>,
     /// Component IDs.
     pub ids: ComponentIds,
 }
-
-/// Which DateField is currently active.
-#[derive(Clone, Debug, PartialEq)]
-pub enum ActiveField {
-    /// The start field is active.
-    Start,
-    /// The end field is active.
-    End,
-}
 ```
+
+`ActiveField` (`Start` / `End`) is owned by [DateRangeField](date-range-field.md) as the first range component to need it; `DateRangePicker` re-exports and reuses that enum rather than redefining it.
 
 ### 1.4 Props
 
@@ -130,37 +147,54 @@ pub enum ActiveField {
 /// Props for the DateRangePicker component.
 #[derive(Clone, Debug, PartialEq, HasId)]
 pub struct Props {
-    /// The ID of the component.
+    /// The stable DOM id for the component.
     pub id: String,
-    /// The value of the component.
+    /// Controlled range value. `None` = uncontrolled, `Some(None)` =
+    /// controlled-and-empty, `Some(Some(range))` = controlled with a range.
     pub value: Option<Option<DateRange>>,
-    /// The default value of the component.
+    /// The initial range used when the component is uncontrolled.
     pub default_value: Option<DateRange>,
-    /// The minimum date.
+    /// The minimum selectable date (forwarded to both fields and the calendar).
     pub min: Option<CalendarDate>,
-    /// The maximum date.
+    /// The maximum selectable date (forwarded to both fields and the calendar).
     pub max: Option<CalendarDate>,
-    /// The date format.
-    pub format: DateFormat,
+    /// The "today" date, injected by the adapter for testability and SSR
+    /// determinism. Forwarded to the embedded calendar. Defaults to a fixed
+    /// date; adapters inject the real today.
+    pub today: CalendarDate,
+    /// Named preset ranges offered as one-click shortcuts (rendered as
+    /// `PresetTrigger` items inside the popover).
+    pub presets: Vec<Preset>,
+    /// Number of months displayed side-by-side in the calendar popover.
+    /// Default: `2`. Forwarded to the embedded calendar's `visible_months`.
+    pub visible_months: usize,
+    /// Right-to-left layout direction (forwarded to the embedded calendar).
+    pub is_rtl: bool,
     /// Whether the component is disabled.
     pub disabled: bool,
-    /// Whether the component is readonly.
+    /// Whether the component is readonly (viewing allowed, editing blocked).
     pub readonly: bool,
     /// Whether the component is required.
     pub required: bool,
-    /// The name of the component (for single hidden input submission).
+    /// When `true`, numeric segments in both child fields display with leading
+    /// zeros. Defaults to `false`, which uses locale-aware formatting.
+    pub force_leading_zeros: bool,
+    /// Whether a `Description` element is rendered (wires the control's
+    /// `aria-describedby`).
+    pub has_description: bool,
+    /// Whether an `ErrorMessage` element is rendered (wires the control's
+    /// `aria-describedby`).
+    pub has_error_message: bool,
+    /// Form field name for a single hidden input carrying the range value as the
+    /// ISO 8601 interval `YYYY-MM-DD/YYYY-MM-DD`.
     pub name: Option<String>,
-    /// Form field name for the start date (alternative to `name` for separate
-    /// start/end hidden inputs). When set, the start date is submitted under
-    /// this key in ISO 8601 format.
+    /// Form field name for a separate hidden input carrying the start date
+    /// (alternative to `name`). Submitted in ISO 8601 format.
     pub start_name: Option<String>,
-    /// Form field name for the end date. When set, the end date is submitted
-    /// under this key in ISO 8601 format.
+    /// Form field name for a separate hidden input carrying the end date.
     pub end_name: Option<String>,
-    /// Whether to close the popover after a date is selected. Default: true.
+    /// Whether to close the popover after a range is completed. Default: `true`.
     pub close_on_select: bool,
-    /// The positioning options.
-    pub positioning: PositioningOptions,
 }
 
 impl Default for Props {
@@ -171,16 +205,47 @@ impl Default for Props {
             default_value: None,
             min: None,
             max: None,
-            format: DateFormat::default(),
+            today: CalendarDate::new_gregorian(2025, 1, 1)
+                .expect("2025-01-01 is a valid Gregorian date"),
+            presets: Vec::new(),
+            visible_months: 2,
+            is_rtl: false,
             disabled: false,
             readonly: false,
             required: false,
+            force_leading_zeros: false,
+            has_description: false,
+            has_error_message: false,
             name: None,
             start_name: None,
             end_name: None,
             close_on_select: true,
-            positioning: PositioningOptions::default(),
         }
+    }
+}
+```
+
+### 1.4.1 Preset
+
+```rust
+/// A named preset range offered as a one-click shortcut (e.g. "Last 7 days").
+///
+/// The consumer supplies an already-localized `label` and a concrete `range`.
+/// Relative presets are computed by the consumer against the same `today`
+/// injected into `Props::today`, keeping the agnostic core deterministic and
+/// free of closures.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Preset {
+    /// The pre-localized label shown on the preset trigger.
+    pub label: String,
+    /// The concrete range applied when this preset is selected.
+    pub range: DateRange,
+}
+
+impl Preset {
+    /// Creates a preset from a label and a concrete range.
+    pub fn new(label: impl Into<String>, range: DateRange) -> Self {
+        Self { label: label.into(), range }
     }
 }
 ```
@@ -201,41 +266,47 @@ fn is_readonly(ctx: &Context) -> bool { ctx.readonly }
 
 ### 1.7 Composition Pattern
 
-Event bridging from child components to DateRangePicker:
+The adapter bridges child-component events back to DateRangePicker. The children
+are configured via the picker's `*_props()` builders; the picker runs no child
+machines itself.
 
 ```text
-Calendar.SelectRangeEnd -> DateRangePicker.SelectRangeComplete { range }
-StartDateField.SetValue -> DateRangePicker.StartInputChange { value } (parse, update range.start)
-EndDateField.SetValue   -> DateRangePicker.EndInputChange { value }   (parse, update range.end)
+RangeCalendar value completed -> DateRangePicker.SelectRangeComplete { range }
+StartDateField value change   -> DateRangePicker.StartValueChange(Option<CalendarDate>)
+EndDateField value change     -> DateRangePicker.EndValueChange(Option<CalendarDate>)
+PresetTrigger click           -> DateRangePicker.SelectPreset { index }
 ```
 
 > **Multi-month recommendation**: DateRangePicker uses `visible_months: 2` by default so users see start and end month grids side-by-side.
 
 #### 1.7.1 State Ownership and Synchronization
 
-The **Calendar** component is the single source of truth for the selected date range.
+The DateRangePicker context is the single source of truth for the selected
+range. It tracks the two field values independently (`start_date`/`end_date`)
+and derives the canonical normalized `value` from them.
 
 ```rust
-// DateRangePicker context owns the canonical range
 struct Context {
-    /// Source of truth for the selected range.
-    range: Bindable<Option<DateRange>>,
+    /// Canonical, normalized range derived from the two field values.
+    value: Bindable<Option<DateRange>>,
+    /// Per-field working values.
+    start_date: Option<CalendarDate>,
+    end_date: Option<CalendarDate>,
     // ...
 }
 ```
 
 **Sync Rules:**
 
-1. When the user selects a range via the Calendar, the DateFields update to reflect the new range.
-2. When the user edits a date via a DateField, the Calendar updates to reflect the new value.
-3. In controlled mode (`value` prop set), both Calendar and DateFields reflect the controlled value. User edits trigger `on_change` but do not update internal state.
-4. In uncontrolled mode, internal `range` is the source of truth. Both Calendar and DateFields read from and write to it.
+1. When the user completes a range via the calendar (`SelectRangeComplete`), both field values and the canonical `value` are updated.
+2. When the user edits a date via a field (`StartValueChange`/`EndValueChange`), the changed field is stored and the canonical range is recomputed via `DateRange::normalized`; the adapter feeds the updated `value` back to the calendar through `range_calendar_props()`.
+3. In controlled mode (`value` prop set), `get()` returns the parent's value; field edits update the per-field working values and the internal (pending) value but the override stands until the parent reconciles via the next `SyncProps`. The internal value is kept in lockstep with the override so a later controlled→uncontrolled switch reveals a value consistent with the fields.
+4. In uncontrolled mode, the internal `value` is the source of truth; both the fields and the calendar read from and write to it.
 
-**Conflict Resolution:**
+**Normalization & invalid ranges:**
 
-- If a DateField edit produces an invalid range (start > end), the edit is accepted but the range is marked invalid via `ctx.is_invalid = true`.
-- The Calendar highlights the invalid range with a visual indicator.
-- `on_change` fires with the invalid range; the consumer decides whether to correct it.
+- Field edits are normalized by `DateRange::normalized` so the stored range always satisfies `start <= end` (an out-of-order edit swaps the endpoints rather than being rejected).
+- A range whose endpoints fall outside `[min, max]` is _valid in order but out of bounds_; `Root` then carries `data-ars-invalid` and each child field reports its own `invalid`. Each child field is bounded only by the global `min`/`max` (never by the opposite endpoint), so an out-of-order edit reaches the parent for the normalizing swap instead of being clamped away by the child.
 
 ### 1.8 Full Machine Implementation
 
@@ -249,41 +320,41 @@ impl ars_core::Machine for Machine {
     type Context = Context;
     type Props = Props;
     type Messages = Messages;
+    type Effect = NoEffect;
     type Api<'a> = Api<'a>;
 
     fn init(props: &Self::Props, env: &Env, messages: &Self::Messages) -> (Self::State, Self::Context) {
-        let locale = env.locale.clone();
-        let messages = messages.clone();
-
-        let (start_text, end_text, parsed_start, parsed_end) = match &props.default_value {
-            Some(range) => (
-                format_date(&range.start, &props.format, &locale),
-                format_date(&range.end, &props.format, &locale),
-                Some(range.start.clone()),
-                Some(range.end.clone()),
-            ),
-            None => (String::new(), String::new(), None, None),
+        let value = if let Some(value) = &props.value {
+            Bindable::controlled(value.clone())
+        } else {
+            Bindable::uncontrolled(props.default_value.clone())
         };
 
+        let initial_range = value.get().clone();
+        let start_date = initial_range.as_ref().map(|range| range.start.clone());
+        let end_date = initial_range.as_ref().map(|range| range.end.clone());
+
         let ctx = Context {
-            value: match &props.value {
-                Some(v) => Bindable::controlled(v.clone()),
-                None => Bindable::uncontrolled(props.default_value.clone()),
-            },
+            value,
             open: Bindable::uncontrolled(false),
-            start_input_text: start_text,
-            end_input_text: end_text,
-            parsed_start,
-            parsed_end,
+            start_date,
+            end_date,
             active_field: ActiveField::Start,
             min: props.min.clone(),
             max: props.max.clone(),
-            locale,
-            messages,
-            format: props.format.clone(),
+            today: props.today.clone(),
+            presets: props.presets.clone(),
+            visible_months: props.visible_months,
+            is_rtl: props.is_rtl,
+            locale: env.locale.clone(),
+            intl_backend: Arc::clone(&env.intl_backend),
+            messages: messages.clone(),
             disabled: props.disabled,
             readonly: props.readonly,
             required: props.required,
+            force_leading_zeros: props.force_leading_zeros,
+            has_description: props.has_description,
+            has_error_message: props.has_error_message,
             name: props.name.clone(),
             start_name: props.start_name.clone(),
             end_name: props.end_name.clone(),
@@ -296,78 +367,91 @@ impl ars_core::Machine for Machine {
         state: &Self::State,
         event: &Self::Event,
         ctx: &Self::Context,
-        _props: &Self::Props,
+        props: &Self::Props,
     ) -> Option<TransitionPlan<Self>> {
-        if ctx.disabled { return None; }
+        // `SyncProps` must process even when disabled so adapter-driven prop
+        // updates (including re-enabling) still reach the context.
+        if ctx.disabled && !matches!(event, Event::SyncProps(_)) {
+            return None;
+        }
 
         match (state, event) {
-            (State::Closed, Event::Open) | (State::Closed, Event::Toggle) => {
-                Some(TransitionPlan::to(State::Open).apply(|ctx| {
-                    ctx.open.set(true);
-                }))
+            (_, Event::SyncProps(next)) => {
+                let next = next.as_ref().clone();
+                Some(TransitionPlan::context_only(move |ctx| sync_props(ctx, &next)))
             }
 
-            (State::Open, Event::Close) | (State::Open, Event::Toggle) => {
-                Some(TransitionPlan::to(State::Closed).apply(|ctx| {
-                    ctx.open.set(false);
-                }))
+            (State::Closed, Event::Open | Event::Toggle) => {
+                Some(TransitionPlan::to(State::Open).apply(|ctx| ctx.open.set(true)))
+            }
+
+            (State::Open, Event::Close | Event::Toggle) => {
+                Some(TransitionPlan::to(State::Closed).apply(|ctx| ctx.open.set(false)))
             }
 
             (State::Open, Event::SelectRangeComplete { range }) => {
+                if ctx.readonly { return None; }
                 let range = range.clone();
-                let should_close = _props.close_on_select;
+                let should_close = props.close_on_select;
                 let next_state = if should_close { State::Closed } else { State::Open };
-                Some(TransitionPlan::to(next_state).apply(move |ctx| {
-                    ctx.start_input_text = format_date(&range.start, &ctx.format, &ctx.locale);
-                    ctx.end_input_text = format_date(&range.end, &ctx.format, &ctx.locale);
-                    ctx.parsed_start = Some(range.start.clone());
-                    ctx.parsed_end = Some(range.end.clone());
-                    ctx.value.set(Some(range));
-                    if should_close {
-                        ctx.open.set(false);
-                    }
-                }))
+                Some(TransitionPlan::to(next_state)
+                    .apply(move |ctx| apply_complete_range(ctx, range, should_close)))
             }
 
-            (_, Event::StartInputChange { value }) => {
-                let text = value.clone();
+            (_, Event::SelectPreset { index }) => {
+                if ctx.readonly { return None; }
+                let range = ctx.presets.get(*index)?.range.clone();
+                let should_close = props.close_on_select && *state == State::Open;
+                let next_state = if should_close { State::Closed } else { state.clone() };
+                Some(TransitionPlan::to(next_state)
+                    .apply(move |ctx| apply_complete_range(ctx, range, should_close)))
+            }
+
+            (_, Event::StartValueChange(date)) => {
+                if ctx.readonly { return None; }
+                let date = date.clone();
                 Some(TransitionPlan::context_only(move |ctx| {
-                    ctx.parsed_start = parse_date(&text, &ctx.format, &ctx.locale);
-                    ctx.start_input_text = text;
                     ctx.active_field = ActiveField::Start;
-                    // Update range if both dates are valid
-                    if let (Some(start), Some(end)) = (&ctx.parsed_start, &ctx.parsed_end) {
-                        ctx.value.set(Some(DateRange::normalized(start.clone(), end.clone())));
-                    }
+                    ctx.start_date = date;
+                    recompute_range(ctx);
                 }))
             }
 
-            (_, Event::EndInputChange { value }) => {
-                let text = value.clone();
+            (_, Event::EndValueChange(date)) => {
+                if ctx.readonly { return None; }
+                let date = date.clone();
                 Some(TransitionPlan::context_only(move |ctx| {
-                    ctx.parsed_end = parse_date(&text, &ctx.format, &ctx.locale);
-                    ctx.end_input_text = text;
                     ctx.active_field = ActiveField::End;
-                    if let (Some(start), Some(end)) = (&ctx.parsed_start, &ctx.parsed_end) {
-                        ctx.value.set(Some(DateRange::normalized(start.clone(), end.clone())));
-                    }
+                    ctx.end_date = date;
+                    recompute_range(ctx);
+                }))
+            }
+
+            (_, Event::Clear) => {
+                if ctx.readonly { return None; }
+                Some(TransitionPlan::context_only(|ctx| {
+                    ctx.start_date = None;
+                    ctx.end_date = None;
+                    ctx.value.set(None);
                 }))
             }
 
             (State::Open, Event::KeyDown { key }) if *key == KeyboardKey::Escape => {
-                Self::transition(state, &Event::Close, ctx, _props)
+                Self::transition(state, &Event::Close, ctx, props)
             }
 
             (State::Closed, Event::KeyDown { key }) if *key == KeyboardKey::ArrowDown => {
-                Self::transition(state, &Event::Open, ctx, _props)
+                Self::transition(state, &Event::Open, ctx, props)
             }
 
-            (_, Event::FocusOut) if *state == State::Open => {
-                Self::transition(state, &Event::Close, ctx, _props)
-            }
+            (State::Open, Event::FocusOut) => Self::transition(state, &Event::Close, ctx, props),
 
             _ => None,
         }
+    }
+
+    fn on_props_changed(old: &Self::Props, new: &Self::Props) -> Vec<Self::Event> {
+        if old == new { Vec::new() } else { vec![Event::SyncProps(Box::new(new.clone()))] }
     }
 
     fn connect<'a>(
@@ -379,9 +463,70 @@ impl ars_core::Machine for Machine {
         Api { state, ctx, props, send }
     }
 }
+
+/// Re-derives mutable context fields from changed props. `open` is always
+/// uncontrolled and is left untouched.
+fn sync_props(ctx: &mut Context, props: &Props) {
+    ctx.min = props.min.clone();
+    ctx.max = props.max.clone();
+    ctx.today = props.today.clone();
+    ctx.presets = props.presets.clone();
+    ctx.visible_months = props.visible_months;
+    ctx.is_rtl = props.is_rtl;
+    ctx.disabled = props.disabled;
+    ctx.readonly = props.readonly;
+    ctx.required = props.required;
+    ctx.force_leading_zeros = props.force_leading_zeros;
+    ctx.has_description = props.has_description;
+    ctx.has_error_message = props.has_error_message;
+    ctx.name = props.name.clone();
+    ctx.start_name = props.start_name.clone();
+    ctx.end_name = props.end_name.clone();
+
+    if let Some(controlled) = &props.value {
+        ctx.value.sync_controlled(Some(controlled.clone()));
+        // Keep the internal value in lockstep so a later controlled→uncontrolled
+        // switch reveals a value consistent with the per-field values.
+        ctx.value.set(controlled.clone());
+        ctx.start_date = controlled.as_ref().map(|range| range.start.clone());
+        ctx.end_date = controlled.as_ref().map(|range| range.end.clone());
+    } else {
+        // Genuinely uncontrolled: drop any stale override but keep the internal
+        // working state and per-field values so in-progress edits survive.
+        ctx.value.sync_controlled(None);
+    }
+}
+
+/// Applies a completed range to the context (fields, canonical value, and — when
+/// `close` — the open state).
+fn apply_complete_range(ctx: &mut Context, range: DateRange, close: bool) {
+    ctx.start_date = Some(range.start.clone());
+    ctx.end_date = Some(range.end.clone());
+    ctx.value.set(Some(range));
+    if close { ctx.open.set(false); }
+}
+
+/// Recomputes the canonical range from the two field values, normalizing so
+/// `start <= end`. Clears the range when either field is empty or the dates are
+/// not comparable.
+fn recompute_range(ctx: &mut Context) {
+    match (ctx.start_date.clone(), ctx.end_date.clone()) {
+        (Some(start), Some(end)) => match DateRange::normalized(start, end) {
+            Some(range) => {
+                ctx.start_date = Some(range.start.clone());
+                ctx.end_date = Some(range.end.clone());
+                ctx.value.set(Some(range));
+            }
+            None => ctx.value.set(None),
+        },
+        _ => ctx.value.set(None),
+    }
+}
 ```
 
 ### 1.9 Connect / API
+
+`ActiveField` is re-exported from [DateRangeField](date-range-field.md).
 
 ```rust
 #[derive(ComponentPart)]
@@ -395,6 +540,8 @@ pub enum Part {
     EndInput,
     Trigger,
     ClearTrigger,
+    /// A preset shortcut button; the index selects into `Props::presets`.
+    PresetTrigger { index: usize },
     Positioner,
     Content,
     Description,
@@ -404,262 +551,144 @@ pub enum Part {
 
 /// API for the DateRangePicker component.
 pub struct Api<'a> {
-    /// The state of the component.
     state: &'a State,
-    /// The context of the component.
     ctx: &'a Context,
-    /// The props of the component.
     props: &'a Props,
-    /// The send function.
     send: &'a dyn Fn(Event),
 }
 
 impl<'a> Api<'a> {
-    /// Attributes for the root element.
+    /// Root element. Carries scope/part/id/state plus `data-ars-disabled`,
+    /// `data-ars-readonly`, `data-ars-required`, and `data-ars-invalid` flags.
     pub fn root_attrs(&self) -> AttrMap {
         let mut attrs = AttrMap::new();
         let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Root.data_attrs();
-        attrs.set(scope_attr, scope_val);
-        attrs.set(part_attr, part_val);
-        attrs.set(HtmlAttr::Id, self.ctx.ids.id());
-        attrs.set(HtmlAttr::Data("ars-state"), self.state_name());
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Id, self.ctx.ids.id())
+            .set(HtmlAttr::Data("ars-state"), self.state_name());
         if self.ctx.disabled { attrs.set_bool(HtmlAttr::Data("ars-disabled"), true); }
         if self.ctx.readonly { attrs.set_bool(HtmlAttr::Data("ars-readonly"), true); }
         if self.ctx.required { attrs.set_bool(HtmlAttr::Data("ars-required"), true); }
+        if self.ctx.is_invalid() { attrs.set_bool(HtmlAttr::Data("ars-invalid"), true); }
         attrs
     }
 
-    /// Attributes for the label element.
-    pub fn label_attrs(&self) -> AttrMap {
-        let mut attrs = AttrMap::new();
-        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Label.data_attrs();
-        attrs.set(scope_attr, scope_val);
-        attrs.set(part_attr, part_val);
-        attrs.set(HtmlAttr::Id, self.ctx.ids.part("label"));
-        attrs.set(HtmlAttr::For, self.ctx.ids.part("start-input"));
-        attrs
-    }
+    /// Label element: `id={id}-label`, `for={id}-start-input`.
+    pub fn label_attrs(&self) -> AttrMap { /* scope/part + id + For(start-input) */ }
 
-    /// Attributes for the control element.
-    pub fn control_attrs(&self) -> AttrMap {
-        let mut attrs = AttrMap::new();
-        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Control.data_attrs();
-        attrs.set(scope_attr, scope_val);
-        attrs.set(part_attr, part_val);
-        attrs.set(HtmlAttr::Role, "group");
-        attrs.set(HtmlAttr::Aria(AriaAttr::LabelledBy), self.ctx.ids.part("label"));
-        attrs
-    }
+    /// Control group: `role="group"`, `aria-labelledby={id}-label`, and
+    /// `aria-describedby` chaining the description/error ids when present.
+    pub fn control_attrs(&self) -> AttrMap { /* ... */ }
 
-    /// Attributes for the separator element.
-    pub fn separator_attrs(&self) -> AttrMap {
-        let mut attrs = AttrMap::new();
-        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Separator.data_attrs();
-        attrs.set(scope_attr, scope_val);
-        attrs.set(part_attr, part_val);
-        attrs.set(HtmlAttr::Aria(AriaAttr::Hidden), "true");
-        attrs
-    }
+    /// Marker attributes for the start/end input wrappers (scope/part only); the
+    /// child `DateField` is configured through `start_field_props`/`end_field_props`.
+    pub fn start_input_attrs(&self) -> AttrMap { /* scope/part */ }
+    pub fn end_input_attrs(&self) -> AttrMap { /* scope/part */ }
 
-    /// Build DateField Props for the start date input.
+    /// Separator element: `aria-hidden="true"`.
+    pub fn separator_attrs(&self) -> AttrMap { /* ... */ }
+
+    /// Builds the child `DateField` props for the start input. Bounded only by
+    /// the global `min`/`max` (never by the opposite endpoint); `invalid`
+    /// reflects whether this field's own value is out of bounds.
     pub fn start_field_props(&self) -> date_field::Props {
         date_field::Props {
             id: self.ctx.ids.part("start-input"),
-            value: Some(self.ctx.parsed_start.clone()),
-            format: self.ctx.format.clone(),
-            min: self.ctx.min.clone(),
-            max: self.ctx.parsed_end.clone(), // start can't exceed end
+            value: Some(self.ctx.start_date.clone()),
+            min_value: self.ctx.min.clone(),
+            max_value: self.ctx.max.clone(),
             disabled: self.ctx.disabled,
             readonly: self.ctx.readonly,
+            required: self.ctx.required,
+            invalid: date_out_of_bounds(self.ctx.start_date.as_ref(), self.ctx.min.as_ref(), self.ctx.max.as_ref()),
             aria_label: Some((self.ctx.messages.start_label)(&self.ctx.locale)),
-            ..Default::default()
+            force_leading_zeros: self.ctx.force_leading_zeros,
+            ..date_field::Props::default()
         }
     }
 
-    /// Build DateField Props for the end date input.
-    pub fn end_field_props(&self) -> date_field::Props {
-        date_field::Props {
-            id: self.ctx.ids.part("end-input"),
-            value: Some(self.ctx.parsed_end.clone()),
-            format: self.ctx.format.clone(),
-            min: self.ctx.parsed_start.clone(), // end can't precede start
-            max: self.ctx.max.clone(),
-            disabled: self.ctx.disabled,
-            readonly: self.ctx.readonly,
-            aria_label: Some((self.ctx.messages.end_label)(&self.ctx.locale)),
-            ..Default::default()
-        }
-    }
+    /// Builds the child `DateField` props for the end input (mirror of start).
+    pub fn end_field_props(&self) -> date_field::Props { /* id = {id}-end-input, value = end_date, ... */ }
 
-    /// Attributes for the trigger element.
-    pub fn trigger_attrs(&self) -> AttrMap {
-        let mut attrs = AttrMap::new();
-        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Trigger.data_attrs();
-        attrs.set(scope_attr, scope_val);
-        attrs.set(part_attr, part_val);
-        attrs.set(HtmlAttr::Id, self.ctx.ids.part("trigger"));
-        attrs.set(HtmlAttr::Type, "button");
-        attrs.set(HtmlAttr::Aria(AriaAttr::Label), (self.ctx.messages.trigger_label)(&self.ctx.locale));
-        attrs.set(HtmlAttr::Aria(AriaAttr::HasPopup), "dialog");
-        attrs.set(HtmlAttr::Aria(AriaAttr::Expanded), if *self.ctx.open.get() { "true" } else { "false" });
-        attrs.set(HtmlAttr::Aria(AriaAttr::Controls), self.ctx.ids.part("content"));
-        if self.ctx.disabled { attrs.set_bool(HtmlAttr::Disabled, true); }
-        attrs
-    }
+    /// Trigger: `aria-haspopup="dialog"`, `aria-expanded`, `aria-controls={id}-content`,
+    /// `aria-label` from `messages.trigger_label`; `disabled` when disabled.
+    pub fn trigger_attrs(&self) -> AttrMap { /* ... */ }
 
-    /// Attributes for the clear trigger element.
-    pub fn clear_trigger_attrs(&self) -> AttrMap {
-        let mut attrs = AttrMap::new();
-        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::ClearTrigger.data_attrs();
-        attrs.set(scope_attr, scope_val);
-        attrs.set(part_attr, part_val);
-        attrs.set(HtmlAttr::Type, "button");
-        attrs.set(HtmlAttr::Aria(AriaAttr::Label), (self.ctx.messages.clear_label)(&self.ctx.locale));
-        if self.ctx.disabled || self.ctx.value.get().is_none() {
-            attrs.set_bool(HtmlAttr::Disabled, true);
-        }
-        attrs
-    }
+    /// Clear trigger: `aria-label` from `messages.clear_label`; `disabled` when
+    /// disabled or no range is selected.
+    pub fn clear_trigger_attrs(&self) -> AttrMap { /* ... */ }
 
-    /// Attributes for the positioner element.
-    pub fn positioner_attrs(&self) -> AttrMap {
-        let mut attrs = AttrMap::new();
-        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Positioner.data_attrs();
-        attrs.set(scope_attr, scope_val);
-        attrs.set(part_attr, part_val);
-        attrs
-    }
+    /// Preset trigger at `index`: `data-ars-index={index}`, `type="button"`;
+    /// `disabled` when the component is disabled or the index is out of range.
+    pub fn preset_trigger_attrs(&self, index: usize) -> AttrMap { /* ... */ }
 
-    /// Attributes for the content element.
-    pub fn content_attrs(&self) -> AttrMap {
-        let mut attrs = AttrMap::new();
-        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Content.data_attrs();
-        attrs.set(scope_attr, scope_val);
-        attrs.set(part_attr, part_val);
-        attrs.set(HtmlAttr::Id, self.ctx.ids.part("content"));
-        attrs.set(HtmlAttr::Role, "dialog");
-        attrs.set(HtmlAttr::Aria(AriaAttr::Modal), "false");
-        attrs.set(HtmlAttr::Aria(AriaAttr::LabelledBy), self.ctx.ids.part("label"));
-        attrs
-    }
+    /// Positioner: scope/part only (positioning is performed by the adapter).
+    pub fn positioner_attrs(&self) -> AttrMap { /* ... */ }
 
-    /// Attributes for the description element.
-    pub fn description_attrs(&self) -> AttrMap {
-        let mut attrs = AttrMap::new();
-        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Description.data_attrs();
-        attrs.set(scope_attr, scope_val);
-        attrs.set(part_attr, part_val);
-        attrs.set(HtmlAttr::Id, self.ctx.ids.part("description"));
-        attrs
-    }
+    /// Content: `role="dialog"`, `aria-modal="false"`, `aria-labelledby={id}-label`,
+    /// `id={id}-content`.
+    pub fn content_attrs(&self) -> AttrMap { /* ... */ }
 
-    /// Attributes for the error message element.
-    pub fn error_message_attrs(&self) -> AttrMap {
-        let mut attrs = AttrMap::new();
-        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::ErrorMessage.data_attrs();
-        attrs.set(scope_attr, scope_val);
-        attrs.set(part_attr, part_val);
-        attrs.set(HtmlAttr::Id, self.ctx.ids.part("error-message"));
-        attrs.set(HtmlAttr::Role, "alert");
-        attrs
-    }
+    pub fn description_attrs(&self) -> AttrMap { /* id={id}-description */ }
+    pub fn error_message_attrs(&self) -> AttrMap { /* id={id}-error-message, role="alert" */ }
 
-    /// Attributes for the hidden input element (form submission).
-    /// When `name` is set, submits range as `"YYYY-MM-DD/YYYY-MM-DD"`.
-    /// When `start_name`/`end_name` are set, use `start_hidden_input_attrs()`
-    /// and `end_hidden_input_attrs()` instead for separate form fields.
-    pub fn hidden_input_attrs(&self) -> AttrMap {
-        let mut attrs = AttrMap::new();
-        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::HiddenInput.data_attrs();
-        attrs.set(scope_attr, scope_val);
-        attrs.set(part_attr, part_val);
-        attrs.set(HtmlAttr::Type, "hidden");
-        if let Some(name) = &self.ctx.name {
-            attrs.set(HtmlAttr::Name, name);
-        }
-        // Submit range as two ISO 8601 dates separated by "/"
-        if let Some(range) = &self.ctx.value.get() {
-            let iso = format!("{}/{}", range.start.to_iso_string(), range.end.to_iso_string());
-            attrs.set(HtmlAttr::Value, iso);
-        }
-        attrs
-    }
+    /// Combined hidden input: `value = range.to_iso8601()` (the `start/end`
+    /// interval), or empty. `name` from props; `disabled` mirrors the component.
+    pub fn hidden_input_attrs(&self) -> AttrMap { /* ... */ }
 
-    /// Attributes for a separate hidden input carrying the start date.
-    /// Only rendered when `start_name` is set on Props.
-    pub fn start_hidden_input_attrs(&self) -> AttrMap {
-        let mut attrs = AttrMap::new();
-        attrs.set(HtmlAttr::Type, "hidden");
-        if let Some(name) = &self.ctx.start_name {
-            attrs.set(HtmlAttr::Name, name);
-        }
-        if let Some(range) = &self.ctx.value.get() {
-            attrs.set(HtmlAttr::Value, range.start.to_iso_string());
-        }
-        attrs
-    }
+    /// Separate hidden inputs carrying each endpoint as `CalendarDate::to_iso8601`.
+    /// Used when `start_name`/`end_name` are set.
+    pub fn start_hidden_input_attrs(&self) -> AttrMap { /* name from start_name, value = start_date.to_iso8601() */ }
+    pub fn end_hidden_input_attrs(&self) -> AttrMap { /* name from end_name, value = end_date.to_iso8601() */ }
 
-    /// Attributes for a separate hidden input carrying the end date.
-    /// Only rendered when `end_name` is set on Props.
-    pub fn end_hidden_input_attrs(&self) -> AttrMap {
-        let mut attrs = AttrMap::new();
-        attrs.set(HtmlAttr::Type, "hidden");
-        if let Some(name) = &self.ctx.end_name {
-            attrs.set(HtmlAttr::Name, name);
-        }
-        if let Some(range) = &self.ctx.value.get() {
-            attrs.set(HtmlAttr::Value, range.end.to_iso_string());
-        }
-        attrs
-    }
-
-    /// Build Calendar Props with range mode enabled.
-    /// Uses `visible_months: 2` by default so users see start and end month
-    /// grids side-by-side.
-    pub fn calendar_props(&self) -> calendar::Props {
-        calendar::Props {
+    /// Builds the embedded `RangeCalendar` props. The calendar reflects the
+    /// picker's canonical range as a controlled value and inherits the picker's
+    /// bounds, today, visible-month count, and layout direction.
+    pub fn range_calendar_props(&self) -> range_calendar::Props {
+        range_calendar::Props {
             id: self.ctx.ids.part("calendar"),
-            is_range: true,
-            visible_months: 2,
-            page_behavior: PageBehavior::Visible,
-            range_start: self.ctx.parsed_start.clone(),
-            range_end: self.ctx.parsed_end.clone(),
+            value: Some(self.ctx.value.get().clone()),
             min: self.ctx.min.clone(),
             max: self.ctx.max.clone(),
-            ..Default::default()
+            today: self.ctx.today.clone(),
+            visible_months: self.ctx.visible_months,
+            is_rtl: self.ctx.is_rtl,
+            disabled: self.ctx.disabled,
+            readonly: self.ctx.readonly,
+            ..range_calendar::Props::default()
         }
     }
 
-    /// Screen reader description of the full date range (e.g., "March 1 to March 15").
-    /// Returns `None` if no complete range is selected.
-    /// The adapter can use this as an `aria-description` on the root or as a live announcement.
-    pub fn range_description(&self) -> Option<String> {
-        let range = self.ctx.value.get().as_ref()?;
-        let start = format_date(&range.start, &self.ctx.format, &self.ctx.locale);
-        let end = format_date(&range.end, &self.ctx.format, &self.ctx.locale);
-        Some((self.ctx.messages.range_description)(&start, &end, &self.ctx.locale))
-    }
+    /// Screen-reader description of the full range (e.g. "March 1, 2025 to
+    /// March 15, 2025"), or `None` if no complete range is selected.
+    pub fn range_description(&self) -> Option<String> { /* via shared format_date_label + messages.range_description */ }
 
-    // -- Imperative methods -----------------------------------------------
-
-    /// Open the popover.
+    // Imperative dispatch + getters
     pub fn open(&self)   { (self.send)(Event::Open); }
-    /// Close the popover.
     pub fn close(&self)  { (self.send)(Event::Close); }
-    /// Toggle the popover.
     pub fn toggle(&self) { (self.send)(Event::Toggle); }
-    /// Check if the popover is open.
-    pub fn is_open(&self) -> bool { *self.ctx.open.get() }
-    /// Get the selected range.
-    pub fn selected_range(&self) -> Option<&DateRange> {
-        self.ctx.value.get().as_ref()
+    pub fn clear(&self)  { (self.send)(Event::Clear); }
+    pub fn select_range(&self, range: DateRange) { (self.send)(Event::SelectRangeComplete { range }); }
+    pub fn select_preset(&self, index: usize)    { (self.send)(Event::SelectPreset { index }); }
+    pub fn set_start_value(&self, date: Option<CalendarDate>) { (self.send)(Event::StartValueChange(date)); }
+    pub fn set_end_value(&self, date: Option<CalendarDate>)   { (self.send)(Event::EndValueChange(date)); }
+    pub fn focus_in(&self)  { (self.send)(Event::FocusIn); }
+    pub fn focus_out(&self) { (self.send)(Event::FocusOut); }
+    pub fn on_key_down(&self, key: KeyboardKey) { (self.send)(Event::KeyDown { key }); }
+
+    pub fn is_open(&self) -> bool { matches!(self.state, State::Open) }
+    pub fn selected_range(&self) -> Option<&DateRange> { self.ctx.value.get().as_ref() }
+    pub fn active_field(&self) -> ActiveField { self.ctx.active_field }
+    pub fn presets(&self) -> &[Preset] { &self.ctx.presets }
+    pub fn preset_label(&self, index: usize) -> Option<&str> {
+        self.ctx.presets.get(index).map(|preset| preset.label.as_str())
     }
+    pub fn is_invalid(&self) -> bool { self.ctx.is_invalid() }
 
     fn state_name(&self) -> &'static str {
-        match self.state {
-            State::Closed => "closed",
-            State::Open   => "open",
-        }
+        match self.state { State::Closed => "closed", State::Open => "open" }
     }
 }
 
@@ -671,11 +700,12 @@ impl ConnectApi for Api<'_> {
             Part::Root => self.root_attrs(),
             Part::Label => self.label_attrs(),
             Part::Control => self.control_attrs(),
-            Part::StartInput => self.start_field_props().into(), // delegates to DateField
+            Part::StartInput => self.start_input_attrs(),
             Part::Separator => self.separator_attrs(),
-            Part::EndInput => self.end_field_props().into(), // delegates to DateField
+            Part::EndInput => self.end_input_attrs(),
             Part::Trigger => self.trigger_attrs(),
             Part::ClearTrigger => self.clear_trigger_attrs(),
+            Part::PresetTrigger { index } => self.preset_trigger_attrs(index),
             Part::Positioner => self.positioner_attrs(),
             Part::Content => self.content_attrs(),
             Part::Description => self.description_attrs(),
@@ -693,34 +723,36 @@ DateRangePicker
 +-- Root                                  data-ars-scope="date-range-picker"
 |   +-- Label                             <label for="{id}-start-input">
 |   +-- Control                           role="group" aria-labelledby="{id}-label"
-|   |   +-- StartInput                    (DateField)
+|   |   +-- StartInput                    (DateField wrapper)
 |   |   +-- Separator                     aria-hidden="true"  "--"
-|   |   +-- EndInput                      (DateField)
+|   |   +-- EndInput                      (DateField wrapper)
 |   |   +-- Trigger                       aria-haspopup="dialog" aria-expanded
 |   |   +-- ClearTrigger                  aria-label="Clear date range"
 |   +-- Positioner
 |   |   +-- Content                       role="dialog" aria-labelledby="{id}-label"
-|   |       +-- (Calendar)                is_range=true  visible_months=2
+|   |       +-- PresetTrigger*            data-ars-index   (one per Props::presets entry)
+|   |       +-- (RangeCalendar)           visible_months=2
 |   +-- Description                       help text
 |   +-- ErrorMessage                      role="alert"
 |   +-- HiddenInput                       type="hidden" value="2024-01-10/2024-01-20"
 ```
 
-| Part           | Element       | Key Attributes                                                      |
-| -------------- | ------------- | ------------------------------------------------------------------- |
-| `Root`         | `<div>`       | `data-ars-scope="date-range-picker"`, `data-ars-part="root"`, state |
-| `Label`        | `<label>`     | `for="{id}-start-input"`                                            |
-| `Control`      | `<div>`       | `role="group"`, `aria-labelledby`                                   |
-| `StartInput`   | _(DateField)_ | Start date field                                                    |
-| `Separator`    | `<span>`      | `aria-hidden="true"`                                                |
-| `EndInput`     | _(DateField)_ | End date field                                                      |
-| `Trigger`      | `<button>`    | `aria-haspopup="dialog"`, `aria-expanded`, `aria-controls`          |
-| `ClearTrigger` | `<button>`    | `aria-label="Clear date range"`                                     |
-| `Positioner`   | `<div>`       | Floating positioner (via positioning engine)                        |
-| `Content`      | `<div>`       | `role="dialog"`, `aria-modal="false"`, `aria-labelledby`            |
-| `Description`  | `<div>`       | Help text, wired via `aria-describedby`                             |
-| `ErrorMessage` | `<div>`       | `role="alert"`, validation error                                    |
-| `HiddenInput`  | `<input>`     | `type="hidden"`, ISO 8601 range value                               |
+| Part            | Element               | Key Attributes                                                                          |
+| --------------- | --------------------- | --------------------------------------------------------------------------------------- |
+| `Root`          | `<div>`               | `data-ars-scope="date-range-picker"`, `data-ars-part="root"`, state, `data-ars-invalid` |
+| `Label`         | `<label>`             | `for="{id}-start-input"`                                                                |
+| `Control`       | `<div>`               | `role="group"`, `aria-labelledby`, `aria-describedby`                                   |
+| `StartInput`    | `<div>` _(DateField)_ | Start date field wrapper (child configured via `start_field_props`)                     |
+| `Separator`     | `<span>`              | `aria-hidden="true"`                                                                    |
+| `EndInput`      | `<div>` _(DateField)_ | End date field wrapper (child configured via `end_field_props`)                         |
+| `Trigger`       | `<button>`            | `aria-haspopup="dialog"`, `aria-expanded`, `aria-controls`                              |
+| `ClearTrigger`  | `<button>`            | `aria-label="Clear date range"`, disabled when empty                                    |
+| `PresetTrigger` | `<button>`            | `data-ars-index`, one per `Props::presets` entry; disabled when out of range            |
+| `Positioner`    | `<div>`               | Floating positioner (positioned by the adapter)                                         |
+| `Content`       | `<div>`               | `role="dialog"`, `aria-modal="false"`, `aria-labelledby`                                |
+| `Description`   | `<div>`               | Help text, wired via the control's `aria-describedby`                                   |
+| `ErrorMessage`  | `<div>`               | `role="alert"`, validation error                                                        |
+| `HiddenInput`   | `<input>`             | `type="hidden"`, ISO 8601 range value `start/end`                                       |
 
 ## 3. Accessibility
 
@@ -760,7 +792,7 @@ DateRangePicker
 
 ```rust
 /// Messages for the DateRangePicker component.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Messages {
     /// Trigger button label (default: "Open date range picker").
     pub trigger_label: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
@@ -805,26 +837,27 @@ impl ComponentMessages for Messages {}
 
 ### 6.1 Props
 
-| Feature               | ars-ui            | Ark UI                | React Aria                  | Notes                                               |
-| --------------------- | ----------------- | --------------------- | --------------------------- | --------------------------------------------------- |
-| Controlled range      | `value`           | `value` (DateValue[]) | `value` (RangeValue)        | Equivalent                                          |
-| Default range         | `default_value`   | `defaultValue`        | `defaultValue`              | Equivalent                                          |
-| Min/max               | `min`, `max`      | `min`, `max`          | `minValue`, `maxValue`      | Equivalent                                          |
-| Disabled              | `disabled`        | `disabled`            | `isDisabled`                | Equivalent                                          |
-| Read-only             | `readonly`        | `readOnly`            | `isReadOnly`                | Equivalent                                          |
-| Required              | `required`        | `required`            | `isRequired`                | Equivalent                                          |
-| Close on select       | `close_on_select` | `closeOnSelect`       | `shouldCloseOnSelect`       | Equivalent                                          |
-| Locale                | `locale`          | `locale`              | -- (context)                | Equivalent                                          |
-| Format                | `format`          | `format`              | --                          | Equivalent                                          |
-| Name                  | `name`            | `name`                | `startName`, `endName`      | React Aria has separate form names                  |
-| Positioning           | `positioning`     | `positioning`         | --                          | Equivalent                                          |
-| Allows non-contiguous | --                | --                    | `allowsNonContiguousRanges` | React Aria feature                                  |
-| Max visible months    | --                | `numOfMonths`         | `maxVisibleMonths`          | ars-ui uses `visible_months: 2` default on Calendar |
-| Start/end form names  | --                | --                    | `startName`, `endName`      | React Aria has separate form names for start/end    |
+| Feature               | ars-ui                   | Ark UI                | React Aria                  | Notes                                                   |
+| --------------------- | ------------------------ | --------------------- | --------------------------- | ------------------------------------------------------- |
+| Controlled range      | `value`                  | `value` (DateValue[]) | `value` (RangeValue)        | Equivalent                                              |
+| Default range         | `default_value`          | `defaultValue`        | `defaultValue`              | Equivalent                                              |
+| Min/max               | `min`, `max`             | `min`, `max`          | `minValue`, `maxValue`      | Equivalent                                              |
+| Disabled              | `disabled`               | `disabled`            | `isDisabled`                | Equivalent                                              |
+| Read-only             | `readonly`               | `readOnly`            | `isReadOnly`                | Equivalent                                              |
+| Required              | `required`               | `required`            | `isRequired`                | Equivalent                                              |
+| Close on select       | `close_on_select`        | `closeOnSelect`       | `shouldCloseOnSelect`       | Equivalent                                              |
+| Locale                | (context)                | `locale`              | -- (context)                | Resolved from `Env`, not a prop                         |
+| Today (injected)      | `today`                  | --                    | `todayValue` (context)      | Adapter-injected for determinism; forwarded to calendar |
+| Presets               | `presets`                | `presetTrigger`       | (userland)                  | ars-ui takes pre-localized concrete-range presets       |
+| Name                  | `name`                   | `name`                | `startName`, `endName`      | React Aria has separate form names                      |
+| Allows non-contiguous | --                       | --                    | `allowsNonContiguousRanges` | React Aria feature                                      |
+| Max visible months    | `visible_months`         | `numOfMonths`         | `maxVisibleMonths`          | ars-ui default `2`, forwarded to RangeCalendar          |
+| Start/end form names  | `start_name`, `end_name` | --                    | `startName`, `endName`      | ars-ui matches React Aria's separate form names         |
 
 **Gaps:**
 
 - `allowsNonContiguousRanges`: React Aria allows selecting ranges that span unavailable dates. Currently ars-ui's RangeCalendar blocks selection of unavailable dates. This is a niche feature; not adopting.
+- The date _format_ is owned by each child `DateField` (segment order / leading zeros), not a picker-level `format` prop; popover _positioning_ is an adapter concern (no `positioning` prop on the agnostic core).
 
 ### 6.2 Anatomy
 
@@ -858,128 +891,125 @@ impl ComponentMessages for Messages {}
 
 ### 6.4 Features
 
-| Feature               | ars-ui                      | Ark UI            | React Aria            |
-| --------------------- | --------------------------- | ----------------- | --------------------- |
-| Two-field input       | Yes (StartInput + EndInput) | Yes (Input index) | Yes (start/end slots) |
-| Calendar popover      | Yes                         | Yes               | Yes                   |
-| Range normalization   | Yes                         | Yes               | Yes                   |
-| Close on select       | Yes                         | Yes               | Yes                   |
-| Clear button          | Yes                         | Yes               | No                    |
-| Multi-month calendar  | Yes (default 2)             | Yes               | Yes                   |
-| Non-contiguous ranges | No                          | No                | Yes                   |
-| Separate form names   | No                          | No                | Yes                   |
-| Hidden form input     | Yes                         | No                | No                    |
+| Feature               | ars-ui                        | Ark UI                | React Aria            |
+| --------------------- | ----------------------------- | --------------------- | --------------------- |
+| Two-field input       | Yes (StartInput + EndInput)   | Yes (Input index)     | Yes (start/end slots) |
+| Calendar popover      | Yes                           | Yes                   | Yes                   |
+| Range normalization   | Yes                           | Yes                   | Yes                   |
+| Close on select       | Yes                           | Yes                   | Yes                   |
+| Clear button          | Yes                           | Yes                   | No                    |
+| Multi-month calendar  | Yes (default 2)               | Yes                   | Yes                   |
+| Preset shortcuts      | Yes (`presets`)               | Yes (`presetTrigger`) | Userland              |
+| Non-contiguous ranges | No                            | No                    | Yes                   |
+| Separate form names   | Yes (`start_name`/`end_name`) | No                    | Yes                   |
+| Hidden form input     | Yes                           | No                    | No                    |
 
 **Gaps:** None.
 
 ### 6.5 Summary
 
 - **Overall:** Full parity.
-- **Divergences:** React Aria supports `allowsNonContiguousRanges` which is a niche feature not adopted. ars-ui submits ranges via a single hidden input while React Aria uses separate form names.
+- **Divergences:** React Aria supports `allowsNonContiguousRanges`, a niche feature not adopted. ars-ui submits ranges via a single hidden input (`name`) and additionally supports separate `start_name`/`end_name` inputs (matching React Aria). Presets are taken as pre-localized concrete-range values (mirroring Ark UI's `presetTrigger`) rather than relative tokens, keeping the agnostic core deterministic.
 - **Recommended additions:** None.
 
 ## Appendix: Testing
+
+The full unit, ARIA, snapshot, spec-conformance, and proptest suites live in
+`crates/ars-components/src/date_time/date_range_picker/` (`tests.rs` +
+`snapshots/`), `crates/ars-components/tests/spec_conformance/date_time.rs`, and
+`crates/ars-components/tests/proptest_state_machines/date_time.rs`. The
+illustrative cases below drive the machine through a `Service`.
 
 ```rust
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ars_core::Service;
+    use ars_i18n::{CalendarDate, DateRange, locales::en_us};
+
+    fn date(y: i32, m: u8, d: u8) -> CalendarDate {
+        CalendarDate::new_gregorian(y, m, d).expect("valid date")
+    }
+
+    fn service() -> Service<Machine> {
+        Service::<Machine>::new(
+            Props { id: "range".into(), ..Props::default() },
+            &Env::default(),
+            &Messages::default(),
+        )
+    }
 
     #[test]
     fn initial_state_is_closed() {
-        let (state, ctx) = Machine::init(&Props::default(), &Env::default(), &Default::default());
-        assert_eq!(state, State::Closed);
-        assert_eq!(*ctx.open.get(), false);
-        assert!(ctx.value.get().is_none());
+        let svc = service();
+        assert_eq!(*svc.state(), State::Closed);
+        assert!(svc.context().value.get().is_none());
     }
 
     #[test]
     fn open_and_close() {
-        let props = Props::default();
-        let (state, ctx) = Machine::init(&props, &Env::default(), &Default::default());
-        let plan = Machine::transition(&state, &Event::Open, &ctx, &props).unwrap();
-        assert_eq!(plan.target, Some(State::Open));
-
-        let (state, ctx) = (State::Open, /* apply plan */);
-        let plan = Machine::transition(&state, &Event::Close, &ctx, &props).unwrap();
-        assert_eq!(plan.target, Some(State::Closed));
+        let mut svc = service();
+        drop(svc.send(Event::Open));
+        assert_eq!(*svc.state(), State::Open);
+        drop(svc.send(Event::Close));
+        assert_eq!(*svc.state(), State::Closed);
     }
 
     #[test]
     fn select_range_complete_closes_and_sets_value() {
-        let props = Props::default();
-        let (_, ctx) = Machine::init(&props, &Env::default(), &Default::default());
-        let range = DateRange::new(
-            CalendarDate::new_gregorian(2025, nzu8(3), nzu8(1)),
-            CalendarDate::new_gregorian(2025, nzu8(3), nzu8(15)),
+        let mut svc = service();
+        drop(svc.send(Event::Open));
+        let selected = DateRange::new(date(2025, 3, 1), date(2025, 3, 15)).unwrap();
+        drop(svc.send(Event::SelectRangeComplete { range: selected.clone() }));
+        assert_eq!(*svc.state(), State::Closed);
+        assert_eq!(*svc.context().value.get(), Some(selected));
+    }
+
+    #[test]
+    fn field_edits_assemble_and_normalize_range() {
+        let mut svc = service();
+        // A segmented DateField emits an Option<CalendarDate>, not text.
+        drop(svc.send(Event::StartValueChange(Some(date(2025, 6, 25)))));
+        drop(svc.send(Event::EndValueChange(Some(date(2025, 6, 1)))));
+        assert_eq!(
+            *svc.context().value.get(),
+            DateRange::new(date(2025, 6, 1), date(2025, 6, 25)).ok(),
         );
-        let plan = Machine::transition(
-            &State::Open,
-            &Event::SelectRangeComplete { range: range.clone() },
-            &ctx,
-            &props,
-        ).unwrap();
-        assert_eq!(plan.target, Some(State::Closed));
     }
 
     #[test]
-    fn start_input_change_parses_date() {
-        let props = Props { ..Props::default() };
-        let (state, ctx) = Machine::init(&props, &Env::default(), &Default::default());
-        let plan = Machine::transition(
-            &state,
-            &Event::StartInputChange { value: "03/01/2025".to_string() },
-            &ctx,
-            &props,
-        ).unwrap();
-        // Plan should update start_input_text and parsed_start
-        assert!(plan.target.is_none()); // context-only
+    fn select_preset_applies_range() {
+        let preset_range = DateRange::new(date(2025, 5, 26), date(2025, 6, 1)).unwrap();
+        let mut svc = Service::<Machine>::new(
+            Props {
+                id: "range".into(),
+                presets: vec![Preset { label: "Last 7 days".into(), range: preset_range.clone() }],
+                ..Props::default()
+            },
+            &Env::default(),
+            &Messages::default(),
+        );
+        drop(svc.send(Event::SelectPreset { index: 0 }));
+        assert_eq!(*svc.context().value.get(), Some(preset_range));
     }
 
     #[test]
-    fn escape_closes_popover() {
-        let props = Props::default();
-        let (_, ctx) = Machine::init(&props, &Env::default(), &Default::default());
-        let plan = Machine::transition(
-            &State::Open,
-            &Event::KeyDown { key: KeyboardKey::Escape },
-            &ctx,
-            &props,
-        ).unwrap();
-        assert_eq!(plan.target, Some(State::Closed));
+    fn escape_closes_and_arrow_down_opens() {
+        let mut svc = service();
+        drop(svc.send(Event::KeyDown { key: KeyboardKey::ArrowDown }));
+        assert_eq!(*svc.state(), State::Open);
+        drop(svc.send(Event::KeyDown { key: KeyboardKey::Escape }));
+        assert_eq!(*svc.state(), State::Closed);
     }
 
     #[test]
     fn disabled_ignores_events() {
-        let props = Props { disabled: true, ..Props::default() };
-        let (state, ctx) = Machine::init(&props, &Env::default(), &Default::default());
-        assert!(Machine::transition(&state, &Event::Open, &ctx, &props).is_none());
-    }
-
-    #[test]
-    fn focusout_closes_popover() {
-        let props = Props::default();
-        let (_, ctx) = Machine::init(&props, &Env::default(), &Default::default());
-        let plan = Machine::transition(
-            &State::Open,
-            &Event::FocusOut,
-            &ctx,
-            &props,
-        ).unwrap();
-        assert_eq!(plan.target, Some(State::Closed));
-    }
-
-    #[test]
-    fn arrow_down_opens_from_closed() {
-        let props = Props::default();
-        let (state, ctx) = Machine::init(&props, &Env::default(), &Default::default());
-        let plan = Machine::transition(
-            &state,
-            &Event::KeyDown { key: KeyboardKey::ArrowDown },
-            &ctx,
-            &props,
-        ).unwrap();
-        assert_eq!(plan.target, Some(State::Open));
+        let mut svc = Service::<Machine>::new(
+            Props { id: "range".into(), disabled: true, ..Props::default() },
+            &Env::default(),
+            &Messages::default(),
+        );
+        assert!(!svc.send(Event::Open).state_changed);
     }
 }
 ```

--- a/spec/dioxus-components/date-time/date-range-picker.md
+++ b/spec/dioxus-components/date-time/date-range-picker.md
@@ -243,7 +243,7 @@ struct OverlayProps {
 
 #[component]
 fn Overlay(props: OverlayProps) -> Element {
-    let calendar_props = props.machine.with_api_snapshot(|api| api.calendar_props());
+    let calendar_props = props.machine.with_api_snapshot(|api| api.range_calendar_props());
     rsx! { RangeCalendar { ..calendar_props } }
 }
 ```

--- a/spec/leptos-components/date-time/date-range-picker.md
+++ b/spec/leptos-components/date-time/date-range-picker.md
@@ -220,7 +220,7 @@ view! {
 
 ```rust
 fn overlay(machine: UseMachineReturn<date_range_picker::Machine>) -> impl IntoView {
-    let calendar_props = machine.with_api_snapshot(|api| api.calendar_props());
+    let calendar_props = machine.with_api_snapshot(|api| api.range_calendar_props());
     view! {
         <Positioner>
             <FocusScope>


### PR DESCRIPTION
Implements the framework-agnostic **DateRangePicker** core (epic #224).

## Summary

A popover state machine that owns the canonical `DateRange`, two segmented `DateField` inputs (start/end), an embedded `RangeCalendar`, named preset shortcuts, validation, and form integration. It exposes child-props builders (`start_field_props()`, `end_field_props()`, `range_calendar_props()`) the adapter feeds to the child machines, bridging their events back.

- **Composition** mirrors the proven siblings: value-based field coordination from `date_range_field` (`StartValueChange`/`EndValueChange(Option<CalendarDate>)` + `DateRange::normalized`) and the popover lifecycle from `date_picker`. `type Effect = NoEffect` — live focus, positioning, and return-focus are adapter concerns per the issue's element/ref note. Reuses `date_range_field`'s `ActiveField`, `date_out_of_bounds`, and `format_date_label` (promoted to `pub(crate)`).
- **Presets** (`Preset { label, range }`, selected via `SelectPreset` / the `PresetTrigger { index }` part): the consumer supplies a pre-localized label and a concrete range computed against the same injected `today`, keeping the core deterministic.
- **Form integration**: combined hidden input (`name`) carrying the `start/end` ISO 8601 interval, plus optional split `start_name`/`end_name` inputs.

## Spec synchronization

The spec predated the finalized `date_field`/`range_calendar` APIs. `spec/components/date-time/date-range-picker.md` §1/§2/§6 are rewritten to match the real value-based composition (dropping the text-input/`DateFormat`/`calendar{is_range}` model, fixing `to_iso8601` and the `DateRange::normalized` `Option` type error, adding `today`/`presets`/`visible_months`/`is_rtl`), and the new `Preset` API is specced. Both adapter specs updated (`calendar_props` → `range_calendar_props`).

## Post-implementation audit

- **Phase 1 (drift):** 3 spec-only fixes — `State` `Eq`, `Messages` `PartialEq`, `Preset::new` (impl was correct).
- **Phase 2:** adapter-spec method rename (×2); snapshot-count/manifest OK.
- **Phase 3 (coverage):** filled reachable gaps; fixed a public→private intra-doc-link warning. One non-comparable-mixed-calendar defensive branch left uncovered (consistent with `date_range_field`).
- A **proptest caught a real bug**: a controlled→uncontrolled switch revealed a stale internal value diverging from the fields — fixed in `sync_props` + named regression test + spec note.

## Tests

82 unit/ARIA/snapshot tests (28 committed `.snap` fixtures), a spec-conformance anatomy test (14 parts), and a proptest invariant block. **Coverage 99.86% line / 100% function.** `cargo xci-fast` passed all 10 gates.

Closes #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)