### PR TITLE
Harden adapter outcome parity workflow

### DIFF
--- a/docs/implementation/adapter-component-delivery.md
+++ b/docs/implementation/adapter-component-delivery.md
@@ -15,6 +15,7 @@ The detailed workflow is split across:
 - [adapter-components/04-adapter-tests.md](adapter-components/04-adapter-tests.md)
 - [adapter-components/05-e2e-fixtures-and-harnesses.md](adapter-components/05-e2e-fixtures-and-harnesses.md)
 - [adapter-components/06-widgets-examples.md](adapter-components/06-widgets-examples.md)
+- [adapter-components/09-browser-parity-harness.md](adapter-components/09-browser-parity-harness.md)
 - [adapter-components/08-validation-and-pr-closeout.md](adapter-components/08-validation-and-pr-closeout.md)
 - [adapter-components/checklists/component-delivery.md](adapter-components/checklists/component-delivery.md)
 - [adapter-components/checklists/e2e-feature-matrix.md](adapter-components/checklists/e2e-feature-matrix.md)
@@ -42,6 +43,8 @@ Adapter delivery spans several distinct concerns:
 - adapter SSR/unit and wasm browser tests;
 - E2E fixtures, harnesses, matrix entries, axe, and computed visual assertions;
 - public widgets demos in all six example crates;
+- repeatable browser evidence with `playwright-cli` comparing the local widgets
+  page against the chosen counterpart;
 - validation, audit, PR, CI, and Codex review closeout.
 
 Keeping these directions as separate files makes it easier to review the
@@ -54,16 +57,17 @@ inspect the live documentation page for the strongest counterpart, using this
 preference order:
 
 1. React Aria / React Spectrum;
-2. Ark UI;
-3. Radix UI;
+2. Ark UI / Chakra UI;
+3. Radix UI / shadcn/ui;
 4. another mature component library only when the first three do not cover the
    primitive or feature axis.
 
-Adapter-level components target maximum practical parity with that reference,
-not merely minimum spec completion. The counterpart's simplest example sets the
-minimum UX quality bar for the first widgets demo, and every supported
-counterpart feature must map to agnostic logic, adapter wiring, adapter tests,
-E2E assertions, and widgets visual coverage in the same PR.
+Adapter-level components target maximum practical outcome parity with that
+reference, not API-shape parity with the reference framework and not merely
+minimum spec completion. The counterpart's simplest example sets the minimum UX
+quality bar for the first widgets demo, and every supported counterpart feature
+must map to agnostic logic, adapter wiring, adapter tests, E2E assertions,
+widgets visual coverage, and repeatable browser evidence in the same PR.
 
 Renderer-independent behavior belongs in `crates/ars-components` or another
 shared crate before adapter wiring. Duplicating selection, layout, drag/drop,
@@ -80,4 +84,4 @@ drag image setup may live in Leptos/Dioxus because it needs `DataTransfer`, but
 the dragged key set must come from `crates/ars-components`.
 
 For details, read [adapter-components/07-parity-review.md](adapter-components/07-parity-review.md)
-and [adapter-components/06-widgets-examples.md](adapter-components/06-widgets-examples.md).
+and [adapter-components/09-browser-parity-harness.md](adapter-components/09-browser-parity-harness.md).

--- a/docs/implementation/adapter-components/01-before-you-code.md
+++ b/docs/implementation/adapter-components/01-before-you-code.md
@@ -73,13 +73,15 @@ Before planning the adapter API or examples, inspect the live documentation page
 for the strongest mature counterpart in this order:
 
 1. React Aria / React Spectrum;
-2. Ark UI;
-3. Radix UI;
-4. another mature component library.
+2. Ark UI / Chakra UI;
+3. Radix UI / shadcn/ui;
+4. another mature component library only when the first three do not cover the
+   primitive or feature axis.
 
-The implementation target is maximum practical parity with that reference. Do
-not claim full parity unless the component spec contains a real feature matrix
-showing every supported, unsupported, and not-applicable axis with reasons.
+The implementation target is maximum practical outcome parity with that
+reference. Do not claim full parity unless the component spec contains a real
+feature matrix showing every supported, unsupported, and not-applicable axis
+with reasons.
 
 ## Planning Output
 
@@ -87,7 +89,7 @@ Every adapter implementation plan must include:
 
 - blocker-check command results;
 - spec files read;
