### PR TITLE
Shard coverage CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -332,10 +332,21 @@ jobs:
   coverage:
     name: Coverage
     needs: [coverage-native, coverage-wasm]
+    if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
+      - name: Require coverage shards
+        run: |
+          if [ "${{ needs.coverage-native.result }}" != "success" ]; then
+            echo "coverage-native result was ${{ needs.coverage-native.result }}"
+            exit 1
+          fi
+          if [ "${{ needs.coverage-wasm.result }}" != "success" ]; then
+            echo "coverage-wasm result was ${{ needs.coverage-wasm.result }}"
+            exit 1
+          fi
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       # Pinned to match crap::CARGO_CRAP_VERSION; bump both together.
@@ -348,7 +359,19 @@ jobs:
           path: target/coverage/downloads
           merge-multiple: true
       - name: Merge coverage
-        run: cargo xtask coverage merge --output lcov.info --file target/coverage/downloads/*.lcov
+        run: |
+          files=(target/coverage/downloads/*.lcov)
+          if [ "${files[0]}" = "target/coverage/downloads/*.lcov" ]; then
+            echo "No coverage LCOV artifacts were downloaded"
+            exit 1
+          fi
+
+          args=()
+          for file in "${files[@]}"; do
+            args+=(--file "$file")
+          done
+
+          cargo xtask coverage merge --output lcov.info "${args[@]}"
       - name: Coverage thresholds
         run: cargo xtask coverage check-all --file lcov.info
       # Reuses the merged lcov.info from the coverage step (no recompile).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,11 +208,55 @@ jobs:
       - name: Error Variant Coverage
         run: cargo xtask ci error-variant-coverage
 
-  coverage:
-    name: Coverage
+  coverage-native:
+    name: Coverage Native (${{ matrix.partition }}/8)
     needs: [clippy]
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        partition: [1, 2, 3, 4, 5, 6, 7, 8]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@nextest
+      - uses: taiki-e/install-action@cargo-llvm-cov
+      - uses: ./.github/actions/install-dioxus-desktop-deps
+      - name: Native coverage shard
+        run: cargo xtask coverage native --file target/coverage/native-${{ matrix.partition }}.lcov --partition hash:${{ matrix.partition }}/8
+      - name: Upload native lcov
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-native-${{ matrix.partition }}
+          path: target/coverage/native-${{ matrix.partition }}.lcov
+          if-no-files-found: warn
+
+  coverage-wasm:
+    name: Coverage Wasm (${{ matrix.package }})
+    needs: [clippy]
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - package: ars-dom
+            args: --feature web
+          - package: ars-i18n
+            args: --no-default-features --feature web-intl
+          - package: ars-leptos
+            args: --feature csr
+          - package: ars-dioxus
+            args: --feature web
+          - package: ars-test-harness-leptos
+            args: ""
+          - package: ars-test-harness-dioxus
+            args: --no-default-features --feature ars-i18n/web-intl
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -223,12 +267,6 @@ jobs:
           targets: wasm32-unknown-unknown
           components: llvm-tools-preview
       - uses: Swatinem/rust-cache@v2
-      - uses: taiki-e/install-action@nextest
-      - uses: taiki-e/install-action@cargo-llvm-cov
-      # Pinned to match crap::CARGO_CRAP_VERSION; bump both together.
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-crap@0.2.2
       - name: Reclaim runner disk space
         run: |
           df -h
@@ -281,8 +319,38 @@ jobs:
       - name: Configure wasm coverage clang
         run: echo "WASM_COVERAGE_CLANG=/usr/bin/clang-22" >> "$GITHUB_ENV"
       - uses: ./.github/actions/install-dioxus-desktop-deps
-      - name: Coverage
-        run: cargo xtask ci coverage
+      - name: Wasm coverage shard
+        run: cargo xtask coverage wasm --package ${{ matrix.package }} --file target/coverage/${{ matrix.package }}-wasm.lcov ${{ matrix.args }}
+      - name: Upload wasm lcov
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-wasm-${{ matrix.package }}
+          path: target/coverage/${{ matrix.package }}-wasm.lcov
+          if-no-files-found: warn
+
+  coverage:
+    name: Coverage
+    needs: [coverage-native, coverage-wasm]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      # Pinned to match crap::CARGO_CRAP_VERSION; bump both together.
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-crap@0.2.2
+      - uses: actions/download-artifact@v7
+        with:
+          pattern: coverage-[nw]*
+          path: target/coverage/downloads
+          merge-multiple: true
+      - name: Merge coverage
+        run: cargo xtask coverage merge --output lcov.info --file target/coverage/downloads/*.lcov
+      - name: Coverage thresholds
+        run: cargo xtask coverage check-all --file lcov.info
       # Reuses the merged lcov.info from the coverage step (no recompile).
       # Regression-mode gate: fails the job only when a tracked (>= CRAP 30)
       # shipped-library function regresses vs the committed baseline. Output is
@@ -297,6 +365,7 @@ jobs:
           path: |
             lcov.info
             target/coverage/*.lcov
+            target/coverage/downloads/*.lcov
             target/wasm-coverage/**/profraw/*.profraw
           if-no-files-found: ignore
       - name: Snapshot Count

--- a/spec/testing/14-ci.md
+++ b/spec/testing/14-ci.md
@@ -432,13 +432,34 @@ coverage-wasm:
 coverage:
     name: Coverage
     needs: [coverage-native, coverage-wasm]
+    if: always()
     steps:
+        - run: |
+              if [ "${{ needs.coverage-native.result }}" != "success" ]; then
+                  echo "coverage-native result was ${{ needs.coverage-native.result }}"
+                  exit 1
+              fi
+              if [ "${{ needs.coverage-wasm.result }}" != "success" ]; then
+                  echo "coverage-wasm result was ${{ needs.coverage-wasm.result }}"
+                  exit 1
+              fi
         - uses: actions/download-artifact@v7
           with:
               pattern: coverage-[nw]*
               path: target/coverage/downloads
               merge-multiple: true
-        - run: cargo xtask coverage merge --output lcov.info --file target/coverage/downloads/*.lcov
+        - run: |
+              files=(target/coverage/downloads/*.lcov)
+              if [ "${files[0]}" = "target/coverage/downloads/*.lcov" ]; then
+                  echo "No coverage LCOV artifacts were downloaded"
+                  exit 1
+              fi
+
+              args=()
+              for file in "${files[@]}"; do
+                  args+=(--file "$file")
+              done
+              cargo xtask coverage merge --output lcov.info "${args[@]}"
         - run: cargo xtask coverage check-all --file lcov.info
         - run: cargo xtask ci crap
         - uses: actions/upload-artifact@v7

--- a/spec/testing/14-ci.md
+++ b/spec/testing/14-ci.md
@@ -391,73 +391,67 @@ coverage for crates that contain `feature = "web"` / `target_arch = "wasm32"`
 code paths and expose browser-executable tests.
 
 ```yaml
+coverage-native:
+    name: Coverage Native (${{ matrix.partition }}/8)
+    needs: [clippy]
+    strategy:
+        matrix:
+            partition: [1, 2, 3, 4, 5, 6, 7, 8]
+    steps:
+        - run: cargo xtask coverage native --file target/coverage/native-${{ matrix.partition }}.lcov --partition hash:${{ matrix.partition }}/8
+        - uses: actions/upload-artifact@v7
+          with:
+              name: coverage-native-${{ matrix.partition }}
+              path: target/coverage/native-${{ matrix.partition }}.lcov
+
+coverage-wasm:
+    name: Coverage Wasm (${{ matrix.package }})
+    needs: [clippy]
+    strategy:
+        matrix:
+            include:
+                - package: ars-dom
+                  args: --feature web
+                - package: ars-i18n
+                  args: --no-default-features --feature web-intl
+                - package: ars-leptos
+                  args: --feature csr
+                - package: ars-dioxus
+                  args: --feature web
+                - package: ars-test-harness-leptos
+                  args: ""
+                - package: ars-test-harness-dioxus
+                  args: --no-default-features --feature ars-i18n/web-intl
+    steps:
+        - run: cargo xtask coverage wasm --package ${{ matrix.package }} --file target/coverage/${{ matrix.package }}-wasm.lcov ${{ matrix.args }}
+        - uses: actions/upload-artifact@v7
+          with:
+              name: coverage-wasm-${{ matrix.package }}
+              path: target/coverage/${{ matrix.package }}-wasm.lcov
+
 coverage:
     name: Coverage
-    runs-on: ubuntu-latest
-    needs: [clippy]
+    needs: [coverage-native, coverage-wasm]
     steps:
-        - uses: actions/checkout@v6
-        - uses: dtolnay/rust-toolchain@stable
+        - uses: actions/download-artifact@v7
           with:
-              components: llvm-tools-preview
-        - uses: dtolnay/rust-toolchain@nightly
-          with:
-              targets: wasm32-unknown-unknown
-              components: llvm-tools-preview
-        - uses: actions/cache@v5
-          with:
-              path: |
-                  ~/.cargo/registry
-                  ~/.cargo/git
-                  ~/.cache/wasm-pack
-                  target
-              key: ${{ runner.os }}-cargo-coverage-${{ hashFiles('**/Cargo.lock') }}
-              restore-keys: |
-                  ${{ runner.os }}-cargo-
-        - uses: taiki-e/install-action@nextest
-        - uses: taiki-e/install-action@cargo-llvm-cov
-        # Cache the LLVM 22 .deb packages so re-runs skip the multi-hundred-MB
-        # download. Restored into a user-owned dir; the install step seeds apt's
-        # archive from it (additive — a cache miss installs exactly as before).
-        - uses: actions/cache@v5
-          with:
-              path: ~/.cache/apt-llvm22
-              key: apt-llvm22-${{ runner.os }}-v1
-        - name: Install LLVM 22 for wasm coverage
-          run: |
-              set -eux
-              mkdir -p ~/.cache/apt-llvm22
-              sudo cp -n ~/.cache/apt-llvm22/*.deb /var/cache/apt/archives/ 2>/dev/null || true
-              wget -q https://apt.llvm.org/llvm.sh -O /tmp/llvm.sh
-              chmod +x /tmp/llvm.sh
-              sudo /tmp/llvm.sh 22
-              sudo apt-get install -y clang-22 lld-22
-              sudo cp -n /var/cache/apt/archives/*.deb ~/.cache/apt-llvm22/ 2>/dev/null || true
-              sudo chown -R "$(id -u):$(id -g)" ~/.cache/apt-llvm22
-        - run: cargo install wasm-bindgen-cli --locked --version 0.2.118
-        - name: Configure wasm coverage clang
-          run: echo "WASM_COVERAGE_CLANG=/usr/bin/clang-22" >> "$GITHUB_ENV"
-        - uses: taiki-e/install-action@v2
-          with:
-              tool: cargo-crap@0.2.2
-        - uses: ./.github/actions/install-dioxus-desktop-deps
-        - name: Coverage
-          run: cargo xtask ci coverage
-        - name: CRAP gate
-          run: cargo xtask ci crap
-        - name: Upload merged lcov
-          if: always()
-          uses: actions/upload-artifact@v7
+              pattern: coverage-[nw]*
+              path: target/coverage/downloads
+              merge-multiple: true
+        - run: cargo xtask coverage merge --output lcov.info --file target/coverage/downloads/*.lcov
+        - run: cargo xtask coverage check-all --file lcov.info
+        - run: cargo xtask ci crap
+        - uses: actions/upload-artifact@v7
           with:
               name: coverage-lcov
               path: lcov.info
 ```
 
-`cargo xtask ci coverage` performs three steps:
+GitHub Actions coverage performs three steps:
 
-1. Generate native workspace lcov with `cargo +nightly llvm-cov nextest
---branch`, so native coverage executes the same test binaries through
-   `cargo-nextest` and exports real branch records in the lcov tracefile.
+1. Generate eight native workspace lcov shards with `cargo xtask coverage native
+--partition hash:K/8`, so each shard executes a deterministic partition of
+   the same `cargo +nightly llvm-cov nextest --branch --workspace` test set.
 2. Generate per-package wasm lcov with `cargo xtask coverage wasm` for every
    browser-test crate in `xtask/src/coverage.rs :: default_wasm_coverage_targets()`.
    At the time of writing this includes:
@@ -467,8 +461,14 @@ coverage:
     - `ars-dioxus` with `--features web`
     - `ars-test-harness-leptos`
     - `ars-test-harness-dioxus` with `--no-default-features --features ars-i18n/web-intl`
-3. Merge the native and wasm lcov tracefiles with `cargo xtask coverage merge`
-   so duplicate file records are unioned instead of double-counted.
+3. Merge all native and wasm lcov artifacts with `cargo xtask coverage merge`
+   so duplicate file records are unioned instead of double-counted, then run
+   `cargo xtask coverage check-all --file lcov.info`, the CRAP gate, the merged
+   lcov upload, and Codecov upload from the final job named `Coverage`.
+
+For local full-parity runs, `cargo xtask ci coverage` still performs the same
+logical collection serially: one unpartitioned native lcov, every wasm lcov
+target, a merge into `lcov.info`, and the per-crate threshold check.
 
 > **Note:** The wasm path uses the experimental `wasm-bindgen-test` coverage
 > recipe on nightly Rust. It requires `llvm-tools-preview` on nightly,
@@ -787,7 +787,7 @@ path: |
     target
 ```
 
-The coverage job additionally caches the LLVM 22 `.deb` packages under
+The `coverage-wasm` jobs additionally cache the LLVM 22 `.deb` packages under
 `~/.cache/apt-llvm22` (key `apt-llvm22-${{ runner.os }}-v1`) so the
 `clang-22` / `lld-22` install reuses cached debs instead of re-downloading them
 each run. Likewise, the `install-dioxus-desktop-deps` composite action caches
@@ -836,51 +836,30 @@ concurrency:
 
 ## 5. Job Dependency Graph
 
-```diagram
-                    ┌────────────┐
-                    │  checkout  │
-                    └─────┬──────┘
-          ┌───────────────┼───────────────────┬──────────────────┐
-          │               │                   │                  │
-    ┌─────▼─────┐   ┌─────▼────┐   ┌──────────▼─────────┐  ┌─────▼──────────┐
-    │    fmt    │   │  clippy  │   │  feature-flags     │  │ test-harness   │
-    └───────────┘   └──────────┘   └────────────────────┘  │ check          │
-                                                           └────────────────┘
-
-          ┌───────────────┐   ┌───────────────────┐
-          │  core-tests   │   │ mutual-exclusion  │
-          └──────┬────────┘   └───────────────────┘
-                 │
-          ┌──────┼──────────────────┐
-          │      │                  │
-   ┌──────▼───┐  │   ┌──────▼───┐   │
-   │ leptos   │  │   │ dioxus   │   │
-   │ adapter  │  │   │ adapter  │   │
-   └────┬─────┘  │   └────┬─────┘   │
-        │        │        │         │
-        └────────┴────────┘         │
-                 │                  │
-    ┌────────────▼─────┐  ┌─────────▼────────┐
-    │ adapter-         │  │ error-coverage   │
-    │ parity           │  │ needs:           │
-    └──────────────────┘  │ [core-tests]     │
-                          └──────────────────┘
-    ┌──────────────┐
-    │  coverage    │◄── needs: [core-tests, adapter-tests]
-    │  (llvm-cov)  │
-    └──────┬───────┘
-           │
-    ┌──────▼──────┐
-    │  codecov    │
-    │  upload     │
-    └─────────────┘
+```text
+Formatting
+    -> Clippy
+        -> Unit Tests
+        -> I18n Browser Tests
+        -> DOM Browser Tests
+        -> Release Verification
+        -> Integration Tests
+        -> Adapter Tests
+        -> Adapter Parity
+        -> Error Variant Coverage
+        -> Mutual Exclusion Guard
+        -> Coverage Native (8-way matrix)
+        -> Coverage Wasm (6-package matrix)
+             -> Coverage (merge, thresholds, CRAP, Codecov)
+        -> Feature Flags groups
 ```
 
-`fmt`, `clippy`, `feature-flags`, `test-harness`, and `mutual-exclusion` run in parallel with
-no dependencies. `core-tests` gates the adapter tests and error-coverage.
-Coverage runs after both `core-tests` and `adapter-tests` complete. Adapter
-parity runs after both adapter test jobs complete. Codecov upload runs after
-coverage collection.
+`fmt` gates `clippy`. After `clippy`, the test, feature-flag, lint, native
+coverage, and wasm coverage jobs fan out. The final `Coverage` job depends on
+both coverage producer matrices, merges their lcov artifacts, enforces
+thresholds, runs the CRAP gate, and uploads to Codecov. Adapter parity runs
+after `clippy` and compares the adapter test trees; it is independent from the
+coverage merge.
 
 ---
 
@@ -891,6 +870,7 @@ coverage collection.
 | `cargo xtest`                             | Run the staged cargo-based test surface with aggregate totals | PR pipeline / Developer |
 | `cargo xtask coverage check-all`          | Parse lcov output, enforce per-crate coverage thresholds      | Coverage pipeline       |
 | `cargo xtask coverage check`              | Ad-hoc single-crate coverage check for local development      | Developer               |
+| `cargo xtask coverage native`             | Generate native workspace lcov, optionally partitioned        | Coverage pipeline       |
 | `cargo xtask coverage wasm`               | Generate experimental browser-test lcov for one wasm package  | Coverage pipeline       |
 | `cargo xtask coverage merge`              | Merge native and wasm lcov without double-counting records    | Coverage pipeline       |
 | `cargo xtask lint snapshot-count`         | Verify snapshot count per component state meets minimum       | Coverage pipeline       |
@@ -927,29 +907,15 @@ have nonzero tests and the per-component delta must remain within tolerance.
 
 ## 7. Test Harness Compilation Check
 
-The test harness crates from [15-test-harness.md](./15-test-harness.md) underpin all adapter-level tests. If they fail to compile, adapter tests silently break. This job runs as part of the PR pipeline alongside core-tests.
+The test harness crates from [15-test-harness.md](./15-test-harness.md)
+underpin all adapter-level tests. CI compiles them through the `Unit Tests`,
+`Adapter Tests`, and coverage jobs rather than a standalone harness job. When a
+PR edits harness code directly, run focused local checks before handoff:
 
-```yaml
-test-harness:
-    name: Test Harness Check
-    runs-on: ubuntu-latest
-    steps:
-        - uses: actions/checkout@v6
-        - uses: dtolnay/rust-toolchain@stable
-        - uses: actions/cache@v5
-          with:
-              path: |
-                  ~/.cargo/registry
-                  ~/.cargo/git
-                  target
-              key: ${{ runner.os }}-cargo-harness-${{ hashFiles('**/Cargo.lock') }}
-              restore-keys: |
-                  ${{ runner.os }}-cargo-
-        - name: Check test harness crates compile
-          run: |
-              cargo check -p ars-test-harness
-              cargo check -p ars-test-harness-leptos
-              cargo check -p ars-test-harness-dioxus
+```bash
+cargo check -p ars-test-harness
+cargo check -p ars-test-harness-leptos
+cargo check -p ars-test-harness-dioxus
 ```
 
 ---

