### PR TITLE
[codex] Cover nightly missed mutants

### DIFF
--- a/crates/ars-collections/src/typeahead.rs
+++ b/crates/ars-collections/src/typeahead.rs
@@ -517,6 +517,31 @@ mod tests {
         assert_eq!(state.search, "ap");
     }
 
+    #[test]
+    fn timeout_boundary_resets_at_exact_timeout() {
+        let c = fruit_collection();
+
+        let state = State {
+            search: String::from("a"),
+            last_key_time: Duration::from_millis(100),
+            search_start_key: Some(Key::int(1)),
+        };
+
+        let (state, found) = state.process_char(
+            'b',
+            Duration::from_millis(600),
+            Some(&Key::int(1)),
+            &c,
+            &no_disabled(),
+            DisabledBehavior::Skip,
+        );
+
+        assert_eq!(state.search, "b");
+        assert_eq!(state.last_key_time, Duration::from_millis(600));
+        assert_eq!(state.search_start_key, Some(Key::int(1)));
+        assert_eq!(found, Some(Key::int(2)));
+    }
+
     // ------------------------------------------------------------------ //
     // Prefix matching                                                     //
     // ------------------------------------------------------------------ //
@@ -743,6 +768,53 @@ mod tests {
         assert_eq!(found, Some(Key::int(4)));
     }
 
+    #[test]
+    fn locale_wrapper_delegates_to_process_char_in_non_i18n_builds() {
+        let c = fruit_collection();
+
+        let state = State::default();
+
+        let (direct_state, direct_found) = state.process_char(
+            'b',
+            Duration::from_millis(100),
+            Some(&Key::int(1)),
+            &c,
+            &no_disabled(),
+            DisabledBehavior::Skip,
+        );
+
+        let (wrapped_state, wrapped_found) = state.process_char_with_locale(
+            'b',
+            Duration::from_millis(100),
+            Some(&Key::int(1)),
+            &c,
+            &(),
+            &no_disabled(),
+            DisabledBehavior::Skip,
+        );
+
+        assert_eq!(wrapped_state, direct_state);
+        assert_eq!(wrapped_found, direct_found);
+    }
+
+    #[test]
+    fn single_char_scan_wraps_from_last_item_without_dividing_index() {
+        let c = fruit_collection();
+
+        let state = State::default();
+
+        let (_, found) = state.process_char(
+            'd',
+            Duration::from_millis(100),
+            Some(&Key::int(5)),
+            &c,
+            &no_disabled(),
+            DisabledBehavior::Skip,
+        );
+
+        assert_eq!(found, Some(Key::int(5)));
+    }
+
     // ------------------------------------------------------------------ //
     // Match cycling (repeated same character)                             //
     // ------------------------------------------------------------------ //
@@ -845,6 +917,30 @@ mod tests {
         );
 
         assert_eq!(found, Some(Key::int(3))); // Blueberry, not Banana
+    }
+
+    #[test]
+    fn skip_disabled_requires_focusable_and_not_disabled() {
+        let c = CollectionBuilder::new()
+            .section(Key::str("section"), "Berries")
+            .item(Key::int(1), "Banana", "banana")
+            .item(Key::int(2), "Blueberry", "blueberry")
+            .separator()
+            .item(Key::int(3), "Blackberry", "blackberry")
+            .build();
+
+        let disabled = BTreeSet::from([Key::int(1), Key::int(2)]);
+
+        let (_, found) = State::default().process_char(
+            'b',
+            Duration::from_millis(100),
+            None,
+            &c,
+            &disabled,
+            DisabledBehavior::Skip,
+        );
+
+        assert_eq!(found, Some(Key::int(3)));
     }
 
     #[test]

--- a/crates/ars-components/src/date_time/date_picker/tests.rs
+++ b/crates/ars-components/src/date_time/date_picker/tests.rs
@@ -486,6 +486,39 @@ fn default_format_for_german_is_day_month_year_with_dot() {
 }
 
 #[test]