-- counterpart UX brief source URLs and feature axes;
+- counterpart outcome matrix source URLs and feature axes;
 - shared agnostic work required before adapter wiring;
 - adapter crate deliverables;
 - adapter test deliverables;

--- a/docs/implementation/adapter-components/05-e2e-fixtures-and-harnesses.md
+++ b/docs/implementation/adapter-components/05-e2e-fixtures-and-harnesses.md
@@ -68,6 +68,8 @@ that axis is not applicable to the other adapter.
 
 If the adapter spec lists a feature and no E2E test function drives it, the
 coverage is incomplete.
+If the counterpart outcome matrix marks an axis as supported and no E2E test
+drives it, the parity claim is incomplete.
 
 ## Axe Across Visible States
 
@@ -99,6 +101,8 @@ Account for every axis:
 - focus;
 - state;
 - forms;
+- validation;
+- hover and press;
 - visual;
 - accessibility;
 - lifecycle.
@@ -120,6 +124,8 @@ Prefer computed style and layout assertions:
 - popup anchoring;
 - selected, hovered, focused, disabled, invalid, loading, and drop-target
   feedback;
+- indeterminate, readonly, required, pressed, focus-visible, and form
+  validation feedback when supported;
 - clean browser console after representative interactions.
 
 Avoid brittle screenshot baselines unless rendering is deterministic enough to

--- a/docs/implementation/adapter-components/06-widgets-examples.md
+++ b/docs/implementation/adapter-components/06-widgets-examples.md
@@ -35,6 +35,8 @@ Each component demo panel should exercise the supported feature surface:
 - single and multiple selection;
 - disabled, readonly, invalid, selected, focused, active, loading, and empty
   states;
+- checked or selected, indeterminate, focus-visible, hovered, pressed,
+  required, form submit, and form reset states where relevant;
 - callbacks with visible readouts;
 - links and actions;
 - grouping or sections;
@@ -57,8 +59,11 @@ missing a required surface.
 
 ## Counterpart Baseline
 
-The first public demo should be visually comparable to the counterpart's
-simplest documented example. For React Aria GridList, that meant visible
+The first public demo should be visually comparable to the chosen
+counterpart's simplest documented example. React Aria / React Spectrum is the
+default counterpart when available; otherwise use Ark UI / Chakra UI, then
+Radix UI / shadcn/ui, then another mature library only when those do not cover
+the component or feature axis. For React Aria GridList, that meant visible
 checkboxes, row-wide selected feedback, and clear focus/selection affordances.
 
 Additional sections should cover supported advanced examples from the
@@ -83,6 +88,8 @@ Demo CSS must make features tangible:
 - drop targets should highlight the full placement area;
 - popup and overlay positioners should visibly anchor to their trigger;
 - controls should not shrink, shift, or overlap after state changes.
+- form submit and reset buttons should use ars-ui components when the demo is
+  proving ars-ui component integration.
 
 Honour `data-ars-visually-hidden`. Do not override hidden helper styles in demo
 CSS.
@@ -120,15 +127,19 @@ At minimum, widget smoke should:
 - navigate to the relevant category;
 - perform representative pointer and keyboard interactions;
 - assert clean browser console;
-- assert visible selected, active, open, disabled, invalid, loading, and drop
-  states where supported;
+- assert visible selected or checked, indeterminate, active, open, disabled,
+  readonly, invalid, required, focus-visible, hovered, pressed, loading, and
+  drop states where supported;
 - assert controls maintain stable dimensions;
 - assert hidden form inputs serialize values where relevant.
 
 ## Browser Review
 
-Before presenting the result, use the browser to compare the local widgets page
-with the counterpart docs used in the parity brief.
+Before presenting the result, use `playwright-cli` or an equivalent checked-in
+browser harness to compare the local widgets page with the counterpart docs used
+in the counterpart outcome matrix. Follow
+[09-browser-parity-harness.md](09-browser-parity-harness.md) for snapshots,
+computed style checks, console review, and artifact paths.
 
 Record in the PR body:
 

--- a/docs/implementation/adapter-components/07-parity-review.md
+++ b/docs/implementation/adapter-components/07-parity-review.md
@@ -4,17 +4,18 @@ Counterpart review is a design input, not a late checklist. The initial
 adapter, widgets examples, and E2E matrix should be shaped by the best
 available counterpart before implementation starts.
 