--- a/xtask/src/ci/mod.rs
+++ b/xtask/src/ci/mod.rs
@@ -716,12 +716,6 @@ fn is_expected_mutual_exclusion_failure(stderr: &str) -> bool {
 }
 
 fn run_coverage() -> Result<(), Error> {
-    preflight_llvm_cov()?;
-
-    preflight_nextest()?;
-
-    coverage::preflight_nightly().map_err(Error::Coverage)?;
-
     let coverage_dir = Path::new("target").join("coverage");
 
     fs::create_dir_all(&coverage_dir).map_err(Error::Io)?;
@@ -730,21 +724,11 @@ fn run_coverage() -> Result<(), Error> {
 
     let merged_lcov = PathBuf::from("lcov.info");
 
-    // Generate native lcov via cargo-llvm-cov + cargo-nextest.
-    cargo(
-        Step::Coverage,
-        &[
-            "+nightly",
-            "llvm-cov",
-            "nextest",
-            "--branch",
-            "--workspace",
-            "--lcov",
-            "--output-path",
-            native_lcov.to_str().expect("valid utf-8 path"),
-            "--no-fail-fast",
-        ],
-    )?;
+    coverage::generate_native_lcov(&coverage::NativeCoverageOptions {
+        output: native_lcov.clone(),
+        partition: None,
+    })
+    .map_err(Error::Coverage)?;
 
     let mut reports = vec![native_lcov];
 

--- a/xtask/src/coverage.rs
+++ b/xtask/src/coverage.rs
@@ -372,6 +372,16 @@ pub struct WasmCoverageOptions {
     pub extra_test_args: Vec<String>,
 }
 
+/// Options for generating native workspace LCOV.
+#[derive(Debug, Clone)]
+pub struct NativeCoverageOptions {
+    /// Output lcov path to write.
+    pub output: PathBuf,
+
+    /// Optional `cargo-nextest` partition selector, such as `hash:1/8`.
+    pub partition: Option<String>,
+}
+
 /// Default wasm/browser coverage target used by CI.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct WasmCoverageTarget {
@@ -665,6 +675,44 @@ pub fn merge_files(files: &[PathBuf], output: &Path) -> Result<String, Error> {
         "Merged {} lcov files into {}",
         files.len(),
         output.display()
+    ))
+}
+
+/// Generate native workspace coverage through `cargo-llvm-cov` and
+/// `cargo-nextest`.
+///
+/// When `partition` is set, only that nextest partition is executed, producing
+/// a partial LCOV file that must later be merged with the other partitions.
+///
+/// # Errors
+///
+/// Returns [`Error`] if required tools are missing, tests fail, or the lcov
+/// file cannot be generated.
+pub fn generate_native_lcov(options: &NativeCoverageOptions) -> Result<String, Error> {
+    preflight_nightly()?;
+    preflight_cargo_subcommand(
+        "llvm-cov",
+        "cargo-llvm-cov",
+        "cargo install cargo-llvm-cov --locked",
+    )?;
+    preflight_cargo_subcommand(
+        "nextest",
+        "cargo-nextest",
+        "cargo install cargo-nextest --locked",
+    )?;
+
+    let parent = options
+        .output
+        .parent()
+        .map_or_else(|| PathBuf::from("."), Path::to_path_buf);
+
+    fs::create_dir_all(parent).map_err(Error::Io)?;
+
+    run_command(process::Command::new("cargo").args(native_coverage_args(options)))?;
+
+    Ok(format!(
+        "Generated native lcov at {}",
+        options.output.display()
     ))
 }
 