+fn default_format_uses_locale_order_and_visible_separator_edges() {
+    let korean = service_with(
+        Props {
+            default_value: Some(date(2024, 3, 15)),
+            ..props()
+        },
+        Locale::parse("ko-KR").expect("locale parses"),
+    );
+
+    assert_eq!(korean.context().input_text, "2024.03.15");
+
+    let british = service_with(
+        Props {
+            default_value: Some(date(2024, 3, 15)),
+            ..props()
+        },
+        en_gb(),
+    );
+
+    assert_eq!(british.context().input_text, "15/03/2024");
+
+    let japanese = service_with(
+        Props {
+            default_value: Some(date(2024, 3, 15)),
+            ..props()
+        },
+        ja_jp(),
+    );
+
+    assert_eq!(japanese.context().input_text, "2024/03/15");
+}
+
+#[test]
 fn typing_updates_calendar_props_value() {
     let mut svc = service();
 
@@ -1295,6 +1328,37 @@ fn api_and_messages_debug_eq_impls() {
     assert_eq!(messages.clone(), messages);
     // Manual `Debug`.
     assert!(format!("{messages:?}").contains("Messages"));
+
+    assert_ne!(
+        Messages {
+            trigger_label: MessageFn::static_str("Open"),
+            ..messages.clone()
+        },
+        messages
+    );
+    assert_ne!(
+        Messages {
+            clear_label: MessageFn::static_str("Clear"),
+            ..messages.clone()
+        },
+        messages
+    );
+    assert_ne!(
+        Messages {
+            content_label: MessageFn::static_str("Content"),
+            ..messages.clone()
+        },
+        messages
+    );
+    assert_ne!(
+        Messages {
+            selected_date_label: MessageFn::new(|date: &str, _locale: &Locale| {
+                format!("Picked {date}")
+            }),
+            ..messages.clone()
+        },
+        messages
+    );
 }
 
 // ────────────────────────────────────────────────────────────────────

--- a/crates/ars-components/src/layout/splitter/mod.rs
+++ b/crates/ars-components/src/layout/splitter/mod.rs
@@ -1759,6 +1759,75 @@ mod tests {
     }
 
     #[test]
+    fn rebalance_to_total_reduces_from_end_without_crossing_minimums() {
+        let panels = [
+            Panel {
+                min_size: 15.0,
+                ..panel("left", 40.0)
+            },
+            Panel {
+                min_size: 20.0,
+                ..panel("middle", 35.0)
+            },
+            Panel {
+                min_size: 25.0,
+                ..panel("right", 45.0)
+            },
+        ];
+
+        let sizes = rebalance_to_total(vec![40.0, 35.0, 45.0], &panels, 90.0);
+
+        assert_eq!(sizes, vec![40.0, 25.0, 25.0]);
+    }
+
+    #[test]
+    fn rebalance_to_total_increases_from_end_without_crossing_maximums() {
+        let panels = [
+            Panel {
+                max_size: Some(50.0),
+                ..panel("left", 30.0)
+            },
+            Panel {
+                max_size: Some(42.0),
+                ..panel("middle", 30.0)
+            },
+            Panel {
+                max_size: Some(45.0),
+                ..panel("right", 30.0)
+            },
+        ];
+
+        let sizes = rebalance_to_total(vec![30.0, 30.0, 30.0], &panels, 125.0);
+
+        assert_eq!(sizes, vec![38.0, 42.0, 45.0]);
+    }
+
+    #[test]
+    fn collapse_panel_distributes_freed_size_to_available_recipients() {
+        let mut middle = collapsible_panel("middle", 40.0);
+
+        middle.collapsed_size = 5.0;
+
+        let panels = [
+            Panel {
+                max_size: Some(55.0),
+                ..panel("left", 30.0)
+            },
+            middle,
+            Panel {
+                max_size: Some(50.0),
+                ..panel("right", 30.0)
+            },
+        ];
+
+        let mut sizes = vec![30.0, 40.0, 30.0];
+
+        collapse_panel(&mut sizes, 1, &panels);
+
+        assert_eq!(sizes, vec![45.0, 5.0, 50.0]);
+    }
+
+    #[test]
     fn compute_resize_zero_delta_does_not_snap_collapsible_panel() {
         let mut left = collapsible_panel("left", 0.25);
 
@@ -2277,6 +2346,32 @@ mod tests {
         }));
 
         assert_eq!(service.context().sizes.get(), &vec![90.0, 10.0]);
+    }
+
+    #[test]
+    fn end_key_uses_remaining_capacity_not_sum_of_current_size() {
+        let mut left = panel("left", 30.0);
+
+        left.max_size = Some(70.0);
+
+        let mut right = panel("right", 70.0);
+
+        right.min_size = 20.0;
+        right.max_size = None;
+
+        let mut service = service(
+            Props::new()
+                .id("split")
+                .panels(vec![left, right])
+                .default_sizes(vec![30.0, 70.0]),
+        );
+
+        drop(service.send(Event::KeyDown {
+            handle_index: 0,
+            event: key(KeyboardKey::End),
+        }));
+
+        assert_eq!(service.context().sizes.get(), &vec![70.0, 30.0]);
     }
 
     #[test]

--- a/crates/ars-components/src/layout/toolbar/mod.rs
+++ b/crates/ars-components/src/layout/toolbar/mod.rs
@@ -770,6 +770,30 @@ mod tests {
     }
 
     #[test]