-The goal is maximum practical parity with the chosen reference implementation,
-not minimum spec completion. A PR must not say "full parity" unless the spec
-and PR body include a real parity matrix that proves it.
+The goal is maximum practical outcome parity with the chosen reference
+implementation, not framework API parity and not minimum spec completion. A PR
+must not say "full parity" unless the spec and PR body include a real parity
+matrix that proves it.
 
 ## Source Order
 
 Inspect external component libraries in this order:
 
 1. React Aria / React Spectrum;
-2. Ark UI;
-3. Radix UI;
+2. Ark UI / Chakra UI;
+3. Radix UI / shadcn/ui;
 4. another mature component library only when the first three do not cover the
    primitive or a needed feature axis.
 
@@ -37,16 +38,20 @@ For each counterpart, review:
 The simplest counterpart example sets the minimum UX quality bar for the first
 widgets demo.
 
-## Counterpart UX Brief
+## Counterpart Outcome Matrix
 
 Before coding, write a short brief in the plan, issue note, local task note, or
 PR draft:
 
 ```md
-## Counterpart UX Brief
+## Counterpart Outcome Matrix
 
 Primary counterpart: React Aria <Component>
 URL: <docs URL>
+Fallback counterparts inspected:
+
+- Ark UI / Chakra UI: <URL or NotApplicable with reason>
+- Radix UI / shadcn/ui: <URL or NotApplicable with reason>
 
 Observed examples:
 
@@ -56,13 +61,11 @@ Observed examples:
 - Drag/drop: ...
 - Forms: ...
 
-Implemented in ars-ui:
-
-- [ ] ...
-
-Not applicable:
-
-- <axis>: <reason>
+| Axis          | Reference evidence | Local evidence     | Tests/E2E     | Status    | Notes                             |
+| ------------- | ------------------ | ------------------ | ------------- | --------- | --------------------------------- |
+| Basic         | <snapshot or note> | <snapshot or note> | <test name>   | Supported | <intentional differences>         |
+| Invalid/error | <snapshot or note> | <snapshot or note> | <test name>   | Supported | <native/custom validation policy> |
+| Loading       | NotApplicable      | NotApplicable      | NotApplicable | N/A       | <reason>                          |
 ```
 
 Do not leave a feature gap unexplained.
@@ -72,9 +75,10 @@ Do not leave a feature gap unexplained.
 Feature surface:
 
 - controlled and uncontrolled state;
-- disabled, readonly, invalid, required, selected, active, focused, loading,
-  and empty states;
+- disabled, readonly, invalid, required, selected or checked, indeterminate,
+  active, focused, focus-visible, hovered, pressed, loading, and empty states;
 - grouping, sections, slots, composition, links, actions, and forms;
+- form submit and form reset behavior;
 - async loading, virtualization, drag/drop, overlays, and portals where
   relevant.
 
@@ -91,7 +95,8 @@ Interaction surface:
 
 Visual/UX surface:
 
-- selected, hovered, focused, disabled, invalid, and loading feedback;
+- selected or checked, indeterminate, hovered, pressed, focused,
+  focus-visible, disabled, readonly, invalid, required, and loading feedback;
 - icon and control alignment;
 - full-row or full-card feedback when the state applies to the whole item;
 - popup anchoring;
@@ -137,6 +142,8 @@ Every supported parity axis must have:
 - adapter wiring in both in-scope adapters;
 - adapter tests for API/semantic output;
 - E2E assertions for browser behavior;
-- widgets visual coverage and widget-smoke/computed-visual assertions.
+- widgets visual coverage and widget-smoke/computed-visual assertions;
+- browser comparison evidence following
+  [09-browser-parity-harness.md](09-browser-parity-harness.md).
 
 Unsupported axes must be listed as N/A with reasons in the PR body.

--- a/docs/implementation/adapter-components/08-validation-and-pr-closeout.md
+++ b/docs/implementation/adapter-components/08-validation-and-pr-closeout.md
@@ -54,7 +54,8 @@ Run any existing category E2E command that exercises the widgets page. Do not
 list a dedicated `cargo xtask e2e widgets` command unless the PR implements it.
 For visible adapter components, the PR must also run or add a browser widget
 smoke path that loads the public widgets examples with their real styling; cargo
-check alone is only a compile gate.
+check alone is only a compile gate. Browser evidence should follow
+[09-browser-parity-harness.md](09-browser-parity-harness.md).
 
 ## Spec And Workspace Gates
 
@@ -91,7 +92,11 @@ The audit must cover:
 Before any commit, present:
 
 - changed surfaces;