@@ -1472,6 +1520,56 @@ version = "0.2.118"
     }
 
     #[test]
+    fn native_coverage_args_build_unpartitioned_workspace_command() {
+        let args = native_coverage_args(&NativeCoverageOptions {
+            output: PathBuf::from("target/coverage/native.lcov"),
+            partition: None,
+        });
+
+        let args = args
+            .into_iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            args,
+            [
+                "+nightly",
+                "llvm-cov",
+                "nextest",
+                "--branch",
+                "--workspace",
+                "--lcov",
+                "--output-path",
+                "target/coverage/native.lcov",
+                "--no-fail-fast",
+            ]
+        );
+    }
+
+    #[test]
+    fn native_coverage_args_includes_nextest_partition() {
+        let args = native_coverage_args(&NativeCoverageOptions {
+            output: PathBuf::from("target/coverage/native-1.lcov"),
+            partition: Some("hash:1/8".into()),
+        });
+
+        let args = args
+            .into_iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+
+        assert!(
+            args.windows(2)
+                .any(|pair| pair == ["--partition", "hash:1/8"])
+        );
+        assert!(
+            args.windows(2)
+                .any(|pair| pair == ["--output-path", "target/coverage/native-1.lcov"])
+        );
+    }
+
+    #[test]
     fn native_thresholds_exclude_wasm_targets_and_derive() {
         let native: Vec<String> = native_thresholds()
             .into_iter()
@@ -1627,6 +1725,28 @@ fn wasm_no_run_args(options: &WasmCoverageOptions) -> Vec<OsString> {
     args
 }
 
+fn native_coverage_args(options: &NativeCoverageOptions) -> Vec<OsString> {
+    let mut args = vec![
+        OsString::from("+nightly"),
+        OsString::from("llvm-cov"),
+        OsString::from("nextest"),
+        OsString::from("--branch"),
+        OsString::from("--workspace"),
+    ];
+
+    if let Some(partition) = &options.partition {
+        args.push(OsString::from("--partition"));
+        args.push(OsString::from(partition));
+    }
+
+    args.push(OsString::from("--lcov"));
+    args.push(OsString::from("--output-path"));
+    args.push(options.output.as_os_str().to_owned());
+    args.push(OsString::from("--no-fail-fast"));
+
+    args
+}
+
 fn llvm_profile_file(profraw_dir: impl AsRef<Path>) -> PathBuf {
     let profraw_dir = profraw_dir.as_ref();
 
@@ -1686,6 +1806,28 @@ fn run_command(command: &mut process::Command) -> Result<(), Error> {
         Err(Error::CommandFailed {
             command: display,
             code: status.code(),
+        })
+    }
+}
+
+fn preflight_cargo_subcommand(
+    subcommand: &str,
+    tool: &str,
+    install_hint: &str,
+) -> Result<(), Error> {
+    let status = process::Command::new("cargo")
+        .args([subcommand, "--version"])
+        .stdout(process::Stdio::null())
+        .stderr(process::Stdio::null())
+        .status()
+        .map_err(Error::Io)?;
+
+    if status.success() {
+        Ok(())
+    } else {
+        Err(Error::MissingTool {
+            tool: tool.into(),
+            install_hint: install_hint.into(),
         })
     }
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -204,6 +204,17 @@ enum Command {
 
 #[derive(Subcommand)]
 enum CoverageCommand {
+    /// Generate native workspace lcov, optionally for a nextest partition.
+    Native {
+        /// Path to write the generated lcov file.
+        #[arg(long)]
+        file: PathBuf,
+
+        /// Optional cargo-nextest partition, for example `hash:1/8`.
+        #[arg(long)]
+        partition: Option<String>,
+    },
+
     /// Generate experimental wasm lcov for a single package.
     Wasm {
         /// Crate name (e.g., "ars-dom").
@@ -754,6 +765,13 @@ fn main() {
         // ── Coverage ──────────────────────────────────────────────────
         Command::Coverage { cmd } => {
             let result = match cmd {
+                CoverageCommand::Native { file, partition } => {
+                    coverage::generate_native_lcov(&coverage::NativeCoverageOptions {
+                        output: file,
+                        partition,
+                    })
+                }
+
                 CoverageCommand::Wasm {
                     package,
                     file,


### PR DESCRIPTION
## Summary
- split coverage collection into 8 native nextest partitions and per-package wasm coverage jobs
- add `cargo xtask coverage native` for native LCOV generation with optional nextest partitioning
- keep the final `Coverage` job responsible for LCOV merge, threshold checks, CRAP, snapshot count, merged artifact upload, and Codecov
- update the CI testing spec to document the sharded coverage topology

## Verification
- cargo test -p xtask --lib
- cargo check -p xtask
- cargo xtask coverage native --help
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); puts 'ci.yml parsed'"\n- cargo xtask coverage merge --output /tmp/ars-ui-coverage-merged.lcov --file /tmp/ars-ui-coverage-a.lcov --file /tmp/ars-ui-coverage-b.lcov\n- cargo xtask coverage check-all --file /tmp/ars-ui-coverage-merged.lcov\n- cargo xfmt\n- cargo xclippy\n- cargo xci --profile fast