### PR TITLE
Implement Carousel agnostic core (#278)

### DIFF
--- a/crates/ars-components/src/layout/carousel/mod.rs
+++ b/crates/ars-components/src/layout/carousel/mod.rs
@@ -150,6 +150,15 @@ pub enum Event {
 
     /// Focus left the carousel.
     Blur,
+
+    /// The parent pushed a new controlled `index` value through `set_props`.
+    /// Emitted by [`Machine::on_props_changed`](ars_core::Machine::on_props_changed)
+    /// so the stored [`Bindable`] tracks the controlled signal without going
+    /// through a `Transitioning` animation or stopping auto-play.
+    SyncControlledIndex {
+        /// The new controlled slide index.
+        index: usize,
+    },
 }
 
 // ────────────────────────────────────────────────────────────────────
@@ -554,11 +563,23 @@ impl ars_core::Machine for Machine {
             State::Idle
         };
 
+        // Normalize `slides_per_view`: a non-finite or non-positive value
+        // would make `track_offset_percent` divide by zero/NaN and corrupt the
+        // visible-window math, so fall back to one full slide.
+        let slides_per_view = props
+            .slides_per_view
+            .filter(|value| value.is_finite() && *value > 0.0)
+            .unwrap_or(1.0);
+
+        // `slides_per_move` of zero would make every navigation a no-op (while
+        // still able to stop auto-play), so clamp it to at least one.
+        let slides_per_move = props.slides_per_move.unwrap_or(1).max(1);
+
         // Clamp the uncontrolled default to the last valid starting index so
         // `current_index < slide_count` holds from the very first render (a
         // bad `default_index` would otherwise yield "Slide 100 of 3" with no
         // item marked current). Accounts for `slides_per_view`.
-        let visible_count = (props.slides_per_view.unwrap_or(1.0).ceil() as usize).max(1);
+        let visible_count = (slides_per_view.ceil() as usize).max(1);
         let max_index = props.slide_count.get().saturating_sub(visible_count);
         let initial_index = props.default_index.unwrap_or(0).min(max_index);
 
@@ -573,8 +594,8 @@ impl ars_core::Machine for Machine {
             auto_play_stopped: false,
             auto_play_paused: false,
             spacing: props.spacing.unwrap_or(0.0),
-            slides_per_view: props.slides_per_view.unwrap_or(1.0),
-            slides_per_move: props.slides_per_move.unwrap_or(1),
+            slides_per_view,
+            slides_per_move,
             align: props.align.unwrap_or_default(),
             orientation: props.orientation.unwrap_or_default(),
             is_rtl: props.is_rtl,
@@ -608,6 +629,28 @@ impl ars_core::Machine for Machine {
         } else {
             Vec::new()
         }
+    }
+
+    fn on_props_changed(old: &Self::Props, new: &Self::Props) -> Vec<Self::Event> {
+        assert_eq!(
+            old.id, new.id,
+            "carousel::Props.id must remain stable after initialization"
+        );
+
+        // In controlled mode the parent owns the slide index and pushes new
+        // values through `set_props`. Detect a changed controlled value and
+        // forward it so the stored `Bindable` tracks it (otherwise the active
+        // slide, progress text, and indicators stay stuck on the initial
+        // controlled value).
+        let old_index = old.index.as_ref().map(|bindable| *bindable.get());
+        let new_index = new.index.as_ref().map(|bindable| *bindable.get());
+        if old_index != new_index
+            && let Some(index) = new_index
+        {
+            return vec![Event::SyncControlledIndex { index }];
+        }
+
+        Vec::new()
     }
 
     fn transition(
@@ -679,7 +722,11 @@ impl ars_core::Machine for Machine {
             ),
 
             Event::AutoPlayTick => {
-                if *state != State::AutoPlaying {
+                // Ignore ticks that cannot advance: at the final non-looping
+                // page `clamp_index` would return the same index, so entering
+                // `Transitioning` risks a missing `transitionend` (the
+                // transform never changes) leaving the machine stuck.
+                if *state != State::AutoPlaying || !ctx.can_go_next() {
                     return None;
                 }
 
@@ -832,12 +879,35 @@ impl ars_core::Machine for Machine {
                 Some(plan)
             }
 
-            Event::PointerCancel => Some(TransitionPlan::context_only(|ctx: &mut Context| {
-                ctx.drag_start_pos = None;
-                ctx.drag_delta = 0.0;
-                ctx.swipe_velocity = 0.0;
-                ctx.drag_last_timestamp = None;
-            })),
+            Event::PointerCancel => {
+                // The drag is aborted (e.g. touch scrolling or pointer-capture
+                // interruption). `PointerDown` cancelled the timer, so if the
+                // gesture was interrupting an active auto-play carousel, re-arm
+                // the timer — otherwise rotation silently dies even though the
+                // state still reads `AutoPlaying`.
+                let resume = ctx.drag_start_pos.is_some()
+                    && ctx.auto_play.is_some()
+                    && !ctx.auto_play_stopped
+                    && !ctx.auto_play_paused;
+
+                let mut plan = if resume {
+                    TransitionPlan::to(State::AutoPlaying)
+                } else {
+                    TransitionPlan::new()
+                }
+                .apply(|ctx: &mut Context| {
+                    ctx.drag_start_pos = None;
+                    ctx.drag_delta = 0.0;
+                    ctx.swipe_velocity = 0.0;
+                    ctx.drag_last_timestamp = None;
+                });
+
+                if resume {
+                    plan = plan.with_effect(PendingEffect::named(Effect::AutoPlayTimer));
+                }
+
+                Some(plan)
+            }
 
             Event::FocusSlide { index } => {
                 // Clamp to the last valid starting index: a focused slide is a
@@ -871,6 +941,16 @@ impl ars_core::Machine for Machine {
                     if idx != current {
                         ctx.index.set(idx);
                     }
+                }))
+            }
+
+            Event::SyncControlledIndex { index } => {
+                // Push the parent's controlled value into the stored bindable
+                // without animating or stopping auto-play. Clamp defensively so
+                // a bad controlled value can't break the index invariant.
+                let idx = (*index).min(ctx.last_index());
+                Some(TransitionPlan::context_only(move |ctx: &mut Context| {
+                    ctx.index.sync_controlled(Some(idx));
                 }))
             }
 
@@ -1188,7 +1268,9 @@ impl Api<'_> {
 
         attrs.set(scope_attr, scope_val).set(part_attr, part_val);
 
-        let is_playing = !self.ctx.auto_play_stopped && !self.ctx.auto_play_paused;
+        let is_playing = self.ctx.auto_play.is_some()
+            && !self.ctx.auto_play_stopped
+            && !self.ctx.auto_play_paused;
 
         let label = if is_playing {
             (self.ctx.messages.pause_auto_play_label)(&self.ctx.locale)
@@ -1212,7 +1294,9 @@ impl Api<'_> {
 
         attrs.set(scope_attr, scope_val).set(part_attr, part_val);
 
-        let is_playing = !self.ctx.auto_play_stopped && !self.ctx.auto_play_paused;
+        let is_playing = self.ctx.auto_play.is_some()
+            && !self.ctx.auto_play_stopped
+            && !self.ctx.auto_play_paused;
 
         attrs
             .set(
@@ -2750,5 +2834,111 @@ mod tests {
             captured_keydown(&service, KeyboardKey::End),
             vec![Event::GoToSlide { index: 1 }]
         );
+    }
+
+    // ── Codex review #716 (second pass) ──────────────────────────────
+
+    #[test]
+    fn controlled_index_syncs_from_props() {
+        let mut service = service(Props {
+            index: Some(Bindable::controlled(0)),
+            ..props(4)
+        });
+        assert_eq!(service.context().current_index(), 0);
+
+        // Parent pushes a new controlled value via set_props.
+        drop(service.set_props(Props {
+            index: Some(Bindable::controlled(2)),
+            ..props(4)
+        }));
+        assert_eq!(service.context().current_index(), 2);
+    }
+
+    #[test]
+    fn slides_per_move_zero_is_clamped_to_one() {
+        let mut service = service(Props {
+            slides_per_move: Some(0),
+            ..props(4)
+        });
+        assert_eq!(service.context().slides_per_move, 1);
+        drop(service.send(Event::GoToNext));
+        assert_eq!(service.context().current_index(), 1);
+    }
+
+    #[test]
+    fn slides_per_view_zero_is_normalized() {
+        let ctx = service(Props {
+            slides_per_view: Some(0.0),
+            ..props(3)
+        })
+        .context()
+        .clone();
+        assert_eq!(ctx.slides_per_view, 1.0);
+        assert!(ctx.track_offset_percent(200.0).is_finite());
+    }
+
+    #[test]
+    fn slides_per_view_non_finite_is_normalized() {
+        let ctx = service(Props {
+            slides_per_view: Some(f64::NAN),
+            ..props(3)
+        })
+        .context()
+        .clone();
+        assert_eq!(ctx.slides_per_view, 1.0);
+    }
+
+    #[test]
+    fn pointer_cancel_resumes_autoplay() {
+        let mut service = service(autoplay_props(3));
+        drop(service.take_initial_effects());
+        drop(service.send(Event::PointerDown {
+            pos: 100.0,
+            timestamp: 0.0,
+        }));
+        let result = service.send(Event::PointerCancel);
+        assert_eq!(service.state(), &State::AutoPlaying);
+        assert!(service.context().drag_start_pos.is_none());
+        assert_eq!(pending_effect_names(&result), vec![Effect::AutoPlayTimer]);
+    }
+
+    #[test]
+    fn pointer_cancel_without_autoplay_only_clears_drag() {
+        let mut service = service(props(3));
+        drop(service.send(Event::PointerDown {
+            pos: 100.0,
+            timestamp: 0.0,
+        }));
+        let result = service.send(Event::PointerCancel);
+        assert_eq!(service.state(), &State::Idle);
+        assert!(service.context().drag_start_pos.is_none());
+        assert!(result.pending_effects.is_empty());
+    }
+
+    #[test]
+    fn auto_play_trigger_not_playing_without_config() {
+        let service = service(props(3));
+        let trigger = service.connect(&|_| {}).auto_play_trigger_attrs();
+        assert_eq!(
+            trigger.get(&HtmlAttr::Aria(AriaAttr::Pressed)),
+            Some("false")
+        );
+        let indicator = service.connect(&|_| {}).auto_play_indicator_attrs();
+        assert_eq!(indicator.get(&HtmlAttr::Data("ars-state")), Some("paused"));
+    }
+
+    #[test]
+    fn autoplay_tick_ignored_at_last_page_non_looping() {
+        let mut service = service(Props {
+            default_index: Some(2),
+            ..autoplay_props(3)
+        });
+        drop(service.take_initial_effects());
+        // At the last slide of a non-looping carousel, a tick cannot advance,
+        // so it must not enter Transitioning (which could stall).
+        let result = service.send(Event::AutoPlayTick);
+        assert!(!result.state_changed);
+        assert_eq!(service.state(), &State::AutoPlaying);
+        assert_eq!(service.context().current_index(), 2);
     }
 }

--- a/crates/ars-components/src/layout/carousel/mod.rs
+++ b/crates/ars-components/src/layout/carousel/mod.rs
@@ -164,6 +164,12 @@ pub enum Event {
     /// Pointer cancelled (drag abort).
     PointerCancel,
 
+    /// Keyboard focus entered the carousel on a part other than a slide (a
+    /// control such as Prev/Next, an indicator, or the auto-play trigger).
+    /// Pauses auto-play when [`AutoPlayOptions::pause_on_focus`] is set, without
+    /// changing the slide index. Slide focus uses [`Event::FocusSlide`].
+    FocusEnter,
+
     /// A slide received focus.
     FocusSlide {
         /// Zero-based index of the slide that received focus.
@@ -811,7 +817,14 @@ impl ars_core::Machine for Machine {
 
             Event::TransitionEnd => {
                 if ctx.auto_play.is_some() && !ctx.auto_play_stopped && !ctx.is_auto_play_paused() {
-                    Some(TransitionPlan::to(State::AutoPlaying))
+                    // Always (re-)arm the timer on entering AutoPlaying: a swipe
+                    // cancelled it on PointerDown and kept it cancelled through
+                    // the snap, so settling here must restart it — otherwise the
+                    // controls report "playing" with no interval running.
+                    Some(
+                        TransitionPlan::to(State::AutoPlaying)
+                            .with_effect(PendingEffect::named(Effect::AutoPlayTimer)),
+                    )
                 } else {
                     Some(TransitionPlan::to(State::Idle))
                 }
@@ -972,6 +985,13 @@ impl ars_core::Machine for Machine {
             }
 
             Event::PointerDown { pos, timestamp } => {
+                // Don't start a drag mid-snap: a slide animation is in progress
+                // and accepting a new gesture would let rapid pointer input skip
+                // slides, the same way button/keyboard nav is blocked during
+                // `Transitioning`.
+                if *state == State::Transitioning {
+                    return None;
+                }
                 let pos = *pos;
                 let timestamp = *timestamp;
                 Some(
@@ -1008,6 +1028,19 @@ impl ars_core::Machine for Machine {
                 // was never cancelled, creating duplicate intervals). Mirrors
                 // the `PointerMove`/`PointerCancel` guards.
                 ctx.drag_start_pos?;
+
+                // Never navigate mid-snap: if a slide animation is still running
+                // a release must not set a new index (button/keyboard nav is
+                // blocked the same way). Just clear the drag and let the current
+                // transition settle.
+                if *state == State::Transitioning {
+                    return Some(TransitionPlan::context_only(|ctx: &mut Context| {
+                        ctx.drag_start_pos = None;
+                        ctx.drag_delta = 0.0;
+                        ctx.swipe_velocity = 0.0;
+                        ctx.drag_last_timestamp = None;
+                    }));
+                }
 
                 let delta = ctx.drag_delta;
                 let velocity = ctx.swipe_velocity;
@@ -1112,6 +1145,30 @@ impl ars_core::Machine for Machine {
                 }
 
                 Some(plan)
+            }
+
+            Event::FocusEnter => {
+                // Focus entered a control (not a slide). Pause auto-play when
+                // `pause_on_focus` is set, mirroring `FocusSlide`'s pause but
+                // without moving the index. `Blur` resumes on focus-out.
+                if !ctx
+                    .auto_play
+                    .as_ref()
+                    .is_some_and(|options| options.pause_on_focus)
+                {
+                    return None;
+                }
+                let plan = if *state == State::AutoPlaying {
+                    TransitionPlan::to(State::Idle)
+                } else {
+                    TransitionPlan::new()
+                };
+                Some(
+                    plan.apply(|ctx: &mut Context| {
+                        ctx.auto_play_paused_focus = true;
+                    })
+                    .cancel_effect(Effect::AutoPlayTimer),
+                )
             }
 
             Event::FocusSlide { index } => {
@@ -1674,7 +1731,7 @@ impl Api<'_> {
             KeyboardKey::Home => (self.send)(Event::GoToSlide { index: 0 }),
 
             KeyboardKey::End => (self.send)(Event::GoToSlide {
-                index: self.ctx.last_index(),
+                index: self.ctx.max_start_index(),
             }),
 
             _ => {}
@@ -1721,6 +1778,21 @@ impl Api<'_> {
     /// Dispatch a hover-end (pointer left the carousel), resuming a hover pause.
     pub fn on_root_pointer_leave(&self) {
         (self.send)(Event::HoverEnd);
+    }
+
+    /// Dispatch focus entering the carousel on a control (not a slide; slides
+    /// use [`on_root_keydown`](Self::on_root_keydown)'s sibling
+    /// [`Event::FocusSlide`] via the slide focus handler). Auto-play pauses only
+    /// when [`AutoPlayOptions::pause_on_focus`] is set. Adapters fire this from
+    /// `focusin` on a carousel control.
+    pub fn on_root_focus_in(&self) {
+        (self.send)(Event::FocusEnter);
+    }
+
+    /// Dispatch focus leaving the carousel, resuming a focus pause. Adapters
+    /// fire this from `focusout` when focus exits the whole carousel.
+    pub fn on_root_focus_out(&self) {
+        (self.send)(Event::Blur);
     }
 
     /// Dispatch a pointer-down (drag start) with adapter-normalized position
@@ -3812,5 +3884,129 @@ mod tests {
         // Subsequent navigation is not blocked.
         drop(service.send(Event::GoToNext));
         assert_eq!(service.context().current_index(), 2);
+    }
+
+    // ── Codex review #716 (eighth pass) ──────────────────────────────
+
+    #[test]
+    fn swipe_settle_rearms_autoplay_timer() {
+        // T1: a swipe cancels the timer on PointerDown and keeps it cancelled
+        // through the snap, so TransitionEnd must re-arm it (not just flip state).
+        let mut service = service(Props {
+            auto_play: Some(AutoPlayOptions {
+                stop_on_interaction: false,
+                ..AutoPlayOptions::default()
+            }),
+            ..props(4)
+        });
+        drop(service.take_initial_effects());
+        drop(service.send(Event::PointerDown {
+            pos: 100.0,
+            timestamp: 0.0,
+        }));
+        drop(service.send(Event::PointerMove {
+            pos: 40.0,
+            timestamp: 1000.0,
+        }));
+        drop(service.send(Event::PointerUp));
+        assert_eq!(service.state(), &State::Transitioning);
+        // Settling re-arms the interval.
+        let settled = service.send(Event::TransitionEnd);
+        assert_eq!(service.state(), &State::AutoPlaying);
+        assert!(
+            settled
+                .pending_effects
+                .iter()
+                .any(|effect| effect.name == Effect::AutoPlayTimer)
+        );
+    }
+
+    #[test]
+    fn pointer_down_ignored_during_transition() {
+        // T2: a slide animation is in progress → don't start a new drag.
+        let mut service = service(props(4));
+        drop(service.send(Event::GoToSlide { index: 1 }));
+        assert_eq!(service.state(), &State::Transitioning);
+        let result = service.send(Event::PointerDown {
+            pos: 100.0,
+            timestamp: 0.0,
+        });
+        assert!(!result.context_changed);
+        assert_eq!(service.context().drag_start_pos, None);
+    }
+
+    #[test]
+    fn pointer_up_during_transition_does_not_navigate() {
+        // T2: a release mid-snap must not set a new index. Set up an active drag
+        // (PointerDown leaves state unchanged), then enter Transitioning via a
+        // programmatic jump before release.
+        let mut service = service(props(4));
+        drop(service.send(Event::PointerDown {
+            pos: 100.0,
+            timestamp: 0.0,
+        }));
+        drop(service.send(Event::PointerMove {
+            pos: 30.0,
+            timestamp: 1000.0,
+        }));
+        drop(service.send(Event::GoToSlide { index: 1 }));
+        assert_eq!(service.state(), &State::Transitioning);
+        assert_eq!(service.context().current_index(), 1);
+
+        // Release mid-snap: clears the drag, does NOT navigate again.
+        drop(service.send(Event::PointerUp));
+        assert_eq!(service.state(), &State::Transitioning);
+        assert_eq!(service.context().current_index(), 1);
+        assert_eq!(service.context().drag_start_pos, None);
+    }
+
+    #[test]
+    fn end_key_targets_final_slide_when_looping() {
+        // T3: looped multi-view → End reaches the final slide, not last_index.
+        let service = service(Props {
+            loop_nav: true,
+            slides_per_view: Some(2.0),
+            ..props(5)
+        });
+        assert_eq!(
+            captured_keydown(&service, KeyboardKey::End),
+            vec![Event::GoToSlide { index: 4 }]
+        );
+    }
+
+    #[test]
+    fn focus_enter_pauses_and_blur_resumes() {
+        // T4: focusing a control (not a slide) pauses; focus-out resumes.
+        let mut service = service(autoplay_props(3));
+        drop(service.take_initial_effects());
+        let paused = service.send(Event::FocusEnter);
+        assert_eq!(service.state(), &State::Idle);
+        assert!(service.context().auto_play_paused_focus);
+        assert_eq!(paused.cancel_effects, vec![Effect::AutoPlayTimer]);
+
+        let resumed = service.send(Event::Blur);
+        assert_eq!(service.state(), &State::AutoPlaying);
+        assert!(!service.context().is_auto_play_paused());
+        assert!(
+            resumed
+                .pending_effects
+                .iter()
+                .any(|effect| effect.name == Effect::AutoPlayTimer)
+        );
+    }
+
+    #[test]
+    fn focus_enter_without_pause_on_focus_is_noop() {
+        let mut service = service(Props {
+            auto_play: Some(AutoPlayOptions {
+                pause_on_focus: false,
+                ..AutoPlayOptions::default()
+            }),
+            ..props(3)
+        });
+        drop(service.take_initial_effects());
+        let result = service.send(Event::FocusEnter);
+        assert!(!result.state_changed);
+        assert!(!service.context().auto_play_paused_focus);
     }
 }

--- a/crates/ars-components/src/layout/carousel/mod.rs
+++ b/crates/ars-components/src/layout/carousel/mod.rs
@@ -384,6 +384,20 @@ impl Context {
         }
     }
 
+    /// Clamp or wrap an **absolute** `usize` target (a direct `GoToSlide` /
+    /// `FocusSlide` index). Unlike [`clamp_index`](Self::clamp_index) this never
+    /// routes through `as isize`, so a target above `isize::MAX` saturates
+    /// (non-looping) or wraps (looping) correctly instead of overflowing into a
+    /// negative value.
+    #[must_use]
+    pub fn clamp_index_usize(&self, index: usize) -> usize {
+        if self.loop_nav {
+            index % self.slide_count.get()
+        } else {
+            index.min(self.last_index())
+        }
+    }
+
     /// Whether the carousel can navigate to a previous slide.
     ///
     /// Always `false` when [`last_index`](Self::last_index) is `0` (a single
@@ -791,7 +805,7 @@ impl ars_core::Machine for Machine {
                 // `last_index`); when not looping it saturates at `last_index`
                 // (contain-scroll). A direct jump is a manual interaction, so it
                 // honours `stop_on_interaction` like Next/Prev.
-                let idx = ctx.clamp_index(*index as isize);
+                let idx = ctx.clamp_index_usize(*index);
                 navigate_to(ctx, idx)
             }
 
@@ -1179,7 +1193,7 @@ impl ars_core::Machine for Machine {
                 let scroll = !ctx.is_slide_visible(*index);
                 // Clamp via `clamp_index` so it wraps under `loop_nav` and
                 // saturates at `last_index` otherwise (matching `GoToSlide`).
-                let idx = ctx.clamp_index(*index as isize);
+                let idx = ctx.clamp_index_usize(*index);
                 let should_pause = ctx.auto_play.as_ref().is_some_and(|o| o.pause_on_focus);
 
                 if should_pause {
@@ -1228,22 +1242,25 @@ impl ars_core::Machine for Machine {
                 let want_timer =
                     new_auto.is_some() && !ctx.auto_play_stopped && !ctx.is_auto_play_paused();
 
-                // Only the auto-play transition moves the resting state:
-                // enabling/resuming → AutoPlaying; disabling while playing → Idle.
-                let target = if auto_changed {
-                    if want_timer {
-                        State::AutoPlaying
-                    } else if *state == State::AutoPlaying {
-                        State::Idle
-                    } else {
-                        *state
-                    }
+                // Resting target. Never exit an in-flight `Transitioning` snap —
+                // doing so would accept ticks/navigation before the adapter's
+                // `TransitionEnd`; the snap settles on its own (and re-arms).
+                let target = if *state == State::Transitioning {
+                    State::Transitioning
+                } else if want_timer {
+                    State::AutoPlaying
                 } else {
-                    *state
+                    State::Idle
                 };
+                // Only emit a state transition when the state actually changes.
+                // A no-op `to(current)` would still flag `state_changed`, and the
+                // adapter drains active effect cleanups on any state change —
+                // silently killing the running auto-play interval on an unrelated
+                // prop change (e.g. `spacing`/`is_rtl`/controlled `index`).
+                let changes_state = target != *state;
 
                 let props = props.clone();
-                let mut plan = TransitionPlan::to(target).apply(move |ctx: &mut Context| {
+                let apply = move |ctx: &mut Context| {
                     let slides_per_view = props
                         .slides_per_view
                         .filter(|value| value.is_finite() && *value > 0.0)
@@ -1263,20 +1280,21 @@ impl ars_core::Machine for Machine {
                         .unwrap_or_else(|| Duration::from_millis(300));
                     ctx.swipe_threshold = props.swipe_threshold.unwrap_or(50.0);
 
-                    // Track the controlled signal (clamped to the largest
-                    // reachable start, loop-aware); `None` returns the bindable
-                    // to uncontrolled mode.
+                    // The currently displayed index (the controlled value while
+                    // controlled), captured before clearing control so releasing
+                    // control preserves it instead of revealing a stale internal.
+                    let displayed = ctx.current_index();
                     let controlled = props
                         .index
                         .as_ref()
                         .map(|bindable| (*bindable.get()).min(ctx.max_start_index()));
                     ctx.index.sync_controlled(controlled);
 
-                    // Keep an uncontrolled index in range if the slide count or
-                    // visible window shrank.
+                    // Uncontrolled now: seed the internal value from what was
+                    // displayed (the prior controlled value when releasing
+                    // control), re-clamped to the new bounds.
                     if !ctx.index.is_controlled() {
-                        let clamped = ctx.current_index().min(ctx.max_start_index());
-                        ctx.index.set(clamped);
+                        ctx.index.set(displayed.min(ctx.max_start_index()));
                     }
 
                     // Without auto-play configured, the play/pause flags are
@@ -1287,14 +1305,35 @@ impl ars_core::Machine for Machine {
                         ctx.auto_play_paused_focus = false;
                         ctx.auto_play_stopped = false;
                     }
-                });
+                };
+                let mut plan = if changes_state {
+                    TransitionPlan::to(target).apply(apply)
+                } else {
+                    TransitionPlan::context_only(apply)
+                };
 
-                // Restart the interval when auto-play config changed so a new
-                // interval/enable takes effect; tear it down when disabled.
-                if auto_changed {
-                    plan = plan.cancel_effect(Effect::AutoPlayTimer);
-                    if want_timer {
-                        plan = plan.with_effect(PendingEffect::named(Effect::AutoPlayTimer));
+                // Reconcile the timer to match `target`.
+                match target {
+                    State::AutoPlaying => {
+                        // Must end up running. (Re)arm when the state change
+                        // drained effects, or the auto-play config changed (new
+                        // interval / re-enable). When the state and config are
+                        // unchanged the interval is still running (no drain) — leave it.
+                        if changes_state || auto_changed {
+                            plan = plan
+                                .cancel_effect(Effect::AutoPlayTimer)
+                                .with_effect(PendingEffect::named(Effect::AutoPlayTimer));
+                        }
+                    }
+                    State::Idle => {
+                        plan = plan.cancel_effect(Effect::AutoPlayTimer);
+                    }
+                    State::Transitioning => {
+                        // Stay in the snap; `TransitionEnd` re-arms on settle.
+                        // Only cancel if auto-play was turned off mid-snap.
+                        if !want_timer {
+                            plan = plan.cancel_effect(Effect::AutoPlayTimer);
+                        }
                     }
                 }
 
@@ -4008,5 +4047,62 @@ mod tests {
         let result = service.send(Event::FocusEnter);
         assert!(!result.state_changed);
         assert!(!service.context().auto_play_paused_focus);
+    }
+
+    // ── Codex review #716 (ninth pass) ───────────────────────────────
+
+    #[test]
+    fn prop_sync_keeps_autoplay_timer_running() {
+        // U1: an unrelated prop change while steadily autoplaying must not flag
+        // a state change (which would make the adapter drain the interval) nor
+        // cancel the timer.
+        let mut service = service(autoplay_props(3));
+        drop(service.take_initial_effects());
+        let result = service.set_props(Props {
+            spacing: Some(12.0),
+            ..autoplay_props(3)
+        });
+        assert_eq!(service.state(), &State::AutoPlaying);
+        assert!(!result.state_changed);
+        assert!(!result.cancel_effects.contains(&Effect::AutoPlayTimer));
+        assert_eq!(service.context().spacing, 12.0);
+    }
+
+    #[test]
+    fn prop_sync_during_transition_stays_transitioning() {
+        // U2: a config/auto-play change mid-snap must not exit Transitioning.
+        let mut service = service(props(4));
+        drop(service.send(Event::GoToSlide { index: 1 }));
+        assert_eq!(service.state(), &State::Transitioning);
+        drop(service.set_props(autoplay_props(4)));
+        assert_eq!(service.state(), &State::Transitioning);
+    }
+
+    #[test]
+    fn releasing_control_preserves_latest_index() {
+        // U3: controlled 0 → controlled 2 → uncontrolled must keep index 2, not
+        // revert to the stale internal 0.
+        let mut service = service(Props {
+            index: Some(Bindable::controlled(0)),
+            ..props(4)
+        });
+        drop(service.set_props(Props {
+            index: Some(Bindable::controlled(2)),
+            ..props(4)
+        }));
+        assert_eq!(service.context().current_index(), 2);
+
+        drop(service.set_props(props(4)));
+        assert!(!service.context().index.is_controlled());
+        assert_eq!(service.context().current_index(), 2);
+    }
+
+    #[test]
+    fn goto_slide_oversized_index_saturates_without_wrapping() {
+        // U4: a target above isize::MAX must saturate to last_index (non-loop),
+        // not wrap through `as isize` to slide 0.
+        let mut service = service(props(3));
+        drop(service.send(Event::GoToSlide { index: usize::MAX }));
+        assert_eq!(service.context().current_index(), 2);
     }
 }

--- a/crates/ars-components/src/layout/carousel/mod.rs
+++ b/crates/ars-components/src/layout/carousel/mod.rs
@@ -763,6 +763,12 @@ impl ars_core::Machine for Machine {
             }
 
             Event::AutoPlayPause => {
+                // Nothing to pause without auto-play configured. Guarding here
+                // (not just in the trigger handler) keeps a stray `paused` flag
+                // from being set while `auto_play` is `None` — a stale flag
+                // would suppress the timer if the parent later enables autoplay.
+                ctx.auto_play.as_ref()?;
+
                 let plan = if *state == State::AutoPlaying {
                     TransitionPlan::to(State::Idle)
                 } else {
@@ -778,26 +784,24 @@ impl ars_core::Machine for Machine {
             }
 
             Event::AutoPlayResume => {
-                // Resume is also the "restart" path the auto-play trigger
-                // dispatches when rotation was permanently stopped (the
-                // trigger shows the "Start" label and sends `AutoPlayResume`),
-                // so it clears BOTH the paused and the stopped flags. Without
-                // clearing `auto_play_stopped`, a stopped carousel's start
-                // control would be inert with no way to resume rotation.
-                if ctx.auto_play.is_some() {
-                    return Some(
-                        TransitionPlan::to(State::AutoPlaying)
-                            .apply(|ctx: &mut Context| {
-                                ctx.auto_play_paused = false;
-                                ctx.auto_play_stopped = false;
-                            })
-                            .with_effect(PendingEffect::named(Effect::AutoPlayTimer)),
-                    );
-                }
+                // Nothing to resume without auto-play configured (the paused and
+                // stopped flags are only ever set while it is configured).
+                ctx.auto_play.as_ref()?;
 
-                Some(TransitionPlan::context_only(|ctx: &mut Context| {
-                    ctx.auto_play_paused = false;
-                }))
+                // Resume is also the "restart" path the auto-play trigger
+                // dispatches when rotation was permanently stopped (the trigger
+                // shows the "Start" label and sends `AutoPlayResume`), so it
+                // clears BOTH the paused and the stopped flags. Without clearing
+                // `auto_play_stopped`, a stopped carousel's start control would
+                // be inert with no way to resume rotation.
+                Some(
+                    TransitionPlan::to(State::AutoPlaying)
+                        .apply(|ctx: &mut Context| {
+                            ctx.auto_play_paused = false;
+                            ctx.auto_play_stopped = false;
+                        })
+                        .with_effect(PendingEffect::named(Effect::AutoPlayTimer)),
+                )
             }
 
             Event::PointerDown { pos, timestamp } => {
@@ -1471,7 +1475,14 @@ impl Api<'_> {
     }
 
     /// Toggle auto-play: resume when stopped/paused, otherwise pause.
+    ///
+    /// No-op when auto-play is not configured — there is nothing to toggle, and
+    /// dispatching `AutoPlayPause` would set a stale `paused` flag that suppresses
+    /// the timer if the parent later enables auto-play.
     pub fn on_auto_play_trigger_click(&self) {
+        if self.ctx.auto_play.is_none() {
+            return;
+        }
         if self.ctx.auto_play_stopped || self.ctx.auto_play_paused {
             (self.send)(Event::AutoPlayResume);
         } else {
@@ -2687,30 +2698,30 @@ mod tests {
     }
 
     #[test]
-    fn autoplay_pause_when_idle_sets_flag_without_state_change() {
-        // No auto-play config → resting in `Idle`; pause keeps the state but
-        // still records the paused flag and cancels the (absent) timer.
-        let mut service = service(props(3));
+    fn autoplay_pause_when_not_playing_sets_flag_without_state_change() {
+        // An auto-play carousel mid-transition (not in `AutoPlaying`): pause
+        // keeps the state but records the paused flag and cancels the timer.
+        let mut service = service(autoplay_props(3));
+        drop(service.take_initial_effects());
+        drop(service.send(Event::AutoPlayTick));
+        assert_eq!(service.state(), &State::Transitioning);
 
         let result = service.send(Event::AutoPlayPause);
 
-        assert_eq!(service.state(), &State::Idle);
+        assert_eq!(service.state(), &State::Transitioning);
         assert!(service.context().auto_play_paused);
         assert_eq!(result.cancel_effects, vec![Effect::AutoPlayTimer]);
     }
 
     #[test]
-    fn autoplay_resume_without_config_clears_paused_flag() {
+    fn autoplay_resume_without_config_is_noop() {
+        // The paused/stopped flags are never set while auto-play is absent, so
+        // a stray `AutoPlayResume` has nothing to do.
         let mut service = service(props(3));
-
-        drop(service.send(Event::AutoPlayPause));
-
-        assert!(service.context().auto_play_paused);
-
         let result = service.send(Event::AutoPlayResume);
-
-        assert!(!service.context().auto_play_paused);
+        assert!(!result.state_changed);
         assert!(result.pending_effects.is_empty());
+        assert!(!service.context().auto_play_paused);
     }
 
     // ── Codex review #716: autoplay timer lifecycle ──────────────────
@@ -3116,6 +3127,49 @@ mod tests {
         assert!(!result.state_changed);
         assert!(!service.context().auto_play_stopped);
         assert_eq!(service.state(), &State::AutoPlaying);
+    }
+
+    // ── Codex review #716 (fourth pass) ──────────────────────────────
+
+    #[test]
+    fn autoplay_pause_without_config_is_noop() {
+        let mut service = service(props(3));
+        let result = service.send(Event::AutoPlayPause);
+        assert!(!result.state_changed);
+        assert!(!service.context().auto_play_paused);
+    }
+
+    #[test]
+    fn auto_play_trigger_click_without_config_dispatches_nothing() {
+        let service = service(props(3));
+        let recorder: RefCell<Vec<Event>> = RefCell::new(Vec::new());
+        {
+            let record = |event| recorder.borrow_mut().push(event);
+            let api = service.connect(&record);
+            api.on_auto_play_trigger_click();
+        }
+        assert!(recorder.into_inner().is_empty());
+    }
+
+    #[test]
+    fn enabling_autoplay_after_trigger_click_starts_timer() {
+        // Regression: clicking the trigger while auto-play is off must not set a
+        // stale paused flag that suppresses the timer once autoplay is enabled.
+        let mut service = service(props(3));
+        {
+            let api = service.connect(&|_| {});
+            api.on_auto_play_trigger_click();
+        }
+        assert!(!service.context().auto_play_paused);
+
+        let result = service.set_props(autoplay_props(3));
+        assert_eq!(service.state(), &State::AutoPlaying);
+        assert!(
+            result
+                .pending_effects
+                .iter()
+                .any(|effect| effect.name == Effect::AutoPlayTimer)
+        );
     }
 
     #[test]

--- a/crates/ars-components/src/layout/carousel/mod.rs
+++ b/crates/ars-components/src/layout/carousel/mod.rs
@@ -30,8 +30,9 @@ use core::{
 };
 
 use ars_core::{
-    AriaAttr, AttrMap, Bindable, ComponentIds, ComponentMessages, ComponentPart, ConnectApi,
-    CssProperty, Env, HtmlAttr, KeyboardKey, Locale, MessageFn, PendingEffect, TransitionPlan,
+    AriaAttr, AttrMap, Bindable, Callback, ComponentIds, ComponentMessages, ComponentPart,
+    ConnectApi, CssProperty, Env, HtmlAttr, KeyboardKey, Locale, MessageFn, PendingEffect,
+    TransitionPlan,
 };
 use ars_i18n::Orientation;
 use ars_interactions::KeyboardEventData;
@@ -61,6 +62,15 @@ pub enum Effect {
     /// [`Event::AutoPlayStop`], [`Event::AutoPlayPause`], and
     /// [`Event::PointerDown`].
     AutoPlayTimer,
+
+    /// Adapter invokes [`Props::on_index_change`] with the newly requested
+    /// slide index. Emitted whenever the machine changes the index (manual
+    /// navigation, swipe, auto-play tick, focus-driven scroll). This is the
+    /// round-trip path for **controlled** carousels: in controlled mode
+    /// [`Bindable::set`](ars_core::Bindable::set) only updates the pending
+    /// internal value, so the parent must observe this callback and push the
+    /// new value back through `Props::index` for the visible slide to change.
+    IndexChange,
 }
 
 // ────────────────────────────────────────────────────────────────────
@@ -111,8 +121,18 @@ pub enum Event {
     /// Auto-play timer fired; advance one slide.
     AutoPlayTick,
 
-    /// Temporarily pause auto-play (hover/focus).
+    /// Manually pause auto-play (e.g. the auto-play trigger button). Pauses
+    /// regardless of the `pause_on_*` options, which gate the automatic
+    /// hover/focus pauses ([`Event::HoverStart`] / [`Event::FocusSlide`]).
     AutoPlayPause,
+
+    /// Pointer entered the carousel. Pauses auto-play **only** when
+    /// [`AutoPlayOptions::pause_on_hover`] is set; otherwise a no-op.
+    HoverStart,
+
+    /// Pointer left the carousel. Resumes a hover/focus auto-play pause (the
+    /// counterpart of [`Event::HoverStart`], mirroring [`Event::Blur`]).
+    HoverEnd,
 
     /// Resume auto-play after pause.
     AutoPlayResume,
@@ -328,19 +348,24 @@ impl Context {
     }
 
     /// Whether the carousel can navigate to a previous slide.
+    ///
+    /// Always `false` when [`last_index`](Self::last_index) is `0` (a single
+    /// slide, or `slides_per_view` already shows them all): there is no
+    /// distinct target to move to, even when looping.
     #[must_use]
     pub fn can_go_prev(&self) -> bool {
-        self.loop_nav || self.current_index() > 0
+        self.current_index() > 0 || (self.loop_nav && self.last_index() > 0)
     }
 
     /// Whether the carousel can navigate to a next slide.
     ///
     /// For `slides_per_view > 1` the boundary is the last full page
     /// ([`last_index`](Self::last_index)), so `Next` disables once the final
-    /// slide is already in view rather than allowing a partial page.
+    /// slide is already in view rather than allowing a partial page. Always
+    /// `false` when `last_index` is `0`, even when looping.
     #[must_use]
     pub fn can_go_next(&self) -> bool {
-        self.loop_nav || self.current_index() < self.last_index()
+        self.current_index() < self.last_index() || (self.loop_nav && self.last_index() > 0)
     }
 
     /// Whether `index` is within the currently visible window of
@@ -434,6 +459,15 @@ pub struct Props {
 
     /// Whether the carousel is right-to-left.
     pub is_rtl: bool,
+
+    /// Callback fired with the newly requested slide index whenever the machine
+    /// changes the index. **Required for controlled usage** (when [`index`] is
+    /// `Some`): the parent must update its controlled signal from this callback
+    /// and push it back through [`index`], otherwise navigation only updates the
+    /// hidden pending value and the visible slide never moves.
+    ///
+    /// [`index`]: Self::index
+    pub on_index_change: Option<Callback<dyn Fn(usize) + Send + Sync>>,
 }
 
 impl Default for Props {
@@ -453,6 +487,7 @@ impl Default for Props {
             transition_duration: None,
             swipe_threshold: None,
             is_rtl: false,
+            on_index_change: None,
         }
     }
 }
@@ -542,16 +577,34 @@ fn navigate_to(ctx: &Context, idx: usize) -> Option<TransitionPlan<Machine>> {
         .auto_play
         .as_ref()
         .is_some_and(|o| o.stop_on_interaction);
-    let mut plan = TransitionPlan::to(State::Transitioning).apply(move |ctx: &mut Context| {
-        ctx.index.set(idx);
-        if stop {
-            ctx.auto_play_stopped = true;
-        }
-    });
+    let mut plan = TransitionPlan::to(State::Transitioning)
+        .apply(move |ctx: &mut Context| {
+            ctx.index.set(idx);
+            if stop {
+                ctx.auto_play_stopped = true;
+            }
+        })
+        .with_effect(index_change_effect(idx));
     if stop {
         plan = plan.cancel_effect(Effect::AutoPlayTimer);
     }
     Some(plan)
+}
+
+/// Build the [`Effect::IndexChange`] notification carrying the newly requested
+/// slide `index`. The adapter resolves it by invoking [`Props::on_index_change`]
+/// — the round-trip path that lets a controlled parent observe navigation and
+/// push the new index back through [`Props::index`].
+fn index_change_effect(index: usize) -> PendingEffect<Machine> {
+    PendingEffect::new(
+        Effect::IndexChange,
+        move |_ctx: &Context, props: &Props, _send| {
+            if let Some(callback) = &props.on_index_change {
+                callback(index);
+            }
+            ars_core::no_cleanup()
+        },
+    )
 }
 
 impl ars_core::Machine for Machine {
@@ -756,9 +809,11 @@ impl ars_core::Machine for Machine {
                 }
 
                 Some(
-                    TransitionPlan::to(State::Transitioning).apply(move |ctx: &mut Context| {
-                        ctx.index.set(next);
-                    }),
+                    TransitionPlan::to(State::Transitioning)
+                        .apply(move |ctx: &mut Context| {
+                            ctx.index.set(next);
+                        })
+                        .with_effect(index_change_effect(next)),
                 )
             }
 
@@ -781,6 +836,47 @@ impl ars_core::Machine for Machine {
                     })
                     .cancel_effect(Effect::AutoPlayTimer),
                 )
+            }
+
+            Event::HoverStart => {
+                // Hover-pause is opt-in via `pause_on_hover`; otherwise hovering
+                // does nothing. When enabled it pauses like `AutoPlayPause`:
+                // leave `AutoPlaying` and cancel the timer.
+                if !ctx
+                    .auto_play
+                    .as_ref()
+                    .is_some_and(|options| options.pause_on_hover)
+                {
+                    return None;
+                }
+
+                let plan = if *state == State::AutoPlaying {
+                    TransitionPlan::to(State::Idle)
+                } else {
+                    TransitionPlan::new()
+                };
+
+                Some(
+                    plan.apply(|ctx: &mut Context| {
+                        ctx.auto_play_paused = true;
+                    })
+                    .cancel_effect(Effect::AutoPlayTimer),
+                )
+            }
+
+            Event::HoverEnd => {
+                // Resume a hover/focus pause when the pointer leaves, mirroring
+                // `Blur` for focus-out.
+                if ctx.auto_play_paused && !ctx.auto_play_stopped && ctx.auto_play.is_some() {
+                    return Some(
+                        TransitionPlan::to(State::AutoPlaying)
+                            .apply(|ctx: &mut Context| {
+                                ctx.auto_play_paused = false;
+                            })
+                            .with_effect(PendingEffect::named(Effect::AutoPlayTimer)),
+                    );
+                }
+                None
             }
 
             Event::AutoPlayResume => {
@@ -836,6 +932,12 @@ impl ars_core::Machine for Machine {
             }
 
             Event::PointerUp => {
+                // No-op without an active drag: a stray/adapter-level pointer-up
+                // must not run the resume logic (which would re-arm a timer that
+                // was never cancelled, creating duplicate intervals). Mirrors
+                // the `PointerMove`/`PointerCancel` guards.
+                ctx.drag_start_pos?;
+
                 let delta = ctx.drag_delta;
                 let velocity = ctx.swipe_velocity;
                 let threshold = ctx.swipe_threshold;
@@ -848,11 +950,14 @@ impl ars_core::Machine for Machine {
                 };
 
                 let cur = ctx.current_index() as isize;
+                // A swipe advances by `slides_per_move`, matching button and
+                // keyboard navigation (page-by-page when configured).
+                let step = ctx.slides_per_move as isize;
 
                 let next_idx = if delta < -effective && ctx.can_go_next() {
-                    Some(ctx.clamp_index(cur + 1))
+                    Some(ctx.clamp_index(cur + step))
                 } else if delta > effective && ctx.can_go_prev() {
-                    Some(ctx.clamp_index(cur - 1))
+                    Some(ctx.clamp_index(cur - step))
                 } else {
                     None
                 };
@@ -882,6 +987,8 @@ impl ars_core::Machine for Machine {
                     State::Idle
                 };
 
+                let index_changed = next_idx.is_some_and(|idx| idx != ctx.current_index());
+
                 let mut plan = TransitionPlan::to(target).apply(move |ctx: &mut Context| {
                     ctx.drag_start_pos = None;
                     ctx.drag_delta = 0.0;
@@ -896,6 +1003,10 @@ impl ars_core::Machine for Machine {
                         ctx.auto_play_stopped = true;
                     }
                 });
+
+                if index_changed && let Some(idx) = next_idx {
+                    plan = plan.with_effect(index_change_effect(idx));
+                }
 
                 if resume {
                     plan = plan.with_effect(PendingEffect::named(Effect::AutoPlayTimer));
@@ -935,11 +1046,14 @@ impl ars_core::Machine for Machine {
             }
 
             Event::FocusSlide { index } => {
-                // Clamp to the last valid starting index: a focused slide is a
-                // real slide, but focusing one already inside the visible
-                // window must not push `current_index` past the boundary.
+                // Only scroll when the focused slide is not already on-screen.
+                // With `slides_per_view > 1`, tabbing into a non-leading but
+                // visible slide must NOT shift the track (that would move
+                // content out from under the user during normal focus nav).
+                let scroll = !ctx.is_slide_visible(*index);
+                // Clamp to the last valid starting index so a focused slide near
+                // the end maps to the last full page rather than overscrolling.
                 let idx = (*index).min(ctx.last_index());
-                let current = ctx.current_index();
                 let should_pause = ctx.auto_play.as_ref().is_some_and(|o| o.pause_on_focus);
 
                 if should_pause {
@@ -951,22 +1065,30 @@ impl ars_core::Machine for Machine {
                     } else {
                         TransitionPlan::new()
                     };
-                    return Some(
-                        plan.apply(move |ctx: &mut Context| {
-                            if idx != current {
+                    let mut plan = plan
+                        .apply(move |ctx: &mut Context| {
+                            if scroll {
                                 ctx.index.set(idx);
                             }
                             ctx.auto_play_paused = true;
                         })
-                        .cancel_effect(Effect::AutoPlayTimer),
-                    );
+                        .cancel_effect(Effect::AutoPlayTimer);
+                    if scroll {
+                        plan = plan.with_effect(index_change_effect(idx));
+                    }
+                    return Some(plan);
                 }
 
-                Some(TransitionPlan::context_only(move |ctx: &mut Context| {
-                    if idx != current {
+                if !scroll {
+                    return None;
+                }
+
+                Some(
+                    TransitionPlan::context_only(move |ctx: &mut Context| {
                         ctx.index.set(idx);
-                    }
-                }))
+                    })
+                    .with_effect(index_change_effect(idx)),
+                )
             }
 
             Event::SyncProps { props } => {
@@ -1490,6 +1612,17 @@ impl Api<'_> {
         }
     }
 
+    /// Dispatch a hover-start (pointer entered the carousel). Auto-play pauses
+    /// only when [`AutoPlayOptions::pause_on_hover`] is set.
+    pub fn on_root_pointer_enter(&self) {
+        (self.send)(Event::HoverStart);
+    }
+
+    /// Dispatch a hover-end (pointer left the carousel), resuming a hover pause.
+    pub fn on_root_pointer_leave(&self) {
+        (self.send)(Event::HoverEnd);
+    }
+
     /// Dispatch a pointer-down (drag start) with adapter-normalized position
     /// and timestamp.
     pub fn on_viewport_pointerdown(&self, pos: f64, timestamp: f64) {
@@ -1530,8 +1663,9 @@ impl ConnectApi for Api<'_> {
 #[cfg(test)]
 mod tests {
     use core::cell::RefCell;
+    use std::sync::{Arc, Mutex};
 
-    use ars_core::{Env, SendResult, Service};
+    use ars_core::{Env, SendResult, Service, StrongSend, callback};
     use insta::assert_snapshot;
 
     use super::*;
@@ -2794,7 +2928,10 @@ mod tests {
         assert_eq!(service.context().current_index(), 1);
         assert_eq!(service.state(), &State::Idle);
         assert!(service.context().auto_play_stopped);
-        assert!(result.pending_effects.is_empty());
+        // Index changed → IndexChange notification, but rotation is stopped so
+        // no timer is re-armed.
+        assert!(pending_effect_names(&result).contains(&Effect::IndexChange));
+        assert!(!pending_effect_names(&result).contains(&Effect::AutoPlayTimer));
     }
 
     #[test]
@@ -2819,7 +2956,9 @@ mod tests {
         assert_eq!(service.context().current_index(), 1);
         assert_eq!(service.state(), &State::AutoPlaying);
         assert!(!service.context().auto_play_stopped);
-        assert_eq!(pending_effect_names(&result), vec![Effect::AutoPlayTimer]);
+        // Rotation resumes (timer re-armed) and the index change is notified.
+        assert!(pending_effect_names(&result).contains(&Effect::AutoPlayTimer));
+        assert!(pending_effect_names(&result).contains(&Effect::IndexChange));
     }
 
     #[test]
@@ -3188,5 +3327,178 @@ mod tests {
                 .iter()
                 .any(|effect| effect.name == Effect::AutoPlayTimer)
         );
+    }
+
+    // ── Codex review #716 (fifth pass) ───────────────────────────────
+
+    #[test]
+    fn pointer_up_without_active_drag_is_noop() {
+        let mut service = service(autoplay_props(3));
+        drop(service.take_initial_effects());
+        // No preceding PointerDown → must not run resume logic / re-arm a timer.
+        let result = service.send(Event::PointerUp);
+        assert!(!result.state_changed);
+        assert!(result.pending_effects.is_empty());
+    }
+
+    #[test]
+    fn swipe_advances_by_slides_per_move() {
+        let mut service = service(Props {
+            slides_per_move: Some(2),
+            ..props(6)
+        });
+        drop(service.send(Event::PointerDown {
+            pos: 100.0,
+            timestamp: 0.0,
+        }));
+        drop(service.send(Event::PointerMove {
+            pos: 40.0,
+            timestamp: 1000.0,
+        }));
+        drop(service.send(Event::PointerUp));
+        assert_eq!(service.context().current_index(), 2);
+    }
+
+    #[test]
+    fn focus_visible_slide_does_not_scroll() {
+        let mut service = service(Props {
+            slides_per_view: Some(2.0),
+            ..props(3)
+        });
+        // index 0, slides 0 & 1 visible. Focusing slide 1 must not move.
+        let result = service.send(Event::FocusSlide { index: 1 });
+        assert!(!result.context_changed);
+        assert_eq!(service.context().current_index(), 0);
+    }
+
+    #[test]
+    fn focus_offscreen_slide_scrolls_into_view() {
+        let mut service = service(Props {
+            slides_per_view: Some(2.0),
+            ..props(4)
+        });
+        // index 0, window {0,1}. Focusing slide 3 (off-screen) scrolls to the
+        // last full page (index 2).
+        drop(service.send(Event::FocusSlide { index: 3 }));
+        assert_eq!(service.context().current_index(), 2);
+    }
+
+    #[test]
+    fn loop_controls_disabled_with_single_position() {
+        // Single slide, looping: no distinct target, so both controls disabled.
+        let ctx = service(Props {
+            loop_nav: true,
+            ..props(1)
+        })
+        .context()
+        .clone();
+        assert_eq!(ctx.last_index(), 0);
+        assert!(!ctx.can_go_prev());
+        assert!(!ctx.can_go_next());
+
+        // slides_per_view covering every slide: likewise nowhere to move.
+        let ctx_all = service(Props {
+            loop_nav: true,
+            slides_per_view: Some(3.0),
+            ..props(3)
+        })
+        .context()
+        .clone();
+        assert_eq!(ctx_all.last_index(), 0);
+        assert!(!ctx_all.can_go_next());
+    }
+
+    /// Run every pending effect from `result`, then return the captured values.
+    fn captured_index_changes(service: &Service<Machine>, event: Event) -> Vec<usize> {
+        let changes = Arc::new(Mutex::new(Vec::new()));
+        let captured = Arc::clone(&changes);
+        // The on_index_change callback lives in props; build a fresh service so
+        // the effect can read it. (Caller passes a service already wired.)
+        let mut service = Service::<Machine>::new(
+            Props {
+                on_index_change: Some(callback(move |index: usize| {
+                    captured.lock().expect("lock").push(index);
+                })),
+                ..service.props().clone()
+            },
+            &Env::default(),
+            &Messages::default(),
+        );
+        drop(service.take_initial_effects());
+        let mut result = service.send(event);
+        let send: StrongSend<Event> = Arc::new(|_| {});
+        for effect in result.pending_effects.drain(..) {
+            drop(effect.run(service.context(), service.props(), Arc::clone(&send)));
+        }
+        changes.lock().expect("lock").clone()
+    }
+
+    #[test]
+    fn controlled_navigation_round_trips_via_on_index_change() {
+        // Controlled carousel: navigation must notify the parent of the
+        // requested index so it can push it back through `Props::index`.
+        let base = service(Props {
+            index: Some(Bindable::controlled(0)),
+            ..props(4)
+        });
+        let changes = captured_index_changes(&base, Event::GoToNext);
+        assert_eq!(changes, vec![1]);
+    }
+
+    #[test]
+    fn manual_navigation_emits_index_change_effect() {
+        let mut service = service(props(4));
+        let result = service.send(Event::GoToNext);
+        assert!(
+            result
+                .pending_effects
+                .iter()
+                .any(|effect| effect.name == Effect::IndexChange)
+        );
+    }
+
+    #[test]
+    fn hover_start_pauses_when_pause_on_hover_enabled() {
+        let mut service = service(autoplay_props(3));
+        drop(service.take_initial_effects());
+        let result = service.send(Event::HoverStart);
+        assert_eq!(service.state(), &State::Idle);
+        assert!(service.context().auto_play_paused);
+        assert_eq!(result.cancel_effects, vec![Effect::AutoPlayTimer]);
+
+        // Pointer leaving resumes rotation.
+        let resumed = service.send(Event::HoverEnd);
+        assert_eq!(service.state(), &State::AutoPlaying);
+        assert!(!service.context().auto_play_paused);
+        assert!(
+            resumed
+                .pending_effects
+                .iter()
+                .any(|effect| effect.name == Effect::AutoPlayTimer)
+        );
+    }
+
+    #[test]
+    fn hover_start_is_noop_when_pause_on_hover_disabled() {
+        let mut service = service(Props {
+            auto_play: Some(AutoPlayOptions {
+                pause_on_hover: false,
+                ..AutoPlayOptions::default()
+            }),
+            ..props(3)
+        });
+        drop(service.take_initial_effects());
+        let result = service.send(Event::HoverStart);
+        assert!(!result.state_changed);
+        assert!(!service.context().auto_play_paused);
+        assert_eq!(service.state(), &State::AutoPlaying);
+    }
+
+    #[test]
+    fn hover_start_without_autoplay_is_noop() {
+        let mut service = service(props(3));
+        let result = service.send(Event::HoverStart);
+        assert!(!result.state_changed);
+        assert!(!service.context().auto_play_paused);
     }
 }

--- a/crates/ars-components/src/layout/carousel/mod.rs
+++ b/crates/ars-components/src/layout/carousel/mod.rs
@@ -86,7 +86,9 @@ pub enum State {
 // ────────────────────────────────────────────────────────────────────
 
 /// Events accepted by the [`Carousel`](self) state machine.
-#[derive(Clone, Copy, Debug, PartialEq)]
+///
+/// Not `Copy` because [`Event::SyncProps`] carries an owned [`Props`].
+#[derive(Clone, Debug, PartialEq)]
 pub enum Event {
     /// Navigate to a specific slide by index.
     GoToSlide {
@@ -151,13 +153,14 @@ pub enum Event {
     /// Focus left the carousel.
     Blur,
 
-    /// The parent pushed a new controlled `index` value through `set_props`.
-    /// Emitted by [`Machine::on_props_changed`](ars_core::Machine::on_props_changed)
-    /// so the stored [`Bindable`] tracks the controlled signal without going
-    /// through a `Transitioning` animation or stopping auto-play.
-    SyncControlledIndex {
-        /// The new controlled slide index.
-        index: usize,
+    /// The parent re-rendered with new [`Props`] (via `set_props`). Emitted by
+    /// [`Machine::on_props_changed`](ars_core::Machine::on_props_changed) so the
+    /// machine re-derives its mutable configuration, tracks the controlled
+    /// `index` signal (including controlled→uncontrolled), and reconciles the
+    /// auto-play timer — all without animating.
+    SyncProps {
+        /// The new props to reconcile against the current context.
+        props: Props,
     },
 }
 
@@ -526,7 +529,15 @@ pub struct Machine;
 /// cancel its timer. The cancellation is essential: without it the adapter's
 /// recurring interval keeps running after rotation has "stopped", leaking the
 /// timer and dispatching ignored [`Event::AutoPlayTick`]s forever.
-fn navigate_to(ctx: &Context, idx: usize) -> TransitionPlan<Machine> {
+///
+/// Returns `None` when `idx` equals the current index: the track transform
+/// would not change, so the adapter has no CSS transition to report and
+/// `TransitionEnd` may never arrive — entering `Transitioning` would strand
+/// the machine and block all further navigation.
+fn navigate_to(ctx: &Context, idx: usize) -> Option<TransitionPlan<Machine>> {
+    if idx == ctx.current_index() {
+        return None;
+    }
     let stop = ctx
         .auto_play
         .as_ref()
@@ -540,7 +551,7 @@ fn navigate_to(ctx: &Context, idx: usize) -> TransitionPlan<Machine> {
     if stop {
         plan = plan.cancel_effect(Effect::AutoPlayTimer);
     }
-    plan
+    Some(plan)
 }
 
 impl ars_core::Machine for Machine {
@@ -583,11 +594,16 @@ impl ars_core::Machine for Machine {
         let max_index = props.slide_count.get().saturating_sub(visible_count);
         let initial_index = props.default_index.unwrap_or(0).min(max_index);
 
+        // Clamp the controlled value too: a caller-supplied controlled `index`
+        // past `last_index()` would start the machine out of range before any
+        // prop-change sync could run.
+        let index = match &props.index {
+            Some(controlled) => Bindable::controlled((*controlled.get()).min(max_index)),
+            None => Bindable::uncontrolled(initial_index),
+        };
+
         let ctx = Context {
-            index: props
-                .index
-                .clone()
-                .unwrap_or_else(|| Bindable::uncontrolled(initial_index)),
+            index,
             slide_count: props.slide_count,
             loop_nav: props.loop_nav,
             auto_play: props.auto_play.clone(),
@@ -637,20 +653,14 @@ impl ars_core::Machine for Machine {
             "carousel::Props.id must remain stable after initialization"
         );
 
-        // In controlled mode the parent owns the slide index and pushes new
-        // values through `set_props`. Detect a changed controlled value and
-        // forward it so the stored `Bindable` tracks it (otherwise the active
-        // slide, progress text, and indicators stay stuck on the initial
-        // controlled value).
-        let old_index = old.index.as_ref().map(|bindable| *bindable.get());
-        let new_index = new.index.as_ref().map(|bindable| *bindable.get());
-        if old_index != new_index
-            && let Some(index) = new_index
-        {
-            return vec![Event::SyncControlledIndex { index }];
+        // Any prop change re-syncs the machine's mutable configuration, the
+        // controlled-index signal, and the auto-play timer (see the
+        // `SyncProps` arm). Mirrors the `splitter` convention.
+        if old == new {
+            Vec::new()
+        } else {
+            vec![Event::SyncProps { props: new.clone() }]
         }
-
-        Vec::new()
     }
 
     fn transition(
@@ -671,7 +681,7 @@ impl ars_core::Machine for Machine {
                 // invariant). A direct jump is a manual interaction, so it
                 // honours `stop_on_interaction` like Next/Prev.
                 let idx = (*index).min(ctx.last_index());
-                Some(navigate_to(ctx, idx))
+                navigate_to(ctx, idx)
             }
 
             Event::GoToNext => {
@@ -681,7 +691,7 @@ impl ars_core::Machine for Machine {
 
                 let step = ctx.slides_per_move as isize;
                 let next = ctx.clamp_index(ctx.current_index() as isize + step);
-                Some(navigate_to(ctx, next))
+                navigate_to(ctx, next)
             }
 
             Event::GoToPrev => {
@@ -691,7 +701,7 @@ impl ars_core::Machine for Machine {
 
                 let step = ctx.slides_per_move as isize;
                 let prev = ctx.clamp_index(ctx.current_index() as isize - step);
-                Some(navigate_to(ctx, prev))
+                navigate_to(ctx, prev)
             }
 
             Event::TransitionEnd => {
@@ -707,8 +717,14 @@ impl ars_core::Machine for Machine {
                     return None;
                 }
 
+                // Clear any prior pause: starting auto-play means it is now
+                // actively rotating, so the paused live-region mode and
+                // `aria-pressed="false"` must not linger.
                 Some(
                     TransitionPlan::to(State::AutoPlaying)
+                        .apply(|ctx: &mut Context| {
+                            ctx.auto_play_paused = false;
+                        })
                         .with_effect(PendingEffect::named(Effect::AutoPlayTimer)),
                 )
             }
@@ -722,17 +738,22 @@ impl ars_core::Machine for Machine {
             ),
 
             Event::AutoPlayTick => {
-                // Ignore ticks that cannot advance: at the final non-looping
-                // page `clamp_index` would return the same index, so entering
-                // `Transitioning` risks a missing `transitionend` (the
-                // transform never changes) leaving the machine stuck.
-                if *state != State::AutoPlaying || !ctx.can_go_next() {
+                if *state != State::AutoPlaying {
                     return None;
                 }
 
                 let step = ctx.slides_per_move as isize;
-
                 let next = ctx.clamp_index(ctx.current_index() as isize + step);
+
+                // Ignore ticks that would not move the track: the non-looping
+                // boundary (`clamp` returns the same index) and the looped
+                // no-op case (single slide, or `slides_per_move` a multiple of
+                // `slide_count`). Entering `Transitioning` with no transform
+                // change risks a missing `transitionend` that strands the
+                // machine.
+                if next == ctx.current_index() {
+                    return None;
+                }
 
                 Some(
                     TransitionPlan::to(State::Transitioning).apply(move |ctx: &mut Context| {
@@ -944,14 +965,85 @@ impl ars_core::Machine for Machine {
                 }))
             }
 
-            Event::SyncControlledIndex { index } => {
-                // Push the parent's controlled value into the stored bindable
-                // without animating or stopping auto-play. Clamp defensively so
-                // a bad controlled value can't break the index invariant.
-                let idx = (*index).min(ctx.last_index());
-                Some(TransitionPlan::context_only(move |ctx: &mut Context| {
-                    ctx.index.sync_controlled(Some(idx));
-                }))
+            Event::SyncProps { props } => {
+                // Re-derive mutable configuration from the new props, track the
+                // controlled-index signal (including controlled→uncontrolled),
+                // and reconcile the auto-play timer — all without animating.
+                let new_auto = props.auto_play.clone();
+                let auto_changed = ctx.auto_play != new_auto;
+                // After syncing, should a timer be running? (Honours the
+                // preserved stopped/paused flags.)
+                let want_timer =
+                    new_auto.is_some() && !ctx.auto_play_stopped && !ctx.auto_play_paused;
+
+                // Only the auto-play transition moves the resting state:
+                // enabling/resuming → AutoPlaying; disabling while playing → Idle.
+                let target = if auto_changed {
+                    if want_timer {
+                        State::AutoPlaying
+                    } else if *state == State::AutoPlaying {
+                        State::Idle
+                    } else {
+                        *state
+                    }
+                } else {
+                    *state
+                };
+
+                let props = props.clone();
+                let mut plan = TransitionPlan::to(target).apply(move |ctx: &mut Context| {
+                    let slides_per_view = props
+                        .slides_per_view
+                        .filter(|value| value.is_finite() && *value > 0.0)
+                        .unwrap_or(1.0);
+
+                    ctx.slide_count = props.slide_count;
+                    ctx.loop_nav = props.loop_nav;
+                    ctx.auto_play = props.auto_play.clone();
+                    ctx.spacing = props.spacing.unwrap_or(0.0);
+                    ctx.slides_per_view = slides_per_view;
+                    ctx.slides_per_move = props.slides_per_move.unwrap_or(1).max(1);
+                    ctx.align = props.align.unwrap_or_default();
+                    ctx.orientation = props.orientation.unwrap_or_default();
+                    ctx.is_rtl = props.is_rtl;
+                    ctx.transition_duration = props
+                        .transition_duration
+                        .unwrap_or_else(|| Duration::from_millis(300));
+                    ctx.swipe_threshold = props.swipe_threshold.unwrap_or(50.0);
+
+                    // Track the controlled signal (clamped); `None` returns the
+                    // bindable to uncontrolled mode.
+                    let controlled = props
+                        .index
+                        .as_ref()
+                        .map(|bindable| (*bindable.get()).min(ctx.last_index()));
+                    ctx.index.sync_controlled(controlled);
+
+                    // Keep an uncontrolled index in range if the slide count or
+                    // visible window shrank.
+                    if !ctx.index.is_controlled() {
+                        let clamped = ctx.current_index().min(ctx.last_index());
+                        ctx.index.set(clamped);
+                    }
+
+                    // Without auto-play configured, the play/pause flags are
+                    // meaningless — reset them so the controls read correctly.
+                    if ctx.auto_play.is_none() {
+                        ctx.auto_play_paused = false;
+                        ctx.auto_play_stopped = false;
+                    }
+                });
+
+                // Restart the interval when auto-play config changed so a new
+                // interval/enable takes effect; tear it down when disabled.
+                if auto_changed {
+                    plan = plan.cancel_effect(Effect::AutoPlayTimer);
+                    if want_timer {
+                        plan = plan.with_effect(PendingEffect::named(Effect::AutoPlayTimer));
+                    }
+                }
+
+                Some(plan)
             }
 
             Event::Blur => {
@@ -2940,5 +3032,107 @@ mod tests {
         assert!(!result.state_changed);
         assert_eq!(service.state(), &State::AutoPlaying);
         assert_eq!(service.context().current_index(), 2);
+    }
+
+    // ── Codex review #716 (third pass) ───────────────────────────────
+
+    #[test]
+    fn init_clamps_out_of_range_controlled_index() {
+        let service = service(Props {
+            index: Some(Bindable::controlled(100)),
+            ..props(3)
+        });
+        assert_eq!(service.context().current_index(), 2);
+    }
+
+    #[test]
+    fn controlled_to_uncontrolled_via_props() {
+        let mut service = service(Props {
+            index: Some(Bindable::controlled(1)),
+            ..props(4)
+        });
+        assert!(service.context().index.is_controlled());
+
+        // Parent drops controlled mode.
+        drop(service.set_props(props(4)));
+        assert!(!service.context().index.is_controlled());
+
+        // Navigation now actually moves the visible index.
+        drop(service.send(Event::GoToNext));
+        assert_eq!(service.context().current_index(), 2);
+    }
+
+    #[test]
+    fn autoplay_disabled_via_props_cancels_timer() {
+        let mut service = service(autoplay_props(3));
+        drop(service.take_initial_effects());
+        let result = service.set_props(props(3));
+        assert!(service.context().auto_play.is_none());
+        assert_eq!(service.state(), &State::Idle);
+        assert!(result.cancel_effects.contains(&Effect::AutoPlayTimer));
+    }
+
+    #[test]
+    fn autoplay_enabled_via_props_starts_timer() {
+        let mut service = service(props(3));
+        assert_eq!(service.state(), &State::Idle);
+        let result = service.set_props(autoplay_props(3));
+        assert_eq!(service.state(), &State::AutoPlaying);
+        assert!(
+            result
+                .pending_effects
+                .iter()
+                .any(|effect| effect.name == Effect::AutoPlayTimer)
+        );
+    }
+
+    #[test]
+    fn autoplay_tick_noop_for_looped_single_slide() {
+        let mut service = service(Props {
+            loop_nav: true,
+            ..autoplay_props(1)
+        });
+        drop(service.take_initial_effects());
+        let result = service.send(Event::AutoPlayTick);
+        assert!(!result.state_changed);
+        assert_eq!(service.state(), &State::AutoPlaying);
+    }
+
+    #[test]
+    fn goto_slide_to_current_index_is_noop() {
+        let mut service = service(props(3));
+        let result = service.send(Event::GoToSlide { index: 0 });
+        assert!(!result.state_changed);
+        assert_eq!(service.state(), &State::Idle);
+    }
+
+    #[test]
+    fn goto_slide_to_current_does_not_stop_autoplay() {
+        let mut service = service(autoplay_props(3));
+        drop(service.take_initial_effects());
+        // Clicking the already-active indicator is a no-op — it must not stop
+        // rotation or strand the machine in Transitioning.
+        let result = service.send(Event::GoToSlide { index: 0 });
+        assert!(!result.state_changed);
+        assert!(!service.context().auto_play_stopped);
+        assert_eq!(service.state(), &State::AutoPlaying);
+    }
+
+    #[test]
+    fn autoplay_start_after_pause_clears_paused_flag() {
+        let mut service = service(autoplay_props(3));
+        drop(service.take_initial_effects());
+        drop(service.send(Event::AutoPlayPause));
+        assert!(service.context().auto_play_paused);
+
+        let result = service.send(Event::AutoPlayStart);
+        assert_eq!(service.state(), &State::AutoPlaying);
+        assert!(!service.context().auto_play_paused);
+        assert!(
+            result
+                .pending_effects
+                .iter()
+                .any(|effect| effect.name == Effect::AutoPlayTimer)
+        );
     }
 }

--- a/crates/ars-components/src/layout/carousel/mod.rs
+++ b/crates/ars-components/src/layout/carousel/mod.rs
@@ -1,0 +1,2418 @@
+//! Carousel component machine.
+//!
+//! `Carousel` presents a sequence of slides with previous/next buttons, dot
+//! indicators, keyboard arrow keys, touch/pointer swipe with momentum, and
+//! optional auto-play. It supports looping navigation, fractional
+//! slides-per-view, configurable alignment, and full WAI-ARIA carousel
+//! pattern compliance.
+//!
+//! The agnostic core owns the slide index, loop / transition / autoplay
+//! state, swipe-threshold math computed from adapter-supplied pointer deltas,
+//! and the ARIA / data attribute output for every anatomy part. It never
+//! queries DOM nodes by id, never reads viewport geometry, never moves focus,
+//! and never installs timers directly. Framework adapters own the live
+//! viewport/track/slide handles, the actual scrolling/transform application,
+//! focus movement, hover/focus listeners, geometry reads, and the auto-play
+//! interval — the latter surfaced as the typed [`Effect`] enum so adapters
+//! can translate it into `set_interval`/`set_timeout` (see
+//! `spec/components/layout/carousel.md` §1.5).
+
+use alloc::{
+    format,
+    string::{String, ToString as _},
+    vec,
+    vec::Vec,
+};
+use core::{
+    fmt::{self, Debug},
+    num::NonZero,
+    time::Duration,
+};
+
+use ars_core::{
+    AriaAttr, AttrMap, Bindable, ComponentIds, ComponentMessages, ComponentPart, ConnectApi,
+    CssProperty, Env, HtmlAttr, KeyboardKey, Locale, MessageFn, PendingEffect, TransitionPlan,
+};
+use ars_i18n::Orientation;
+use ars_interactions::KeyboardEventData;
+
+// ────────────────────────────────────────────────────────────────────
+// Effect
+// ────────────────────────────────────────────────────────────────────
+
+/// Typed identifier for every named effect intent the carousel machine
+/// emits.
+///
+/// Adapters dispatch on `effect.name` exhaustively (`match effect.name {
+/// carousel::Effect::AutoPlayTimer => … }`) so name typos and unhandled
+/// variants surface at compile time — the same convention used by
+/// [`toast::single::Effect`](crate::overlay::toast::single::Effect) and the
+/// overlay machines. The variant name itself is the contract; there is no
+/// parallel kebab-case wire form to keep in sync.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Effect {
+    /// Adapter starts (or restarts) a recurring auto-play interval of
+    /// [`Context::auto_play`]'s `interval` that dispatches
+    /// [`Event::AutoPlayTick`] on each fire. Emitted on mount when the
+    /// carousel boots into [`State::AutoPlaying`] (see
+    /// [`Machine::initial_effects`](ars_core::Machine::initial_effects)), on
+    /// [`Event::AutoPlayStart`], on [`Event::AutoPlayResume`], and on
+    /// [`Event::Blur`] when resuming a focus/hover pause. Cancelled on
+    /// [`Event::AutoPlayStop`], [`Event::AutoPlayPause`], and
+    /// [`Event::PointerDown`].
+    AutoPlayTimer,
+}
+
+// ────────────────────────────────────────────────────────────────────
+// State
+// ────────────────────────────────────────────────────────────────────
+
+/// States for the [`Carousel`](self) component.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum State {
+    /// No animation or auto-play in progress.
+    #[default]
+    Idle,
+
+    /// Auto-play timer is running.
+    AutoPlaying,
+
+    /// A slide transition animation is in progress.
+    Transitioning,
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Event
+// ────────────────────────────────────────────────────────────────────
+
+/// Events accepted by the [`Carousel`](self) state machine.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Event {
+    /// Navigate to a specific slide by index.
+    GoToSlide {
+        /// Zero-based slide index to navigate to.
+        index: usize,
+    },
+
+    /// Navigate to the next slide.
+    GoToNext,
+
+    /// Navigate to the previous slide.
+    GoToPrev,
+
+    /// Start the auto-play timer.
+    AutoPlayStart,
+
+    /// Permanently stop auto-play.
+    AutoPlayStop,
+
+    /// Auto-play timer fired; advance one slide.
+    AutoPlayTick,
+
+    /// Temporarily pause auto-play (hover/focus).
+    AutoPlayPause,
+
+    /// Resume auto-play after pause.
+    AutoPlayResume,
+
+    /// The CSS transition animation completed.
+    TransitionEnd,
+
+    /// Pointer down on the viewport (drag start).
+    PointerDown {
+        /// Pointer position along the carousel axis, in pixels.
+        pos: f64,
+
+        /// Event timestamp in milliseconds (from `performance.now()`).
+        timestamp: f64,
+    },
+
+    /// Pointer moved during drag.
+    PointerMove {
+        /// Pointer position along the carousel axis, in pixels.
+        pos: f64,
+
+        /// Event timestamp in milliseconds (from `performance.now()`).
+        timestamp: f64,
+    },
+
+    /// Pointer released (drag end).
+    PointerUp,
+
+    /// Pointer cancelled (drag abort).
+    PointerCancel,
+
+    /// A slide received focus.
+    FocusSlide {
+        /// Zero-based index of the slide that received focus.
+        index: usize,
+    },
+
+    /// Focus left the carousel.
+    Blur,
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Context configuration types
+// ────────────────────────────────────────────────────────────────────
+
+/// Slide alignment within the viewport.
+#[derive(Clone, Debug, Copy, PartialEq, Eq, Default)]
+pub enum SlideAlignment {
+    /// Align the active slide to the start edge of the viewport.
+    #[default]
+    Start,
+
+    /// Center the active slide within the viewport.
+    Center,
+
+    /// Align the active slide to the end edge of the viewport.
+    End,
+}
+
+/// Auto-play configuration.
+#[derive(Clone, Debug, PartialEq)]
+pub struct AutoPlayOptions {
+    /// Interval between automatic slide advances.
+    pub interval: Duration,
+
+    /// Whether manual interaction permanently stops auto-play.
+    pub stop_on_interaction: bool,
+
+    /// Whether keyboard focus within the carousel pauses auto-play.
+    pub pause_on_focus: bool,
+
+    /// Whether pointer hover over the carousel pauses auto-play.
+    pub pause_on_hover: bool,
+}
+
+impl Default for AutoPlayOptions {
+    fn default() -> Self {
+        AutoPlayOptions {
+            interval: Duration::from_millis(4000),
+            stop_on_interaction: true,
+            pause_on_focus: true,
+            pause_on_hover: true,
+        }
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Context
+// ────────────────────────────────────────────────────────────────────
+
+/// Runtime context for the Carousel state machine.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Context {
+    /// Current slide index (controlled/uncontrolled).
+    pub index: Bindable<usize>,
+
+    /// Total number of slides.
+    pub slide_count: NonZero<usize>,
+
+    /// Whether navigation wraps around.
+    pub loop_nav: bool,
+
+    /// Auto-play configuration. `None` disables auto-play.
+    pub auto_play: Option<AutoPlayOptions>,
+
+    /// Whether auto-play has been permanently stopped by user interaction.
+    pub auto_play_stopped: bool,
+
+    /// Whether auto-play is temporarily paused (hover/focus).
+    pub auto_play_paused: bool,
+
+    /// Gap between slides in pixels.
+    pub spacing: f64,
+
+    /// Number of slides visible at once (fractional supported).
+    pub slides_per_view: f64,
+
+    /// Number of slides to advance per navigation action. Defaults to `1`.
+    /// When `slides_per_view > 1`, setting this to match `slides_per_view`
+    /// provides page-by-page navigation.
+    pub slides_per_move: usize,
+
+    /// Slide alignment within the viewport.
+    pub align: SlideAlignment,
+
+    /// Slide axis.
+    pub orientation: Orientation,
+
+    /// CSS transition duration for slide animations.
+    pub transition_duration: Duration,
+
+    /// Pointer position at drag start. `None` when not dragging.
+    pub drag_start_pos: Option<f64>,
+
+    /// Accumulated drag distance in pixels.
+    pub drag_delta: f64,
+
+    /// Distance threshold (pixels) to trigger a swipe navigation.
+    pub swipe_threshold: f64,
+
+    /// Time-normalized swipe velocity (px/ms). Independent of display refresh
+    /// rate.
+    pub swipe_velocity: f64,
+
+    /// Timestamp of the last `PointerMove` event (ms, from
+    /// `performance.now()`).
+    pub drag_last_timestamp: Option<f64>,
+
+    /// Whether the carousel is right-to-left.
+    pub is_rtl: bool,
+
+    /// Resolved locale for `MessageFn` calls.
+    pub locale: Locale,
+
+    /// Resolved translatable messages.
+    pub messages: Messages,
+
+    /// Component IDs.
+    pub ids: ComponentIds,
+}
+
+impl Context {
+    /// The current slide index.
+    #[must_use]
+    pub fn current_index(&self) -> usize {
+        *self.index.get()
+    }
+
+    /// Clamp or wrap an index according to `loop_nav`.
+    ///
+    /// When `loop_nav` is `true`, out-of-range indices wrap around modulo the
+    /// slide count; otherwise they are clamped to the `[0, slide_count - 1]`
+    /// range.
+    #[must_use]
+    pub fn clamp_index(&self, i: isize) -> usize {
+        let n = self.slide_count.get() as isize;
+
+        if self.loop_nav {
+            ((i % n) + n) as usize % self.slide_count.get()
+        } else {
+            (i.max(0) as usize).min(self.slide_count.get().saturating_sub(1))
+        }
+    }
+
+    /// Whether the carousel can navigate to a previous slide.
+    #[must_use]
+    pub fn can_go_prev(&self) -> bool {
+        self.loop_nav || self.current_index() > 0
+    }
+
+    /// Whether the carousel can navigate to a next slide.
+    #[must_use]
+    pub fn can_go_next(&self) -> bool {
+        self.loop_nav || self.current_index() + 1 < self.slide_count.get()
+    }
+
+    /// CSS translate percentage for the slide track, given the live viewport
+    /// extent supplied by the adapter.
+    ///
+    /// The agnostic core does not read geometry; the adapter passes the
+    /// measured viewport extent **along the carousel axis** — width for a
+    /// [`Orientation::Horizontal`] carousel, height for an
+    /// [`Orientation::Vertical`] one — so the drag-follow correction can be
+    /// expressed as a percentage of the track. Returns the percentage the
+    /// adapter should apply as a `translate` along the carousel axis.
+    #[must_use]
+    pub fn track_offset_percent(&self, viewport_width: f64) -> f64 {
+        let idx = self.current_index() as f64;
+
+        let per_slide = 100.0 / self.slides_per_view;
+
+        let drag_correction = if viewport_width > 0.0 {
+            (self.drag_delta / viewport_width) * 100.0
+        } else {
+            0.0
+        };
+
+        -(idx * per_slide) + drag_correction
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Props
+// ────────────────────────────────────────────────────────────────────
+
+/// External configuration for the [`Carousel`](self) component.
+#[derive(Clone, Debug, PartialEq, ars_core::HasId)]
+pub struct Props {
+    /// The id of the component.
+    pub id: String,
+
+    /// Total number of slides.
+    pub slide_count: NonZero<usize>,
+
+    /// Controlled slide index.
+    pub index: Option<Bindable<usize>>,
+
+    /// Default slide index for uncontrolled usage.
+    pub default_index: Option<usize>,
+
+    /// Whether navigation wraps around.
+    pub loop_nav: bool,
+
+    /// Auto-play configuration.
+    pub auto_play: Option<AutoPlayOptions>,
+
+    /// Gap between slides in pixels.
+    pub spacing: Option<f64>,
+
+    /// Number of slides visible at once.
+    pub slides_per_view: Option<f64>,
+
+    /// Number of slides to advance per navigation action.
+    pub slides_per_move: Option<usize>,
+
+    /// Slide alignment.
+    pub align: Option<SlideAlignment>,
+
+    /// Slide axis.
+    pub orientation: Option<Orientation>,
+
+    /// CSS transition duration.
+    pub transition_duration: Option<Duration>,
+
+    /// Swipe distance threshold in pixels.
+    pub swipe_threshold: Option<f64>,
+
+    /// Whether the carousel is right-to-left.
+    pub is_rtl: bool,
+}
+
+impl Default for Props {
+    fn default() -> Self {
+        Self {
+            id: String::new(),
+            slide_count: NonZero::new(1).expect("non-zero"),
+            index: None,
+            default_index: None,
+            loop_nav: false,
+            auto_play: None,
+            spacing: None,
+            slides_per_view: None,
+            slides_per_move: None,
+            align: None,
+            orientation: None,
+            transition_duration: None,
+            swipe_threshold: None,
+            is_rtl: false,
+        }
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Messages
+// ────────────────────────────────────────────────────────────────────
+
+/// Closure type for the slide label message, given a slide's one-based
+/// position, the total slide count, and the active locale.
+pub type SlideLabelFn = dyn Fn(usize, usize, &Locale) -> String + Send + Sync;
+
+/// Translatable messages for the [`Carousel`](self) component.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Messages {
+    /// Accessible label for the carousel region (`aria-label` on `Root`).
+    pub carousel_label: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
+
+    /// Role description for the carousel region
+    /// (`aria-roledescription` on `Root`).
+    pub role_description: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
+
+    /// Role description for each slide (`aria-roledescription` on `Item`).
+    pub slide_role_description: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
+
+    /// Accessible label for a slide, given its one-based position and the
+    /// total slide count (e.g. "Slide 2 of 5").
+    pub slide_label: MessageFn<SlideLabelFn>,
+
+    /// Accessible label for the previous-slide trigger.
+    pub prev_label: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
+
+    /// Accessible label for the next-slide trigger.
+    pub next_label: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
+
+    /// Accessible label for the auto-play trigger while auto-play is running.
+    pub pause_auto_play_label: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
+
+    /// Accessible label for the auto-play trigger while auto-play is stopped
+    /// or paused.
+    pub start_auto_play_label: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
+}
+
+impl Default for Messages {
+    fn default() -> Self {
+        Self {
+            carousel_label: MessageFn::static_str("Carousel"),
+            role_description: MessageFn::static_str("carousel"),
+            slide_role_description: MessageFn::static_str("slide"),
+            slide_label: MessageFn::new(|index, total, _locale: &Locale| {
+                format!("Slide {index} of {total}")
+            }),
+            prev_label: MessageFn::static_str("Previous slide"),
+            next_label: MessageFn::static_str("Next slide"),
+            pause_auto_play_label: MessageFn::static_str("Pause automatic slide show"),
+            start_auto_play_label: MessageFn::static_str("Start automatic slide show"),
+        }
+    }
+}
+
+impl ComponentMessages for Messages {}
+
+// ────────────────────────────────────────────────────────────────────
+// Machine
+// ────────────────────────────────────────────────────────────────────
+
+/// The [`Carousel`](self) state machine.
+#[derive(Debug)]
+pub struct Machine;
+
+impl ars_core::Machine for Machine {
+    type State = State;
+    type Event = Event;
+    type Context = Context;
+    type Props = Props;
+    type Messages = Messages;
+    type Effect = Effect;
+    type Api<'a> = Api<'a>;
+
+    fn init(
+        props: &Self::Props,
+        env: &Env,
+        messages: &Self::Messages,
+    ) -> (Self::State, Self::Context) {
+        let initial_state = if props.auto_play.is_some() {
+            State::AutoPlaying
+        } else {
+            State::Idle
+        };
+
+        let initial_index = props.default_index.unwrap_or(0);
+
+        let ctx = Context {
+            index: props
+                .index
+                .clone()
+                .unwrap_or_else(|| Bindable::uncontrolled(initial_index)),
+            slide_count: props.slide_count,
+            loop_nav: props.loop_nav,
+            auto_play: props.auto_play.clone(),
+            auto_play_stopped: false,
+            auto_play_paused: false,
+            spacing: props.spacing.unwrap_or(0.0),
+            slides_per_view: props.slides_per_view.unwrap_or(1.0),
+            slides_per_move: props.slides_per_move.unwrap_or(1),
+            align: props.align.unwrap_or_default(),
+            orientation: props.orientation.unwrap_or_default(),
+            is_rtl: props.is_rtl,
+            transition_duration: props
+                .transition_duration
+                .unwrap_or_else(|| Duration::from_millis(300)),
+            drag_start_pos: None,
+            drag_delta: 0.0,
+            swipe_threshold: props.swipe_threshold.unwrap_or(50.0),
+            swipe_velocity: 0.0,
+            drag_last_timestamp: None,
+            locale: env.locale.clone(),
+            messages: messages.clone(),
+            ids: ComponentIds::from_id(&props.id),
+        };
+
+        (initial_state, ctx)
+    }
+
+    fn initial_effects(
+        state: &Self::State,
+        _ctx: &Self::Context,
+        _props: &Self::Props,
+    ) -> Vec<PendingEffect<Self>> {
+        // `init` boots into `AutoPlaying` when `auto_play.is_some()`, but no
+        // `AutoPlayStart` event fires on mount — so the recurring auto-play
+        // interval must be armed here. Adapters drain this via
+        // `Service::take_initial_effects()` on first mount.
+        if *state == State::AutoPlaying {
+            vec![PendingEffect::named(Effect::AutoPlayTimer)]
+        } else {
+            Vec::new()
+        }
+    }
+
+    fn transition(
+        state: &Self::State,
+        event: &Self::Event,
+        ctx: &Self::Context,
+        _props: &Self::Props,
+    ) -> Option<TransitionPlan<Self>> {
+        match event {
+            Event::GoToSlide { index } => {
+                if *state == State::Transitioning {
+                    return None;
+                }
+
+                // A direct jump never wraps; clamp out-of-range targets to the
+                // last slide so `current_index` can never exceed the slide
+                // count (every connect method relies on that invariant).
+                let idx = (*index).min(ctx.slide_count.get() - 1);
+                Some(
+                    TransitionPlan::to(State::Transitioning).apply(move |ctx: &mut Context| {
+                        ctx.index.set(idx);
+                    }),
+                )
+            }
+
+            Event::GoToNext => {
+                if *state == State::Transitioning || !ctx.can_go_next() {
+                    return None;
+                }
+
+                let step = ctx.slides_per_move as isize;
+
+                let next = ctx.clamp_index(ctx.current_index() as isize + step);
+
+                let stop = ctx
+                    .auto_play
+                    .as_ref()
+                    .is_some_and(|o| o.stop_on_interaction);
+
+                Some(
+                    TransitionPlan::to(State::Transitioning).apply(move |ctx: &mut Context| {
+                        ctx.index.set(next);
+
+                        if stop {
+                            ctx.auto_play_stopped = true;
+                        }
+                    }),
+                )
+            }
+
+            Event::GoToPrev => {
+                if *state == State::Transitioning || !ctx.can_go_prev() {
+                    return None;
+                }
+
+                let step = ctx.slides_per_move as isize;
+
+                let prev = ctx.clamp_index(ctx.current_index() as isize - step);
+
+                let stop = ctx
+                    .auto_play
+                    .as_ref()
+                    .is_some_and(|o| o.stop_on_interaction);
+
+                Some(
+                    TransitionPlan::to(State::Transitioning).apply(move |ctx: &mut Context| {
+                        ctx.index.set(prev);
+
+                        if stop {
+                            ctx.auto_play_stopped = true;
+                        }
+                    }),
+                )
+            }
+
+            Event::TransitionEnd => {
+                if ctx.auto_play.is_some() && !ctx.auto_play_stopped && !ctx.auto_play_paused {
+                    Some(TransitionPlan::to(State::AutoPlaying))
+                } else {
+                    Some(TransitionPlan::to(State::Idle))
+                }
+            }
+
+            Event::AutoPlayStart => {
+                if ctx.auto_play_stopped || ctx.auto_play.is_none() {
+                    return None;
+                }
+
+                Some(
+                    TransitionPlan::to(State::AutoPlaying)
+                        .with_effect(PendingEffect::named(Effect::AutoPlayTimer)),
+                )
+            }
+
+            Event::AutoPlayStop => Some(
+                TransitionPlan::to(State::Idle)
+                    .apply(|ctx: &mut Context| {
+                        ctx.auto_play_stopped = true;
+                    })
+                    .cancel_effect(Effect::AutoPlayTimer),
+            ),
+
+            Event::AutoPlayTick => {
+                if *state != State::AutoPlaying {
+                    return None;
+                }
+
+                let step = ctx.slides_per_move as isize;
+
+                let next = ctx.clamp_index(ctx.current_index() as isize + step);
+
+                Some(
+                    TransitionPlan::to(State::Transitioning).apply(move |ctx: &mut Context| {
+                        ctx.index.set(next);
+                    }),
+                )
+            }
+
+            Event::AutoPlayPause => {
+                let plan = if *state == State::AutoPlaying {
+                    TransitionPlan::to(State::Idle)
+                } else {
+                    TransitionPlan::new()
+                };
+
+                Some(
+                    plan.apply(|ctx: &mut Context| {
+                        ctx.auto_play_paused = true;
+                    })
+                    .cancel_effect(Effect::AutoPlayTimer),
+                )
+            }
+
+            Event::AutoPlayResume => {
+                if ctx.auto_play_stopped {
+                    return None;
+                }
+
+                if ctx.auto_play.is_some() {
+                    return Some(
+                        TransitionPlan::to(State::AutoPlaying)
+                            .apply(|ctx: &mut Context| {
+                                ctx.auto_play_paused = false;
+                            })
+                            .with_effect(PendingEffect::named(Effect::AutoPlayTimer)),
+                    );
+                }
+
+                Some(TransitionPlan::context_only(|ctx: &mut Context| {
+                    ctx.auto_play_paused = false;
+                }))
+            }
+
+            Event::PointerDown { pos, timestamp } => {
+                let pos = *pos;
+                let timestamp = *timestamp;
+                Some(
+                    TransitionPlan::context_only(move |ctx: &mut Context| {
+                        ctx.drag_start_pos = Some(pos);
+                        ctx.drag_delta = 0.0;
+                        ctx.swipe_velocity = 0.0;
+                        ctx.drag_last_timestamp = Some(timestamp);
+                    })
+                    .cancel_effect(Effect::AutoPlayTimer),
+                )
+            }
+
+            Event::PointerMove { pos, timestamp } => {
+                let start = ctx.drag_start_pos?;
+                let pos = *pos;
+                let timestamp = *timestamp;
+                let prev_delta = ctx.drag_delta;
+                let prev_ts = ctx.drag_last_timestamp;
+                Some(TransitionPlan::context_only(move |ctx: &mut Context| {
+                    ctx.drag_delta = pos - start;
+
+                    let pixel_delta = ctx.drag_delta - prev_delta;
+                    let dt = prev_ts.map_or(0.0, |t| timestamp - t);
+
+                    ctx.swipe_velocity = if dt > 0.0 { pixel_delta / dt } else { 0.0 };
+                    ctx.drag_last_timestamp = Some(timestamp);
+                }))
+            }
+
+            Event::PointerUp => {
+                let delta = ctx.drag_delta;
+                let velocity = ctx.swipe_velocity;
+                let threshold = ctx.swipe_threshold;
+
+                // A brisk flick (>0.5 px/ms) reduces the distance threshold.
+                let effective = if velocity.abs() > 0.5 {
+                    threshold * 0.3
+                } else {
+                    threshold
+                };
+
+                let cur = ctx.current_index() as isize;
+
+                let next_idx = if delta < -effective && ctx.can_go_next() {
+                    Some(ctx.clamp_index(cur + 1))
+                } else if delta > effective && ctx.can_go_prev() {
+                    Some(ctx.clamp_index(cur - 1))
+                } else {
+                    None
+                };
+
+                Some(
+                    TransitionPlan::to(State::Idle).apply(move |ctx: &mut Context| {
+                        ctx.drag_start_pos = None;
+                        ctx.drag_delta = 0.0;
+                        ctx.swipe_velocity = 0.0;
+                        ctx.drag_last_timestamp = None;
+
+                        if let Some(idx) = next_idx {
+                            ctx.index.set(idx);
+                        }
+                    }),
+                )
+            }
+
+            Event::PointerCancel => Some(TransitionPlan::context_only(|ctx: &mut Context| {
+                ctx.drag_start_pos = None;
+                ctx.drag_delta = 0.0;
+                ctx.swipe_velocity = 0.0;
+                ctx.drag_last_timestamp = None;
+            })),
+
+            Event::FocusSlide { index } => {
+                // Defensive: focus is always reported for a real slide, but
+                // clamp anyway so an out-of-range index can never desync
+                // `current_index` past the slide count.
+                let idx = (*index).min(ctx.slide_count.get() - 1);
+                let current = ctx.current_index();
+                let should_pause = ctx.auto_play.as_ref().is_some_and(|o| o.pause_on_focus);
+
+                Some(TransitionPlan::context_only(move |ctx: &mut Context| {
+                    if idx != current {
+                        ctx.index.set(idx);
+                    }
+
+                    if should_pause {
+                        ctx.auto_play_paused = true;
+                    }
+                }))
+            }
+
+            Event::Blur => {
+                if ctx.auto_play_paused && !ctx.auto_play_stopped && ctx.auto_play.is_some() {
+                    return Some(
+                        TransitionPlan::to(State::AutoPlaying)
+                            .apply(|ctx: &mut Context| {
+                                ctx.auto_play_paused = false;
+                            })
+                            .with_effect(PendingEffect::named(Effect::AutoPlayTimer)),
+                    );
+                }
+
+                None
+            }
+        }
+    }
+
+    fn connect<'a>(
+        state: &'a Self::State,
+        ctx: &'a Self::Context,
+        props: &'a Self::Props,
+        send: &'a dyn Fn(Self::Event),
+    ) -> Self::Api<'a> {
+        Api {
+            state,
+            ctx,
+            props,
+            send,
+        }
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Part
+// ────────────────────────────────────────────────────────────────────
+
+/// The anatomy parts of the [`Carousel`](self) component.
+#[derive(ComponentPart)]
+#[scope = "carousel"]
+pub enum Part {
+    /// The root carousel region (`<section>`).
+    Root,
+
+    /// The viewport that clips the slide track.
+    Viewport,
+
+    /// The group wrapping all slides (the live region).
+    ItemGroup,
+
+    /// A single slide by index.
+    Item {
+        /// Zero-based slide index.
+        index: usize,
+    },
+
+    /// The previous-slide trigger.
+    PrevTrigger,
+
+    /// The next-slide trigger.
+    NextTrigger,
+
+    /// The group wrapping the dot indicators (`role="tablist"`).
+    IndicatorGroup,
+
+    /// A single dot indicator by index.
+    Indicator {
+        /// Zero-based slide index this indicator targets.
+        index: usize,
+    },
+
+    /// The auto-play play/pause trigger.
+    AutoPlayTrigger,
+
+    /// The decorative auto-play status indicator.
+    AutoPlayIndicator,
+
+    /// The live progress-text element (e.g. "Slide 2 of 5").
+    ProgressText,
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Api
+// ────────────────────────────────────────────────────────────────────
+
+/// Connect API producing attributes and event handlers for the
+/// [`Carousel`](self) anatomy parts.
+pub struct Api<'a> {
+    state: &'a State,
+    ctx: &'a Context,
+    props: &'a Props,
+    send: &'a dyn Fn(Event),
+}
+
+impl Debug for Api<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Api")
+            .field("state", self.state)
+            .field("ctx", self.ctx)
+            .field("props", self.props)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Api<'_> {
+    /// Attributes for the root carousel region.
+    #[must_use]
+    pub fn root_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Root.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Role, "region")
+            .set(
+                HtmlAttr::Aria(AriaAttr::Label),
+                (self.ctx.messages.carousel_label)(&self.ctx.locale),
+            )
+            .set(
+                HtmlAttr::Aria(AriaAttr::RoleDescription),
+                (self.ctx.messages.role_description)(&self.ctx.locale),
+            )
+            .set(
+                HtmlAttr::Data("ars-state"),
+                match self.state {
+                    State::Idle => "idle",
+                    State::AutoPlaying => "auto-playing",
+                    State::Transitioning => "transitioning",
+                },
+            )
+            .set(
+                HtmlAttr::Data("ars-orientation"),
+                match self.ctx.orientation {
+                    Orientation::Horizontal => "horizontal",
+                    Orientation::Vertical => "vertical",
+                },
+            );
+
+        attrs
+    }
+
+    /// Attributes for the viewport that clips the slide track.
+    #[must_use]
+    pub fn viewport_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::Viewport.data_attrs();
+
+        attrs.set(scope_attr, scope_val).set(part_attr, part_val);
+
+        let touch_action = if self.ctx.orientation == Orientation::Horizontal {
+            "pan-y"
+        } else {
+            "pan-x"
+        };
+
+        attrs
+            .set_style(CssProperty::Overflow, "hidden")
+            .set_style(CssProperty::TouchAction, touch_action);
+
+        attrs
+    }
+
+    /// Attributes for the group wrapping all slides (the live region).
+    #[must_use]
+    pub fn item_group_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::ItemGroup.data_attrs();
+
+        attrs.set(scope_attr, scope_val).set(part_attr, part_val);
+
+        let live = if self.ctx.auto_play_stopped || self.ctx.auto_play.is_none() {
+            "polite"
+        } else {
+            "off"
+        };
+
+        attrs.set(HtmlAttr::Aria(AriaAttr::Live), live);
+
+        attrs
+    }
+
+    /// Attributes for a single slide by index.
+    #[must_use]
+    pub fn item_attrs(&self, index: usize) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = (Part::Item { index }).data_attrs();
+
+        attrs.set(scope_attr, scope_val).set(part_attr, part_val);
+
+        let is_current = index == self.ctx.current_index();
+        let is_hidden = !is_current;
+
+        attrs
+            .set(HtmlAttr::Role, "group")
+            .set(
+                HtmlAttr::Aria(AriaAttr::RoleDescription),
+                (self.ctx.messages.slide_role_description)(&self.ctx.locale),
+            )
+            .set(
+                HtmlAttr::Aria(AriaAttr::Label),
+                (self.ctx.messages.slide_label)(
+                    index + 1,
+                    self.ctx.slide_count.get(),
+                    &self.ctx.locale,
+                ),
+            )
+            .set(HtmlAttr::Data("ars-index"), index.to_string())
+            .set_bool(HtmlAttr::Data("ars-active"), is_current);
+
+        if is_hidden {
+            attrs
+                .set(HtmlAttr::Aria(AriaAttr::Hidden), "true")
+                .set_bool(HtmlAttr::Inert, true);
+        }
+
+        attrs
+    }
+
+    /// Attributes for the previous-slide trigger.
+    #[must_use]
+    pub fn prev_trigger_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::PrevTrigger.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(
+                HtmlAttr::Aria(AriaAttr::Label),
+                (self.ctx.messages.prev_label)(&self.ctx.locale),
+            );
+
+        if !self.ctx.can_go_prev() {
+            attrs.set(HtmlAttr::Aria(AriaAttr::Disabled), "true");
+        }
+
+        attrs
+    }
+
+    /// Attributes for the next-slide trigger.
+    #[must_use]
+    pub fn next_trigger_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::NextTrigger.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(
+                HtmlAttr::Aria(AriaAttr::Label),
+                (self.ctx.messages.next_label)(&self.ctx.locale),
+            );
+
+        if !self.ctx.can_go_next() {
+            attrs.set(HtmlAttr::Aria(AriaAttr::Disabled), "true");
+        }
+
+        attrs
+    }
+
+    /// Attributes for the group wrapping the dot indicators.
+    #[must_use]
+    pub fn indicator_group_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::IndicatorGroup.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Role, "tablist");
+
+        attrs
+    }
+
+    /// Attributes for a single dot indicator by index.
+    #[must_use]
+    pub fn indicator_attrs(&self, index: usize) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] =
+            (Part::Indicator { index }).data_attrs();
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Role, "tab")
+            .set(
+                HtmlAttr::Aria(AriaAttr::Selected),
+                if index == self.ctx.current_index() {
+                    "true"
+                } else {
+                    "false"
+                },
+            );
+
+        attrs
+    }
+
+    /// Attributes for the auto-play play/pause trigger.
+    #[must_use]
+    pub fn auto_play_trigger_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::AutoPlayTrigger.data_attrs();
+
+        attrs.set(scope_attr, scope_val).set(part_attr, part_val);
+
+        let is_playing = !self.ctx.auto_play_stopped && !self.ctx.auto_play_paused;
+
+        let label = if is_playing {
+            (self.ctx.messages.pause_auto_play_label)(&self.ctx.locale)
+        } else {
+            (self.ctx.messages.start_auto_play_label)(&self.ctx.locale)
+        };
+
+        attrs.set(HtmlAttr::Aria(AriaAttr::Label), label).set(
+            HtmlAttr::Aria(AriaAttr::Pressed),
+            if is_playing { "true" } else { "false" },
+        );
+
+        attrs
+    }
+
+    /// Attributes for the decorative auto-play status indicator.
+    #[must_use]
+    pub fn auto_play_indicator_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::AutoPlayIndicator.data_attrs();
+
+        attrs.set(scope_attr, scope_val).set(part_attr, part_val);
+
+        let is_playing = !self.ctx.auto_play_stopped && !self.ctx.auto_play_paused;
+
+        attrs
+            .set(
+                HtmlAttr::Data("ars-state"),
+                if is_playing { "playing" } else { "paused" },
+            )
+            .set(HtmlAttr::Aria(AriaAttr::Hidden), "true");
+
+        attrs
+    }
+
+    /// Attributes for the progress text element (e.g. "2 of 5").
+    #[must_use]
+    pub fn progress_text_attrs(&self) -> AttrMap {
+        let mut attrs = AttrMap::new();
+        let [(scope_attr, scope_val), (part_attr, part_val)] = Part::ProgressText.data_attrs();
+
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Aria(AriaAttr::Live), "polite")
+            .set(HtmlAttr::Aria(AriaAttr::Atomic), "true");
+
+        attrs
+    }
+
+    /// Human-readable progress string (e.g. "Slide 2 of 5").
+    #[must_use]
+    pub fn progress_text(&self) -> String {
+        (self.ctx.messages.slide_label)(
+            self.ctx.current_index() + 1,
+            self.ctx.slide_count.get(),
+            &self.ctx.locale,
+        )
+    }
+
+    /// Handle a keydown on the root region: arrow keys navigate (reversed for
+    /// RTL horizontal carousels), `Home`/`End` jump to the first/last slide.
+    pub fn on_root_keydown(&self, data: &KeyboardEventData) {
+        let is_horizontal = self.ctx.orientation == Orientation::Horizontal;
+
+        let (prev_key, next_key) = if is_horizontal {
+            if self.ctx.is_rtl {
+                (KeyboardKey::ArrowRight, KeyboardKey::ArrowLeft)
+            } else {
+                (KeyboardKey::ArrowLeft, KeyboardKey::ArrowRight)
+            }
+        } else {
+            (KeyboardKey::ArrowUp, KeyboardKey::ArrowDown)
+        };
+
+        match data.key {
+            key if key == prev_key => (self.send)(Event::GoToPrev),
+
+            key if key == next_key => (self.send)(Event::GoToNext),
+
+            KeyboardKey::Home => (self.send)(Event::GoToSlide { index: 0 }),
+
+            KeyboardKey::End => (self.send)(Event::GoToSlide {
+                index: self.ctx.slide_count.get().saturating_sub(1),
+            }),
+
+            _ => {}
+        }
+    }
+
+    /// Dispatch a previous-slide navigation.
+    pub fn on_prev_trigger_click(&self) {
+        (self.send)(Event::GoToPrev);
+    }
+
+    /// Dispatch a next-slide navigation.
+    pub fn on_next_trigger_click(&self) {
+        (self.send)(Event::GoToNext);
+    }
+
+    /// Dispatch navigation to the indicator's slide.
+    pub fn on_indicator_click(&self, index: usize) {
+        (self.send)(Event::GoToSlide { index });
+    }
+
+    /// Toggle auto-play: resume when stopped/paused, otherwise pause.
+    pub fn on_auto_play_trigger_click(&self) {
+        if self.ctx.auto_play_stopped || self.ctx.auto_play_paused {
+            (self.send)(Event::AutoPlayResume);
+        } else {
+            (self.send)(Event::AutoPlayPause);
+        }
+    }
+
+    /// Dispatch a pointer-down (drag start) with adapter-normalized position
+    /// and timestamp.
+    pub fn on_viewport_pointerdown(&self, pos: f64, timestamp: f64) {
+        (self.send)(Event::PointerDown { pos, timestamp });
+    }
+
+    /// Dispatch a pointer-move during a drag.
+    pub fn on_viewport_pointermove(&self, pos: f64, timestamp: f64) {
+        (self.send)(Event::PointerMove { pos, timestamp });
+    }
+
+    /// Dispatch a pointer-up (drag end).
+    pub fn on_viewport_pointerup(&self) {
+        (self.send)(Event::PointerUp);
+    }
+}
+
+impl ConnectApi for Api<'_> {
+    type Part = Part;
+
+    fn part_attrs(&self, part: Part) -> AttrMap {
+        match part {
+            Part::Root => self.root_attrs(),
+            Part::Viewport => self.viewport_attrs(),
+            Part::ItemGroup => self.item_group_attrs(),
+            Part::Item { index } => self.item_attrs(index),
+            Part::PrevTrigger => self.prev_trigger_attrs(),
+            Part::NextTrigger => self.next_trigger_attrs(),
+            Part::IndicatorGroup => self.indicator_group_attrs(),
+            Part::Indicator { index } => self.indicator_attrs(index),
+            Part::AutoPlayTrigger => self.auto_play_trigger_attrs(),
+            Part::AutoPlayIndicator => self.auto_play_indicator_attrs(),
+            Part::ProgressText => self.progress_text_attrs(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::cell::RefCell;
+
+    use ars_core::{Env, SendResult, Service};
+    use insta::assert_snapshot;
+
+    use super::*;
+
+    // ── helpers ──────────────────────────────────────────────────────
+
+    fn nz(n: usize) -> NonZero<usize> {
+        NonZero::new(n).expect("non-zero slide count")
+    }
+
+    /// Plain carousel with `slide_count` slides and no auto-play.
+    fn props(slide_count: usize) -> Props {
+        Props {
+            id: String::from("carousel"),
+            slide_count: nz(slide_count),
+            ..Props::default()
+        }
+    }
+
+    /// Carousel with default auto-play enabled.
+    fn autoplay_props(slide_count: usize) -> Props {
+        Props {
+            auto_play: Some(AutoPlayOptions::default()),
+            ..props(slide_count)
+        }
+    }
+
+    fn service(props: Props) -> Service<Machine> {
+        Service::<Machine>::new(props, &Env::default(), &Messages::default())
+    }
+
+    fn snapshot_attrs(attrs: &AttrMap) -> String {
+        format!("{attrs:#?}")
+    }
+
+    fn keydown(key: KeyboardKey) -> KeyboardEventData {
+        KeyboardEventData {
+            key,
+            character: None,
+            code: String::new(),
+            shift_key: false,
+            ctrl_key: false,
+            alt_key: false,
+            meta_key: false,
+            repeat: false,
+            is_composing: false,
+        }
+    }
+
+    fn pending_effect_names(result: &SendResult<Machine>) -> Vec<Effect> {
+        result
+            .pending_effects
+            .iter()
+            .map(|effect| effect.name)
+            .collect()
+    }
+
+    /// Drive a slide change to completion: navigate then settle the
+    /// transition so the machine returns to a resting state.
+    fn settle(service: &mut Service<Machine>) {
+        drop(service.send(Event::TransitionEnd));
+    }
+
+    // ── init / state transitions ─────────────────────────────────────
+
+    #[test]
+    fn init_idle_without_autoplay() {
+        let service = service(props(3));
+
+        assert_eq!(service.state(), &State::Idle);
+        assert_eq!(service.context().current_index(), 0);
+    }
+
+    #[test]
+    fn init_autoplaying_with_autoplay() {
+        let service = service(autoplay_props(3));
+
+        assert_eq!(service.state(), &State::AutoPlaying);
+    }
+
+    #[test]
+    fn init_default_index_seeds_current_index() {
+        let service = service(Props {
+            default_index: Some(2),
+            ..props(3)
+        });
+
+        assert_eq!(service.context().current_index(), 2);
+    }
+
+    #[test]
+    fn goto_slide_enters_transitioning_and_sets_index() {
+        let mut service = service(props(3));
+
+        drop(service.send(Event::GoToSlide { index: 2 }));
+
+        assert_eq!(service.state(), &State::Transitioning);
+        assert_eq!(service.context().current_index(), 2);
+    }
+
+    #[test]
+    fn goto_slide_clamps_out_of_range_to_last() {
+        let mut service = service(props(3));
+
+        drop(service.send(Event::GoToSlide { index: 99 }));
+
+        assert_eq!(service.context().current_index(), 2);
+    }
+
+    #[test]
+    fn focus_slide_clamps_out_of_range_to_last() {
+        let mut service = service(props(3));
+
+        drop(service.send(Event::FocusSlide { index: 99 }));
+
+        assert_eq!(service.context().current_index(), 2);
+    }
+
+    #[test]
+    fn nav_blocked_while_transitioning() {
+        let mut service = service(props(3));
+
+        drop(service.send(Event::GoToSlide { index: 1 }));
+
+        assert_eq!(service.state(), &State::Transitioning);
+
+        let result = service.send(Event::GoToNext);
+
+        assert!(!result.state_changed);
+        assert_eq!(service.context().current_index(), 1);
+    }
+
+    #[test]
+    fn transition_end_returns_to_idle_without_autoplay() {
+        let mut service = service(props(3));
+
+        drop(service.send(Event::GoToSlide { index: 1 }));
+
+        settle(&mut service);
+
+        assert_eq!(service.state(), &State::Idle);
+    }
+
+    #[test]
+    fn transition_end_returns_to_autoplaying_when_active() {
+        let mut service = service(autoplay_props(3));
+
+        drop(service.send(Event::GoToSlide { index: 1 }));
+
+        assert_eq!(service.state(), &State::Transitioning);
+
+        // GoToSlide does not set stop_on_interaction, so auto-play resumes.
+        settle(&mut service);
+
+        assert_eq!(service.state(), &State::AutoPlaying);
+    }
+
+    // ── slide navigation ─────────────────────────────────────────────
+
+    #[test]
+    fn goto_next_and_prev_advance_by_one() {
+        let mut service = service(props(4));
+
+        drop(service.send(Event::GoToNext));
+
+        assert_eq!(service.context().current_index(), 1);
+
+        settle(&mut service);
+
+        drop(service.send(Event::GoToNext));
+
+        assert_eq!(service.context().current_index(), 2);
+
+        settle(&mut service);
+
+        drop(service.send(Event::GoToPrev));
+
+        assert_eq!(service.context().current_index(), 1);
+    }
+
+    #[test]
+    fn slides_per_move_advances_in_pages() {
+        let mut service = service(Props {
+            slides_per_move: Some(2),
+            ..props(6)
+        });
+
+        drop(service.send(Event::GoToNext));
+
+        assert_eq!(service.context().current_index(), 2);
+    }
+
+    #[test]
+    fn goto_prev_at_start_blocked_without_loop() {
+        let mut service = service(props(3));
+
+        let result = service.send(Event::GoToPrev);
+
+        assert!(!result.state_changed);
+        assert_eq!(service.context().current_index(), 0);
+    }
+
+    #[test]
+    fn goto_next_at_end_blocked_without_loop() {
+        let mut service = service(Props {
+            default_index: Some(2),
+            ..props(3)
+        });
+
+        let result = service.send(Event::GoToNext);
+
+        assert!(!result.state_changed);
+        assert_eq!(service.context().current_index(), 2);
+    }
+
+    #[test]
+    fn can_go_prev_next_at_boundaries() {
+        let ctx = service(props(3)).context().clone();
+
+        assert!(!ctx.can_go_prev());
+        assert!(ctx.can_go_next());
+    }
+
+    // ── loop mode ────────────────────────────────────────────────────
+
+    #[test]
+    fn loop_wraps_next_from_last() {
+        let mut service = service(Props {
+            loop_nav: true,
+            default_index: Some(2),
+            ..props(3)
+        });
+
+        drop(service.send(Event::GoToNext));
+
+        assert_eq!(service.context().current_index(), 0);
+    }
+
+    #[test]
+    fn loop_wraps_prev_from_first() {
+        let mut service = service(Props {
+            loop_nav: true,
+            ..props(3)
+        });
+
+        drop(service.send(Event::GoToPrev));
+
+        assert_eq!(service.context().current_index(), 2);
+    }
+
+    #[test]
+    fn clamp_index_wraps_and_clamps() {
+        let looped = service(Props {
+            loop_nav: true,
+            ..props(3)
+        });
+
+        assert_eq!(looped.context().clamp_index(-1), 2);
+        assert_eq!(looped.context().clamp_index(3), 0);
+
+        let clamped = service(props(3));
+
+        assert_eq!(clamped.context().clamp_index(-1), 0);
+        assert_eq!(clamped.context().clamp_index(5), 2);
+    }
+
+    // ── auto-play ─────────────────────────────────────────────────────
+
+    #[test]
+    fn initial_effects_emit_timer_when_autoplaying() {
+        let mut service = service(autoplay_props(3));
+
+        let effects = service
+            .take_initial_effects()
+            .iter()
+            .map(|effect| effect.name)
+            .collect::<Vec<_>>();
+
+        assert_eq!(effects, vec![Effect::AutoPlayTimer]);
+    }
+
+    #[test]
+    fn initial_effects_empty_when_idle() {
+        let mut service = service(props(3));
+
+        assert!(service.take_initial_effects().is_empty());
+    }
+
+    #[test]
+    fn autoplay_tick_advances_and_transitions() {
+        let mut service = service(autoplay_props(3));
+
+        drop(service.take_initial_effects());
+        drop(service.send(Event::AutoPlayTick));
+
+        assert_eq!(service.state(), &State::Transitioning);
+        assert_eq!(service.context().current_index(), 1);
+    }
+
+    #[test]
+    fn autoplay_tick_ignored_when_not_autoplaying() {
+        let mut service = service(props(3));
+
+        let result = service.send(Event::AutoPlayTick);
+
+        assert!(!result.state_changed);
+        assert_eq!(service.context().current_index(), 0);
+    }
+
+    #[test]
+    fn autoplay_tick_wraps_with_loop() {
+        let mut service = service(Props {
+            loop_nav: true,
+            default_index: Some(2),
+            ..autoplay_props(3)
+        });
+
+        drop(service.take_initial_effects());
+        drop(service.send(Event::AutoPlayTick));
+
+        assert_eq!(service.context().current_index(), 0);
+    }
+
+    #[test]
+    fn autoplay_start_emits_timer() {
+        let mut service = service(Props {
+            auto_play: Some(AutoPlayOptions::default()),
+            ..props(3)
+        });
+
+        // Move to Idle first (stop), then start fresh.
+        drop(service.send(Event::AutoPlayPause));
+        drop(service.send(Event::AutoPlayResume));
+
+        let result = service.send(Event::AutoPlayStart);
+
+        assert_eq!(service.state(), &State::AutoPlaying);
+        assert_eq!(pending_effect_names(&result), vec![Effect::AutoPlayTimer]);
+    }
+
+    #[test]
+    fn autoplay_start_noop_when_stopped() {
+        let mut service = service(autoplay_props(3));
+
+        drop(service.send(Event::AutoPlayStop));
+
+        assert!(service.context().auto_play_stopped);
+
+        let result = service.send(Event::AutoPlayStart);
+
+        assert!(!result.state_changed);
+    }
+
+    #[test]
+    fn autoplay_stop_sets_stopped_and_cancels_timer() {
+        let mut service = service(autoplay_props(3));
+
+        let result = service.send(Event::AutoPlayStop);
+
+        assert_eq!(service.state(), &State::Idle);
+        assert!(service.context().auto_play_stopped);
+        assert_eq!(result.cancel_effects, vec![Effect::AutoPlayTimer]);
+    }
+
+    #[test]
+    fn item_group_live_is_polite_once_autoplay_stopped() {
+        let mut service = service(autoplay_props(3));
+
+        // Active auto-play → "off".
+        let live_off = service.connect(&|_| {}).item_group_attrs();
+
+        assert_eq!(live_off.get(&HtmlAttr::Aria(AriaAttr::Live)), Some("off"));
+
+        // After stopping, the live region must become "polite" again.
+        drop(service.send(Event::AutoPlayStop));
+
+        let live_polite = service.connect(&|_| {}).item_group_attrs();
+
+        assert_eq!(
+            live_polite.get(&HtmlAttr::Aria(AriaAttr::Live)),
+            Some("polite")
+        );
+    }
+
+    #[test]
+    fn stop_on_interaction_marks_stopped_on_manual_nav() {
+        let mut service = service(autoplay_props(3));
+
+        drop(service.send(Event::GoToNext));
+
+        assert!(service.context().auto_play_stopped);
+    }
+
+    #[test]
+    fn stop_on_interaction_disabled_keeps_playing() {
+        let mut service = service(Props {
+            auto_play: Some(AutoPlayOptions {
+                stop_on_interaction: false,
+                ..AutoPlayOptions::default()
+            }),
+            ..props(3)
+        });
+
+        drop(service.send(Event::GoToNext));
+
+        assert!(!service.context().auto_play_stopped);
+    }
+
+    // ── pause on hover / focus ───────────────────────────────────────
+
+    #[test]
+    fn autoplay_pause_sets_paused_and_cancels_timer() {
+        let mut service = service(autoplay_props(3));
+
+        let result = service.send(Event::AutoPlayPause);
+
+        assert_eq!(service.state(), &State::Idle);
+        assert!(service.context().auto_play_paused);
+        assert_eq!(result.cancel_effects, vec![Effect::AutoPlayTimer]);
+    }
+
+    #[test]
+    fn autoplay_resume_restarts_timer() {
+        let mut service = service(autoplay_props(3));
+
+        drop(service.send(Event::AutoPlayPause));
+
+        let result = service.send(Event::AutoPlayResume);
+
+        assert_eq!(service.state(), &State::AutoPlaying);
+        assert!(!service.context().auto_play_paused);
+        assert_eq!(pending_effect_names(&result), vec![Effect::AutoPlayTimer]);
+    }
+
+    #[test]
+    fn autoplay_resume_noop_when_stopped() {
+        let mut service = service(autoplay_props(3));
+
+        drop(service.send(Event::AutoPlayStop));
+
+        let result = service.send(Event::AutoPlayResume);
+
+        assert!(!result.state_changed);
+        assert!(!service.context().auto_play_paused);
+    }
+
+    #[test]
+    fn focus_slide_pauses_and_syncs_index() {
+        let mut service = service(autoplay_props(3));
+
+        drop(service.send(Event::FocusSlide { index: 2 }));
+
+        assert!(service.context().auto_play_paused);
+        assert_eq!(service.context().current_index(), 2);
+    }
+
+    #[test]
+    fn focus_slide_without_pause_on_focus_keeps_playing() {
+        let mut service = service(Props {
+            auto_play: Some(AutoPlayOptions {
+                pause_on_focus: false,
+                ..AutoPlayOptions::default()
+            }),
+            ..props(3)
+        });
+
+        drop(service.send(Event::FocusSlide { index: 1 }));
+
+        assert!(!service.context().auto_play_paused);
+    }
+
+    #[test]
+    fn blur_resumes_when_paused() {
+        let mut service = service(autoplay_props(3));
+
+        drop(service.send(Event::AutoPlayPause));
+
+        let result = service.send(Event::Blur);
+
+        assert_eq!(service.state(), &State::AutoPlaying);
+        assert!(!service.context().auto_play_paused);
+        assert_eq!(pending_effect_names(&result), vec![Effect::AutoPlayTimer]);
+    }
+
+    #[test]
+    fn blur_noop_when_not_paused() {
+        let mut service = service(autoplay_props(3));
+
+        let result = service.send(Event::Blur);
+
+        assert!(!result.state_changed);
+    }
+
+    // ── swipe gesture (injected pointer deltas) ──────────────────────
+
+    #[test]
+    fn pointer_down_records_start_and_cancels_timer() {
+        let mut service = service(autoplay_props(3));
+
+        let result = service.send(Event::PointerDown {
+            pos: 100.0,
+            timestamp: 0.0,
+        });
+
+        assert_eq!(service.context().drag_start_pos, Some(100.0));
+        assert_eq!(result.cancel_effects, vec![Effect::AutoPlayTimer]);
+    }
+
+    #[test]
+    fn pointer_move_accumulates_delta_and_velocity() {
+        let mut service = service(props(3));
+
+        drop(service.send(Event::PointerDown {
+            pos: 100.0,
+            timestamp: 0.0,
+        }));
+        drop(service.send(Event::PointerMove {
+            pos: 80.0,
+            timestamp: 10.0,
+        }));
+
+        assert_eq!(service.context().drag_delta, -20.0);
+        assert_eq!(service.context().swipe_velocity, -2.0);
+    }
+
+    #[test]
+    fn pointer_move_ignored_without_down() {
+        let mut service = service(props(3));
+
+        let result = service.send(Event::PointerMove {
+            pos: 50.0,
+            timestamp: 5.0,
+        });
+
+        assert!(!result.context_changed);
+        assert_eq!(service.context().drag_delta, 0.0);
+    }
+
+    #[test]
+    fn pointer_up_navigates_next_past_threshold() {
+        let mut service = service(props(3));
+
+        drop(service.send(Event::PointerDown {
+            pos: 100.0,
+            timestamp: 0.0,
+        }));
+
+        // delta -60 over 1000ms → slow drag, threshold stays 50.
+        drop(service.send(Event::PointerMove {
+            pos: 40.0,
+            timestamp: 1000.0,
+        }));
+        drop(service.send(Event::PointerUp));
+
+        assert_eq!(service.state(), &State::Idle);
+        assert_eq!(service.context().current_index(), 1);
+        assert_eq!(service.context().drag_delta, 0.0);
+    }
+
+    #[test]
+    fn pointer_up_navigates_prev_past_threshold() {
+        let mut service = service(Props {
+            default_index: Some(1),
+            ..props(3)
+        });
+
+        drop(service.send(Event::PointerDown {
+            pos: 40.0,
+            timestamp: 0.0,
+        }));
+        drop(service.send(Event::PointerMove {
+            pos: 100.0,
+            timestamp: 1000.0,
+        }));
+        drop(service.send(Event::PointerUp));
+
+        assert_eq!(service.context().current_index(), 0);
+    }
+
+    #[test]
+    fn pointer_up_velocity_flick_lowers_threshold() {
+        let mut service = service(props(3));
+
+        drop(service.send(Event::PointerDown {
+            pos: 100.0,
+            timestamp: 0.0,
+        }));
+        // delta -20 (< 50) but fast (2 px/ms) → effective threshold 15.
+        drop(service.send(Event::PointerMove {
+            pos: 80.0,
+            timestamp: 10.0,
+        }));
+        drop(service.send(Event::PointerUp));
+
+        assert_eq!(service.context().current_index(), 1);
+    }
+
+    #[test]
+    fn pointer_up_below_threshold_does_not_navigate() {
+        let mut service = service(props(3));
+
+        drop(service.send(Event::PointerDown {
+            pos: 100.0,
+            timestamp: 0.0,
+        }));
+        // delta -10, slow → no navigation.
+        drop(service.send(Event::PointerMove {
+            pos: 90.0,
+            timestamp: 1000.0,
+        }));
+        drop(service.send(Event::PointerUp));
+
+        assert_eq!(service.context().current_index(), 0);
+    }
+
+    #[test]
+    fn pointer_cancel_resets_drag_state() {
+        let mut service = service(props(3));
+
+        drop(service.send(Event::PointerDown {
+            pos: 100.0,
+            timestamp: 0.0,
+        }));
+        drop(service.send(Event::PointerMove {
+            pos: 70.0,
+            timestamp: 10.0,
+        }));
+        drop(service.send(Event::PointerCancel));
+
+        assert_eq!(service.context().drag_start_pos, None);
+        assert_eq!(service.context().drag_delta, 0.0);
+        assert_eq!(service.context().current_index(), 0);
+    }
+
+    // ── keyboard navigation ──────────────────────────────────────────
+
+    fn captured_keydown(service: &Service<Machine>, key: KeyboardKey) -> Vec<Event> {
+        let recorder = RefCell::new(Vec::new());
+
+        {
+            let record = |event| recorder.borrow_mut().push(event);
+
+            let api = service.connect(&record);
+
+            api.on_root_keydown(&keydown(key));
+        }
+
+        recorder.into_inner()
+    }
+
+    #[test]
+    fn keydown_horizontal_ltr_arrows() {
+        let service = service(props(3));
+
+        assert_eq!(
+            captured_keydown(&service, KeyboardKey::ArrowRight),
+            vec![Event::GoToNext]
+        );
+        assert_eq!(
+            captured_keydown(&service, KeyboardKey::ArrowLeft),
+            vec![Event::GoToPrev]
+        );
+    }
+
+    #[test]
+    fn keydown_horizontal_rtl_reverses_arrows() {
+        let service = service(Props {
+            is_rtl: true,
+            ..props(3)
+        });
+
+        assert_eq!(
+            captured_keydown(&service, KeyboardKey::ArrowRight),
+            vec![Event::GoToPrev]
+        );
+        assert_eq!(
+            captured_keydown(&service, KeyboardKey::ArrowLeft),
+            vec![Event::GoToNext]
+        );
+    }
+
+    #[test]
+    fn keydown_vertical_uses_up_down() {
+        let service = service(Props {
+            orientation: Some(Orientation::Vertical),
+            ..props(3)
+        });
+
+        assert_eq!(
+            captured_keydown(&service, KeyboardKey::ArrowDown),
+            vec![Event::GoToNext]
+        );
+        assert_eq!(
+            captured_keydown(&service, KeyboardKey::ArrowUp),
+            vec![Event::GoToPrev]
+        );
+    }
+
+    #[test]
+    fn keydown_unhandled_key_dispatches_nothing() {
+        let service = service(props(3));
+
+        assert!(captured_keydown(&service, KeyboardKey::Enter).is_empty());
+    }
+
+    #[test]
+    fn keydown_home_end_jump_to_bounds() {
+        let service = service(props(5));
+
+        assert_eq!(
+            captured_keydown(&service, KeyboardKey::Home),
+            vec![Event::GoToSlide { index: 0 }]
+        );
+        assert_eq!(
+            captured_keydown(&service, KeyboardKey::End),
+            vec![Event::GoToSlide { index: 4 }]
+        );
+    }
+
+    // ── click / pointer handler dispatch ─────────────────────────────
+
+    #[test]
+    fn click_handlers_dispatch_expected_events() {
+        let service = service(autoplay_props(3));
+
+        let recorder = RefCell::new(Vec::new());
+
+        {
+            let record = |event| recorder.borrow_mut().push(event);
+
+            let api = service.connect(&record);
+
+            api.on_prev_trigger_click();
+            api.on_next_trigger_click();
+            api.on_indicator_click(2);
+            api.on_auto_play_trigger_click();
+            api.on_viewport_pointerdown(10.0, 1.0);
+            api.on_viewport_pointermove(20.0, 2.0);
+            api.on_viewport_pointerup();
+        }
+
+        assert_eq!(
+            recorder.into_inner(),
+            vec![
+                Event::GoToPrev,
+                Event::GoToNext,
+                Event::GoToSlide { index: 2 },
+                Event::AutoPlayPause,
+                Event::PointerDown {
+                    pos: 10.0,
+                    timestamp: 1.0
+                },
+                Event::PointerMove {
+                    pos: 20.0,
+                    timestamp: 2.0
+                },
+                Event::PointerUp,
+            ]
+        );
+    }
+
+    #[test]
+    fn auto_play_trigger_resumes_when_paused() {
+        let mut service = service(autoplay_props(3));
+
+        drop(service.send(Event::AutoPlayPause));
+
+        let recorder = RefCell::new(Vec::new());
+
+        {
+            let record = |event| recorder.borrow_mut().push(event);
+
+            let api = service.connect(&record);
+
+            api.on_auto_play_trigger_click();
+        }
+
+        assert_eq!(recorder.into_inner(), vec![Event::AutoPlayResume]);
+    }
+
+    // ── track offset math ────────────────────────────────────────────
+
+    #[test]
+    fn track_offset_percent_basic_and_drag() {
+        let service = service(Props {
+            default_index: Some(1),
+            ..props(3)
+        });
+
+        let ctx = service.context();
+
+        // index 1, slides_per_view 1 → -100%.
+        assert_eq!(ctx.track_offset_percent(200.0), -100.0);
+    }
+
+    #[test]
+    fn track_offset_percent_applies_drag_correction() {
+        let mut service = service(props(3));
+
+        drop(service.send(Event::PointerDown {
+            pos: 100.0,
+            timestamp: 0.0,
+        }));
+        drop(service.send(Event::PointerMove {
+            pos: 150.0,
+            timestamp: 10.0,
+        }));
+
+        // index 0 → 0%; drag_delta +50 over 200px viewport → +25%.
+        assert_eq!(service.context().track_offset_percent(200.0), 25.0);
+    }
+
+    #[test]
+    fn track_offset_percent_fractional_view() {
+        let service = service(Props {
+            slides_per_view: Some(2.0),
+            default_index: Some(1),
+            ..props(4)
+        });
+
+        // index 1, per_slide = 50% → -50%.
+        assert_eq!(service.context().track_offset_percent(0.0), -50.0);
+    }
+
+    // ── snapshots: connect()/Api AttrMap output per part & branch ─────
+
+    #[test]
+    fn snapshot_root_idle_horizontal() {
+        let service = service(props(3));
+
+        assert_snapshot!(
+            "root_idle_horizontal",
+            snapshot_attrs(&service.connect(&|_| {}).root_attrs())
+        );
+    }
+
+    #[test]
+    fn snapshot_root_autoplaying() {
+        let service = service(autoplay_props(3));
+
+        assert_snapshot!(
+            "root_autoplaying",
+            snapshot_attrs(&service.connect(&|_| {}).root_attrs())
+        );
+    }
+
+    #[test]
+    fn snapshot_root_transitioning() {
+        let mut service = service(props(3));
+
+        drop(service.send(Event::GoToSlide { index: 1 }));
+
+        assert_snapshot!(
+            "root_transitioning",
+            snapshot_attrs(&service.connect(&|_| {}).root_attrs())
+        );
+    }
+
+    #[test]
+    fn snapshot_root_vertical() {
+        let service = service(Props {
+            orientation: Some(Orientation::Vertical),
+            ..props(3)
+        });
+
+        assert_snapshot!(
+            "root_vertical",
+            snapshot_attrs(&service.connect(&|_| {}).root_attrs())
+        );
+    }
+
+    #[test]
+    fn snapshot_viewport_horizontal() {
+        let service = service(props(3));
+
+        assert_snapshot!(
+            "viewport_horizontal",
+            snapshot_attrs(&service.connect(&|_| {}).viewport_attrs())
+        );
+    }
+
+    #[test]
+    fn snapshot_viewport_vertical() {
+        let service = service(Props {
+            orientation: Some(Orientation::Vertical),
+            ..props(3)
+        });
+
+        assert_snapshot!(
+            "viewport_vertical",
+            snapshot_attrs(&service.connect(&|_| {}).viewport_attrs())
+        );
+    }
+
+    #[test]
+    fn snapshot_item_group_polite_no_autoplay() {
+        let service = service(props(3));
+
+        assert_snapshot!(
+            "item_group_polite",
+            snapshot_attrs(&service.connect(&|_| {}).item_group_attrs())
+        );
+    }
+
+    #[test]
+    fn snapshot_item_group_off_during_autoplay() {
+        let service = service(autoplay_props(3));
+
+        assert_snapshot!(
+            "item_group_off",
+            snapshot_attrs(&service.connect(&|_| {}).item_group_attrs())
+        );
+    }
+
+    #[test]
+    fn snapshot_item_current() {
+        let service = service(props(3));
+
+        assert_snapshot!(
+            "item_current",
+            snapshot_attrs(&service.connect(&|_| {}).item_attrs(0))
+        );
+    }
+
+    #[test]
+    fn snapshot_item_hidden() {
+        let service = service(props(3));
+
+        assert_snapshot!(
+            "item_hidden",
+            snapshot_attrs(&service.connect(&|_| {}).item_attrs(1))
+        );
+    }
+
+    #[test]
+    fn snapshot_prev_trigger_disabled_at_start() {
+        let service = service(props(3));
+
+        assert_snapshot!(
+            "prev_trigger_disabled",
+            snapshot_attrs(&service.connect(&|_| {}).prev_trigger_attrs())
+        );
+    }
+
+    #[test]
+    fn snapshot_prev_trigger_enabled() {
+        let service = service(Props {
+            default_index: Some(1),
+            ..props(3)
+        });
+
+        assert_snapshot!(
+            "prev_trigger_enabled",
+            snapshot_attrs(&service.connect(&|_| {}).prev_trigger_attrs())
+        );
+    }
+
+    #[test]
+    fn snapshot_next_trigger_disabled_at_end() {
+        let service = service(Props {
+            default_index: Some(2),
+            ..props(3)
+        });
+
+        assert_snapshot!(
+            "next_trigger_disabled",
+            snapshot_attrs(&service.connect(&|_| {}).next_trigger_attrs())
+        );
+    }
+
+    #[test]
+    fn snapshot_next_trigger_enabled() {
+        let service = service(props(3));
+
+        assert_snapshot!(
+            "next_trigger_enabled",
+            snapshot_attrs(&service.connect(&|_| {}).next_trigger_attrs())
+        );
+    }
+
+    #[test]
+    fn snapshot_indicator_group() {
+        let service = service(props(3));
+
+        assert_snapshot!(
+            "indicator_group",
+            snapshot_attrs(&service.connect(&|_| {}).indicator_group_attrs())
+        );
+    }
+
+    #[test]
+    fn snapshot_indicator_selected() {
+        let service = service(props(3));
+
+        assert_snapshot!(
+            "indicator_selected",
+            snapshot_attrs(&service.connect(&|_| {}).indicator_attrs(0))
+        );
+    }
+
+    #[test]
+    fn snapshot_indicator_unselected() {
+        let service = service(props(3));
+
+        assert_snapshot!(
+            "indicator_unselected",
+            snapshot_attrs(&service.connect(&|_| {}).indicator_attrs(1))
+        );
+    }
+
+    #[test]
+    fn snapshot_auto_play_trigger_playing() {
+        let service = service(autoplay_props(3));
+
+        assert_snapshot!(
+            "auto_play_trigger_playing",
+            snapshot_attrs(&service.connect(&|_| {}).auto_play_trigger_attrs())
+        );
+    }
+
+    #[test]
+    fn snapshot_auto_play_trigger_paused() {
+        let mut service = service(autoplay_props(3));
+
+        drop(service.send(Event::AutoPlayPause));
+
+        assert_snapshot!(
+            "auto_play_trigger_paused",
+            snapshot_attrs(&service.connect(&|_| {}).auto_play_trigger_attrs())
+        );
+    }
+
+    #[test]
+    fn snapshot_autoplay_indicator_playing() {
+        let service = service(autoplay_props(3));
+
+        assert_snapshot!(
+            "autoplay_indicator_playing",
+            snapshot_attrs(&service.connect(&|_| {}).auto_play_indicator_attrs())
+        );
+    }
+
+    #[test]
+    fn snapshot_autoplay_indicator_paused() {
+        let mut service = service(autoplay_props(3));
+
+        drop(service.send(Event::AutoPlayPause));
+
+        assert_snapshot!(
+            "autoplay_indicator_paused",
+            snapshot_attrs(&service.connect(&|_| {}).auto_play_indicator_attrs())
+        );
+    }
+
+    #[test]
+    fn snapshot_progress_text_attrs() {
+        let service = service(props(3));
+
+        assert_snapshot!(
+            "progress_text_attrs",
+            snapshot_attrs(&service.connect(&|_| {}).progress_text_attrs())
+        );
+    }
+
+    #[test]
+    fn progress_text_renders_human_readable_position() {
+        let service = service(Props {
+            default_index: Some(1),
+            ..props(5)
+        });
+
+        assert_eq!(service.connect(&|_| {}).progress_text(), "Slide 2 of 5");
+    }
+
+    #[test]
+    fn api_debug_is_non_exhaustive() {
+        let service = service(props(3));
+
+        let rendered = format!("{:?}", service.connect(&|_| {}));
+
+        assert!(rendered.starts_with("Api {"));
+        assert!(rendered.contains(".."));
+    }
+
+    #[test]
+    fn part_attrs_delegates_to_each_anatomy_method() {
+        let service = service(autoplay_props(3));
+
+        let api = service.connect(&|_| {});
+
+        assert_eq!(api.part_attrs(Part::Root), api.root_attrs());
+        assert_eq!(api.part_attrs(Part::Viewport), api.viewport_attrs());
+        assert_eq!(api.part_attrs(Part::ItemGroup), api.item_group_attrs());
+        assert_eq!(api.part_attrs(Part::Item { index: 1 }), api.item_attrs(1));
+        assert_eq!(api.part_attrs(Part::PrevTrigger), api.prev_trigger_attrs());
+        assert_eq!(api.part_attrs(Part::NextTrigger), api.next_trigger_attrs());
+        assert_eq!(
+            api.part_attrs(Part::IndicatorGroup),
+            api.indicator_group_attrs()
+        );
+        assert_eq!(
+            api.part_attrs(Part::Indicator { index: 1 }),
+            api.indicator_attrs(1)
+        );
+        assert_eq!(
+            api.part_attrs(Part::AutoPlayTrigger),
+            api.auto_play_trigger_attrs()
+        );
+        assert_eq!(
+            api.part_attrs(Part::AutoPlayIndicator),
+            api.auto_play_indicator_attrs()
+        );
+        assert_eq!(
+            api.part_attrs(Part::ProgressText),
+            api.progress_text_attrs()
+        );
+    }
+
+    #[test]
+    fn goto_slide_blocked_while_transitioning() {
+        let mut service = service(props(4));
+
+        drop(service.send(Event::GoToSlide { index: 1 }));
+
+        assert_eq!(service.state(), &State::Transitioning);
+
+        let result = service.send(Event::GoToSlide { index: 3 });
+
+        assert!(!result.state_changed);
+        assert_eq!(service.context().current_index(), 1);
+    }
+
+    #[test]
+    fn goto_prev_with_stop_on_interaction_marks_stopped() {
+        let mut service = service(Props {
+            default_index: Some(2),
+            ..autoplay_props(3)
+        });
+
+        drop(service.send(Event::GoToPrev));
+
+        assert!(service.context().auto_play_stopped);
+        assert_eq!(service.context().current_index(), 1);
+    }
+
+    #[test]
+    fn autoplay_pause_when_idle_sets_flag_without_state_change() {
+        // No auto-play config → resting in `Idle`; pause keeps the state but
+        // still records the paused flag and cancels the (absent) timer.
+        let mut service = service(props(3));
+
+        let result = service.send(Event::AutoPlayPause);
+
+        assert_eq!(service.state(), &State::Idle);
+        assert!(service.context().auto_play_paused);
+        assert_eq!(result.cancel_effects, vec![Effect::AutoPlayTimer]);
+    }
+
+    #[test]
+    fn autoplay_resume_without_config_clears_paused_flag() {
+        let mut service = service(props(3));
+
+        drop(service.send(Event::AutoPlayPause));
+
+        assert!(service.context().auto_play_paused);
+
+        let result = service.send(Event::AutoPlayResume);
+
+        assert!(!service.context().auto_play_paused);
+        assert!(result.pending_effects.is_empty());
+    }
+}

--- a/crates/ars-components/src/layout/carousel/mod.rs
+++ b/crates/ars-components/src/layout/carousel/mod.rs
@@ -279,11 +279,31 @@ impl Context {
         *self.index.get()
     }
 
+    /// Number of slide slots occupied by the viewport at once, rounding a
+    /// fractional [`slides_per_view`](Self::slides_per_view) up so a partially
+    /// visible trailing slide still counts as on-screen. Always at least `1`.
+    #[must_use]
+    pub fn visible_count(&self) -> usize {
+        (self.slides_per_view.ceil() as usize).max(1)
+    }
+
+    /// Largest valid starting index for non-looping navigation.
+    ///
+    /// With `slides_per_view > 1` the last page is flush to the end
+    /// (contain-scroll): the final starting index is
+    /// `slide_count - visible_count`, so the trailing slide is fully shown
+    /// instead of leaving a partial/blank page past the boundary.
+    #[must_use]
+    pub fn last_index(&self) -> usize {
+        self.slide_count.get().saturating_sub(self.visible_count())
+    }
+
     /// Clamp or wrap an index according to `loop_nav`.
     ///
     /// When `loop_nav` is `true`, out-of-range indices wrap around modulo the
-    /// slide count; otherwise they are clamped to the `[0, slide_count - 1]`
-    /// range.
+    /// slide count; otherwise they are clamped to the `[0, last_index]` range
+    /// (see [`last_index`](Self::last_index), which accounts for
+    /// `slides_per_view`).
     #[must_use]
     pub fn clamp_index(&self, i: isize) -> usize {
         let n = self.slide_count.get() as isize;
@@ -291,7 +311,7 @@ impl Context {
         if self.loop_nav {
             ((i % n) + n) as usize % self.slide_count.get()
         } else {
-            (i.max(0) as usize).min(self.slide_count.get().saturating_sub(1))
+            (i.max(0) as usize).min(self.last_index())
         }
     }
 
@@ -302,9 +322,31 @@ impl Context {
     }
 
     /// Whether the carousel can navigate to a next slide.
+    ///
+    /// For `slides_per_view > 1` the boundary is the last full page
+    /// ([`last_index`](Self::last_index)), so `Next` disables once the final
+    /// slide is already in view rather than allowing a partial page.
     #[must_use]
     pub fn can_go_next(&self) -> bool {
-        self.loop_nav || self.current_index() + 1 < self.slide_count.get()
+        self.loop_nav || self.current_index() < self.last_index()
+    }
+
+    /// Whether `index` is within the currently visible window of
+    /// `visible_count` slides starting at `current_index` (wrapping when
+    /// `loop_nav` is set). Slides outside the window are hidden from
+    /// assistive technology.
+    #[must_use]
+    pub fn is_slide_visible(&self, index: usize) -> bool {
+        let current = self.current_index();
+        let count = self.slide_count.get();
+        (0..self.visible_count()).any(|offset| {
+            let slot = if self.loop_nav {
+                (current + offset) % count
+            } else {
+                current + offset
+            };
+            slot == index
+        })
     }
 
     /// CSS translate percentage for the slide track, given the live viewport
@@ -469,6 +511,29 @@ impl ComponentMessages for Messages {}
 #[derive(Debug)]
 pub struct Machine;
 
+/// Build the transition for a manual navigation to `idx`: enter
+/// [`State::Transitioning`] and set the index, and — when
+/// `stop_on_interaction` is configured — permanently stop auto-play and
+/// cancel its timer. The cancellation is essential: without it the adapter's
+/// recurring interval keeps running after rotation has "stopped", leaking the
+/// timer and dispatching ignored [`Event::AutoPlayTick`]s forever.
+fn navigate_to(ctx: &Context, idx: usize) -> TransitionPlan<Machine> {
+    let stop = ctx
+        .auto_play
+        .as_ref()
+        .is_some_and(|o| o.stop_on_interaction);
+    let mut plan = TransitionPlan::to(State::Transitioning).apply(move |ctx: &mut Context| {
+        ctx.index.set(idx);
+        if stop {
+            ctx.auto_play_stopped = true;
+        }
+    });
+    if stop {
+        plan = plan.cancel_effect(Effect::AutoPlayTimer);
+    }
+    plan
+}
+
 impl ars_core::Machine for Machine {
     type State = State;
     type Event = Event;
@@ -489,7 +554,13 @@ impl ars_core::Machine for Machine {
             State::Idle
         };
 
-        let initial_index = props.default_index.unwrap_or(0);
+        // Clamp the uncontrolled default to the last valid starting index so
+        // `current_index < slide_count` holds from the very first render (a
+        // bad `default_index` would otherwise yield "Slide 100 of 3" with no
+        // item marked current). Accounts for `slides_per_view`.
+        let visible_count = (props.slides_per_view.unwrap_or(1.0).ceil() as usize).max(1);
+        let max_index = props.slide_count.get().saturating_sub(visible_count);
+        let initial_index = props.default_index.unwrap_or(0).min(max_index);
 
         let ctx = Context {
             index: props
@@ -552,14 +623,12 @@ impl ars_core::Machine for Machine {
                 }
 
                 // A direct jump never wraps; clamp out-of-range targets to the
-                // last slide so `current_index` can never exceed the slide
-                // count (every connect method relies on that invariant).
-                let idx = (*index).min(ctx.slide_count.get() - 1);
-                Some(
-                    TransitionPlan::to(State::Transitioning).apply(move |ctx: &mut Context| {
-                        ctx.index.set(idx);
-                    }),
-                )
+                // last valid starting index so `current_index` can never
+                // exceed the boundary (every connect method relies on that
+                // invariant). A direct jump is a manual interaction, so it
+                // honours `stop_on_interaction` like Next/Prev.
+                let idx = (*index).min(ctx.last_index());
+                Some(navigate_to(ctx, idx))
             }
 
             Event::GoToNext => {
@@ -568,23 +637,8 @@ impl ars_core::Machine for Machine {
                 }
 
                 let step = ctx.slides_per_move as isize;
-
                 let next = ctx.clamp_index(ctx.current_index() as isize + step);
-
-                let stop = ctx
-                    .auto_play
-                    .as_ref()
-                    .is_some_and(|o| o.stop_on_interaction);
-
-                Some(
-                    TransitionPlan::to(State::Transitioning).apply(move |ctx: &mut Context| {
-                        ctx.index.set(next);
-
-                        if stop {
-                            ctx.auto_play_stopped = true;
-                        }
-                    }),
-                )
+                Some(navigate_to(ctx, next))
             }
 
             Event::GoToPrev => {
@@ -593,23 +647,8 @@ impl ars_core::Machine for Machine {
                 }
 
                 let step = ctx.slides_per_move as isize;
-
                 let prev = ctx.clamp_index(ctx.current_index() as isize - step);
-
-                let stop = ctx
-                    .auto_play
-                    .as_ref()
-                    .is_some_and(|o| o.stop_on_interaction);
-
-                Some(
-                    TransitionPlan::to(State::Transitioning).apply(move |ctx: &mut Context| {
-                        ctx.index.set(prev);
-
-                        if stop {
-                            ctx.auto_play_stopped = true;
-                        }
-                    }),
-                )
+                Some(navigate_to(ctx, prev))
             }
 
             Event::TransitionEnd => {
@@ -671,15 +710,18 @@ impl ars_core::Machine for Machine {
             }
 
             Event::AutoPlayResume => {
-                if ctx.auto_play_stopped {
-                    return None;
-                }
-
+                // Resume is also the "restart" path the auto-play trigger
+                // dispatches when rotation was permanently stopped (the
+                // trigger shows the "Start" label and sends `AutoPlayResume`),
+                // so it clears BOTH the paused and the stopped flags. Without
+                // clearing `auto_play_stopped`, a stopped carousel's start
+                // control would be inert with no way to resume rotation.
                 if ctx.auto_play.is_some() {
                     return Some(
                         TransitionPlan::to(State::AutoPlaying)
                             .apply(|ctx: &mut Context| {
                                 ctx.auto_play_paused = false;
+                                ctx.auto_play_stopped = false;
                             })
                             .with_effect(PendingEffect::named(Effect::AutoPlayTimer)),
                     );
@@ -743,18 +785,51 @@ impl ars_core::Machine for Machine {
                     None
                 };
 
-                Some(
-                    TransitionPlan::to(State::Idle).apply(move |ctx: &mut Context| {
-                        ctx.drag_start_pos = None;
-                        ctx.drag_delta = 0.0;
-                        ctx.swipe_velocity = 0.0;
-                        ctx.drag_last_timestamp = None;
+                // `PointerDown` cancelled the auto-play timer for the duration
+                // of the drag. Resolve rotation now the gesture ended:
+                //  - a navigating swipe with `stop_on_interaction` permanently
+                //    stops it (mark stopped; the timer stays cancelled);
+                //  - otherwise, if rotation was still active (not stopped, not
+                //    focus/hover-paused), re-arm the timer so it resumes —
+                //    without this a swipe silently kills rotation, or leaves
+                //    the state reporting "playing" with no timer running.
+                let navigated = next_idx.is_some();
+                let stop_on_interaction = ctx
+                    .auto_play
+                    .as_ref()
+                    .is_some_and(|o| o.stop_on_interaction);
+                let mark_stopped = navigated && stop_on_interaction;
+                let resume = ctx.auto_play.is_some()
+                    && !mark_stopped
+                    && !ctx.auto_play_stopped
+                    && !ctx.auto_play_paused;
 
-                        if let Some(idx) = next_idx {
-                            ctx.index.set(idx);
-                        }
-                    }),
-                )
+                let target = if resume {
+                    State::AutoPlaying
+                } else {
+                    State::Idle
+                };
+
+                let mut plan = TransitionPlan::to(target).apply(move |ctx: &mut Context| {
+                    ctx.drag_start_pos = None;
+                    ctx.drag_delta = 0.0;
+                    ctx.swipe_velocity = 0.0;
+                    ctx.drag_last_timestamp = None;
+
+                    if let Some(idx) = next_idx {
+                        ctx.index.set(idx);
+                    }
+
+                    if mark_stopped {
+                        ctx.auto_play_stopped = true;
+                    }
+                });
+
+                if resume {
+                    plan = plan.with_effect(PendingEffect::named(Effect::AutoPlayTimer));
+                }
+
+                Some(plan)
             }
 
             Event::PointerCancel => Some(TransitionPlan::context_only(|ctx: &mut Context| {
@@ -765,20 +840,36 @@ impl ars_core::Machine for Machine {
             })),
 
             Event::FocusSlide { index } => {
-                // Defensive: focus is always reported for a real slide, but
-                // clamp anyway so an out-of-range index can never desync
-                // `current_index` past the slide count.
-                let idx = (*index).min(ctx.slide_count.get() - 1);
+                // Clamp to the last valid starting index: a focused slide is a
+                // real slide, but focusing one already inside the visible
+                // window must not push `current_index` past the boundary.
+                let idx = (*index).min(ctx.last_index());
                 let current = ctx.current_index();
                 let should_pause = ctx.auto_play.as_ref().is_some_and(|o| o.pause_on_focus);
+
+                if should_pause {
+                    // Pausing on focus mirrors `AutoPlayPause`: leave
+                    // `AutoPlaying` and cancel the timer so slides do not keep
+                    // advancing under keyboard focus.
+                    let plan = if *state == State::AutoPlaying {
+                        TransitionPlan::to(State::Idle)
+                    } else {
+                        TransitionPlan::new()
+                    };
+                    return Some(
+                        plan.apply(move |ctx: &mut Context| {
+                            if idx != current {
+                                ctx.index.set(idx);
+                            }
+                            ctx.auto_play_paused = true;
+                        })
+                        .cancel_effect(Effect::AutoPlayTimer),
+                    );
+                }
 
                 Some(TransitionPlan::context_only(move |ctx: &mut Context| {
                     if idx != current {
                         ctx.index.set(idx);
-                    }
-
-                    if should_pause {
-                        ctx.auto_play_paused = true;
                     }
                 }))
             }
@@ -952,7 +1043,13 @@ impl Api<'_> {
 
         attrs.set(scope_attr, scope_val).set(part_attr, part_val);
 
-        let live = if self.ctx.auto_play_stopped || self.ctx.auto_play.is_none() {
+        // "off" only while rotation is actively advancing; once auto-play is
+        // absent, permanently stopped, OR temporarily paused (hover/focus),
+        // manual slide changes must be announced politely.
+        let live = if self.ctx.auto_play.is_none()
+            || self.ctx.auto_play_stopped
+            || self.ctx.auto_play_paused
+        {
             "polite"
         } else {
             "off"
@@ -972,7 +1069,11 @@ impl Api<'_> {
         attrs.set(scope_attr, scope_val).set(part_attr, part_val);
 
         let is_current = index == self.ctx.current_index();
-        let is_hidden = !is_current;
+        // With `slides_per_view > 1` several slides are on-screen at once; only
+        // slides outside the visible window are hidden from assistive tech and
+        // `inert`. Marking a visible slide hidden would make on-screen content
+        // unreachable to screen-reader and keyboard users.
+        let is_hidden = !self.ctx.is_slide_visible(index);
 
         attrs
             .set(HtmlAttr::Role, "group")
@@ -1171,7 +1272,7 @@ impl Api<'_> {
             KeyboardKey::Home => (self.send)(Event::GoToSlide { index: 0 }),
 
             KeyboardKey::End => (self.send)(Event::GoToSlide {
-                index: self.ctx.slide_count.get().saturating_sub(1),
+                index: self.ctx.last_index(),
             }),
 
             _ => {}
@@ -1390,14 +1491,14 @@ mod tests {
     #[test]
     fn transition_end_returns_to_autoplaying_when_active() {
         let mut service = service(autoplay_props(3));
+        drop(service.take_initial_effects());
 
-        drop(service.send(Event::GoToSlide { index: 1 }));
-
+        // An auto-play tick advances without stopping rotation, so settling
+        // the transition returns to AutoPlaying.
+        drop(service.send(Event::AutoPlayTick));
         assert_eq!(service.state(), &State::Transitioning);
 
-        // GoToSlide does not set stop_on_interaction, so auto-play resumes.
         settle(&mut service);
-
         assert_eq!(service.state(), &State::AutoPlaying);
     }
 
@@ -1679,15 +1780,20 @@ mod tests {
     }
 
     #[test]
-    fn autoplay_resume_noop_when_stopped() {
+    fn autoplay_resume_restarts_stopped_carousel() {
         let mut service = service(autoplay_props(3));
+        drop(service.take_initial_effects());
 
         drop(service.send(Event::AutoPlayStop));
+        assert!(service.context().auto_play_stopped);
 
+        // Resume is the restart path: it clears the stopped flag, returns to
+        // AutoPlaying, and re-arms the timer.
         let result = service.send(Event::AutoPlayResume);
-
-        assert!(!result.state_changed);
+        assert_eq!(service.state(), &State::AutoPlaying);
+        assert!(!service.context().auto_play_stopped);
         assert!(!service.context().auto_play_paused);
+        assert_eq!(pending_effect_names(&result), vec![Effect::AutoPlayTimer]);
     }
 
     #[test]
@@ -2179,6 +2285,21 @@ mod tests {
     }
 
     #[test]
+    fn snapshot_item_visible_not_current_multi_view() {
+        // slides_per_view = 2, index 0: slide 1 is on-screen but not the
+        // leading slide — visible (no aria-hidden/inert) yet ars-active=false.
+        let service = service(Props {
+            slides_per_view: Some(2.0),
+            ..props(3)
+        });
+
+        assert_snapshot!(
+            "item_visible_not_current_multi_view",
+            snapshot_attrs(&service.connect(&|_| {}).item_attrs(1))
+        );
+    }
+
+    #[test]
     fn snapshot_prev_trigger_disabled_at_start() {
         let service = service(props(3));
 
@@ -2414,5 +2535,220 @@ mod tests {
 
         assert!(!service.context().auto_play_paused);
         assert!(result.pending_effects.is_empty());
+    }
+
+    // ── Codex review #716: autoplay timer lifecycle ──────────────────
+
+    #[test]
+    fn manual_next_with_stop_on_interaction_cancels_timer() {
+        let mut service = service(autoplay_props(3));
+        drop(service.take_initial_effects());
+        let result = service.send(Event::GoToNext);
+        assert!(service.context().auto_play_stopped);
+        assert_eq!(result.cancel_effects, vec![Effect::AutoPlayTimer]);
+        // Once stopped, settling the transition rests in Idle (no leaked timer).
+        settle(&mut service);
+        assert_eq!(service.state(), &State::Idle);
+    }
+
+    #[test]
+    fn manual_prev_with_stop_on_interaction_cancels_timer() {
+        let mut service = service(Props {
+            default_index: Some(2),
+            ..autoplay_props(3)
+        });
+        drop(service.take_initial_effects());
+        let result = service.send(Event::GoToPrev);
+        assert!(service.context().auto_play_stopped);
+        assert_eq!(result.cancel_effects, vec![Effect::AutoPlayTimer]);
+    }
+
+    #[test]
+    fn goto_slide_with_stop_on_interaction_stops_and_cancels() {
+        let mut service = service(autoplay_props(3));
+        drop(service.take_initial_effects());
+        let result = service.send(Event::GoToSlide { index: 2 });
+        assert_eq!(service.context().current_index(), 2);
+        assert!(service.context().auto_play_stopped);
+        assert_eq!(result.cancel_effects, vec![Effect::AutoPlayTimer]);
+    }
+
+    #[test]
+    fn manual_nav_without_stop_on_interaction_keeps_timer() {
+        let mut service = service(Props {
+            auto_play: Some(AutoPlayOptions {
+                stop_on_interaction: false,
+                ..AutoPlayOptions::default()
+            }),
+            ..props(3)
+        });
+        drop(service.take_initial_effects());
+        let result = service.send(Event::GoToNext);
+        assert!(!service.context().auto_play_stopped);
+        assert!(result.cancel_effects.is_empty());
+        // Auto-play resumes once the transition settles.
+        settle(&mut service);
+        assert_eq!(service.state(), &State::AutoPlaying);
+    }
+
+    #[test]
+    fn swipe_navigation_with_stop_on_interaction_stops_rotation() {
+        let mut service = service(autoplay_props(3));
+        drop(service.take_initial_effects());
+        drop(service.send(Event::PointerDown {
+            pos: 100.0,
+            timestamp: 0.0,
+        }));
+        drop(service.send(Event::PointerMove {
+            pos: 40.0,
+            timestamp: 1000.0,
+        }));
+        let result = service.send(Event::PointerUp);
+        assert_eq!(service.context().current_index(), 1);
+        assert_eq!(service.state(), &State::Idle);
+        assert!(service.context().auto_play_stopped);
+        assert!(result.pending_effects.is_empty());
+    }
+
+    #[test]
+    fn swipe_navigation_resumes_when_stop_on_interaction_disabled() {
+        let mut service = service(Props {
+            auto_play: Some(AutoPlayOptions {
+                stop_on_interaction: false,
+                ..AutoPlayOptions::default()
+            }),
+            ..props(3)
+        });
+        drop(service.take_initial_effects());
+        drop(service.send(Event::PointerDown {
+            pos: 100.0,
+            timestamp: 0.0,
+        }));
+        drop(service.send(Event::PointerMove {
+            pos: 40.0,
+            timestamp: 1000.0,
+        }));
+        let result = service.send(Event::PointerUp);
+        assert_eq!(service.context().current_index(), 1);
+        assert_eq!(service.state(), &State::AutoPlaying);
+        assert!(!service.context().auto_play_stopped);
+        assert_eq!(pending_effect_names(&result), vec![Effect::AutoPlayTimer]);
+    }
+
+    #[test]
+    fn non_navigating_drag_resumes_autoplay() {
+        let mut service = service(autoplay_props(3));
+        drop(service.take_initial_effects());
+        drop(service.send(Event::PointerDown {
+            pos: 100.0,
+            timestamp: 0.0,
+        }));
+        // Slow, below-threshold drag → no navigation, no stop.
+        drop(service.send(Event::PointerMove {
+            pos: 90.0,
+            timestamp: 1000.0,
+        }));
+        let result = service.send(Event::PointerUp);
+        assert_eq!(service.context().current_index(), 0);
+        assert_eq!(service.state(), &State::AutoPlaying);
+        assert!(!service.context().auto_play_stopped);
+        assert_eq!(pending_effect_names(&result), vec![Effect::AutoPlayTimer]);
+    }
+
+    #[test]
+    fn focus_pause_leaves_autoplaying_and_cancels_timer() {
+        let mut service = service(autoplay_props(3));
+        drop(service.take_initial_effects());
+        let result = service.send(Event::FocusSlide { index: 1 });
+        assert_eq!(service.state(), &State::Idle);
+        assert!(service.context().auto_play_paused);
+        assert_eq!(result.cancel_effects, vec![Effect::AutoPlayTimer]);
+    }
+
+    #[test]
+    fn item_group_live_is_polite_when_paused() {
+        let mut service = service(autoplay_props(3));
+        drop(service.send(Event::AutoPlayPause));
+        assert_eq!(
+            service
+                .connect(&|_| {})
+                .item_group_attrs()
+                .get(&HtmlAttr::Aria(AriaAttr::Live)),
+            Some("polite")
+        );
+    }
+
+    // ── Codex review #716: init clamp + multi-slide-view ─────────────
+
+    #[test]
+    fn init_clamps_out_of_range_default_index() {
+        let service = service(Props {
+            default_index: Some(99),
+            ..props(3)
+        });
+        assert_eq!(service.context().current_index(), 2);
+    }
+
+    #[test]
+    fn last_index_accounts_for_slides_per_view() {
+        let ctx = service(Props {
+            slides_per_view: Some(2.0),
+            ..props(3)
+        })
+        .context()
+        .clone();
+        // 3 slides, 2 visible → last full page starts at index 1.
+        assert_eq!(ctx.last_index(), 1);
+        assert_eq!(ctx.visible_count(), 2);
+    }
+
+    #[test]
+    fn can_go_next_stops_at_last_full_page() {
+        let mut service = service(Props {
+            slides_per_view: Some(2.0),
+            default_index: Some(1),
+            ..props(3)
+        });
+        assert!(!service.context().can_go_next());
+        let api_disabled = service
+            .connect(&|_| {})
+            .next_trigger_attrs()
+            .get(&HtmlAttr::Aria(AriaAttr::Disabled))
+            == Some("true");
+        assert!(api_disabled);
+        // Navigation past the last full page is rejected.
+        let result = service.send(Event::GoToNext);
+        assert!(!result.state_changed);
+        assert_eq!(service.context().current_index(), 1);
+    }
+
+    #[test]
+    fn multi_view_keeps_visible_slides_accessible() {
+        let service = service(Props {
+            slides_per_view: Some(2.0),
+            ..props(3)
+        });
+        let api = service.connect(&|_| {});
+        // index 0 with two visible: slides 0 and 1 are on-screen.
+        let slide0 = api.item_attrs(0);
+        let slide1 = api.item_attrs(1);
+        let slide2 = api.item_attrs(2);
+        assert_eq!(slide0.get(&HtmlAttr::Aria(AriaAttr::Hidden)), None);
+        assert_eq!(slide1.get(&HtmlAttr::Aria(AriaAttr::Hidden)), None);
+        assert_eq!(slide1.get(&HtmlAttr::Inert), None);
+        // slide 2 is off-screen → hidden + inert.
+        assert_eq!(slide2.get(&HtmlAttr::Aria(AriaAttr::Hidden)), Some("true"));
+    }
+
+    #[test]
+    fn end_key_jumps_to_last_full_page() {
+        let service = service(Props {
+            slides_per_view: Some(2.0),
+            ..props(3)
+        });
+        assert_eq!(
+            captured_keydown(&service, KeyboardKey::End),
+            vec![Event::GoToSlide { index: 1 }]
+        );
     }
 }

--- a/crates/ars-components/src/layout/carousel/mod.rs
+++ b/crates/ars-components/src/layout/carousel/mod.rs
@@ -348,6 +348,19 @@ impl Context {
         self.slide_count.get().saturating_sub(self.visible_count())
     }
 
+    /// Largest reachable starting index. Under `loop_nav` any slide can be the
+    /// leading one (the window wraps), so it is `slide_count - 1`; otherwise it
+    /// is the contain-scroll [`last_index`](Self::last_index). Used to clamp
+    /// caller-supplied (default/controlled) indices.
+    #[must_use]
+    pub fn max_start_index(&self) -> usize {
+        if self.loop_nav {
+            self.slide_count.get().saturating_sub(1)
+        } else {
+            self.last_index()
+        }
+    }
+
     /// Clamp or wrap an index according to `loop_nav`.
     ///
     /// When `loop_nav` is `true`, out-of-range indices wrap around modulo the
@@ -535,6 +548,10 @@ pub struct Messages {
     /// total slide count (e.g. "Slide 2 of 5").
     pub slide_label: MessageFn<SlideLabelFn>,
 
+    /// Accessible name for the indicator `tablist` (`aria-label` on
+    /// `IndicatorGroup`), so screen-reader users know the tabs choose a slide.
+    pub indicators_label: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
+
     /// Accessible label for the previous-slide trigger.
     pub prev_label: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
 
@@ -558,6 +575,7 @@ impl Default for Messages {
             slide_label: MessageFn::new(|index, total, _locale: &Locale| {
                 format!("Slide {index} of {total}")
             }),
+            indicators_label: MessageFn::static_str("Choose slide"),
             prev_label: MessageFn::static_str("Previous slide"),
             next_label: MessageFn::static_str("Next slide"),
             pause_auto_play_label: MessageFn::static_str("Pause automatic slide show"),
@@ -606,7 +624,19 @@ fn navigate_to(ctx: &Context, idx: usize) -> Option<TransitionPlan<Machine>> {
     if stop {
         plan = plan.cancel_effect(Effect::AutoPlayTimer);
     }
-    Some(plan)
+    Some(settle_if_instant(ctx, plan))
+}
+
+/// When the configured transition is zero-length (animation disabled or
+/// reduced-motion), a zero-duration CSS transition fires no `transitionend`, so
+/// the adapter never settles `Transitioning`. Self-dispatch `TransitionEnd` so
+/// the machine settles synchronously instead of stranding in `Transitioning`.
+fn settle_if_instant(ctx: &Context, plan: TransitionPlan<Machine>) -> TransitionPlan<Machine> {
+    if ctx.transition_duration.is_zero() {
+        plan.then(Event::TransitionEnd)
+    } else {
+        plan
+    }
 }
 
 /// Build the [`Effect::IndexChange`] notification carrying the newly requested
@@ -657,17 +687,19 @@ impl ars_core::Machine for Machine {
         // still able to stop auto-play), so clamp it to at least one.
         let slides_per_move = props.slides_per_move.unwrap_or(1).max(1);
 
-        // Clamp the uncontrolled default to the last valid starting index so
-        // `current_index < slide_count` holds from the very first render (a
-        // bad `default_index` would otherwise yield "Slide 100 of 3" with no
-        // item marked current). Accounts for `slides_per_view`.
+        // Clamp the default/controlled index to the largest reachable starting
+        // index so `current_index < slide_count` holds from the first render.
+        // Under `loop_nav` that's `slide_count - 1` (the window wraps, so any
+        // slide is a valid start); otherwise it's the contain-scroll last page
+        // (`slide_count - ceil(slides_per_view)`).
         let visible_count = (slides_per_view.ceil() as usize).max(1);
-        let max_index = props.slide_count.get().saturating_sub(visible_count);
+        let max_index = if props.loop_nav {
+            props.slide_count.get().saturating_sub(1)
+        } else {
+            props.slide_count.get().saturating_sub(visible_count)
+        };
         let initial_index = props.default_index.unwrap_or(0).min(max_index);
 
-        // Clamp the controlled value too: a caller-supplied controlled `index`
-        // past `last_index()` would start the machine out of range before any
-        // prop-change sync could run.
         let index = match &props.index {
             Some(controlled) => Bindable::controlled((*controlled.get()).min(max_index)),
             None => Bindable::uncontrolled(initial_index),
@@ -834,13 +866,14 @@ impl ars_core::Machine for Machine {
                     return None;
                 }
 
-                Some(
+                Some(settle_if_instant(
+                    ctx,
                     TransitionPlan::to(State::Transitioning)
                         .apply(move |ctx: &mut Context| {
                             ctx.index.set(next);
                         })
                         .with_effect(index_change_effect(next)),
-                )
+                ))
             }
 
             Event::AutoPlayPause => {
@@ -1001,55 +1034,53 @@ impl ars_core::Machine for Machine {
                 };
 
                 // `PointerDown` cancelled the auto-play timer for the duration
-                // of the drag. Resolve rotation now the gesture ended:
-                //  - a navigating swipe with `stop_on_interaction` permanently
-                //    stops it (mark stopped; the timer stays cancelled);
-                //  - otherwise, if rotation was still active (not stopped, not
-                //    focus/hover-paused), re-arm the timer so it resumes —
-                //    without this a swipe silently kills rotation, or leaves
-                //    the state reporting "playing" with no timer running.
-                let navigated = next_idx.is_some();
-                let stop_on_interaction = ctx
-                    .auto_play
-                    .as_ref()
-                    .is_some_and(|o| o.stop_on_interaction);
-                let mark_stopped = navigated && stop_on_interaction;
-                let resume = ctx.auto_play.is_some()
-                    && !mark_stopped
-                    && !ctx.auto_play_stopped
-                    && !ctx.is_auto_play_paused();
+                // of the drag.
+                let target_idx = next_idx.filter(|&idx| idx != ctx.current_index());
 
-                let target = if resume {
-                    State::AutoPlaying
+                if let Some(idx) = target_idx {
+                    // A navigating swipe animates through `Transitioning`, like
+                    // button/auto-play navigation, so auto-play ticks and further
+                    // navigation are blocked until `TransitionEnd`. The timer
+                    // stays cancelled across the snap; `TransitionEnd` then
+                    // resumes auto-play (or stays `Idle` if `stop_on_interaction`
+                    // stopped it).
+                    let stop = ctx
+                        .auto_play
+                        .as_ref()
+                        .is_some_and(|o| o.stop_on_interaction);
+                    let plan = TransitionPlan::to(State::Transitioning)
+                        .apply(move |ctx: &mut Context| {
+                            ctx.drag_start_pos = None;
+                            ctx.drag_delta = 0.0;
+                            ctx.swipe_velocity = 0.0;
+                            ctx.drag_last_timestamp = None;
+                            ctx.index.set(idx);
+                            if stop {
+                                ctx.auto_play_stopped = true;
+                            }
+                        })
+                        .with_effect(index_change_effect(idx));
+                    return Some(settle_if_instant(ctx, plan));
+                }
+
+                // No navigation: reset the drag and resume auto-play if it was
+                // active (the timer was cancelled on `PointerDown`).
+                let resume =
+                    ctx.auto_play.is_some() && !ctx.auto_play_stopped && !ctx.is_auto_play_paused();
+                let mut plan = if resume {
+                    TransitionPlan::to(State::AutoPlaying)
                 } else {
-                    State::Idle
-                };
-
-                let index_changed = next_idx.is_some_and(|idx| idx != ctx.current_index());
-
-                let mut plan = TransitionPlan::to(target).apply(move |ctx: &mut Context| {
+                    TransitionPlan::to(State::Idle)
+                }
+                .apply(|ctx: &mut Context| {
                     ctx.drag_start_pos = None;
                     ctx.drag_delta = 0.0;
                     ctx.swipe_velocity = 0.0;
                     ctx.drag_last_timestamp = None;
-
-                    if let Some(idx) = next_idx {
-                        ctx.index.set(idx);
-                    }
-
-                    if mark_stopped {
-                        ctx.auto_play_stopped = true;
-                    }
                 });
-
-                if index_changed && let Some(idx) = next_idx {
-                    plan = plan.with_effect(index_change_effect(idx));
-                }
-
                 if resume {
                     plan = plan.with_effect(PendingEffect::named(Effect::AutoPlayTimer));
                 }
-
                 Some(plan)
             }
 
@@ -1175,18 +1206,19 @@ impl ars_core::Machine for Machine {
                         .unwrap_or_else(|| Duration::from_millis(300));
                     ctx.swipe_threshold = props.swipe_threshold.unwrap_or(50.0);
 
-                    // Track the controlled signal (clamped); `None` returns the
-                    // bindable to uncontrolled mode.
+                    // Track the controlled signal (clamped to the largest
+                    // reachable start, loop-aware); `None` returns the bindable
+                    // to uncontrolled mode.
                     let controlled = props
                         .index
                         .as_ref()
-                        .map(|bindable| (*bindable.get()).min(ctx.last_index()));
+                        .map(|bindable| (*bindable.get()).min(ctx.max_start_index()));
                     ctx.index.sync_controlled(controlled);
 
                     // Keep an uncontrolled index in range if the slide count or
                     // visible window shrank.
                     if !ctx.index.is_controlled() {
-                        let clamped = ctx.current_index().min(ctx.last_index());
+                        let clamped = ctx.current_index().min(ctx.max_start_index());
                         ctx.index.set(clamped);
                     }
 
@@ -1502,7 +1534,11 @@ impl Api<'_> {
         attrs
             .set(scope_attr, scope_val)
             .set(part_attr, part_val)
-            .set(HtmlAttr::Role, "tablist");
+            .set(HtmlAttr::Role, "tablist")
+            .set(
+                HtmlAttr::Aria(AriaAttr::Label),
+                (self.ctx.messages.indicators_label)(&self.ctx.locale),
+            );
 
         attrs
     }
@@ -1609,6 +1645,14 @@ impl Api<'_> {
 
     /// Handle a keydown on the root region: arrow keys navigate (reversed for
     /// RTL horizontal carousels), `Home`/`End` jump to the first/last slide.
+    ///
+    /// **Adapter contract:** the agnostic core cannot inspect the DOM event
+    /// target, so the adapter MUST only forward keydowns that the carousel owns
+    /// — those whose target is the carousel root/controls, not events bubbled
+    /// from interactive slide content (text inputs, sliders, nested widgets).
+    /// Otherwise `ArrowLeft`/`ArrowRight` typed into a slide's `<input>` would
+    /// be hijacked into slide navigation. Gate on the event target (e.g. skip
+    /// when `event.target` is an interactive descendant) before calling this.
     pub fn on_root_keydown(&self, data: &KeyboardEventData) {
         let is_horizontal = self.ctx.orientation == Orientation::Horizontal;
 
@@ -2306,9 +2350,13 @@ mod tests {
         }));
         drop(service.send(Event::PointerUp));
 
-        assert_eq!(service.state(), &State::Idle);
+        // A navigating swipe animates through Transitioning; the snap settles to
+        // Idle on TransitionEnd.
+        assert_eq!(service.state(), &State::Transitioning);
         assert_eq!(service.context().current_index(), 1);
         assert_eq!(service.context().drag_delta, 0.0);
+        settle(&mut service);
+        assert_eq!(service.state(), &State::Idle);
     }
 
     #[test]
@@ -3007,12 +3055,14 @@ mod tests {
         }));
         let result = service.send(Event::PointerUp);
         assert_eq!(service.context().current_index(), 1);
-        assert_eq!(service.state(), &State::Idle);
+        // Navigating swipe animates through Transitioning; IndexChange fires now,
+        // the timer stays cancelled, and the stop settles to Idle.
+        assert_eq!(service.state(), &State::Transitioning);
         assert!(service.context().auto_play_stopped);
-        // Index changed → IndexChange notification, but rotation is stopped so
-        // no timer is re-armed.
         assert!(pending_effect_names(&result).contains(&Effect::IndexChange));
         assert!(!pending_effect_names(&result).contains(&Effect::AutoPlayTimer));
+        settle(&mut service);
+        assert_eq!(service.state(), &State::Idle);
     }
 
     #[test]
@@ -3035,11 +3085,14 @@ mod tests {
         }));
         let result = service.send(Event::PointerUp);
         assert_eq!(service.context().current_index(), 1);
-        assert_eq!(service.state(), &State::AutoPlaying);
+        // Navigating swipe animates through Transitioning (blocking ticks during
+        // the snap); auto-play resumes on TransitionEnd, not immediately.
+        assert_eq!(service.state(), &State::Transitioning);
         assert!(!service.context().auto_play_stopped);
-        // Rotation resumes (timer re-armed) and the index change is notified.
-        assert!(pending_effect_names(&result).contains(&Effect::AutoPlayTimer));
         assert!(pending_effect_names(&result).contains(&Effect::IndexChange));
+        assert!(!pending_effect_names(&result).contains(&Effect::AutoPlayTimer));
+        settle(&mut service);
+        assert_eq!(service.state(), &State::AutoPlaying);
     }
 
     #[test]
@@ -3675,5 +3728,89 @@ mod tests {
         ] {
             assert_eq!(attrs.get(&HtmlAttr::Type), Some("button"));
         }
+    }
+
+    // ── Codex review #716 (seventh pass) ─────────────────────────────
+
+    #[test]
+    fn swipe_transition_blocks_autoplay_tick_until_settle() {
+        // S1: a navigating swipe stays in Transitioning until TransitionEnd, so
+        // an AutoPlayTick during the snap is ignored (no double-advance).
+        let mut service = service(Props {
+            auto_play: Some(AutoPlayOptions {
+                stop_on_interaction: false,
+                ..AutoPlayOptions::default()
+            }),
+            ..props(4)
+        });
+        drop(service.take_initial_effects());
+        drop(service.send(Event::PointerDown {
+            pos: 100.0,
+            timestamp: 0.0,
+        }));
+        drop(service.send(Event::PointerMove {
+            pos: 40.0,
+            timestamp: 1000.0,
+        }));
+        drop(service.send(Event::PointerUp));
+        assert_eq!(service.state(), &State::Transitioning);
+        assert_eq!(service.context().current_index(), 1);
+
+        // Tick mid-snap is dropped.
+        let tick = service.send(Event::AutoPlayTick);
+        assert!(!tick.state_changed);
+        assert_eq!(service.context().current_index(), 1);
+
+        settle(&mut service);
+        assert_eq!(service.state(), &State::AutoPlaying);
+    }
+
+    #[test]
+    fn init_clamps_controlled_index_loop_aware() {
+        // S2: looped multi-view must allow wrapped starts past last_index.
+        let default_start = service(Props {
+            loop_nav: true,
+            slides_per_view: Some(2.0),
+            default_index: Some(4),
+            ..props(5)
+        });
+        assert_eq!(default_start.context().current_index(), 4);
+
+        let controlled = service(Props {
+            loop_nav: true,
+            slides_per_view: Some(2.0),
+            index: Some(Bindable::controlled(4)),
+            ..props(5)
+        });
+        assert_eq!(controlled.context().current_index(), 4);
+    }
+
+    #[test]
+    fn indicator_group_is_labeled() {
+        // S3: the indicator tablist carries an accessible name.
+        let service = service(props(3));
+        assert_eq!(
+            service
+                .connect(&|_| {})
+                .indicator_group_attrs()
+                .get(&HtmlAttr::Aria(AriaAttr::Label)),
+            Some("Choose slide")
+        );
+    }
+
+    #[test]
+    fn zero_transition_duration_settles_immediately() {
+        // S4: zero-duration transitions fire no transitionend, so navigation
+        // must self-settle rather than strand in Transitioning.
+        let mut service = service(Props {
+            transition_duration: Some(Duration::ZERO),
+            ..props(3)
+        });
+        drop(service.send(Event::GoToNext));
+        assert_eq!(service.context().current_index(), 1);
+        assert_eq!(service.state(), &State::Idle);
+        // Subsequent navigation is not blocked.
+        drop(service.send(Event::GoToNext));
+        assert_eq!(service.context().current_index(), 2);
     }
 }

--- a/crates/ars-components/src/layout/carousel/mod.rs
+++ b/crates/ars-components/src/layout/carousel/mod.rs
@@ -251,8 +251,18 @@ pub struct Context {
     /// Whether auto-play has been permanently stopped by user interaction.
     pub auto_play_stopped: bool,
 
-    /// Whether auto-play is temporarily paused (hover/focus).
-    pub auto_play_paused: bool,
+    /// Whether the auto-play trigger button manually paused rotation. Tracked
+    /// separately from the hover/focus pauses so a hover/focus *exit* never
+    /// resumes a manual pause. See [`is_auto_play_paused`](Self::is_auto_play_paused).
+    pub auto_play_paused_manual: bool,
+
+    /// Whether pointer hover currently pauses auto-play (set by
+    /// [`Event::HoverStart`] when [`AutoPlayOptions::pause_on_hover`]).
+    pub auto_play_paused_hover: bool,
+
+    /// Whether keyboard focus within the carousel currently pauses auto-play
+    /// (set by [`Event::FocusSlide`] when [`AutoPlayOptions::pause_on_focus`]).
+    pub auto_play_paused_focus: bool,
 
     /// Gap between slides in pixels.
     pub spacing: f64,
@@ -309,6 +319,14 @@ impl Context {
     #[must_use]
     pub fn current_index(&self) -> usize {
         *self.index.get()
+    }
+
+    /// Whether auto-play is temporarily paused by any source — the manual
+    /// trigger pause, a pointer hover, or keyboard focus. Auto-play rotates
+    /// only when configured, not stopped, and not paused by any source.
+    #[must_use]
+    pub const fn is_auto_play_paused(&self) -> bool {
+        self.auto_play_paused_manual || self.auto_play_paused_hover || self.auto_play_paused_focus
     }
 
     /// Number of slide slots occupied by the viewport at once, rounding a
@@ -661,7 +679,9 @@ impl ars_core::Machine for Machine {
             loop_nav: props.loop_nav,
             auto_play: props.auto_play.clone(),
             auto_play_stopped: false,
-            auto_play_paused: false,
+            auto_play_paused_manual: false,
+            auto_play_paused_hover: false,
+            auto_play_paused_focus: false,
             spacing: props.spacing.unwrap_or(0.0),
             slides_per_view,
             slides_per_move,
@@ -728,12 +748,12 @@ impl ars_core::Machine for Machine {
                     return None;
                 }
 
-                // A direct jump never wraps; clamp out-of-range targets to the
-                // last valid starting index so `current_index` can never
-                // exceed the boundary (every connect method relies on that
-                // invariant). A direct jump is a manual interaction, so it
+                // Clamp the target via `clamp_index`: when looping it wraps to a
+                // valid position (any slide can be selected, including those past
+                // `last_index`); when not looping it saturates at `last_index`
+                // (contain-scroll). A direct jump is a manual interaction, so it
                 // honours `stop_on_interaction` like Next/Prev.
-                let idx = (*index).min(ctx.last_index());
+                let idx = ctx.clamp_index(*index as isize);
                 navigate_to(ctx, idx)
             }
 
@@ -758,7 +778,7 @@ impl ars_core::Machine for Machine {
             }
 
             Event::TransitionEnd => {
-                if ctx.auto_play.is_some() && !ctx.auto_play_stopped && !ctx.auto_play_paused {
+                if ctx.auto_play.is_some() && !ctx.auto_play_stopped && !ctx.is_auto_play_paused() {
                     Some(TransitionPlan::to(State::AutoPlaying))
                 } else {
                     Some(TransitionPlan::to(State::Idle))
@@ -770,13 +790,15 @@ impl ars_core::Machine for Machine {
                     return None;
                 }
 
-                // Clear any prior pause: starting auto-play means it is now
+                // Clear every pause source: starting auto-play means it is now
                 // actively rotating, so the paused live-region mode and
                 // `aria-pressed="false"` must not linger.
                 Some(
                     TransitionPlan::to(State::AutoPlaying)
                         .apply(|ctx: &mut Context| {
-                            ctx.auto_play_paused = false;
+                            ctx.auto_play_paused_manual = false;
+                            ctx.auto_play_paused_hover = false;
+                            ctx.auto_play_paused_focus = false;
                         })
                         .with_effect(PendingEffect::named(Effect::AutoPlayTimer)),
                 )
@@ -791,7 +813,11 @@ impl ars_core::Machine for Machine {
             ),
 
             Event::AutoPlayTick => {
-                if *state != State::AutoPlaying {
+                // Drop ticks that arrive while a drag is in progress: `PointerDown`
+                // cancels the timer, but an interval callback queued just before
+                // the cancellation could still fire and advance the slide under
+                // the user's pointer.
+                if *state != State::AutoPlaying || ctx.drag_start_pos.is_some() {
                     return None;
                 }
 
@@ -832,7 +858,7 @@ impl ars_core::Machine for Machine {
 
                 Some(
                     plan.apply(|ctx: &mut Context| {
-                        ctx.auto_play_paused = true;
+                        ctx.auto_play_paused_manual = true;
                     })
                     .cancel_effect(Effect::AutoPlayTimer),
                 )
@@ -858,42 +884,54 @@ impl ars_core::Machine for Machine {
 
                 Some(
                     plan.apply(|ctx: &mut Context| {
-                        ctx.auto_play_paused = true;
+                        ctx.auto_play_paused_hover = true;
                     })
                     .cancel_effect(Effect::AutoPlayTimer),
                 )
             }
 
             Event::HoverEnd => {
-                // Resume a hover/focus pause when the pointer leaves, mirroring
-                // `Blur` for focus-out.
-                if ctx.auto_play_paused && !ctx.auto_play_stopped && ctx.auto_play.is_some() {
-                    return Some(
-                        TransitionPlan::to(State::AutoPlaying)
-                            .apply(|ctx: &mut Context| {
-                                ctx.auto_play_paused = false;
-                            })
-                            .with_effect(PendingEffect::named(Effect::AutoPlayTimer)),
-                    );
+                // Clear only the hover pause; resume rotation only if no other
+                // pause source (manual trigger or focus) still holds it — a
+                // pointer-out must not restart a manual pause or a carousel that
+                // still has focus inside it.
+                if !ctx.auto_play_paused_hover {
+                    return None;
                 }
-                None
+                let resume = !ctx.auto_play_paused_manual
+                    && !ctx.auto_play_paused_focus
+                    && !ctx.auto_play_stopped
+                    && ctx.auto_play.is_some();
+                let mut plan = if resume {
+                    TransitionPlan::to(State::AutoPlaying)
+                } else {
+                    TransitionPlan::new()
+                }
+                .apply(|ctx: &mut Context| {
+                    ctx.auto_play_paused_hover = false;
+                });
+                if resume {
+                    plan = plan.with_effect(PendingEffect::named(Effect::AutoPlayTimer));
+                }
+                Some(plan)
             }
 
             Event::AutoPlayResume => {
-                // Nothing to resume without auto-play configured (the paused and
+                // Nothing to resume without auto-play configured (the pause and
                 // stopped flags are only ever set while it is configured).
                 ctx.auto_play.as_ref()?;
 
                 // Resume is also the "restart" path the auto-play trigger
                 // dispatches when rotation was permanently stopped (the trigger
                 // shows the "Start" label and sends `AutoPlayResume`), so it
-                // clears BOTH the paused and the stopped flags. Without clearing
-                // `auto_play_stopped`, a stopped carousel's start control would
-                // be inert with no way to resume rotation.
+                // clears every pause source AND the stopped flag — an explicit
+                // play request overrides hover/focus/manual pauses.
                 Some(
                     TransitionPlan::to(State::AutoPlaying)
                         .apply(|ctx: &mut Context| {
-                            ctx.auto_play_paused = false;
+                            ctx.auto_play_paused_manual = false;
+                            ctx.auto_play_paused_hover = false;
+                            ctx.auto_play_paused_focus = false;
                             ctx.auto_play_stopped = false;
                         })
                         .with_effect(PendingEffect::named(Effect::AutoPlayTimer)),
@@ -979,7 +1017,7 @@ impl ars_core::Machine for Machine {
                 let resume = ctx.auto_play.is_some()
                     && !mark_stopped
                     && !ctx.auto_play_stopped
-                    && !ctx.auto_play_paused;
+                    && !ctx.is_auto_play_paused();
 
                 let target = if resume {
                     State::AutoPlaying
@@ -1024,7 +1062,7 @@ impl ars_core::Machine for Machine {
                 let resume = ctx.drag_start_pos.is_some()
                     && ctx.auto_play.is_some()
                     && !ctx.auto_play_stopped
-                    && !ctx.auto_play_paused;
+                    && !ctx.is_auto_play_paused();
 
                 let mut plan = if resume {
                     TransitionPlan::to(State::AutoPlaying)
@@ -1051,9 +1089,9 @@ impl ars_core::Machine for Machine {
                 // visible slide must NOT shift the track (that would move
                 // content out from under the user during normal focus nav).
                 let scroll = !ctx.is_slide_visible(*index);
-                // Clamp to the last valid starting index so a focused slide near
-                // the end maps to the last full page rather than overscrolling.
-                let idx = (*index).min(ctx.last_index());
+                // Clamp via `clamp_index` so it wraps under `loop_nav` and
+                // saturates at `last_index` otherwise (matching `GoToSlide`).
+                let idx = ctx.clamp_index(*index as isize);
                 let should_pause = ctx.auto_play.as_ref().is_some_and(|o| o.pause_on_focus);
 
                 if should_pause {
@@ -1070,7 +1108,7 @@ impl ars_core::Machine for Machine {
                             if scroll {
                                 ctx.index.set(idx);
                             }
-                            ctx.auto_play_paused = true;
+                            ctx.auto_play_paused_focus = true;
                         })
                         .cancel_effect(Effect::AutoPlayTimer);
                     if scroll {
@@ -1100,7 +1138,7 @@ impl ars_core::Machine for Machine {
                 // After syncing, should a timer be running? (Honours the
                 // preserved stopped/paused flags.)
                 let want_timer =
-                    new_auto.is_some() && !ctx.auto_play_stopped && !ctx.auto_play_paused;
+                    new_auto.is_some() && !ctx.auto_play_stopped && !ctx.is_auto_play_paused();
 
                 // Only the auto-play transition moves the resting state:
                 // enabling/resuming → AutoPlaying; disabling while playing → Idle.
@@ -1155,7 +1193,9 @@ impl ars_core::Machine for Machine {
                     // Without auto-play configured, the play/pause flags are
                     // meaningless — reset them so the controls read correctly.
                     if ctx.auto_play.is_none() {
-                        ctx.auto_play_paused = false;
+                        ctx.auto_play_paused_manual = false;
+                        ctx.auto_play_paused_hover = false;
+                        ctx.auto_play_paused_focus = false;
                         ctx.auto_play_stopped = false;
                     }
                 });
@@ -1173,17 +1213,27 @@ impl ars_core::Machine for Machine {
             }
 
             Event::Blur => {
-                if ctx.auto_play_paused && !ctx.auto_play_stopped && ctx.auto_play.is_some() {
-                    return Some(
-                        TransitionPlan::to(State::AutoPlaying)
-                            .apply(|ctx: &mut Context| {
-                                ctx.auto_play_paused = false;
-                            })
-                            .with_effect(PendingEffect::named(Effect::AutoPlayTimer)),
-                    );
+                // Clear only the focus pause; resume rotation only if no other
+                // pause source (manual trigger or hover) still holds it.
+                if !ctx.auto_play_paused_focus {
+                    return None;
                 }
-
-                None
+                let resume = !ctx.auto_play_paused_manual
+                    && !ctx.auto_play_paused_hover
+                    && !ctx.auto_play_stopped
+                    && ctx.auto_play.is_some();
+                let mut plan = if resume {
+                    TransitionPlan::to(State::AutoPlaying)
+                } else {
+                    TransitionPlan::new()
+                }
+                .apply(|ctx: &mut Context| {
+                    ctx.auto_play_paused_focus = false;
+                });
+                if resume {
+                    plan = plan.with_effect(PendingEffect::named(Effect::AutoPlayTimer));
+                }
+                Some(plan)
             }
         }
     }
@@ -1346,7 +1396,7 @@ impl Api<'_> {
         // manual slide changes must be announced politely.
         let live = if self.ctx.auto_play.is_none()
             || self.ctx.auto_play_stopped
-            || self.ctx.auto_play_paused
+            || self.ctx.is_auto_play_paused()
         {
             "polite"
         } else {
@@ -1408,6 +1458,7 @@ impl Api<'_> {
         attrs
             .set(scope_attr, scope_val)
             .set(part_attr, part_val)
+            .set(HtmlAttr::Type, "button")
             .set(
                 HtmlAttr::Aria(AriaAttr::Label),
                 (self.ctx.messages.prev_label)(&self.ctx.locale),
@@ -1429,6 +1480,7 @@ impl Api<'_> {
         attrs
             .set(scope_attr, scope_val)
             .set(part_attr, part_val)
+            .set(HtmlAttr::Type, "button")
             .set(
                 HtmlAttr::Aria(AriaAttr::Label),
                 (self.ctx.messages.next_label)(&self.ctx.locale),
@@ -1465,6 +1517,7 @@ impl Api<'_> {
         attrs
             .set(scope_attr, scope_val)
             .set(part_attr, part_val)
+            .set(HtmlAttr::Type, "button")
             .set(HtmlAttr::Role, "tab")
             .set(
                 HtmlAttr::Aria(AriaAttr::Selected),
@@ -1484,11 +1537,14 @@ impl Api<'_> {
         let mut attrs = AttrMap::new();
         let [(scope_attr, scope_val), (part_attr, part_val)] = Part::AutoPlayTrigger.data_attrs();
 
-        attrs.set(scope_attr, scope_val).set(part_attr, part_val);
+        attrs
+            .set(scope_attr, scope_val)
+            .set(part_attr, part_val)
+            .set(HtmlAttr::Type, "button");
 
         let is_playing = self.ctx.auto_play.is_some()
             && !self.ctx.auto_play_stopped
-            && !self.ctx.auto_play_paused;
+            && !self.ctx.is_auto_play_paused();
 
         let label = if is_playing {
             (self.ctx.messages.pause_auto_play_label)(&self.ctx.locale)
@@ -1514,7 +1570,7 @@ impl Api<'_> {
 
         let is_playing = self.ctx.auto_play.is_some()
             && !self.ctx.auto_play_stopped
-            && !self.ctx.auto_play_paused;
+            && !self.ctx.is_auto_play_paused();
 
         attrs
             .set(
@@ -1605,7 +1661,7 @@ impl Api<'_> {
         if self.ctx.auto_play.is_none() {
             return;
         }
-        if self.ctx.auto_play_stopped || self.ctx.auto_play_paused {
+        if self.ctx.auto_play_stopped || self.ctx.is_auto_play_paused() {
             (self.send)(Event::AutoPlayResume);
         } else {
             (self.send)(Event::AutoPlayPause);
@@ -1632,6 +1688,13 @@ impl Api<'_> {
     /// Dispatch a pointer-move during a drag.
     pub fn on_viewport_pointermove(&self, pos: f64, timestamp: f64) {
         (self.send)(Event::PointerMove { pos, timestamp });
+    }
+
+    /// Dispatch a pointer-cancel (gesture aborted by the browser, e.g.
+    /// pointer-capture loss or touch-scroll). Clears drag state and re-arms
+    /// auto-play, so a cancelled gesture cannot strand the drag offset or timer.
+    pub fn on_viewport_pointercancel(&self) {
+        (self.send)(Event::PointerCancel);
     }
 
     /// Dispatch a pointer-up (drag end).
@@ -2083,7 +2146,7 @@ mod tests {
         let result = service.send(Event::AutoPlayPause);
 
         assert_eq!(service.state(), &State::Idle);
-        assert!(service.context().auto_play_paused);
+        assert!(service.context().is_auto_play_paused());
         assert_eq!(result.cancel_effects, vec![Effect::AutoPlayTimer]);
     }
 
@@ -2096,7 +2159,7 @@ mod tests {
         let result = service.send(Event::AutoPlayResume);
 
         assert_eq!(service.state(), &State::AutoPlaying);
-        assert!(!service.context().auto_play_paused);
+        assert!(!service.context().is_auto_play_paused());
         assert_eq!(pending_effect_names(&result), vec![Effect::AutoPlayTimer]);
     }
 
@@ -2113,7 +2176,7 @@ mod tests {
         let result = service.send(Event::AutoPlayResume);
         assert_eq!(service.state(), &State::AutoPlaying);
         assert!(!service.context().auto_play_stopped);
-        assert!(!service.context().auto_play_paused);
+        assert!(!service.context().is_auto_play_paused());
         assert_eq!(pending_effect_names(&result), vec![Effect::AutoPlayTimer]);
     }
 
@@ -2123,7 +2186,7 @@ mod tests {
 
         drop(service.send(Event::FocusSlide { index: 2 }));
 
-        assert!(service.context().auto_play_paused);
+        assert!(service.context().is_auto_play_paused());
         assert_eq!(service.context().current_index(), 2);
     }
 
@@ -2139,20 +2202,38 @@ mod tests {
 
         drop(service.send(Event::FocusSlide { index: 1 }));
 
-        assert!(!service.context().auto_play_paused);
+        assert!(!service.context().is_auto_play_paused());
     }
 
     #[test]
-    fn blur_resumes_when_paused() {
+    fn blur_resumes_focus_pause() {
         let mut service = service(autoplay_props(3));
+        drop(service.take_initial_effects());
 
-        drop(service.send(Event::AutoPlayPause));
+        // Focus pauses (pause_on_focus default true); Blur (focus-out) resumes.
+        drop(service.send(Event::FocusSlide { index: 0 }));
+        assert!(service.context().is_auto_play_paused());
 
         let result = service.send(Event::Blur);
-
         assert_eq!(service.state(), &State::AutoPlaying);
-        assert!(!service.context().auto_play_paused);
-        assert_eq!(pending_effect_names(&result), vec![Effect::AutoPlayTimer]);
+        assert!(!service.context().is_auto_play_paused());
+        assert!(
+            result
+                .pending_effects
+                .iter()
+                .any(|effect| effect.name == Effect::AutoPlayTimer)
+        );
+    }
+
+    #[test]
+    fn blur_does_not_resume_manual_pause() {
+        // R3: a manual (trigger) pause must NOT be resumed by a focus-out.
+        let mut service = service(autoplay_props(3));
+        drop(service.take_initial_effects());
+        drop(service.send(Event::AutoPlayPause));
+        let result = service.send(Event::Blur);
+        assert!(!result.state_changed);
+        assert!(service.context().is_auto_play_paused());
     }
 
     #[test]
@@ -2843,7 +2924,7 @@ mod tests {
         let result = service.send(Event::AutoPlayPause);
 
         assert_eq!(service.state(), &State::Transitioning);
-        assert!(service.context().auto_play_paused);
+        assert!(service.context().is_auto_play_paused());
         assert_eq!(result.cancel_effects, vec![Effect::AutoPlayTimer]);
     }
 
@@ -2855,7 +2936,7 @@ mod tests {
         let result = service.send(Event::AutoPlayResume);
         assert!(!result.state_changed);
         assert!(result.pending_effects.is_empty());
-        assert!(!service.context().auto_play_paused);
+        assert!(!service.context().is_auto_play_paused());
     }
 
     // ── Codex review #716: autoplay timer lifecycle ──────────────────
@@ -2987,7 +3068,7 @@ mod tests {
         drop(service.take_initial_effects());
         let result = service.send(Event::FocusSlide { index: 1 });
         assert_eq!(service.state(), &State::Idle);
-        assert!(service.context().auto_play_paused);
+        assert!(service.context().is_auto_play_paused());
         assert_eq!(result.cancel_effects, vec![Effect::AutoPlayTimer]);
     }
 
@@ -3275,7 +3356,7 @@ mod tests {
         let mut service = service(props(3));
         let result = service.send(Event::AutoPlayPause);
         assert!(!result.state_changed);
-        assert!(!service.context().auto_play_paused);
+        assert!(!service.context().is_auto_play_paused());
     }
 
     #[test]
@@ -3299,7 +3380,7 @@ mod tests {
             let api = service.connect(&|_| {});
             api.on_auto_play_trigger_click();
         }
-        assert!(!service.context().auto_play_paused);
+        assert!(!service.context().is_auto_play_paused());
 
         let result = service.set_props(autoplay_props(3));
         assert_eq!(service.state(), &State::AutoPlaying);
@@ -3316,11 +3397,11 @@ mod tests {
         let mut service = service(autoplay_props(3));
         drop(service.take_initial_effects());
         drop(service.send(Event::AutoPlayPause));
-        assert!(service.context().auto_play_paused);
+        assert!(service.context().is_auto_play_paused());
 
         let result = service.send(Event::AutoPlayStart);
         assert_eq!(service.state(), &State::AutoPlaying);
-        assert!(!service.context().auto_play_paused);
+        assert!(!service.context().is_auto_play_paused());
         assert!(
             result
                 .pending_effects
@@ -3463,13 +3544,13 @@ mod tests {
         drop(service.take_initial_effects());
         let result = service.send(Event::HoverStart);
         assert_eq!(service.state(), &State::Idle);
-        assert!(service.context().auto_play_paused);
+        assert!(service.context().is_auto_play_paused());
         assert_eq!(result.cancel_effects, vec![Effect::AutoPlayTimer]);
 
         // Pointer leaving resumes rotation.
         let resumed = service.send(Event::HoverEnd);
         assert_eq!(service.state(), &State::AutoPlaying);
-        assert!(!service.context().auto_play_paused);
+        assert!(!service.context().is_auto_play_paused());
         assert!(
             resumed
                 .pending_effects
@@ -3490,7 +3571,7 @@ mod tests {
         drop(service.take_initial_effects());
         let result = service.send(Event::HoverStart);
         assert!(!result.state_changed);
-        assert!(!service.context().auto_play_paused);
+        assert!(!service.context().is_auto_play_paused());
         assert_eq!(service.state(), &State::AutoPlaying);
     }
 
@@ -3499,6 +3580,100 @@ mod tests {
         let mut service = service(props(3));
         let result = service.send(Event::HoverStart);
         assert!(!result.state_changed);
-        assert!(!service.context().auto_play_paused);
+        assert!(!service.context().is_auto_play_paused());
+    }
+
+    #[test]
+    fn hover_end_does_not_resume_manual_pause() {
+        // R3: pausing via the trigger then hovering and leaving must NOT resume.
+        let mut service = service(autoplay_props(3));
+        drop(service.take_initial_effects());
+        drop(service.send(Event::AutoPlayPause));
+        drop(service.send(Event::HoverStart));
+        let result = service.send(Event::HoverEnd);
+        assert!(service.context().is_auto_play_paused());
+        assert!(
+            !result
+                .pending_effects
+                .iter()
+                .any(|effect| effect.name == Effect::AutoPlayTimer)
+        );
+    }
+
+    #[test]
+    fn hover_end_keeps_pause_while_focus_still_inside() {
+        // R3: hover + focus both pause; leaving hover while focus remains inside
+        // must keep rotation paused.
+        let mut service = service(autoplay_props(3));
+        drop(service.take_initial_effects());
+        drop(service.send(Event::FocusSlide { index: 0 }));
+        drop(service.send(Event::HoverStart));
+        let result = service.send(Event::HoverEnd);
+        assert!(service.context().is_auto_play_paused());
+        assert_eq!(service.state(), &State::Idle);
+        assert!(result.pending_effects.is_empty());
+        // Focus-out then resumes (no sources left).
+        let resumed = service.send(Event::Blur);
+        assert_eq!(service.state(), &State::AutoPlaying);
+        assert!(!service.context().is_auto_play_paused());
+        assert!(
+            resumed
+                .pending_effects
+                .iter()
+                .any(|effect| effect.name == Effect::AutoPlayTimer)
+        );
+    }
+
+    #[test]
+    fn autoplay_tick_ignored_during_drag() {
+        let mut service = service(autoplay_props(3));
+        drop(service.take_initial_effects());
+        drop(service.send(Event::PointerDown {
+            pos: 100.0,
+            timestamp: 0.0,
+        }));
+        // A tick queued before PointerDown's cancel must not advance mid-drag.
+        let result = service.send(Event::AutoPlayTick);
+        assert!(!result.state_changed);
+        assert_eq!(service.context().current_index(), 0);
+    }
+
+    #[test]
+    fn loop_goto_slide_reaches_wrapped_target() {
+        // R1: with loop + slides_per_view > 1, a direct jump to the last slide
+        // is not clamped to last_index.
+        let mut service = service(Props {
+            loop_nav: true,
+            slides_per_view: Some(2.0),
+            ..props(5)
+        });
+        drop(service.send(Event::GoToSlide { index: 4 }));
+        assert_eq!(service.context().current_index(), 4);
+    }
+
+    #[test]
+    fn pointer_cancel_handler_dispatches_event() {
+        let service = service(props(3));
+        let recorder: RefCell<Vec<Event>> = RefCell::new(Vec::new());
+        {
+            let record = |event| recorder.borrow_mut().push(event);
+            let api = service.connect(&record);
+            api.on_viewport_pointercancel();
+        }
+        assert_eq!(recorder.into_inner(), vec![Event::PointerCancel]);
+    }
+
+    #[test]
+    fn trigger_controls_set_button_type() {
+        let service = service(autoplay_props(3));
+        let api = service.connect(&|_| {});
+        for attrs in [
+            api.prev_trigger_attrs(),
+            api.next_trigger_attrs(),
+            api.indicator_attrs(0),
+            api.auto_play_trigger_attrs(),
+        ] {
+            assert_eq!(attrs.get(&HtmlAttr::Type), Some("button"));
+        }
     }
 }

--- a/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__auto_play_trigger_paused.snap
+++ b/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__auto_play_trigger_paused.snap
@@ -36,6 +36,12 @@ AttrMap {
                 "false",
             ),
         ),
+        (
+            Type,
+            String(
+                "button",
+            ),
+        ),
     ],
     styles: [],
 }

--- a/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__auto_play_trigger_paused.snap
+++ b/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__auto_play_trigger_paused.snap
@@ -1,0 +1,41 @@
+---
+source: crates/ars-components/src/layout/carousel/mod.rs
+expression: "snapshot_attrs(&service.connect(&|_| {}).auto_play_trigger_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "auto-play-trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "carousel",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Start automatic slide show",
+            ),
+        ),
+        (
+            Aria(
+                Pressed,
+            ),
+            String(
+                "false",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__auto_play_trigger_playing.snap
+++ b/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__auto_play_trigger_playing.snap
@@ -1,0 +1,41 @@
+---
+source: crates/ars-components/src/layout/carousel/mod.rs
+expression: "snapshot_attrs(&service.connect(&|_| {}).auto_play_trigger_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "auto-play-trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "carousel",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Pause automatic slide show",
+            ),
+        ),
+        (
+            Aria(
+                Pressed,
+            ),
+            String(
+                "true",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__auto_play_trigger_playing.snap
+++ b/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__auto_play_trigger_playing.snap
@@ -36,6 +36,12 @@ AttrMap {
                 "true",
             ),
         ),
+        (
+            Type,
+            String(
+                "button",
+            ),
+        ),
     ],
     styles: [],
 }

--- a/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__autoplay_indicator_paused.snap
+++ b/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__autoplay_indicator_paused.snap
@@ -1,0 +1,41 @@
+---
+source: crates/ars-components/src/layout/carousel/mod.rs
+expression: "snapshot_attrs(&service.connect(&|_| {}).autoplay_indicator_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "auto-play-indicator",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "carousel",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "paused",
+            ),
+        ),
+        (
+            Aria(
+                Hidden,
+            ),
+            String(
+                "true",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__autoplay_indicator_playing.snap
+++ b/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__autoplay_indicator_playing.snap
@@ -1,0 +1,41 @@
+---
+source: crates/ars-components/src/layout/carousel/mod.rs
+expression: "snapshot_attrs(&service.connect(&|_| {}).autoplay_indicator_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "auto-play-indicator",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "carousel",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "playing",
+            ),
+        ),
+        (
+            Aria(
+                Hidden,
+            ),
+            String(
+                "true",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__indicator_group.snap
+++ b/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__indicator_group.snap
@@ -1,0 +1,31 @@
+---
+source: crates/ars-components/src/layout/carousel/mod.rs
+expression: "snapshot_attrs(&service.connect(&|_| {}).indicator_group_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "indicator-group",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "carousel",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "tablist",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__indicator_group.snap
+++ b/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__indicator_group.snap
@@ -21,6 +21,14 @@ AttrMap {
             ),
         ),
         (
+            Aria(
+                Label,
+            ),
+            String(
+                "Choose slide",
+            ),
+        ),
+        (
             Role,
             String(
                 "tablist",

--- a/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__indicator_selected.snap
+++ b/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__indicator_selected.snap
@@ -1,0 +1,39 @@
+---
+source: crates/ars-components/src/layout/carousel/mod.rs
+expression: "snapshot_attrs(&service.connect(&|_| {}).indicator_attrs(0))"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "indicator",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "carousel",
+            ),
+        ),
+        (
+            Aria(
+                Selected,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "tab",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__indicator_selected.snap
+++ b/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__indicator_selected.snap
@@ -34,6 +34,12 @@ AttrMap {
                 "tab",
             ),
         ),
+        (
+            Type,
+            String(
+                "button",
+            ),
+        ),
     ],
     styles: [],
 }

--- a/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__indicator_unselected.snap
+++ b/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__indicator_unselected.snap
@@ -1,0 +1,39 @@
+---
+source: crates/ars-components/src/layout/carousel/mod.rs
+expression: "snapshot_attrs(&service.connect(&|_| {}).indicator_attrs(1))"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "indicator",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "carousel",
+            ),
+        ),
+        (
+            Aria(
+                Selected,
+            ),
+            String(
+                "false",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "tab",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__indicator_unselected.snap
+++ b/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__indicator_unselected.snap
@@ -34,6 +34,12 @@ AttrMap {
                 "tab",
             ),
         ),
+        (
+            Type,
+            String(
+                "button",
+            ),
+        ),
     ],
     styles: [],
 }

--- a/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__item_current.snap
+++ b/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__item_current.snap
@@ -1,0 +1,63 @@
+---
+source: crates/ars-components/src/layout/carousel/mod.rs
+expression: "snapshot_attrs(&service.connect(&|_| {}).item_attrs(0))"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-active",
+            ),
+            Bool(
+                true,
+            ),
+        ),
+        (
+            Data(
+                "ars-index",
+            ),
+            String(
+                "0",
+            ),
+        ),
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "item",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "carousel",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Slide 1 of 3",
+            ),
+        ),
+        (
+            Aria(
+                RoleDescription,
+            ),
+            String(
+                "slide",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "group",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__item_group_off.snap
+++ b/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__item_group_off.snap
@@ -1,0 +1,33 @@
+---
+source: crates/ars-components/src/layout/carousel/mod.rs
+expression: "snapshot_attrs(&service.connect(&|_| {}).item_group_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "item-group",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "carousel",
+            ),
+        ),
+        (
+            Aria(
+                Live,
+            ),
+            String(
+                "off",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__item_group_polite.snap
+++ b/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__item_group_polite.snap
@@ -1,0 +1,33 @@
+---
+source: crates/ars-components/src/layout/carousel/mod.rs
+expression: "snapshot_attrs(&service.connect(&|_| {}).item_group_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "item-group",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "carousel",
+            ),
+        ),
+        (
+            Aria(
+                Live,
+            ),
+            String(
+                "polite",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__item_hidden.snap
+++ b/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__item_hidden.snap
@@ -1,0 +1,77 @@
+---
+source: crates/ars-components/src/layout/carousel/mod.rs
+expression: "snapshot_attrs(&service.connect(&|_| {}).item_attrs(1))"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-active",
+            ),
+            Bool(
+                false,
+            ),
+        ),
+        (
+            Data(
+                "ars-index",
+            ),
+            String(
+                "1",
+            ),
+        ),
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "item",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "carousel",
+            ),
+        ),
+        (
+            Aria(
+                Hidden,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Slide 2 of 3",
+            ),
+        ),
+        (
+            Aria(
+                RoleDescription,
+            ),
+            String(
+                "slide",
+            ),
+        ),
+        (
+            Inert,
+            Bool(
+                true,
+            ),
+        ),
+        (
+            Role,
+            String(
+                "group",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__item_visible_not_current_multi_view.snap
+++ b/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__item_visible_not_current_multi_view.snap
@@ -1,0 +1,63 @@
+---
+source: crates/ars-components/src/layout/carousel/mod.rs
+expression: "snapshot_attrs(&service.connect(&|_| {}).item_attrs(1))"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-active",
+            ),
+            Bool(
+                false,
+            ),
+        ),
+        (
+            Data(
+                "ars-index",
+            ),
+            String(
+                "1",
+            ),
+        ),
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "item",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "carousel",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Slide 2 of 3",
+            ),
+        ),
+        (
+            Aria(
+                RoleDescription,
+            ),
+            String(
+                "slide",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "group",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__next_trigger_disabled.snap
+++ b/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__next_trigger_disabled.snap
@@ -36,6 +36,12 @@ AttrMap {
                 "Next slide",
             ),
         ),
+        (
+            Type,
+            String(
+                "button",
+            ),
+        ),
     ],
     styles: [],
 }

--- a/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__next_trigger_disabled.snap
+++ b/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__next_trigger_disabled.snap
@@ -1,0 +1,41 @@
+---
+source: crates/ars-components/src/layout/carousel/mod.rs
+expression: "snapshot_attrs(&service.connect(&|_| {}).next_trigger_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "next-trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "carousel",
+            ),
+        ),
+        (
+            Aria(
+                Disabled,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Next slide",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__next_trigger_enabled.snap
+++ b/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__next_trigger_enabled.snap
@@ -28,6 +28,12 @@ AttrMap {
                 "Next slide",
             ),
         ),
+        (
+            Type,
+            String(
+                "button",
+            ),
+        ),
     ],
     styles: [],
 }

--- a/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__next_trigger_enabled.snap
+++ b/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__next_trigger_enabled.snap
@@ -1,0 +1,33 @@
+---
+source: crates/ars-components/src/layout/carousel/mod.rs
+expression: "snapshot_attrs(&service.connect(&|_| {}).next_trigger_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "next-trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "carousel",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Next slide",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__prev_trigger_disabled.snap
+++ b/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__prev_trigger_disabled.snap
@@ -36,6 +36,12 @@ AttrMap {
                 "Previous slide",
             ),
         ),
+        (
+            Type,
+            String(
+                "button",
+            ),
+        ),
     ],
     styles: [],
 }

--- a/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__prev_trigger_disabled.snap
+++ b/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__prev_trigger_disabled.snap
@@ -1,0 +1,41 @@
+---
+source: crates/ars-components/src/layout/carousel/mod.rs
+expression: "snapshot_attrs(&service.connect(&|_| {}).prev_trigger_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "prev-trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "carousel",
+            ),
+        ),
+        (
+            Aria(
+                Disabled,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Previous slide",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__prev_trigger_enabled.snap
+++ b/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__prev_trigger_enabled.snap
@@ -1,0 +1,33 @@
+---
+source: crates/ars-components/src/layout/carousel/mod.rs
+expression: "snapshot_attrs(&service.connect(&|_| {}).prev_trigger_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "prev-trigger",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "carousel",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Previous slide",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__prev_trigger_enabled.snap
+++ b/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__prev_trigger_enabled.snap
@@ -28,6 +28,12 @@ AttrMap {
                 "Previous slide",
             ),
         ),
+        (
+            Type,
+            String(
+                "button",
+            ),
+        ),
     ],
     styles: [],
 }

--- a/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__progress_text_attrs.snap
+++ b/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__progress_text_attrs.snap
@@ -1,0 +1,41 @@
+---
+source: crates/ars-components/src/layout/carousel/mod.rs
+expression: "snapshot_attrs(&service.connect(&|_| {}).progress_text_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "progress-text",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "carousel",
+            ),
+        ),
+        (
+            Aria(
+                Atomic,
+            ),
+            String(
+                "true",
+            ),
+        ),
+        (
+            Aria(
+                Live,
+            ),
+            String(
+                "polite",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__root_autoplaying.snap
+++ b/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__root_autoplaying.snap
@@ -1,0 +1,63 @@
+---
+source: crates/ars-components/src/layout/carousel/mod.rs
+expression: "snapshot_attrs(&service.connect(&|_| {}).root_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-orientation",
+            ),
+            String(
+                "horizontal",
+            ),
+        ),
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "carousel",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "auto-playing",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Carousel",
+            ),
+        ),
+        (
+            Aria(
+                RoleDescription,
+            ),
+            String(
+                "carousel",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "region",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__root_idle_horizontal.snap
+++ b/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__root_idle_horizontal.snap
@@ -1,0 +1,63 @@
+---
+source: crates/ars-components/src/layout/carousel/mod.rs
+expression: "snapshot_attrs(&service.connect(&|_| {}).root_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-orientation",
+            ),
+            String(
+                "horizontal",
+            ),
+        ),
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "carousel",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "idle",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Carousel",
+            ),
+        ),
+        (
+            Aria(
+                RoleDescription,
+            ),
+            String(
+                "carousel",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "region",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__root_transitioning.snap
+++ b/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__root_transitioning.snap
@@ -1,0 +1,63 @@
+---
+source: crates/ars-components/src/layout/carousel/mod.rs
+expression: "snapshot_attrs(&service.connect(&|_| {}).root_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-orientation",
+            ),
+            String(
+                "horizontal",
+            ),
+        ),
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "carousel",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "transitioning",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Carousel",
+            ),
+        ),
+        (
+            Aria(
+                RoleDescription,
+            ),
+            String(
+                "carousel",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "region",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__root_vertical.snap
+++ b/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__root_vertical.snap
@@ -1,0 +1,63 @@
+---
+source: crates/ars-components/src/layout/carousel/mod.rs
+expression: "snapshot_attrs(&service.connect(&|_| {}).root_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-orientation",
+            ),
+            String(
+                "vertical",
+            ),
+        ),
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "root",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "carousel",
+            ),
+        ),
+        (
+            Data(
+                "ars-state",
+            ),
+            String(
+                "idle",
+            ),
+        ),
+        (
+            Aria(
+                Label,
+            ),
+            String(
+                "Carousel",
+            ),
+        ),
+        (
+            Aria(
+                RoleDescription,
+            ),
+            String(
+                "carousel",
+            ),
+        ),
+        (
+            Role,
+            String(
+                "region",
+            ),
+        ),
+    ],
+    styles: [],
+}

--- a/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__viewport_horizontal.snap
+++ b/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__viewport_horizontal.snap
@@ -1,0 +1,34 @@
+---
+source: crates/ars-components/src/layout/carousel/mod.rs
+expression: "snapshot_attrs(&service.connect(&|_| {}).viewport_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "viewport",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "carousel",
+            ),
+        ),
+    ],
+    styles: [
+        (
+            Overflow,
+            "hidden",
+        ),
+        (
+            TouchAction,
+            "pan-y",
+        ),
+    ],
+}

--- a/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__viewport_vertical.snap
+++ b/crates/ars-components/src/layout/carousel/snapshots/ars_components__layout__carousel__tests__viewport_vertical.snap
@@ -1,0 +1,34 @@
+---
+source: crates/ars-components/src/layout/carousel/mod.rs
+expression: "snapshot_attrs(&service.connect(&|_| {}).viewport_attrs())"
+---
+AttrMap {
+    attrs: [
+        (
+            Data(
+                "ars-part",
+            ),
+            String(
+                "viewport",
+            ),
+        ),
+        (
+            Data(
+                "ars-scope",
+            ),
+            String(
+                "carousel",
+            ),
+        ),
+    ],
+    styles: [
+        (
+            Overflow,
+            "hidden",
+        ),
+        (
+            TouchAction,
+            "pan-x",
+        ),
+    ],
+}

--- a/crates/ars-components/src/layout/mod.rs
+++ b/crates/ars-components/src/layout/mod.rs
@@ -3,6 +3,9 @@
 /// `AspectRatio` component connect API.
 pub mod aspect_ratio;
 
+/// Carousel component machine.
+pub mod carousel;
+
 /// Center component connect API.
 pub mod center;
 

--- a/crates/ars-components/tests/proptest_state_machines/layout.rs
+++ b/crates/ars-components/tests/proptest_state_machines/layout.rs
@@ -1,4 +1,6 @@
-use ars_components::layout::{collapsible, portal, scroll_area, splitter, toolbar};
+use core::{num::NonZero, time::Duration};
+
+use ars_components::layout::{carousel, collapsible, portal, scroll_area, splitter, toolbar};
 use ars_core::{
     AriaAttr, Direction, Env, HtmlAttr, KeyboardKey, Orientation, RenderMode, SendResult, Service,
 };
@@ -714,6 +716,117 @@ proptest! {
             drop(service.send(event));
 
             assert_scroll_area_invariants(&service)?;
+        }
+    }
+}
+
+fn arb_carousel_options() -> impl Strategy<Value = carousel::AutoPlayOptions> {
+    (any::<bool>(), any::<bool>(), any::<bool>()).prop_map(
+        |(stop_on_interaction, pause_on_focus, pause_on_hover)| carousel::AutoPlayOptions {
+            interval: Duration::from_millis(1000),
+            stop_on_interaction,
+            pause_on_focus,
+            pause_on_hover,
+        },
+    )
+}
+
+fn arb_carousel_props() -> impl Strategy<Value = carousel::Props> {
+    (
+        1usize..8,
+        any::<bool>(),
+        prop::option::of(arb_carousel_options()),
+        prop_oneof![Just(Orientation::Horizontal), Just(Orientation::Vertical)],
+        any::<bool>(),
+        1usize..4,
+    )
+        .prop_flat_map(
+            |(count, loop_nav, auto_play, orientation, is_rtl, slides_per_move)| {
+                (0usize..count).prop_map(move |default_index| carousel::Props {
+                    id: String::from("carousel"),
+                    slide_count: NonZero::new(count).expect("non-zero slide count"),
+                    loop_nav,
+                    auto_play: auto_play.clone(),
+                    orientation: Some(orientation),
+                    is_rtl,
+                    slides_per_move: Some(slides_per_move),
+                    default_index: Some(default_index),
+                    ..carousel::Props::default()
+                })
+            },
+        )
+}
+
+/// `GoToSlide`/`FocusSlide` indices are generated past the valid slide range
+/// on purpose: the machine saturating-clamps them to the last slide (spec
+/// §1.5), so the `current_index < slide_count` invariant must hold even for
+/// out-of-range targets.
+fn arb_carousel_event(slide_count: usize) -> impl Strategy<Value = carousel::Event> {
+    prop_oneof![
+        (0..slide_count + 4).prop_map(|index| carousel::Event::GoToSlide { index }),
+        Just(carousel::Event::GoToNext),
+        Just(carousel::Event::GoToPrev),
+        Just(carousel::Event::AutoPlayStart),
+        Just(carousel::Event::AutoPlayStop),
+        Just(carousel::Event::AutoPlayTick),
+        Just(carousel::Event::AutoPlayPause),
+        Just(carousel::Event::AutoPlayResume),
+        Just(carousel::Event::TransitionEnd),
+        (-500.0f64..500.0, 0.0f64..10_000.0)
+            .prop_map(|(pos, timestamp)| carousel::Event::PointerDown { pos, timestamp }),
+        (-500.0f64..500.0, 0.0f64..10_000.0)
+            .prop_map(|(pos, timestamp)| carousel::Event::PointerMove { pos, timestamp }),
+        Just(carousel::Event::PointerUp),
+        Just(carousel::Event::PointerCancel),
+        (0..slide_count + 4).prop_map(|index| carousel::Event::FocusSlide { index }),
+        Just(carousel::Event::Blur),
+    ]
+}
+
+fn assert_carousel_invariants(service: &Service<carousel::Machine>) -> TestCaseResult {
+    let ctx = service.context();
+
+    prop_assert!(ctx.current_index() < ctx.slide_count.get());
+    prop_assert!(ctx.drag_delta.is_finite());
+    prop_assert!(ctx.swipe_velocity.is_finite());
+
+    if let Some(pos) = ctx.drag_start_pos {
+        prop_assert!(pos.is_finite());
+    }
+
+    if let Some(timestamp) = ctx.drag_last_timestamp {
+        prop_assert!(timestamp.is_finite());
+    }
+
+    Ok(())
+}
+
+proptest! {
+    #![proptest_config(super::common::proptest_config())]
+
+    #[test]
+    #[ignore = "proptest — nightly extended-proptest job"]
+    fn proptest_carousel_event_sequences_preserve_invariants(
+        (props, events) in arb_carousel_props().prop_flat_map(|props| {
+            let slide_count = props.slide_count.get();
+            (
+                Just(props),
+                prop::collection::vec(arb_carousel_event(slide_count), 0..128),
+            )
+        }),
+    ) {
+        let mut service = Service::<carousel::Machine>::new(
+            props,
+            &Env::default(),
+            &carousel::Messages::default(),
+        );
+
+        assert_carousel_invariants(&service)?;
+
+        for event in events {
+            drop(service.send(event));
+
+            assert_carousel_invariants(&service)?;
         }
     }
 }

--- a/crates/ars-components/tests/spec_conformance/layout.rs
+++ b/crates/ars-components/tests/spec_conformance/layout.rs
@@ -4,10 +4,30 @@
 //! spec's §2 anatomy table and asserts the impl's `Part` enum matches.
 
 use ars_components::layout::{
-    aspect_ratio, center, collapsible, frame, grid, scroll_area, splitter, stack, toolbar,
+    aspect_ratio, carousel, center, collapsible, frame, grid, scroll_area, splitter, stack, toolbar,
 };
 
 use super::helper::assert_anatomy;
+
+#[test]
+fn carousel_anatomy_matches_spec() {
+    assert_anatomy(
+        "carousel",
+        &[
+            (carousel::Part::Root, "root"),
+            (carousel::Part::Viewport, "viewport"),
+            (carousel::Part::ItemGroup, "item-group"),
+            (carousel::Part::Item { index: 0 }, "item"),
+            (carousel::Part::PrevTrigger, "prev-trigger"),
+            (carousel::Part::NextTrigger, "next-trigger"),
+            (carousel::Part::IndicatorGroup, "indicator-group"),
+            (carousel::Part::Indicator { index: 0 }, "indicator"),
+            (carousel::Part::AutoPlayTrigger, "auto-play-trigger"),
+            (carousel::Part::AutoPlayIndicator, "auto-play-indicator"),
+            (carousel::Part::ProgressText, "progress-text"),
+        ],
+    );
+}
 
 #[test]
 fn aspect_ratio_anatomy_matches_spec() {

--- a/spec/components/layout/carousel.md
+++ b/spec/components/layout/carousel.md
@@ -161,18 +161,44 @@ pub struct Context {
 impl Context {
     pub fn current_index(&self) -> usize { *self.index.get() }
 
+    /// Number of slide slots occupied at once, rounding a fractional
+    /// `slides_per_view` up so a partially visible trailing slide still counts
+    /// as on-screen. Always at least `1`.
+    pub fn visible_count(&self) -> usize {
+        (self.slides_per_view.ceil() as usize).max(1)
+    }
+
+    /// Largest valid starting index for non-looping navigation. With
+    /// `slides_per_view > 1` the last page is flush to the end
+    /// (contain-scroll): `slide_count - visible_count`.
+    pub fn last_index(&self) -> usize {
+        self.slide_count.get().saturating_sub(self.visible_count())
+    }
+
     /// Clamp or wrap an index according to `loop_nav`.
     pub fn clamp_index(&self, i: isize) -> usize {
         let n = self.slide_count.get() as isize;
         if self.loop_nav {
             ((i % n) + n) as usize % self.slide_count.get()
         } else {
-            (i.max(0) as usize).min(self.slide_count.get().saturating_sub(1))
+            (i.max(0) as usize).min(self.last_index())
         }
     }
 
     pub fn can_go_prev(&self) -> bool { self.loop_nav || self.current_index() > 0 }
-    pub fn can_go_next(&self) -> bool { self.loop_nav || self.current_index() + 1 < self.slide_count.get() }
+    pub fn can_go_next(&self) -> bool { self.loop_nav || self.current_index() < self.last_index() }
+
+    /// Whether `index` is within the visible window of `visible_count` slides
+    /// starting at `current_index` (wrapping when `loop_nav` is set). Slides
+    /// outside the window are hidden from assistive technology.
+    pub fn is_slide_visible(&self, index: usize) -> bool {
+        let current = self.current_index();
+        let count = self.slide_count.get();
+        (0..self.visible_count()).any(|offset| {
+            let slot = if self.loop_nav { (current + offset) % count } else { current + offset };
+            slot == index
+        })
+    }
 
     /// CSS translate percentage for the slide track.
     pub fn track_offset_percent(&self, viewport_width: f64) -> f64 {
@@ -272,6 +298,22 @@ pub enum Effect {
 
 pub struct Machine;
 
+/// Build the transition for a manual navigation to `idx`: enter
+/// `Transitioning` and set the index, and — when `stop_on_interaction` is
+/// configured — permanently stop auto-play and cancel its timer. The
+/// cancellation is essential: without it the adapter's recurring interval
+/// keeps running after rotation has "stopped", leaking the timer and
+/// dispatching ignored `AutoPlayTick`s.
+fn navigate_to(ctx: &Context, idx: usize) -> TransitionPlan<Machine> {
+    let stop = ctx.auto_play.as_ref().is_some_and(|o| o.stop_on_interaction);
+    let mut plan = TransitionPlan::to(State::Transitioning).apply(move |ctx| {
+        ctx.index.set(idx);
+        if stop { ctx.auto_play_stopped = true; }
+    });
+    if stop { plan = plan.cancel_effect(Effect::AutoPlayTimer); }
+    plan
+}
+
 impl ars_core::Machine for Machine {
     type State = State;
     type Event = Event;
@@ -287,7 +329,11 @@ impl ars_core::Machine for Machine {
         } else {
             State::Idle
         };
-        let initial_index = props.default_index.unwrap_or(0);
+        // Clamp the uncontrolled default to the last valid starting index so
+        // `current_index < slide_count` holds from the first render.
+        let visible_count = (props.slides_per_view.unwrap_or(1.0).ceil() as usize).max(1);
+        let max_index = props.slide_count.get().saturating_sub(visible_count);
+        let initial_index = props.default_index.unwrap_or(0).min(max_index);
         let locale = env.locale.clone();
         let messages = messages.clone();
         let ctx = Context {
@@ -344,34 +390,25 @@ impl ars_core::Machine for Machine {
             Event::GoToSlide { index } => {
                 if *state == State::Transitioning { return None; }
                 // A direct jump never wraps; clamp out-of-range targets to the
-                // last slide so `current_index` can never exceed the slide
-                // count (every connect method relies on that invariant).
-                let idx = (*index).min(ctx.slide_count.get() - 1);
-                Some(TransitionPlan::to(State::Transitioning).apply(move |ctx| {
-                    ctx.index.set(idx);
-                }))
+                // last valid starting index. A direct jump is a manual
+                // interaction, so it honours `stop_on_interaction` like
+                // Next/Prev (see `navigate_to`).
+                let idx = (*index).min(ctx.last_index());
+                Some(navigate_to(ctx, idx))
             }
 
             Event::GoToNext => {
                 if *state == State::Transitioning || !ctx.can_go_next() { return None; }
                 let step = ctx.slides_per_move as isize;
                 let next = ctx.clamp_index(ctx.current_index() as isize + step);
-                let stop = ctx.auto_play.as_ref().is_some_and(|o| o.stop_on_interaction);
-                Some(TransitionPlan::to(State::Transitioning).apply(move |ctx| {
-                    ctx.index.set(next);
-                    if stop { ctx.auto_play_stopped = true; }
-                }))
+                Some(navigate_to(ctx, next))
             }
 
             Event::GoToPrev => {
                 if *state == State::Transitioning || !ctx.can_go_prev() { return None; }
                 let step = ctx.slides_per_move as isize;
                 let prev = ctx.clamp_index(ctx.current_index() as isize - step);
-                let stop = ctx.auto_play.as_ref().is_some_and(|o| o.stop_on_interaction);
-                Some(TransitionPlan::to(State::Transitioning).apply(move |ctx| {
-                    ctx.index.set(prev);
-                    if stop { ctx.auto_play_stopped = true; }
-                }))
+                Some(navigate_to(ctx, prev))
             }
 
             Event::TransitionEnd => {
@@ -413,10 +450,15 @@ impl ars_core::Machine for Machine {
             }
 
             Event::AutoPlayResume => {
-                if ctx.auto_play_stopped { return None; }
+                // Resume is also the "restart" path the auto-play trigger
+                // dispatches when rotation was stopped (the trigger shows the
+                // "Start" label and sends `AutoPlayResume`), so it clears BOTH
+                // the paused and the stopped flags — otherwise a stopped
+                // carousel's start control would be inert.
                 if ctx.auto_play.is_some() {
                     return Some(TransitionPlan::to(State::AutoPlaying).apply(|ctx| {
                         ctx.auto_play_paused = false;
+                        ctx.auto_play_stopped = false;
                     }).with_effect(PendingEffect::named(Effect::AutoPlayTimer)));
                 }
                 Some(TransitionPlan::context_only(|ctx| { ctx.auto_play_paused = false; }))
@@ -465,7 +507,22 @@ impl ars_core::Machine for Machine {
                     None
                 };
 
-                Some(TransitionPlan::to(State::Idle).apply(move |ctx| {
+                // `PointerDown` cancelled the timer for the drag. Resolve
+                // rotation now the gesture ended: a navigating swipe with
+                // `stop_on_interaction` stops it; otherwise, if rotation was
+                // still active, re-arm the timer (resume) — without this a
+                // swipe silently kills rotation, or leaves the state reporting
+                // "playing" with no timer running.
+                let navigated = next_idx.is_some();
+                let stop = ctx.auto_play.as_ref().is_some_and(|o| o.stop_on_interaction);
+                let mark_stopped = navigated && stop;
+                let resume = ctx.auto_play.is_some()
+                    && !mark_stopped
+                    && !ctx.auto_play_stopped
+                    && !ctx.auto_play_paused;
+                let target = if resume { State::AutoPlaying } else { State::Idle };
+
+                let mut plan = TransitionPlan::to(target).apply(move |ctx| {
                     ctx.drag_start_pos = None;
                     ctx.drag_delta = 0.0;
                     ctx.swipe_velocity = 0.0;
@@ -473,7 +530,10 @@ impl ars_core::Machine for Machine {
                     if let Some(idx) = next_idx {
                         ctx.index.set(idx);
                     }
-                }))
+                    if mark_stopped { ctx.auto_play_stopped = true; }
+                });
+                if resume { plan = plan.with_effect(PendingEffect::named(Effect::AutoPlayTimer)); }
+                Some(plan)
             }
 
             Event::PointerCancel => {
@@ -486,15 +546,28 @@ impl ars_core::Machine for Machine {
             }
 
             Event::FocusSlide { index } => {
-                // Defensive: focus is always reported for a real slide, but
-                // clamp anyway so an out-of-range index can never desync
-                // `current_index` past the slide count.
-                let idx = (*index).min(ctx.slide_count.get() - 1);
+                // Clamp to the last valid starting index: focusing a slide
+                // already inside the visible window must not push
+                // `current_index` past the boundary.
+                let idx = (*index).min(ctx.last_index());
                 let current = ctx.current_index();
                 let should_pause = ctx.auto_play.as_ref().is_some_and(|o| o.pause_on_focus);
+                if should_pause {
+                    // Pausing on focus mirrors `AutoPlayPause`: leave
+                    // `AutoPlaying` and cancel the timer so slides do not keep
+                    // advancing under keyboard focus.
+                    let plan = if *state == State::AutoPlaying {
+                        TransitionPlan::to(State::Idle)
+                    } else {
+                        TransitionPlan::new()
+                    };
+                    return Some(plan.apply(move |ctx| {
+                        if idx != current { ctx.index.set(idx); }
+                        ctx.auto_play_paused = true;
+                    }).cancel_effect(Effect::AutoPlayTimer));
+                }
                 Some(TransitionPlan::context_only(move |ctx| {
                     if idx != current { ctx.index.set(idx); }
-                    if should_pause { ctx.auto_play_paused = true; }
                 }))
             }
 
@@ -587,7 +660,12 @@ impl<'a> Api<'a> {
         let [(scope_attr, scope_val), (part_attr, part_val)] = Part::ItemGroup.data_attrs();
         attrs.set(scope_attr, scope_val);
         attrs.set(part_attr, part_val);
-        let live = if self.ctx.auto_play_stopped || self.ctx.auto_play.is_none() {
+        // "off" only while rotation is actively advancing; absent, stopped, or
+        // paused (hover/focus) carousels announce manual changes politely.
+        let live = if self.ctx.auto_play.is_none()
+            || self.ctx.auto_play_stopped
+            || self.ctx.auto_play_paused
+        {
             "polite"
         } else {
             "off"
@@ -603,7 +681,10 @@ impl<'a> Api<'a> {
         attrs.set(scope_attr, scope_val);
         attrs.set(part_attr, part_val);
         let is_current = index == self.ctx.current_index();
-        let is_hidden = !is_current;
+        // With `slides_per_view > 1` several slides are on-screen; only slides
+        // outside the visible window are hidden/inert. Marking a visible slide
+        // hidden would make on-screen content unreachable to AT and keyboard.
+        let is_hidden = !self.ctx.is_slide_visible(index);
         attrs.set(HtmlAttr::Role, "group");
         attrs.set(HtmlAttr::Aria(AriaAttr::RoleDescription), (self.ctx.messages.slide_role_description)(&self.ctx.locale));
         attrs.set(HtmlAttr::Aria(AriaAttr::Label), (self.ctx.messages.slide_label)(index + 1, self.ctx.slide_count.get(), &self.ctx.locale));
@@ -725,7 +806,7 @@ impl<'a> Api<'a> {
             k if k == next_key => (self.send)(Event::GoToNext),
             KeyboardKey::Home => (self.send)(Event::GoToSlide { index: 0 }),
             KeyboardKey::End => (self.send)(Event::GoToSlide {
-                index: self.ctx.slide_count.get().saturating_sub(1),
+                index: self.ctx.last_index(),
             }),
             _ => {}
         }
@@ -839,7 +920,7 @@ RTL: Arrow keys reverse per `03-accessibility.md` §4.1.
 
 - `aria-live` on `ItemGroup` is `"off"` during auto-play to prevent disruptive announcements, and `"polite"` when paused or stopped.
 - Auto-play MUST pause on hover (`mouseenter`) and on focus within the carousel (`focusin`). Resumes on `mouseleave` / `focusout` unless `stop_on_interaction` triggered.
-- Non-current slides receive both `aria-hidden="true"` and `inert`, ensuring they are invisible to assistive technology.
+- Slides **outside the visible window** (`current_index` through `current_index + ceil(slides_per_view)`, wrapping when `loop_nav` is set) receive both `aria-hidden="true"` and `inert`, ensuring off-screen slides are invisible to assistive technology. With `slides_per_view > 1` every on-screen slide stays accessible — only the leading slide carries `data-ars-active`.
 
 ## 4. Internationalization
 

--- a/spec/components/layout/carousel.md
+++ b/spec/components/layout/carousel.md
@@ -48,8 +48,15 @@ pub enum Event {
     AutoPlayStop,
     /// Auto-play timer fired; advance one slide.
     AutoPlayTick,
-    /// Temporarily pause auto-play (hover/focus).
+    /// Manually pause auto-play (e.g. the auto-play trigger button). Pauses
+    /// regardless of the `pause_on_*` options, which gate the automatic
+    /// hover/focus pauses (`HoverStart` / `FocusSlide`).
     AutoPlayPause,
+    /// Pointer entered the carousel. Pauses auto-play only when
+    /// `AutoPlayOptions::pause_on_hover` is set; otherwise a no-op.
+    HoverStart,
+    /// Pointer left the carousel. Resumes a hover/focus auto-play pause.
+    HoverEnd,
     /// Resume auto-play after pause.
     AutoPlayResume,
     /// The CSS transition animation completed.
@@ -191,8 +198,14 @@ impl Context {
         }
     }
 
-    pub fn can_go_prev(&self) -> bool { self.loop_nav || self.current_index() > 0 }
-    pub fn can_go_next(&self) -> bool { self.loop_nav || self.current_index() < self.last_index() }
+    // Always `false` when `last_index() == 0` (one slide, or `slides_per_view`
+    // already shows them all): no distinct target exists, even when looping.
+    pub fn can_go_prev(&self) -> bool {
+        self.current_index() > 0 || (self.loop_nav && self.last_index() > 0)
+    }
+    pub fn can_go_next(&self) -> bool {
+        self.current_index() < self.last_index() || (self.loop_nav && self.last_index() > 0)
+    }
 
     /// Whether `index` is within the visible window of `visible_count` slides
     /// starting at `current_index` (wrapping when `loop_nav` is set). Slides
@@ -253,6 +266,13 @@ pub struct Props {
     pub swipe_threshold: Option<f64>,
     /// Whether the carousel is right-to-left.
     pub is_rtl: bool,
+    /// Callback fired with the newly requested slide index whenever the machine
+    /// changes the index. **Required for controlled usage** (`index` is
+    /// `Some`): in controlled mode `Bindable::set` only updates the pending
+    /// internal value, so the parent must update its controlled signal from
+    /// this callback and push it back through `index`, otherwise the visible
+    /// slide never moves.
+    pub on_index_change: Option<Callback<dyn Fn(usize) + Send + Sync>>,
 }
 
 impl Default for Props {
@@ -272,6 +292,7 @@ impl Default for Props {
             transition_duration: None,
             swipe_threshold: None,
             is_rtl: false,
+            on_index_change: None,
         }
     }
 }
@@ -300,6 +321,13 @@ pub enum Effect {
     /// on `Blur` when resuming a focus/hover pause. Cancelled on
     /// `AutoPlayStop`, `AutoPlayPause`, and `PointerDown`.
     AutoPlayTimer,
+    /// Adapter invokes `Props::on_index_change` with the newly requested slide
+    /// index. Emitted whenever the machine changes the index (manual nav,
+    /// swipe, auto-play tick, focus scroll). This is the round-trip path for
+    /// **controlled** carousels: in controlled mode `Bindable::set` only updates
+    /// the pending internal value, so the parent must observe this callback and
+    /// push the new value back through `Props::index`.
+    IndexChange,
 }
 
 pub struct Machine;
@@ -317,12 +345,25 @@ pub struct Machine;
 fn navigate_to(ctx: &Context, idx: usize) -> Option<TransitionPlan<Machine>> {
     if idx == ctx.current_index() { return None; }
     let stop = ctx.auto_play.as_ref().is_some_and(|o| o.stop_on_interaction);
-    let mut plan = TransitionPlan::to(State::Transitioning).apply(move |ctx| {
-        ctx.index.set(idx);
-        if stop { ctx.auto_play_stopped = true; }
-    });
+    let mut plan = TransitionPlan::to(State::Transitioning)
+        .apply(move |ctx| {
+            ctx.index.set(idx);
+            if stop { ctx.auto_play_stopped = true; }
+        })
+        .with_effect(index_change_effect(idx));
     if stop { plan = plan.cancel_effect(Effect::AutoPlayTimer); }
     Some(plan)
+}
+
+/// Build the `Effect::IndexChange` notification carrying the newly requested
+/// slide `index`; the adapter resolves it by invoking `Props::on_index_change`.
+fn index_change_effect(index: usize) -> PendingEffect<Machine> {
+    PendingEffect::new(Effect::IndexChange, move |_ctx, props: &Props, _send| {
+        if let Some(callback) = &props.on_index_change {
+            callback(index);
+        }
+        no_cleanup()
+    })
 }
 
 impl ars_core::Machine for Machine {
@@ -480,9 +521,9 @@ impl ars_core::Machine for Machine {
                 // `Transitioning` with no transform change risks a missing
                 // `transitionend` that strands the machine.
                 if next == ctx.current_index() { return None; }
-                Some(TransitionPlan::to(State::Transitioning).apply(move |ctx| {
-                    ctx.index.set(next);
-                }))
+                Some(TransitionPlan::to(State::Transitioning)
+                    .apply(move |ctx| { ctx.index.set(next); })
+                    .with_effect(index_change_effect(next)))
             }
 
             Event::AutoPlayPause => {
@@ -497,6 +538,28 @@ impl ars_core::Machine for Machine {
                     TransitionPlan::new()
                 };
                 Some(plan.apply(|ctx| { ctx.auto_play_paused = true; }).cancel_effect(Effect::AutoPlayTimer))
+            }
+
+            Event::HoverStart => {
+                // Hover-pause is opt-in via `pause_on_hover`; otherwise hovering
+                // does nothing. When enabled it pauses like `AutoPlayPause`.
+                if !ctx.auto_play.as_ref().is_some_and(|o| o.pause_on_hover) { return None; }
+                let plan = if *state == State::AutoPlaying {
+                    TransitionPlan::to(State::Idle)
+                } else {
+                    TransitionPlan::new()
+                };
+                Some(plan.apply(|ctx| { ctx.auto_play_paused = true; }).cancel_effect(Effect::AutoPlayTimer))
+            }
+
+            Event::HoverEnd => {
+                // Resume a hover/focus pause when the pointer leaves, mirroring `Blur`.
+                if ctx.auto_play_paused && !ctx.auto_play_stopped && ctx.auto_play.is_some() {
+                    return Some(TransitionPlan::to(State::AutoPlaying).apply(|ctx| {
+                        ctx.auto_play_paused = false;
+                    }).with_effect(PendingEffect::named(Effect::AutoPlayTimer)));
+                }
+                None
             }
 
             Event::AutoPlayResume => {
@@ -542,6 +605,11 @@ impl ars_core::Machine for Machine {
             }
 
             Event::PointerUp => {
+                // No-op without an active drag: a stray pointer-up must not run
+                // the resume logic (which would re-arm a timer that was never
+                // cancelled, creating duplicate intervals).
+                ctx.drag_start_pos?;
+
                 let delta = ctx.drag_delta;
                 let velocity = ctx.swipe_velocity;
                 let threshold = ctx.swipe_threshold;
@@ -549,10 +617,12 @@ impl ars_core::Machine for Machine {
                 let effective = if velocity.abs() > 0.5 { threshold * 0.3 } else { threshold };
 
                 let cur = ctx.current_index() as isize;
+                // A swipe advances by `slides_per_move`, matching button/keyboard nav.
+                let step = ctx.slides_per_move as isize;
                 let next_idx = if delta < -effective && ctx.can_go_next() {
-                    Some(ctx.clamp_index(cur + 1))
+                    Some(ctx.clamp_index(cur + step))
                 } else if delta > effective && ctx.can_go_prev() {
-                    Some(ctx.clamp_index(cur - 1))
+                    Some(ctx.clamp_index(cur - step))
                 } else {
                     None
                 };
@@ -571,6 +641,7 @@ impl ars_core::Machine for Machine {
                     && !ctx.auto_play_stopped
                     && !ctx.auto_play_paused;
                 let target = if resume { State::AutoPlaying } else { State::Idle };
+                let index_changed = next_idx.is_some_and(|idx| idx != ctx.current_index());
 
                 let mut plan = TransitionPlan::to(target).apply(move |ctx| {
                     ctx.drag_start_pos = None;
@@ -582,6 +653,9 @@ impl ars_core::Machine for Machine {
                     }
                     if mark_stopped { ctx.auto_play_stopped = true; }
                 });
+                if index_changed && let Some(idx) = next_idx {
+                    plan = plan.with_effect(index_change_effect(idx));
+                }
                 if resume { plan = plan.with_effect(PendingEffect::named(Effect::AutoPlayTimer)); }
                 Some(plan)
             }
@@ -610,11 +684,13 @@ impl ars_core::Machine for Machine {
             }
 
             Event::FocusSlide { index } => {
-                // Clamp to the last valid starting index: focusing a slide
-                // already inside the visible window must not push
-                // `current_index` past the boundary.
+                // Only scroll when the focused slide is not already on-screen.
+                // With `slides_per_view > 1`, tabbing into a visible non-leading
+                // slide must NOT shift the track under the user.
+                let scroll = !ctx.is_slide_visible(*index);
+                // Clamp to the last valid starting index so a slide near the end
+                // maps to the last full page rather than overscrolling.
                 let idx = (*index).min(ctx.last_index());
-                let current = ctx.current_index();
                 let should_pause = ctx.auto_play.as_ref().is_some_and(|o| o.pause_on_focus);
                 if should_pause {
                     // Pausing on focus mirrors `AutoPlayPause`: leave
@@ -625,14 +701,17 @@ impl ars_core::Machine for Machine {
                     } else {
                         TransitionPlan::new()
                     };
-                    return Some(plan.apply(move |ctx| {
-                        if idx != current { ctx.index.set(idx); }
+                    let mut plan = plan.apply(move |ctx| {
+                        if scroll { ctx.index.set(idx); }
                         ctx.auto_play_paused = true;
-                    }).cancel_effect(Effect::AutoPlayTimer));
+                    }).cancel_effect(Effect::AutoPlayTimer);
+                    if scroll { plan = plan.with_effect(index_change_effect(idx)); }
+                    return Some(plan);
                 }
+                if !scroll { return None; }
                 Some(TransitionPlan::context_only(move |ctx| {
-                    if idx != current { ctx.index.set(idx); }
-                }))
+                    ctx.index.set(idx);
+                }).with_effect(index_change_effect(idx)))
             }
 
             Event::Blur => {
@@ -945,6 +1024,10 @@ impl<'a> Api<'a> {
             (self.send)(Event::AutoPlayPause);
         }
     }
+    /// Pointer entered the carousel; auto-play pauses only when `pause_on_hover`.
+    pub fn on_root_pointer_enter(&self) { (self.send)(Event::HoverStart); }
+    /// Pointer left the carousel; resumes a hover pause.
+    pub fn on_root_pointer_leave(&self) { (self.send)(Event::HoverEnd); }
     pub fn on_viewport_pointerdown(&self, pos: f64, timestamp: f64) {
         (self.send)(Event::PointerDown { pos, timestamp });
     }
@@ -1042,7 +1125,7 @@ RTL: Arrow keys reverse per `03-accessibility.md` §4.1.
 ### 3.3 Screen Reader Announcements
 
 - `aria-live` on `ItemGroup` is `"off"` during auto-play to prevent disruptive announcements, and `"polite"` when paused or stopped.
-- Auto-play MUST pause on hover (`mouseenter`) and on focus within the carousel (`focusin`). Resumes on `mouseleave` / `focusout` unless `stop_on_interaction` triggered.
+- Auto-play pauses on hover (`mouseenter` → `HoverStart`) when `AutoPlayOptions::pause_on_hover` is set, and on focus within the carousel (`focusin` → `FocusSlide`) when `pause_on_focus` is set. Each gate is enforced in the core, not the adapter. Rotation resumes on `mouseleave` / `focusout` (`HoverEnd` / `Blur`) unless permanently stopped. The auto-play trigger button's manual pause (`AutoPlayPause`) is unconditional and independent of these options.
 - Slides **outside the visible window** (`current_index` through `current_index + ceil(slides_per_view)`, wrapping when `loop_nav` is set) receive both `aria-hidden="true"` and `inert`, ensuring off-screen slides are invisible to assistive technology. With `slides_per_view > 1` every on-screen slide stays accessible — only the leading slide carries `data-ars-active`.
 
 ## 4. Internationalization

--- a/spec/components/layout/carousel.md
+++ b/spec/components/layout/carousel.md
@@ -71,8 +71,10 @@ pub enum Event {
 ### 1.3 Context
 
 ```rust
-use crate::{Bindable, Duration};
+use ars_core::Bindable;
 use ars_i18n::Orientation;
+use core::num::NonZero;
+use core::time::Duration;
 
 /// Slide alignment within the viewport.
 #[derive(Clone, Debug, Copy, PartialEq, Eq, Default)]
@@ -245,7 +247,29 @@ impl Default for Props {
 
 ### 1.5 Full Machine Implementation
 
+Auto-play timing is an adapter concern, not an agnostic one: the core never calls
+`set_interval`/`set_timeout` directly. Instead it emits a typed [`Effect`] marker that adapters
+dispatch on (`match effect.name { Effect::AutoPlayTimer => … }`) — the same convention used by
+`toast::single::Effect`, `dialog::Effect`, `popover::Effect`, and `tooltip::Effect`. The adapter
+resolving `Effect::AutoPlayTimer` runs a recurring interval of `ctx.auto_play.interval` that
+dispatches `Event::AutoPlayTick`, and tears it down when the effect is cancelled.
+
 ```rust
+/// Typed identifier for every named effect intent the carousel machine emits.
+///
+/// Adapters dispatch on `effect.name` exhaustively so unhandled variants and
+/// name typos surface at compile time.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Effect {
+    /// Adapter starts (or restarts) a recurring auto-play interval of
+    /// `Context::auto_play.interval` that dispatches `Event::AutoPlayTick`.
+    /// Emitted on mount when the carousel boots into `State::AutoPlaying`
+    /// (see `initial_effects`), on `AutoPlayStart`, on `AutoPlayResume`, and
+    /// on `Blur` when resuming a focus/hover pause. Cancelled on
+    /// `AutoPlayStop`, `AutoPlayPause`, and `PointerDown`.
+    AutoPlayTimer,
+}
+
 pub struct Machine;
 
 impl ars_core::Machine for Machine {
@@ -254,6 +278,7 @@ impl ars_core::Machine for Machine {
     type Context = Context;
     type Props = Props;
     type Messages = Messages;
+    type Effect = Effect;
     type Api<'a> = Api<'a>;
 
     fn init(props: &Self::Props, env: &Env, messages: &Self::Messages) -> (Self::State, Self::Context) {
@@ -293,6 +318,22 @@ impl ars_core::Machine for Machine {
         (initial_state, ctx)
     }
 
+    fn initial_effects(
+        state: &Self::State,
+        _ctx: &Self::Context,
+        _props: &Self::Props,
+    ) -> Vec<PendingEffect<Self>> {
+        // `init` boots into `AutoPlaying` when `auto_play.is_some()`, but no
+        // `AutoPlayStart` event fires on mount — so the recurring auto-play
+        // interval must be armed here. Adapters drain this via
+        // `Service::take_initial_effects()` on first mount.
+        if *state == State::AutoPlaying {
+            vec![PendingEffect::named(Effect::AutoPlayTimer)]
+        } else {
+            Vec::new()
+        }
+    }
+
     fn transition(
         state: &Self::State,
         event: &Self::Event,
@@ -302,7 +343,10 @@ impl ars_core::Machine for Machine {
         match event {
             Event::GoToSlide { index } => {
                 if *state == State::Transitioning { return None; }
-                let idx = *index;
+                // A direct jump never wraps; clamp out-of-range targets to the
+                // last slide so `current_index` can never exceed the slide
+                // count (every connect method relies on that invariant).
+                let idx = (*index).min(ctx.slide_count.get() - 1);
                 Some(TransitionPlan::to(State::Transitioning).apply(move |ctx| {
                     ctx.index.set(idx);
                 }))
@@ -312,7 +356,7 @@ impl ars_core::Machine for Machine {
                 if *state == State::Transitioning || !ctx.can_go_next() { return None; }
                 let step = ctx.slides_per_move as isize;
                 let next = ctx.clamp_index(ctx.current_index() as isize + step);
-                let stop = ctx.auto_play.as_ref().map_or(false, |o| o.stop_on_interaction);
+                let stop = ctx.auto_play.as_ref().is_some_and(|o| o.stop_on_interaction);
                 Some(TransitionPlan::to(State::Transitioning).apply(move |ctx| {
                     ctx.index.set(next);
                     if stop { ctx.auto_play_stopped = true; }
@@ -323,7 +367,7 @@ impl ars_core::Machine for Machine {
                 if *state == State::Transitioning || !ctx.can_go_prev() { return None; }
                 let step = ctx.slides_per_move as isize;
                 let prev = ctx.clamp_index(ctx.current_index() as isize - step);
-                let stop = ctx.auto_play.as_ref().map_or(false, |o| o.stop_on_interaction);
+                let stop = ctx.auto_play.as_ref().is_some_and(|o| o.stop_on_interaction);
                 Some(TransitionPlan::to(State::Transitioning).apply(move |ctx| {
                     ctx.index.set(prev);
                     if stop { ctx.auto_play_stopped = true; }
@@ -340,20 +384,14 @@ impl ars_core::Machine for Machine {
 
             Event::AutoPlayStart => {
                 if ctx.auto_play_stopped || ctx.auto_play.is_none() { return None; }
-                let interval = ctx.auto_play.as_ref()?.interval;
-                Some(TransitionPlan::to(State::AutoPlaying).with_named_effect(
-                    "auto-play",
-                    move |_ctx, _props, send| {
-                        let handle = set_interval(move || send(Event::AutoPlayTick), interval);
-                        Box::new(move || clear_interval(handle))
-                    },
-                ))
+                Some(TransitionPlan::to(State::AutoPlaying)
+                    .with_effect(PendingEffect::named(Effect::AutoPlayTimer)))
             }
 
             Event::AutoPlayStop => {
                 Some(TransitionPlan::to(State::Idle).apply(|ctx| {
                     ctx.auto_play_stopped = true;
-                }).cancel_effect("auto-play"))
+                }).cancel_effect(Effect::AutoPlayTimer))
             }
 
             Event::AutoPlayTick => {
@@ -371,19 +409,15 @@ impl ars_core::Machine for Machine {
                 } else {
                     TransitionPlan::new()
                 };
-                Some(plan.apply(|ctx| { ctx.auto_play_paused = true; }).cancel_effect("auto-play"))
+                Some(plan.apply(|ctx| { ctx.auto_play_paused = true; }).cancel_effect(Effect::AutoPlayTimer))
             }
 
             Event::AutoPlayResume => {
                 if ctx.auto_play_stopped { return None; }
-                if let Some(ref opts) = ctx.auto_play {
-                    let interval = opts.interval;
+                if ctx.auto_play.is_some() {
                     return Some(TransitionPlan::to(State::AutoPlaying).apply(|ctx| {
                         ctx.auto_play_paused = false;
-                    }).with_named_effect("auto-play", move |_ctx, _props, send| {
-                        let handle = set_interval(move || send(Event::AutoPlayTick), interval);
-                        Box::new(move || clear_interval(handle))
-                    }));
+                    }).with_effect(PendingEffect::named(Effect::AutoPlayTimer)));
                 }
                 Some(TransitionPlan::context_only(|ctx| { ctx.auto_play_paused = false; }))
             }
@@ -396,7 +430,7 @@ impl ars_core::Machine for Machine {
                     ctx.drag_delta = 0.0;
                     ctx.swipe_velocity = 0.0;
                     ctx.drag_last_timestamp = Some(ts);
-                }).cancel_effect("auto-play"))
+                }).cancel_effect(Effect::AutoPlayTimer))
             }
 
             Event::PointerMove { pos, timestamp } => {
@@ -452,9 +486,12 @@ impl ars_core::Machine for Machine {
             }
 
             Event::FocusSlide { index } => {
-                let idx = *index;
+                // Defensive: focus is always reported for a real slide, but
+                // clamp anyway so an out-of-range index can never desync
+                // `current_index` past the slide count.
+                let idx = (*index).min(ctx.slide_count.get() - 1);
                 let current = ctx.current_index();
-                let should_pause = ctx.auto_play.as_ref().map_or(false, |o| o.pause_on_focus);
+                let should_pause = ctx.auto_play.as_ref().is_some_and(|o| o.pause_on_focus);
                 Some(TransitionPlan::context_only(move |ctx| {
                     if idx != current { ctx.index.set(idx); }
                     if should_pause { ctx.auto_play_paused = true; }
@@ -462,16 +499,10 @@ impl ars_core::Machine for Machine {
             }
 
             Event::Blur => {
-                if ctx.auto_play_paused && !ctx.auto_play_stopped {
-                    if let Some(ref opts) = ctx.auto_play {
-                        let interval = opts.interval;
-                        return Some(TransitionPlan::to(State::AutoPlaying).apply(|ctx| {
-                            ctx.auto_play_paused = false;
-                        }).with_named_effect("auto-play", move |_ctx, _props, send| {
-                            let handle = set_interval(move || send(Event::AutoPlayTick), interval);
-                            Box::new(move || clear_interval(handle))
-                        }));
-                    }
+                if ctx.auto_play_paused && !ctx.auto_play_stopped && ctx.auto_play.is_some() {
+                    return Some(TransitionPlan::to(State::AutoPlaying).apply(|ctx| {
+                        ctx.auto_play_paused = false;
+                    }).with_effect(PendingEffect::named(Effect::AutoPlayTimer)));
                 }
                 None
             }
@@ -647,7 +678,7 @@ impl<'a> Api<'a> {
         attrs
     }
 
-    pub fn autoplay_indicator_attrs(&self) -> AttrMap {
+    pub fn auto_play_indicator_attrs(&self) -> AttrMap {
         let mut attrs = AttrMap::new();
         let [(scope_attr, scope_val), (part_attr, part_val)] = Part::AutoPlayIndicator.data_attrs();
         attrs.set(scope_attr, scope_val);
@@ -733,7 +764,7 @@ impl ConnectApi for Api<'_> {
             Part::IndicatorGroup => self.indicator_group_attrs(),
             Part::Indicator { index } => self.indicator_attrs(index),
             Part::AutoPlayTrigger => self.auto_play_trigger_attrs(),
-            Part::AutoPlayIndicator => self.autoplay_indicator_attrs(),
+            Part::AutoPlayIndicator => self.auto_play_indicator_attrs(),
             Part::ProgressText => self.progress_text_attrs(),
         }
     }
@@ -815,12 +846,16 @@ RTL: Arrow keys reverse per `03-accessibility.md` §4.1.
 ### 4.1 Messages
 
 ```rust
-#[derive(Clone, Debug)]
+/// Closure type for the slide label message (factored into a type alias to
+/// satisfy the workspace `clippy::type_complexity` lint).
+pub type SlideLabelFn = dyn Fn(usize, usize, &Locale) -> String + Send + Sync;
+
+#[derive(Clone, Debug, PartialEq)]
 pub struct Messages {
     pub carousel_label: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
     pub role_description: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
     pub slide_role_description: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
-    pub slide_label: MessageFn<dyn Fn(usize, usize, &Locale) -> String + Send + Sync>,
+    pub slide_label: MessageFn<SlideLabelFn>,
     pub prev_label: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
     pub next_label: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
     pub pause_auto_play_label: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,

--- a/spec/components/layout/carousel.md
+++ b/spec/components/layout/carousel.md
@@ -65,6 +65,10 @@ pub enum Event {
     FocusSlide { index: usize },
     /// Focus left the carousel.
     Blur,
+    /// The parent pushed a new controlled `index` value through `set_props`.
+    /// Emitted by `on_props_changed` so the stored `Bindable` tracks the
+    /// controlled signal without animating or stopping auto-play.
+    SyncControlledIndex { index: usize },
 }
 ```
 
@@ -329,9 +333,16 @@ impl ars_core::Machine for Machine {
         } else {
             State::Idle
         };
+        // Normalize `slides_per_view`: a non-finite or non-positive value would
+        // make `track_offset_percent` divide by zero/NaN, so fall back to one.
+        let slides_per_view = props.slides_per_view
+            .filter(|value| value.is_finite() && *value > 0.0)
+            .unwrap_or(1.0);
+        // `slides_per_move` of zero makes every navigation a no-op, so clamp to one.
+        let slides_per_move = props.slides_per_move.unwrap_or(1).max(1);
         // Clamp the uncontrolled default to the last valid starting index so
         // `current_index < slide_count` holds from the first render.
-        let visible_count = (props.slides_per_view.unwrap_or(1.0).ceil() as usize).max(1);
+        let visible_count = (slides_per_view.ceil() as usize).max(1);
         let max_index = props.slide_count.get().saturating_sub(visible_count);
         let initial_index = props.default_index.unwrap_or(0).min(max_index);
         let locale = env.locale.clone();
@@ -345,8 +356,8 @@ impl ars_core::Machine for Machine {
             auto_play_stopped: false,
             auto_play_paused: false,
             spacing: props.spacing.unwrap_or(0.0),
-            slides_per_view: props.slides_per_view.unwrap_or(1.0),
-            slides_per_move: props.slides_per_move.unwrap_or(1),
+            slides_per_view,
+            slides_per_move,
             align: props.align.unwrap_or_default(),
             orientation: props.orientation.unwrap_or_default(),
             is_rtl: props.is_rtl,
@@ -378,6 +389,20 @@ impl ars_core::Machine for Machine {
         } else {
             Vec::new()
         }
+    }
+
+    fn on_props_changed(old: &Self::Props, new: &Self::Props) -> Vec<Self::Event> {
+        assert_eq!(old.id, new.id, "carousel::Props.id must remain stable after initialization");
+        // In controlled mode the parent owns the index and pushes new values
+        // through `set_props`. Forward a changed controlled value so the stored
+        // `Bindable` tracks it (otherwise the active slide, progress text, and
+        // indicators stay stuck on the initial controlled value).
+        let old_index = old.index.as_ref().map(|bindable| *bindable.get());
+        let new_index = new.index.as_ref().map(|bindable| *bindable.get());
+        if old_index != new_index && let Some(index) = new_index {
+            return vec![Event::SyncControlledIndex { index }];
+        }
+        Vec::new()
     }
 
     fn transition(
@@ -432,7 +457,10 @@ impl ars_core::Machine for Machine {
             }
 
             Event::AutoPlayTick => {
-                if *state != State::AutoPlaying { return None; }
+                // Ignore ticks that cannot advance: at the final non-looping
+                // page entering `Transitioning` risks a missing `transitionend`
+                // (the transform never changes) leaving the machine stuck.
+                if *state != State::AutoPlaying || !ctx.can_go_next() { return None; }
                 let step = ctx.slides_per_move as isize;
                 let next = ctx.clamp_index(ctx.current_index() as isize + step);
                 Some(TransitionPlan::to(State::Transitioning).apply(move |ctx| {
@@ -537,12 +565,26 @@ impl ars_core::Machine for Machine {
             }
 
             Event::PointerCancel => {
-                Some(TransitionPlan::context_only(|ctx| {
+                // The drag is aborted (touch scroll / pointer-capture loss).
+                // `PointerDown` cancelled the timer, so re-arm it if the gesture
+                // interrupted an active auto-play carousel — otherwise rotation
+                // silently dies while the state still reads `AutoPlaying`.
+                let resume = ctx.drag_start_pos.is_some()
+                    && ctx.auto_play.is_some()
+                    && !ctx.auto_play_stopped
+                    && !ctx.auto_play_paused;
+                let mut plan = if resume {
+                    TransitionPlan::to(State::AutoPlaying)
+                } else {
+                    TransitionPlan::new()
+                }.apply(|ctx| {
                     ctx.drag_start_pos = None;
                     ctx.drag_delta = 0.0;
                     ctx.swipe_velocity = 0.0;
                     ctx.drag_last_timestamp = None;
-                }))
+                });
+                if resume { plan = plan.with_effect(PendingEffect::named(Effect::AutoPlayTimer)); }
+                Some(plan)
             }
 
             Event::FocusSlide { index } => {
@@ -578,6 +620,15 @@ impl ars_core::Machine for Machine {
                     }).with_effect(PendingEffect::named(Effect::AutoPlayTimer)));
                 }
                 None
+            }
+
+            Event::SyncControlledIndex { index } => {
+                // Push the parent's controlled value into the stored bindable
+                // without animating or stopping auto-play. Clamp defensively.
+                let idx = (*index).min(ctx.last_index());
+                Some(TransitionPlan::context_only(move |ctx| {
+                    ctx.index.sync_controlled(Some(idx));
+                }))
             }
         }
     }
@@ -748,7 +799,9 @@ impl<'a> Api<'a> {
         let [(scope_attr, scope_val), (part_attr, part_val)] = Part::AutoPlayTrigger.data_attrs();
         attrs.set(scope_attr, scope_val);
         attrs.set(part_attr, part_val);
-        let is_playing = !self.ctx.auto_play_stopped && !self.ctx.auto_play_paused;
+        let is_playing = self.ctx.auto_play.is_some()
+            && !self.ctx.auto_play_stopped
+            && !self.ctx.auto_play_paused;
         let label = if is_playing {
             (self.ctx.messages.pause_auto_play_label)(&self.ctx.locale)
         } else {
@@ -764,7 +817,9 @@ impl<'a> Api<'a> {
         let [(scope_attr, scope_val), (part_attr, part_val)] = Part::AutoPlayIndicator.data_attrs();
         attrs.set(scope_attr, scope_val);
         attrs.set(part_attr, part_val);
-        let is_playing = !self.ctx.auto_play_stopped && !self.ctx.auto_play_paused;
+        let is_playing = self.ctx.auto_play.is_some()
+            && !self.ctx.auto_play_stopped
+            && !self.ctx.auto_play_paused;
         attrs.set(HtmlAttr::Data("ars-state"), if is_playing { "playing" } else { "paused" });
         attrs.set(HtmlAttr::Aria(AriaAttr::Hidden), "true");
         attrs

--- a/spec/components/layout/carousel.md
+++ b/spec/components/layout/carousel.md
@@ -69,6 +69,10 @@ pub enum Event {
     PointerUp,
     /// Pointer cancelled (drag abort).
     PointerCancel,
+    /// Keyboard focus entered the carousel on a control (Prev/Next, indicator,
+    /// auto-play trigger) rather than a slide. Pauses auto-play when
+    /// `pause_on_focus` is set, without changing the index.
+    FocusEnter,
     /// A slide received focus.
     FocusSlide { index: usize },
     /// Focus left the carousel.
@@ -522,7 +526,12 @@ impl ars_core::Machine for Machine {
 
             Event::TransitionEnd => {
                 if ctx.auto_play.is_some() && !ctx.auto_play_stopped && !ctx.is_auto_play_paused() {
-                    Some(TransitionPlan::to(State::AutoPlaying))
+                    // Always re-arm the timer on entering AutoPlaying: a swipe
+                    // cancelled it on PointerDown and kept it cancelled through
+                    // the snap, so settling here must restart it (otherwise the
+                    // controls report "playing" with no interval running).
+                    Some(TransitionPlan::to(State::AutoPlaying)
+                        .with_effect(PendingEffect::named(Effect::AutoPlayTimer)))
                 } else {
                     Some(TransitionPlan::to(State::Idle))
                 }
@@ -626,6 +635,10 @@ impl ars_core::Machine for Machine {
             }
 
             Event::PointerDown { pos, timestamp } => {
+                // Don't start a drag mid-snap (a slide animation is running);
+                // accepting one would let rapid pointer input skip slides, the
+                // same way button/keyboard nav is blocked during `Transitioning`.
+                if *state == State::Transitioning { return None; }
                 let p = *pos;
                 let ts = *timestamp;
                 Some(TransitionPlan::context_only(move |ctx| {
@@ -657,6 +670,18 @@ impl ars_core::Machine for Machine {
                 // the resume logic (which would re-arm a timer that was never
                 // cancelled, creating duplicate intervals).
                 ctx.drag_start_pos?;
+
+                // Never navigate mid-snap: a release while a slide animation is
+                // running just clears the drag (button/keyboard nav is blocked
+                // the same way); the in-flight transition settles on its own.
+                if *state == State::Transitioning {
+                    return Some(TransitionPlan::context_only(|ctx| {
+                        ctx.drag_start_pos = None;
+                        ctx.drag_delta = 0.0;
+                        ctx.swipe_velocity = 0.0;
+                        ctx.drag_last_timestamp = None;
+                    }));
+                }
 
                 let delta = ctx.drag_delta;
                 let velocity = ctx.swipe_velocity;
@@ -736,6 +761,19 @@ impl ars_core::Machine for Machine {
                 });
                 if resume { plan = plan.with_effect(PendingEffect::named(Effect::AutoPlayTimer)); }
                 Some(plan)
+            }
+
+            Event::FocusEnter => {
+                // Focus entered a control (not a slide). Pause when
+                // `pause_on_focus` is set, without moving the index; `Blur`
+                // resumes on focus-out.
+                if !ctx.auto_play.as_ref().is_some_and(|o| o.pause_on_focus) { return None; }
+                let plan = if *state == State::AutoPlaying {
+                    TransitionPlan::to(State::Idle)
+                } else {
+                    TransitionPlan::new()
+                };
+                Some(plan.apply(|ctx| { ctx.auto_play_paused_focus = true; }).cancel_effect(Effect::AutoPlayTimer))
             }
 
             Event::FocusSlide { index } => {
@@ -1082,7 +1120,7 @@ impl<'a> Api<'a> {
             k if k == next_key => (self.send)(Event::GoToNext),
             KeyboardKey::Home => (self.send)(Event::GoToSlide { index: 0 }),
             KeyboardKey::End => (self.send)(Event::GoToSlide {
-                index: self.ctx.last_index(),
+                index: self.ctx.max_start_index(),
             }),
             _ => {}
         }
@@ -1105,6 +1143,10 @@ impl<'a> Api<'a> {
     pub fn on_root_pointer_enter(&self) { (self.send)(Event::HoverStart); }
     /// Pointer left the carousel; resumes a hover pause.
     pub fn on_root_pointer_leave(&self) { (self.send)(Event::HoverEnd); }
+    /// Focus entered the carousel on a control; pauses when `pause_on_focus`.
+    pub fn on_root_focus_in(&self) { (self.send)(Event::FocusEnter); }
+    /// Focus left the carousel; resumes a focus pause.
+    pub fn on_root_focus_out(&self) { (self.send)(Event::Blur); }
     pub fn on_viewport_pointerdown(&self, pos: f64, timestamp: f64) {
         (self.send)(Event::PointerDown { pos, timestamp });
     }
@@ -1206,7 +1248,7 @@ Arrow-key navigation applies only to keydowns the carousel owns. Because the agn
 ### 3.3 Screen Reader Announcements
 
 - `aria-live` on `ItemGroup` is `"off"` during auto-play to prevent disruptive announcements, and `"polite"` when paused or stopped.
-- Auto-play pauses on hover (`mouseenter` → `HoverStart`) when `AutoPlayOptions::pause_on_hover` is set, and on focus within the carousel (`focusin` → `FocusSlide`) when `pause_on_focus` is set. Each gate is enforced in the core, not the adapter. Rotation resumes on `mouseleave` / `focusout` (`HoverEnd` / `Blur`) unless permanently stopped. The auto-play trigger button's manual pause (`AutoPlayPause`) is unconditional and independent of these options.
+- Auto-play pauses on hover (`mouseenter` → `HoverStart`) when `AutoPlayOptions::pause_on_hover` is set, and on focus within the carousel when `pause_on_focus` is set — `focusin` on a slide → `FocusSlide`, on a control (Prev/Next, indicators, auto-play trigger) → `FocusEnter`. Each gate is enforced in the core, not the adapter. Rotation resumes on `mouseleave` / `focusout` (`HoverEnd` / `Blur`) unless permanently stopped. The auto-play trigger button's manual pause (`AutoPlayPause`) is unconditional and independent of these options.
 - Slides **outside the visible window** (`current_index` through `current_index + ceil(slides_per_view)`, wrapping when `loop_nav` is set) receive both `aria-hidden="true"` and `inert`, ensuring off-screen slides are invisible to assistive technology. With `slides_per_view > 1` every on-screen slide stays accessible — only the leading slide carries `data-ars-active`.
 
 ## 4. Internationalization

--- a/spec/components/layout/carousel.md
+++ b/spec/components/layout/carousel.md
@@ -221,6 +221,13 @@ impl Context {
         }
     }
 
+    /// Clamp/wrap an absolute `usize` target (direct `GoToSlide`/`FocusSlide`)
+    /// without routing through `as isize`, so a target above `isize::MAX`
+    /// saturates (non-loop) or wraps (loop) instead of overflowing negative.
+    pub fn clamp_index_usize(&self, index: usize) -> usize {
+        if self.loop_nav { index % self.slide_count.get() } else { index.min(self.last_index()) }
+    }
+
     // Always `false` when `last_index() == 0` (one slide, or `slides_per_view`
     // already shows them all): no distinct target exists, even when looping.
     pub fn can_go_prev(&self) -> bool {
@@ -506,7 +513,7 @@ impl ars_core::Machine for Machine {
                 // selectable, including past `last_index`), saturates at
                 // `last_index` otherwise. A direct jump is a manual interaction,
                 // so it honours `stop_on_interaction` like Next/Prev.
-                let idx = ctx.clamp_index(*index as isize);
+                let idx = ctx.clamp_index_usize(*index);
                 navigate_to(ctx, idx)
             }
 
@@ -783,7 +790,7 @@ impl ars_core::Machine for Machine {
                 let scroll = !ctx.is_slide_visible(*index);
                 // Clamp via `clamp_index` (wraps under `loop_nav`, saturates at
                 // `last_index` otherwise), matching `GoToSlide`.
-                let idx = ctx.clamp_index(*index as isize);
+                let idx = ctx.clamp_index_usize(*index);
                 let should_pause = ctx.auto_play.as_ref().is_some_and(|o| o.pause_on_focus);
                 if should_pause {
                     // Pausing on focus mirrors `AutoPlayPause`: leave
@@ -831,16 +838,23 @@ impl ars_core::Machine for Machine {
                 let new_auto = props.auto_play.clone();
                 let auto_changed = ctx.auto_play != new_auto;
                 let want_timer = new_auto.is_some() && !ctx.auto_play_stopped && !ctx.is_auto_play_paused();
-                // Only the auto-play transition moves the resting state.
-                let target = if auto_changed {
-                    if want_timer { State::AutoPlaying }
-                    else if *state == State::AutoPlaying { State::Idle }
-                    else { *state }
+                // Resting target. Never exit an in-flight `Transitioning` snap
+                // (that would accept ticks/nav before the adapter's
+                // `TransitionEnd`); it settles + re-arms on its own.
+                let target = if *state == State::Transitioning {
+                    State::Transitioning
+                } else if want_timer {
+                    State::AutoPlaying
                 } else {
-                    *state
+                    State::Idle
                 };
+                // Only emit a transition when the state changes: a no-op
+                // `to(current)` still flags `state_changed`, and the adapter
+                // drains active effect cleanups on any state change — silently
+                // killing the running interval on an unrelated prop change.
+                let changes_state = target != *state;
                 let props = props.clone();
-                let mut plan = TransitionPlan::to(target).apply(move |ctx| {
+                let apply = move |ctx: &mut Context| {
                     let slides_per_view = props.slides_per_view
                         .filter(|value| value.is_finite() && *value > 0.0)
                         .unwrap_or(1.0);
@@ -856,14 +870,15 @@ impl ars_core::Machine for Machine {
                     ctx.transition_duration = props.transition_duration
                         .unwrap_or_else(|| Duration::from_millis(300));
                     ctx.swipe_threshold = props.swipe_threshold.unwrap_or(50.0);
-                    // Track the controlled signal (clamped to the largest
-                    // reachable start, loop-aware); `None` returns to uncontrolled.
+                    // Capture the displayed index (controlled value while
+                    // controlled) before clearing control, so releasing control
+                    // preserves it instead of revealing a stale internal.
+                    let displayed = ctx.current_index();
                     let controlled = props.index.as_ref()
                         .map(|bindable| (*bindable.get()).min(ctx.max_start_index()));
                     ctx.index.sync_controlled(controlled);
                     if !ctx.index.is_controlled() {
-                        let clamped = ctx.current_index().min(ctx.max_start_index());
-                        ctx.index.set(clamped);
+                        ctx.index.set(displayed.min(ctx.max_start_index()));
                     }
                     if ctx.auto_play.is_none() {
                         ctx.auto_play_paused_manual = false;
@@ -871,10 +886,27 @@ impl ars_core::Machine for Machine {
                         ctx.auto_play_paused_focus = false;
                         ctx.auto_play_stopped = false;
                     }
-                });
-                if auto_changed {
-                    plan = plan.cancel_effect(Effect::AutoPlayTimer);
-                    if want_timer { plan = plan.with_effect(PendingEffect::named(Effect::AutoPlayTimer)); }
+                };
+                let mut plan = if changes_state {
+                    TransitionPlan::to(target).apply(apply)
+                } else {
+                    TransitionPlan::context_only(apply)
+                };
+                // Reconcile the timer to match `target`.
+                match target {
+                    State::AutoPlaying => {
+                        // (Re)arm when the state change drained effects or the
+                        // config changed; otherwise the interval is still running.
+                        if changes_state || auto_changed {
+                            plan = plan.cancel_effect(Effect::AutoPlayTimer)
+                                .with_effect(PendingEffect::named(Effect::AutoPlayTimer));
+                        }
+                    }
+                    State::Idle => { plan = plan.cancel_effect(Effect::AutoPlayTimer); }
+                    State::Transitioning => {
+                        // Stay in the snap; `TransitionEnd` re-arms on settle.
+                        if !want_timer { plan = plan.cancel_effect(Effect::AutoPlayTimer); }
+                    }
                 }
                 Some(plan)
             }

--- a/spec/components/layout/carousel.md
+++ b/spec/components/layout/carousel.md
@@ -486,6 +486,11 @@ impl ars_core::Machine for Machine {
             }
 
             Event::AutoPlayPause => {
+                // Nothing to pause without auto-play configured. Guarding here
+                // (not just in the trigger handler) keeps a stray `paused` flag
+                // from being set while `auto_play` is `None`, which would
+                // suppress the timer if the parent later enables autoplay.
+                ctx.auto_play.as_ref()?;
                 let plan = if *state == State::AutoPlaying {
                     TransitionPlan::to(State::Idle)
                 } else {
@@ -495,18 +500,18 @@ impl ars_core::Machine for Machine {
             }
 
             Event::AutoPlayResume => {
+                // Nothing to resume without auto-play configured (the paused and
+                // stopped flags are only ever set while it is configured).
+                ctx.auto_play.as_ref()?;
                 // Resume is also the "restart" path the auto-play trigger
                 // dispatches when rotation was stopped (the trigger shows the
                 // "Start" label and sends `AutoPlayResume`), so it clears BOTH
                 // the paused and the stopped flags — otherwise a stopped
                 // carousel's start control would be inert.
-                if ctx.auto_play.is_some() {
-                    return Some(TransitionPlan::to(State::AutoPlaying).apply(|ctx| {
-                        ctx.auto_play_paused = false;
-                        ctx.auto_play_stopped = false;
-                    }).with_effect(PendingEffect::named(Effect::AutoPlayTimer)));
-                }
-                Some(TransitionPlan::context_only(|ctx| { ctx.auto_play_paused = false; }))
+                Some(TransitionPlan::to(State::AutoPlaying).apply(|ctx| {
+                    ctx.auto_play_paused = false;
+                    ctx.auto_play_stopped = false;
+                }).with_effect(PendingEffect::named(Effect::AutoPlayTimer)))
             }
 
             Event::PointerDown { pos, timestamp } => {
@@ -931,6 +936,9 @@ impl<'a> Api<'a> {
     pub fn on_next_trigger_click(&self) { (self.send)(Event::GoToNext); }
     pub fn on_indicator_click(&self, index: usize) { (self.send)(Event::GoToSlide { index }); }
     pub fn on_auto_play_trigger_click(&self) {
+        // No-op without auto-play configured: there is nothing to toggle, and
+        // dispatching `AutoPlayPause` would set a stale `paused` flag.
+        if self.ctx.auto_play.is_none() { return; }
         if self.ctx.auto_play_stopped || self.ctx.auto_play_paused {
             (self.send)(Event::AutoPlayResume);
         } else {

--- a/spec/components/layout/carousel.md
+++ b/spec/components/layout/carousel.md
@@ -33,7 +33,8 @@ pub enum State {
 ### 1.2 Events
 
 ```rust
-#[derive(Clone, Copy, Debug, PartialEq)]
+// Not `Copy` because `SyncProps` carries an owned `Props`.
+#[derive(Clone, Debug, PartialEq)]
 pub enum Event {
     /// Navigate to a specific slide by index.
     GoToSlide { index: usize },
@@ -65,10 +66,11 @@ pub enum Event {
     FocusSlide { index: usize },
     /// Focus left the carousel.
     Blur,
-    /// The parent pushed a new controlled `index` value through `set_props`.
-    /// Emitted by `on_props_changed` so the stored `Bindable` tracks the
-    /// controlled signal without animating or stopping auto-play.
-    SyncControlledIndex { index: usize },
+    /// The parent re-rendered with new `Props` (via `set_props`). Emitted by
+    /// `on_props_changed` so the machine re-derives its mutable configuration,
+    /// tracks the controlled `index` signal (including controlled→uncontrolled),
+    /// and reconciles the auto-play timer — all without animating.
+    SyncProps { props: Props },
 }
 ```
 
@@ -308,14 +310,19 @@ pub struct Machine;
 /// cancellation is essential: without it the adapter's recurring interval
 /// keeps running after rotation has "stopped", leaking the timer and
 /// dispatching ignored `AutoPlayTick`s.
-fn navigate_to(ctx: &Context, idx: usize) -> TransitionPlan<Machine> {
+///
+/// Returns `None` when `idx` equals the current index: the transform would not
+/// change, so the adapter has no CSS transition to report and `TransitionEnd`
+/// may never arrive — entering `Transitioning` would strand the machine.
+fn navigate_to(ctx: &Context, idx: usize) -> Option<TransitionPlan<Machine>> {
+    if idx == ctx.current_index() { return None; }
     let stop = ctx.auto_play.as_ref().is_some_and(|o| o.stop_on_interaction);
     let mut plan = TransitionPlan::to(State::Transitioning).apply(move |ctx| {
         ctx.index.set(idx);
         if stop { ctx.auto_play_stopped = true; }
     });
     if stop { plan = plan.cancel_effect(Effect::AutoPlayTimer); }
-    plan
+    Some(plan)
 }
 
 impl ars_core::Machine for Machine {
@@ -347,9 +354,14 @@ impl ars_core::Machine for Machine {
         let initial_index = props.default_index.unwrap_or(0).min(max_index);
         let locale = env.locale.clone();
         let messages = messages.clone();
+        // Clamp the controlled value too: a caller-supplied controlled `index`
+        // past `max_index` would start the machine out of range.
+        let index = match &props.index {
+            Some(controlled) => Bindable::controlled((*controlled.get()).min(max_index)),
+            None => Bindable::uncontrolled(initial_index),
+        };
         let ctx = Context {
-            index: props.index.clone()
-                .unwrap_or_else(|| Bindable::uncontrolled(initial_index)),
+            index,
             slide_count: props.slide_count,
             loop_nav: props.loop_nav,
             auto_play: props.auto_play.clone(),
@@ -393,16 +405,14 @@ impl ars_core::Machine for Machine {
 
     fn on_props_changed(old: &Self::Props, new: &Self::Props) -> Vec<Self::Event> {
         assert_eq!(old.id, new.id, "carousel::Props.id must remain stable after initialization");
-        // In controlled mode the parent owns the index and pushes new values
-        // through `set_props`. Forward a changed controlled value so the stored
-        // `Bindable` tracks it (otherwise the active slide, progress text, and
-        // indicators stay stuck on the initial controlled value).
-        let old_index = old.index.as_ref().map(|bindable| *bindable.get());
-        let new_index = new.index.as_ref().map(|bindable| *bindable.get());
-        if old_index != new_index && let Some(index) = new_index {
-            return vec![Event::SyncControlledIndex { index }];
+        // Any prop change re-syncs mutable configuration, the controlled-index
+        // signal, and the auto-play timer (see the `SyncProps` arm). Mirrors
+        // the `splitter` convention.
+        if old == new {
+            Vec::new()
+        } else {
+            vec![Event::SyncProps { props: new.clone() }]
         }
-        Vec::new()
     }
 
     fn transition(
@@ -419,21 +429,21 @@ impl ars_core::Machine for Machine {
                 // interaction, so it honours `stop_on_interaction` like
                 // Next/Prev (see `navigate_to`).
                 let idx = (*index).min(ctx.last_index());
-                Some(navigate_to(ctx, idx))
+                navigate_to(ctx, idx)
             }
 
             Event::GoToNext => {
                 if *state == State::Transitioning || !ctx.can_go_next() { return None; }
                 let step = ctx.slides_per_move as isize;
                 let next = ctx.clamp_index(ctx.current_index() as isize + step);
-                Some(navigate_to(ctx, next))
+                navigate_to(ctx, next)
             }
 
             Event::GoToPrev => {
                 if *state == State::Transitioning || !ctx.can_go_prev() { return None; }
                 let step = ctx.slides_per_move as isize;
                 let prev = ctx.clamp_index(ctx.current_index() as isize - step);
-                Some(navigate_to(ctx, prev))
+                navigate_to(ctx, prev)
             }
 
             Event::TransitionEnd => {
@@ -446,7 +456,11 @@ impl ars_core::Machine for Machine {
 
             Event::AutoPlayStart => {
                 if ctx.auto_play_stopped || ctx.auto_play.is_none() { return None; }
+                // Clear any prior pause: starting auto-play means it is now
+                // actively rotating, so the paused live-region mode and
+                // `aria-pressed="false"` must not linger.
                 Some(TransitionPlan::to(State::AutoPlaying)
+                    .apply(|ctx| { ctx.auto_play_paused = false; })
                     .with_effect(PendingEffect::named(Effect::AutoPlayTimer)))
             }
 
@@ -457,12 +471,15 @@ impl ars_core::Machine for Machine {
             }
 
             Event::AutoPlayTick => {
-                // Ignore ticks that cannot advance: at the final non-looping
-                // page entering `Transitioning` risks a missing `transitionend`
-                // (the transform never changes) leaving the machine stuck.
-                if *state != State::AutoPlaying || !ctx.can_go_next() { return None; }
+                if *state != State::AutoPlaying { return None; }
                 let step = ctx.slides_per_move as isize;
                 let next = ctx.clamp_index(ctx.current_index() as isize + step);
+                // Ignore ticks that would not move the track: the non-looping
+                // boundary and the looped no-op case (single slide, or
+                // `slides_per_move` a multiple of `slide_count`). Entering
+                // `Transitioning` with no transform change risks a missing
+                // `transitionend` that strands the machine.
+                if next == ctx.current_index() { return None; }
                 Some(TransitionPlan::to(State::Transitioning).apply(move |ctx| {
                     ctx.index.set(next);
                 }))
@@ -622,13 +639,56 @@ impl ars_core::Machine for Machine {
                 None
             }
 
-            Event::SyncControlledIndex { index } => {
-                // Push the parent's controlled value into the stored bindable
-                // without animating or stopping auto-play. Clamp defensively.
-                let idx = (*index).min(ctx.last_index());
-                Some(TransitionPlan::context_only(move |ctx| {
-                    ctx.index.sync_controlled(Some(idx));
-                }))
+            Event::SyncProps { props } => {
+                // Re-derive mutable configuration from the new props, track the
+                // controlled-index signal (including controlled→uncontrolled),
+                // and reconcile the auto-play timer — all without animating.
+                let new_auto = props.auto_play.clone();
+                let auto_changed = ctx.auto_play != new_auto;
+                let want_timer = new_auto.is_some() && !ctx.auto_play_stopped && !ctx.auto_play_paused;
+                // Only the auto-play transition moves the resting state.
+                let target = if auto_changed {
+                    if want_timer { State::AutoPlaying }
+                    else if *state == State::AutoPlaying { State::Idle }
+                    else { *state }
+                } else {
+                    *state
+                };
+                let props = props.clone();
+                let mut plan = TransitionPlan::to(target).apply(move |ctx| {
+                    let slides_per_view = props.slides_per_view
+                        .filter(|value| value.is_finite() && *value > 0.0)
+                        .unwrap_or(1.0);
+                    ctx.slide_count = props.slide_count;
+                    ctx.loop_nav = props.loop_nav;
+                    ctx.auto_play = props.auto_play.clone();
+                    ctx.spacing = props.spacing.unwrap_or(0.0);
+                    ctx.slides_per_view = slides_per_view;
+                    ctx.slides_per_move = props.slides_per_move.unwrap_or(1).max(1);
+                    ctx.align = props.align.unwrap_or_default();
+                    ctx.orientation = props.orientation.unwrap_or_default();
+                    ctx.is_rtl = props.is_rtl;
+                    ctx.transition_duration = props.transition_duration
+                        .unwrap_or_else(|| Duration::from_millis(300));
+                    ctx.swipe_threshold = props.swipe_threshold.unwrap_or(50.0);
+                    // Track the controlled signal (clamped); `None` returns to uncontrolled.
+                    let controlled = props.index.as_ref()
+                        .map(|bindable| (*bindable.get()).min(ctx.last_index()));
+                    ctx.index.sync_controlled(controlled);
+                    if !ctx.index.is_controlled() {
+                        let clamped = ctx.current_index().min(ctx.last_index());
+                        ctx.index.set(clamped);
+                    }
+                    if ctx.auto_play.is_none() {
+                        ctx.auto_play_paused = false;
+                        ctx.auto_play_stopped = false;
+                    }
+                });
+                if auto_changed {
+                    plan = plan.cancel_effect(Effect::AutoPlayTimer);
+                    if want_timer { plan = plan.with_effect(PendingEffect::named(Effect::AutoPlayTimer)); }
+                }
+                Some(plan)
             }
         }
     }

--- a/spec/components/layout/carousel.md
+++ b/spec/components/layout/carousel.md
@@ -200,6 +200,13 @@ impl Context {
         self.slide_count.get().saturating_sub(self.visible_count())
     }
 
+    /// Largest reachable starting index. Under `loop_nav` any slide can lead
+    /// (the window wraps), so `slide_count - 1`; otherwise the contain-scroll
+    /// `last_index`. Used to clamp caller-supplied (default/controlled) indices.
+    pub fn max_start_index(&self) -> usize {
+        if self.loop_nav { self.slide_count.get().saturating_sub(1) } else { self.last_index() }
+    }
+
     /// Clamp or wrap an index according to `loop_nav`.
     pub fn clamp_index(&self, i: isize) -> usize {
         let n = self.slide_count.get() as isize;
@@ -364,7 +371,14 @@ fn navigate_to(ctx: &Context, idx: usize) -> Option<TransitionPlan<Machine>> {
         })
         .with_effect(index_change_effect(idx));
     if stop { plan = plan.cancel_effect(Effect::AutoPlayTimer); }
-    Some(plan)
+    Some(settle_if_instant(ctx, plan))
+}
+
+/// A zero-length transition fires no `transitionend`, so the adapter never
+/// settles `Transitioning`. Self-dispatch `TransitionEnd` so the machine
+/// settles synchronously rather than stranding in `Transitioning`.
+fn settle_if_instant(ctx: &Context, plan: TransitionPlan<Machine>) -> TransitionPlan<Machine> {
+    if ctx.transition_duration.is_zero() { plan.then(Event::TransitionEnd) } else { plan }
 }
 
 /// Build the `Effect::IndexChange` notification carrying the newly requested
@@ -400,10 +414,15 @@ impl ars_core::Machine for Machine {
             .unwrap_or(1.0);
         // `slides_per_move` of zero makes every navigation a no-op, so clamp to one.
         let slides_per_move = props.slides_per_move.unwrap_or(1).max(1);
-        // Clamp the uncontrolled default to the last valid starting index so
-        // `current_index < slide_count` holds from the first render.
+        // Clamp the default/controlled index to the largest reachable start so
+        // `current_index < slide_count` holds from the first render — loop-aware
+        // (`slide_count - 1` under loop, else the contain-scroll last page).
         let visible_count = (slides_per_view.ceil() as usize).max(1);
-        let max_index = props.slide_count.get().saturating_sub(visible_count);
+        let max_index = if props.loop_nav {
+            props.slide_count.get().saturating_sub(1)
+        } else {
+            props.slide_count.get().saturating_sub(visible_count)
+        };
         let initial_index = props.default_index.unwrap_or(0).min(max_index);
         let locale = env.locale.clone();
         let messages = messages.clone();
@@ -542,9 +561,9 @@ impl ars_core::Machine for Machine {
                 // `Transitioning` with no transform change risks a missing
                 // `transitionend` that strands the machine.
                 if next == ctx.current_index() { return None; }
-                Some(TransitionPlan::to(State::Transitioning)
+                Some(settle_if_instant(ctx, TransitionPlan::to(State::Transitioning)
                     .apply(move |ctx| { ctx.index.set(next); })
-                    .with_effect(index_change_effect(next)))
+                    .with_effect(index_change_effect(next))))
             }
 
             Event::AutoPlayPause => {
@@ -656,35 +675,42 @@ impl ars_core::Machine for Machine {
                     None
                 };
 
-                // `PointerDown` cancelled the timer for the drag. Resolve
-                // rotation now the gesture ended: a navigating swipe with
-                // `stop_on_interaction` stops it; otherwise, if rotation was
-                // still active, re-arm the timer (resume) — without this a
-                // swipe silently kills rotation, or leaves the state reporting
-                // "playing" with no timer running.
-                let navigated = next_idx.is_some();
-                let stop = ctx.auto_play.as_ref().is_some_and(|o| o.stop_on_interaction);
-                let mark_stopped = navigated && stop;
+                // `PointerDown` cancelled the timer for the drag.
+                let target_idx = next_idx.filter(|&idx| idx != ctx.current_index());
+                if let Some(idx) = target_idx {
+                    // A navigating swipe animates through `Transitioning`, like
+                    // button/auto-play nav, so ticks and further navigation are
+                    // blocked until `TransitionEnd` (which then resumes auto-play
+                    // or stays `Idle` if `stop_on_interaction` stopped it).
+                    let stop = ctx.auto_play.as_ref().is_some_and(|o| o.stop_on_interaction);
+                    let plan = TransitionPlan::to(State::Transitioning)
+                        .apply(move |ctx| {
+                            ctx.drag_start_pos = None;
+                            ctx.drag_delta = 0.0;
+                            ctx.swipe_velocity = 0.0;
+                            ctx.drag_last_timestamp = None;
+                            ctx.index.set(idx);
+                            if stop { ctx.auto_play_stopped = true; }
+                        })
+                        .with_effect(index_change_effect(idx));
+                    return Some(settle_if_instant(ctx, plan));
+                }
+
+                // No navigation: reset the drag and resume auto-play if it was
+                // active (the timer was cancelled on `PointerDown`).
                 let resume = ctx.auto_play.is_some()
-                    && !mark_stopped
                     && !ctx.auto_play_stopped
                     && !ctx.is_auto_play_paused();
-                let target = if resume { State::AutoPlaying } else { State::Idle };
-                let index_changed = next_idx.is_some_and(|idx| idx != ctx.current_index());
-
-                let mut plan = TransitionPlan::to(target).apply(move |ctx| {
+                let mut plan = if resume {
+                    TransitionPlan::to(State::AutoPlaying)
+                } else {
+                    TransitionPlan::to(State::Idle)
+                }.apply(|ctx| {
                     ctx.drag_start_pos = None;
                     ctx.drag_delta = 0.0;
                     ctx.swipe_velocity = 0.0;
                     ctx.drag_last_timestamp = None;
-                    if let Some(idx) = next_idx {
-                        ctx.index.set(idx);
-                    }
-                    if mark_stopped { ctx.auto_play_stopped = true; }
                 });
-                if index_changed && let Some(idx) = next_idx {
-                    plan = plan.with_effect(index_change_effect(idx));
-                }
                 if resume { plan = plan.with_effect(PendingEffect::named(Effect::AutoPlayTimer)); }
                 Some(plan)
             }
@@ -792,12 +818,13 @@ impl ars_core::Machine for Machine {
                     ctx.transition_duration = props.transition_duration
                         .unwrap_or_else(|| Duration::from_millis(300));
                     ctx.swipe_threshold = props.swipe_threshold.unwrap_or(50.0);
-                    // Track the controlled signal (clamped); `None` returns to uncontrolled.
+                    // Track the controlled signal (clamped to the largest
+                    // reachable start, loop-aware); `None` returns to uncontrolled.
                     let controlled = props.index.as_ref()
-                        .map(|bindable| (*bindable.get()).min(ctx.last_index()));
+                        .map(|bindable| (*bindable.get()).min(ctx.max_start_index()));
                     ctx.index.sync_controlled(controlled);
                     if !ctx.index.is_controlled() {
-                        let clamped = ctx.current_index().min(ctx.last_index());
+                        let clamped = ctx.current_index().min(ctx.max_start_index());
                         ctx.index.set(clamped);
                     }
                     if ctx.auto_play.is_none() {
@@ -963,6 +990,7 @@ impl<'a> Api<'a> {
         attrs.set(scope_attr, scope_val);
         attrs.set(part_attr, part_val);
         attrs.set(HtmlAttr::Role, "tablist");
+        attrs.set(HtmlAttr::Aria(AriaAttr::Label), (self.ctx.messages.indicators_label)(&self.ctx.locale));
         attrs
     }
 
@@ -1032,6 +1060,12 @@ impl<'a> Api<'a> {
         )
     }
 
+    /// **Adapter contract:** the agnostic core cannot inspect the DOM event
+    /// target, so the adapter MUST only forward keydowns the carousel owns —
+    /// those targeting the carousel root/controls, not events bubbled from
+    /// interactive slide content (text inputs, sliders, nested widgets).
+    /// Otherwise `ArrowLeft`/`ArrowRight` typed into a slide's `<input>` would
+    /// be hijacked into slide navigation. Gate on the event target first.
     pub fn on_root_keydown(&self, data: &KeyboardEventData) {
         let is_horizontal = self.ctx.orientation == Orientation::Horizontal;
         let (prev_key, next_key) = if is_horizontal {
@@ -1167,6 +1201,8 @@ The carousel follows the [WAI-ARIA Carousel Pattern](https://www.w3.org/WAI/ARIA
 
 RTL: Arrow keys reverse per `03-accessibility.md` §4.1.
 
+Arrow-key navigation applies only to keydowns the carousel owns. Because the agnostic core cannot inspect the DOM event target, the adapter MUST gate `on_root_keydown` on the event target and not forward arrow keys bubbled from interactive slide content (text inputs, sliders, nested widgets), so typing inside a slide operates that control rather than navigating the carousel.
+
 ### 3.3 Screen Reader Announcements
 
 - `aria-live` on `ItemGroup` is `"off"` during auto-play to prevent disruptive announcements, and `"polite"` when paused or stopped.
@@ -1188,6 +1224,8 @@ pub struct Messages {
     pub role_description: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
     pub slide_role_description: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
     pub slide_label: MessageFn<SlideLabelFn>,
+    /// Accessible name for the indicator `tablist` (`aria-label` on `IndicatorGroup`).
+    pub indicators_label: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
     pub prev_label: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
     pub next_label: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
     pub pause_auto_play_label: MessageFn<dyn Fn(&Locale) -> String + Send + Sync>,
@@ -1201,6 +1239,7 @@ impl Default for Messages {
             role_description: MessageFn::static_str("carousel"),
             slide_role_description: MessageFn::static_str("slide"),
             slide_label: MessageFn::new(|index, total, _locale| format!("Slide {index} of {total}")),
+            indicators_label: MessageFn::static_str("Choose slide"),
             prev_label: MessageFn::static_str("Previous slide"),
             next_label: MessageFn::static_str("Next slide"),
             pause_auto_play_label: MessageFn::static_str("Pause automatic slide show"),

--- a/spec/components/layout/carousel.md
+++ b/spec/components/layout/carousel.md
@@ -135,8 +135,14 @@ pub struct Context {
     pub auto_play: Option<AutoPlayOptions>,
     /// Whether auto-play has been permanently stopped by user interaction.
     pub auto_play_stopped: bool,
-    /// Whether auto-play is temporarily paused (hover/focus).
-    pub auto_play_paused: bool,
+    /// Whether the auto-play trigger button manually paused rotation. Tracked
+    /// separately from hover/focus so a hover/focus exit never resumes a manual
+    /// pause. See `is_auto_play_paused`.
+    pub auto_play_paused_manual: bool,
+    /// Whether pointer hover currently pauses auto-play (`HoverStart`).
+    pub auto_play_paused_hover: bool,
+    /// Whether keyboard focus within the carousel pauses auto-play (`FocusSlide`).
+    pub auto_play_paused_focus: bool,
     /// Gap between slides in pixels.
     pub spacing: f64,
     /// Number of slides visible at once (fractional supported).
@@ -173,6 +179,12 @@ pub struct Context {
 
 impl Context {
     pub fn current_index(&self) -> usize { *self.index.get() }
+
+    /// Whether auto-play is temporarily paused by any source — the manual
+    /// trigger pause, a pointer hover, or keyboard focus.
+    pub const fn is_auto_play_paused(&self) -> bool {
+        self.auto_play_paused_manual || self.auto_play_paused_hover || self.auto_play_paused_focus
+    }
 
     /// Number of slide slots occupied at once, rounding a fractional
     /// `slides_per_view` up so a partially visible trailing slide still counts
@@ -407,7 +419,9 @@ impl ars_core::Machine for Machine {
             loop_nav: props.loop_nav,
             auto_play: props.auto_play.clone(),
             auto_play_stopped: false,
-            auto_play_paused: false,
+            auto_play_paused_manual: false,
+            auto_play_paused_hover: false,
+            auto_play_paused_focus: false,
             spacing: props.spacing.unwrap_or(0.0),
             slides_per_view,
             slides_per_move,
@@ -465,11 +479,11 @@ impl ars_core::Machine for Machine {
         match event {
             Event::GoToSlide { index } => {
                 if *state == State::Transitioning { return None; }
-                // A direct jump never wraps; clamp out-of-range targets to the
-                // last valid starting index. A direct jump is a manual
-                // interaction, so it honours `stop_on_interaction` like
-                // Next/Prev (see `navigate_to`).
-                let idx = (*index).min(ctx.last_index());
+                // Clamp via `clamp_index`: wraps under `loop_nav` (any slide
+                // selectable, including past `last_index`), saturates at
+                // `last_index` otherwise. A direct jump is a manual interaction,
+                // so it honours `stop_on_interaction` like Next/Prev.
+                let idx = ctx.clamp_index(*index as isize);
                 navigate_to(ctx, idx)
             }
 
@@ -488,7 +502,7 @@ impl ars_core::Machine for Machine {
             }
 
             Event::TransitionEnd => {
-                if ctx.auto_play.is_some() && !ctx.auto_play_stopped && !ctx.auto_play_paused {
+                if ctx.auto_play.is_some() && !ctx.auto_play_stopped && !ctx.is_auto_play_paused() {
                     Some(TransitionPlan::to(State::AutoPlaying))
                 } else {
                     Some(TransitionPlan::to(State::Idle))
@@ -501,7 +515,11 @@ impl ars_core::Machine for Machine {
                 // actively rotating, so the paused live-region mode and
                 // `aria-pressed="false"` must not linger.
                 Some(TransitionPlan::to(State::AutoPlaying)
-                    .apply(|ctx| { ctx.auto_play_paused = false; })
+                    .apply(|ctx| {
+                        ctx.auto_play_paused_manual = false;
+                        ctx.auto_play_paused_hover = false;
+                        ctx.auto_play_paused_focus = false;
+                    })
                     .with_effect(PendingEffect::named(Effect::AutoPlayTimer)))
             }
 
@@ -512,7 +530,10 @@ impl ars_core::Machine for Machine {
             }
 
             Event::AutoPlayTick => {
-                if *state != State::AutoPlaying { return None; }
+                // Drop ticks during a drag: `PointerDown` cancels the timer, but
+                // a callback queued just before could still fire and advance the
+                // slide under the pointer.
+                if *state != State::AutoPlaying || ctx.drag_start_pos.is_some() { return None; }
                 let step = ctx.slides_per_move as isize;
                 let next = ctx.clamp_index(ctx.current_index() as isize + step);
                 // Ignore ticks that would not move the track: the non-looping
@@ -537,7 +558,7 @@ impl ars_core::Machine for Machine {
                 } else {
                     TransitionPlan::new()
                 };
-                Some(plan.apply(|ctx| { ctx.auto_play_paused = true; }).cancel_effect(Effect::AutoPlayTimer))
+                Some(plan.apply(|ctx| { ctx.auto_play_paused_manual = true; }).cancel_effect(Effect::AutoPlayTimer))
             }
 
             Event::HoverStart => {
@@ -549,30 +570,38 @@ impl ars_core::Machine for Machine {
                 } else {
                     TransitionPlan::new()
                 };
-                Some(plan.apply(|ctx| { ctx.auto_play_paused = true; }).cancel_effect(Effect::AutoPlayTimer))
+                Some(plan.apply(|ctx| { ctx.auto_play_paused_hover = true; }).cancel_effect(Effect::AutoPlayTimer))
             }
 
             Event::HoverEnd => {
-                // Resume a hover/focus pause when the pointer leaves, mirroring `Blur`.
-                if ctx.auto_play_paused && !ctx.auto_play_stopped && ctx.auto_play.is_some() {
-                    return Some(TransitionPlan::to(State::AutoPlaying).apply(|ctx| {
-                        ctx.auto_play_paused = false;
-                    }).with_effect(PendingEffect::named(Effect::AutoPlayTimer)));
-                }
-                None
+                // Clear only the hover pause; resume only if no other source
+                // (manual trigger or focus) still holds it.
+                if !ctx.auto_play_paused_hover { return None; }
+                let resume = !ctx.auto_play_paused_manual
+                    && !ctx.auto_play_paused_focus
+                    && !ctx.auto_play_stopped
+                    && ctx.auto_play.is_some();
+                let mut plan = if resume {
+                    TransitionPlan::to(State::AutoPlaying)
+                } else {
+                    TransitionPlan::new()
+                }.apply(|ctx| { ctx.auto_play_paused_hover = false; });
+                if resume { plan = plan.with_effect(PendingEffect::named(Effect::AutoPlayTimer)); }
+                Some(plan)
             }
 
             Event::AutoPlayResume => {
-                // Nothing to resume without auto-play configured (the paused and
+                // Nothing to resume without auto-play configured (the pause and
                 // stopped flags are only ever set while it is configured).
                 ctx.auto_play.as_ref()?;
                 // Resume is also the "restart" path the auto-play trigger
-                // dispatches when rotation was stopped (the trigger shows the
-                // "Start" label and sends `AutoPlayResume`), so it clears BOTH
-                // the paused and the stopped flags — otherwise a stopped
-                // carousel's start control would be inert.
+                // dispatches when rotation was stopped; it clears every pause
+                // source AND the stopped flag — an explicit play request
+                // overrides hover/focus/manual pauses.
                 Some(TransitionPlan::to(State::AutoPlaying).apply(|ctx| {
-                    ctx.auto_play_paused = false;
+                    ctx.auto_play_paused_manual = false;
+                    ctx.auto_play_paused_hover = false;
+                    ctx.auto_play_paused_focus = false;
                     ctx.auto_play_stopped = false;
                 }).with_effect(PendingEffect::named(Effect::AutoPlayTimer)))
             }
@@ -639,7 +668,7 @@ impl ars_core::Machine for Machine {
                 let resume = ctx.auto_play.is_some()
                     && !mark_stopped
                     && !ctx.auto_play_stopped
-                    && !ctx.auto_play_paused;
+                    && !ctx.is_auto_play_paused();
                 let target = if resume { State::AutoPlaying } else { State::Idle };
                 let index_changed = next_idx.is_some_and(|idx| idx != ctx.current_index());
 
@@ -668,7 +697,7 @@ impl ars_core::Machine for Machine {
                 let resume = ctx.drag_start_pos.is_some()
                     && ctx.auto_play.is_some()
                     && !ctx.auto_play_stopped
-                    && !ctx.auto_play_paused;
+                    && !ctx.is_auto_play_paused();
                 let mut plan = if resume {
                     TransitionPlan::to(State::AutoPlaying)
                 } else {
@@ -688,9 +717,9 @@ impl ars_core::Machine for Machine {
                 // With `slides_per_view > 1`, tabbing into a visible non-leading
                 // slide must NOT shift the track under the user.
                 let scroll = !ctx.is_slide_visible(*index);
-                // Clamp to the last valid starting index so a slide near the end
-                // maps to the last full page rather than overscrolling.
-                let idx = (*index).min(ctx.last_index());
+                // Clamp via `clamp_index` (wraps under `loop_nav`, saturates at
+                // `last_index` otherwise), matching `GoToSlide`.
+                let idx = ctx.clamp_index(*index as isize);
                 let should_pause = ctx.auto_play.as_ref().is_some_and(|o| o.pause_on_focus);
                 if should_pause {
                     // Pausing on focus mirrors `AutoPlayPause`: leave
@@ -703,7 +732,7 @@ impl ars_core::Machine for Machine {
                     };
                     let mut plan = plan.apply(move |ctx| {
                         if scroll { ctx.index.set(idx); }
-                        ctx.auto_play_paused = true;
+                        ctx.auto_play_paused_focus = true;
                     }).cancel_effect(Effect::AutoPlayTimer);
                     if scroll { plan = plan.with_effect(index_change_effect(idx)); }
                     return Some(plan);
@@ -715,12 +744,20 @@ impl ars_core::Machine for Machine {
             }
 
             Event::Blur => {
-                if ctx.auto_play_paused && !ctx.auto_play_stopped && ctx.auto_play.is_some() {
-                    return Some(TransitionPlan::to(State::AutoPlaying).apply(|ctx| {
-                        ctx.auto_play_paused = false;
-                    }).with_effect(PendingEffect::named(Effect::AutoPlayTimer)));
-                }
-                None
+                // Clear only the focus pause; resume only if no other source
+                // (manual trigger or hover) still holds it.
+                if !ctx.auto_play_paused_focus { return None; }
+                let resume = !ctx.auto_play_paused_manual
+                    && !ctx.auto_play_paused_hover
+                    && !ctx.auto_play_stopped
+                    && ctx.auto_play.is_some();
+                let mut plan = if resume {
+                    TransitionPlan::to(State::AutoPlaying)
+                } else {
+                    TransitionPlan::new()
+                }.apply(|ctx| { ctx.auto_play_paused_focus = false; });
+                if resume { plan = plan.with_effect(PendingEffect::named(Effect::AutoPlayTimer)); }
+                Some(plan)
             }
 
             Event::SyncProps { props } => {
@@ -729,7 +766,7 @@ impl ars_core::Machine for Machine {
                 // and reconcile the auto-play timer — all without animating.
                 let new_auto = props.auto_play.clone();
                 let auto_changed = ctx.auto_play != new_auto;
-                let want_timer = new_auto.is_some() && !ctx.auto_play_stopped && !ctx.auto_play_paused;
+                let want_timer = new_auto.is_some() && !ctx.auto_play_stopped && !ctx.is_auto_play_paused();
                 // Only the auto-play transition moves the resting state.
                 let target = if auto_changed {
                     if want_timer { State::AutoPlaying }
@@ -764,7 +801,9 @@ impl ars_core::Machine for Machine {
                         ctx.index.set(clamped);
                     }
                     if ctx.auto_play.is_none() {
-                        ctx.auto_play_paused = false;
+                        ctx.auto_play_paused_manual = false;
+                        ctx.auto_play_paused_hover = false;
+                        ctx.auto_play_paused_focus = false;
                         ctx.auto_play_stopped = false;
                     }
                 });
@@ -859,7 +898,7 @@ impl<'a> Api<'a> {
         // paused (hover/focus) carousels announce manual changes politely.
         let live = if self.ctx.auto_play.is_none()
             || self.ctx.auto_play_stopped
-            || self.ctx.auto_play_paused
+            || self.ctx.is_auto_play_paused()
         {
             "polite"
         } else {
@@ -897,6 +936,7 @@ impl<'a> Api<'a> {
         let [(scope_attr, scope_val), (part_attr, part_val)] = Part::PrevTrigger.data_attrs();
         attrs.set(scope_attr, scope_val);
         attrs.set(part_attr, part_val);
+        attrs.set(HtmlAttr::Type, "button");
         attrs.set(HtmlAttr::Aria(AriaAttr::Label), (self.ctx.messages.prev_label)(&self.ctx.locale));
         if !self.ctx.can_go_prev() {
             attrs.set(HtmlAttr::Aria(AriaAttr::Disabled), "true");
@@ -909,6 +949,7 @@ impl<'a> Api<'a> {
         let [(scope_attr, scope_val), (part_attr, part_val)] = Part::NextTrigger.data_attrs();
         attrs.set(scope_attr, scope_val);
         attrs.set(part_attr, part_val);
+        attrs.set(HtmlAttr::Type, "button");
         attrs.set(HtmlAttr::Aria(AriaAttr::Label), (self.ctx.messages.next_label)(&self.ctx.locale));
         if !self.ctx.can_go_next() {
             attrs.set(HtmlAttr::Aria(AriaAttr::Disabled), "true");
@@ -931,6 +972,7 @@ impl<'a> Api<'a> {
             Part::Indicator { index }.data_attrs();
         attrs.set(scope_attr, scope_val);
         attrs.set(part_attr, part_val);
+        attrs.set(HtmlAttr::Type, "button");
         attrs.set(HtmlAttr::Role, "tab");
         attrs.set(HtmlAttr::Aria(AriaAttr::Selected),
             if index == self.ctx.current_index() { "true" } else { "false" },
@@ -943,9 +985,10 @@ impl<'a> Api<'a> {
         let [(scope_attr, scope_val), (part_attr, part_val)] = Part::AutoPlayTrigger.data_attrs();
         attrs.set(scope_attr, scope_val);
         attrs.set(part_attr, part_val);
+        attrs.set(HtmlAttr::Type, "button");
         let is_playing = self.ctx.auto_play.is_some()
             && !self.ctx.auto_play_stopped
-            && !self.ctx.auto_play_paused;
+            && !self.ctx.is_auto_play_paused();
         let label = if is_playing {
             (self.ctx.messages.pause_auto_play_label)(&self.ctx.locale)
         } else {
@@ -963,7 +1006,7 @@ impl<'a> Api<'a> {
         attrs.set(part_attr, part_val);
         let is_playing = self.ctx.auto_play.is_some()
             && !self.ctx.auto_play_stopped
-            && !self.ctx.auto_play_paused;
+            && !self.ctx.is_auto_play_paused();
         attrs.set(HtmlAttr::Data("ars-state"), if is_playing { "playing" } else { "paused" });
         attrs.set(HtmlAttr::Aria(AriaAttr::Hidden), "true");
         attrs
@@ -1018,7 +1061,7 @@ impl<'a> Api<'a> {
         // No-op without auto-play configured: there is nothing to toggle, and
         // dispatching `AutoPlayPause` would set a stale `paused` flag.
         if self.ctx.auto_play.is_none() { return; }
-        if self.ctx.auto_play_stopped || self.ctx.auto_play_paused {
+        if self.ctx.auto_play_stopped || self.ctx.is_auto_play_paused() {
             (self.send)(Event::AutoPlayResume);
         } else {
             (self.send)(Event::AutoPlayPause);
@@ -1034,6 +1077,8 @@ impl<'a> Api<'a> {
     pub fn on_viewport_pointermove(&self, pos: f64, timestamp: f64) {
         (self.send)(Event::PointerMove { pos, timestamp });
     }
+    /// Gesture aborted by the browser (pointer-capture loss / touch-scroll).
+    pub fn on_viewport_pointercancel(&self) { (self.send)(Event::PointerCancel); }
     pub fn on_viewport_pointerup(&self) { (self.send)(Event::PointerUp); }
 }
 
@@ -1081,11 +1126,11 @@ Carousel
 | Viewport          | `<div>`     | `overflow:hidden`, `touch-action`                       |
 | ItemGroup         | `<div>`     | `aria-live="off\|polite"`                               |
 | Item              | `<div>`     | `role="group"`, `aria-roledescription="slide"`, `inert` |
-| PrevTrigger       | `<button>`  | `aria-disabled` when at boundary                        |
-| NextTrigger       | `<button>`  | `aria-disabled` when at boundary                        |
+| PrevTrigger       | `<button>`  | `type="button"`, `aria-disabled` when at boundary       |
+| NextTrigger       | `<button>`  | `type="button"`, `aria-disabled` when at boundary       |
 | IndicatorGroup    | `<div>`     | `role="tablist"`                                        |
-| Indicator         | `<button>`  | `role="tab"`, `aria-selected`                           |
-| AutoPlayTrigger   | `<button>`  | `aria-pressed`                                          |
+| Indicator         | `<button>`  | `type="button"`, `role="tab"`, `aria-selected`          |
+| AutoPlayTrigger   | `<button>`  | `type="button"`, `aria-pressed`                         |
 | AutoPlayIndicator | `<div>`     | `aria-hidden="true"`, `data-ars-state`                  |
 | ProgressText      | `<div>`     | `aria-live="polite"`, `aria-atomic="true"`              |
 


### PR DESCRIPTION
Implements the framework-agnostic `Carousel` state machine in `ars-components` (epic #226).

## What
- **State machine** (`Idle`/`AutoPlaying`/`Transitioning`): slide navigation (`next`/`prev`/`goto`, `slides_per_move` paging), loop-wrap, auto-play with pause-on-hover/focus, momentum swipe computed from adapter-injected pointer deltas, and RTL-aware keyboard navigation.
- **ConnectApi / anatomy**: all 11 WAI-ARIA carousel parts (`Root`, `Viewport`, `ItemGroup`, `Item`, `Prev/NextTrigger`, `IndicatorGroup`, `Indicator`, `AutoPlayTrigger`, `AutoPlayIndicator`, `ProgressText`) with `role`/`aria-roledescription`/`aria-live`/`inert`/`aria-selected`/`aria-pressed` output.
- **Auto-play timing as adapter intent**: surfaced as a typed `Effect::AutoPlayTimer` marker (toast/dialog/popover convention) and armed on mount via an `initial_effects` override. The agnostic core never calls timer or DOM APIs and never looks up DOM nodes by id.

## Spec synchronization (landed here)
`spec/components/layout/carousel.md` §1.5/§4.1:
- Replaced direct `set_interval`/`clear_interval` machine code with the `Effect` enum + `PendingEffect::named`/`cancel_effect` and an `initial_effects` override.
- Fixed imports (`core::time::Duration`, `ars_core::Bindable`), added `PartialEq` to `Messages`, factored the slide-label closure into `SlideLabelFn` (clippy `type_complexity`).
- Saturating-clamp out-of-range `GoToSlide`/`FocusSlide` indices so `current_index < slide_count` always holds; switched `map_or(false, ..)` → `is_some_and`.

## Tests
- Spec-conformance anatomy test (11 parts).
- 82 unit + snapshot tests; 22 committed `.snap` fixtures covering every anatomy part and each output-affecting state/prop/context branch (`cargo insta --unreferenced=reject` clean).
- Proptest asserting index/drag invariants across random event sequences (out-of-range nav included to exercise the clamp).

## Verification
- `cargo xci-fast`: all 10 steps pass.
- `ars-components` coverage: 98.4% line / 90.1% branch (residual uncovered are `|_| {}` no-op test closures).
- post-implementation-audit ran all three phases; every finding landed in this PR.

Closes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)