-- counterpart UX brief summary;
+- counterpart outcome matrix summary;
+- counterpart outcome matrix status: outcome-complete, partial, or
+  intentionally scoped;
+- `playwright-cli` or browser-harness artifact paths for reference and local
+  evidence;
 - validation commands and results;
 - known N/A axes with reasons;
 - remaining risk.
@@ -104,7 +109,11 @@ The PR body must include:
 
 - issue auto-close keywords;
 - spec references;
-- counterpart UX brief;
+- counterpart outcome matrix summary;
+- chosen counterpart and fallback counterparts inspected;
+- Playwright/browser evidence paths;
+- intentional differences from the chosen counterpart;
+- parity status: outcome-complete, partial, or intentionally scoped;
 - supported parity axes and N/A axes;
 - validation commands;
 - snapshot review note if `.snap` files changed.

--- a/docs/implementation/adapter-components/09-browser-parity-harness.md
+++ b/docs/implementation/adapter-components/09-browser-parity-harness.md
@@ -1,0 +1,126 @@
+# Browser Parity Harness
+
+This workflow turns counterpart comparison into repeatable evidence. Use it for
+every visible adapter component before claiming outcome parity.
+
+## Counterpart Sessions
+
+Use `playwright-cli` with separate sessions for the reference page and local
+widgets page:
+
+```bash
+playwright-cli -s=reference open <counterpart-url>
+playwright-cli -s=local open http://localhost:<port>/
+```
+
+The in-app browser is fine for quick orientation, but PR evidence must be
+reproducible with `playwright-cli` commands or a checked-in browser harness.
+
+Store artifacts only under `.playwright-cli/` or `/tmp/`. Do not add snapshots,
+screenshots, traces, or videos to the repo root.
+
+## Required Evidence Loop
+
+For each supported counterpart axis:
+
+1. Capture the reference state.
+2. Drive the same local state.
+3. Compare behavior, visible feedback, and accessibility state.
+4. Record the artifact path or harness test that proves the comparison.
+
+Use snapshots after page load and after every meaningful state transition:
+
+```bash
+playwright-cli -s=reference snapshot --filename=.playwright-cli/reference-checkbox-invalid.yml
+playwright-cli -s=local snapshot --filename=.playwright-cli/local-checkbox-invalid.yml
+```
+
+Use screenshots only when geometry, spacing, icon shape, or visual alignment is
+the thing being reviewed:
+
+```bash
+playwright-cli -s=reference screenshot --filename=/tmp/reference-checkbox-invalid.png
+playwright-cli -s=local screenshot --filename=/tmp/local-checkbox-invalid.png
+```
+
+## Computed Checks
+
+Do not rely on screenshots alone. Use `eval` for measurable state:
+
+```bash
+playwright-cli -s=local eval "el => {
+  const style = getComputedStyle(el);
+  const rect = el.getBoundingClientRect();
+  return {
+    ariaChecked: el.getAttribute('aria-checked'),
+    ariaInvalid: el.getAttribute('aria-invalid'),
+    state: el.getAttribute('data-ars-state'),
+    color: style.color,
+    backgroundColor: style.backgroundColor,
+    borderColor: style.borderColor,
+    cursor: style.cursor,
+    width: rect.width,
+    height: rect.height
+  };
+}" e5
+```
+
+Check at least the state attrs, ARIA attrs, computed colors, cursor/opacity when
+disabled, visible dimensions, and whether controls keep stable dimensions after
+interaction.
+
+## Forms And Validation
+
+For form-participating components, the browser review must exercise both submit
+and reset paths. Avoid treating browser-native validation popups as sufficient
+visual proof unless the chosen parity target intentionally uses them.
+
+Use `eval` to inspect serialized form values and hidden inputs:
+
+```bash
+playwright-cli -s=local eval "() => {
+  const form = document.querySelector('#component-demo-form');
+  return {
+    values: Array.from(new FormData(form).entries()),
+    hiddenInputs: Array.from(form.querySelectorAll('input[type=\"hidden\"], input.ars-sr-input'))
+      .map(input => ({
+        name: input.name,
+        value: input.value,
+        checked: input.checked,
+        required: input.required,
+        disabled: input.disabled
+      }))
+  };
+}"
+```
+
+Submit and reset controls should use ars-ui components when the demo is proving
+ars-ui component integration, not raw browser buttons, unless the component
+under review is the raw form primitive itself.
+
+## Console And Network
+
+Before presenting work, inspect the browser console after representative
+interactions:
+
+```bash
+playwright-cli -s=local console
+playwright-cli -s=local console warning
+playwright-cli -s=local network
+```
+
+Reactive-context warnings, hydration warnings, missing asset failures, and
+uncaught exceptions are user-visible regressions.
+
+## Outcome Matrix
+
+Record the result in the issue note, plan, PR draft, or PR body:
+
+| Axis    | Reference evidence                    | Local evidence                    | Tests/E2E                      | Status    | Notes                                 |
+| ------- | ------------------------------------- | --------------------------------- | ------------------------------ | --------- | ------------------------------------- |
+| Basic   | `.playwright-cli/reference-basic.yml` | `.playwright-cli/local-basic.yml` | `basic_pointer_and_keyboard`   | Supported | Matches outcome, not API shape        |
+| Invalid | `/tmp/reference-invalid.png`          | `/tmp/local-invalid.png`          | `invalid_visual_and_axe_clean` | Supported | Custom error UI replaces native popup |
+| Loading | NotApplicable                         | NotApplicable                     | NotApplicable                  | N/A       | Component has no loading state        |
+
+Use `Supported`, `IntentionallyDifferent`, or `NotApplicable`. Do not leave a
+counterpart feature unclassified.