+    fn keyboard_navigation_ignores_cross_axis_arrow_keys() {
+        let captured = alloc::rc::Rc::new(core::cell::RefCell::new(Vec::new()));
+        let send = {
+            let captured = alloc::rc::Rc::clone(&captured);
+            move |event| captured.borrow_mut().push(event)
+        };
+
+        service(Props::new())
+            .connect(&send)
+            .on_root_keydown(&keyboard(KeyboardKey::ArrowDown));
+        service(Props::new())
+            .connect(&send)
+            .on_root_keydown(&keyboard(KeyboardKey::ArrowUp));
+        service(Props::new().orientation(Orientation::Vertical))
+            .connect(&send)
+            .on_root_keydown(&keyboard(KeyboardKey::ArrowRight));
+        service(Props::new().orientation(Orientation::Vertical))
+            .connect(&send)
+            .on_root_keydown(&keyboard(KeyboardKey::ArrowLeft));
+
+        assert!(captured.borrow().is_empty());
+    }
+
+    #[test]
     fn home_end_focus_first_and_last_enabled_items() {
         let mut service = service(Props::new());
 
@@ -836,6 +860,17 @@ mod tests {
     }
 
     #[test]
+    fn focus_item_ignores_disabled_index_without_clearing_current_focus() {
+        let mut service = service(Props::new());
+
+        assert_eq!(service.context().focused_index, Some(0));
+
+        drop(service.send(Event::FocusItem(2)));
+
+        assert_eq!(service.context().focused_index, Some(0));
+    }
+
+    #[test]
     fn set_items_normalizes_disabled_items_and_prunes_invalid_focus() {
         let mut service = service(Props::new());
 
@@ -860,6 +895,20 @@ mod tests {
         }));
 
         assert_eq!(*service.context(), before);
+    }
+
+    #[test]
+    fn set_items_keeps_disabled_index_strictly_below_count() {
+        let mut service =
+            Service::<Machine>::new(Props::new().id("toolbar"), &Env::default(), &Messages);
+
+        drop(service.send(Event::SetItems {
+            count: 3,
+            disabled_items: vec![2, 3],
+        }));
+
+        assert_eq!(service.context().disabled_items, vec![2]);
+        assert_eq!(service.context().focused_index, Some(0));
     }
 
     #[test]
@@ -947,6 +996,40 @@ mod tests {
         assert_eq!(service.context().orientation, Orientation::Vertical);
         assert_eq!(service.context().dir, Direction::Rtl);
         assert!(!service.context().disabled);
+    }
+
+    #[test]
+    fn each_output_prop_change_syncs_independently() {
+        let mut orientation = service(Props::new().id("toolbar"));
+
+        drop(
+            orientation.set_props(
+                Props::new()
+                    .id("toolbar")
+                    .orientation(Orientation::Vertical),
+            ),
+        );
+
+        assert_eq!(orientation.context().orientation, Orientation::Vertical);
+        assert_eq!(orientation.context().dir, Direction::Ltr);
+        assert!(!orientation.context().disabled);
+
+        let mut dir = service(Props::new().id("toolbar"));
+
+        drop(dir.set_props(Props::new().id("toolbar").dir(Direction::Rtl)));
+
+        assert_eq!(dir.context().orientation, Orientation::Horizontal);
+        assert_eq!(dir.context().dir, Direction::Rtl);
+        assert!(!dir.context().disabled);
+
+        let mut disabled = service(Props::new().id("toolbar"));
+
+        drop(disabled.set_props(Props::new().id("toolbar").disabled(true)));
+
+        assert_eq!(disabled.context().orientation, Orientation::Horizontal);
+        assert_eq!(disabled.context().dir, Direction::Ltr);
+        assert!(disabled.context().disabled);
+        assert_eq!(disabled.context().focused_index, None);
     }
 
     #[test]

--- a/crates/ars-components/src/specialized/file_upload/tests.rs
+++ b/crates/ars-components/src/specialized/file_upload/tests.rs
@@ -440,6 +440,33 @@ fn file_upload_upload_error_marks_failed() {
 }
 
 #[test]