--- a/docs/implementation/adapter-components/README.md
+++ b/docs/implementation/adapter-components/README.md
@@ -19,7 +19,8 @@ file below:
 5. [04-adapter-tests.md](04-adapter-tests.md)
 6. [05-e2e-fixtures-and-harnesses.md](05-e2e-fixtures-and-harnesses.md)
 7. [06-widgets-examples.md](06-widgets-examples.md)
-8. [08-validation-and-pr-closeout.md](08-validation-and-pr-closeout.md)
+8. [09-browser-parity-harness.md](09-browser-parity-harness.md)
+9. [08-validation-and-pr-closeout.md](08-validation-and-pr-closeout.md)
 
 Then keep the checklists open while implementing:
 
@@ -41,7 +42,9 @@ An adapter component task is complete only when the same PR includes:
   assertions;
 - widgets examples in all six widgets crates;
 - counterpart-driven visual UX review, starting with React Aria / React
-  Spectrum when available;
+  Spectrum when available, then Ark UI / Chakra UI, then Radix UI / shadcn/ui;
+- repeatable browser comparison evidence collected with `playwright-cli` or an
+  equivalent checked-in browser harness;
 - spec synchronization for any drift surfaced during implementation;
 - focused validation, `post-implementation-audit`, user review before commit,
   `cargo xci-fast`, and the Codex review loop after push.

--- a/docs/implementation/adapter-components/checklists/component-delivery.md
+++ b/docs/implementation/adapter-components/checklists/component-delivery.md
@@ -13,7 +13,9 @@ workflow docs.
 - [ ] `adapter-contract.md` read.
 - [ ] `examples/widgets-ownership.md` read.
 - [ ] Framework skills loaded when touching Leptos/Dioxus.
-- [ ] Counterpart UX brief written from live browser review.
+- [ ] Counterpart outcome matrix written from live browser review.
+- [ ] Counterpart outcome matrix records primary and fallback sources.
+- [ ] `playwright-cli` reference/local browser evidence plan written.
 
 ## Adapter Code
 
@@ -39,6 +41,7 @@ workflow docs.
 - [ ] Computed visual assertions cover visible states.
 - [ ] Widgets examples updated in all six crates.
 - [ ] Widget smoke covers counterpart UX states.
+- [ ] Browser evidence compares counterpart and local widgets pages.
 
 ## Closeout
 
@@ -49,5 +52,6 @@ workflow docs.
 - [ ] Results presented before commit.
 - [ ] User approval received before commit/push.
 - [ ] `cargo xci-fast` passes before push.
-- [ ] PR opened with auto-close keyword and counterpart UX brief.
+- [ ] PR opened with auto-close keyword and counterpart outcome matrix.
+- [ ] PR body includes browser evidence paths and parity status.
 - [ ] `waiting-for-codex-review` loop completed after every push.

--- a/docs/implementation/adapter-components/checklists/e2e-feature-matrix.md
+++ b/docs/implementation/adapter-components/checklists/e2e-feature-matrix.md
@@ -3,16 +3,18 @@
 For every supported component feature, record the fixture id and harness test
 that proves it.
 
-| Axis      | Fixture id | Harness test | Visual assertion | Axe state | Notes |
-| --------- | ---------- | ------------ | ---------------- | --------- | ----- |
-| Pointer   |            |              |                  |           |       |
-| Keyboard  |            |              |                  |           |       |
-| Focus     |            |              |                  |           |       |
-| State     |            |              |                  |           |       |
-| Forms     |            |              |                  |           |       |
-| Visual    |            |              |                  |           |       |
-| A11y      |            |              |                  |           |       |
-| Lifecycle |            |              |                  |           |       |
+| Axis        | Fixture id | Harness test | Visual assertion | Axe state | Reference evidence | Local evidence | Notes |
+| ----------- | ---------- | ------------ | ---------------- | --------- | ------------------ | -------------- | ----- |
+| Pointer     |            |              |                  |           |                    |                |       |
+| Keyboard    |            |              |                  |           |                    |                |       |
+| Focus       |            |              |                  |           |                    |                |       |
+| State       |            |              |                  |           |                    |                |       |
+| Forms       |            |              |                  |           |                    |                |       |
+| Validation  |            |              |                  |           |                    |                |       |
+| Hover/press |            |              |                  |           |                    |                |       |
+| Visual      |            |              |                  |           |                    |                |       |
+| A11y        |            |              |                  |           |                    |                |       |
+| Lifecycle   |            |              |                  |           |                    |                |       |
 
 ## Required Notes
 
@@ -20,5 +22,8 @@ that proves it.
   matrix and PR body.
 - If a counterpart feature is supported, it must appear in this matrix.
 - If a visible state exists, it needs a computed visual assertion.
+- If a visible state comes from counterpart review, include both reference and
+  local browser evidence paths or the checked-in harness assertion that replaces
+  the artifact.
 - If a state can be reached in the browser, axe must run in that state unless a
   scoped exception is documented.

--- a/docs/implementation/adapter-components/checklists/widgets-visual-review.md
+++ b/docs/implementation/adapter-components/checklists/widgets-visual-review.md
@@ -6,17 +6,25 @@ the browser.
 ## Counterpart Comparison
 
 - [ ] React Aria / React Spectrum page inspected when available.
+- [ ] Ark UI / Chakra UI fallback inspected when React Aria / Spectrum does not
+      cover the component or feature axis.
+- [ ] Radix UI / shadcn/ui fallback inspected when earlier counterparts do not
+      cover the component or feature axis.
 - [ ] Simplest counterpart example mapped to our first demo section.
 - [ ] Advanced counterpart examples mapped to supported demo sections.
 - [ ] Intentional visual/content differences documented.
+- [ ] `playwright-cli` artifact paths recorded for reference and local pages.
 
 ## Visible States
 
 - [ ] Selected state is visible across the full item area.
+- [ ] Checked and indeterminate states are visible where supported.
 - [ ] Focus-visible state is clear.
-- [ ] Hover/active feedback is visible where supported.
+- [ ] Hover/pressed/active feedback is visible where supported.
 - [ ] Disabled state is visually distinct.
+- [ ] Readonly and required states are visually distinct where supported.
 - [ ] Invalid/error state is visible and announced where supported.
+- [ ] Form submit and reset behavior is visible where supported.
 - [ ] Empty state has clear text.
 - [ ] Loading state has visible status, not only a sentinel.
 - [ ] Links and actions are distinguishable.
@@ -28,6 +36,8 @@ the browser.
 
 - [ ] Text fits on mobile and desktop.
 - [ ] Controls do not shift after selection or loading state changes.
+- [ ] Computed dimensions, colors, opacity, cursor, and visibility were checked
+      for every supported visible state.
 - [ ] Popups/overlays anchor to their trigger.
 - [ ] Scrollable areas show affordances.
 - [ ] Browser console is clean after page load and representative interactions.


### PR DESCRIPTION
## Summary
- add a browser parity harness workflow for repeatable `playwright-cli` evidence
- update adapter delivery docs to target outcome parity rather than framework API parity
- document counterpart fallback order: React Aria / React Spectrum, Ark UI / Chakra UI, Radix UI / shadcn/ui, then another mature library
- strengthen E2E, widgets, closeout, and checklist requirements for counterpart matrices, visible-state assertions, and browser evidence

## Validation
- `cargo xtask spec validate`
- `cargo +nightly fmt --all --check`

Docs-only PR; no issue auto-close keyword.