+fn file_upload_upload_error_keeps_uploading_state_when_other_file_uploads() {
+    let mut service = Service::<Machine>::new(
+        Props::new().id("upload").default_files(vec![
+            item("file-1", "a.png", Status::Pending),
+            item("file-2", "b.png", Status::Pending),
+        ]),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    drop(service.send(Event::StartUpload));
+
+    assert_eq!(service.state(), &State::Uploading);
+
+    drop(service.send(Event::UploadError {
+        file_id: "file-1".into(),
+        error: "network".into(),
+    }));
+
+    let files = service.context().files.get();
+
+    assert!(matches!(files[0].status, Status::Failed(_)));
+    assert_eq!(files[1].status, Status::Uploading);
+    assert_eq!(service.state(), &State::Uploading);
+}
+
+#[test]
 fn file_upload_accept_extension_pattern_matches_by_filename() {
     let mut service = Service::<Machine>::new(
         Props::new().id("upload").accept(vec![".png".into()]),
@@ -686,6 +713,27 @@ fn file_upload_min_file_size_rejects_small_files() {
 }
 
 #[test]
+fn file_upload_size_limits_accept_exact_boundaries() {
+    let mut service = Service::<Machine>::new(
+        Props::new()
+            .id("upload")
+            .multiple(true)
+            .max_file_size(100)
+            .min_file_size(10),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    drop(service.send(Event::FilesSelected(vec![
+        raw_file("min.png", 10, "image/png"),
+        raw_file("max.png", 100, "image/png"),
+    ])));
+
+    assert_eq!(service.context().files.get().len(), 2);
+    assert!(service.context().rejected_files.is_empty());
+}
+
+#[test]
 fn file_upload_max_files_rejects_excess() {
     let mut service = Service::<Machine>::new(
         Props::new()
@@ -726,6 +774,28 @@ fn file_upload_remove_file_filters_queue() {
 
     assert_eq!(service.context().files.get().len(), 1);
     assert_eq!(service.context().files.get()[0].id, "file-2");
+}
+
+#[test]
+fn file_upload_remove_keeps_uploading_state_when_other_file_uploads() {
+    let mut service = Service::<Machine>::new(
+        Props::new().id("upload").default_files(vec![
+            item("file-1", "a.png", Status::Pending),
+            item("file-2", "b.png", Status::Pending),
+        ]),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    drop(service.send(Event::StartUpload));
+    drop(service.send(Event::RemoveFile {
+        file_id: "file-1".into(),
+    }));
+
+    assert_eq!(service.context().files.get().len(), 1);
+    assert_eq!(service.context().files.get()[0].id, "file-2");
+    assert_eq!(service.context().files.get()[0].status, Status::Uploading);
+    assert_eq!(service.state(), &State::Uploading);
 }
 
 #[test]
@@ -2367,6 +2437,41 @@ fn file_upload_retry_targets_specific_failed_file_after_a_mismatch() {
             .status,
         Status::Pending
     );
+}
+
+#[test]
+fn file_upload_retry_does_not_touch_nonmatching_failed_files() {
+    let mut service = Service::<Machine>::new(
+        Props::new().id("upload").default_files(vec![
+            Item {
+                status: Status::Failed("first".into()),
+                error: Some("first".into()),
+                progress: 0.75,
+                ..item("file-1", "a.png", Status::Failed("first".into()))
+            },
+            Item {
+                status: Status::Failed("second".into()),
+                error: Some("second".into()),
+                progress: 0.5,
+                ..item("file-2", "b.png", Status::Failed("second".into()))
+            },
+        ]),
+        &Env::default(),
+        &Messages::default(),
+    );
+
+    drop(service.send(Event::RetryFile {
+        file_id: "file-2".into(),
+    }));
+
+    let files = service.context().files.get();
+
+    assert_eq!(files[0].status, Status::Failed("first".into()));
+    assert_eq!(files[0].error, Some("first".into()));
+    assert_eq!(files[0].progress, 0.75);
+    assert_eq!(files[1].status, Status::Pending);
+    assert_eq!(files[1].error, None);
+    assert_eq!(files[1].progress, 0.0);
 }
 
 #[test]

--- a/crates/ars-components/src/specialized/image_cropper/mod.rs
+++ b/crates/ars-components/src/specialized/image_cropper/mod.rs
@@ -1880,6 +1880,33 @@ mod tests {
     }
 
     #[test]
+    fn constrain_to_ratio_pulls_origin_inside_when_minimum_exceeds_room() {
+        let mut crop = CropArea {
+            x: 0.98,
+            y: 0.98,
+            width: 0.01,
+            height: 0.01,
+            rotation: 0.0,
+        };
+
+        constrain_to_ratio(&mut crop, 1.0);
+
+        assert_eq!(crop.width, MIN_CROP_SIZE);
+        assert_eq!(crop.height, MIN_CROP_SIZE);
+        assert!((crop.x - (1.0 - MIN_CROP_SIZE)).abs() < 1e-9);
+        assert!((crop.y - (1.0 - MIN_CROP_SIZE)).abs() < 1e-9);
+    }
+
+    #[test]
+    fn normalize_rotation_wraps_and_rejects_non_finite_values() {
+        assert_eq!(normalize_rotation(270.0), -90.0);
+        assert_eq!(normalize_rotation(-270.0), 90.0);
+        assert_eq!(normalize_rotation(540.0), -180.0);
+        assert_eq!(normalize_rotation(f64::NAN), 0.0);
+        assert_eq!(normalize_rotation(f64::INFINITY), 0.0);
+    }
+
+    #[test]
     fn crop_handle_token_and_all_cover_eight_positions() {
         let tokens: Vec<&str> = CropHandle::all().iter().map(|h| h.token()).collect();
 
@@ -2212,6 +2239,121 @@ mod tests {
     }
 
     #[test]
+    fn resize_each_handle_uses_delta_from_drag_origin() {
+        let cases = [
+            (
+                CropHandle::TopLeft,
+                0.0,
+                0.0,
+                CropArea {
+                    x: 0.0,
+                    y: 0.0,
+                    width: 0.9,
+                    height: 0.9,
+                    rotation: 0.0,
+                },
+            ),
+            (
+                CropHandle::TopRight,
+                1.0,
+                0.0,
+                CropArea {
+                    x: 0.1,
+                    y: 0.0,
+                    width: 0.9,
+                    height: 0.9,
+                    rotation: 0.0,
+                },
+            ),
+            (
+                CropHandle::BottomLeft,
+                0.0,
+                1.0,
+                CropArea {
+                    x: 0.0,
+                    y: 0.1,
+                    width: 0.9,
+                    height: 0.9,
+                    rotation: 0.0,
+                },
+            ),
+            (
+                CropHandle::BottomRight,
+                1.0,
+                1.0,
+                CropArea {
+                    x: 0.1,
+                    y: 0.1,
+                    width: 0.9,
+                    height: 0.9,
+                    rotation: 0.0,
+                },
+            ),
+            (
+                CropHandle::Top,
+                0.5,
+                0.0,
+                CropArea {
+                    x: 0.1,
+                    y: 0.0,
+                    width: 0.8,
+                    height: 0.9,
+                    rotation: 0.0,
+                },
+            ),
+            (
+                CropHandle::Bottom,
+                0.5,
+                1.0,
+                CropArea {
+                    x: 0.1,
+                    y: 0.1,
+                    width: 0.8,
+                    height: 0.9,
+                    rotation: 0.0,
+                },
+            ),
+            (
+                CropHandle::Left,
+                0.0,
+                0.5,
+                CropArea {
+                    x: 0.0,
+                    y: 0.1,
+                    width: 0.9,
+                    height: 0.8,
+                    rotation: 0.0,
+                },
+            ),
+            (
+                CropHandle::Right,
+                1.0,
+                0.5,
+                CropArea {
+                    x: 0.1,
+                    y: 0.1,
+                    width: 0.9,
+                    height: 0.8,
+                    rotation: 0.0,
+                },
+            ),
+        ];
+
+        for (handle, x, y, expected) in cases {
+            let mut service = fresh_service(test_props());
+
+            drop(service.send(Event::ResizeStart {
+                handle,
+                x: 0.9,
+                y: 0.9,
+            }));
+            drop(service.send(Event::ResizeMove { x, y }));
+
+            assert_eq!(*service.context().crop.get(), expected, "{handle:?}");
+        }
+    }
+
+    #[test]
     fn set_aspect_ratio_reclamps_when_height_overflows_bottom() {
         // Default crop (y=0.1, width=0.8) under Portrait3x4 would compute
         // height = 0.8 / 0.75 = 1.067, overflowing the bottom and hitting the
@@ -2528,6 +2670,14 @@ mod tests {
     #[test]
     fn api_state_accessors_reflect_state() {
         assert!(
+            !Fixture {
+                state: State::Idle,
+                ..Default::default()
+            }
+            .api()
+            .is_resizing()
+        );
+        assert!(
             Fixture {
                 state: State::Dragging,
                 ..Default::default()
@@ -2644,16 +2794,10 @@ mod tests {
         let events = log.lock().unwrap();
 
         assert_eq!(events.len(), 6);
-        assert!(matches!(events[0], Event::SetZoom(_)));
-        let Event::SetRotation(rotation) = events[2] else {
-            panic!("expected positive SetRotation, got {:?}", events[2]);
-        };
-        assert!(rotation > 0.0);
-
-        let Event::SetRotation(rotation) = events[3] else {
-            panic!("expected negative SetRotation, got {:?}", events[3]);
-        };
-        assert!(rotation < 0.0);
+        assert_eq!(events[0], Event::SetZoom(1.1));
+        assert_eq!(events[1], Event::SetZoom(0.9));
+        assert_eq!(events[2], Event::SetRotation(90.0));
+        assert_eq!(events[3], Event::SetRotation(-90.0));
         assert_eq!(events[4], Event::FlipHorizontal);
         assert_eq!(events[5], Event::FlipVertical);
     }
@@ -3099,6 +3243,28 @@ mod tests {
             (crop.width - crop.height).abs() < 1e-9,
             "controlled crop not square after aspect change: {crop:?}"
         );
+    }
+
+    #[test]
+    fn sync_props_disabling_cancels_active_resize_snapshot() {
+        let mut service = fresh_service(test_props());
+
+        drop(service.send(Event::ResizeStart {
+            handle: CropHandle::Right,
+            x: 0.9,
+            y: 0.5,
+        }));
+
+        assert!(matches!(service.state(), State::Resizing { .. }));
+        assert!(service.context().drag_origin.is_some());
+        assert!(service.context().drag_start_crop.is_some());
+
+        drop(service.set_props(test_props().disabled(true)));
+
+        assert_eq!(service.state(), &State::Idle);
+        assert!(service.context().drag_origin.is_none());
+        assert!(service.context().drag_start_crop.is_none());
+        assert!(service.context().disabled);
     }
 
     #[test]

--- a/crates/ars-components/src/specialized/qr_code/mod.rs
+++ b/crates/ars-components/src/specialized/qr_code/mod.rs
@@ -624,6 +624,16 @@ mod tests {
     }
 
     #[test]
+    fn matrix_accessor_returns_injected_matrix() {
+        let props = Props::default();
+        let connected = api(&props, Some(sample_matrix()));
+        let matrix = connected.matrix().expect("injected matrix");
+
+        assert_eq!(matrix.size, 3);
+        assert!(matrix.get(1, 1));
+    }
+
+    #[test]
     fn qr_matrix_new_computes_size_and_get() {
         let matrix = sample_matrix();
 

--- a/crates/ars-core/src/color.rs
+++ b/crates/ars-core/src/color.rs
@@ -956,6 +956,51 @@ mod tests {
     }
 
     #[test]
+    fn min_max_helpers_preserve_rhs_on_equal_signed_zero() {
+        assert_eq!(fmin(-0.0, 0.0).to_bits(), 0.0f64.to_bits());
+        assert_eq!(fmax(0.0, -0.0).to_bits(), (-0.0f64).to_bits());
+    }
+
+    #[test]
+    fn hex_alpha_is_emitted_only_when_requested_and_translucent() {
+        let translucent = ColorValue::new(210.0, 1.0, 0.5, 0.5);
+        let opaque = ColorValue::new(210.0, 1.0, 0.5, 1.0);
+
+        assert_eq!(translucent.to_hex(false).len(), 7);
+        assert_eq!(translucent.to_hex(true).len(), 9);
+        assert_eq!(opaque.to_hex(true).len(), 7);
+        assert_eq!(
+            format_color_string(&translucent, ColorFormat::Hex),
+            translucent.to_hex(true)
+        );
+    }
+
+    #[test]
+    fn rgb_to_hsl_selects_correct_hue_branch_and_saturation_formula() {
+        let magenta = ColorValue::from_rgb(255, 0, 128);
+        let pale_green = ColorValue::from_rgb(204, 255, 204);
+        let dark_blue = ColorValue::from_rgb(0, 20, 80);
+
+        rgb_close(magenta.to_rgb(), (255, 0, 128), 1);
+
+        assert!((magenta.hue - 329.882_352_941_176_46).abs() < 1e-9);
+        assert!(magenta.saturation > 0.99);
+        assert!((magenta.lightness - 0.5).abs() < 1e-9);
+
+        rgb_close(pale_green.to_rgb(), (204, 255, 204), 1);
+
+        assert!((pale_green.hue - 120.0).abs() < 1e-9);
+        assert!((pale_green.saturation - 1.0).abs() < 1e-9);
+        assert!(pale_green.lightness > 0.89);
+
+        rgb_close(dark_blue.to_rgb(), (0, 20, 80), 1);
+
+        assert!((dark_blue.hue - 225.0).abs() < 1e-9);
+        assert!(dark_blue.saturation > 0.99);
+        assert!(dark_blue.lightness < 0.16);
+    }
+
+    #[test]
     fn hex_parse_and_format() {
         let color = ColorValue::from_hex("#3366ff").unwrap();
 
@@ -1175,6 +1220,22 @@ mod tests {
     }
 
     #[test]
+    fn hsb_conversion_preserves_boundary_brightness_and_saturation() {
+        let white = ColorValue::from_hsb(42.0, 0.0, 1.0);
+        let black = ColorValue::from_hsb(42.0, 1.0, 0.0);
+        let vivid_mid = ColorValue::from_hsb(210.0, 0.75, 0.8);
+
+        assert_eq!(white.to_rgb(), (255, 255, 255));
+        assert_eq!(black.to_rgb(), (0, 0, 0));
+
+        let (hue, saturation, brightness) = vivid_mid.to_hsb();
+
+        assert!((hue - 210.0).abs() < 1e-9);
+        assert!((saturation - 0.75).abs() < 1e-9);
+        assert!((brightness - 0.8).abs() < 1e-9);
+    }
+
+    #[test]
     fn channel_value_reads_every_channel() {
         let color = ColorValue::new(120.0, 0.4, 0.6, 0.8);
 
@@ -1210,6 +1271,25 @@ mod tests {
     }
 
     #[test]
+    fn with_channel_brightness_preserves_hue_saturation_and_alpha() {
+        let mut base = ColorValue::from_hsb(210.0, 0.6, 0.4);
+
+        base.alpha = 0.35;
+
+        let updated = with_channel(&base, ColorChannel::Brightness, 0.9);
+        let (hue, saturation, brightness) = updated.to_hsb();
+
+        assert!((hue - 210.0).abs() < 1e-9);
+        assert!((saturation - 0.6).abs() < 1e-9);
+        assert!((brightness - 0.9).abs() < 1e-9);
+        assert!((updated.alpha - 0.35).abs() < 1e-9);
+
+        let black = with_channel(&base, ColorChannel::Brightness, 0.0);
+
+        assert_eq!(black.to_rgb(), (0, 0, 0));
+    }
+
+    #[test]
     fn perceptual_naming_covers_lightness_and_chroma_modifiers() {
         // A dark vivid color picks up a lightness modifier and "vibrant".
         let dark_blue = ColorValue::from_rgb(0, 0, 90).color_name_en();
@@ -1224,6 +1304,28 @@ mod tests {
             pastel.contains("light") || pastel.contains("pale"),
             "got {pastel:?}"
         );
+    }
+
+    #[test]
+    fn perceptual_naming_distinguishes_achromatic_and_chroma_modifiers() {
+        assert_eq!(
+            ColorValue::from_rgb(0, 0, 0).color_name_parts().hue,
+            "black"
+        );
+        assert_eq!(
+            ColorValue::from_rgb(255, 255, 255).color_name_parts().hue,
+            "white"
+        );
+
+        let pale = ColorValue::from_rgb(255, 220, 210).color_name_parts();
+
+        assert_eq!(pale.chroma, "pale");
+        assert_ne!(pale.hue, "gray");
+
+        let vibrant = ColorValue::from_rgb(255, 0, 128).color_name_parts();
+
+        assert_eq!(vibrant.chroma, "vibrant");
+        assert_ne!(vibrant.hue, "gray");
     }
 
     #[test]
@@ -1247,6 +1349,23 @@ mod tests {
     }
 
     #[test]
+    fn hue_name_boundaries_use_next_bucket_at_exact_cutover() {
+        assert_eq!(hue_name(35.0), "red-orange");
+        assert_eq!(hue_name(55.0), "orange");
+        assert_eq!(hue_name(75.0), "yellow-orange");
+        assert_eq!(hue_name(90.0), "yellow");
+        assert_eq!(hue_name(110.0), "yellow-green");
+        assert_eq!(hue_name(135.0), "green");
+        assert_eq!(hue_name(165.0), "cyan-green");
+        assert_eq!(hue_name(185.0), "cyan");
+        assert_eq!(hue_name(205.0), "cyan-blue");
+        assert_eq!(hue_name(240.0), "blue");
+        assert_eq!(hue_name(280.0), "purple");
+        assert_eq!(hue_name(320.0), "magenta");
+        assert_eq!(hue_name(350.0), "red");
+    }
+
+    #[test]
     fn wcag_large_text_thresholds() {
         // ~3.4:1 passes AA-large (3:1) but fails AA-normal (4.5:1).
         let fg = ColorValue::from_rgb(140, 140, 140);
@@ -1260,6 +1379,26 @@ mod tests {
 
         assert!(black.passes_wcag_aaa(&bg, true));
         assert!(black.passes_wcag_aaa(&bg, false));
+    }
+
+    #[test]
+    fn wcag_aaa_has_real_failing_cases_and_symmetric_ratio() {
+        let black = ColorValue::from_rgb(0, 0, 0);
+        let white = ColorValue::from_rgb(255, 255, 255);
+        let mid_gray = ColorValue::from_rgb(110, 110, 110);
+        let light_gray = ColorValue::from_rgb(180, 180, 180);
+
+        assert!((black.contrast_ratio(&white) - white.contrast_ratio(&black)).abs() < 1e-12);
+        assert!(mid_gray.passes_wcag_aa(&white, false));
+        assert!(!mid_gray.passes_wcag_aaa(&white, false));
+        assert!(!light_gray.passes_wcag_aaa(&white, true));
+    }
+
+    #[test]
+    fn srgb_linearization_uses_low_and_high_channel_branches() {
+        assert!((srgb_to_linear(10) - (10.0 / 255.0) / 12.92).abs() < 1e-12);
+        assert!((srgb_to_linear(12) - 0.003_676_507_324_047_436).abs() < 1e-15);
+        assert!((srgb_to_linear(255) - 1.0).abs() < 1e-12);
     }
 
     #[test]
@@ -1320,6 +1459,22 @@ mod tests {
             (255, 0, 0),
             "200% saturation clamps to full red"
         );
+    }
+
+    #[test]
+    fn parser_scales_percent_hsl_and_hsb_channels() {
+        let hsl = parse_color_string("hsl(210, 40%, 60%)").expect("hsl parses");
+
+        assert!((hsl.hue - 210.0).abs() < 1e-9);
+        assert!((hsl.saturation - 0.4).abs() < 1e-9);
+        assert!((hsl.lightness - 0.6).abs() < 1e-9);
+
+        let hsb = parse_color_string("hsb(210, 75%, 80%)").expect("hsb parses");
+        let (hue, saturation, brightness) = hsb.to_hsb();
+
+        assert!((hue - 210.0).abs() < 1e-9);
+        assert!((saturation - 0.75).abs() < 1e-9);
+        assert!((brightness - 0.8).abs() < 1e-9);
     }
 
     #[test]

--- a/crates/ars-core/src/connect.rs
+++ b/crates/ars-core/src/connect.rs
@@ -3477,6 +3477,11 @@ mod tests {
 
         assert_eq!(original, cloned);
 
+        let original_optional = AttrValue::reactive_optional(|| Some(String::from("x")));
+        let cloned_optional = original_optional.clone();
+
+        assert_eq!(original_optional, cloned_optional);
+
         let original_bool = AttrValue::reactive_bool(|| true);
         let cloned_bool = original_bool.clone();
 
@@ -3493,6 +3498,11 @@ mod tests {
         let b = AttrValue::reactive(|| String::from("x"));
 
         assert_ne!(a, b);
+
+        let optional_a = AttrValue::reactive_optional(|| Some(String::from("x")));
+        let optional_b = AttrValue::reactive_optional(|| Some(String::from("x")));
+
+        assert_ne!(optional_a, optional_b);
     }
 
     /// `Debug` for reactive variants must redact the inner closure to

--- a/crates/ars-core/src/platform.rs
+++ b/crates/ars-core/src/platform.rs
@@ -637,6 +637,7 @@ mod tests {
     #[test]
     fn null_now_returns_zero() {
         assert_eq!(NullPlatformEffects.now(), Duration::ZERO);
+        assert_eq!(NullPlatformEffects.now().as_nanos(), 0);
     }
 
     #[test]
@@ -743,6 +744,7 @@ mod tests {
 
         assert!(!MissingProviderEffects.is_mac_platform());
         assert_eq!(MissingProviderEffects.now(), Duration::ZERO);
+        assert_eq!(MissingProviderEffects.now().as_nanos(), 0);
         assert!(MissingProviderEffects.get_bounding_rect("id").is_none());
     }
 


### PR DESCRIPTION
## Summary
- add targeted regression coverage for the current Nightly missed mutants in ars-core color/connect/platform code
- cover retained typeahead mutation cases around timeout boundaries, focus starts, disabled filtering, wrapping, and locale delegation
- expand component state-machine and connect API assertions for the still-applicable ars-components Nightly missed mutants

## Verification
- cargo test -p ars-core color
- cargo test -p ars-core connect
- cargo test -p ars-core platform
- cargo test -p ars-collections typeahead
- cargo test -p ars-components --lib -- date_time::calendar date_time::date_picker layout::scroll_area layout::splitter layout::toolbar selection::context_menu selection::listbox selection::menu selection::menu_bar specialized::file_upload specialized::image_cropper specialized::qr_code specialized::signature_pad
- cargo test -p ars-components --test spec_conformance -- date_time::calendar date_time::date_picker layout::scroll_area layout::splitter layout::toolbar selection::context_menu selection::listbox selection::menu selection::menu_bar specialized::file_upload specialized::image_cropper specialized::qr_code specialized::signature_pad
- cargo xfmt
- cargo xclippy
- cargo xci --profile fast

## Mutation Testing
Local mutation testing was intentionally not run per request. The next Nightly mutation-testing run is the validation source for any remaining found mutants.